### PR TITLE
Add #[ruma_api(body)] attr to get_room_event endpoint

### DIFF
--- a/ruma-client-api/CHANGELOG.md
+++ b/ruma-client-api/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Bug fixes:
 
+* Fix deserialization of `r0::room::get_room_event::Response`
 * More missing fields in `r0::sync::sync_events::Response` can be deserialized
 
 Breaking changes:

--- a/ruma-client-api/src/r0/room/get_room_event.rs
+++ b/ruma-client-api/src/r0/room/get_room_event.rs
@@ -26,6 +26,7 @@ ruma_api! {
 
     response {
         /// Arbitrary JSON of the event body. Returns both room and state events.
+        #[ruma_api(body)]
         pub event: EventJson<AnyRoomEvent>,
     }
 


### PR DESCRIPTION
https://matrix.org/docs/spec/client_server/r0.6.0#get-matrix-client-r0-rooms-roomid-event-eventid

Was our fix correct?