### PR TITLE
Add membership_change method to stub and stripped state events

### DIFF
--- a/ruma-events-macros/src/event_enum.rs
+++ b/ruma-events-macros/src/event_enum.rs
@@ -218,7 +218,7 @@ fn to_event_path(name: &LitStr, struct_name: &Ident) -> TokenStream {
     let path = path.iter().map(|s| Ident::new(s, span));
 
     match struct_name.to_string().as_str() {
-        "MessageEvent" | "MessageEventStub" if *event_str == "m.room.redaction" => {
+        "MessageEvent" | "MessageEventStub" if name == "m.room.redaction" => {
             let redaction = if struct_name == "MessageEvent" {
                 quote! { RedactionEvent }
             } else {

--- a/ruma-events/src/enums.rs
+++ b/ruma-events/src/enums.rs
@@ -36,6 +36,7 @@ event_enum! {
         "m.call.invite",
         "m.call.hangup",
         "m.call.candidates",
+        "m.room.encrypted",
         "m.room.message",
         "m.room.message.feedback",
         "m.room.redaction",


### PR DESCRIPTION
Fix redaction event detection in event_enum! macro. Add encrypted event to AnyMessageEvent enum not sure if this is ok.