### PR TITLE
Add ServerName identifier.

### DIFF
--- a/ruma-events/src/direct.rs
+++ b/ruma-events/src/direct.rs
@@ -48,8 +48,8 @@ mod tests {
     fn serialization() {
         let mut content = DirectEventContent(BTreeMap::new());
         let server_name = ServerNameRef::try_from("ruma.io").unwrap();
-        let alice = UserId::new(&server_name);
-        let room = vec![RoomId::new(&server_name)];
+        let alice = UserId::new(server_name);
+        let room = vec![RoomId::new(server_name)];
 
         content.insert(alice.clone(), room.clone());
 
@@ -67,8 +67,8 @@ mod tests {
     #[test]
     fn deserialization() {
         let server_name = ServerNameRef::try_from("ruma.io").unwrap();
-        let alice = UserId::new(&server_name);
-        let rooms = vec![RoomId::new(&server_name), RoomId::new(&server_name)];
+        let alice = UserId::new(server_name);
+        let rooms = vec![RoomId::new(server_name), RoomId::new(server_name)];
 
         let json_data = json!({
             "content": {

--- a/ruma-events/src/direct.rs
+++ b/ruma-events/src/direct.rs
@@ -36,9 +36,9 @@ impl DerefMut for DirectEventContent {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
+    use std::{collections::BTreeMap, convert::TryFrom};
 
-    use ruma_identifiers::{RoomId, UserId};
+    use ruma_identifiers::{RoomId, ServerNameRef, UserId};
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     use super::{DirectEvent, DirectEventContent};
@@ -47,8 +47,9 @@ mod tests {
     #[test]
     fn serialization() {
         let mut content = DirectEventContent(BTreeMap::new());
-        let alice = UserId::new("ruma.io").unwrap();
-        let room = vec![RoomId::new("ruma.io").unwrap()];
+        let server_name = ServerNameRef::try_from("ruma.io").unwrap();
+        let alice = UserId::new(&server_name);
+        let room = vec![RoomId::new(&server_name)];
 
         content.insert(alice.clone(), room.clone());
 
@@ -65,8 +66,9 @@ mod tests {
 
     #[test]
     fn deserialization() {
-        let alice = UserId::new("ruma.io").unwrap();
-        let rooms = vec![RoomId::new("ruma.io").unwrap(), RoomId::new("ruma.io").unwrap()];
+        let server_name = ServerNameRef::try_from("ruma.io").unwrap();
+        let alice = UserId::new(&server_name);
+        let rooms = vec![RoomId::new(&server_name), RoomId::new(&server_name)];
 
         let json_data = json!({
             "content": {

--- a/ruma-events/src/room/pinned_events.rs
+++ b/ruma-events/src/room/pinned_events.rs
@@ -19,9 +19,12 @@ pub struct PinnedEventsEventContent {
 
 #[cfg(test)]
 mod tests {
-    use std::time::{Duration, UNIX_EPOCH};
+    use std::{
+        convert::TryFrom,
+        time::{Duration, UNIX_EPOCH},
+    };
 
-    use ruma_identifiers::{EventId, RoomId, UserId};
+    use ruma_identifiers::{EventId, RoomId, ServerNameRef, UserId};
     use serde_json::to_string;
 
     use super::PinnedEventsEventContent;
@@ -30,17 +33,18 @@ mod tests {
     #[test]
     fn serialization_deserialization() {
         let mut content: PinnedEventsEventContent = PinnedEventsEventContent { pinned: Vec::new() };
+        let server_name = ServerNameRef::try_from("example.com").unwrap();
 
-        content.pinned.push(EventId::new("example.com").unwrap());
-        content.pinned.push(EventId::new("example.com").unwrap());
+        content.pinned.push(EventId::new(&server_name));
+        content.pinned.push(EventId::new(&server_name));
 
         let event = StateEvent {
             content: content.clone(),
-            event_id: EventId::new("example.com").unwrap(),
+            event_id: EventId::new(&server_name),
             origin_server_ts: UNIX_EPOCH + Duration::from_millis(1_432_804_485_886u64),
             prev_content: None,
-            room_id: RoomId::new("example.com").unwrap(),
-            sender: UserId::new("example.com").unwrap(),
+            room_id: RoomId::new(&server_name),
+            sender: UserId::new(&server_name),
             state_key: "".to_string(),
             unsigned: UnsignedData::default(),
         };

--- a/ruma-events/src/room/pinned_events.rs
+++ b/ruma-events/src/room/pinned_events.rs
@@ -35,16 +35,16 @@ mod tests {
         let mut content: PinnedEventsEventContent = PinnedEventsEventContent { pinned: Vec::new() };
         let server_name = ServerNameRef::try_from("example.com").unwrap();
 
-        content.pinned.push(EventId::new(&server_name));
-        content.pinned.push(EventId::new(&server_name));
+        content.pinned.push(EventId::new(server_name));
+        content.pinned.push(EventId::new(server_name));
 
         let event = StateEvent {
             content: content.clone(),
-            event_id: EventId::new(&server_name),
+            event_id: EventId::new(server_name),
             origin_server_ts: UNIX_EPOCH + Duration::from_millis(1_432_804_485_886u64),
             prev_content: None,
-            room_id: RoomId::new(&server_name),
-            sender: UserId::new(&server_name),
+            room_id: RoomId::new(server_name),
+            sender: UserId::new(server_name),
             state_key: "".to_string(),
             unsigned: UnsignedData::default(),
         };

--- a/ruma-identifiers/CHANGELOG.md
+++ b/ruma-identifiers/CHANGELOG.md
@@ -8,10 +8,30 @@ Breaking changes:
 * Update `parse_with_server_name`s signature (instead of `Into<String>` it now requires
   `Into<Box<str>>` of the id type). This is technically a breaking change, but extremely unlikely
   to affect any existing code.
+* Modify identifier types to use the new `ServerName` type:
+  * Change signature of `new()` methods of `EventId`, `RoomId`, and `UserId` from
+  ```rust
+  fn new(&str) -> Result<Self, Error>
+  //...
+  ```
+  to
+  ```rust
+  fn new(&ServerName<&str>) -> Self
+  ```
+  * Change signature of `server_name()` for `EventId`, `RoomAliasId`, `RoomId`, `RoomIdOrAliasId`, `UserId` from
+  ```rust
+  fn server_name() -> &str
+  ```
+  to
+  ```rust
+  fn server_name() -> ServerName<&str>
+  ```
+
 
 Improvements:
 
 * Add `DeviceKeyId`, `DeviceKeyAlgorithm`, `ServerKeyId`, and `ServerKeyAlgorithm`
+* Add `ServerName` and `ServerNameRef` types
 
 # 0.16.2
 

--- a/ruma-identifiers/CHANGELOG.md
+++ b/ruma-identifiers/CHANGELOG.md
@@ -10,22 +10,23 @@ Breaking changes:
   to affect any existing code.
 * Modify identifier types to use the new `ServerName` type:
   * Change signature of `new()` methods of `EventId`, `RoomId`, and `UserId` from
-  ```rust
-  fn new(&str) -> Result<Self, Error>
-  //...
-  ```
-  to
-  ```rust
-  fn new(&ServerName<&str>) -> Self
-  ```
+    ```rust
+    fn new(&str) -> Result<Self, Error>
+    //...
+    ```
+    to
+    ```rust
+    fn new(&ServerName<&str>) -> Self
+    ```
+
   * Change signature of `server_name()` for `EventId`, `RoomAliasId`, `RoomId`, `RoomIdOrAliasId`, `UserId` from
-  ```rust
-  fn server_name() -> &str
-  ```
-  to
-  ```rust
-  fn server_name() -> ServerName<&str>
-  ```
+    ```rust
+    fn server_name() -> &str
+    ```
+    to
+    ```rust
+    fn server_name() -> ServerName<&str>
+    ```
 
 
 Improvements:

--- a/ruma-identifiers/CHANGELOG.md
+++ b/ruma-identifiers/CHANGELOG.md
@@ -25,7 +25,7 @@ Breaking changes:
     ```
     to
     ```rust
-    fn server_name() -> ServerName<&str>
+    fn server_name() -> ServerNameRef<'_>
     ```
 
 Deprecations:

--- a/ruma-identifiers/CHANGELOG.md
+++ b/ruma-identifiers/CHANGELOG.md
@@ -16,7 +16,7 @@ Breaking changes:
     ```
     to
     ```rust
-    fn new(&ServerName<&str>) -> Self
+    fn new(ServerNameRef<'_>) -> Self
     ```
 
   * Change signature of `server_name()` for `EventId`, `RoomAliasId`, `RoomId`, `RoomIdOrAliasId`, `UserId` from

--- a/ruma-identifiers/CHANGELOG.md
+++ b/ruma-identifiers/CHANGELOG.md
@@ -28,6 +28,10 @@ Breaking changes:
     fn server_name() -> ServerName<&str>
     ```
 
+Deprecations:
+
+* Mark `server_name::is_valid_server_name` as deprecated in favor of `ServerName::try_from()`
+
 
 Improvements:
 

--- a/ruma-identifiers/src/event_id.rs
+++ b/ruma-identifiers/src/event_id.rs
@@ -1,8 +1,8 @@
 //! Matrix event identifiers.
 
-use std::num::NonZeroU8;
+use std::{convert::TryFrom, num::NonZeroU8};
 
-use crate::{error::Error, parse_id, validate_id};
+use crate::{error::Error, parse_id, server_name::ServerName, validate_id};
 
 /// A Matrix event ID.
 ///
@@ -55,18 +55,15 @@ impl<T> EventId<T> {
     /// parsed as a valid host.
     #[cfg(feature = "rand")]
     #[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
-    pub fn new(server_name: &str) -> Result<Self, Error>
+    pub fn new(server_name: &ServerName<&str>) -> Self
     where
         String: Into<T>,
     {
-        use crate::{generate_localpart, is_valid_server_name};
+        use crate::generate_localpart;
 
-        if !is_valid_server_name(server_name) {
-            return Err(Error::InvalidServerName);
-        }
         let full_id = format!("${}:{}", generate_localpart(18), server_name).into();
 
-        Ok(Self { full_id, colon_idx: NonZeroU8::new(19) })
+        Self { full_id, colon_idx: NonZeroU8::new(19) }
     }
 
     /// Returns the event's unique ID. For the original event format as used by Matrix room
@@ -87,11 +84,13 @@ impl<T> EventId<T> {
     /// Returns the server name of the event ID.
     ///
     /// Only applicable to events in the original format as used by Matrix room versions 1 and 2.
-    pub fn server_name(&self) -> Option<&str>
+    pub fn server_name(&self) -> Option<ServerName<&str>>
     where
         T: AsRef<str>,
     {
-        self.colon_idx.map(|idx| &self.full_id.as_ref()[idx.get() as usize + 1..])
+        self.colon_idx.map(|idx| {
+            ServerName::try_from(&self.full_id.as_ref()[idx.get() as usize + 1..]).unwrap()
+        })
     }
 }
 
@@ -123,7 +122,7 @@ mod tests {
     #[cfg(feature = "serde")]
     use serde_json::{from_str, to_string};
 
-    use crate::error::Error;
+    use crate::{error::Error, ServerNameRef};
 
     type EventId = super::EventId<Box<str>>;
 
@@ -160,17 +159,13 @@ mod tests {
     #[cfg(feature = "rand")]
     #[test]
     fn generate_random_valid_event_id() {
-        let event_id = EventId::new("example.com").expect("Failed to generate EventId.");
+        let server_name =
+            ServerNameRef::try_from("example.com").expect("Failed to parse ServerName");
+        let event_id = EventId::new(&server_name);
         let id_str: &str = event_id.as_ref();
 
         assert!(id_str.starts_with('$'));
         assert_eq!(id_str.len(), 31);
-    }
-
-    #[cfg(feature = "rand")]
-    #[test]
-    fn generate_random_invalid_event_id() {
-        assert!(EventId::new("").is_err());
     }
 
     #[cfg(feature = "serde")]

--- a/ruma-identifiers/src/event_id.rs
+++ b/ruma-identifiers/src/event_id.rs
@@ -2,7 +2,7 @@
 
 use std::{convert::TryFrom, num::NonZeroU8};
 
-use crate::{error::Error, parse_id, server_name::ServerName, validate_id};
+use crate::{error::Error, parse_id, validate_id, ServerNameRef};
 
 /// A Matrix event ID.
 ///
@@ -55,7 +55,7 @@ impl<T> EventId<T> {
     /// parsed as a valid host.
     #[cfg(feature = "rand")]
     #[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
-    pub fn new(server_name: &ServerName<&str>) -> Self
+    pub fn new(server_name: ServerNameRef<'_>) -> Self
     where
         String: Into<T>,
     {
@@ -84,12 +84,12 @@ impl<T> EventId<T> {
     /// Returns the server name of the event ID.
     ///
     /// Only applicable to events in the original format as used by Matrix room versions 1 and 2.
-    pub fn server_name(&self) -> Option<ServerName<&str>>
+    pub fn server_name(&self) -> Option<ServerNameRef<'_>>
     where
         T: AsRef<str>,
     {
         self.colon_idx.map(|idx| {
-            ServerName::try_from(&self.full_id.as_ref()[idx.get() as usize + 1..]).unwrap()
+            ServerNameRef::try_from(&self.full_id.as_ref()[idx.get() as usize + 1..]).unwrap()
         })
     }
 }
@@ -161,7 +161,7 @@ mod tests {
     fn generate_random_valid_event_id() {
         let server_name =
             ServerNameRef::try_from("example.com").expect("Failed to parse ServerName");
-        let event_id = EventId::new(&server_name);
+        let event_id = EventId::new(server_name);
         let id_str: &str = event_id.as_ref();
 
         assert!(id_str.starts_with('$'));

--- a/ruma-identifiers/src/lib.rs
+++ b/ruma-identifiers/src/lib.rs
@@ -17,13 +17,13 @@ use std::{convert::TryFrom, num::NonZeroU8};
 use serde::de::{self, Deserialize as _, Deserializer, Unexpected};
 
 #[doc(inline)]
-pub use crate::error::Error;
+#[allow(deprecated)]
+pub use crate::{error::Error, server_name::is_valid_server_name};
 
 #[macro_use]
 mod macros;
 
 mod error;
-mod server_name;
 
 pub mod device_id;
 pub mod device_key_id;
@@ -34,6 +34,8 @@ pub mod room_id;
 pub mod room_id_or_room_alias_id;
 pub mod room_version_id;
 pub mod server_key_id;
+#[allow(deprecated)]
+pub mod server_name;
 pub mod user_id;
 
 /// Allowed algorithms for homeserver signing keys.

--- a/ruma-identifiers/src/lib.rs
+++ b/ruma-identifiers/src/lib.rs
@@ -127,20 +127,20 @@ pub type ServerKeyAlgorithm = key_algorithms::ServerKeyAlgorithm;
 /// and `Deserialize` if the `serde` feature is enabled.
 pub type ServerKeyId = server_key_id::ServerKeyId<Box<str>>;
 
-/// An reference to a homeserver signing key identifier containing a key
+/// A reference to a homeserver signing key identifier containing a key
 /// algorithm and version.
 ///
 /// Can be created via `TryFrom<&str>`; implements `Serialize`
 /// and `Deserialize` if the `serde` feature is enabled.
 pub type ServerKeyIdRef<'a> = server_key_id::ServerKeyId<&'a str>;
 
-/// An homeserver IP address or hostname.
+/// An owned homeserver IP address or hostname.
 ///
 /// Can be created via `TryFrom<String>` and `TryFrom<&str>`; implements `Serialize`
 /// and `Deserialize` if the `serde` feature is enabled.
 pub type ServerName = server_name::ServerName<Box<str>>;
 
-/// An homeserver IP address or hostname.
+/// A reference to a homeserver IP address or hostname.
 ///
 /// Can be created via `TryFrom<&str>`; implements `Serialize`
 /// and `Deserialize` if the `serde` feature is enabled.

--- a/ruma-identifiers/src/room_alias_id.rs
+++ b/ruma-identifiers/src/room_alias_id.rs
@@ -1,8 +1,8 @@
 //! Matrix room alias identifiers.
 
-use std::num::NonZeroU8;
+use std::{convert::TryFrom, num::NonZeroU8};
 
-use crate::{error::Error, parse_id};
+use crate::{error::Error, parse_id, server_name::ServerName};
 
 /// A Matrix room alias ID.
 ///
@@ -33,8 +33,8 @@ impl<T: AsRef<str>> RoomAliasId<T> {
     }
 
     /// Returns the server name of the room alias ID.
-    pub fn server_name(&self) -> &str {
-        &self.full_id.as_ref()[self.colon_idx.get() as usize + 1..]
+    pub fn server_name(&self) -> ServerName<&str> {
+        ServerName::try_from(&self.full_id.as_ref()[self.colon_idx.get() as usize + 1..]).unwrap()
     }
 }
 

--- a/ruma-identifiers/src/room_id_or_room_alias_id.rs
+++ b/ruma-identifiers/src/room_id_or_room_alias_id.rs
@@ -2,7 +2,9 @@
 
 use std::{convert::TryFrom, hint::unreachable_unchecked, num::NonZeroU8};
 
-use crate::{error::Error, parse_id, room_alias_id::RoomAliasId, room_id::RoomId};
+use crate::{
+    error::Error, parse_id, room_alias_id::RoomAliasId, room_id::RoomId, server_name::ServerName,
+};
 
 /// A Matrix room ID or a Matrix room alias ID.
 ///
@@ -39,8 +41,8 @@ impl<T: AsRef<str>> RoomIdOrAliasId<T> {
     }
 
     /// Returns the server name of the room (alias) ID.
-    pub fn server_name(&self) -> &str {
-        &self.full_id.as_ref()[self.colon_idx.get() as usize + 1..]
+    pub fn server_name(&self) -> ServerName<&str> {
+        ServerName::try_from(&self.full_id.as_ref()[self.colon_idx.get() as usize + 1..]).unwrap()
     }
 
     /// Whether this is a room id (starts with `'!'`)

--- a/ruma-identifiers/src/server_name.rs
+++ b/ruma-identifiers/src/server_name.rs
@@ -1,8 +1,8 @@
-/// Check whether a given string is a valid server name according to [the specification][].
-///
-/// [the specification]: https://matrix.org/docs/spec/appendices#server-name
+//! Matrix-spec compliant server names.
+
 use crate::error::Error;
 
+/// A Matrix-spec compliant server name.
 #[derive(Clone, Copy, Debug)]
 pub struct ServerName<T> {
     full_id: T,
@@ -20,7 +20,14 @@ where
 
 common_impls!(ServerName, try_from, "An IP address or hostname");
 
-fn is_valid_server_name(name: &str) -> bool {
+/// Check whether a given string is a valid server name according to [the specification][].
+///
+/// Deprecated. Use the `try_from()` method of [`ServerName`](server_name/struct.ServerName.html) to construct
+/// a server name instead.
+///
+/// [the specification]: https://matrix.org/docs/spec/appendices#server-name
+#[deprecated]
+pub fn is_valid_server_name(name: &str) -> bool {
     use std::net::Ipv6Addr;
 
     if name.is_empty() {

--- a/ruma-identifiers/src/server_name.rs
+++ b/ruma-identifiers/src/server_name.rs
@@ -1,7 +1,26 @@
 /// Check whether a given string is a valid server name according to [the specification][].
 ///
 /// [the specification]: https://matrix.org/docs/spec/appendices#server-name
-pub fn is_valid_server_name(name: &str) -> bool {
+use crate::error::Error;
+
+#[derive(Clone, Copy, Debug)]
+pub struct ServerName<T> {
+    full_id: T,
+}
+
+fn try_from<S, T>(server_name: S) -> Result<ServerName<T>, Error>
+where
+    S: AsRef<str> + Into<T>,
+{
+    if !is_valid_server_name(server_name.as_ref()) {
+        return Err(Error::InvalidServerName);
+    }
+    Ok(ServerName { full_id: server_name.into() })
+}
+
+common_impls!(ServerName, try_from, "An IP address or hostname");
+
+fn is_valid_server_name(name: &str) -> bool {
     use std::net::Ipv6Addr;
 
     if name.is_empty() {

--- a/ruma-identifiers/src/server_name.rs
+++ b/ruma-identifiers/src/server_name.rs
@@ -3,6 +3,9 @@
 use crate::error::Error;
 
 /// A Matrix-spec compliant server name.
+///
+/// It is discouraged to use this type directly – instead use one of the aliases ([`ServerName`](../type.ServerName.html) and
+/// [`ServerNameRef`](../type.ServerNameRef.html)) in the crate root.
 #[derive(Clone, Copy, Debug)]
 pub struct ServerName<T> {
     full_id: T,


### PR DESCRIPTION
Fixes #27. To keep this PR from being too big to review easily, I think when this is merged, I'll update the other crates in a separate PR.

I had an issue when declaring `fn new(&ServerName<&str>)`, specifically that you can't use a `&ServerName<Box<str>>` as `&ServerName<&str>`. Is that what #28 is about?