### PR TITLE
Generate stub/stripped Any*Event enums in event_enum! macro

### DIFF
--- a/ruma-events-macros/src/event_enum.rs
+++ b/ruma-events-macros/src/event_enum.rs
@@ -107,23 +107,10 @@ pub fn expand_content_enum(input: &EventEnumInput) -> syn::Result<TokenStream> {
         }
     };
 
-    let any_event_variant_impl = quote! {
-        impl #ident {
-            fn is_compatible(event_type: &str) -> bool {
-                match event_type {
-                    #( #event_type_str => true, )*
-                    _ => false,
-                }
-            }
-        }
-    };
-
     let marker_trait_impls = marker_traits(&ident);
 
     Ok(quote! {
         #content_enum
-
-        #any_event_variant_impl
 
         #event_content_impl
 
@@ -316,18 +303,19 @@ pub struct EventEnumInput {
 impl Parse for EventEnumInput {
     fn parse(input: ParseStream<'_>) -> parse::Result<Self> {
         let attrs = input.call(Attribute::parse_outer)?;
-        // name field
+        // "name" field
         input.parse::<kw::name>()?;
         input.parse::<Token![:]>()?;
+
         // the name of our event enum
         let name: Ident = input.parse()?;
         input.parse::<Token![,]>()?;
 
-        // events field
+        // "events" field
         input.parse::<kw::events>()?;
         input.parse::<Token![:]>()?;
 
-        // an array of event names `["m.room.whatever"]`
+        // an array of event names `["m.room.whatever", ...]`
         let ev_array = input.parse::<syn::ExprArray>()?;
         let events = ev_array
             .elems

--- a/ruma-events-macros/src/event_enum.rs
+++ b/ruma-events-macros/src/event_enum.rs
@@ -42,7 +42,7 @@ pub fn expand_event_enum(input: EventEnumInput) -> syn::Result<TokenStream> {
                 use ::serde::de::Error as _;
 
                 let json = Box::<::serde_json::value::RawValue>::deserialize(deserializer)?;
-                let ::ruma_events::EventDeHelper { ev_type } = ::ruma_events::from_raw_json_value(&json)?;
+                let ::ruma_events::EventDeHelper { ev_type, .. } = ::ruma_events::from_raw_json_value(&json)?;
                 match ev_type.as_str() {
                     #(
                         #event_type_str => {

--- a/ruma-events/src/enums.rs
+++ b/ruma-events/src/enums.rs
@@ -45,23 +45,6 @@ event_enum! {
 }
 
 event_enum! {
-    /// Any message event stub (message event without a `room_id`, as returned in `/sync` responses)
-    name: AnyMessageEventStub,
-    events: [
-        "m.call.answer",
-        "m.call.invite",
-        "m.call.hangup",
-        "m.call.candidates",
-        "m.room.encrypted",
-        "m.room.message",
-        "m.room.message.feedback",
-        "m.room.redaction",
-        "m.sticker",
-
-    ]
-}
-
-event_enum! {
     /// Any state event.
     name: AnyStateEvent,
     events: [
@@ -77,56 +60,7 @@ event_enum! {
         "m.room.name",
         "m.room.pinned_events",
         "m.room.power_levels",
-        "m.room.redaction",
-        "m.room.server_acl",
-        "m.room.third_party_invite",
-        "m.room.tombstone",
-        "m.room.topic",
-    ]
-}
-
-event_enum! {
-    /// Any state event stub (state event without a `room_id`, as returned in `/sync` responses)
-    name: AnyStateEventStub,
-    events: [
-        "m.room.aliases",
-        "m.room.avatar",
-        "m.room.canonical_alias",
-        "m.room.create",
-        "m.room.encryption",
-        "m.room.guest_access",
-        "m.room.history_visibility",
-        "m.room.join_rules",
-        "m.room.member",
-        "m.room.name",
-        "m.room.pinned_events",
-        "m.room.power_levels",
-        "m.room.redaction",
-        "m.room.server_acl",
-        "m.room.third_party_invite",
-        "m.room.tombstone",
-        "m.room.topic",
-    ]
-}
-
-event_enum! {
-    /// Any stripped state event stub (stripped-down state event, as returned for rooms the user has
-    /// been invited to in `/sync` responses)
-    name: AnyStrippedStateEventStub,
-    events: [
-        "m.room.aliases",
-        "m.room.avatar",
-        "m.room.canonical_alias",
-        "m.room.create",
-        "m.room.encryption",
-        "m.room.guest_access",
-        "m.room.history_visibility",
-        "m.room.join_rules",
-        "m.room.member",
-        "m.room.name",
-        "m.room.pinned_events",
-        "m.room.power_levels",
-        "m.room.redaction",
+        // "m.room.redaction",
         "m.room.server_acl",
         "m.room.third_party_invite",
         "m.room.tombstone",

--- a/ruma-events/src/enums.rs
+++ b/ruma-events/src/enums.rs
@@ -5,10 +5,7 @@ use serde::{
 };
 use serde_json::value::RawValue as RawJsonValue;
 
-use crate::{
-    event_kinds::{MessageEventStub, StateEventStub, StrippedStateEventStub},
-    from_raw_json_value, EventDeHelper,
-};
+use crate::{from_raw_json_value, EventDeHelper};
 
 event_enum! {
     /// Any basic event.
@@ -51,8 +48,74 @@ event_enum! {
 }
 
 event_enum! {
+    /// Any message event stub (message event without a `room_id`, as returned in `/sync` responses)
+    name: AnyMessageEventStub,
+    events: [
+        "m.call.answer",
+        "m.call.invite",
+        "m.call.hangup",
+        "m.call.candidates",
+        "m.room.encrypted",
+        "m.room.message",
+        "m.room.message.feedback",
+        "m.room.redaction",
+        "m.sticker",
+
+    ]
+}
+
+event_enum! {
     /// Any state event.
     name: AnyStateEvent,
+    events: [
+        "m.room.aliases",
+        "m.room.avatar",
+        "m.room.canonical_alias",
+        "m.room.create",
+        "m.room.encryption",
+        "m.room.guest_access",
+        "m.room.history_visibility",
+        "m.room.join_rules",
+        "m.room.member",
+        "m.room.name",
+        "m.room.pinned_events",
+        "m.room.power_levels",
+        "m.room.redaction",
+        "m.room.server_acl",
+        "m.room.third_party_invite",
+        "m.room.tombstone",
+        "m.room.topic",
+    ]
+}
+
+event_enum! {
+    /// Any state event stub (state event without a `room_id`, as returned in `/sync` responses)
+    name: AnyStateEventStub,
+    events: [
+        "m.room.aliases",
+        "m.room.avatar",
+        "m.room.canonical_alias",
+        "m.room.create",
+        "m.room.encryption",
+        "m.room.guest_access",
+        "m.room.history_visibility",
+        "m.room.join_rules",
+        "m.room.member",
+        "m.room.name",
+        "m.room.pinned_events",
+        "m.room.power_levels",
+        "m.room.redaction",
+        "m.room.server_acl",
+        "m.room.third_party_invite",
+        "m.room.tombstone",
+        "m.room.topic",
+    ]
+}
+
+event_enum! {
+    /// Any stripped state event stub (stripped-down state event, as returned for rooms the user has
+    /// been invited to in `/sync` responses)
+    name: AnyStrippedStateEventStub,
     events: [
         "m.room.aliases",
         "m.room.avatar",
@@ -91,16 +154,6 @@ event_enum! {
         "m.room.encrypted",
     ]
 }
-
-/// Any message event stub (message event without a `room_id`, as returned in `/sync` responses)
-pub type AnyMessageEventStub = MessageEventStub<AnyMessageEventContent>;
-
-/// Any state event stub (state event without a `room_id`, as returned in `/sync` responses)
-pub type AnyStateEventStub = StateEventStub<AnyStateEventContent>;
-
-/// Any stripped state event stub (stripped-down state event, as returned for rooms the user has
-/// been invited to in `/sync` responses)
-pub type AnyStrippedStateEventStub = StrippedStateEventStub<AnyStateEventContent>;
 
 /// Any event.
 #[derive(Clone, Debug, Serialize)]

--- a/ruma-events/src/enums.rs
+++ b/ruma-events/src/enums.rs
@@ -128,7 +128,7 @@ impl<'de> de::Deserialize<'de> for AnyEvent {
         let json = Box::<RawJsonValue>::deserialize(deserializer)?;
         let EventDeHelper { state_key, event_id, room_id, .. } = from_raw_json_value(&json)?;
 
-        // Determine wether the event is a state, message, ephemeral, or basic event
+        // Determine whether the event is a state, message, ephemeral, or basic event
         // based on the fields present.
         if state_key.is_some() {
             Ok(AnyEvent::State(from_raw_json_value(&json)?))

--- a/ruma-events/src/lib.rs
+++ b/ruma-events/src/lib.rs
@@ -240,8 +240,11 @@ pub trait StateEventContent: RoomEventContent {}
 pub struct EventDeHelper {
     #[serde(rename = "type")]
     pub ev_type: String,
+    #[serde(default)]
+    pub state_key: Option<String>,
+    #[serde(default)]
+    pub event_id: Option<String>,
 }
-
 /// Helper function for serde_json::value::RawValue deserialization.
 #[doc(hidden)]
 pub fn from_raw_json_value<T, E>(val: &RawJsonValue) -> Result<T, E>

--- a/ruma-events/src/lib.rs
+++ b/ruma-events/src/lib.rs
@@ -245,13 +245,15 @@ pub struct EventDeHelper {
     #[serde(rename = "type")]
     pub ev_type: String,
 
-    /// If present the event is a state event.
+    /// If `state_key` is present the event will be deserialized as a state event.
     pub state_key: Option<IgnoredAny>,
 
-    /// If no `state_key` is found but an `event_id` is present the a message event is deserialized.
+    /// If no `state_key` is found but an `event_id` is present the event
+    /// will be deserialized as a message event.
     pub event_id: Option<IgnoredAny>,
 
-    /// If no `event_id` or `state_key` are found but a `room_id` is present an ephemeral event is deserialized.
+    /// If no `event_id` or `state_key` are found but a `room_id` is present
+    /// the event will be deserialized as a ephemeral event.
     pub room_id: Option<IgnoredAny>,
 }
 

--- a/ruma-events/src/room/redaction.rs
+++ b/ruma-events/src/room/redaction.rs
@@ -64,6 +64,12 @@ pub struct RedactionEventContent {
     pub reason: Option<String>,
 }
 
+impl ruma_events::RoomEventContent for RedactionEventContent {}
+
+impl ruma_events::MessageEventContent for RedactionEventContent {}
+
+impl ruma_events::StateEventContent for RedactionEventContent {}
+
 #[cfg(test)]
 mod tests {
     use std::{

--- a/ruma-events/src/room/redaction.rs
+++ b/ruma-events/src/room/redaction.rs
@@ -68,8 +68,6 @@ impl ruma_events::RoomEventContent for RedactionEventContent {}
 
 impl ruma_events::MessageEventContent for RedactionEventContent {}
 
-impl ruma_events::StateEventContent for RedactionEventContent {}
-
 #[cfg(test)]
 mod tests {
     use std::{

--- a/ruma-events/tests/enums.rs
+++ b/ruma-events/tests/enums.rs
@@ -10,9 +10,8 @@ use ruma_events::{
         message::{MessageEventContent, TextMessageEventContent},
         power_levels::PowerLevelsEventContent,
     },
-    AnyEvent, AnyMessageEvent, AnyMessageEventContent, AnyRoomEvent, AnyRoomEventStub,
-    AnyStateEvent, AnyStateEventContent, MessageEvent, MessageEventStub, StateEvent,
-    StateEventStub,
+    AnyEvent, AnyMessageEvent, AnyMessageEventStub, AnyRoomEvent, AnyRoomEventStub, AnyStateEvent,
+    AnyStateEventStub, MessageEvent, MessageEventStub, StateEvent, StateEventStub,
 };
 
 fn message_event() -> JsonValue {
@@ -120,12 +119,12 @@ fn power_event_stub_deserialization() {
     assert_matches!(
         from_json_value::<AnyRoomEventStub>(json_data),
         Ok(AnyRoomEventStub::State(
-            StateEventStub {
-                content: AnyStateEventContent::RoomPowerLevels(PowerLevelsEventContent {
+            AnyStateEventStub::RoomPowerLevels(StateEventStub {
+                content: PowerLevelsEventContent {
                     ban, ..
-                }),
+                },
                 ..
-            }
+            })
         ))
         if ban == js_int::Int::new(50).unwrap()
     );
@@ -138,14 +137,14 @@ fn message_event_stub_deserialization() {
     assert_matches!(
         from_json_value::<AnyRoomEventStub>(json_data),
         Ok(AnyRoomEventStub::Message(
-            MessageEventStub {
-                content: AnyMessageEventContent::RoomMessage(MessageEventContent::Text(TextMessageEventContent {
+            AnyMessageEventStub::RoomMessage(MessageEventStub {
+                content: MessageEventContent::Text(TextMessageEventContent {
                     body,
                     formatted: Some(formatted),
                     relates_to: None,
-                })),
+                }),
                 ..
-            }
+            })
         ))
         if body == "baba" && formatted.body == "<strong>baba</strong>"
     );
@@ -158,12 +157,12 @@ fn aliases_event_stub_deserialization() {
     assert_matches!(
         from_json_value::<AnyRoomEventStub>(json_data),
         Ok(AnyRoomEventStub::State(
-            StateEventStub {
-                content: AnyStateEventContent::RoomAliases(AliasesEventContent {
+            AnyStateEventStub::RoomAliases(StateEventStub {
+                content: AliasesEventContent {
                     aliases,
-                }),
+                },
                 ..
-            }
+            })
         ))
         if aliases == vec![ RoomAliasId::try_from("#somewhere:localhost").unwrap() ]
     );

--- a/ruma-events/tests/redaction.rs
+++ b/ruma-events/tests/redaction.rs
@@ -1,0 +1,73 @@
+use std::{
+    convert::TryFrom,
+    time::{Duration, UNIX_EPOCH},
+};
+
+use matches::assert_matches;
+use ruma_events::{
+    room::redaction::{RedactionEvent, RedactionEventContent},
+    AnyMessageEvent, EventJson, UnsignedData,
+};
+use ruma_identifiers::{EventId, RoomId, UserId};
+use serde_json::{
+    from_value as from_json_value, json, to_value as to_json_value, Value as JsonValue,
+};
+
+fn redaction() -> JsonValue {
+    json!({
+        "content": {
+            "reason": "being a turd"
+        },
+        "redacts": "$nomore:example.com",
+        "event_id": "$h29iv0s8:example.com",
+        "sender": "@carl:example.com",
+        "origin_server_ts": 1,
+        "room_id": "!roomid:room.com",
+        "type": "m.room.redaction"
+    })
+}
+
+#[test]
+fn serialize_redaction() {
+    let aliases_event = RedactionEvent {
+        content: RedactionEventContent { reason: Some("being a turd".to_string()) },
+        redacts: EventId::try_from("$nomore:example.com").unwrap(),
+        event_id: EventId::try_from("$h29iv0s8:example.com").unwrap(),
+        origin_server_ts: UNIX_EPOCH + Duration::from_millis(1),
+        room_id: RoomId::try_from("!roomid:room.com").unwrap(),
+        sender: UserId::try_from("@carl:example.com").unwrap(),
+        unsigned: UnsignedData::default(),
+    };
+
+    let actual = to_json_value(&aliases_event).unwrap();
+    let expected = redaction();
+
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn deserialize_redaction() {
+    let json_data = redaction();
+
+    assert_matches!(
+        from_json_value::<EventJson<AnyMessageEvent>>(json_data)
+            .unwrap()
+            .deserialize()
+            .unwrap(),
+        AnyMessageEvent::RoomRedaction(RedactionEvent {
+            content: RedactionEventContent { reason: Some(reas) },
+            redacts,
+            event_id,
+            origin_server_ts,
+            room_id,
+            sender,
+            unsigned,
+        }) if reas == "being a turd"
+            && event_id == EventId::try_from("$h29iv0s8:example.com").unwrap()
+            && redacts == EventId::try_from("$nomore:example.com").unwrap()
+            && origin_server_ts == UNIX_EPOCH + Duration::from_millis(1)
+            && room_id == RoomId::try_from("!roomid:room.com").unwrap()
+            && sender == UserId::try_from("@carl:example.com").unwrap()
+            && unsigned.is_empty()
+    );
+}


### PR DESCRIPTION
I didn't want to push this to the other PR incase it wasn't the direction you were thinking, if it is I can either merge it into the first PR or close that one. I also took a shot at handling the State, Message, and Basic event deserialization when a custom event is encountered.