### PR TITLE
Fix failing deserialization when encountering an unknown field

### DIFF
--- a/ruma-events-macros/src/event.rs
+++ b/ruma-events-macros/src/event.rs
@@ -212,12 +212,14 @@ fn expand_deserialize_event(
             where
                 D: ::serde::de::Deserializer<'de>,
             {
-                #[derive(serde::Deserialize)]
+                #[derive(::serde::Deserialize)]
                 #[serde(field_identifier, rename_all = "snake_case")]
                 enum Field {
                     // since this is represented as an enum we have to add it so the JSON picks it up
                     Type,
-                    #( #enum_variants ),*
+                    #( #enum_variants, )*
+                    #[serde(other)]
+                    Unknown,
                 }
 
                 /// Visits the fields of an event struct to handle deserialization of
@@ -242,6 +244,7 @@ fn expand_deserialize_event(
 
                         while let Some(key) = map.next_key()? {
                             match key {
+                                Field::Unknown => continue,
                                 Field::Type => {
                                     if event_type.is_some() {
                                         return Err(::serde::de::Error::duplicate_field("type"));

--- a/ruma-events/tests/state_event.rs
+++ b/ruma-events/tests/state_event.rs
@@ -7,10 +7,29 @@ use js_int::UInt;
 use matches::assert_matches;
 use ruma_events::{
     room::{aliases::AliasesEventContent, avatar::AvatarEventContent, ImageInfo, ThumbnailInfo},
-    AnyStateEventContent, EventJson, StateEvent, UnsignedData,
+    AnyStateEventContent, EventJson, StateEvent, StateEventStub, UnsignedData,
 };
 use ruma_identifiers::{EventId, RoomAliasId, RoomId, UserId};
-use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+use serde_json::{
+    from_value as from_json_value, json, to_value as to_json_value, Value as JsonValue,
+};
+
+fn aliases_event_with_prev_content() -> JsonValue {
+    json!({
+        "content": {
+            "aliases": [ "#somewhere:localhost" ]
+        },
+        "event_id": "$h29iv0s8:example.com",
+        "origin_server_ts": 1,
+        "prev_content": {
+            "aliases": [ "#inner:localhost" ]
+        },
+        "room_id": "!roomid:room.com",
+        "sender": "@carl:example.com",
+        "state_key": "",
+        "type": "m.room.aliases"
+    })
+}
 
 #[test]
 fn serialize_aliases_with_prev_content() {
@@ -21,7 +40,7 @@ fn serialize_aliases_with_prev_content() {
         event_id: EventId::try_from("$h29iv0s8:example.com").unwrap(),
         origin_server_ts: UNIX_EPOCH + Duration::from_millis(1),
         prev_content: Some(AnyStateEventContent::RoomAliases(AliasesEventContent {
-            aliases: vec![RoomAliasId::try_from("#somewhere:localhost").unwrap()],
+            aliases: vec![RoomAliasId::try_from("#inner:localhost").unwrap()],
         })),
         room_id: RoomId::try_from("!roomid:room.com").unwrap(),
         sender: UserId::try_from("@carl:example.com").unwrap(),
@@ -30,20 +49,7 @@ fn serialize_aliases_with_prev_content() {
     };
 
     let actual = to_json_value(&aliases_event).unwrap();
-    let expected = json!({
-        "content": {
-            "aliases": [ "#somewhere:localhost" ]
-        },
-        "event_id": "$h29iv0s8:example.com",
-        "origin_server_ts": 1,
-        "prev_content": {
-            "aliases": [ "#somewhere:localhost" ]
-        },
-        "room_id": "!roomid:room.com",
-        "sender": "@carl:example.com",
-        "state_key": "",
-        "type": "m.room.aliases",
-    });
+    let expected = aliases_event_with_prev_content();
 
     assert_eq!(actual, expected);
 }
@@ -97,20 +103,7 @@ fn deserialize_aliases_content() {
 
 #[test]
 fn deserialize_aliases_with_prev_content() {
-    let json_data = json!({
-        "content": {
-            "aliases": [ "#somewhere:localhost" ]
-        },
-        "event_id": "$h29iv0s8:example.com",
-        "origin_server_ts": 1,
-        "prev_content": {
-            "aliases": [ "#inner:localhost" ]
-        },
-        "room_id": "!roomid:room.com",
-        "sender": "@carl:example.com",
-        "state_key": "",
-        "type": "m.room.aliases"
-    });
+    let json_data = aliases_event_with_prev_content();
 
     assert_matches!(
         from_json_value::<EventJson<StateEvent<AnyStateEventContent>>>(json_data)
@@ -131,6 +124,58 @@ fn deserialize_aliases_with_prev_content() {
             && origin_server_ts == UNIX_EPOCH + Duration::from_millis(1)
             && prev_content.aliases == vec![RoomAliasId::try_from("#inner:localhost").unwrap()]
             && room_id == RoomId::try_from("!roomid:room.com").unwrap()
+            && sender == UserId::try_from("@carl:example.com").unwrap()
+            && state_key == ""
+            && unsigned.is_empty()
+    );
+}
+
+#[test]
+fn deserialize_aliases_stub_with_room_id_non_event_json() {
+    let json_data = aliases_event_with_prev_content();
+
+    assert_matches!(
+        from_json_value::<StateEventStub<AnyStateEventContent>>(json_data)
+            .unwrap(),
+        StateEventStub {
+            content: AnyStateEventContent::RoomAliases(content),
+            event_id,
+            origin_server_ts,
+            prev_content: Some(AnyStateEventContent::RoomAliases(prev_content)),
+            sender,
+            state_key,
+            unsigned,
+        } if content.aliases == vec![RoomAliasId::try_from("#somewhere:localhost").unwrap()]
+            && event_id == EventId::try_from("$h29iv0s8:example.com").unwrap()
+            && origin_server_ts == UNIX_EPOCH + Duration::from_millis(1)
+            && prev_content.aliases == vec![RoomAliasId::try_from("#inner:localhost").unwrap()]
+            && sender == UserId::try_from("@carl:example.com").unwrap()
+            && state_key == ""
+            && unsigned.is_empty()
+    );
+}
+
+#[test]
+fn deserialize_aliases_stub_with_room_id_event_json() {
+    let json_data = aliases_event_with_prev_content();
+
+    assert_matches!(
+        from_json_value::<EventJson<StateEventStub<AnyStateEventContent>>>(json_data)
+            .unwrap()
+            .deserialize()
+            .unwrap(),
+        StateEventStub {
+            content: AnyStateEventContent::RoomAliases(content),
+            event_id,
+            origin_server_ts,
+            prev_content: Some(AnyStateEventContent::RoomAliases(prev_content)),
+            sender,
+            state_key,
+            unsigned,
+        } if content.aliases == vec![RoomAliasId::try_from("#somewhere:localhost").unwrap()]
+            && event_id == EventId::try_from("$h29iv0s8:example.com").unwrap()
+            && origin_server_ts == UNIX_EPOCH + Duration::from_millis(1)
+            && prev_content.aliases == vec![RoomAliasId::try_from("#inner:localhost").unwrap()]
             && sender == UserId::try_from("@carl:example.com").unwrap()
             && state_key == ""
             && unsigned.is_empty()

--- a/ruma-events/tests/state_event.rs
+++ b/ruma-events/tests/state_event.rs
@@ -131,38 +131,11 @@ fn deserialize_aliases_with_prev_content() {
 }
 
 #[test]
-fn deserialize_aliases_stub_with_room_id_non_event_json() {
+fn deserialize_aliases_stub_with_room_id() {
     let json_data = aliases_event_with_prev_content();
 
     assert_matches!(
         from_json_value::<StateEventStub<AnyStateEventContent>>(json_data)
-            .unwrap(),
-        StateEventStub {
-            content: AnyStateEventContent::RoomAliases(content),
-            event_id,
-            origin_server_ts,
-            prev_content: Some(AnyStateEventContent::RoomAliases(prev_content)),
-            sender,
-            state_key,
-            unsigned,
-        } if content.aliases == vec![RoomAliasId::try_from("#somewhere:localhost").unwrap()]
-            && event_id == EventId::try_from("$h29iv0s8:example.com").unwrap()
-            && origin_server_ts == UNIX_EPOCH + Duration::from_millis(1)
-            && prev_content.aliases == vec![RoomAliasId::try_from("#inner:localhost").unwrap()]
-            && sender == UserId::try_from("@carl:example.com").unwrap()
-            && state_key == ""
-            && unsigned.is_empty()
-    );
-}
-
-#[test]
-fn deserialize_aliases_stub_with_room_id_event_json() {
-    let json_data = aliases_event_with_prev_content();
-
-    assert_matches!(
-        from_json_value::<EventJson<StateEventStub<AnyStateEventContent>>>(json_data)
-            .unwrap()
-            .deserialize()
             .unwrap(),
         StateEventStub {
             content: AnyStateEventContent::RoomAliases(content),


### PR DESCRIPTION
This is an odd test failure with no difference other than one being `EventJson<StateEventStub<AnyStateEventContent>>` and the other `StateEventStub<AnyStateEventContent>` the `EventJson` test fails the other passes?

```bash
thread 'deserialize_aliases_stub_with_room_id_event_json' panicked at
'called `Result::unwrap()` on an `Err` value:
InvalidEvent { message: "expected `,` or `}` at line 1 column 162", kind: Validation }',
ruma-events/tests/state_event.rs:163:9
```