### PR TITLE
Add guard in ruma_api! macro for non-ASCII in path

### DIFF
--- a/ruma-api-macros/src/api.rs
+++ b/ruma-api-macros/src/api.rs
@@ -269,7 +269,7 @@ impl ToTokens for Api {
                     *http_request.uri_mut() = ruma_api::exports::http::uri::Builder::new()
                         .path_and_query(path_and_query.as_str())
                         .build()
-                        // The ruma_api! macro guards against invalid path input but, if there are
+                        // The ruma_api! macro guards against invalid path input, but if there are
                         // invalid (non ASCII) bytes in the fields with the query attribute this will panic.
                         .unwrap();
 

--- a/ruma-api-macros/src/api.rs
+++ b/ruma-api-macros/src/api.rs
@@ -269,8 +269,8 @@ impl ToTokens for Api {
                     *http_request.uri_mut() = ruma_api::exports::http::uri::Builder::new()
                         .path_and_query(path_and_query.as_str())
                         .build()
-                        // The only way this can fail is if the path given in the API definition is
-                        // invalid. It is okay to panic in that case.
+                        // The ruma_api! macro guards against invalid path input but, if there are
+                        // invalid (non ASCII) bytes in the fields with the query attribute this will panic.
                         .unwrap();
 
                     { #add_headers_to_request }

--- a/ruma-api-macros/src/api/metadata.rs
+++ b/ruma-api-macros/src/api/metadata.rs
@@ -61,7 +61,7 @@ impl TryFrom<RawMetadata> for Metadata {
                 },
                 "path" => match expr {
                     Expr::Lit(ExprLit { lit: Lit::Str(literal), .. }) => {
-                        if !util::is_printable(&literal.value()) {
+                        if !util::is_ascii_printable(&literal.value()) {
                             return Err(syn::Error::new_spanned(
                                 literal,
                                 "path may only contain printable ASCII characters",

--- a/ruma-api-macros/src/api/metadata.rs
+++ b/ruma-api-macros/src/api/metadata.rs
@@ -61,10 +61,11 @@ impl TryFrom<RawMetadata> for Metadata {
                 },
                 "path" => match expr {
                     Expr::Lit(ExprLit { lit: Lit::Str(literal), .. }) => {
-                        if !util::is_ascii_printable(&literal.value()) {
+                        let path_str = literal.value();
+                        if !util::is_ascii_printable(&path_str) || path_str.contains(' ') {
                             return Err(syn::Error::new_spanned(
                                 literal,
-                                "path may only contain printable ASCII characters",
+                                "path may only contain printable ASCII characters with no spaces",
                             ));
                         }
                         path = Some(literal);

--- a/ruma-api-macros/src/api/metadata.rs
+++ b/ruma-api-macros/src/api/metadata.rs
@@ -61,6 +61,12 @@ impl TryFrom<RawMetadata> for Metadata {
                 },
                 "path" => match expr {
                     Expr::Lit(ExprLit { lit: Lit::Str(literal), .. }) => {
+                        if !literal.value().is_ascii() {
+                            return Err(syn::Error::new_spanned(
+                                literal,
+                                "path may only contain printable ASCII characters",
+                            ));
+                        }
                         path = Some(literal);
                     }
                     _ => return Err(syn::Error::new_spanned(expr, "expected a string literal")),

--- a/ruma-api-macros/src/api/metadata.rs
+++ b/ruma-api-macros/src/api/metadata.rs
@@ -62,7 +62,7 @@ impl TryFrom<RawMetadata> for Metadata {
                 "path" => match expr {
                     Expr::Lit(ExprLit { lit: Lit::Str(literal), .. }) => {
                         let path_str = literal.value();
-                        if !util::is_ascii_printable(&path_str) || path_str.contains(' ') {
+                        if !util::is_valid_endpoint_path(&path_str) {
                             return Err(syn::Error::new_spanned(
                                 literal,
                                 "path may only contain printable ASCII characters with no spaces",

--- a/ruma-api-macros/src/api/metadata.rs
+++ b/ruma-api-macros/src/api/metadata.rs
@@ -4,7 +4,7 @@ use std::convert::TryFrom;
 
 use syn::{Expr, ExprLit, ExprPath, Ident, Lit, LitBool, LitStr, Member};
 
-use crate::api::RawMetadata;
+use crate::{api::RawMetadata, util};
 
 /// The result of processing the `metadata` section of the macro.
 pub struct Metadata {
@@ -61,7 +61,7 @@ impl TryFrom<RawMetadata> for Metadata {
                 },
                 "path" => match expr {
                     Expr::Lit(ExprLit { lit: Lit::Str(literal), .. }) => {
-                        if !literal.value().is_ascii() {
+                        if !util::is_printable(&literal.value()) {
                             return Err(syn::Error::new_spanned(
                                 literal,
                                 "path may only contain printable ASCII characters",

--- a/ruma-api-macros/src/util.rs
+++ b/ruma-api-macros/src/util.rs
@@ -258,6 +258,6 @@ pub(crate) fn req_res_name_value<T>(
     Ok(field_kind)
 }
 
-pub(crate) fn is_ascii_printable(string: &str) -> bool {
-    string.as_bytes().iter().all(|b| (0x20..=0x7E).contains(b))
+pub(crate) fn is_valid_endpoint_path(string: &str) -> bool {
+    string.as_bytes().iter().all(|b| (0x21..=0x7E).contains(b))
 }

--- a/ruma-api-macros/src/util.rs
+++ b/ruma-api-macros/src/util.rs
@@ -258,10 +258,6 @@ pub(crate) fn req_res_name_value<T>(
     Ok(field_kind)
 }
 
-fn is_ascii_printable(b: &u8) -> bool {
-    b.wrapping_sub(b' ') < 0x5F
-}
-
-pub(crate) fn is_printable(string: &str) -> bool {
-    string.as_bytes().iter().all(is_ascii_printable)
+pub(crate) fn is_ascii_printable(string: &str) -> bool {
+    string.as_bytes().iter().all(|b| (0x20..=0x7E).contains(b))
 }

--- a/ruma-api-macros/src/util.rs
+++ b/ruma-api-macros/src/util.rs
@@ -257,3 +257,11 @@ pub(crate) fn req_res_name_value<T>(
     *header = Some(value);
     Ok(field_kind)
 }
+
+fn is_ascii_printable(b: &u8) -> bool {
+    b.wrapping_sub(b' ') < 0x5F
+}
+
+pub(crate) fn is_printable(string: &str) -> bool {
+    string.as_bytes().into_iter().all(is_ascii_printable)
+}

--- a/ruma-api-macros/src/util.rs
+++ b/ruma-api-macros/src/util.rs
@@ -263,5 +263,5 @@ fn is_ascii_printable(b: &u8) -> bool {
 }
 
 pub(crate) fn is_printable(string: &str) -> bool {
-    string.as_bytes().into_iter().all(is_ascii_printable)
+    string.as_bytes().iter().all(is_ascii_printable)
 }

--- a/ruma-api/tests/ruma_api.rs
+++ b/ruma-api/tests/ruma_api.rs
@@ -2,4 +2,5 @@
 fn ui() {
     let t = trybuild::TestCases::new();
     t.pass("tests/ui/01-api-sanity-check.rs");
+    t.compile_fail("tests/ui/02-invalid-path.rs");
 }

--- a/ruma-api/tests/ui/02-invalid-path.rs
+++ b/ruma-api/tests/ui/02-invalid-path.rs
@@ -5,7 +5,25 @@ ruma_api! {
         description: "This will fail.",
         method: GET,
         name: "invalid_path",
-        path: "µ / ° / § / €",
+        path: "µ/°/§/€",
+        rate_limited: false,
+        requires_authentication: false,
+    }
+
+    request: {
+        #[ruma_api(query_map)]
+        pub fields: Vec<(String, String)>,
+    }
+
+    response: { }
+}
+
+ruma_api! {
+    metadata: {
+        description: "This will fail.",
+        method: GET,
+        name: "invalid_path",
+        path: "path/to/invalid space/endpoint",
         rate_limited: false,
         requires_authentication: false,
     }

--- a/ruma-api/tests/ui/02-invalid-path.rs
+++ b/ruma-api/tests/ui/02-invalid-path.rs
@@ -5,7 +5,7 @@ ruma_api! {
         description: "Does something.",
         method: GET,
         name: "newtype_body_endpoint",
-        path: "/_matrix/some/query/map/\u{ffff}",
+        path: "µ / ° / § / €",
         rate_limited: false,
         requires_authentication: false,
     }

--- a/ruma-api/tests/ui/02-invalid-path.rs
+++ b/ruma-api/tests/ui/02-invalid-path.rs
@@ -1,0 +1,21 @@
+use ruma_api::ruma_api;
+
+ruma_api! {
+    metadata: {
+        description: "Does something.",
+        method: GET,
+        name: "newtype_body_endpoint",
+        path: "/_matrix/some/query/map/\u{ffff}",
+        rate_limited: false,
+        requires_authentication: false,
+    }
+
+    request: {
+        #[ruma_api(query_map)]
+        pub fields: Vec<(String, String)>,
+    }
+
+    response: { }
+}
+
+fn main() {}

--- a/ruma-api/tests/ui/02-invalid-path.rs
+++ b/ruma-api/tests/ui/02-invalid-path.rs
@@ -2,9 +2,9 @@ use ruma_api::ruma_api;
 
 ruma_api! {
     metadata: {
-        description: "Does something.",
+        description: "This will fail.",
         method: GET,
-        name: "newtype_body_endpoint",
+        name: "invalid_path",
         path: "µ / ° / § / €",
         rate_limited: false,
         requires_authentication: false,

--- a/ruma-api/tests/ui/02-invalid-path.stderr
+++ b/ruma-api/tests/ui/02-invalid-path.stderr
@@ -1,5 +1,11 @@
-error: path may only contain printable ASCII characters
+error: path may only contain printable ASCII characters with no spaces
  --> $DIR/02-invalid-path.rs:8:15
   |
-8 |         path: "µ / ° / § / €",
-  |               ^^^^^^^^^^^^^^^
+8 |         path: "µ/°/§/€",
+  |               ^^^^^^^^^
+
+error: path may only contain printable ASCII characters with no spaces
+  --> $DIR/02-invalid-path.rs:26:15
+   |
+26 |         path: "path/to/invalid space/endpoint",
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/ruma-api/tests/ui/02-invalid-path.stderr
+++ b/ruma-api/tests/ui/02-invalid-path.stderr
@@ -1,0 +1,5 @@
+error: path may only contain printable ASCII characters
+ --> $DIR/02-invalid-path.rs:8:15
+  |
+8 |         path: "/_matrix/some/query/map/\u{ffff}",
+  |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/ruma-api/tests/ui/02-invalid-path.stderr
+++ b/ruma-api/tests/ui/02-invalid-path.stderr
@@ -1,5 +1,5 @@
 error: path may only contain printable ASCII characters
  --> $DIR/02-invalid-path.rs:8:15
   |
-8 |         path: "/_matrix/some/query/map/\u{ffff}",
-  |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+8 |         path: "µ / ° / § / €",
+  |               ^^^^^^^^^^^^^^^


### PR DESCRIPTION
Returns a compiler error if any non-ASCII characters are found. Add trybuild test for invalid path characters.