### PR TITLE
Add get event auth endpoint

### DIFF
--- a/ruma-federation-api/CHANGELOG.md
+++ b/ruma-federation-api/CHANGELOG.md
@@ -8,6 +8,7 @@ Improvements:
 
 * Add endpoints:
     ```
+    authorization::get_event_authorization::v1,
     directory::get_public_rooms::v1,
     discovery::{
         discover_homeserver,

--- a/ruma-federation-api/src/authorization.rs
+++ b/ruma-federation-api/src/authorization.rs
@@ -1,0 +1,3 @@
+//! Endpoints to retrieve the complete auth chain for a given event.
+
+pub mod get_event_authorization;

--- a/ruma-federation-api/src/authorization/get_event_authorization/mod.rs
+++ b/ruma-federation-api/src/authorization/get_event_authorization/mod.rs
@@ -1,0 +1,2 @@
+//! Endpoint to retrieve the complete auth chain for a given event.
+pub mod v1;

--- a/ruma-federation-api/src/authorization/get_event_authorization/v1.rs
+++ b/ruma-federation-api/src/authorization/get_event_authorization/v1.rs
@@ -1,0 +1,32 @@
+//! [GET /_matrix/federation/v1/event_auth/{roomId}/{eventId}](https://matrix.org/docs/spec/server_server/r0.1.4#get-matrix-federation-v1-event-auth-roomid-eventid)
+
+use ruma_api::ruma_api;
+use ruma_events::pdu::Pdu;
+use ruma_identifiers::{EventId, RoomId};
+
+ruma_api! {
+    metadata: {
+        description: "Retrieves the complete auth chain for a given event.",
+        name: "get_event_authorization",
+        method: GET,
+        path: "/_matrix/federation/v1/event_auth/:room_id/:event_id",
+        rate_limited: false,
+        requires_authentication: true,
+    }
+
+    request: {
+        /// The room ID to get the auth chain for.
+        #[ruma_api(path)]
+        pub room_id: RoomId,
+
+        /// The event ID to get the auth chain for.
+        #[ruma_api(path)]
+        pub event_id: EventId,
+    }
+
+    response: {
+        /// The full set of authorization events that make up the state of the room,
+        /// and their authorization events, recursively.
+        pub auth_chain: Vec<Pdu>,
+    }
+}

--- a/ruma-federation-api/src/lib.rs
+++ b/ruma-federation-api/src/lib.rs
@@ -4,6 +4,7 @@
 
 mod serde;
 
+pub mod authorization;
 pub mod directory;
 pub mod discovery;
 pub mod membership;


### PR DESCRIPTION
Edit(jplatte): resolves #65

Let me know if the response is incorrect. It looks like the auth chain is just a `Vec` of `PDU`s, but I could be interpreting the docs wrong.

Also, wasn't sure if a new `authorization` directory was the best place to put this.