### PR TITLE
Skip serializing optional values on RoomEncryption

### DIFF
--- a/ruma-events/CHANGELOG.md
+++ b/ruma-events/CHANGELOG.md
@@ -16,6 +16,7 @@ Breaking changes:
 Improvements:
 
 * Add `room::MessageFormat` and `room::FormattedBody`
+* Skip serialization of optional values on `room::encryption::EncryptionEventContent`
 
 Deprecations:
 

--- a/ruma-events/src/room/encryption.rs
+++ b/ruma-events/src/room/encryption.rs
@@ -21,10 +21,12 @@ pub struct EncryptionEventContent {
     /// How long the session should be used before changing it.
     ///
     /// 604800000 (a week) is the recommended default.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub rotation_period_ms: Option<UInt>,
 
     /// How many messages should be sent before changing the session.
     ///
     /// 100 is the recommended default.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub rotation_period_msgs: Option<UInt>,
 }


### PR DESCRIPTION
If this parameters are not skipped, they are sent as null and some
clients (at least, Riot) coerces them to 0.