### PR TITLE
Use newly added AnyEphemeralRoomEventStub in sync response

### DIFF
--- a/ruma-client-api/src/r0/sync/sync_events.rs
+++ b/ruma-client-api/src/r0/sync/sync_events.rs
@@ -6,7 +6,7 @@ use js_int::UInt;
 use ruma_api::ruma_api;
 use ruma_common::presence::PresenceState;
 use ruma_events::{
-    presence::PresenceEvent, AnyBasicEvent, AnyEphemeralRoomEvent, AnyRoomEventStub,
+    presence::PresenceEvent, AnyBasicEvent, AnyEphemeralRoomEventStub, AnyRoomEventStub,
     AnyStateEventStub, AnyStrippedStateEventStub, AnyToDeviceEvent, EventJson,
 };
 use ruma_identifiers::{RoomId, UserId};
@@ -284,7 +284,7 @@ impl AccountData {
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Ephemeral {
     /// A list of events.
-    pub events: Vec<EventJson<AnyEphemeralRoomEvent>>,
+    pub events: Vec<EventJson<AnyEphemeralRoomEventStub>>,
 }
 
 impl Ephemeral {

--- a/ruma-events-macros/src/event_enum.rs
+++ b/ruma-events-macros/src/event_enum.rs
@@ -19,7 +19,8 @@ pub fn expand_event_enum(input: EventEnumInput) -> syn::Result<TokenStream> {
         || ident == "AnyEphemeralRoomEvent"
         || ident == "AnyBasicEvent";
 
-    let needs_event_stub = ident == "AnyStateEvent" || ident == "AnyMessageEvent";
+    let needs_event_stub =
+        ident == "AnyStateEvent" || ident == "AnyMessageEvent" || ident == "AnyEphemeralRoomEvent";
 
     let needs_stripped_event = ident == "AnyStateEvent";
 

--- a/ruma-events/src/lib.rs
+++ b/ruma-events/src/lib.rs
@@ -165,9 +165,9 @@ pub use self::{
     algorithm::Algorithm,
     enums::{
         AnyBasicEvent, AnyBasicEventContent, AnyEphemeralRoomEvent, AnyEphemeralRoomEventContent,
-        AnyEvent, AnyMessageEvent, AnyMessageEventContent, AnyMessageEventStub, AnyRoomEvent,
-        AnyRoomEventStub, AnyStateEvent, AnyStateEventContent, AnyStateEventStub,
-        AnyStrippedStateEventStub, AnyToDeviceEvent, AnyToDeviceEventContent,
+        AnyEphemeralRoomEventStub, AnyEvent, AnyMessageEvent, AnyMessageEventContent,
+        AnyMessageEventStub, AnyRoomEvent, AnyRoomEventStub, AnyStateEvent, AnyStateEventContent,
+        AnyStateEventStub, AnyStrippedStateEventStub, AnyToDeviceEvent, AnyToDeviceEventContent,
     },
     error::{FromStrError, InvalidInput},
     event_kinds::{


### PR DESCRIPTION
In a real (looking at mitmproxy logs from rumatui) sync response I noticed this never has a room_id field.