### PR TITLE
Support building ruma-identifiers without std

### DIFF
--- a/ruma-identifiers/Cargo.toml
+++ b/ruma-identifiers/Cargo.toml
@@ -17,7 +17,9 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = ["serde"]
+default = ["serde", "std"]
+alloc = []
+std = ["alloc"]
 
 [dependencies]
 either = { version = "1.5.3", optional = true }

--- a/ruma-identifiers/src/device_id.rs
+++ b/ruma-identifiers/src/device_id.rs
@@ -7,7 +7,8 @@ use crate::generate_localpart;
 ///
 /// Device identifiers in Matrix are completely opaque character sequences. This type alias is
 /// provided simply for its semantic value.
-pub type DeviceId = String;
+#[cfg(feature = "alloc")]
+pub type DeviceId = alloc::string::String;
 
 /// Generates a random `DeviceId`, suitable for assignment to a new device.
 #[cfg(feature = "rand")]

--- a/ruma-identifiers/src/device_key_id.rs
+++ b/ruma-identifiers/src/device_key_id.rs
@@ -1,7 +1,8 @@
 //! Identifiers for device keys for end-to-end encryption.
 
+use core::{num::NonZeroU8, str::FromStr};
+
 use crate::{error::Error, key_algorithms::DeviceKeyAlgorithm, DeviceIdRef};
-use std::{num::NonZeroU8, str::FromStr};
 
 /// A key algorithm and a device id, combined with a ':'
 #[derive(Clone, Debug)]
@@ -50,7 +51,7 @@ common_impls!(DeviceKeyId, try_from, "Device key ID with algorithm and device ID
 
 #[cfg(test)]
 mod test {
-    use std::convert::TryFrom;
+    use core::convert::TryFrom;
 
     #[cfg(feature = "serde")]
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};

--- a/ruma-identifiers/src/error.rs
+++ b/ruma-identifiers/src/error.rs
@@ -1,6 +1,6 @@
 //! Error conditions.
 
-use std::fmt::{self, Display, Formatter};
+use core::fmt::{self, Display, Formatter};
 
 /// An error encountered when trying to parse an invalid ID string.
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
@@ -51,4 +51,5 @@ impl Display for Error {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for Error {}

--- a/ruma-identifiers/src/event_id.rs
+++ b/ruma-identifiers/src/event_id.rs
@@ -1,6 +1,6 @@
 //! Matrix event identifiers.
 
-use std::{convert::TryFrom, num::NonZeroU8};
+use core::{convert::TryFrom, num::NonZeroU8};
 
 use crate::{error::Error, parse_id, validate_id, ServerNameRef};
 
@@ -22,7 +22,7 @@ use crate::{error::Error, parse_id, validate_id, ServerNameRef};
 /// original event format.
 ///
 /// ```
-/// # use std::convert::TryFrom;
+/// # use core::convert::TryFrom;
 /// # use ruma_identifiers::EventId;
 /// // Original format
 /// assert_eq!(
@@ -46,9 +46,11 @@ pub struct EventId<T> {
     colon_idx: Option<NonZeroU8>,
 }
 
+#[cfg(feature = "rand")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
 impl<T> EventId<T>
 where
-    String: Into<T>,
+    alloc::string::String: Into<T>,
 {
     /// Attempts to generate an `EventId` for the given origin server with a localpart consisting
     /// of 18 random ASCII characters. This should only be used for events in the original format
@@ -56,8 +58,6 @@ where
     ///
     /// Does not currently ever fail, but may fail in the future if the homeserver cannot be parsed
     /// parsed as a valid host.
-    #[cfg(feature = "rand")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
     pub fn new(server_name: ServerNameRef<'_>) -> Self {
         use crate::generate_localpart;
 
@@ -121,7 +121,7 @@ common_impls!(EventId, try_from, "a Matrix event ID");
 
 #[cfg(test)]
 mod tests {
-    use std::convert::TryFrom;
+    use core::convert::TryFrom;
 
     #[cfg(feature = "serde")]
     use serde_json::{from_str, to_string};

--- a/ruma-identifiers/src/lib.rs
+++ b/ruma-identifiers/src/lib.rs
@@ -5,9 +5,13 @@
 #![deny(missing_copy_implementations, missing_debug_implementations, missing_docs)]
 // Since we support Rust 1.36.0, we can't apply this suggestion yet
 #![allow(clippy::use_self)]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-use std::{convert::TryFrom, num::NonZeroU8};
+use core::{convert::TryFrom, num::NonZeroU8};
+
+#[cfg(any(feature = "alloc", feature = "rand", feature = "serde"))]
+extern crate alloc;
 
 #[cfg(feature = "serde")]
 use serde::de::{self, Deserialize as _, Deserializer, Unexpected};
@@ -40,7 +44,8 @@ pub type DeviceKeyAlgorithm = key_algorithms::DeviceKeyAlgorithm;
 ///
 /// Can be created via `TryFrom<String>` and `TryFrom<&str>`; implements `Serialize`
 /// and `Deserialize` if the `serde` feature is enabled.
-pub type DeviceKeyId = device_key_id::DeviceKeyId<Box<str>>;
+#[cfg(feature = "alloc")]
+pub type DeviceKeyId = device_key_id::DeviceKeyId<alloc::boxed::Box<str>>;
 
 /// A reference to a device key identifier containing a key algorithm and device ID.
 ///
@@ -51,6 +56,7 @@ pub type DeviceKeyIdRef<'a> = device_key_id::DeviceKeyId<&'a str>;
 /// An owned device ID.
 ///
 /// While this is currently just a `String`, that will likely change in the future.
+#[cfg(feature = "alloc")]
 pub use device_id::DeviceId;
 
 /// A reference to a device ID.
@@ -62,7 +68,8 @@ pub type DeviceIdRef<'a> = &'a str;
 ///
 /// Can be created via `new` (if the `rand` feature is enabled) and `TryFrom<String>` +
 /// `TryFrom<&str>`, implements `Serialize` and `Deserialize` if the `serde` feature is enabled.
-pub type EventId = event_id::EventId<Box<str>>;
+#[cfg(feature = "alloc")]
+pub type EventId = event_id::EventId<alloc::boxed::Box<str>>;
 
 /// A reference to an event ID.
 ///
@@ -73,7 +80,8 @@ pub type EventIdRef<'a> = event_id::EventId<&'a str>;
 ///
 /// Can be created via `TryFrom<String>` and `TryFrom<&str>`, implements `Serialize` and
 /// `Deserialize` if the `serde` feature is enabled.
-pub type RoomAliasId = room_alias_id::RoomAliasId<Box<str>>;
+#[cfg(feature = "alloc")]
+pub type RoomAliasId = room_alias_id::RoomAliasId<alloc::boxed::Box<str>>;
 
 /// A reference to a room alias ID.
 ///
@@ -84,7 +92,8 @@ pub type RoomAliasIdRef<'a> = room_alias_id::RoomAliasId<&'a str>;
 ///
 /// Can be created via `new` (if the `rand` feature is enabled) and `TryFrom<String>` +
 /// `TryFrom<&str>`, implements `Serialize` and `Deserialize` if the `serde` feature is enabled.
-pub type RoomId = room_id::RoomId<Box<str>>;
+#[cfg(feature = "alloc")]
+pub type RoomId = room_id::RoomId<alloc::boxed::Box<str>>;
 
 /// A reference to a room ID.
 ///
@@ -95,7 +104,8 @@ pub type RoomIdRef<'a> = room_id::RoomId<&'a str>;
 ///
 /// Can be created via `TryFrom<String>`, `TryFrom<&str>`, `From<RoomId>` and `From<RoomAliasId>`;
 /// implements `Serialize` and `Deserialize` if the `serde` feature is enabled.
-pub type RoomIdOrAliasId = room_id_or_room_alias_id::RoomIdOrAliasId<Box<str>>;
+#[cfg(feature = "alloc")]
+pub type RoomIdOrAliasId = room_id_or_room_alias_id::RoomIdOrAliasId<alloc::boxed::Box<str>>;
 
 /// A reference to a room alias ID or room ID.
 ///
@@ -107,7 +117,8 @@ pub type RoomIdOrAliasIdRef<'a> = room_id_or_room_alias_id::RoomIdOrAliasId<&'a 
 ///
 /// Can be created using the `version_N` constructor functions, `TryFrom<String>` and
 /// `TryFrom<&str>`; implements `Serialize` and `Deserialize` if the `serde` feature is enabled.
-pub type RoomVersionId = room_version_id::RoomVersionId<Box<str>>;
+#[cfg(feature = "alloc")]
+pub type RoomVersionId = room_version_id::RoomVersionId<alloc::boxed::Box<str>>;
 
 /// A reference to a room version ID.
 ///
@@ -122,7 +133,8 @@ pub type ServerKeyAlgorithm = key_algorithms::ServerKeyAlgorithm;
 ///
 /// Can be created via `TryFrom<String>` and `TryFrom<&str>`; implements `Serialize`
 /// and `Deserialize` if the `serde` feature is enabled.
-pub type ServerKeyId = server_key_id::ServerKeyId<Box<str>>;
+#[cfg(feature = "alloc")]
+pub type ServerKeyId = server_key_id::ServerKeyId<alloc::boxed::Box<str>>;
 
 /// A reference to a homeserver signing key identifier containing a key
 /// algorithm and version.
@@ -135,7 +147,8 @@ pub type ServerKeyIdRef<'a> = server_key_id::ServerKeyId<&'a str>;
 ///
 /// Can be created via `TryFrom<String>` and `TryFrom<&str>`; implements `Serialize`
 /// and `Deserialize` if the `serde` feature is enabled.
-pub type ServerName = server_name::ServerName<Box<str>>;
+#[cfg(feature = "alloc")]
+pub type ServerName = server_name::ServerName<alloc::boxed::Box<str>>;
 
 /// A reference to a homeserver IP address or hostname.
 ///
@@ -146,7 +159,8 @@ pub type ServerNameRef<'a> = server_name::ServerName<&'a str>;
 ///
 /// Can be created via `new` (if the `rand` feature is enabled) and `TryFrom<String>` +
 /// `TryFrom<&str>`, implements `Serialize` and `Deserialize` if the `serde` feature is enabled.
-pub type UserId = user_id::UserId<Box<str>>;
+#[cfg(feature = "alloc")]
+pub type UserId = user_id::UserId<alloc::boxed::Box<str>>;
 
 /// A reference to a user ID.
 ///
@@ -171,7 +185,7 @@ const MIN_CHARS: usize = 4;
 
 /// Generates a random identifier localpart.
 #[cfg(feature = "rand")]
-fn generate_localpart(length: usize) -> String {
+fn generate_localpart(length: usize) -> alloc::string::String {
     use rand::Rng as _;
     rand::thread_rng().sample_iter(&rand::distributions::Alphanumeric).take(length).collect()
 }
@@ -215,9 +229,9 @@ fn parse_id(id: &str, valid_sigils: &[char]) -> Result<NonZeroU8, Error> {
 fn deserialize_id<'de, D, T>(deserializer: D, expected_str: &str) -> Result<T, D::Error>
 where
     D: Deserializer<'de>,
-    T: for<'a> std::convert::TryFrom<&'a str>,
+    T: for<'a> core::convert::TryFrom<&'a str>,
 {
-    std::borrow::Cow::<'_, str>::deserialize(deserializer).and_then(|v| {
+    alloc::string::String::deserialize(deserializer).and_then(|v| {
         T::try_from(&v).map_err(|_| de::Error::invalid_value(Unexpected::Str(&v), &expected_str))
     })
 }

--- a/ruma-identifiers/src/macros.rs
+++ b/ruma-identifiers/src/macros.rs
@@ -7,7 +7,7 @@ macro_rules! doc_concat {
 
 macro_rules! common_impls {
     ($id:ident, $try_from:ident, $desc:literal) => {
-        impl<T: ::std::convert::AsRef<str>> $id<T> {
+        impl<T: ::core::convert::AsRef<str>> $id<T> {
             doc_concat! {
                 #[doc = concat!("Creates a string slice from this `", stringify!($id), "`")]
                 pub fn as_str(&self) -> &str {
@@ -16,19 +16,21 @@ macro_rules! common_impls {
             }
         }
 
-        impl<'a> ::std::convert::From<&'a $id<Box<str>>> for $id<&'a str> {
-            fn from(id: &'a $id<Box<str>>) -> Self {
+        #[cfg(feature = "alloc")]
+        impl<'a> ::core::convert::From<&'a $id<::alloc::boxed::Box<str>>> for $id<&'a str> {
+            fn from(id: &'a $id<::alloc::boxed::Box<str>>) -> Self {
                 id.as_ref()
             }
         }
 
-        impl ::std::convert::From<$id<Box<str>>> for ::std::string::String {
-            fn from(id: $id<Box<str>>) -> Self {
+        #[cfg(feature = "alloc")]
+        impl ::core::convert::From<$id<::alloc::boxed::Box<str>>> for ::alloc::string::String {
+            fn from(id: $id<::alloc::boxed::Box<str>>) -> Self {
                 id.full_id.into()
             }
         }
 
-        impl<'a> ::std::convert::TryFrom<&'a str> for $id<&'a str> {
+        impl<'a> ::core::convert::TryFrom<&'a str> for $id<&'a str> {
             type Error = crate::error::Error;
 
             fn try_from(s: &'a str) -> Result<Self, Self::Error> {
@@ -36,7 +38,7 @@ macro_rules! common_impls {
             }
         }
 
-        impl ::std::convert::TryFrom<&str> for $id<Box<str>> {
+        impl ::core::convert::TryFrom<&str> for $id<::alloc::boxed::Box<str>> {
             type Error = crate::error::Error;
 
             fn try_from(s: &str) -> Result<Self, Self::Error> {
@@ -44,48 +46,48 @@ macro_rules! common_impls {
             }
         }
 
-        impl ::std::convert::TryFrom<String> for $id<Box<str>> {
+        impl ::core::convert::TryFrom<::alloc::string::String> for $id<::alloc::boxed::Box<str>> {
             type Error = crate::error::Error;
 
-            fn try_from(s: String) -> Result<Self, Self::Error> {
+            fn try_from(s: ::alloc::string::String) -> Result<Self, Self::Error> {
                 $try_from(s)
             }
         }
 
-        impl<T: ::std::convert::AsRef<str>> ::std::convert::AsRef<str> for $id<T> {
+        impl<T: ::core::convert::AsRef<str>> ::core::convert::AsRef<str> for $id<T> {
             fn as_ref(&self) -> &str {
                 self.full_id.as_ref()
             }
         }
 
-        impl<T: ::std::fmt::Display> ::std::fmt::Display for $id<T> {
-            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        impl<T: ::core::fmt::Display> ::core::fmt::Display for $id<T> {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
                 write!(f, "{}", self.full_id)
             }
         }
 
-        impl<T: ::std::cmp::PartialEq> ::std::cmp::PartialEq for $id<T> {
+        impl<T: ::core::cmp::PartialEq> ::core::cmp::PartialEq for $id<T> {
             fn eq(&self, other: &Self) -> bool {
                 self.full_id == other.full_id
             }
         }
 
-        impl<T: ::std::cmp::Eq> ::std::cmp::Eq for $id<T> {}
+        impl<T: ::core::cmp::Eq> ::core::cmp::Eq for $id<T> {}
 
-        impl<T: ::std::cmp::PartialOrd> ::std::cmp::PartialOrd for $id<T> {
-            fn partial_cmp(&self, other: &Self) -> Option<::std::cmp::Ordering> {
-                ::std::cmp::PartialOrd::partial_cmp(&self.full_id, &other.full_id)
+        impl<T: ::core::cmp::PartialOrd> ::core::cmp::PartialOrd for $id<T> {
+            fn partial_cmp(&self, other: &Self) -> Option<::core::cmp::Ordering> {
+                ::core::cmp::PartialOrd::partial_cmp(&self.full_id, &other.full_id)
             }
         }
 
-        impl<T: ::std::cmp::Ord> ::std::cmp::Ord for $id<T> {
-            fn cmp(&self, other: &Self) -> ::std::cmp::Ordering {
-                ::std::cmp::Ord::cmp(&self.full_id, &other.full_id)
+        impl<T: ::core::cmp::Ord> ::core::cmp::Ord for $id<T> {
+            fn cmp(&self, other: &Self) -> ::core::cmp::Ordering {
+                ::core::cmp::Ord::cmp(&self.full_id, &other.full_id)
             }
         }
 
-        impl<T: ::std::hash::Hash> ::std::hash::Hash for $id<T> {
-            fn hash<H: ::std::hash::Hasher>(&self, state: &mut H) {
+        impl<T: ::core::hash::Hash> ::core::hash::Hash for $id<T> {
+            fn hash<H: ::core::hash::Hasher>(&self, state: &mut H) {
                 self.full_id.hash(state);
             }
         }
@@ -101,7 +103,7 @@ macro_rules! common_impls {
         }
 
         #[cfg(feature = "serde")]
-        impl<'de> ::serde::Deserialize<'de> for $id<Box<str>> {
+        impl<'de> ::serde::Deserialize<'de> for $id<::alloc::boxed::Box<str>> {
             fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
             where
                 D: ::serde::Deserializer<'de>,
@@ -110,25 +112,26 @@ macro_rules! common_impls {
             }
         }
 
-        impl<T: AsRef<str>> ::std::cmp::PartialEq<&str> for $id<T> {
+        impl<T: AsRef<str>> ::core::cmp::PartialEq<&str> for $id<T> {
             fn eq(&self, other: &&str) -> bool {
                 self.full_id.as_ref() == *other
             }
         }
 
-        impl<T: AsRef<str>> ::std::cmp::PartialEq<$id<T>> for &str {
+        impl<T: AsRef<str>> ::core::cmp::PartialEq<$id<T>> for &str {
             fn eq(&self, other: &$id<T>) -> bool {
                 *self == other.full_id.as_ref()
             }
         }
 
-        impl<T: AsRef<str>> ::std::cmp::PartialEq<::std::string::String> for $id<T> {
-            fn eq(&self, other: &::std::string::String) -> bool {
+        #[cfg(feature = "alloc")]
+        impl<T: AsRef<str>> ::core::cmp::PartialEq<::alloc::string::String> for $id<T> {
+            fn eq(&self, other: &::alloc::string::String) -> bool {
                 self.full_id.as_ref() == &other[..]
             }
         }
 
-        impl<T: AsRef<str>> ::std::cmp::PartialEq<$id<T>> for ::std::string::String {
+        impl<T: AsRef<str>> ::core::cmp::PartialEq<$id<T>> for ::alloc::string::String {
             fn eq(&self, other: &$id<T>) -> bool {
                 &self[..] == other.full_id.as_ref()
             }

--- a/ruma-identifiers/src/room_alias_id.rs
+++ b/ruma-identifiers/src/room_alias_id.rs
@@ -1,6 +1,6 @@
 //! Matrix room alias identifiers.
 
-use std::{convert::TryFrom, num::NonZeroU8};
+use core::{convert::TryFrom, num::NonZeroU8};
 
 use crate::{error::Error, parse_id, server_name::ServerName};
 
@@ -13,7 +13,7 @@ use crate::{error::Error, parse_id, server_name::ServerName};
 /// needed.
 ///
 /// ```
-/// # use std::convert::TryFrom;
+/// # use core::convert::TryFrom;
 /// # use ruma_identifiers::RoomAliasId;
 /// assert_eq!(
 ///     RoomAliasId::try_from("#ruma:example.com").unwrap().as_ref(),
@@ -62,7 +62,7 @@ common_impls!(RoomAliasId, try_from, "a Matrix room alias ID");
 
 #[cfg(test)]
 mod tests {
-    use std::convert::TryFrom;
+    use core::convert::TryFrom;
 
     #[cfg(feature = "serde")]
     use serde_json::{from_str, to_string};

--- a/ruma-identifiers/src/room_id.rs
+++ b/ruma-identifiers/src/room_id.rs
@@ -1,6 +1,6 @@
 //! Matrix room identifiers.
 
-use std::{convert::TryFrom, num::NonZeroU8};
+use core::{convert::TryFrom, num::NonZeroU8};
 
 use crate::{error::Error, parse_id, ServerNameRef};
 
@@ -13,7 +13,7 @@ use crate::{error::Error, parse_id, ServerNameRef};
 /// `RoomIdRef`) in the crate root.
 ///
 /// ```
-/// # use std::convert::TryFrom;
+/// # use core::convert::TryFrom;
 /// # use ruma_identifiers::RoomId;
 /// assert_eq!(
 ///     RoomId::try_from("!n8f893n9:example.com").unwrap().as_ref(),
@@ -26,16 +26,16 @@ pub struct RoomId<T> {
     pub(crate) colon_idx: NonZeroU8,
 }
 
+#[cfg(feature = "rand")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
 impl<T> RoomId<T>
 where
-    String: Into<T>,
+    alloc::string::String: Into<T>,
 {
     /// Attempts to generate a `RoomId` for the given origin server with a localpart consisting of
     /// 18 random ASCII characters.
     ///
     /// Fails if the given homeserver cannot be parsed as a valid host.
-    #[cfg(feature = "rand")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
     pub fn new(server_name: ServerNameRef<'_>) -> Self {
         use crate::generate_localpart;
 
@@ -82,7 +82,7 @@ common_impls!(RoomId, try_from, "a Matrix room ID");
 
 #[cfg(test)]
 mod tests {
-    use std::convert::TryFrom;
+    use core::convert::TryFrom;
 
     #[cfg(feature = "serde")]
     use serde_json::{from_str, to_string};

--- a/ruma-identifiers/src/room_id_or_room_alias_id.rs
+++ b/ruma-identifiers/src/room_id_or_room_alias_id.rs
@@ -1,6 +1,6 @@
 //! Matrix identifiers for places where a room ID or room alias ID are used interchangeably.
 
-use std::{convert::TryFrom, hint::unreachable_unchecked, num::NonZeroU8};
+use core::{convert::TryFrom, hint::unreachable_unchecked, num::NonZeroU8};
 
 use crate::{
     error::Error, parse_id, room_alias_id::RoomAliasId, room_id::RoomId, server_name::ServerName,
@@ -16,7 +16,7 @@ use crate::{
 /// (`RoomIdOrRoomAliasId` and `RoomIdOrRoomAliasIdRef`) in the crate root.
 ///
 /// ```
-/// # use std::convert::TryFrom;
+/// # use core::convert::TryFrom;
 /// # use ruma_identifiers::RoomIdOrAliasId;
 /// assert_eq!(
 ///     RoomIdOrAliasId::try_from("#ruma:example.com").unwrap().as_ref(),
@@ -148,7 +148,7 @@ impl<T: AsRef<str>> TryFrom<RoomIdOrAliasId<T>> for RoomAliasId<T> {
 
 #[cfg(test)]
 mod tests {
-    use std::convert::TryFrom;
+    use core::convert::TryFrom;
 
     #[cfg(feature = "serde")]
     use serde_json::{from_str, to_string};

--- a/ruma-identifiers/src/room_version_id.rs
+++ b/ruma-identifiers/src/room_version_id.rs
@@ -1,6 +1,6 @@
 //! Matrix room version identifiers.
 
-use std::{
+use core::{
     cmp::Ordering,
     convert::TryFrom,
     fmt::{self, Display, Formatter},
@@ -23,7 +23,7 @@ const MAX_CODE_POINTS: usize = 32;
 /// and `RoomVersionIdRef`) in the crate root.
 ///
 /// ```
-/// # use std::convert::TryFrom;
+/// # use core::convert::TryFrom;
 /// # use ruma_identifiers::RoomVersionId;
 /// assert_eq!(RoomVersionId::try_from("1").unwrap().as_ref(), "1");
 /// ```
@@ -131,8 +131,9 @@ impl<T> RoomVersionId<T> {
     }
 }
 
-impl From<RoomVersionId<Box<str>>> for String {
-    fn from(id: RoomVersionId<Box<str>>) -> Self {
+#[cfg(feature = "alloc")]
+impl From<RoomVersionId<alloc::boxed::Box<str>>> for alloc::string::String {
+    fn from(id: RoomVersionId<alloc::boxed::Box<str>>) -> Self {
         match id.0 {
             InnerRoomVersionId::Version1 => "1".to_owned(),
             InnerRoomVersionId::Version2 => "2".to_owned(),
@@ -188,7 +189,7 @@ impl<T: AsRef<str>> Serialize for RoomVersionId<T> {
 }
 
 #[cfg(feature = "serde")]
-impl<'de> Deserialize<'de> for RoomVersionId<Box<str>> {
+impl<'de> Deserialize<'de> for RoomVersionId<alloc::boxed::Box<str>> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -230,7 +231,8 @@ impl<'a> TryFrom<&'a str> for RoomVersionId<&'a str> {
     }
 }
 
-impl TryFrom<&str> for RoomVersionId<Box<str>> {
+#[cfg(feature = "alloc")]
+impl TryFrom<&str> for RoomVersionId<alloc::boxed::Box<str>> {
     type Error = crate::error::Error;
 
     fn try_from(s: &str) -> Result<Self, Error> {
@@ -238,10 +240,11 @@ impl TryFrom<&str> for RoomVersionId<Box<str>> {
     }
 }
 
-impl TryFrom<String> for RoomVersionId<Box<str>> {
+#[cfg(feature = "alloc")]
+impl TryFrom<alloc::string::String> for RoomVersionId<alloc::boxed::Box<str>> {
     type Error = crate::error::Error;
 
-    fn try_from(s: String) -> Result<Self, Error> {
+    fn try_from(s: alloc::string::String) -> Result<Self, Error> {
         try_from(s)
     }
 }
@@ -258,13 +261,15 @@ impl<T: AsRef<str>> PartialEq<RoomVersionId<T>> for &str {
     }
 }
 
-impl<T: AsRef<str>> PartialEq<String> for RoomVersionId<T> {
-    fn eq(&self, other: &String) -> bool {
+#[cfg(feature = "alloc")]
+impl<T: AsRef<str>> PartialEq<alloc::string::String> for RoomVersionId<T> {
+    fn eq(&self, other: &alloc::string::String) -> bool {
         self.as_ref() == other
     }
 }
 
-impl<T: AsRef<str>> PartialEq<RoomVersionId<T>> for String {
+#[cfg(feature = "alloc")]
+impl<T: AsRef<str>> PartialEq<RoomVersionId<T>> for alloc::string::String {
     fn eq(&self, other: &RoomVersionId<T>) -> bool {
         self == other.as_ref()
     }
@@ -272,7 +277,7 @@ impl<T: AsRef<str>> PartialEq<RoomVersionId<T>> for String {
 
 #[cfg(test)]
 mod tests {
-    use std::convert::TryFrom;
+    use core::convert::TryFrom;
 
     #[cfg(feature = "serde")]
     use serde_json::{from_str, to_string};

--- a/ruma-identifiers/src/server_key_id.rs
+++ b/ruma-identifiers/src/server_key_id.rs
@@ -1,6 +1,6 @@
 //! Identifiers for homeserver signing keys used for federation.
 
-use std::{num::NonZeroU8, str::FromStr};
+use core::{num::NonZeroU8, str::FromStr};
 
 use crate::{error::Error, key_algorithms::ServerKeyAlgorithm};
 
@@ -69,7 +69,7 @@ fn validate_server_key_algorithm(algorithm: &str) -> Result<(), Error> {
 
 #[cfg(test)]
 mod tests {
-    use std::convert::TryFrom;
+    use core::convert::TryFrom;
 
     #[cfg(feature = "serde")]
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};

--- a/ruma-identifiers/src/server_name.rs
+++ b/ruma-identifiers/src/server_name.rs
@@ -25,7 +25,7 @@ fn try_from<S, T>(server_name: S) -> Result<ServerName<T>, Error>
 where
     S: AsRef<str> + Into<T>,
 {
-    use std::net::Ipv6Addr;
+    use core::net::Ipv6Addr;
 
     let name = server_name.as_ref();
 
@@ -75,7 +75,7 @@ common_impls!(ServerName, try_from, "An IP address or hostname");
 
 #[cfg(test)]
 mod tests {
-    use std::convert::TryFrom;
+    use core::convert::TryFrom;
 
     use crate::ServerNameRef;
 

--- a/ruma-identifiers/src/user_id.rs
+++ b/ruma-identifiers/src/user_id.rs
@@ -1,6 +1,6 @@
 //! Matrix user identifiers.
 
-use std::{convert::TryFrom, num::NonZeroU8};
+use core::{convert::TryFrom, num::NonZeroU8};
 
 use crate::{error::Error, parse_id, ServerNameRef};
 
@@ -13,7 +13,7 @@ use crate::{error::Error, parse_id, ServerNameRef};
 /// `UserIdRef`) in the crate root.
 ///
 /// ```
-/// # use std::convert::TryFrom;
+/// # use core::convert::TryFrom;
 /// # use ruma_identifiers::UserId;
 /// assert_eq!(
 ///     UserId::try_from("@carl:example.com").unwrap().as_ref(),
@@ -32,14 +32,14 @@ pub struct UserId<T> {
     is_historical: bool,
 }
 
+#[cfg(feature = "rand")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
 impl<T> UserId<T>
 where
-    String: Into<T>,
+    alloc::string::String: Into<T>,
 {
     /// Attempts to generate a `UserId` for the given origin server with a localpart consisting of
     /// 12 random ASCII characters.
-    #[cfg(feature = "rand")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
     pub fn new(server_name: ServerNameRef<'_>) -> Self {
         use crate::generate_localpart;
 
@@ -153,7 +153,7 @@ pub fn localpart_is_fully_comforming(localpart: &str) -> Result<bool, Error> {
 
 #[cfg(test)]
 mod tests {
-    use std::convert::TryFrom;
+    use core::convert::TryFrom;
 
     #[cfg(feature = "serde")]
     use serde_json::{from_str, to_string};


### PR DESCRIPTION
Blocked on https://github.com/rust-lang/rfcs/pull/2832, ~~strum supporting `no_std` or replacing it~~.