### PR TITLE
Properly serialize `get_tags` Response

### DIFF
--- a/ruma-client-api/CHANGELOG.md
+++ b/ruma-client-api/CHANGELOG.md
@@ -3,6 +3,7 @@
 Bug fixes:
 
 * More missing fields in `r0::sync::sync_events::Response` can be deserialized
+* Fix `get_tags::Response` serialization
 
 Breaking changes:
 

--- a/ruma-client-api/src/r0/tag/get_tags.rs
+++ b/ruma-client-api/src/r0/tag/get_tags.rs
@@ -1,7 +1,7 @@
 //! [GET /_matrix/client/r0/user/{userId}/rooms/{roomId}/tags](https://matrix.org/docs/spec/client_server/r0.6.0#get-matrix-client-r0-user-userid-rooms-roomid-tags)
 
 use ruma_api::ruma_api;
-use ruma_events::{tag::Tags};
+use ruma_events::tag::Tags;
 use ruma_identifiers::{RoomId, UserId};
 
 ruma_api! {
@@ -37,25 +37,20 @@ mod tests {
     use serde_json::json;
 
     use super::Response;
-    use ruma_events::tag::{Tags, TagInfo};
+    use ruma_events::tag::{TagInfo, Tags};
     use std::convert::TryFrom;
 
     #[test]
     fn test_serializing_get_tags_response() {
         let mut tags = Tags::new();
-        tags.insert("m.favourite".to_string(), TagInfo {
-            order: Some(0.25),
-        });
-        tags.insert("u.user_tag".to_string(), TagInfo {
-            order: Some(0.11),
-        });
-        let response = Response {
-            tags,
-        };
+        tags.insert("m.favourite".to_string(), TagInfo { order: Some(0.25) });
+        tags.insert("u.user_tag".to_string(), TagInfo { order: Some(0.11) });
+        let response = Response { tags };
 
         let http_response = http::Response::<Vec<u8>>::try_from(response).unwrap();
 
-        let json_response: serde_json::Value = serde_json::from_slice(http_response.body()).unwrap();
+        let json_response: serde_json::Value =
+            serde_json::from_slice(http_response.body()).unwrap();
         assert_eq!(
             json_response,
             json!({

--- a/ruma-client-api/src/r0/tag/get_tags.rs
+++ b/ruma-client-api/src/r0/tag/get_tags.rs
@@ -1,7 +1,7 @@
 //! [GET /_matrix/client/r0/user/{userId}/rooms/{roomId}/tags](https://matrix.org/docs/spec/client_server/r0.6.0#get-matrix-client-r0-user-userid-rooms-roomid-tags)
 
 use ruma_api::ruma_api;
-use ruma_events::{tag::TagEventContent, EventJson};
+use ruma_events::{tag::Tags};
 use ruma_identifiers::{RoomId, UserId};
 
 ruma_api! {
@@ -26,8 +26,48 @@ ruma_api! {
 
     response {
         /// The user's tags for the room.
-        pub tags: EventJson<TagEventContent>,
+        pub tags: Tags,
     }
 
     error: crate::Error
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::Response;
+    use ruma_events::tag::{Tags, TagInfo};
+    use std::convert::TryFrom;
+
+    #[test]
+    fn test_serializing_get_tags_response() {
+        let mut tags = Tags::new();
+        tags.insert("m.favourite".to_string(), TagInfo {
+            order: Some(0.25),
+        });
+        tags.insert("u.user_tag".to_string(), TagInfo {
+            order: Some(0.11),
+        });
+        let response = Response {
+            tags,
+        };
+
+        let http_response = http::Response::<Vec<u8>>::try_from(response).unwrap();
+
+        let json_response: serde_json::Value = serde_json::from_slice(http_response.body()).unwrap();
+        assert_eq!(
+            json_response,
+            json!({
+                "tags": {
+                    "m.favourite": {
+                        "order": 0.25,
+                    },
+                    "u.user_tag": {
+                        "order": 0.11,
+                    }
+                }
+            })
+        );
+    }
 }

--- a/ruma-events/src/tag.rs
+++ b/ruma-events/src/tag.rs
@@ -9,13 +9,15 @@ use crate::BasicEvent;
 
 /// Informs the client of tags on a room.
 pub type TagEvent = BasicEvent<TagEventContent>;
+/// Map of tag names to tag info.
+pub type Tags = BTreeMap<String, TagInfo>;
 
 /// The payload for `TagEvent`.
 #[derive(Clone, Debug, Deserialize, Serialize, BasicEventContent)]
 #[ruma_event(type = "m.tag")]
 pub struct TagEventContent {
     /// A map of tag names to tag info.
-    pub tags: BTreeMap<String, TagInfo>,
+    pub tags: Tags,
 }
 
 /// Information about a tag.


### PR DESCRIPTION
`get_tags` route response was adding the `tags` property twice, which is
not the expected behaviour. This is an example of the current
serialzation of the `get_tags` route.

```{"tags":{"tags":{"u.example":{"order":0.55},"u.another":{"order":0.11}}}}```

The new serialization removes the first `tags` property.