### PR TITLE
Revert making identifier types generic over the underlying string type

### DIFF
--- a/ruma-client-api/src/r0/account/register.rs
+++ b/ruma-client-api/src/r0/account/register.rs
@@ -35,7 +35,7 @@ ruma_api! {
         /// If this does not correspond to a known client device, a new device will be created.
         /// The server will auto-generate a device_id if this is not specified.
         #[serde(skip_serializing_if = "Option::is_none")]
-        pub device_id: Option<DeviceId>,
+        pub device_id: Option<Box<DeviceId>>,
 
         /// A display name to assign to the newly-created device.
         ///
@@ -78,7 +78,7 @@ ruma_api! {
         /// ID of the registered device.
         ///
         /// Will be the same as the corresponding parameter in the request, if one was specified.
-        pub device_id: Option<DeviceId>,
+        pub device_id: Option<Box<DeviceId>>,
     }
 
     error: UiaaResponse

--- a/ruma-client-api/src/r0/device.rs
+++ b/ruma-client-api/src/r0/device.rs
@@ -15,7 +15,7 @@ pub mod update_device;
 #[derive(Clone, Debug, Deserialize, Hash, PartialEq, Serialize)]
 pub struct Device {
     /// Device ID
-    pub device_id: DeviceId,
+    pub device_id: Box<DeviceId>,
 
     /// Public display name of the device.
     pub display_name: Option<String>,

--- a/ruma-client-api/src/r0/device/delete_device.rs
+++ b/ruma-client-api/src/r0/device/delete_device.rs
@@ -18,7 +18,7 @@ ruma_api! {
     request: {
         /// The device to delete.
         #[ruma_api(path)]
-        pub device_id: DeviceId,
+        pub device_id: Box<DeviceId>,
 
         /// Additional authentication information for the user-interactive authentication API.
         #[serde(skip_serializing_if = "Option::is_none")]

--- a/ruma-client-api/src/r0/device/delete_devices.rs
+++ b/ruma-client-api/src/r0/device/delete_devices.rs
@@ -17,7 +17,7 @@ ruma_api! {
 
     request: {
         /// List of devices to delete.
-        pub devices: Vec<DeviceId>,
+        pub devices: Vec<Box<DeviceId>>,
 
         /// Additional authentication information for the user-interactive authentication API.
         #[serde(skip_serializing_if = "Option::is_none")]

--- a/ruma-client-api/src/r0/device/get_device.rs
+++ b/ruma-client-api/src/r0/device/get_device.rs
@@ -17,7 +17,7 @@ ruma_api! {
     request: {
         /// The device to retrieve.
         #[ruma_api(path)]
-        pub device_id: DeviceId,
+        pub device_id: Box<DeviceId>,
     }
 
     response: {

--- a/ruma-client-api/src/r0/device/update_device.rs
+++ b/ruma-client-api/src/r0/device/update_device.rs
@@ -16,7 +16,7 @@ ruma_api! {
     request: {
         /// The device to update.
         #[ruma_api(path)]
-        pub device_id: DeviceId,
+        pub device_id: Box<DeviceId>,
 
         /// The new display name for this device. If this is `None`, the display name won't be
         /// changed.

--- a/ruma-client-api/src/r0/keys.rs
+++ b/ruma-client-api/src/r0/keys.rs
@@ -60,7 +60,7 @@ impl TryFrom<&'_ str> for KeyAlgorithm {
 
 /// A key algorithm and a device id, combined with a ':'
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct AlgorithmAndDeviceId(pub KeyAlgorithm, pub DeviceId);
+pub struct AlgorithmAndDeviceId(pub KeyAlgorithm, pub Box<DeviceId>);
 
 impl Display for AlgorithmAndDeviceId {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
@@ -102,7 +102,7 @@ impl<'de> Deserialize<'de> for AlgorithmAndDeviceId {
 
         let algorithm_result = KeyAlgorithm::try_from(parts[0]);
         match algorithm_result {
-            Ok(algorithm) => Ok(AlgorithmAndDeviceId(algorithm, parts[1].to_string())),
+            Ok(algorithm) => Ok(AlgorithmAndDeviceId(algorithm, parts[1].into())),
             Err(_) => {
                 Err(de::Error::invalid_value(Unexpected::Str(parts[0]), &"valid key algorithm"))
             }
@@ -117,7 +117,7 @@ pub struct DeviceKeys {
     pub user_id: UserId,
 
     /// The ID of the device these keys belong to. Must match the device ID used when logging in.
-    pub device_id: DeviceId,
+    pub device_id: Box<DeviceId>,
 
     /// The encryption algorithms supported by this device.
     pub algorithms: Vec<Algorithm>,

--- a/ruma-client-api/src/r0/keys/claim_keys.rs
+++ b/ruma-client-api/src/r0/keys/claim_keys.rs
@@ -31,7 +31,7 @@ ruma_api! {
         pub timeout: Option<Duration>,
 
         /// The keys to be claimed.
-        pub one_time_keys: BTreeMap<UserId, BTreeMap<DeviceId, KeyAlgorithm>>,
+        pub one_time_keys: BTreeMap<UserId, BTreeMap<Box<DeviceId>, KeyAlgorithm>>,
     }
 
     response: {
@@ -40,8 +40,11 @@ ruma_api! {
         pub failures: BTreeMap<String, JsonValue>,
 
         /// One-time keys for the queried devices.
-        pub one_time_keys: BTreeMap<UserId, BTreeMap<DeviceId, BTreeMap<AlgorithmAndDeviceId, OneTimeKey>>>,
+        pub one_time_keys: BTreeMap<UserId, OneTimeKeys>,
     }
 
     error: crate::Error
 }
+
+/// The one-time keys for a given device.
+pub type OneTimeKeys = BTreeMap<Box<DeviceId>, BTreeMap<AlgorithmAndDeviceId, OneTimeKey>>;

--- a/ruma-client-api/src/r0/keys/get_keys.rs
+++ b/ruma-client-api/src/r0/keys/get_keys.rs
@@ -30,7 +30,7 @@ ruma_api! {
 
         /// The keys to be downloaded. An empty list indicates all devices for
         /// the corresponding user.
-        pub device_keys: BTreeMap<UserId, Vec<DeviceId>>,
+        pub device_keys: BTreeMap<UserId, Vec<Box<DeviceId>>>,
 
         /// If the client is fetching keys as a result of a device update
         /// received in a sync request, this should be the 'since' token of that
@@ -48,7 +48,7 @@ ruma_api! {
         pub failures: BTreeMap<String, JsonValue>,
 
         /// Information on the queried devices.
-        pub device_keys: BTreeMap<UserId, BTreeMap<DeviceId, DeviceKeys>>,
+        pub device_keys: BTreeMap<UserId, BTreeMap<Box<DeviceId>, DeviceKeys>>,
     }
 
     error: crate::Error

--- a/ruma-client-api/src/r0/session/login.rs
+++ b/ruma-client-api/src/r0/session/login.rs
@@ -27,7 +27,7 @@ ruma_api! {
 
         /// ID of the client device
         #[serde(skip_serializing_if = "Option::is_none")]
-        pub device_id: Option<DeviceId>,
+        pub device_id: Option<Box<DeviceId>>,
 
         /// A display name to assign to the newly-created device. Ignored if device_id corresponds
         /// to a known device.

--- a/ruma-client-api/src/r0/to_device.rs
+++ b/ruma-client-api/src/r0/to_device.rs
@@ -17,7 +17,7 @@ pub mod send_event_to_device;
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum DeviceIdOrAllDevices {
     /// Represents a device Id for one of a user's devices.
-    DeviceId(DeviceId),
+    DeviceId(Box<DeviceId>),
 
     /// Represents all devices for a user.
     AllDevices,
@@ -40,7 +40,7 @@ impl TryFrom<&str> for DeviceIdOrAllDevices {
         } else if "*" == device_id_or_all_devices {
             Ok(DeviceIdOrAllDevices::AllDevices)
         } else {
-            Ok(DeviceIdOrAllDevices::DeviceId(device_id_or_all_devices.to_string()))
+            Ok(DeviceIdOrAllDevices::DeviceId(device_id_or_all_devices.into()))
         }
     }
 }

--- a/ruma-events/src/direct.rs
+++ b/ruma-events/src/direct.rs
@@ -38,7 +38,7 @@ impl DerefMut for DirectEventContent {
 mod tests {
     use std::{collections::BTreeMap, convert::TryFrom};
 
-    use ruma_identifiers::{RoomId, ServerNameRef, UserId};
+    use ruma_identifiers::{RoomId, ServerName, UserId};
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     use super::{DirectEvent, DirectEventContent};
@@ -47,7 +47,7 @@ mod tests {
     #[test]
     fn serialization() {
         let mut content = DirectEventContent(BTreeMap::new());
-        let server_name = ServerNameRef::try_from("ruma.io").unwrap();
+        let server_name = <&ServerName>::try_from("ruma.io").unwrap();
         let alice = UserId::new(server_name);
         let room = vec![RoomId::new(server_name)];
 
@@ -66,7 +66,7 @@ mod tests {
 
     #[test]
     fn deserialization() {
-        let server_name = ServerNameRef::try_from("ruma.io").unwrap();
+        let server_name = <&ServerName>::try_from("ruma.io").unwrap();
         let alice = UserId::new(server_name);
         let rooms = vec![RoomId::new(server_name), RoomId::new(server_name)];
 

--- a/ruma-events/src/key/verification/request.rs
+++ b/ruma-events/src/key/verification/request.rs
@@ -19,7 +19,7 @@ pub type RequestEvent = BasicEvent<RequestEventContent>;
 #[ruma_event(type = "m.key.verification.request")]
 pub struct RequestEventContent {
     /// The device ID which is initiating the request.
-    pub from_device: DeviceId,
+    pub from_device: Box<DeviceId>,
 
     /// An opaque identifier for the verification request.
     ///

--- a/ruma-events/src/key/verification/start.rs
+++ b/ruma-events/src/key/verification/start.rs
@@ -29,7 +29,7 @@ pub enum StartEventContent {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct MSasV1Content {
     /// The device ID which is initiating the process.
-    pub(crate) from_device: DeviceId,
+    pub(crate) from_device: Box<DeviceId>,
 
     /// An opaque identifier for the verification process.
     ///
@@ -63,7 +63,7 @@ pub struct MSasV1Content {
 #[derive(Clone, Debug, Deserialize)]
 pub struct MSasV1ContentOptions {
     /// The device ID which is initiating the process.
-    pub from_device: DeviceId,
+    pub from_device: Box<DeviceId>,
 
     /// An opaque identifier for the verification process.
     ///
@@ -270,7 +270,7 @@ mod tests {
                 key_agreement_protocols,
                 message_authentication_codes,
                 short_authentication_string,
-            }) if from_device == "123"
+            }) if from_device.as_ref() == "123"
                 && transaction_id == "456"
                 && hashes == vec![HashAlgorithm::Sha256]
                 && key_agreement_protocols == vec![KeyAgreementProtocol::Curve25519]
@@ -305,7 +305,7 @@ mod tests {
                     message_authentication_codes,
                     short_authentication_string,
                 })
-            } if from_device == "123"
+            } if from_device.as_ref() == "123"
                 && transaction_id == "456"
                 && hashes == vec![HashAlgorithm::Sha256]
                 && key_agreement_protocols == vec![KeyAgreementProtocol::Curve25519]

--- a/ruma-events/src/room/encrypted.rs
+++ b/ruma-events/src/room/encrypted.rs
@@ -60,7 +60,7 @@ pub struct MegolmV1AesSha2Content {
     pub sender_key: String,
 
     /// The ID of the sending device.
-    pub device_id: DeviceId,
+    pub device_id: Box<DeviceId>,
 
     /// The ID of the session used to encrypt the message.
     pub session_id: String,
@@ -117,7 +117,7 @@ mod tests {
                 session_id,
             }) if ciphertext == "ciphertext"
                 && sender_key == "sender_key"
-                && device_id == "device_id"
+                && device_id.as_ref() == "device_id"
                 && session_id == "session_id"
         );
     }

--- a/ruma-events/src/room/pinned_events.rs
+++ b/ruma-events/src/room/pinned_events.rs
@@ -24,7 +24,7 @@ mod tests {
         time::{Duration, UNIX_EPOCH},
     };
 
-    use ruma_identifiers::{EventId, RoomId, ServerNameRef, UserId};
+    use ruma_identifiers::{EventId, RoomId, ServerName, UserId};
     use serde_json::to_string;
 
     use super::PinnedEventsEventContent;
@@ -33,7 +33,7 @@ mod tests {
     #[test]
     fn serialization_deserialization() {
         let mut content: PinnedEventsEventContent = PinnedEventsEventContent { pinned: Vec::new() };
-        let server_name = ServerNameRef::try_from("example.com").unwrap();
+        let server_name = <&ServerName>::try_from("example.com").unwrap();
 
         content.pinned.push(EventId::new(server_name));
         content.pinned.push(EventId::new(server_name));

--- a/ruma-events/src/room_key_request.rs
+++ b/ruma-events/src/room_key_request.rs
@@ -26,7 +26,7 @@ pub struct RoomKeyRequestEventContent {
     pub body: Option<RequestedKeyInfo>,
 
     /// ID of the device requesting the key.
-    pub requesting_device_id: DeviceId,
+    pub requesting_device_id: Box<DeviceId>,
 
     /// A random string uniquely identifying the request for a key.
     ///

--- a/ruma-identifiers/src/device_id.rs
+++ b/ruma-identifiers/src/device_id.rs
@@ -7,12 +7,12 @@ use crate::generate_localpart;
 ///
 /// Device identifiers in Matrix are completely opaque character sequences. This type alias is
 /// provided simply for its semantic value.
-pub type DeviceId = String;
+pub type DeviceId = str;
 
 /// Generates a random `DeviceId`, suitable for assignment to a new device.
 #[cfg(feature = "rand")]
 #[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
-pub fn generate() -> DeviceId {
+pub fn generate() -> Box<DeviceId> {
     generate_localpart(8)
 }
 

--- a/ruma-identifiers/src/device_key_id.rs
+++ b/ruma-identifiers/src/device_key_id.rs
@@ -1,24 +1,16 @@
 //! Identifiers for device keys for end-to-end encryption.
 
-use crate::{error::Error, key_algorithms::DeviceKeyAlgorithm, DeviceIdRef};
+use crate::{error::Error, key_algorithms::DeviceKeyAlgorithm, DeviceId};
 use std::{num::NonZeroU8, str::FromStr};
 
 /// A key algorithm and a device id, combined with a ':'
 #[derive(Clone, Debug)]
-pub struct DeviceKeyId<T> {
-    full_id: T,
+pub struct DeviceKeyId {
+    full_id: Box<str>,
     colon_idx: NonZeroU8,
 }
 
-impl<T> DeviceKeyId<T>
-where
-    T: AsRef<str>,
-{
-    /// Creates a reference to this `DeviceKeyId`.
-    pub fn as_ref(&self) -> DeviceKeyId<&str> {
-        DeviceKeyId { full_id: self.full_id.as_ref(), colon_idx: self.colon_idx }
-    }
-
+impl DeviceKeyId {
     /// Returns key algorithm of the device key ID.
     pub fn algorithm(&self) -> DeviceKeyAlgorithm {
         DeviceKeyAlgorithm::from_str(&self.full_id.as_ref()[..self.colon_idx.get() as usize])
@@ -26,14 +18,14 @@ where
     }
 
     /// Returns device ID of the device key ID.
-    pub fn device_id(&self) -> DeviceIdRef<'_> {
+    pub fn device_id(&self) -> &DeviceId {
         &self.full_id.as_ref()[self.colon_idx.get() as usize + 1..]
     }
 }
 
-fn try_from<S, T>(key_id: S) -> Result<DeviceKeyId<T>, Error>
+fn try_from<S>(key_id: S) -> Result<DeviceKeyId, Error>
 where
-    S: AsRef<str> + Into<T>,
+    S: AsRef<str> + Into<Box<str>>,
 {
     let key_str = key_id.as_ref();
     let colon_idx =
@@ -56,12 +48,12 @@ mod test {
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     use super::DeviceKeyId;
-    use crate::{device_id::DeviceId, error::Error, key_algorithms::DeviceKeyAlgorithm};
+    use crate::{error::Error, key_algorithms::DeviceKeyAlgorithm};
 
     #[test]
     fn convert_device_key_id() {
         assert_eq!(
-            DeviceKeyId::<&str>::try_from("ed25519:JLAFKJWSCS")
+            DeviceKeyId::try_from("ed25519:JLAFKJWSCS")
                 .expect("Failed to create device key ID.")
                 .as_ref(),
             "ed25519:JLAFKJWSCS"
@@ -71,7 +63,7 @@ mod test {
     #[cfg(feature = "serde")]
     #[test]
     fn serialize_device_key_id() {
-        let device_key_id = DeviceKeyId::<&str>::try_from("ed25519:JLAFKJWSCS").unwrap();
+        let device_key_id = DeviceKeyId::try_from("ed25519:JLAFKJWSCS").unwrap();
         let serialized = to_json_value(device_key_id).unwrap();
 
         let expected = json!("ed25519:JLAFKJWSCS");
@@ -81,7 +73,7 @@ mod test {
     #[cfg(feature = "serde")]
     #[test]
     fn deserialize_device_key_id() {
-        let deserialized: DeviceKeyId<_> = from_json_value(json!("ed25519:JLAFKJWSCS")).unwrap();
+        let deserialized: DeviceKeyId = from_json_value(json!("ed25519:JLAFKJWSCS")).unwrap();
 
         let expected = DeviceKeyId::try_from("ed25519:JLAFKJWSCS").unwrap();
         assert_eq!(deserialized, expected);
@@ -89,16 +81,13 @@ mod test {
 
     #[test]
     fn missing_key_algorithm() {
-        assert_eq!(
-            DeviceKeyId::<&str>::try_from(":JLAFKJWSCS").unwrap_err(),
-            Error::UnknownKeyAlgorithm
-        );
+        assert_eq!(DeviceKeyId::try_from(":JLAFKJWSCS").unwrap_err(), Error::UnknownKeyAlgorithm);
     }
 
     #[test]
     fn missing_delimiter() {
         assert_eq!(
-            DeviceKeyId::<&str>::try_from("ed25519|JLAFKJWSCS").unwrap_err(),
+            DeviceKeyId::try_from("ed25519|JLAFKJWSCS").unwrap_err(),
             Error::MissingDeviceKeyDelimiter,
         );
     }
@@ -106,25 +95,25 @@ mod test {
     #[test]
     fn unknown_key_algorithm() {
         assert_eq!(
-            DeviceKeyId::<&str>::try_from("signed_curve25510:JLAFKJWSCS").unwrap_err(),
+            DeviceKeyId::try_from("signed_curve25510:JLAFKJWSCS").unwrap_err(),
             Error::UnknownKeyAlgorithm,
         );
     }
 
     #[test]
     fn empty_device_id_ok() {
-        assert!(DeviceKeyId::<&str>::try_from("ed25519:").is_ok());
+        assert!(DeviceKeyId::try_from("ed25519:").is_ok());
     }
 
     #[test]
     fn valid_key_algorithm() {
-        let device_key_id = DeviceKeyId::<&str>::try_from("ed25519:JLAFKJWSCS").unwrap();
+        let device_key_id = DeviceKeyId::try_from("ed25519:JLAFKJWSCS").unwrap();
         assert_eq!(device_key_id.algorithm(), DeviceKeyAlgorithm::Ed25519);
     }
 
     #[test]
     fn valid_device_id() {
-        let device_key_id = DeviceKeyId::<&str>::try_from("ed25519:JLAFKJWSCS").unwrap();
-        assert_eq!(device_key_id.device_id(), DeviceId::from("JLAFKJWSCS"));
+        let device_key_id = DeviceKeyId::try_from("ed25519:JLAFKJWSCS").unwrap();
+        assert_eq!(device_key_id.device_id(), "JLAFKJWSCS");
     }
 }

--- a/ruma-identifiers/src/lib.rs
+++ b/ruma-identifiers/src/lib.rs
@@ -13,152 +13,44 @@ use std::{convert::TryFrom, num::NonZeroU8};
 use serde::de::{self, Deserialize as _, Deserializer, Unexpected};
 
 #[doc(inline)]
-pub use crate::error::Error;
+pub use crate::{
+    device_id::DeviceId,
+    device_key_id::DeviceKeyId,
+    error::Error,
+    event_id::EventId,
+    key_algorithms::{DeviceKeyAlgorithm, ServerKeyAlgorithm},
+    room_alias_id::RoomAliasId,
+    room_id::RoomId,
+    room_id_or_room_alias_id::RoomIdOrAliasId,
+    room_version_id::RoomVersionId,
+    server_key_id::ServerKeyId,
+    server_name::ServerName,
+    user_id::UserId,
+};
 
 #[macro_use]
 mod macros;
 
-mod error;
-
 pub mod device_id;
-pub mod device_key_id;
-pub mod event_id;
-pub mod key_algorithms;
-pub mod room_alias_id;
-pub mod room_id;
-pub mod room_id_or_room_alias_id;
-pub mod room_version_id;
-pub mod server_key_id;
-#[allow(deprecated)]
-pub mod server_name;
 pub mod user_id;
 
-/// Allowed algorithms for homeserver signing keys.
-pub type DeviceKeyAlgorithm = key_algorithms::DeviceKeyAlgorithm;
-
-/// An owned device key identifier containing a key algorithm and device ID.
-///
-/// Can be created via `TryFrom<String>` and `TryFrom<&str>`; implements `Serialize`
-/// and `Deserialize` if the `serde` feature is enabled.
-pub type DeviceKeyId = device_key_id::DeviceKeyId<Box<str>>;
-
-/// A reference to a device key identifier containing a key algorithm and device ID.
-///
-/// Can be created via `TryFrom<&str>`; implements `Serialize` and `Deserialize`
-/// if the `serde` feature is enabled.
-pub type DeviceKeyIdRef<'a> = device_key_id::DeviceKeyId<&'a str>;
-
-/// An owned device ID.
-///
-/// While this is currently just a `String`, that will likely change in the future.
-pub use device_id::DeviceId;
-
-/// A reference to a device ID.
-///
-/// While this is currently just a string slice, that will likely change in the future.
-pub type DeviceIdRef<'a> = &'a str;
-
-/// An owned event ID.
-///
-/// Can be created via `new` (if the `rand` feature is enabled) and `TryFrom<String>` +
-/// `TryFrom<&str>`, implements `Serialize` and `Deserialize` if the `serde` feature is enabled.
-pub type EventId = event_id::EventId<Box<str>>;
-
-/// A reference to an event ID.
-///
-/// Can be created via `TryFrom<&str>`, implements `Serialize` if the `serde` feature is enabled.
-pub type EventIdRef<'a> = event_id::EventId<&'a str>;
-
-/// An owned room alias ID.
-///
-/// Can be created via `TryFrom<String>` and `TryFrom<&str>`, implements `Serialize` and
-/// `Deserialize` if the `serde` feature is enabled.
-pub type RoomAliasId = room_alias_id::RoomAliasId<Box<str>>;
-
-/// A reference to a room alias ID.
-///
-/// Can be created via `TryFrom<&str>`, implements `Serialize` if the `serde` feature is enabled.
-pub type RoomAliasIdRef<'a> = room_alias_id::RoomAliasId<&'a str>;
-
-/// An owned room ID.
-///
-/// Can be created via `new` (if the `rand` feature is enabled) and `TryFrom<String>` +
-/// `TryFrom<&str>`, implements `Serialize` and `Deserialize` if the `serde` feature is enabled.
-pub type RoomId = room_id::RoomId<Box<str>>;
-
-/// A reference to a room ID.
-///
-/// Can be created via `TryFrom<&str>`, implements `Serialize` if the `serde` feature is enabled.
-pub type RoomIdRef<'a> = room_id::RoomId<&'a str>;
-
-/// An owned room alias ID or room ID.
-///
-/// Can be created via `TryFrom<String>`, `TryFrom<&str>`, `From<RoomId>` and `From<RoomAliasId>`;
-/// implements `Serialize` and `Deserialize` if the `serde` feature is enabled.
-pub type RoomIdOrAliasId = room_id_or_room_alias_id::RoomIdOrAliasId<Box<str>>;
-
-/// A reference to a room alias ID or room ID.
-///
-/// Can be created via `TryFrom<&str>`, `From<RoomIdRef>` and `From<RoomAliasIdRef>`; implements
-/// `Serialize` if the `serde` feature is enabled.
-pub type RoomIdOrAliasIdRef<'a> = room_id_or_room_alias_id::RoomIdOrAliasId<&'a str>;
-
-/// An owned room version ID.
-///
-/// Can be created using the `version_N` constructor functions, `TryFrom<String>` and
-/// `TryFrom<&str>`; implements `Serialize` and `Deserialize` if the `serde` feature is enabled.
-pub type RoomVersionId = room_version_id::RoomVersionId<Box<str>>;
-
-/// A reference to a room version ID.
-///
-/// Can be created using the `version_N` constructor functions and via `TryFrom<&str>`, implements
-/// `Serialize` if the `serde` feature is enabled.
-pub type RoomVersionIdRef<'a> = room_version_id::RoomVersionId<&'a str>;
-
-/// Allowed algorithms for homeserver signing keys.
-pub type ServerKeyAlgorithm = key_algorithms::ServerKeyAlgorithm;
-
-/// An owned homeserver signing key identifier containing a key algorithm and version.
-///
-/// Can be created via `TryFrom<String>` and `TryFrom<&str>`; implements `Serialize`
-/// and `Deserialize` if the `serde` feature is enabled.
-pub type ServerKeyId = server_key_id::ServerKeyId<Box<str>>;
-
-/// A reference to a homeserver signing key identifier containing a key
-/// algorithm and version.
-///
-/// Can be created via `TryFrom<&str>`; implements `Serialize`
-/// and `Deserialize` if the `serde` feature is enabled.
-pub type ServerKeyIdRef<'a> = server_key_id::ServerKeyId<&'a str>;
-
-/// An owned homeserver IP address or hostname.
-///
-/// Can be created via `TryFrom<String>` and `TryFrom<&str>`; implements `Serialize`
-/// and `Deserialize` if the `serde` feature is enabled.
-pub type ServerName = server_name::ServerName<Box<str>>;
-
-/// A reference to a homeserver IP address or hostname.
-///
-/// Can be created via `TryFrom<&str>`; implements `Serialize`
-/// and `Deserialize` if the `serde` feature is enabled.
-pub type ServerNameRef<'a> = server_name::ServerName<&'a str>;
-/// An owned user ID.
-///
-/// Can be created via `new` (if the `rand` feature is enabled) and `TryFrom<String>` +
-/// `TryFrom<&str>`, implements `Serialize` and `Deserialize` if the `serde` feature is enabled.
-pub type UserId = user_id::UserId<Box<str>>;
-
-/// A reference to a user ID.
-///
-/// Can be created via `TryFrom<&str>`, implements `Serialize` if the `serde` feature is enabled.
-pub type UserIdRef<'a> = user_id::UserId<&'a str>;
+mod device_key_id;
+mod error;
+mod event_id;
+mod key_algorithms;
+mod room_alias_id;
+mod room_id;
+mod room_id_or_room_alias_id;
+mod room_version_id;
+mod server_key_id;
+mod server_name;
 
 /// Check whether a given string is a valid server name according to [the specification][].
 ///
 /// [the specification]: https://matrix.org/docs/spec/appendices#server-name
 #[deprecated = "Use the [`ServerName`](server_name/struct.ServerName.html) type instead."]
 pub fn is_valid_server_name(name: &str) -> bool {
-    ServerNameRef::try_from(name).is_ok()
+    <&ServerName>::try_from(name).is_ok()
 }
 
 /// All identifiers must be 255 bytes or less.
@@ -171,9 +63,13 @@ const MIN_CHARS: usize = 4;
 
 /// Generates a random identifier localpart.
 #[cfg(feature = "rand")]
-fn generate_localpart(length: usize) -> String {
+fn generate_localpart(length: usize) -> Box<str> {
     use rand::Rng as _;
-    rand::thread_rng().sample_iter(&rand::distributions::Alphanumeric).take(length).collect()
+    rand::thread_rng()
+        .sample_iter(&rand::distributions::Alphanumeric)
+        .take(length)
+        .collect::<String>()
+        .into_boxed_str()
 }
 
 /// Checks if an identifier is valid.
@@ -203,7 +99,7 @@ fn parse_id(id: &str, valid_sigils: &[char]) -> Result<NonZeroU8, Error> {
         return Err(Error::InvalidLocalPart);
     }
 
-    server_name::ServerName::<&str>::try_from(&id[colon_idx + 1..])?;
+    server_name::validate(&id[colon_idx + 1..])?;
 
     Ok(NonZeroU8::new(colon_idx as u8).unwrap())
 }

--- a/ruma-identifiers/src/macros.rs
+++ b/ruma-identifiers/src/macros.rs
@@ -6,8 +6,8 @@ macro_rules! doc_concat {
 }
 
 macro_rules! common_impls {
-    ($id:ident, $try_from:ident, $desc:literal) => {
-        impl<T: ::std::convert::AsRef<str>> $id<T> {
+    ($id:ty, $try_from:ident, $desc:literal) => {
+        impl $id {
             doc_concat! {
                 #[doc = concat!("Creates a string slice from this `", stringify!($id), "`")]
                 pub fn as_str(&self) -> &str {
@@ -16,27 +16,19 @@ macro_rules! common_impls {
             }
         }
 
-        impl<'a> ::std::convert::From<&'a $id<Box<str>>> for $id<&'a str> {
-            fn from(id: &'a $id<Box<str>>) -> Self {
-                id.as_ref()
+        impl ::std::convert::AsRef<str> for $id {
+            fn as_ref(&self) -> &str {
+                self.as_str()
             }
         }
 
-        impl ::std::convert::From<$id<Box<str>>> for ::std::string::String {
-            fn from(id: $id<Box<str>>) -> Self {
+        impl ::std::convert::From<$id> for ::std::string::String {
+            fn from(id: $id) -> Self {
                 id.full_id.into()
             }
         }
 
-        impl<'a> ::std::convert::TryFrom<&'a str> for $id<&'a str> {
-            type Error = crate::error::Error;
-
-            fn try_from(s: &'a str) -> Result<Self, Self::Error> {
-                $try_from(s)
-            }
-        }
-
-        impl ::std::convert::TryFrom<&str> for $id<Box<str>> {
+        impl ::std::convert::TryFrom<&str> for $id {
             type Error = crate::error::Error;
 
             fn try_from(s: &str) -> Result<Self, Self::Error> {
@@ -44,7 +36,7 @@ macro_rules! common_impls {
             }
         }
 
-        impl ::std::convert::TryFrom<String> for $id<Box<str>> {
+        impl ::std::convert::TryFrom<String> for $id {
             type Error = crate::error::Error;
 
             fn try_from(s: String) -> Result<Self, Self::Error> {
@@ -52,56 +44,50 @@ macro_rules! common_impls {
             }
         }
 
-        impl<T: ::std::convert::AsRef<str>> ::std::convert::AsRef<str> for $id<T> {
-            fn as_ref(&self) -> &str {
-                self.full_id.as_ref()
-            }
-        }
-
-        impl<T: ::std::fmt::Display> ::std::fmt::Display for $id<T> {
+        impl ::std::fmt::Display for $id {
             fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-                write!(f, "{}", self.full_id)
+                write!(f, "{}", self.as_str())
             }
         }
 
-        impl<T: ::std::cmp::PartialEq> ::std::cmp::PartialEq for $id<T> {
+        impl ::std::cmp::PartialEq for $id {
             fn eq(&self, other: &Self) -> bool {
-                self.full_id == other.full_id
+                self.as_str() == other.as_str()
             }
         }
 
-        impl<T: ::std::cmp::Eq> ::std::cmp::Eq for $id<T> {}
+        impl ::std::cmp::Eq for $id {}
 
-        impl<T: ::std::cmp::PartialOrd> ::std::cmp::PartialOrd for $id<T> {
+        impl ::std::cmp::PartialOrd for $id {
             fn partial_cmp(&self, other: &Self) -> Option<::std::cmp::Ordering> {
-                ::std::cmp::PartialOrd::partial_cmp(&self.full_id, &other.full_id)
+                ::std::cmp::PartialOrd::partial_cmp(self.as_str(), other.as_str())
             }
         }
 
-        impl<T: ::std::cmp::Ord> ::std::cmp::Ord for $id<T> {
+        impl ::std::cmp::Ord for $id {
             fn cmp(&self, other: &Self) -> ::std::cmp::Ordering {
-                ::std::cmp::Ord::cmp(&self.full_id, &other.full_id)
+                ::std::cmp::Ord::cmp(self.as_str(), other.as_str())
             }
         }
 
-        impl<T: ::std::hash::Hash> ::std::hash::Hash for $id<T> {
+        impl ::std::hash::Hash for $id {
             fn hash<H: ::std::hash::Hasher>(&self, state: &mut H) {
-                self.full_id.hash(state);
+                self.as_str().hash(state);
             }
         }
 
         #[cfg(feature = "serde")]
-        impl<T: AsRef<str>> ::serde::Serialize for $id<T> {
+        impl ::serde::Serialize for $id {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
             where
                 S: ::serde::Serializer,
             {
-                serializer.serialize_str(self.full_id.as_ref())
+                serializer.serialize_str(self.as_str())
             }
         }
 
         #[cfg(feature = "serde")]
-        impl<'de> ::serde::Deserialize<'de> for $id<Box<str>> {
+        impl<'de> ::serde::Deserialize<'de> for $id {
             fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
             where
                 D: ::serde::Deserializer<'de>,
@@ -110,27 +96,27 @@ macro_rules! common_impls {
             }
         }
 
-        impl<T: AsRef<str>> ::std::cmp::PartialEq<&str> for $id<T> {
+        impl ::std::cmp::PartialEq<&str> for $id {
             fn eq(&self, other: &&str) -> bool {
-                self.full_id.as_ref() == *other
+                self.as_str() == *other
             }
         }
 
-        impl<T: AsRef<str>> ::std::cmp::PartialEq<$id<T>> for &str {
-            fn eq(&self, other: &$id<T>) -> bool {
-                *self == other.full_id.as_ref()
+        impl ::std::cmp::PartialEq<$id> for &str {
+            fn eq(&self, other: &$id) -> bool {
+                *self == other.as_str()
             }
         }
 
-        impl<T: AsRef<str>> ::std::cmp::PartialEq<::std::string::String> for $id<T> {
+        impl ::std::cmp::PartialEq<::std::string::String> for $id {
             fn eq(&self, other: &::std::string::String) -> bool {
-                self.full_id.as_ref() == &other[..]
+                self.as_str() == other.as_str()
             }
         }
 
-        impl<T: AsRef<str>> ::std::cmp::PartialEq<$id<T>> for ::std::string::String {
-            fn eq(&self, other: &$id<T>) -> bool {
-                &self[..] == other.full_id.as_ref()
+        impl ::std::cmp::PartialEq<$id> for ::std::string::String {
+            fn eq(&self, other: &$id) -> bool {
+                self.as_str() == other.as_str()
             }
         }
     };


### PR DESCRIPTION
At the same time, this change makes `ServerName` a newtype around str so other identifier types can borrow out their server name part as a `&ServerName`. This technique works for `ServerName` because it keeps no additional metadata. For the other identifier types to support being created in borrowed form from a string slice, custom DSTs first have to be added to Rust.

Reverts ruma/ruma-identifiers#26 since we really weren't getting much from identifier types being constructible from string slices and having the identifier types being generic and `&SomeId` being distinct from the `SomeIdRef<'_>` alias added a lot of weirdness.