### PR TITLE
Add variant for events that have been redacted

### DIFF
--- a/ruma-events/src/lib.rs
+++ b/ruma-events/src/lib.rs
@@ -255,6 +255,10 @@ pub struct EventDeHelper {
     /// If no `event_id` or `state_key` are found but a `room_id` is present
     /// the event will be deserialized as a ephemeral event.
     pub room_id: Option<IgnoredAny>,
+
+    /// If this `UnsignedData` contains a redacted_because key the event is
+    /// immediately deserialized as a redacted event.
+    pub unsigned: Option<UnsignedData>,
 }
 
 /// Helper function for serde_json::value::RawValue deserialization.

--- a/ruma-events/src/room/redaction.rs
+++ b/ruma-events/src/room/redaction.rs
@@ -86,8 +86,8 @@ pub struct RedactedContent {
     pub reason: Option<String>,
 
     // TODO how do we want to handle this...
-    /// The keys that are allowed to be kept inside of the `content` field
-    /// from the original event.
+    /// The keys that are allowed to remain inside of the `content` field
+    /// after the original event has been redacted.
     #[serde(flatten)]
     pub left_over_keys: BTreeMap<String, JsonValue>,
 }
@@ -119,81 +119,3 @@ impl ruma_events::BasicEventContent for RedactedContent {}
 impl ruma_events::MessageEventContent for RedactedContent {}
 
 impl ruma_events::StateEventContent for RedactedContent {}
-
-#[cfg(test)]
-mod tests {
-    use std::{
-        convert::TryFrom,
-        time::{Duration, UNIX_EPOCH},
-    };
-
-    use matches::assert_matches;
-    use ruma_identifiers::{EventId, RoomId, UserId};
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
-
-    use super::{RedactionEvent, RedactionEventContent};
-    use crate::{EventJson, UnsignedData};
-
-    #[test]
-    fn serialization() {
-        let event = RedactionEvent {
-            content: RedactionEventContent { reason: Some("redacted because".into()) },
-            redacts: EventId::try_from("$h29iv0s8:example.com").unwrap(),
-            event_id: EventId::try_from("$h29iv0s8:example.com").unwrap(),
-            origin_server_ts: UNIX_EPOCH + Duration::from_millis(1),
-            room_id: RoomId::try_from("!roomid:room.com").unwrap(),
-            sender: UserId::try_from("@carl:example.com").unwrap(),
-            unsigned: UnsignedData::default(),
-        };
-
-        let json = json!({
-            "content": {
-                "reason": "redacted because"
-            },
-            "event_id": "$h29iv0s8:example.com",
-            "origin_server_ts": 1,
-            "redacts": "$h29iv0s8:example.com",
-            "room_id": "!roomid:room.com",
-            "sender": "@carl:example.com",
-            "type": "m.room.redaction",
-        });
-
-        assert_eq!(to_json_value(&event).unwrap(), json);
-    }
-
-    #[test]
-    fn deserialization() {
-        let e_id = EventId::try_from("$h29iv0s8:example.com").unwrap();
-
-        let json = json!({
-            "content": {
-                "reason": "redacted because"
-            },
-            "event_id": "$h29iv0s8:example.com",
-            "origin_server_ts": 1,
-            "redacts": "$h29iv0s8:example.com",
-            "room_id": "!roomid:room.com",
-            "sender": "@carl:example.com",
-            "type": "m.room.redaction",
-        });
-
-        assert_matches!(
-            from_json_value::<EventJson<RedactionEvent>>(json)
-                .unwrap()
-                .deserialize()
-                .unwrap(),
-            RedactionEvent {
-                content: RedactionEventContent {
-                    reason: Some(reason),
-                },
-                sender,
-                event_id, origin_server_ts, redacts, room_id, unsigned,
-            } if reason == "redacted because" && redacts == e_id
-                && event_id == e_id
-                && sender == "@carl:example.com"
-                && origin_server_ts == UNIX_EPOCH + Duration::from_millis(1)
-                && room_id == RoomId::try_from("!roomid:room.com").unwrap()
-                && unsigned.is_empty()
-        );
-    }
-}

--- a/ruma-events/tests/message_event.rs
+++ b/ruma-events/tests/message_event.rs
@@ -4,15 +4,138 @@ use std::{
 };
 
 use js_int::UInt;
+use maplit::btreemap;
 use matches::assert_matches;
 use ruma_events::{
     call::{answer::AnswerEventContent, SessionDescription, SessionDescriptionType},
-    room::{ImageInfo, ThumbnailInfo},
+    room::{
+        redaction::{RedactedContent, RedactionEvent, RedactionEventContent},
+        ImageInfo, ThumbnailInfo,
+    },
     sticker::StickerEventContent,
-    AnyMessageEventContent, EventJson, MessageEvent, UnsignedData,
+    AnyMessageEventContent, AnyMessageEventStub, AnyRoomEventStub, EventJson, MessageEvent,
+    MessageEventStub, UnsignedData,
 };
 use ruma_identifiers::{EventId, RoomId, UserId};
 use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+
+#[test]
+fn redaction_serialize() {
+    let left_over_keys = btreemap! {
+        "None".to_string() => json!("of message events keys survive"),
+    };
+    let redacted = MessageEventStub {
+        content: RedactedContent {
+            event_type: "m.room.message".to_string(),
+            reason: Some("who cares".to_string()),
+            left_over_keys,
+        },
+        event_id: EventId::try_from("$h29iv0s8:example.com").unwrap(),
+        origin_server_ts: UNIX_EPOCH + Duration::from_millis(1),
+        sender: UserId::try_from("@carl:example.com").unwrap(),
+        unsigned: UnsignedData::default(),
+    };
+
+    let expected = json!({
+      "content": {
+        "None": "of message events keys survive",
+        "reason": "who cares"
+      },
+      "event_id": "$h29iv0s8:example.com",
+      "origin_server_ts": 1,
+      "sender": "@carl:example.com",
+      "type": "m.room.message"
+    });
+
+    let actual = to_json_value(&redacted).unwrap();
+    println!("{}", serde_json::to_string_pretty(&actual).unwrap());
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn redaction_deserialize_any_room_stub() {
+    let mut unsigned = UnsignedData::default();
+    // The presence of `redacted_because` triggers the event enum (AnyRoomEventStub in this case)
+    // to return early with `RedactedContent` instead of failing to deserialize itself according
+    // to the event type string
+    unsigned.redacted_because = Some(EventJson::from(RedactionEvent {
+        content: RedactionEventContent { reason: Some("redacted because".into()) },
+        redacts: EventId::try_from("$h29iv0s8:example.com").unwrap(),
+        event_id: EventId::try_from("$h29iv0s8:example.com").unwrap(),
+        origin_server_ts: UNIX_EPOCH + Duration::from_millis(1),
+        room_id: RoomId::try_from("!roomid:room.com").unwrap(),
+        sender: UserId::try_from("@carl:example.com").unwrap(),
+        unsigned: UnsignedData::default(),
+    }));
+
+    let redacted = MessageEventStub {
+        content: RedactedContent {
+            event_type: "m.room.message".to_string(),
+            reason: Some("who cares".to_string()),
+            left_over_keys: btreemap! {
+                "None".to_string() => json!("of message events keys survive"),
+            },
+        },
+        event_id: EventId::try_from("$h29iv0s8:example.com").unwrap(),
+        origin_server_ts: UNIX_EPOCH + Duration::from_millis(1),
+        sender: UserId::try_from("@carl:example.com").unwrap(),
+        unsigned,
+    };
+
+    let actual = to_json_value(&redacted).unwrap();
+
+    assert_matches!(
+        from_json_value::<EventJson<AnyRoomEventStub>>(actual)
+            .unwrap()
+            .deserialize()
+            .unwrap(),
+        AnyRoomEventStub::Message(AnyMessageEventStub::IsRedacted(MessageEventStub {
+            event_id, content, unsigned, ..
+        })) if event_id == redacted.event_id && content.reason == redacted.content.reason
+            && unsigned.age == redacted.unsigned.age
+    )
+}
+
+#[test]
+fn redaction_deserialize_to_event_kind() {
+    let mut unsigned = UnsignedData::default();
+    unsigned.redacted_because = Some(EventJson::from(RedactionEvent {
+        content: RedactionEventContent { reason: Some("redacted because".into()) },
+        redacts: EventId::try_from("$h29iv0s8:example.com").unwrap(),
+        event_id: EventId::try_from("$h29iv0s8:example.com").unwrap(),
+        origin_server_ts: UNIX_EPOCH + Duration::from_millis(1),
+        room_id: RoomId::try_from("!roomid:room.com").unwrap(),
+        sender: UserId::try_from("@carl:example.com").unwrap(),
+        unsigned: UnsignedData::default(),
+    }));
+
+    let redacted = MessageEventStub {
+        content: RedactedContent {
+            event_type: "m.room.message".to_string(),
+            reason: Some("who cares".to_string()),
+            left_over_keys: btreemap! {
+                "None".to_string() => json!("of message events keys survive"),
+            },
+        },
+        event_id: EventId::try_from("$h29iv0s8:example.com").unwrap(),
+        origin_server_ts: UNIX_EPOCH + Duration::from_millis(1),
+        sender: UserId::try_from("@carl:example.com").unwrap(),
+        unsigned,
+    };
+
+    let actual = to_json_value(&redacted).unwrap();
+
+    assert_matches!(
+        from_json_value::<EventJson<MessageEventStub<RedactedContent>>>(actual)
+            .unwrap()
+            .deserialize()
+            .unwrap(),
+        MessageEventStub {
+            event_id, content, unsigned, ..
+        } if event_id == redacted.event_id && content.reason == redacted.content.reason
+            && unsigned.age == redacted.unsigned.age
+    )
+}
 
 #[test]
 fn message_serialize_sticker() {

--- a/ruma-events/tests/message_event.rs
+++ b/ruma-events/tests/message_event.rs
@@ -4,138 +4,15 @@ use std::{
 };
 
 use js_int::UInt;
-use maplit::btreemap;
 use matches::assert_matches;
 use ruma_events::{
     call::{answer::AnswerEventContent, SessionDescription, SessionDescriptionType},
-    room::{
-        redaction::{RedactedContent, RedactionEvent, RedactionEventContent},
-        ImageInfo, ThumbnailInfo,
-    },
+    room::{ImageInfo, ThumbnailInfo},
     sticker::StickerEventContent,
-    AnyMessageEventContent, AnyMessageEventStub, AnyRoomEventStub, EventJson, MessageEvent,
-    MessageEventStub, UnsignedData,
+    AnyMessageEventContent, EventJson, MessageEvent, UnsignedData,
 };
 use ruma_identifiers::{EventId, RoomId, UserId};
 use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
-
-#[test]
-fn redaction_serialize() {
-    let left_over_keys = btreemap! {
-        "None".to_string() => json!("of message events keys survive"),
-    };
-    let redacted = MessageEventStub {
-        content: RedactedContent {
-            event_type: "m.room.message".to_string(),
-            reason: Some("who cares".to_string()),
-            left_over_keys,
-        },
-        event_id: EventId::try_from("$h29iv0s8:example.com").unwrap(),
-        origin_server_ts: UNIX_EPOCH + Duration::from_millis(1),
-        sender: UserId::try_from("@carl:example.com").unwrap(),
-        unsigned: UnsignedData::default(),
-    };
-
-    let expected = json!({
-      "content": {
-        "None": "of message events keys survive",
-        "reason": "who cares"
-      },
-      "event_id": "$h29iv0s8:example.com",
-      "origin_server_ts": 1,
-      "sender": "@carl:example.com",
-      "type": "m.room.message"
-    });
-
-    let actual = to_json_value(&redacted).unwrap();
-    println!("{}", serde_json::to_string_pretty(&actual).unwrap());
-    assert_eq!(actual, expected);
-}
-
-#[test]
-fn redaction_deserialize_any_room_stub() {
-    let mut unsigned = UnsignedData::default();
-    // The presence of `redacted_because` triggers the event enum (AnyRoomEventStub in this case)
-    // to return early with `RedactedContent` instead of failing to deserialize itself according
-    // to the event type string
-    unsigned.redacted_because = Some(EventJson::from(RedactionEvent {
-        content: RedactionEventContent { reason: Some("redacted because".into()) },
-        redacts: EventId::try_from("$h29iv0s8:example.com").unwrap(),
-        event_id: EventId::try_from("$h29iv0s8:example.com").unwrap(),
-        origin_server_ts: UNIX_EPOCH + Duration::from_millis(1),
-        room_id: RoomId::try_from("!roomid:room.com").unwrap(),
-        sender: UserId::try_from("@carl:example.com").unwrap(),
-        unsigned: UnsignedData::default(),
-    }));
-
-    let redacted = MessageEventStub {
-        content: RedactedContent {
-            event_type: "m.room.message".to_string(),
-            reason: Some("who cares".to_string()),
-            left_over_keys: btreemap! {
-                "None".to_string() => json!("of message events keys survive"),
-            },
-        },
-        event_id: EventId::try_from("$h29iv0s8:example.com").unwrap(),
-        origin_server_ts: UNIX_EPOCH + Duration::from_millis(1),
-        sender: UserId::try_from("@carl:example.com").unwrap(),
-        unsigned,
-    };
-
-    let actual = to_json_value(&redacted).unwrap();
-
-    assert_matches!(
-        from_json_value::<EventJson<AnyRoomEventStub>>(actual)
-            .unwrap()
-            .deserialize()
-            .unwrap(),
-        AnyRoomEventStub::Message(AnyMessageEventStub::IsRedacted(MessageEventStub {
-            event_id, content, unsigned, ..
-        })) if event_id == redacted.event_id && content.reason == redacted.content.reason
-            && unsigned.age == redacted.unsigned.age
-    )
-}
-
-#[test]
-fn redaction_deserialize_to_event_kind() {
-    let mut unsigned = UnsignedData::default();
-    unsigned.redacted_because = Some(EventJson::from(RedactionEvent {
-        content: RedactionEventContent { reason: Some("redacted because".into()) },
-        redacts: EventId::try_from("$h29iv0s8:example.com").unwrap(),
-        event_id: EventId::try_from("$h29iv0s8:example.com").unwrap(),
-        origin_server_ts: UNIX_EPOCH + Duration::from_millis(1),
-        room_id: RoomId::try_from("!roomid:room.com").unwrap(),
-        sender: UserId::try_from("@carl:example.com").unwrap(),
-        unsigned: UnsignedData::default(),
-    }));
-
-    let redacted = MessageEventStub {
-        content: RedactedContent {
-            event_type: "m.room.message".to_string(),
-            reason: Some("who cares".to_string()),
-            left_over_keys: btreemap! {
-                "None".to_string() => json!("of message events keys survive"),
-            },
-        },
-        event_id: EventId::try_from("$h29iv0s8:example.com").unwrap(),
-        origin_server_ts: UNIX_EPOCH + Duration::from_millis(1),
-        sender: UserId::try_from("@carl:example.com").unwrap(),
-        unsigned,
-    };
-
-    let actual = to_json_value(&redacted).unwrap();
-
-    assert_matches!(
-        from_json_value::<EventJson<MessageEventStub<RedactedContent>>>(actual)
-            .unwrap()
-            .deserialize()
-            .unwrap(),
-        MessageEventStub {
-            event_id, content, unsigned, ..
-        } if event_id == redacted.event_id && content.reason == redacted.content.reason
-            && unsigned.age == redacted.unsigned.age
-    )
-}
 
 #[test]
 fn message_serialize_sticker() {

--- a/ruma-events/tests/redacted.rs
+++ b/ruma-events/tests/redacted.rs
@@ -86,7 +86,7 @@ fn redacted_deserialize_any_room() {
         })) if event_id == EventId::try_from("$h29iv0s8:example.com").unwrap()
             && room_id == RoomId::try_from("!roomid:room.com").unwrap()
             && content.reason == Some("who cares".to_string())
-            && content.event_type == "m.room.message".to_string()
+            && content.event_type == "m.room.message"
     )
 }
 
@@ -129,7 +129,7 @@ fn redacted_deserialize_any_room_stub() {
             event_id, content, ..
         })) if event_id == EventId::try_from("$h29iv0s8:example.com").unwrap()
             && content.reason == Some("who cares".to_string())
-            && content.event_type == "m.room.message".to_string()
+            && content.event_type == "m.room.message"
     )
 }
 
@@ -167,6 +167,6 @@ fn redacted_deserialize_to_event_kind() {
             event_id, content, ..
         } if event_id == EventId::try_from("$h29iv0s8:example.com").unwrap()
             && content.reason == Some("who cares".to_string())
-            && content.event_type == "m.room.message".to_string()
+            && content.event_type == "m.room.message"
     )
 }

--- a/ruma-events/tests/redacted.rs
+++ b/ruma-events/tests/redacted.rs
@@ -1,0 +1,172 @@
+use std::{
+    convert::TryFrom,
+    time::{Duration, UNIX_EPOCH},
+};
+
+use maplit::btreemap;
+use matches::assert_matches;
+use ruma_events::{
+    room::redaction::{RedactedContent, RedactionEvent, RedactionEventContent},
+    AnyMessageEvent, AnyMessageEventStub, AnyRoomEvent, AnyRoomEventStub, EventJson, MessageEvent,
+    MessageEventStub, UnsignedData,
+};
+use ruma_identifiers::{EventId, RoomId, UserId};
+use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+
+#[test]
+fn redacted_serialize() {
+    let left_over_keys = btreemap! {
+        "None".to_string() => json!("of message events keys survive"),
+    };
+    let redacted = MessageEventStub {
+        content: RedactedContent {
+            event_type: "m.room.message".to_string(),
+            reason: Some("who cares".to_string()),
+            left_over_keys,
+        },
+        event_id: EventId::try_from("$h29iv0s8:example.com").unwrap(),
+        origin_server_ts: UNIX_EPOCH + Duration::from_millis(1),
+        sender: UserId::try_from("@carl:example.com").unwrap(),
+        unsigned: UnsignedData::default(),
+    };
+
+    let expected = json!({
+      "content": {
+        "None": "of message events keys survive",
+        "reason": "who cares"
+      },
+      "event_id": "$h29iv0s8:example.com",
+      "origin_server_ts": 1,
+      "sender": "@carl:example.com",
+      "type": "m.room.message"
+    });
+
+    let actual = to_json_value(&redacted).unwrap();
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn redacted_deserialize_any_room() {
+    let mut unsigned = UnsignedData::default();
+    // The presence of `redacted_because` triggers the event enum (AnyRoomEvent in this case)
+    // to return early with `RedactedContent` instead of failing to deserialize itself according
+    // to the event type string.
+    unsigned.redacted_because = Some(EventJson::from(RedactionEvent {
+        content: RedactionEventContent { reason: Some("redacted because".into()) },
+        redacts: EventId::try_from("$h29iv0s8:example.com").unwrap(),
+        event_id: EventId::try_from("$h29iv0s8:example.com").unwrap(),
+        origin_server_ts: UNIX_EPOCH + Duration::from_millis(1),
+        room_id: RoomId::try_from("!roomid:room.com").unwrap(),
+        sender: UserId::try_from("@carl:example.com").unwrap(),
+        unsigned: UnsignedData::default(),
+    }));
+
+    let redacted = json!({
+      "content": {
+        "None": "of message events keys survive",
+        "reason": "who cares"
+      },
+      "event_id": "$h29iv0s8:example.com",
+      "room_id": "!roomid:room.com",
+      "origin_server_ts": 1,
+      "sender": "@carl:example.com",
+      "unsigned": unsigned,
+      "type": "m.room.message"
+    });
+
+    let actual = to_json_value(&redacted).unwrap();
+
+    assert_matches!(
+        from_json_value::<EventJson<AnyRoomEvent>>(actual)
+            .unwrap()
+            .deserialize()
+            .unwrap(),
+        AnyRoomEvent::Message(AnyMessageEvent::IsRedacted(MessageEvent {
+            event_id, content, room_id, ..
+        })) if event_id == EventId::try_from("$h29iv0s8:example.com").unwrap()
+            && room_id == RoomId::try_from("!roomid:room.com").unwrap()
+            && content.reason == Some("who cares".to_string())
+            && content.event_type == "m.room.message".to_string()
+    )
+}
+
+#[test]
+fn redacted_deserialize_any_room_stub() {
+    let mut unsigned = UnsignedData::default();
+    // The presence of `redacted_because` triggers the event enum (AnyRoomEventStub in this case)
+    // to return early with `RedactedContent` instead of failing to deserialize itself according
+    // to the event type string.
+    unsigned.redacted_because = Some(EventJson::from(RedactionEvent {
+        content: RedactionEventContent { reason: Some("redacted because".into()) },
+        redacts: EventId::try_from("$h29iv0s8:example.com").unwrap(),
+        event_id: EventId::try_from("$h29iv0s8:example.com").unwrap(),
+        origin_server_ts: UNIX_EPOCH + Duration::from_millis(1),
+        room_id: RoomId::try_from("!roomid:room.com").unwrap(),
+        sender: UserId::try_from("@carl:example.com").unwrap(),
+        unsigned: UnsignedData::default(),
+    }));
+
+    let redacted = json!({
+      "content": {
+        "None": "of message events keys survive",
+        "reason": "who cares"
+      },
+      "event_id": "$h29iv0s8:example.com",
+      "origin_server_ts": 1,
+      "sender": "@carl:example.com",
+      "unsigned": unsigned,
+      "type": "m.room.message"
+    });
+
+    let actual = to_json_value(&redacted).unwrap();
+
+    assert_matches!(
+        from_json_value::<EventJson<AnyRoomEventStub>>(actual)
+            .unwrap()
+            .deserialize()
+            .unwrap(),
+        AnyRoomEventStub::Message(AnyMessageEventStub::IsRedacted(MessageEventStub {
+            event_id, content, ..
+        })) if event_id == EventId::try_from("$h29iv0s8:example.com").unwrap()
+            && content.reason == Some("who cares".to_string())
+            && content.event_type == "m.room.message".to_string()
+    )
+}
+
+#[test]
+fn redacted_deserialize_to_event_kind() {
+    let mut unsigned = UnsignedData::default();
+    unsigned.redacted_because = Some(EventJson::from(RedactionEvent {
+        content: RedactionEventContent { reason: Some("redacted because".into()) },
+        redacts: EventId::try_from("$h29iv0s8:example.com").unwrap(),
+        event_id: EventId::try_from("$h29iv0s8:example.com").unwrap(),
+        origin_server_ts: UNIX_EPOCH + Duration::from_millis(1),
+        room_id: RoomId::try_from("!roomid:room.com").unwrap(),
+        sender: UserId::try_from("@carl:example.com").unwrap(),
+        unsigned: UnsignedData::default(),
+    }));
+
+    let redacted = json!({
+      "content": {
+        "None": "of message events keys survive",
+        "reason": "who cares"
+      },
+      "event_id": "$h29iv0s8:example.com",
+      "origin_server_ts": 1,
+      "sender": "@carl:example.com",
+      "unsigned": unsigned,
+      "type": "m.room.message"
+    });
+
+    assert_matches!(
+        from_json_value::<EventJson<MessageEventStub<RedactedContent>>>(redacted)
+            .unwrap()
+            .deserialize()
+            .unwrap(),
+        MessageEventStub {
+            event_id, content, ..
+        } if event_id == EventId::try_from("$h29iv0s8:example.com").unwrap()
+            && content.reason == Some("who cares".to_string())
+            && content.event_type == "m.room.message".to_string()
+    )
+}


### PR DESCRIPTION
This adds a new content type `RedactedContent` that contains the reason field, the redacted events event type string, and a `BTreeMap<String, JsonValue>` for the few events that keep content keys. The `Any*Event` enums will return `Self::IsRedacted(Event)` early when an event with a redacted_because field is encountered.