### PR TITLE
Add redact method to all event_enum! generated enums

### DIFF
--- a/ruma-events-macros/src/event_content.rs
+++ b/ruma-events-macros/src/event_content.rs
@@ -153,7 +153,7 @@ pub fn expand_event_content(input: &DeriveInput, emit_redacted: bool) -> syn::Re
             // this is the non redacted event content's impl
             impl #ident {
                 /// Transforms the full event content into a redacted content according to spec.
-                pub fn redact(self) -> #redacted_ident {
+                pub fn redact(self, version: ::ruma_identifiers::RoomVersionId) -> #redacted_ident {
                     #redacted_ident { #( #redaction_struct_fields: self.#redaction_struct_fields, )* }
                 }
             }

--- a/ruma-events-macros/src/event_enum.rs
+++ b/ruma-events-macros/src/event_enum.rs
@@ -233,10 +233,9 @@ fn generate_redacted_fields(
             };
 
             quote! {
-                unsigned: {
-                    let mut unsigned = ::ruma_events::#redaction_type::default();
-                    unsigned.redacted_because = Some(::ruma_events::EventJson::from(redaction));
-                    unsigned
+                unsigned: ::ruma_events::#redaction_type {
+                    redacted_because: Some(::ruma_events::EventJson::from(redaction)),
+                    .. Default::default()
                 },
             }
         } else {

--- a/ruma-events-macros/src/event_enum.rs
+++ b/ruma-events-macros/src/event_enum.rs
@@ -235,7 +235,6 @@ fn generate_redacted_fields(
             quote! {
                 unsigned: ::ruma_events::#redaction_type {
                     redacted_because: Some(::ruma_events::EventJson::from(redaction)),
-                    .. Default::default()
                 },
             }
         } else {

--- a/ruma-events-macros/src/event_enum.rs
+++ b/ruma-events-macros/src/event_enum.rs
@@ -189,11 +189,11 @@ fn generate_redact(
         Some(quote! {
             impl #ident {
                 /// Redacts `Self` given a valid `Redaction[Sync]Event`.
-                pub fn redact(self, redaction: #param) -> #redaction_enum {
+                pub fn redact(self, redaction: #param, version: ::ruma_identifiers::RoomVersionId) -> #redaction_enum {
                     match self {
                         #(
                             Self::#variants(event) => {
-                                let content = event.content.redact();
+                                let content = event.content.redact(version);
                                 #redaction_enum::#variants(#redaction_type {
                                     content,
                                     #fields
@@ -201,7 +201,7 @@ fn generate_redact(
                             }
                         )*
                         Self::Custom(event) => {
-                            let content = event.content.redact();
+                            let content = event.content.redact(version);
                             #redaction_enum::Custom(#redaction_type {
                                 content,
                                 #fields

--- a/ruma-events/src/custom.rs
+++ b/ruma-events/src/custom.rs
@@ -1,5 +1,6 @@
 //! Types for custom events outside of the Matrix specification.
 
+use ruma_identifiers::RoomVersionId;
 use serde::Serialize;
 use serde_json::{value::RawValue as RawJsonValue, Value as JsonValue};
 
@@ -23,7 +24,7 @@ pub struct CustomEventContent {
 
 impl CustomEventContent {
     /// Transforms the full event content into a redacted content according to spec.
-    pub fn redact(self) -> RedactedCustomEventContent {
+    pub fn redact(self, _: RoomVersionId) -> RedactedCustomEventContent {
         RedactedCustomEventContent { event_type: self.event_type }
     }
 }

--- a/ruma-events/src/room/aliases.rs
+++ b/ruma-events/src/room/aliases.rs
@@ -27,6 +27,18 @@ impl AliasesEventContent {
     pub fn new(aliases: Vec<RoomAliasId>) -> Self {
         Self { aliases }
     }
+
+    /// Redact an `AliasesEventContent` according to current Matrix spec.
+    pub fn redact(self) -> RedactedAliasesEventContent {
+        RedactedAliasesEventContent { aliases: None }
+    }
+
+    /// Redact an `AliasesEventContent` according to version 1 of the Matrix spec.
+    ///
+    /// This leaves the `aliases` information intact after redaction.
+    pub fn redact_v1(self) -> RedactedAliasesEventContent {
+        RedactedAliasesEventContent { aliases: Some(self.aliases) }
+    }
 }
 
 /// An aliases event that has been redacted.

--- a/ruma-events/src/room/aliases.rs
+++ b/ruma-events/src/room/aliases.rs
@@ -30,10 +30,17 @@ impl AliasesEventContent {
 
     /// Redact an `AliasesEventContent` according to current Matrix spec.
     pub fn redact(self, version: RoomVersionId) -> RedactedAliasesEventContent {
-        if version.is_version_6() {
-            RedactedAliasesEventContent { aliases: None }
-        } else {
+        // We compare the long way to avoid pre version 6 behavior if/when
+        // the room version is updated.
+        if version.is_version_1()
+            || version.is_version_2()
+            || version.is_version_3()
+            || version.is_version_4()
+            || version.is_version_5()
+        {
             RedactedAliasesEventContent { aliases: Some(self.aliases) }
+        } else {
+            RedactedAliasesEventContent { aliases: None }
         }
     }
 }

--- a/ruma-events/src/room/aliases.rs
+++ b/ruma-events/src/room/aliases.rs
@@ -31,7 +31,7 @@ impl AliasesEventContent {
     /// Redact an `AliasesEventContent` according to current Matrix spec.
     pub fn redact(self, version: RoomVersionId) -> RedactedAliasesEventContent {
         // We compare the long way to avoid pre version 6 behavior if/when
-        // the room version is updated.
+        // a new room version is introduced.
         if version.is_version_1()
             || version.is_version_2()
             || version.is_version_3()

--- a/ruma-events/src/room/aliases.rs
+++ b/ruma-events/src/room/aliases.rs
@@ -1,7 +1,7 @@
 //! Types for the *m.room.aliases* event.
 
 use ruma_events_macros::StateEventContent;
-use ruma_identifiers::RoomAliasId;
+use ruma_identifiers::{RoomAliasId, RoomVersionId};
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue as RawJsonValue;
 
@@ -29,15 +29,12 @@ impl AliasesEventContent {
     }
 
     /// Redact an `AliasesEventContent` according to current Matrix spec.
-    pub fn redact(self) -> RedactedAliasesEventContent {
-        RedactedAliasesEventContent { aliases: None }
-    }
-
-    /// Redact an `AliasesEventContent` according to version 1 of the Matrix spec.
-    ///
-    /// This leaves the `aliases` information intact after redaction.
-    pub fn redact_v1(self) -> RedactedAliasesEventContent {
-        RedactedAliasesEventContent { aliases: Some(self.aliases) }
+    pub fn redact(self, version: RoomVersionId) -> RedactedAliasesEventContent {
+        if version.is_version_6() {
+            RedactedAliasesEventContent { aliases: None }
+        } else {
+            RedactedAliasesEventContent { aliases: Some(self.aliases) }
+        }
     }
 }
 

--- a/ruma-events/tests/redacted.rs
+++ b/ruma-events/tests/redacted.rs
@@ -18,7 +18,7 @@ use ruma_events::{
     RedactedSyncMessageEvent, RedactedSyncStateEvent, RedactedSyncUnsigned, RedactedUnsigned,
     Unsigned,
 };
-use ruma_identifiers::{EventId, RoomId, UserId};
+use ruma_identifiers::{EventId, RoomId, RoomVersionId, UserId};
 use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
 fn full_unsigned() -> RedactedSyncUnsigned {
@@ -325,7 +325,7 @@ fn redact_method_properly_redacts() {
     let event = from_json_value::<EventJson<AnyMessageEvent>>(ev).unwrap().deserialize().unwrap();
 
     assert_matches!(
-        event.redact(redaction),
+        event.redact(redaction, RoomVersionId::version_6()),
         AnyRedactedMessageEvent::RoomMessage(RedactedMessageEvent {
             content: RedactedMessageEventContent,
             event_id,

--- a/ruma-events/tests/redacted.rs
+++ b/ruma-events/tests/redacted.rs
@@ -14,7 +14,7 @@ use ruma_events::{
         redaction::{RedactionEvent, RedactionEventContent, SyncRedactionEvent},
     },
     AnyMessageEvent, AnyRedactedMessageEvent, AnyRedactedSyncMessageEvent,
-    AnyRedactedSyncStateEvent, AnyRoomEvent, AnySyncRoomEvent, EventJson, RedactedMessageEvent,
+    AnyRedactedSyncStateEvent, AnyRoomEvent, AnySyncRoomEvent, RedactedMessageEvent,
     RedactedSyncMessageEvent, RedactedSyncStateEvent, RedactedSyncUnsigned, RedactedUnsigned,
     Unsigned,
 };
@@ -264,10 +264,8 @@ fn redacted_custom_event_serialize() {
             && event_type == "m.made.up"
     );
 
-    let x = from_json_value::<EventJson<AnyRedactedSyncStateEvent>>(redacted)
-        .unwrap()
-        .deserialize()
-        .unwrap();
+    let x =
+        from_json_value::<Raw<AnyRedactedSyncStateEvent>>(redacted).unwrap().deserialize().unwrap();
     assert_eq!(x.event_id(), &EventId::try_from("$h29iv0s8:example.com").unwrap())
 }
 
@@ -322,7 +320,7 @@ fn redact_method_properly_redacts() {
         unsigned: Unsigned::default(),
     };
 
-    let event = from_json_value::<EventJson<AnyMessageEvent>>(ev).unwrap().deserialize().unwrap();
+    let event = from_json_value::<Raw<AnyMessageEvent>>(ev).unwrap().deserialize().unwrap();
 
     assert_matches!(
         event.redact(redaction, RoomVersionId::version_6()),


### PR DESCRIPTION
I did some commit manipulation on this I think I'm getting the hang of it!

What do you think of `redact` returning an `Option<RedactedEvent>`, the method can validate the `EventId`s match and whatever else is needed (I think the event ids are it but maybe in the future it could be more complicated)?