### PR TITLE
Add Any*EventStub and AnyStrippedStateEventStub to enums.rs

### DIFF
--- a/ruma-events/src/enums.rs
+++ b/ruma-events/src/enums.rs
@@ -5,10 +5,7 @@ use serde::{
 };
 use serde_json::value::RawValue as RawJsonValue;
 
-use crate::{
-    event_kinds::{MessageEventStub, StateEventStub, StrippedStateEventStub},
-    from_raw_json_value, EventDeHelper,
-};
+use crate::{from_raw_json_value, EventDeHelper};
 
 event_enum! {
     /// Any basic event.
@@ -51,8 +48,74 @@ event_enum! {
 }
 
 event_enum! {
+    /// Any message event stub (message event without a `room_id`, as returned in `/sync` responses)
+    name: AnyMessageEventStub,
+    events: [
+        "m.call.answer",
+        "m.call.invite",
+        "m.call.hangup",
+        "m.call.candidates",
+        "m.room.encrypted",
+        "m.room.message",
+        "m.room.message.feedback",
+        "m.room.redaction",
+        "m.sticker",
+
+    ]
+}
+
+event_enum! {
     /// Any state event.
     name: AnyStateEvent,
+    events: [
+        "m.room.aliases",
+        "m.room.avatar",
+        "m.room.canonical_alias",
+        "m.room.create",
+        "m.room.encryption",
+        "m.room.guest_access",
+        "m.room.history_visibility",
+        "m.room.join_rules",
+        "m.room.member",
+        "m.room.name",
+        "m.room.pinned_events",
+        "m.room.power_levels",
+        "m.room.redaction",
+        "m.room.server_acl",
+        "m.room.third_party_invite",
+        "m.room.tombstone",
+        "m.room.topic",
+    ]
+}
+
+event_enum! {
+    /// Any state event stub (state event without a `room_id`, as returned in `/sync` responses)
+    name: AnyStateEventStub,
+    events: [
+        "m.room.aliases",
+        "m.room.avatar",
+        "m.room.canonical_alias",
+        "m.room.create",
+        "m.room.encryption",
+        "m.room.guest_access",
+        "m.room.history_visibility",
+        "m.room.join_rules",
+        "m.room.member",
+        "m.room.name",
+        "m.room.pinned_events",
+        "m.room.power_levels",
+        "m.room.redaction",
+        "m.room.server_acl",
+        "m.room.third_party_invite",
+        "m.room.tombstone",
+        "m.room.topic",
+    ]
+}
+
+event_enum! {
+    /// Any stripped state event stub (stripped-down state event, as returned for rooms the user has
+    /// been invited to in `/sync` responses)
+    name: AnyStrippedStateEventStub,
     events: [
         "m.room.aliases",
         "m.room.avatar",
@@ -91,16 +154,6 @@ event_enum! {
         "m.room.encrypted",
     ]
 }
-
-/// Any message event stub (message event without a `room_id`, as returned in `/sync` responses)
-pub type AnyMessageEventStub = MessageEventStub<AnyMessageEventContent>;
-
-/// Any state event stub (state event without a `room_id`, as returned in `/sync` responses)
-pub type AnyStateEventStub = StateEventStub<AnyStateEventContent>;
-
-/// Any stripped state event stub (stripped-down state event, as returned for rooms the user has
-/// been invited to in `/sync` responses)
-pub type AnyStrippedStateEventStub = StrippedStateEventStub<AnyStateEventContent>;
 
 /// Any event.
 #[derive(Clone, Debug, Serialize)]

--- a/ruma-events/src/room/redaction.rs
+++ b/ruma-events/src/room/redaction.rs
@@ -64,6 +64,12 @@ pub struct RedactionEventContent {
     pub reason: Option<String>,
 }
 
+impl ruma_events::RoomEventContent for RedactionEventContent {}
+
+impl ruma_events::MessageEventContent for RedactionEventContent {}
+
+impl ruma_events::StateEventContent for RedactionEventContent {}
+
 #[cfg(test)]
 mod tests {
     use std::{

--- a/ruma-events/tests/enums.rs
+++ b/ruma-events/tests/enums.rs
@@ -10,9 +10,8 @@ use ruma_events::{
         message::{MessageEventContent, TextMessageEventContent},
         power_levels::PowerLevelsEventContent,
     },
-    AnyEvent, AnyMessageEvent, AnyMessageEventContent, AnyRoomEvent, AnyRoomEventStub,
-    AnyStateEvent, AnyStateEventContent, MessageEvent, MessageEventStub, StateEvent,
-    StateEventStub,
+    AnyEvent, AnyMessageEvent, AnyMessageEventStub, AnyRoomEvent, AnyRoomEventStub, AnyStateEvent,
+    AnyStateEventStub, MessageEvent, MessageEventStub, StateEvent, StateEventStub,
 };
 
 fn message_event() -> JsonValue {
@@ -120,12 +119,12 @@ fn power_event_stub_deserialization() {
     assert_matches!(
         from_json_value::<AnyRoomEventStub>(json_data),
         Ok(AnyRoomEventStub::State(
-            StateEventStub {
-                content: AnyStateEventContent::RoomPowerLevels(PowerLevelsEventContent {
+            AnyStateEventStub::RoomPowerLevels(StateEventStub {
+                content: PowerLevelsEventContent {
                     ban, ..
-                }),
+                },
                 ..
-            }
+            })
         ))
         if ban == js_int::Int::new(50).unwrap()
     );
@@ -138,14 +137,14 @@ fn message_event_stub_deserialization() {
     assert_matches!(
         from_json_value::<AnyRoomEventStub>(json_data),
         Ok(AnyRoomEventStub::Message(
-            MessageEventStub {
-                content: AnyMessageEventContent::RoomMessage(MessageEventContent::Text(TextMessageEventContent {
+            AnyMessageEventStub::RoomMessage(MessageEventStub {
+                content: MessageEventContent::Text(TextMessageEventContent {
                     body,
                     formatted: Some(formatted),
                     relates_to: None,
-                })),
+                }),
                 ..
-            }
+            })
         ))
         if body == "baba" && formatted.body == "<strong>baba</strong>"
     );
@@ -158,12 +157,12 @@ fn aliases_event_stub_deserialization() {
     assert_matches!(
         from_json_value::<AnyRoomEventStub>(json_data),
         Ok(AnyRoomEventStub::State(
-            StateEventStub {
-                content: AnyStateEventContent::RoomAliases(AliasesEventContent {
+            AnyStateEventStub::RoomAliases(StateEventStub {
+                content: AliasesEventContent {
                     aliases,
-                }),
+                },
                 ..
-            }
+            })
         ))
         if aliases == vec![ RoomAliasId::try_from("#somewhere:localhost").unwrap() ]
     );

--- a/ruma-events/tests/redaction.rs
+++ b/ruma-events/tests/redaction.rs
@@ -1,0 +1,73 @@
+use std::{
+    convert::TryFrom,
+    time::{Duration, UNIX_EPOCH},
+};
+
+use matches::assert_matches;
+use ruma_events::{
+    room::redaction::{RedactionEvent, RedactionEventContent},
+    AnyMessageEvent, EventJson, UnsignedData,
+};
+use ruma_identifiers::{EventId, RoomId, UserId};
+use serde_json::{
+    from_value as from_json_value, json, to_value as to_json_value, Value as JsonValue,
+};
+
+fn redaction() -> JsonValue {
+    json!({
+        "content": {
+            "reason": "being a turd"
+        },
+        "redacts": "$nomore:example.com",
+        "event_id": "$h29iv0s8:example.com",
+        "sender": "@carl:example.com",
+        "origin_server_ts": 1,
+        "room_id": "!roomid:room.com",
+        "type": "m.room.redaction"
+    })
+}
+
+#[test]
+fn serialize_redaction() {
+    let aliases_event = RedactionEvent {
+        content: RedactionEventContent { reason: Some("being a turd".to_string()) },
+        redacts: EventId::try_from("$nomore:example.com").unwrap(),
+        event_id: EventId::try_from("$h29iv0s8:example.com").unwrap(),
+        origin_server_ts: UNIX_EPOCH + Duration::from_millis(1),
+        room_id: RoomId::try_from("!roomid:room.com").unwrap(),
+        sender: UserId::try_from("@carl:example.com").unwrap(),
+        unsigned: UnsignedData::default(),
+    };
+
+    let actual = to_json_value(&aliases_event).unwrap();
+    let expected = redaction();
+
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn deserialize_redaction() {
+    let json_data = redaction();
+
+    assert_matches!(
+        from_json_value::<EventJson<AnyMessageEvent>>(json_data)
+            .unwrap()
+            .deserialize()
+            .unwrap(),
+        AnyMessageEvent::RoomRedaction(RedactionEvent {
+            content: RedactionEventContent { reason: Some(reas) },
+            redacts,
+            event_id,
+            origin_server_ts,
+            room_id,
+            sender,
+            unsigned,
+        }) if reas == "being a turd"
+            && event_id == EventId::try_from("$h29iv0s8:example.com").unwrap()
+            && redacts == EventId::try_from("$nomore:example.com").unwrap()
+            && origin_server_ts == UNIX_EPOCH + Duration::from_millis(1)
+            && room_id == RoomId::try_from("!roomid:room.com").unwrap()
+            && sender == UserId::try_from("@carl:example.com").unwrap()
+            && unsigned.is_empty()
+    );
+}


### PR DESCRIPTION
Conditionally emit tokens for content enum in event_enum! and the path for each Any*Event variant contents. Add tests for redaction events now that they are part of Any*Event enums. Fix any tests that used Any*EventContent.