### PR TITLE
ruma-signatures: Depend on cjson for canonical json

### DIFF
--- a/ruma-signatures/Cargo.toml
+++ b/ruma-signatures/Cargo.toml
@@ -14,6 +14,7 @@ version = "0.6.0-dev.1"
 
 [dependencies]
 base64 = "0.12.0"
+cjson = { git = "https://github.com/engineerd/cjson", rev = "e98e5e664dd0043985eaa26ba46722fecaabd5de" }
 ring = "0.16.12"
 serde_json = "1.0.50"
 untrusted = "0.7.0"

--- a/ruma-signatures/src/functions.rs
+++ b/ruma-signatures/src/functions.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use base64::{decode_config, encode_config, STANDARD_NO_PAD};
 use ring::digest::{digest, SHA256};
-use serde_json::{from_str, from_value, map::Map, to_string, to_value, Value};
+use serde_json::{from_str, from_value, map::Map, to_value, Value};
 
 use crate::{
     keys::{KeyPair, PublicKeyMap},
@@ -133,7 +133,7 @@ where
     }
 
     // Get the canonical JSON.
-    let json = to_string(&value)?;
+    let json = canonical_json(&value)?;
 
     // Sign the canonical JSON.
     let signature = key_pair.sign(json.as_bytes());
@@ -655,7 +655,7 @@ fn canonical_json_with_fields_to_remove(value: &Value, fields: &[&str]) -> Resul
         }
     }
 
-    to_string(&owned_value).map_err(Error::from)
+    cjson::to_string(&owned_value).map_err(|_| Error::new("cannot write canonical JSON"))
 }
 
 /// Redacts the JSON representation of an event using the rules specified in the Matrix


### PR DESCRIPTION
Currently ruma-signatures doesn't actually use canonical JSON when signing. Depending on `cjson` fixes that. That's also in use over in the matrix-rust-sdk. The specific rev is needed for WASM support.