### PR TITLE
Move and rename ruma_events::json::EventJson to ruma_common::raw::Raw

### DIFF
--- a/ruma-api/Cargo.toml
+++ b/ruma-api/Cargo.toml
@@ -26,5 +26,6 @@ serde_json = "1.0.55"
 strum = "0.18.0"
 
 [dev-dependencies]
+ruma-common = { version = "0.1.3", path = "../ruma-common" }
 ruma-events = { version = "0.21.3", path = "../ruma-events" }
 trybuild = "1.0.30"

--- a/ruma-api/tests/ruma_api_macros.rs
+++ b/ruma-api/tests/ruma_api_macros.rs
@@ -1,6 +1,7 @@
 pub mod some_endpoint {
     use ruma_api::ruma_api;
-    use ruma_events::{tag::TagEvent, AnyRoomEvent, EventJson};
+    use ruma_common::Raw;
+    use ruma_events::{tag::TagEvent, AnyRoomEvent};
 
     ruma_api! {
         metadata: {
@@ -42,11 +43,11 @@ pub mod some_endpoint {
             #[serde(skip_serializing_if = "Option::is_none")]
             pub optional_flag: Option<bool>,
 
-            // Use `EventJson` instead of the actual event to allow additional fields to be sent...
-            pub event: EventJson<TagEvent>,
+            // Use `Raw` instead of the actual event to allow additional fields to be sent...
+            pub event: Raw<TagEvent>,
 
             // ... and to allow unknown events when the endpoint deals with event collections.
-            pub list_of_events: Vec<EventJson<AnyRoomEvent>>,
+            pub list_of_events: Vec<Raw<AnyRoomEvent>>,
         }
     }
 }

--- a/ruma-api/tests/ui/01-api-sanity-check.rs
+++ b/ruma-api/tests/ui/01-api-sanity-check.rs
@@ -1,5 +1,6 @@
 use ruma_api::ruma_api;
-use ruma_events::{tag::TagEvent, AnyRoomEvent, EventJson};
+use ruma_common::Raw;
+use ruma_events::{tag::TagEvent, AnyRoomEvent};
 
 ruma_api! {
     metadata: {
@@ -41,11 +42,11 @@ ruma_api! {
         #[serde(skip_serializing_if = "Option::is_none")]
         pub optional_flag: Option<bool>,
 
-        // Use `EventJson` instead of the actual event to allow additional fields to be sent...
-        pub event: EventJson<TagEvent>,
+        // Use `Raw` instead of the actual event to allow additional fields to be sent...
+        pub event: Raw<TagEvent>,
 
         // ... and to allow unknown events when the endpoint deals with event collections.
-        pub list_of_events: Vec<EventJson<AnyRoomEvent>>,
+        pub list_of_events: Vec<Raw<AnyRoomEvent>>,
     }
 }
 

--- a/ruma-appservice-api/Cargo.toml
+++ b/ruma-appservice-api/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 
 [dependencies]
 ruma-api = { version = "0.16.1", path = "../ruma-api" }
+ruma-common = { version = "0.1.3", path = "../ruma-common" }
 ruma-events = { version = "0.21.3", path = "../ruma-events" }
 ruma-identifiers = { version = "=0.17.0-pre.1", path = "../ruma-identifiers" }
 serde = { version = "1.0.113", features = ["derive"] }

--- a/ruma-appservice-api/src/v1/event/push_events.rs
+++ b/ruma-appservice-api/src/v1/event/push_events.rs
@@ -1,7 +1,8 @@
 //! [PUT /_matrix/app/v1/transactions/{txnId}](https://matrix.org/docs/spec/application_service/r0.1.2#put-matrix-app-v1-transactions-txnid)
 
 use ruma_api::ruma_api;
-use ruma_events::{AnyEvent, EventJson};
+use ruma_common::Raw;
+use ruma_events::AnyEvent;
 
 ruma_api! {
     metadata: {
@@ -21,7 +22,7 @@ ruma_api! {
         pub txn_id: String,
         /// A list of events.
         #[ruma_api(body)]
-        pub events: Vec<EventJson<AnyEvent>>,
+        pub events: Vec<Raw<AnyEvent>>,
     }
 
     response: {}

--- a/ruma-client-api/src/r0/config/get_global_account_data.rs
+++ b/ruma-client-api/src/r0/config/get_global_account_data.rs
@@ -1,7 +1,8 @@
 //! [GET /_matrix/client/r0/user/{userId}/account_data/{type}](https://matrix.org/docs/spec/client_server/r0.6.0#get-matrix-client-r0-user-userid-account-data-type)
 
 use ruma_api::ruma_api;
-use ruma_events::{AnyBasicEvent, EventJson};
+use ruma_common::Raw;
+use ruma_events::AnyBasicEvent;
 use ruma_identifiers::UserId;
 
 ruma_api! {
@@ -27,7 +28,7 @@ ruma_api! {
     response: {
         /// Account data content for the given type.
         #[ruma_api(body)]
-        pub account_data: EventJson<AnyBasicEvent>,
+        pub account_data: Raw<AnyBasicEvent>,
     }
 
     error: crate::Error

--- a/ruma-client-api/src/r0/config/get_room_account_data.rs
+++ b/ruma-client-api/src/r0/config/get_room_account_data.rs
@@ -1,7 +1,8 @@
 //! [GET /_matrix/client/r0/user/{userId}/rooms/{roomId}/account_data/{type}](https://matrix.org/docs/spec/client_server/r0.6.0#get-matrix-client-r0-user-userid-rooms-roomid-account-data-type)
 
 use ruma_api::ruma_api;
-use ruma_events::{AnyBasicEvent, EventJson};
+use ruma_common::Raw;
+use ruma_events::AnyBasicEvent;
 use ruma_identifiers::{RoomId, UserId};
 
 ruma_api! {
@@ -31,7 +32,7 @@ ruma_api! {
     response: {
         /// Account data content for the given type.
         #[ruma_api(body)]
-        pub account_data: EventJson<AnyBasicEvent>,
+        pub account_data: Raw<AnyBasicEvent>,
     }
 
     error: crate::Error

--- a/ruma-client-api/src/r0/context/get_context.rs
+++ b/ruma-client-api/src/r0/context/get_context.rs
@@ -2,7 +2,8 @@
 
 use js_int::{uint, UInt};
 use ruma_api::ruma_api;
-use ruma_events::{AnyRoomEvent, AnyStateEvent, EventJson};
+use ruma_common::Raw;
+use ruma_events::{AnyRoomEvent, AnyStateEvent};
 use ruma_identifiers::{EventId, RoomId};
 
 use crate::r0::filter::RoomEventFilter;
@@ -55,20 +56,20 @@ ruma_api! {
         /// A list of room events that happened just before the requested event,
         /// in reverse-chronological order.
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
-        pub events_before: Vec<EventJson<AnyRoomEvent>>,
+        pub events_before: Vec<Raw<AnyRoomEvent>>,
 
         /// Details of the requested event.
         #[serde(skip_serializing_if = "Option::is_none")]
-        pub event: Option<EventJson<AnyRoomEvent>>,
+        pub event: Option<Raw<AnyRoomEvent>>,
 
         /// A list of room events that happened just after the requested event,
         /// in chronological order.
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
-        pub events_after: Vec<EventJson<AnyRoomEvent>>,
+        pub events_after: Vec<Raw<AnyRoomEvent>>,
 
         /// The state of the room at the last event returned.
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
-        pub state: Vec<EventJson<AnyStateEvent>>,
+        pub state: Vec<Raw<AnyStateEvent>>,
     }
 
     error: crate::Error

--- a/ruma-client-api/src/r0/membership/get_member_events.rs
+++ b/ruma-client-api/src/r0/membership/get_member_events.rs
@@ -1,7 +1,8 @@
 //! [GET /_matrix/client/r0/rooms/{roomId}/members](https://matrix.org/docs/spec/client_server/r0.6.0#get-matrix-client-r0-rooms-roomid-members)
 
 use ruma_api::ruma_api;
-use ruma_events::{room::member::MemberEvent, EventJson};
+use ruma_common::Raw;
+use ruma_events::room::member::MemberEvent;
 use ruma_identifiers::RoomId;
 use serde::{Deserialize, Serialize};
 
@@ -42,7 +43,7 @@ ruma_api! {
 
     response: {
         /// A list of member events.
-        pub chunk: Vec<EventJson<MemberEvent>>
+        pub chunk: Vec<Raw<MemberEvent>>
     }
 
     error: crate::Error

--- a/ruma-client-api/src/r0/message/get_message_events.rs
+++ b/ruma-client-api/src/r0/message/get_message_events.rs
@@ -2,7 +2,8 @@
 
 use js_int::{uint, UInt};
 use ruma_api::ruma_api;
-use ruma_events::{AnyRoomEvent, AnyStateEvent, EventJson};
+use ruma_common::Raw;
+use ruma_events::{AnyRoomEvent, AnyStateEvent};
 use ruma_identifiers::RoomId;
 use serde::{Deserialize, Serialize};
 
@@ -72,11 +73,11 @@ ruma_api! {
 
         /// A list of room events.
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
-        pub chunk: Vec<EventJson<AnyRoomEvent>>,
+        pub chunk: Vec<Raw<AnyRoomEvent>>,
 
         /// A list of state events relevant to showing the `chunk`.
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
-        pub state: Vec<EventJson<AnyStateEvent>>,
+        pub state: Vec<Raw<AnyStateEvent>>,
     }
 
     error: crate::Error

--- a/ruma-client-api/src/r0/push/get_notifications.rs
+++ b/ruma-client-api/src/r0/push/get_notifications.rs
@@ -4,7 +4,8 @@ use std::time::SystemTime;
 
 use js_int::UInt;
 use ruma_api::ruma_api;
-use ruma_events::{AnyEvent, EventJson};
+use ruma_common::Raw;
+use ruma_events::AnyEvent;
 use ruma_identifiers::RoomId;
 use serde::{Deserialize, Serialize};
 
@@ -46,7 +47,7 @@ ruma_api! {
 
 
         /// The list of events that triggered notifications.
-        pub notifications: Vec<EventJson<Notification>>,
+        pub notifications: Vec<Raw<Notification>>,
     }
 
     error: crate::Error
@@ -59,7 +60,7 @@ pub struct Notification {
     pub actions: Vec<Action>,
 
     /// The event that triggered the notification.
-    pub event: EventJson<AnyEvent>,
+    pub event: Raw<AnyEvent>,
 
     /// The profile tag of the rule that matched this event.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/ruma-client-api/src/r0/room/create_room.rs
+++ b/ruma-client-api/src/r0/room/create_room.rs
@@ -1,12 +1,13 @@
 //! [POST /_matrix/client/r0/createRoom](https://matrix.org/docs/spec/client_server/r0.6.0#post-matrix-client-r0-createroom)
 
 use ruma_api::ruma_api;
+use ruma_common::Raw;
 use ruma_events::{
     room::{
         create::{CreateEventContent, PreviousRoom},
         power_levels::PowerLevelsEventContent,
     },
-    EventJson, EventType,
+    EventType,
 };
 use ruma_identifiers::{RoomId, RoomVersionId, UserId};
 use serde::{Deserialize, Serialize};
@@ -58,7 +59,7 @@ ruma_api! {
 
         /// Power level content to override in the default power level event.
         #[serde(skip_serializing_if = "Option::is_none")]
-        pub power_level_content_override: Option<EventJson<PowerLevelsEventContent>>,
+        pub power_level_content_override: Option<Raw<PowerLevelsEventContent>>,
 
         /// Convenience parameter for setting various default state events based on a preset.
         #[serde(skip_serializing_if = "Option::is_none")]

--- a/ruma-client-api/src/r0/room/get_room_event.rs
+++ b/ruma-client-api/src/r0/room/get_room_event.rs
@@ -1,7 +1,8 @@
 //! [GET /_matrix/client/r0/rooms/{roomId}/event/{eventId}](https://matrix.org/docs/spec/client_server/r0.6.0#get-matrix-client-r0-rooms-roomid-event-eventid)
 
 use ruma_api::ruma_api;
-use ruma_events::{AnyRoomEvent, EventJson};
+use ruma_common::Raw;
+use ruma_events::AnyRoomEvent;
 use ruma_identifiers::{EventId, RoomId};
 
 ruma_api! {
@@ -27,7 +28,7 @@ ruma_api! {
     response: {
         /// Arbitrary JSON of the event body. Returns both room and state events.
         #[ruma_api(body)]
-        pub event: EventJson<AnyRoomEvent>,
+        pub event: Raw<AnyRoomEvent>,
     }
 
     error: crate::Error

--- a/ruma-client-api/src/r0/search/search_events.rs
+++ b/ruma-client-api/src/r0/search/search_events.rs
@@ -4,7 +4,8 @@ use std::collections::BTreeMap;
 
 use js_int::{uint, UInt};
 use ruma_api::ruma_api;
-use ruma_events::{AnyEvent, AnyStateEvent, EventJson};
+use ruma_common::Raw;
+use ruma_events::{AnyEvent, AnyStateEvent};
 use ruma_identifiers::{EventId, RoomId, UserId};
 use serde::{Deserialize, Serialize};
 
@@ -119,11 +120,11 @@ pub struct EventContextResult {
 
     /// Events just after the result.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub events_after: Vec<EventJson<AnyEvent>>,
+    pub events_after: Vec<Raw<AnyEvent>>,
 
     /// Events just before the result.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub events_before: Vec<EventJson<AnyEvent>>,
+    pub events_before: Vec<Raw<AnyEvent>>,
 
     /// The historic profile information of the users that sent the events returned.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -216,7 +217,7 @@ pub struct RoomEventJsons {
     /// The current state for every room in the results. This is included if the request had the
     /// `include_state` key set with a value of `true`.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub state: BTreeMap<RoomId, Vec<EventJson<AnyStateEvent>>>,
+    pub state: BTreeMap<RoomId, Vec<Raw<AnyStateEvent>>>,
 
     /// List of words which should be highlighted, useful for stemming which may
     /// change the query terms.
@@ -253,7 +254,7 @@ pub struct SearchResult {
 
     /// The event that matched.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub result: Option<EventJson<AnyEvent>>,
+    pub result: Option<Raw<AnyEvent>>,
 }
 
 /// A user profile.

--- a/ruma-client-api/src/r0/state/get_state_events.rs
+++ b/ruma-client-api/src/r0/state/get_state_events.rs
@@ -1,7 +1,8 @@
 //! [GET /_matrix/client/r0/rooms/{roomId}/state](https://matrix.org/docs/spec/client_server/r0.6.0#get-matrix-client-r0-rooms-roomid-state)
 
 use ruma_api::ruma_api;
-use ruma_events::{AnyStateEvent, EventJson};
+use ruma_common::Raw;
+use ruma_events::AnyStateEvent;
 use ruma_identifiers::RoomId;
 
 ruma_api! {
@@ -25,7 +26,7 @@ ruma_api! {
         /// list of events. If the user has left the room then this will be the state of the
         /// room when they left as a list of events.
         #[ruma_api(body)]
-        pub room_state: Vec<EventJson<AnyStateEvent>>,
+        pub room_state: Vec<Raw<AnyStateEvent>>,
     }
 
     error: crate::Error

--- a/ruma-client-api/src/r0/sync/sync_events.rs
+++ b/ruma-client-api/src/r0/sync/sync_events.rs
@@ -4,10 +4,10 @@ use std::{collections::BTreeMap, time::Duration};
 
 use js_int::UInt;
 use ruma_api::ruma_api;
-use ruma_common::presence::PresenceState;
+use ruma_common::{presence::PresenceState, Raw};
 use ruma_events::{
     presence::PresenceEvent, AnyBasicEvent, AnyStrippedStateEvent, AnySyncEphemeralRoomEvent,
-    AnySyncRoomEvent, AnySyncStateEvent, AnyToDeviceEvent, EventJson,
+    AnySyncRoomEvent, AnySyncStateEvent, AnyToDeviceEvent,
 };
 use ruma_identifiers::{RoomId, UserId};
 use serde::{Deserialize, Serialize};
@@ -242,7 +242,7 @@ pub struct Timeline {
     pub prev_batch: Option<String>,
 
     /// A list of events.
-    pub events: Vec<EventJson<AnySyncRoomEvent>>,
+    pub events: Vec<Raw<AnySyncRoomEvent>>,
 }
 
 impl Timeline {
@@ -256,7 +256,7 @@ impl Timeline {
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct State {
     /// A list of state events.
-    pub events: Vec<EventJson<AnySyncStateEvent>>,
+    pub events: Vec<Raw<AnySyncStateEvent>>,
 }
 
 impl State {
@@ -270,7 +270,7 @@ impl State {
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct AccountData {
     /// A list of events.
-    pub events: Vec<EventJson<AnyBasicEvent>>,
+    pub events: Vec<Raw<AnyBasicEvent>>,
 }
 
 impl AccountData {
@@ -284,7 +284,7 @@ impl AccountData {
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Ephemeral {
     /// A list of events.
-    pub events: Vec<EventJson<AnySyncEphemeralRoomEvent>>,
+    pub events: Vec<Raw<AnySyncEphemeralRoomEvent>>,
 }
 
 impl Ephemeral {
@@ -343,7 +343,7 @@ impl InvitedRoom {
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct InviteState {
     /// A list of state events.
-    pub events: Vec<EventJson<AnyStrippedStateEvent>>,
+    pub events: Vec<Raw<AnyStrippedStateEvent>>,
 }
 
 impl InviteState {
@@ -357,7 +357,7 @@ impl InviteState {
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Presence {
     /// A list of events.
-    pub events: Vec<EventJson<PresenceEvent>>,
+    pub events: Vec<Raw<PresenceEvent>>,
 }
 
 impl Presence {
@@ -371,7 +371,7 @@ impl Presence {
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct ToDevice {
     /// A list of to-device events.
-    pub events: Vec<EventJson<AnyToDeviceEvent>>,
+    pub events: Vec<Raw<AnyToDeviceEvent>>,
 }
 
 impl ToDevice {

--- a/ruma-common/src/lib.rs
+++ b/ruma-common/src/lib.rs
@@ -4,3 +4,6 @@
 
 pub mod presence;
 pub mod push;
+mod raw;
+
+pub use self::raw::Raw;

--- a/ruma-events/CHANGELOG.md
+++ b/ruma-events/CHANGELOG.md
@@ -21,6 +21,7 @@ Improvements:
 Deprecations:
 
 * `presence::PresenceState` has been moved. Import it from `ruma` or `ruma-common`.
+* `EventJson` has been moved and renamed. Import it from `ruma` or `ruma-common`.
 
 # 0.21.3
 

--- a/ruma-events/benches/event_deserialize.rs
+++ b/ruma-events/benches/event_deserialize.rs
@@ -8,9 +8,9 @@
 
 #[cfg(feature = "criterion")]
 use criterion::{criterion_group, criterion_main, Criterion};
+use ruma_common::Raw;
 use ruma_events::{
-    room::power_levels::PowerLevelsEventContent, AnyEvent, AnyRoomEvent, AnyStateEvent, EventJson,
-    StateEvent,
+    room::power_levels::PowerLevelsEventContent, AnyEvent, AnyRoomEvent, AnyStateEvent, StateEvent,
 };
 use serde_json::json;
 
@@ -53,7 +53,7 @@ fn deserialize_any_event(c: &mut Criterion) {
 
     c.bench_function("deserialize to `AnyEvent`", |b| {
         b.iter(|| {
-            let _ = serde_json::from_value::<EventJson<AnyEvent>>(json_data.clone())
+            let _ = serde_json::from_value::<Raw<AnyEvent>>(json_data.clone())
                 .unwrap()
                 .deserialize()
                 .unwrap();
@@ -67,7 +67,7 @@ fn deserialize_any_room_event(c: &mut Criterion) {
 
     c.bench_function("deserialize to `AnyRoomEvent`", |b| {
         b.iter(|| {
-            let _ = serde_json::from_value::<EventJson<AnyRoomEvent>>(json_data.clone())
+            let _ = serde_json::from_value::<Raw<AnyRoomEvent>>(json_data.clone())
                 .unwrap()
                 .deserialize()
                 .unwrap();
@@ -81,7 +81,7 @@ fn deserialize_any_state_event(c: &mut Criterion) {
 
     c.bench_function("deserialize to `AnyStateEvent`", |b| {
         b.iter(|| {
-            let _ = serde_json::from_value::<EventJson<AnyStateEvent>>(json_data.clone())
+            let _ = serde_json::from_value::<Raw<AnyStateEvent>>(json_data.clone())
                 .unwrap()
                 .deserialize()
                 .unwrap();
@@ -95,7 +95,7 @@ fn deserialize_specific_event(c: &mut Criterion) {
 
     c.bench_function("deserialize to `StateEvent<PowerLevelsEventContent>`", |b| {
         b.iter(|| {
-            let _ = serde_json::from_value::<EventJson<StateEvent<PowerLevelsEventContent>>>(
+            let _ = serde_json::from_value::<Raw<StateEvent<PowerLevelsEventContent>>>(
                 json_data.clone(),
             )
             .unwrap()

--- a/ruma-events/src/direct.rs
+++ b/ruma-events/src/direct.rs
@@ -38,11 +38,11 @@ impl DerefMut for DirectEventContent {
 mod tests {
     use std::{collections::BTreeMap, convert::TryFrom};
 
+    use ruma_common::Raw;
     use ruma_identifiers::{RoomId, ServerName, UserId};
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     use super::{DirectEvent, DirectEventContent};
-    use crate::EventJson;
 
     #[test]
     fn serialization() {
@@ -78,7 +78,7 @@ mod tests {
         });
 
         let event: DirectEvent =
-            from_json_value::<EventJson<_>>(json_data).unwrap().deserialize().unwrap();
+            from_json_value::<Raw<_>>(json_data).unwrap().deserialize().unwrap();
         let direct_rooms = event.content.get(&alice).unwrap();
 
         assert!(direct_rooms.contains(&rooms[0]));

--- a/ruma-events/src/dummy.rs
+++ b/ruma-events/src/dummy.rs
@@ -41,7 +41,7 @@ impl DerefMut for DummyEventContent {
 #[cfg(test)]
 mod tests {
     use super::{DummyEvent, DummyEventContent, Empty};
-    use crate::EventJson;
+    use ruma_common::Raw;
 
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
@@ -65,6 +65,6 @@ mod tests {
             "type": "m.dummy"
         });
 
-        assert!(from_json_value::<EventJson<DummyEvent>>(json).unwrap().deserialize().is_ok());
+        assert!(from_json_value::<Raw<DummyEvent>>(json).unwrap().deserialize().is_ok());
     }
 }

--- a/ruma-events/src/ignored_user_list.rs
+++ b/ruma-events/src/ignored_user_list.rs
@@ -23,11 +23,12 @@ mod tests {
     use std::convert::TryFrom;
 
     use matches::assert_matches;
+    use ruma_common::Raw;
     use ruma_identifiers::UserId;
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     use super::IgnoredUserListEventContent;
-    use crate::{AnyBasicEventContent, BasicEvent, EventJson};
+    use crate::{AnyBasicEventContent, BasicEvent};
 
     #[test]
     fn serialization() {
@@ -61,7 +62,7 @@ mod tests {
         });
 
         assert_matches!(
-            from_json_value::<EventJson<BasicEvent<AnyBasicEventContent>>>(json)
+            from_json_value::<Raw<BasicEvent<AnyBasicEventContent>>>(json)
                 .unwrap()
                 .deserialize()
                 .unwrap(),

--- a/ruma-events/src/key/verification/start.rs
+++ b/ruma-events/src/key/verification/start.rs
@@ -165,7 +165,7 @@ mod tests {
         HashAlgorithm, KeyAgreementProtocol, MSasV1Content, MSasV1ContentOptions,
         MessageAuthenticationCode, ShortAuthenticationString, StartEvent, StartEventContent,
     };
-    use crate::EventJson;
+    use ruma_common::Raw;
 
     #[test]
     fn invalid_m_sas_v1_content_missing_required_key_agreement_protocols() {
@@ -277,7 +277,7 @@ mod tests {
 
         // Deserialize the content struct separately to verify `TryFromRaw` is implemented for it.
         assert_matches!(
-            from_json_value::<EventJson<StartEventContent>>(json)
+            from_json_value::<Raw<StartEventContent>>(json)
                 .unwrap()
                 .deserialize()
                 .unwrap(),
@@ -310,7 +310,7 @@ mod tests {
         });
 
         assert_matches!(
-            from_json_value::<EventJson<StartEvent>>(json)
+            from_json_value::<Raw<StartEvent>>(json)
                 .unwrap()
                 .deserialize()
                 .unwrap(),
@@ -335,7 +335,7 @@ mod tests {
     #[test]
     fn deserialization_failure() {
         // Ensure that invalid JSON  creates a `serde_json::Error` and not `InvalidEvent`
-        assert!(serde_json::from_str::<EventJson<StartEventContent>>("{").is_err());
+        assert!(serde_json::from_str::<Raw<StartEventContent>>("{").is_err());
     }
 
     // TODO this fails because the error is a Validation error not deserialization?
@@ -344,7 +344,7 @@ mod tests {
     fn deserialization_structure_mismatch() {
         // Missing several required fields.
         let error =
-            from_json_value::<EventJson<StartEventContent>>(json!({ "from_device": "123" }))
+            from_json_value::<Raw<StartEventContent>>(json!({ "from_device": "123" }))
                 .unwrap()
                 .deserialize()
                 .unwrap_err();
@@ -368,7 +368,7 @@ mod tests {
             "short_authentication_string": ["decimal"]
         });
 
-        let error = from_json_value::<EventJson<StartEventContent>>(json_data)
+        let error = from_json_value::<Raw<StartEventContent>>(json_data)
             .unwrap()
             .deserialize()
             .unwrap_err();
@@ -391,7 +391,7 @@ mod tests {
             "message_authentication_codes": ["hkdf-hmac-sha256"],
             "short_authentication_string": ["decimal"]
         });
-        let error = from_json_value::<EventJson<StartEventContent>>(json_data)
+        let error = from_json_value::<Raw<StartEventContent>>(json_data)
             .unwrap()
             .deserialize()
             .unwrap_err();
@@ -414,7 +414,7 @@ mod tests {
             "message_authentication_codes": [],
             "short_authentication_string": ["decimal"]
         });
-        let error = from_json_value::<EventJson<StartEventContent>>(json_data)
+        let error = from_json_value::<Raw<StartEventContent>>(json_data)
             .unwrap()
             .deserialize()
             .unwrap_err();
@@ -436,7 +436,7 @@ mod tests {
             "message_authentication_codes": ["hkdf-hmac-sha256"],
             "short_authentication_string": []
         });
-        let error = from_json_value::<EventJson<StartEventContent>>(json_data)
+        let error = from_json_value::<Raw<StartEventContent>>(json_data)
             .unwrap()
             .deserialize()
             .unwrap_err();
@@ -463,7 +463,7 @@ mod tests {
             },
             "type": "m.key.verification.start"
         });
-        let error = from_json_value::<EventJson<StartEvent>>(json_data)
+        let error = from_json_value::<Raw<StartEvent>>(json_data)
             .unwrap()
             .deserialize()
             .unwrap_err();

--- a/ruma-events/src/room/canonical_alias.rs
+++ b/ruma-events/src/room/canonical_alias.rs
@@ -36,11 +36,12 @@ mod tests {
         time::{Duration, UNIX_EPOCH},
     };
 
+    use ruma_common::Raw;
     use ruma_identifiers::{EventId, RoomAliasId, RoomId, UserId};
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     use super::CanonicalAliasEventContent;
-    use crate::{EventJson, StateEvent, Unsigned};
+    use crate::{StateEvent, Unsigned};
 
     #[test]
     fn serialization_with_optional_fields_as_none() {
@@ -87,7 +88,7 @@ mod tests {
         });
 
         assert_eq!(
-            from_json_value::<EventJson<StateEvent<CanonicalAliasEventContent>>>(json_data)
+            from_json_value::<Raw<StateEvent<CanonicalAliasEventContent>>>(json_data)
                 .unwrap()
                 .deserialize()
                 .unwrap()
@@ -111,7 +112,7 @@ mod tests {
             "type": "m.room.canonical_alias"
         });
         assert_eq!(
-            from_json_value::<EventJson<StateEvent<CanonicalAliasEventContent>>>(json_data)
+            from_json_value::<Raw<StateEvent<CanonicalAliasEventContent>>>(json_data)
                 .unwrap()
                 .deserialize()
                 .unwrap()
@@ -135,7 +136,7 @@ mod tests {
             "type": "m.room.canonical_alias"
         });
         assert_eq!(
-            from_json_value::<EventJson<StateEvent<CanonicalAliasEventContent>>>(json_data)
+            from_json_value::<Raw<StateEvent<CanonicalAliasEventContent>>>(json_data)
                 .unwrap()
                 .deserialize()
                 .unwrap()
@@ -160,7 +161,7 @@ mod tests {
             "type": "m.room.canonical_alias"
         });
         assert_eq!(
-            from_json_value::<EventJson<StateEvent<CanonicalAliasEventContent>>>(json_data)
+            from_json_value::<Raw<StateEvent<CanonicalAliasEventContent>>>(json_data)
                 .unwrap()
                 .deserialize()
                 .unwrap()

--- a/ruma-events/src/room/create.rs
+++ b/ruma-events/src/room/create.rs
@@ -57,11 +57,11 @@ mod tests {
     use std::convert::TryFrom;
 
     use matches::assert_matches;
+    use ruma_common::Raw;
     use ruma_identifiers::{RoomVersionId, UserId};
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     use super::CreateEventContent;
-    use crate::EventJson;
 
     #[test]
     fn serialization() {
@@ -90,7 +90,7 @@ mod tests {
         });
 
         assert_matches!(
-            from_json_value::<EventJson<CreateEventContent>>(json)
+            from_json_value::<Raw<CreateEventContent>>(json)
                 .unwrap()
                 .deserialize()
                 .unwrap(),

--- a/ruma-events/src/room/encrypted.rs
+++ b/ruma-events/src/room/encrypted.rs
@@ -72,7 +72,7 @@ mod tests {
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     use super::{EncryptedEventContent, MegolmV1AesSha2Content};
-    use crate::EventJson;
+    use ruma_common::Raw;
 
     #[test]
     fn serialization() {
@@ -106,7 +106,7 @@ mod tests {
         });
 
         assert_matches!(
-            from_json_value::<EventJson<EncryptedEventContent>>(json_data)
+            from_json_value::<Raw<EncryptedEventContent>>(json_data)
                 .unwrap()
                 .deserialize()
                 .unwrap(),
@@ -134,7 +134,7 @@ mod tests {
             },
             "algorithm": "m.olm.v1.curve25519-aes-sha2"
         });
-        let content = from_json_value::<EventJson<EncryptedEventContent>>(json_data)
+        let content = from_json_value::<Raw<EncryptedEventContent>>(json_data)
             .unwrap()
             .deserialize()
             .unwrap();
@@ -152,7 +152,7 @@ mod tests {
 
     #[test]
     fn deserialization_failure() {
-        assert!(from_json_value::<EventJson<EncryptedEventContent>>(
+        assert!(from_json_value::<Raw<EncryptedEventContent>>(
             json!({ "algorithm": "m.megolm.v1.aes-sha2" })
         )
         .unwrap()

--- a/ruma-events/src/room/member.rs
+++ b/ruma-events/src/room/member.rs
@@ -249,7 +249,8 @@ mod tests {
     use serde_json::{from_value as from_json_value, json};
 
     use super::{MemberEventContent, MembershipState, SignedContent, ThirdPartyInvite};
-    use crate::{EventJson, StateEvent};
+    use crate::StateEvent;
+    use ruma_common::Raw;
 
     #[test]
     fn serde_with_no_prev_content() {
@@ -266,7 +267,7 @@ mod tests {
         });
 
         assert_matches!(
-            from_json_value::<EventJson<StateEvent<MemberEventContent>>>(json)
+            from_json_value::<Raw<StateEvent<MemberEventContent>>>(json)
                 .unwrap()
                 .deserialize()
                 .unwrap(),
@@ -312,7 +313,7 @@ mod tests {
         });
 
         assert_matches!(
-            from_json_value::<EventJson<StateEvent<MemberEventContent>>>(json)
+            from_json_value::<Raw<StateEvent<MemberEventContent>>>(json)
                 .unwrap()
                 .deserialize()
                 .unwrap(),
@@ -376,7 +377,7 @@ mod tests {
         });
 
         assert_matches!(
-            from_json_value::<EventJson<StateEvent<MemberEventContent>>>(json)
+            from_json_value::<Raw<StateEvent<MemberEventContent>>>(json)
                 .unwrap()
                 .deserialize()
                 .unwrap(),
@@ -450,7 +451,7 @@ mod tests {
         });
 
         assert_matches!(
-            from_json_value::<EventJson<StateEvent<MemberEventContent>>>(json)
+            from_json_value::<Raw<StateEvent<MemberEventContent>>>(json)
                 .unwrap()
                 .deserialize()
                 .unwrap(),

--- a/ruma-events/src/room/message.rs
+++ b/ruma-events/src/room/message.rs
@@ -399,13 +399,14 @@ mod tests {
     };
 
     use matches::assert_matches;
+    use ruma_common::Raw;
     use ruma_identifiers::{EventId, RoomId, UserId};
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     use super::{AudioMessageEventContent, FormattedBody, MessageEventContent, MessageFormat};
     use crate::{
         room::message::{InReplyTo, RelatesTo, TextMessageEventContent},
-        EventJson, MessageEvent, Unsigned,
+        MessageEvent, Unsigned,
     };
 
     #[test]
@@ -531,7 +532,7 @@ mod tests {
         });
 
         assert_matches!(
-            from_json_value::<EventJson<MessageEventContent>>(json_data)
+            from_json_value::<Raw<MessageEventContent>>(json_data)
                 .unwrap()
                 .deserialize()
                 .unwrap(),
@@ -550,7 +551,7 @@ mod tests {
             "body": "test","msgtype": "m.location",
             "url": "http://example.com/audio.mp3"
         });
-        assert!(from_json_value::<EventJson<MessageEventContent>>(json_data)
+        assert!(from_json_value::<Raw<MessageEventContent>>(json_data)
             .unwrap()
             .deserialize()
             .is_err());

--- a/ruma-events/src/room/name.rs
+++ b/ruma-events/src/room/name.rs
@@ -64,10 +64,11 @@ mod tests {
 
     use js_int::Int;
     use matches::assert_matches;
+    use ruma_common::Raw;
     use ruma_identifiers::{EventId, RoomId, UserId};
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
-    use crate::{EventJson, StateEvent, Unsigned};
+    use crate::{StateEvent, Unsigned};
 
     use super::NameEventContent;
 
@@ -145,7 +146,7 @@ mod tests {
             "type": "m.room.name"
         });
         assert_eq!(
-            from_json_value::<EventJson<StateEvent<NameEventContent>>>(json_data)
+            from_json_value::<Raw<StateEvent<NameEventContent>>>(json_data)
                 .unwrap()
                 .deserialize()
                 .unwrap()
@@ -162,7 +163,7 @@ mod tests {
         assert_eq!(long_string.len(), 256);
 
         let long_content_json = json!({ "name": &long_string });
-        let from_raw: EventJson<NameEventContent> = from_json_value(long_content_json).unwrap();
+        let from_raw: Raw<NameEventContent> = from_json_value(long_content_json).unwrap();
 
         let result = from_raw.deserialize();
         assert!(result.is_err(), "Result should be invalid: {:?}", result);
@@ -171,7 +172,7 @@ mod tests {
     #[test]
     fn json_with_empty_name_creates_content_as_none() {
         let long_content_json = json!({ "name": "" });
-        let from_raw: EventJson<NameEventContent> = from_json_value(long_content_json).unwrap();
+        let from_raw: Raw<NameEventContent> = from_json_value(long_content_json).unwrap();
         assert_matches!(from_raw.deserialize().unwrap(), NameEventContent { name: None });
     }
 
@@ -197,7 +198,7 @@ mod tests {
             "type": "m.room.name"
         });
         assert_eq!(
-            from_json_value::<EventJson<StateEvent<NameEventContent>>>(json_data)
+            from_json_value::<Raw<StateEvent<NameEventContent>>>(json_data)
                 .unwrap()
                 .deserialize()
                 .unwrap()
@@ -221,7 +222,7 @@ mod tests {
             "type": "m.room.name"
         });
         assert_eq!(
-            from_json_value::<EventJson<StateEvent<NameEventContent>>>(json_data)
+            from_json_value::<Raw<StateEvent<NameEventContent>>>(json_data)
                 .unwrap()
                 .deserialize()
                 .unwrap()
@@ -247,7 +248,7 @@ mod tests {
         });
 
         assert_eq!(
-            from_json_value::<EventJson<StateEvent<NameEventContent>>>(json_data)
+            from_json_value::<Raw<StateEvent<NameEventContent>>>(json_data)
                 .unwrap()
                 .deserialize()
                 .unwrap()

--- a/ruma-events/src/room/pinned_events.rs
+++ b/ruma-events/src/room/pinned_events.rs
@@ -24,11 +24,12 @@ mod tests {
         time::{Duration, UNIX_EPOCH},
     };
 
+    use ruma_common::Raw;
     use ruma_identifiers::{EventId, RoomId, ServerName, UserId};
     use serde_json::to_string;
 
     use super::PinnedEventsEventContent;
-    use crate::{EventJson, StateEvent, Unsigned};
+    use crate::{StateEvent, Unsigned};
 
     #[test]
     fn serialization_deserialization() {
@@ -50,12 +51,11 @@ mod tests {
         };
 
         let serialized_event = to_string(&event).unwrap();
-        let parsed_event = serde_json::from_str::<EventJson<StateEvent<PinnedEventsEventContent>>>(
-            &serialized_event,
-        )
-        .unwrap()
-        .deserialize()
-        .unwrap();
+        let parsed_event =
+            serde_json::from_str::<Raw<StateEvent<PinnedEventsEventContent>>>(&serialized_event)
+                .unwrap()
+                .deserialize()
+                .unwrap();
 
         assert_eq!(parsed_event.event_id, event.event_id);
         assert_eq!(parsed_event.room_id, event.room_id);

--- a/ruma-events/src/room/server_acl.rs
+++ b/ruma-events/src/room/server_acl.rs
@@ -43,7 +43,8 @@ mod tests {
     use serde_json::{from_value as from_json_value, json};
 
     use super::ServerAclEventContent;
-    use crate::{EventJson, StateEvent};
+    use crate::StateEvent;
+    use ruma_common::Raw;
 
     #[test]
     fn default_values() {
@@ -57,11 +58,10 @@ mod tests {
             "type": "m.room.server_acl"
         });
 
-        let server_acl_event =
-            from_json_value::<EventJson<StateEvent<ServerAclEventContent>>>(json_data)
-                .unwrap()
-                .deserialize()
-                .unwrap();
+        let server_acl_event = from_json_value::<Raw<StateEvent<ServerAclEventContent>>>(json_data)
+            .unwrap()
+            .deserialize()
+            .unwrap();
 
         assert_eq!(server_acl_event.content.allow_ip_literals, true);
         assert!(server_acl_event.content.allow.is_empty());

--- a/ruma-events/tests/custom.rs
+++ b/ruma-events/tests/custom.rs
@@ -4,9 +4,10 @@ use std::{
 };
 
 use matches::assert_matches;
+use ruma_common::Raw;
 use ruma_events::{
     custom::CustomEventContent, AnyMessageEvent, AnyStateEvent, AnyStateEventContent,
-    AnySyncMessageEvent, AnySyncRoomEvent, EventJson, MessageEvent, StateEvent, SyncMessageEvent,
+    AnySyncMessageEvent, AnySyncRoomEvent, MessageEvent, StateEvent, SyncMessageEvent,
     SyncStateEvent, Unsigned,
 };
 use ruma_identifiers::{EventId, RoomId, UserId};
@@ -131,7 +132,7 @@ fn deserialize_custom_state_event() {
     });
 
     assert_matches!(
-        from_json_value::<EventJson<AnyStateEvent>>(json_data)
+        from_json_value::<Raw<AnyStateEvent>>(json_data)
             .unwrap()
             .deserialize()
             .unwrap(),

--- a/ruma-events/tests/enums.rs
+++ b/ruma-events/tests/enums.rs
@@ -161,6 +161,7 @@ fn aliases_event_sync_deserialization() {
             AnySyncStateEvent::RoomAliases(SyncStateEvent {
                 content: AliasesEventContent {
                     aliases,
+                    ..
                 },
                 ..
             })
@@ -199,6 +200,7 @@ fn alias_room_event_deserialization() {
             AnyStateEvent::RoomAliases(StateEvent {
                 content: AliasesEventContent {
                     aliases,
+                    ..
                 },
                 ..
             })
@@ -237,6 +239,7 @@ fn alias_event_deserialization() {
             AnyStateEvent::RoomAliases(StateEvent {
                 content: AliasesEventContent {
                     aliases,
+                    ..
                 },
                 ..
             })
@@ -259,7 +262,8 @@ fn alias_event_field_access() {
     );
 
     let deser = from_json_value::<AnyStateEvent>(json_data).unwrap();
-    if let AnyStateEventContent::RoomAliases(AliasesEventContent { aliases }) = deser.content() {
+    if let AnyStateEventContent::RoomAliases(AliasesEventContent { aliases, .. }) = deser.content()
+    {
         assert_eq!(aliases, vec![RoomAliasId::try_from("#somewhere:localhost").unwrap()])
     } else {
         panic!("the `Any*Event` enum's accessor methods may have been altered")

--- a/ruma-events/tests/ephemeral_event.rs
+++ b/ruma-events/tests/ephemeral_event.rs
@@ -5,13 +5,14 @@ use std::{
 
 use maplit::btreemap;
 use matches::assert_matches;
+use ruma_common::Raw;
 use ruma_identifiers::{EventId, RoomId, UserId};
 use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
 use ruma_events::{
     receipt::{Receipt, ReceiptEventContent, Receipts},
     typing::TypingEventContent,
-    AnyEphemeralRoomEventContent, EphemeralRoomEvent, EventJson,
+    AnyEphemeralRoomEventContent, EphemeralRoomEvent,
 };
 
 #[test]
@@ -46,7 +47,7 @@ fn deserialize_ephemeral_typing() {
     });
 
     assert_matches!(
-        from_json_value::<EventJson<EphemeralRoomEvent<AnyEphemeralRoomEventContent>>>(json_data)
+        from_json_value::<Raw<EphemeralRoomEvent<AnyEphemeralRoomEventContent>>>(json_data)
             .unwrap()
             .deserialize()
             .unwrap(),
@@ -110,7 +111,7 @@ fn deserialize_ephemeral_receipt() {
     });
 
     assert_matches!(
-        from_json_value::<EventJson<EphemeralRoomEvent<AnyEphemeralRoomEventContent>>>(json_data)
+        from_json_value::<Raw<EphemeralRoomEvent<AnyEphemeralRoomEventContent>>>(json_data)
             .unwrap()
             .deserialize()
             .unwrap(),

--- a/ruma-events/tests/message_event.rs
+++ b/ruma-events/tests/message_event.rs
@@ -5,11 +5,12 @@ use std::{
 
 use js_int::UInt;
 use matches::assert_matches;
+use ruma_common::Raw;
 use ruma_events::{
     call::{answer::AnswerEventContent, SessionDescription, SessionDescriptionType},
     room::{ImageInfo, ThumbnailInfo},
     sticker::StickerEventContent,
-    AnyMessageEventContent, EventJson, MessageEvent, Unsigned,
+    AnyMessageEventContent, MessageEvent, RawExt, Unsigned,
 };
 use ruma_identifiers::{EventId, RoomId, UserId};
 use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
@@ -83,7 +84,7 @@ fn deserialize_message_call_answer_content() {
     });
 
     assert_matches!(
-        from_json_value::<EventJson<AnyMessageEventContent>>(json_data)
+        from_json_value::<Raw<AnyMessageEventContent>>(json_data)
             .unwrap()
             .deserialize_content("m.call.answer")
             .unwrap(),
@@ -117,7 +118,7 @@ fn deserialize_message_call_answer() {
     });
 
     assert_matches!(
-        from_json_value::<EventJson<MessageEvent<AnyMessageEventContent>>>(json_data)
+        from_json_value::<Raw<MessageEvent<AnyMessageEventContent>>>(json_data)
             .unwrap()
             .deserialize()
             .unwrap(),
@@ -172,7 +173,7 @@ fn deserialize_message_sticker() {
     });
 
     assert_matches!(
-        from_json_value::<EventJson<MessageEvent<AnyMessageEventContent>>>(json_data)
+        from_json_value::<Raw<MessageEvent<AnyMessageEventContent>>>(json_data)
             .unwrap()
             .deserialize()
             .unwrap(),

--- a/ruma-events/tests/redacted.rs
+++ b/ruma-events/tests/redacted.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use matches::assert_matches;
+use ruma_common::Raw;
 use ruma_events::{
     custom::RedactedCustomEventContent,
     room::{
@@ -13,8 +14,8 @@ use ruma_events::{
         redaction::{RedactionEvent, RedactionEventContent, SyncRedactionEvent},
     },
     AnyRedactedMessageEvent, AnyRedactedSyncMessageEvent, AnyRedactedSyncStateEvent, AnyRoomEvent,
-    AnySyncRoomEvent, EventJson, RedactedMessageEvent, RedactedSyncMessageEvent,
-    RedactedSyncStateEvent, RedactedSyncUnsigned, RedactedUnsigned, Unsigned,
+    AnySyncRoomEvent, RedactedMessageEvent, RedactedSyncMessageEvent, RedactedSyncStateEvent,
+    RedactedSyncUnsigned, RedactedUnsigned, Unsigned,
 };
 use ruma_identifiers::{EventId, RoomId, UserId};
 use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
@@ -24,7 +25,7 @@ fn full_unsigned() -> RedactedSyncUnsigned {
     // The presence of `redacted_because` triggers the event enum to return early
     // with `RedactedContent` instead of failing to deserialize according
     // to the event type string.
-    unsigned.redacted_because = Some(EventJson::from(SyncRedactionEvent {
+    unsigned.redacted_because = Some(Raw::from(SyncRedactionEvent {
         content: RedactionEventContent { reason: Some("redacted because".into()) },
         redacts: EventId::try_from("$h29iv0s8:example.com").unwrap(),
         event_id: EventId::try_from("$h29iv0s8:example.com").unwrap(),
@@ -122,7 +123,7 @@ fn redacted_aliases_deserialize() {
     let actual = to_json_value(&redacted).unwrap();
 
     assert_matches!(
-        from_json_value::<EventJson<AnySyncRoomEvent>>(actual)
+        from_json_value::<Raw<AnySyncRoomEvent>>(actual)
             .unwrap()
             .deserialize()
             .unwrap(),
@@ -150,7 +151,7 @@ fn redacted_deserialize_any_room() {
     let actual = to_json_value(&redacted).unwrap();
 
     assert_matches!(
-        from_json_value::<EventJson<AnyRoomEvent>>(actual)
+        from_json_value::<Raw<AnyRoomEvent>>(actual)
             .unwrap()
             .deserialize()
             .unwrap(),
@@ -168,7 +169,7 @@ fn redacted_deserialize_any_room_sync() {
     // The presence of `redacted_because` triggers the event enum (AnySyncRoomEvent in this case)
     // to return early with `RedactedContent` instead of failing to deserialize according
     // to the event type string.
-    unsigned.redacted_because = Some(EventJson::from(RedactionEvent {
+    unsigned.redacted_because = Some(Raw::from(RedactionEvent {
         content: RedactionEventContent { reason: Some("redacted because".into()) },
         redacts: EventId::try_from("$h29iv0s8:example.com").unwrap(),
         event_id: EventId::try_from("$h29iv0s8:example.com").unwrap(),
@@ -189,7 +190,7 @@ fn redacted_deserialize_any_room_sync() {
     let actual = to_json_value(&redacted).unwrap();
 
     assert_matches!(
-        from_json_value::<EventJson<AnySyncRoomEvent>>(actual)
+        from_json_value::<Raw<AnySyncRoomEvent>>(actual)
             .unwrap()
             .deserialize()
             .unwrap(),
@@ -217,7 +218,7 @@ fn redacted_state_event_deserialize() {
     });
 
     assert_matches!(
-        from_json_value::<EventJson<AnySyncRoomEvent>>(redacted)
+        from_json_value::<Raw<AnySyncRoomEvent>>(redacted)
             .unwrap()
             .deserialize()
             .unwrap(),
@@ -247,7 +248,7 @@ fn redacted_custom_event_serialize() {
     });
 
     assert_matches!(
-        from_json_value::<EventJson<AnySyncRoomEvent>>(redacted.clone())
+        from_json_value::<Raw<AnySyncRoomEvent>>(redacted.clone())
             .unwrap()
             .deserialize()
             .unwrap(),
@@ -262,7 +263,7 @@ fn redacted_custom_event_serialize() {
             && event_type == "m.made.up"
     );
 
-    let x = from_json_value::<EventJson<crate::AnyRedactedSyncStateEvent>>(redacted)
+    let x = from_json_value::<Raw<crate::AnyRedactedSyncStateEvent>>(redacted)
         .unwrap()
         .deserialize()
         .unwrap();

--- a/ruma-events/tests/redaction.rs
+++ b/ruma-events/tests/redaction.rs
@@ -4,9 +4,10 @@ use std::{
 };
 
 use matches::assert_matches;
+use ruma_common::Raw;
 use ruma_events::{
     room::redaction::{RedactionEvent, RedactionEventContent},
-    AnyMessageEvent, EventJson, Unsigned,
+    AnyMessageEvent, Unsigned,
 };
 use ruma_identifiers::{EventId, RoomId, UserId};
 use serde_json::{
@@ -50,7 +51,7 @@ fn deserialize_redaction() {
     let json_data = redaction();
 
     assert_matches!(
-        from_json_value::<EventJson<AnyMessageEvent>>(json_data)
+        from_json_value::<Raw<AnyMessageEvent>>(json_data)
             .unwrap()
             .deserialize()
             .unwrap(),

--- a/ruma-events/tests/state_event.rs
+++ b/ruma-events/tests/state_event.rs
@@ -5,9 +5,10 @@ use std::{
 
 use js_int::UInt;
 use matches::assert_matches;
+use ruma_common::Raw;
 use ruma_events::{
     room::{aliases::AliasesEventContent, avatar::AvatarEventContent, ImageInfo, ThumbnailInfo},
-    AnyRoomEvent, AnyStateEvent, AnyStateEventContent, EventJson, StateEvent, SyncStateEvent,
+    AnyRoomEvent, AnyStateEvent, AnyStateEventContent, RawExt, StateEvent, SyncStateEvent,
     Unsigned,
 };
 use ruma_identifiers::{EventId, RoomAliasId, RoomId, UserId};
@@ -35,14 +36,14 @@ fn aliases_event_with_prev_content() -> JsonValue {
 #[test]
 fn serialize_aliases_with_prev_content() {
     let aliases_event = StateEvent {
-        content: AnyStateEventContent::RoomAliases(AliasesEventContent {
-            aliases: vec![RoomAliasId::try_from("#somewhere:localhost").unwrap()],
-        }),
+        content: AnyStateEventContent::RoomAliases(AliasesEventContent::new(vec![
+            RoomAliasId::try_from("#somewhere:localhost").unwrap(),
+        ])),
         event_id: EventId::try_from("$h29iv0s8:example.com").unwrap(),
         origin_server_ts: UNIX_EPOCH + Duration::from_millis(1),
-        prev_content: Some(AnyStateEventContent::RoomAliases(AliasesEventContent {
-            aliases: vec![RoomAliasId::try_from("#inner:localhost").unwrap()],
-        })),
+        prev_content: Some(AnyStateEventContent::RoomAliases(AliasesEventContent::new(vec![
+            RoomAliasId::try_from("#inner:localhost").unwrap(),
+        ]))),
         room_id: RoomId::try_from("!roomid:room.com").unwrap(),
         sender: UserId::try_from("@carl:example.com").unwrap(),
         state_key: "".into(),
@@ -58,9 +59,9 @@ fn serialize_aliases_with_prev_content() {
 #[test]
 fn serialize_aliases_without_prev_content() {
     let aliases_event = StateEvent {
-        content: AnyStateEventContent::RoomAliases(AliasesEventContent {
-            aliases: vec![RoomAliasId::try_from("#somewhere:localhost").unwrap()],
-        }),
+        content: AnyStateEventContent::RoomAliases(AliasesEventContent::new(vec![
+            RoomAliasId::try_from("#somewhere:localhost").unwrap(),
+        ])),
         event_id: EventId::try_from("$h29iv0s8:example.com").unwrap(),
         origin_server_ts: UNIX_EPOCH + Duration::from_millis(1),
         prev_content: None,
@@ -93,7 +94,7 @@ fn deserialize_aliases_content() {
     });
 
     assert_matches!(
-        from_json_value::<EventJson<AnyStateEventContent>>(json_data)
+        from_json_value::<Raw<AnyStateEventContent>>(json_data)
             .unwrap()
             .deserialize_content("m.room.aliases")
             .unwrap(),
@@ -107,7 +108,7 @@ fn deserialize_aliases_with_prev_content() {
     let json_data = aliases_event_with_prev_content();
 
     assert_matches!(
-        from_json_value::<EventJson<StateEvent<AnyStateEventContent>>>(json_data)
+        from_json_value::<Raw<StateEvent<AnyStateEventContent>>>(json_data)
             .unwrap()
             .deserialize()
             .unwrap(),
@@ -184,7 +185,7 @@ fn deserialize_avatar_without_prev_content() {
     });
 
     assert_matches!(
-        from_json_value::<EventJson<StateEvent<AnyStateEventContent>>>(json_data)
+        from_json_value::<Raw<StateEvent<AnyStateEventContent>>>(json_data)
             .unwrap()
             .deserialize()
             .unwrap(),

--- a/ruma-federation-api/Cargo.toml
+++ b/ruma-federation-api/Cargo.toml
@@ -19,6 +19,7 @@ version = "0.0.2"
 js_int = "0.1.7"
 matches = "0.1.8"
 ruma-api = { version = "0.16.1", path = "../ruma-api" }
+ruma-common = { version = "0.1.3", path = "../ruma-common" }
 ruma-events = { version = "0.21.3", path = "../ruma-events" }
 ruma-identifiers = { version = "=0.17.0-pre.1", path = "../ruma-identifiers" }
 ruma-serde = { version = "0.2.2", path = "../ruma-serde" }

--- a/ruma-federation-api/src/membership/create_join_event/mod.rs
+++ b/ruma-federation-api/src/membership/create_join_event/mod.rs
@@ -2,7 +2,8 @@
 
 pub mod v1;
 
-use ruma_events::{pdu::Pdu, EventJson};
+use ruma_common::Raw;
+use ruma_events::pdu::Pdu;
 use serde::{Deserialize, Serialize};
 
 /// Full state of the room.
@@ -12,7 +13,7 @@ pub struct RoomState {
     pub origin: String,
     /// The full set of authorization events that make up the state of the room,
     /// and their authorization events, recursively.
-    pub auth_chain: Vec<EventJson<Pdu>>,
+    pub auth_chain: Vec<Raw<Pdu>>,
     /// The room state.
-    pub state: Vec<EventJson<Pdu>>,
+    pub state: Vec<Raw<Pdu>>,
 }

--- a/ruma-federation-api/src/membership/create_join_event_template/v1.rs
+++ b/ruma-federation-api/src/membership/create_join_event_template/v1.rs
@@ -2,7 +2,8 @@
 
 use js_int::UInt;
 use ruma_api::ruma_api;
-use ruma_events::{pdu::Pdu, EventJson};
+use ruma_common::Raw;
+use ruma_events::pdu::Pdu;
 use ruma_identifiers::{RoomId, UserId};
 
 ruma_api! {
@@ -32,6 +33,6 @@ ruma_api! {
         /// The version of the room where the server is trying to join.
         pub room_version: Option<UInt>,
         /// An unsigned template event.
-        pub event: EventJson<Pdu>,
+        pub event: Raw<Pdu>,
     }
 }


### PR DESCRIPTION
This fixes #32. Let me know if I made an error when deprecating `EventJson`. I intentionally made `EventJson` an empty struct as I'd figure the end-developer will upgrade to `Raw` when upgrading `ruma-events`.