### PR TITLE
Add field accessor code-gen for the event_enum! macro

### DIFF
--- a/ruma-events-macros/src/event_names.rs
+++ b/ruma-events-macros/src/event_names.rs
@@ -7,8 +7,7 @@ pub const ANY_STATE_EVENT: &str = "AnyStateEvent";
 
 pub const ANY_SYNC_STATE_EVENT: &str = "AnyStateEventStub";
 
-// This is not currently used because of negation used in `has_sender`
-// pub const ANY_STRIPPED_STATE_EVENT: &str = "AnyStrippedStateEventStub";
+pub const ANY_STRIPPED_STATE_EVENT: &str = "AnyStrippedStateEventStub";
 
 // Message events
 pub const ANY_MESSAGE_EVENT: &str = "AnyMessageEvent";
@@ -18,6 +17,8 @@ pub const ANY_SYNC_MESSAGE_EVENT: &str = "AnyMessageEventStub";
 // Ephemeral events
 pub const ANY_EPHEMERAL_EVENT: &str = "AnyEphemeralRoomEvent";
 
+#[allow(dead_code)]
+// This is currently not used but, left for completeness sake.
 pub const ANY_SYNC_EPHEMERAL_EVENT: &str = "AnyEphemeralRoomEventStub";
 
 // Basic event

--- a/ruma-events-macros/src/event_names.rs
+++ b/ruma-events-macros/src/event_names.rs
@@ -1,0 +1,27 @@
+//! The names of the `Any*Event` enums. The event_enum! macro uses these names to generate
+//! certain code for certain enums. If the names change this is the one source of truth,
+//! most comparisons and branching uses these constants.
+
+// State events
+pub const ANY_STATE_EVENT: &str = "AnyStateEvent";
+
+pub const ANY_SYNC_STATE_EVENT: &str = "AnyStateEventStub";
+
+// This is not currently used because of negation used in `has_sender`
+// pub const ANY_STRIPPED_STATE_EVENT: &str = "AnyStrippedStateEventStub";
+
+// Message events
+pub const ANY_MESSAGE_EVENT: &str = "AnyMessageEvent";
+
+pub const ANY_SYNC_MESSAGE_EVENT: &str = "AnyMessageEventStub";
+
+// Ephemeral events
+pub const ANY_EPHEMERAL_EVENT: &str = "AnyEphemeralRoomEvent";
+
+pub const ANY_SYNC_EPHEMERAL_EVENT: &str = "AnyEphemeralRoomEventStub";
+
+// Basic event
+pub const ANY_BASIC_EVENT: &str = "AnyBasicEvent";
+
+// To device event
+pub const ANY_TO_DEVICE_EVENT: &str = "AnyToDeviceEvent";

--- a/ruma-events-macros/src/lib.rs
+++ b/ruma-events-macros/src/lib.rs
@@ -22,6 +22,7 @@ use self::{
 mod event;
 mod event_content;
 mod event_enum;
+mod event_names;
 
 /// Generates an enum to represent the various Matrix event types.
 ///


### PR DESCRIPTION
There are 9 events kinds so I could switch the `if/else` blocks of anyone that has more than 4 `||`? that may shorten it some. Not sure what the best way to go about this is.