### PR TITLE
Make ruma-identifier types DSTs

### DIFF
--- a/ruma-identifiers/Cargo.toml
+++ b/ruma-identifiers/Cargo.toml
@@ -23,6 +23,7 @@ default = ["serde"]
 either = { version = "1.5.3", optional = true }
 rand = { version = "0.7.3", optional = true }
 serde = { version = "1.0.113", optional = true, features = ["derive"] }
+slice-dst = { version = "1.5.1", default-features = false }
 strum = { version = "0.18.0", features = ["derive"] }
 
 [dev-dependencies]

--- a/ruma-identifiers/src/lib.rs
+++ b/ruma-identifiers/src/lib.rs
@@ -13,15 +13,16 @@ use std::{convert::TryFrom, num::NonZeroU8};
 use serde::de::{self, Deserialize as _, Deserializer, Unexpected};
 
 #[doc(inline)]
-pub use crate::error::Error;
+pub use crate::{device_key_id::DeviceKeyId, error::Error};
 
 #[macro_use]
 mod macros;
 
+mod device_key_id;
 mod error;
+mod util;
 
 pub mod device_id;
-pub mod device_key_id;
 pub mod event_id;
 pub mod key_algorithms;
 pub mod room_alias_id;
@@ -35,18 +36,6 @@ pub mod user_id;
 
 /// Allowed algorithms for homeserver signing keys.
 pub type DeviceKeyAlgorithm = key_algorithms::DeviceKeyAlgorithm;
-
-/// An owned device key identifier containing a key algorithm and device ID.
-///
-/// Can be created via `TryFrom<String>` and `TryFrom<&str>`; implements `Serialize`
-/// and `Deserialize` if the `serde` feature is enabled.
-pub type DeviceKeyId = device_key_id::DeviceKeyId<Box<str>>;
-
-/// A reference to a device key identifier containing a key algorithm and device ID.
-///
-/// Can be created via `TryFrom<&str>`; implements `Serialize` and `Deserialize`
-/// if the `serde` feature is enabled.
-pub type DeviceKeyIdRef<'a> = device_key_id::DeviceKeyId<&'a str>;
 
 /// An owned device ID.
 ///

--- a/ruma-identifiers/src/util.rs
+++ b/ruma-identifiers/src/util.rs
@@ -1,0 +1,6 @@
+use std::num::NonZeroU8;
+
+#[derive(Clone, Copy, Debug)]
+pub struct CommonIdentHeader {
+    pub colon_idx: NonZeroU8,
+}


### PR DESCRIPTION
Compared to what we had in ruma-identifiers 0.16, this would mean:

* The owned variant of an identifier type becomes `Box<SomeId>` from just `SomeId`
* Borrowed identifiers are references to `[size, metadata, characters]` rather than references to `[metadata, boxed string slice]` where the boxed string slice is again a reference / pointer to `[size, characters]`. Effectively, we have less indirection.

Compared to what's currently on master,

* There's no more type aliases and our identifier types are not generic
* Creating an identifier type from an existing string (slice) now allocates

Does this sound like something we want? @iinuwa @florianjacob 