### PR TITLE
Create type RoomMemberCountIs

### DIFF
--- a/ruma-common/Cargo.toml
+++ b/ruma-common/Cargo.toml
@@ -16,3 +16,4 @@ ruma-serde = { version = "0.2.2", path = "../ruma-serde" }
 serde = { version = "1.0.113", features = ["derive"] }
 serde_json = { version = "1.0.55", features = ["raw_value"] }
 strum = { version = "0.18.0", features = ["derive"] }
+js_int = { version = "0.1.7", features = ["serde"] }

--- a/ruma-common/src/push.rs
+++ b/ruma-common/src/push.rs
@@ -275,13 +275,13 @@ impl FromStr for RoomMemberCountIs {
         if s.starts_with("<=") {
             let value = UInt::from_str(&s[2..])?;
             Ok(Le(value))
-        } else if s.starts_with("<") {
+        } else if s.starts_with('<') {
             let value = UInt::from_str(&s[1..])?;
             Ok(Lt(value))
         } else if s.starts_with(">=") {
             let value = UInt::from_str(&s[2..])?;
             Ok(Ge(value))
-        } else if s.starts_with(">") {
+        } else if s.starts_with('>') {
             let value = UInt::from_str(&s[1..])?;
             Ok(Gt(value))
         } else if s.starts_with("==") {


### PR DESCRIPTION
Creates a type for `PushCondition::RoomMemberCount`.

Not sure whether it should be an enum or a `{prefix, number}` struct. I tried an enum but replaced it with a struct (https://github.com/ruma/ruma/pull/84/commits/e972eff2cddf464eab94b1c3bd66c834e9e3d2f1) because the implementation seemed simpler this way.

It uses `Display` and `FromStr` for serialization and deserialization. There's probably an easier way of implementing this using [field attributes] `serialize_with` and `deserialize_with`, but I couldn't figure it out.

Closes https://github.com/ruma/ruma/issues/39

[field attributes]: https://serde.rs/field-attrs.html