### PR TITLE
Implement a map_content for event structs and into_full_event for stubs

### DIFF
--- a/ruma-events/src/event_kinds.rs
+++ b/ruma-events/src/event_kinds.rs
@@ -158,3 +158,122 @@ pub struct ToDeviceEvent<C: EventContent> {
     /// The fully-qualified ID of the user who sent this event.
     pub sender: UserId,
 }
+
+//
+//
+//
+use ruma_events::{AnyMessageEventContent, AnyStateEventContent};
+
+impl<C: StateEventContent> StateEvent<C> {
+    /// Maps a `StateEvent<C>` to  `StateEvent<T>` by applying the given
+    /// function to the event.
+    pub fn map_event<T, F>(self, func: F) -> StateEvent<T>
+    where
+        T: StateEventContent,
+        F: FnOnce(Self) -> StateEvent<T>,
+    {
+        func(self)
+    }
+}
+
+impl StateEvent<AnyStateEventContent> {
+    /// Maps a `StateEvent<AnyStateEventContent>` to  `StateEvent<T>` by applying the given
+    /// function to the events content.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use ruma_events::{StateEvent, AnyStateEventContent};
+    ///
+    /// let general_event = StateEvent {
+    ///     content: AnyStateEventContent::RoomName(name_content),
+    ///     .. state_event
+    /// };
+    ///
+    /// let specific = general_event.map_content(|c| {
+    ///     if let AnyStateEventContent::RoomName(n) = c {
+    ///         n
+    ///     } else {
+    ///         panic!()
+    ///     }
+    /// });
+    /// ```
+    pub fn map_content<T, F>(self, func: F) -> StateEvent<T>
+    where
+        T: StateEventContent,
+        F: Fn(AnyStateEventContent) -> T,
+    {
+        let content = func(self.content);
+        let prev_content = if let Some(prev) = self.prev_content { Some(func(prev)) } else { None };
+        StateEvent {
+            content,
+            prev_content,
+            room_id: self.room_id,
+            event_id: self.event_id,
+            sender: self.sender,
+            origin_server_ts: self.origin_server_ts,
+            state_key: self.state_key,
+            unsigned: self.unsigned,
+        }
+    }
+}
+
+impl<C: MessageEventContent> MessageEvent<C> {
+    /// Maps a `MessageEvent<C>` to  `MessageEvent<T>` by applying the given
+    /// function to the event.
+    pub fn map_event<T, F>(self, func: F) -> MessageEvent<T>
+    where
+        T: MessageEventContent,
+        F: FnOnce(Self) -> MessageEvent<T>,
+    {
+        func(self)
+    }
+}
+
+impl MessageEvent<AnyMessageEventContent> {
+    /// Maps a `MessageEvent<AnyMessageEventContent>` to  `MessageEvent<T>` by applying the given
+    /// function to the events content.
+    pub fn map_content<T, F>(self, func: F) -> MessageEvent<T>
+    where
+        T: MessageEventContent,
+        F: Fn(AnyMessageEventContent) -> T,
+    {
+        let content = func(self.content);
+        MessageEvent {
+            content,
+            room_id: self.room_id,
+            event_id: self.event_id,
+            sender: self.sender,
+            origin_server_ts: self.origin_server_ts,
+            unsigned: self.unsigned,
+        }
+    }
+}
+
+impl MessageEventStub<AnyMessageEventContent> {
+    /// Maps a `MessageEventStub<AnyMessageEventContent>` to  `MessageEventStub<T>` by applying the given
+    /// function to the events content.
+    pub fn map_content<T, F>(self, func: F) -> MessageEventStub<T>
+    where
+        T: MessageEventContent,
+        F: Fn(AnyMessageEventContent) -> T,
+    {
+        let content = func(self.content);
+        MessageEventStub {
+            content,
+            event_id: self.event_id,
+            sender: self.sender,
+            origin_server_ts: self.origin_server_ts,
+            unsigned: self.unsigned,
+        }
+    }
+
+    /// Convert a `MessageEventStub` to a `MessageEvent` by adding a room id.
+    pub fn into_full_event<C: MessageEventContent>(
+        self,
+        room_id: RoomId,
+    ) -> MessageEvent<AnyMessageEventContent> {
+        let MessageEventStub { content, event_id, sender, origin_server_ts, unsigned } = self;
+        MessageEvent { content, room_id, event_id, sender, origin_server_ts, unsigned }
+    }
+}


### PR DESCRIPTION
This is just an example of what could be done to fix the pain point of having to convert types all over.

Most important is `impl *Event<Any*EventContent>` but the `into_full_event` may be helpful also.

I also had an idea if you think adding these impl's to the `Event` derive would be preferable: The derive would create private `_map_content` methods and for IDE support a wrapper impl with docs could call the macro generated method? Just a thought.