### PR TITLE
Provide helper method for checking whether an instance of RoomMemberCountIs applies to a given number

### DIFF
--- a/ruma-common/Cargo.toml
+++ b/ruma-common/Cargo.toml
@@ -16,3 +16,4 @@ ruma-serde = { version = "0.2.2", path = "../ruma-serde" }
 serde = { version = "1.0.113", features = ["derive"] }
 serde_json = { version = "1.0.55", features = ["raw_value"] }
 strum = { version = "0.18.0", features = ["derive"] }
+js_int = { version = "0.1.7", features = ["serde"] }

--- a/ruma-common/Cargo.toml
+++ b/ruma-common/Cargo.toml
@@ -11,9 +11,9 @@ repository = "https://github.com/ruma/ruma"
 edition = "2018"
 
 [dependencies]
+js_int = { version = "0.1.7", features = ["serde"] }
 matches = "0.1.8"
 ruma-serde = { version = "0.2.2", path = "../ruma-serde" }
 serde = { version = "1.0.113", features = ["derive"] }
 serde_json = { version = "1.0.55", features = ["raw_value"] }
 strum = { version = "0.18.0", features = ["derive"] }
-js_int = { version = "0.1.7", features = ["serde"] }

--- a/ruma-common/src/push.rs
+++ b/ruma-common/src/push.rs
@@ -2,16 +2,14 @@
 //!
 //! [push]: https://matrix.org/docs/spec/client_server/r0.6.1#id89
 
-use std::{
-    fmt::{self, Display, Formatter},
-    ops::{Bound, RangeBounds, RangeFrom, RangeTo, RangeToInclusive},
-    str::FromStr,
-};
+use std::fmt::{self, Formatter};
 
-use js_int::UInt;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::value::RawValue as RawJsonValue;
 
+pub use room_member_count_is::{RoomMemberCountIs, RoomMemberCountPrefix};
+
+mod room_member_count_is;
 mod tweak_serde;
 
 /// A push ruleset scopes a set of rules according to some criteria.
@@ -211,172 +209,6 @@ impl Serialize for Action {
     }
 }
 
-/// Optional prefix used by `RoomMemberCountIs`
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum RoomMemberCountPrefix {
-    /// Equals (no prefix)
-    Eq,
-    /// Less than
-    Lt,
-    /// Greater than
-    Gt,
-    /// Greater or equal
-    Ge,
-    /// Less or equal
-    Le,
-}
-
-impl Default for RoomMemberCountPrefix {
-    fn default() -> Self {
-        RoomMemberCountPrefix::Eq
-    }
-}
-
-/// A decimal integer optionally prefixed by one of `==`, `<`, `>`, `>=` or `<=`.
-///
-/// A prefix of `<` matches rooms where the member count is strictly less than the given
-/// number and so forth. If no prefix is present, this parameter defaults to `==`.
-///
-/// Can be constructed from a number or a range:
-/// ```
-/// use js_int::uint;
-/// use ruma_common::push::RoomMemberCountIs;
-///
-/// // equivalent to `is: "3"` or `is: "==3"`
-/// let exact = RoomMemberCountIs::from(uint!(3));
-///
-/// // equivalent to `is: ">=3"`
-/// let greater_or_equal = RoomMemberCountIs::from(uint!(3)..);
-///
-/// // equivalent to `is: "<3"`
-/// let less = RoomMemberCountIs::from(..uint!(3));
-///
-/// // equivalent to `is: "<=3"`
-/// let less_or_equal = RoomMemberCountIs::from(..=uint!(3));
-///
-/// // An exclusive range can be constructed with `RoomMemberCountIs::gt`:
-/// // (equivalent to `is: ">3"`)
-/// let greater = RoomMemberCountIs::gt(uint!(3));
-/// ```
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub struct RoomMemberCountIs {
-    /// One of `==`, `<`, `>`, `>=`, `<=`, or no prefix.
-    pub prefix: RoomMemberCountPrefix,
-    /// The number of people in the room.
-    pub count: UInt,
-}
-
-impl RoomMemberCountIs {
-    /// Creates an instance of `RoomMemberCount` equivalent to `<X`,
-    /// where X is the specified member count.
-    pub fn gt(count: UInt) -> Self {
-        RoomMemberCountIs { prefix: RoomMemberCountPrefix::Gt, count }
-    }
-}
-
-impl From<UInt> for RoomMemberCountIs {
-    fn from(x: UInt) -> Self {
-        RoomMemberCountIs { prefix: RoomMemberCountPrefix::Eq, count: x }
-    }
-}
-
-impl From<RangeFrom<UInt>> for RoomMemberCountIs {
-    fn from(x: RangeFrom<UInt>) -> Self {
-        RoomMemberCountIs { prefix: RoomMemberCountPrefix::Ge, count: x.start }
-    }
-}
-
-impl From<RangeTo<UInt>> for RoomMemberCountIs {
-    fn from(x: RangeTo<UInt>) -> Self {
-        RoomMemberCountIs { prefix: RoomMemberCountPrefix::Lt, count: x.end }
-    }
-}
-
-impl From<RangeToInclusive<UInt>> for RoomMemberCountIs {
-    fn from(x: RangeToInclusive<UInt>) -> Self {
-        RoomMemberCountIs { prefix: RoomMemberCountPrefix::Le, count: x.end }
-    }
-}
-
-impl Display for RoomMemberCountIs {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        use RoomMemberCountPrefix::*;
-
-        let prefix = match self.prefix {
-            Eq => "",
-            Lt => "<",
-            Gt => ">",
-            Ge => ">=",
-            Le => "<=",
-        };
-
-        write!(f, "{}{}", prefix, self.count)
-    }
-}
-
-impl Serialize for RoomMemberCountIs {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let s = self.to_string();
-        s.serialize(serializer)
-    }
-}
-
-impl FromStr for RoomMemberCountIs {
-    type Err = js_int::ParseIntError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        use RoomMemberCountPrefix::*;
-
-        let (prefix, count_str) = match s {
-            s if s.starts_with("<=") => (Le, &s[2..]),
-            s if s.starts_with('<') => (Lt, &s[1..]),
-            s if s.starts_with(">=") => (Ge, &s[2..]),
-            s if s.starts_with('>') => (Gt, &s[1..]),
-            s if s.starts_with("==") => (Eq, &s[2..]),
-            s => (Eq, s),
-        };
-
-        Ok(RoomMemberCountIs { prefix, count: UInt::from_str(count_str)? })
-    }
-}
-
-impl<'de> Deserialize<'de> for RoomMemberCountIs {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let s = String::deserialize(deserializer)?;
-        FromStr::from_str(&s).map_err(serde::de::Error::custom)
-    }
-}
-
-impl RangeBounds<UInt> for RoomMemberCountIs {
-    fn start_bound(&self) -> Bound<&UInt> {
-        use RoomMemberCountPrefix::*;
-
-        match self.prefix {
-            Eq => Bound::Included(&self.count),
-            Lt | Le => Bound::Unbounded,
-            Gt => Bound::Excluded(&self.count),
-            Ge => Bound::Included(&self.count),
-        }
-    }
-
-    fn end_bound(&self) -> Bound<&UInt> {
-        use RoomMemberCountPrefix::*;
-
-        match self.prefix {
-            Eq => Bound::Included(&self.count),
-            Gt | Ge => Bound::Unbounded,
-            Lt => Bound::Excluded(&self.count),
-            Le => Bound::Included(&self.count),
-        }
-    }
-}
-
 /// A condition that must apply for an associated push rule's action to be taken.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[non_exhaustive]
@@ -417,8 +249,6 @@ pub enum PushCondition {
 
 #[cfg(test)]
 mod tests {
-    use std::ops::RangeBounds;
-
     use js_int::uint;
     use matches::assert_matches;
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
@@ -588,29 +418,5 @@ mod tests {
                 key
             } if key == "room"
         );
-    }
-
-    #[test]
-    fn roommembercountis_range_contains_its_own_count() {
-        let count = 2u32.into();
-        let range = RoomMemberCountIs::from(count);
-
-        assert!(range.contains(&count));
-    }
-
-    #[test]
-    fn roommembercountis_ge_range_contains_large_number() {
-        let range = RoomMemberCountIs::from(uint!(2)..);
-        let large_number = 9001u32.into();
-
-        assert!(range.contains(&large_number));
-    }
-
-    #[test]
-    fn roommembercountis_gt_range_does_not_contain_initial_point() {
-        let range = RoomMemberCountIs::gt(uint!(2));
-        let initial_point = uint!(2);
-
-        assert!(!range.contains(&initial_point));
     }
 }

--- a/ruma-common/src/push.rs
+++ b/ruma-common/src/push.rs
@@ -7,7 +7,7 @@ use std::fmt::{self, Formatter};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::value::RawValue as RawJsonValue;
 
-pub use room_member_count_is::{RoomMemberCountIs, RoomMemberCountPrefix};
+pub use room_member_count_is::{ComparisonOperator, RoomMemberCountIs};
 
 mod room_member_count_is;
 mod tweak_serde;

--- a/ruma-common/src/push.rs
+++ b/ruma-common/src/push.rs
@@ -352,6 +352,7 @@ impl RangeBounds<UInt> for RoomMemberCountIs {
             Ge => Bound::Included(&self.count),
         }
     }
+
     fn end_bound(&self) -> Bound<&UInt> {
         use RoomMemberCountPrefix::*;
 

--- a/ruma-common/src/push.rs
+++ b/ruma-common/src/push.rs
@@ -241,28 +241,28 @@ impl Default for RoomMemberCountPrefix {
 ///
 /// Can be constructed from a number or a range:
 /// ```
-/// use js_int::UInt;
+/// use js_int::uint;
 /// use ruma_common::push::RoomMemberCountIs;
 ///
 /// // equivalent to `is: "3"`
-/// let exact = RoomMemberCountIs::from(UInt::from(3u32));
+/// let exact = RoomMemberCountIs::from(uint!(3));
 ///
 /// // equivalent to `is: ">=3"`
-/// let greater_or_equal = RoomMemberCountIs::from(UInt::from(3u32)..);
+/// let greater_or_equal = RoomMemberCountIs::from(uint!(3)..);
 ///
 /// // equivalent to `is: "<3"`
-/// let less = RoomMemberCountIs::from(..UInt::from(3u32));
+/// let less = RoomMemberCountIs::from(..uint!(3));
 ///
 /// // equivalent to `is: "<=3"`
-/// let less_or_equal = RoomMemberCountIs::from(..=UInt::from(3u32));
+/// let less_or_equal = RoomMemberCountIs::from(..=uint!(3));
 ///
 /// // An explicit `==` can be constructed with `RoomMemberCountIs::eq`
 /// // (equivalent to `is: "==3"`)
-/// let explicit_equals = RoomMemberCountIs::eq(UInt::from(3u32));
+/// let explicit_equals = RoomMemberCountIs::eq(uint!(3));
 ///
 /// // An exclusive range can be constructed with `RoomMemberCountIs::gt`:
 /// // (equivalent to `is: ">3"`)
-/// let greater = RoomMemberCountIs::gt(UInt::from(3u32));
+/// let greater = RoomMemberCountIs::gt(uint!(3));
 /// ```
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct RoomMemberCountIs {
@@ -432,7 +432,7 @@ pub enum PushCondition {
 mod tests {
     use std::ops::RangeBounds;
 
-    use js_int::UInt;
+    use js_int::uint;
     use matches::assert_matches;
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
@@ -534,7 +534,7 @@ mod tests {
         });
         assert_eq!(
             to_json_value(&PushCondition::RoomMemberCount {
-                is: RoomMemberCountIs::from(UInt::from(2u32))
+                is: RoomMemberCountIs::from(uint!(2))
             })
             .unwrap(),
             json_data
@@ -585,7 +585,7 @@ mod tests {
         assert_matches!(
             from_json_value::<PushCondition>(json_data).unwrap(),
             PushCondition::RoomMemberCount { is }
-            if is == RoomMemberCountIs::from(UInt::from(2u32))
+            if is == RoomMemberCountIs::from(uint!(2))
         );
     }
 
@@ -613,7 +613,7 @@ mod tests {
 
     #[test]
     fn roommembercountis_ge_range_contains_large_number() {
-        let range = RoomMemberCountIs::from(UInt::from(2u32)..);
+        let range = RoomMemberCountIs::from(uint!(2)..);
         let large_number = 9001u32.into();
 
         assert!(range.contains(&large_number));
@@ -621,8 +621,8 @@ mod tests {
 
     #[test]
     fn roommembercountis_gt_range_does_not_contain_initial_point() {
-        let range = RoomMemberCountIs::gt(UInt::from(2u32));
-        let initial_point = UInt::from(2u32);
+        let range = RoomMemberCountIs::gt(uint!(2));
+        let initial_point = uint!(2);
 
         assert!(!range.contains(&initial_point));
     }

--- a/ruma-common/src/push.rs
+++ b/ruma-common/src/push.rs
@@ -275,13 +275,13 @@ impl FromStr for RoomMemberCountIs {
         if s.starts_with("<=") {
             let value = UInt::from_str(&s[2..])?;
             Ok(Le(value))
-        } else if s.starts_with("<") {
+        } else if s.starts_with('<') {
             let value = UInt::from_str(&s[1..])?;
             Ok(Lt(value))
         } else if s.starts_with(">=") {
             let value = UInt::from_str(&s[2..])?;
             Ok(Ge(value))
-        } else if s.starts_with(">") {
+        } else if s.starts_with('>') {
             let value = UInt::from_str(&s[1..])?;
             Ok(Gt(value))
         } else if s.starts_with("==") {

--- a/ruma-common/src/push/room_member_count_is.rs
+++ b/ruma-common/src/push/room_member_count_is.rs
@@ -7,10 +7,12 @@ use std::{
 use js_int::UInt;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-/// Optional prefix used by `RoomMemberCountIs`
+/// One of `==`, `<`, `>`, `>=` or `<=`.
+///
+/// Used by `RoomMemberCountIs`. Defaults to `==`.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum RoomMemberCountPrefix {
-    /// Equals (no prefix)
+pub enum ComparisonOperator {
+    /// Equals
     Eq,
     /// Less than
     Lt,
@@ -22,9 +24,9 @@ pub enum RoomMemberCountPrefix {
     Le,
 }
 
-impl Default for RoomMemberCountPrefix {
+impl Default for ComparisonOperator {
     fn default() -> Self {
-        RoomMemberCountPrefix::Eq
+        ComparisonOperator::Eq
     }
 }
 
@@ -57,7 +59,7 @@ impl Default for RoomMemberCountPrefix {
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct RoomMemberCountIs {
     /// One of `==`, `<`, `>`, `>=`, `<=`, or no prefix.
-    pub prefix: RoomMemberCountPrefix,
+    pub prefix: ComparisonOperator,
     /// The number of people in the room.
     pub count: UInt,
 }
@@ -66,37 +68,37 @@ impl RoomMemberCountIs {
     /// Creates an instance of `RoomMemberCount` equivalent to `<X`,
     /// where X is the specified member count.
     pub fn gt(count: UInt) -> Self {
-        RoomMemberCountIs { prefix: RoomMemberCountPrefix::Gt, count }
+        RoomMemberCountIs { prefix: ComparisonOperator::Gt, count }
     }
 }
 
 impl From<UInt> for RoomMemberCountIs {
     fn from(x: UInt) -> Self {
-        RoomMemberCountIs { prefix: RoomMemberCountPrefix::Eq, count: x }
+        RoomMemberCountIs { prefix: ComparisonOperator::Eq, count: x }
     }
 }
 
 impl From<RangeFrom<UInt>> for RoomMemberCountIs {
     fn from(x: RangeFrom<UInt>) -> Self {
-        RoomMemberCountIs { prefix: RoomMemberCountPrefix::Ge, count: x.start }
+        RoomMemberCountIs { prefix: ComparisonOperator::Ge, count: x.start }
     }
 }
 
 impl From<RangeTo<UInt>> for RoomMemberCountIs {
     fn from(x: RangeTo<UInt>) -> Self {
-        RoomMemberCountIs { prefix: RoomMemberCountPrefix::Lt, count: x.end }
+        RoomMemberCountIs { prefix: ComparisonOperator::Lt, count: x.end }
     }
 }
 
 impl From<RangeToInclusive<UInt>> for RoomMemberCountIs {
     fn from(x: RangeToInclusive<UInt>) -> Self {
-        RoomMemberCountIs { prefix: RoomMemberCountPrefix::Le, count: x.end }
+        RoomMemberCountIs { prefix: ComparisonOperator::Le, count: x.end }
     }
 }
 
 impl Display for RoomMemberCountIs {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        use RoomMemberCountPrefix::*;
+        use ComparisonOperator::*;
 
         let prefix = match self.prefix {
             Eq => "",
@@ -124,7 +126,7 @@ impl FromStr for RoomMemberCountIs {
     type Err = js_int::ParseIntError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        use RoomMemberCountPrefix::*;
+        use ComparisonOperator::*;
 
         let (prefix, count_str) = match s {
             s if s.starts_with("<=") => (Le, &s[2..]),
@@ -151,7 +153,7 @@ impl<'de> Deserialize<'de> for RoomMemberCountIs {
 
 impl RangeBounds<UInt> for RoomMemberCountIs {
     fn start_bound(&self) -> Bound<&UInt> {
-        use RoomMemberCountPrefix::*;
+        use ComparisonOperator::*;
 
         match self.prefix {
             Eq => Bound::Included(&self.count),
@@ -162,7 +164,7 @@ impl RangeBounds<UInt> for RoomMemberCountIs {
     }
 
     fn end_bound(&self) -> Bound<&UInt> {
-        use RoomMemberCountPrefix::*;
+        use ComparisonOperator::*;
 
         match self.prefix {
             Eq => Bound::Included(&self.count),

--- a/ruma-common/src/push/room_member_count_is.rs
+++ b/ruma-common/src/push/room_member_count_is.rs
@@ -1,0 +1,207 @@
+use std::{
+    fmt::{self, Display, Formatter},
+    ops::{Bound, RangeBounds, RangeFrom, RangeTo, RangeToInclusive},
+    str::FromStr,
+};
+
+use js_int::UInt;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// Optional prefix used by `RoomMemberCountIs`
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum RoomMemberCountPrefix {
+    /// Equals (no prefix)
+    Eq,
+    /// Less than
+    Lt,
+    /// Greater than
+    Gt,
+    /// Greater or equal
+    Ge,
+    /// Less or equal
+    Le,
+}
+
+impl Default for RoomMemberCountPrefix {
+    fn default() -> Self {
+        RoomMemberCountPrefix::Eq
+    }
+}
+
+/// A decimal integer optionally prefixed by one of `==`, `<`, `>`, `>=` or `<=`.
+///
+/// A prefix of `<` matches rooms where the member count is strictly less than the given
+/// number and so forth. If no prefix is present, this parameter defaults to `==`.
+///
+/// Can be constructed from a number or a range:
+/// ```
+/// use js_int::uint;
+/// use ruma_common::push::RoomMemberCountIs;
+///
+/// // equivalent to `is: "3"` or `is: "==3"`
+/// let exact = RoomMemberCountIs::from(uint!(3));
+///
+/// // equivalent to `is: ">=3"`
+/// let greater_or_equal = RoomMemberCountIs::from(uint!(3)..);
+///
+/// // equivalent to `is: "<3"`
+/// let less = RoomMemberCountIs::from(..uint!(3));
+///
+/// // equivalent to `is: "<=3"`
+/// let less_or_equal = RoomMemberCountIs::from(..=uint!(3));
+///
+/// // An exclusive range can be constructed with `RoomMemberCountIs::gt`:
+/// // (equivalent to `is: ">3"`)
+/// let greater = RoomMemberCountIs::gt(uint!(3));
+/// ```
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct RoomMemberCountIs {
+    /// One of `==`, `<`, `>`, `>=`, `<=`, or no prefix.
+    pub prefix: RoomMemberCountPrefix,
+    /// The number of people in the room.
+    pub count: UInt,
+}
+
+impl RoomMemberCountIs {
+    /// Creates an instance of `RoomMemberCount` equivalent to `<X`,
+    /// where X is the specified member count.
+    pub fn gt(count: UInt) -> Self {
+        RoomMemberCountIs { prefix: RoomMemberCountPrefix::Gt, count }
+    }
+}
+
+impl From<UInt> for RoomMemberCountIs {
+    fn from(x: UInt) -> Self {
+        RoomMemberCountIs { prefix: RoomMemberCountPrefix::Eq, count: x }
+    }
+}
+
+impl From<RangeFrom<UInt>> for RoomMemberCountIs {
+    fn from(x: RangeFrom<UInt>) -> Self {
+        RoomMemberCountIs { prefix: RoomMemberCountPrefix::Ge, count: x.start }
+    }
+}
+
+impl From<RangeTo<UInt>> for RoomMemberCountIs {
+    fn from(x: RangeTo<UInt>) -> Self {
+        RoomMemberCountIs { prefix: RoomMemberCountPrefix::Lt, count: x.end }
+    }
+}
+
+impl From<RangeToInclusive<UInt>> for RoomMemberCountIs {
+    fn from(x: RangeToInclusive<UInt>) -> Self {
+        RoomMemberCountIs { prefix: RoomMemberCountPrefix::Le, count: x.end }
+    }
+}
+
+impl Display for RoomMemberCountIs {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        use RoomMemberCountPrefix::*;
+
+        let prefix = match self.prefix {
+            Eq => "",
+            Lt => "<",
+            Gt => ">",
+            Ge => ">=",
+            Le => "<=",
+        };
+
+        write!(f, "{}{}", prefix, self.count)
+    }
+}
+
+impl Serialize for RoomMemberCountIs {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let s = self.to_string();
+        s.serialize(serializer)
+    }
+}
+
+impl FromStr for RoomMemberCountIs {
+    type Err = js_int::ParseIntError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        use RoomMemberCountPrefix::*;
+
+        let (prefix, count_str) = match s {
+            s if s.starts_with("<=") => (Le, &s[2..]),
+            s if s.starts_with('<') => (Lt, &s[1..]),
+            s if s.starts_with(">=") => (Ge, &s[2..]),
+            s if s.starts_with('>') => (Gt, &s[1..]),
+            s if s.starts_with("==") => (Eq, &s[2..]),
+            s => (Eq, s),
+        };
+
+        Ok(RoomMemberCountIs { prefix, count: UInt::from_str(count_str)? })
+    }
+}
+
+impl<'de> Deserialize<'de> for RoomMemberCountIs {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        FromStr::from_str(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+impl RangeBounds<UInt> for RoomMemberCountIs {
+    fn start_bound(&self) -> Bound<&UInt> {
+        use RoomMemberCountPrefix::*;
+
+        match self.prefix {
+            Eq => Bound::Included(&self.count),
+            Lt | Le => Bound::Unbounded,
+            Gt => Bound::Excluded(&self.count),
+            Ge => Bound::Included(&self.count),
+        }
+    }
+
+    fn end_bound(&self) -> Bound<&UInt> {
+        use RoomMemberCountPrefix::*;
+
+        match self.prefix {
+            Eq => Bound::Included(&self.count),
+            Gt | Ge => Bound::Unbounded,
+            Lt => Bound::Excluded(&self.count),
+            Le => Bound::Included(&self.count),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ops::RangeBounds;
+
+    use js_int::uint;
+
+    use super::RoomMemberCountIs;
+
+    #[test]
+    fn eq_range_contains_its_own_count() {
+        let count = 2u32.into();
+        let range = RoomMemberCountIs::from(count);
+
+        assert!(range.contains(&count));
+    }
+
+    #[test]
+    fn ge_range_contains_large_number() {
+        let range = RoomMemberCountIs::from(uint!(2)..);
+        let large_number = 9001u32.into();
+
+        assert!(range.contains(&large_number));
+    }
+
+    #[test]
+    fn gt_range_does_not_contain_initial_point() {
+        let range = RoomMemberCountIs::gt(uint!(2));
+        let initial_point = uint!(2);
+
+        assert!(!range.contains(&initial_point));
+    }
+}


### PR DESCRIPTION
Supersedes https://github.com/ruma/ruma/pull/84

Creates a type for `PushCondition::RoomMemberCount`.

It's a `{prefix, number}` struct. I considered using an enum, but went with a struct (https://github.com/ruma/ruma/pull/84/commits/e972eff2cddf464eab94b1c3bd66c834e9e3d2f1) because the implementation seemed simpler this way.

It uses `Display` and `FromStr` for serialization and deserialization. There's probably an easier way of implementing this using [field attributes] `serialize_with` and `deserialize_with`, but I couldn't figure it out.

Implements `std::ops::RangeBounds` for `RoomMemberCountIs`, so that `RangeBounds::contains` can be used to check if a given number is in the specified range.

Closes https://github.com/ruma/ruma/issues/39

[field attributes]: https://serde.rs/field-attrs.html