### PR TITLE
Use strong types

### DIFF
--- a/ruma-client-api/CHANGELOG.md
+++ b/ruma-client-api/CHANGELOG.md
@@ -20,6 +20,7 @@ Breaking changes:
 * Fix event types in `r0::sync::sync_events`
 * Update type of `user_id` in `r0::account::whoami` from `String` to `ruma_identifiers::UserId`
 * Update type of `limited` in `r0::sync::sync_events::Timeline` from `Option<bool>` to `bool`
+* Use `DeviceId` for `device_id` field of `r0::session::login::Response`
 
 Improvements:
 

--- a/ruma-client-api/CHANGELOG.md
+++ b/ruma-client-api/CHANGELOG.md
@@ -21,6 +21,15 @@ Breaking changes:
 * Update type of `user_id` in `r0::account::whoami` from `String` to `ruma_identifiers::UserId`
 * Update type of `limited` in `r0::sync::sync_events::Timeline` from `Option<bool>` to `bool`
 * Use `DeviceId` for `device_id` field of `r0::session::login::Response`
+* Use `ruma_identifiers::ServerName` instead of `String` for `server_name` fields in the following endpoints:
+  ```rust
+  r0::{
+      account::request_openid_token,
+      media::{get_content, get_content_as_filename, get_content_thumbnail},
+      membership::join_room_by_id_or_alias,
+      session::login,
+  }
+  ```
 
 Improvements:
 

--- a/ruma-client-api/src/r0/account/request_openid_token.rs
+++ b/ruma-client-api/src/r0/account/request_openid_token.rs
@@ -3,7 +3,7 @@
 use std::time::Duration;
 
 use ruma_api::ruma_api;
-use ruma_identifiers::UserId;
+use ruma_identifiers::{ServerName, UserId};
 use serde::{Deserialize, Serialize};
 
 ruma_api! {
@@ -30,7 +30,7 @@ ruma_api! {
         pub token_type: TokenType,
 
         /// Homeserver domain for verification of user's identity.
-        pub matrix_server_name: String,
+        pub matrix_server_name: Box<ServerName>,
 
         /// Seconds until token expiration.
         #[serde(with = "ruma_serde::duration::secs")]

--- a/ruma-client-api/src/r0/media/get_content.rs
+++ b/ruma-client-api/src/r0/media/get_content.rs
@@ -1,6 +1,7 @@
 //! [GET /_matrix/media/r0/download/{serverName}/{mediaId}](https://matrix.org/docs/spec/client_server/r0.6.0#get-matrix-media-r0-download-servername-mediaid)
 
 use ruma_api::ruma_api;
+use ruma_identifiers::ServerName;
 
 ruma_api! {
     metadata: {
@@ -19,7 +20,7 @@ ruma_api! {
 
         /// The server name from the mxc:// URI (the authoritory component).
         #[ruma_api(path)]
-        pub server_name: String,
+        pub server_name: Box<ServerName>,
 
         /// Whether to fetch media deemed remote.
         /// Used to prevent routing loops. Defaults to `true`.

--- a/ruma-client-api/src/r0/media/get_content_as_filename.rs
+++ b/ruma-client-api/src/r0/media/get_content_as_filename.rs
@@ -1,6 +1,7 @@
 //! [GET /_matrix/media/r0/download/{serverName}/{mediaId}/{fileName}](https://matrix.org/docs/spec/client_server/r0.6.0#get-matrix-media-r0-download-servername-mediaid-filename)
 
 use ruma_api::ruma_api;
+use ruma_identifiers::ServerName;
 
 ruma_api! {
     metadata: {
@@ -19,7 +20,7 @@ ruma_api! {
 
         /// The server name from the mxc:// URI (the authoritory component).
         #[ruma_api(path)]
-        pub server_name: String,
+        pub server_name: Box<ServerName>,
 
         /// The filename to return in the `Content-Disposition` header.
         #[ruma_api(path)]

--- a/ruma-client-api/src/r0/media/get_content_thumbnail.rs
+++ b/ruma-client-api/src/r0/media/get_content_thumbnail.rs
@@ -2,6 +2,7 @@
 
 use js_int::UInt;
 use ruma_api::ruma_api;
+use ruma_identifiers::ServerName;
 use serde::{Deserialize, Serialize};
 
 /// The desired resizing method.
@@ -39,7 +40,7 @@ ruma_api! {
 
         /// The server name from the mxc:// URI (the authoritory component).
         #[ruma_api(path)]
-        pub server_name: String,
+        pub server_name: Box<ServerName>,
 
         /// The *desired* height of the thumbnail. The actual thumbnail may not match the size
         /// specified.

--- a/ruma-client-api/src/r0/membership/join_room_by_id_or_alias.rs
+++ b/ruma-client-api/src/r0/membership/join_room_by_id_or_alias.rs
@@ -1,7 +1,7 @@
 //! [POST /_matrix/client/r0/join/{roomIdOrAlias}](https://matrix.org/docs/spec/client_server/r0.6.0#post-matrix-client-r0-join-roomidoralias)
 
 use ruma_api::ruma_api;
-use ruma_identifiers::{RoomId, RoomIdOrAliasId};
+use ruma_identifiers::{RoomId, RoomIdOrAliasId, ServerName};
 
 use super::ThirdPartySigned;
 
@@ -24,7 +24,7 @@ ruma_api! {
         /// must be participating in the room.
         #[ruma_api(query)]
         #[serde(default)]
-        pub server_name: Vec<String>,
+        pub server_name: Vec<Box<ServerName>>,
 
         /// The signature of a `m.third_party_invite` token to prove that this user owns a third
         /// party identity which has been invited to the room.

--- a/ruma-client-api/src/r0/session/login.rs
+++ b/ruma-client-api/src/r0/session/login.rs
@@ -51,9 +51,9 @@ ruma_api! {
 
         /// ID of the logged-in device.
         ///
-        /// Will be the same as the corresponging parameter in the request, if one was
+        /// Will be the same as the corresponding parameter in the request, if one was
         /// specified.
-        pub device_id: String,
+        pub device_id: DeviceId,
 
         /// Client configuration provided by the server.
         ///

--- a/ruma-client-api/src/r0/session/login.rs
+++ b/ruma-client-api/src/r0/session/login.rs
@@ -1,7 +1,7 @@
 //! [POST /_matrix/client/r0/login](https://matrix.org/docs/spec/client_server/r0.6.0#post-matrix-client-r0-login)
 
 use ruma_api::ruma_api;
-use ruma_identifiers::{DeviceId, UserId};
+use ruma_identifiers::{DeviceId, ServerName, UserId};
 use serde::{Deserialize, Serialize};
 
 use crate::r0::thirdparty::Medium;
@@ -44,16 +44,16 @@ ruma_api! {
 
         /// The hostname of the homeserver on which the account has been registered.
         ///
-        /// Deprecated: Clients should extract the server_name from user_id (by splitting at the
-        /// first colon) if they require it.
+        /// Deprecated: Clients should instead use the `user_id.server_name()`
+        /// method if they require it.
         #[serde(skip_serializing_if = "Option::is_none")]
-        pub home_server: Option<String>,
+        pub home_server: Option<Box<ServerName>>,
 
         /// ID of the logged-in device.
         ///
         /// Will be the same as the corresponding parameter in the request, if one was
         /// specified.
-        pub device_id: DeviceId,
+        pub device_id: Box<DeviceId>,
 
         /// Client configuration provided by the server.
         ///

--- a/ruma-events/src/pdu.rs
+++ b/ruma-events/src/pdu.rs
@@ -12,7 +12,7 @@ use std::{collections::BTreeMap, time::SystemTime};
 
 use js_int::UInt;
 use ruma_events::EventType;
-use ruma_identifiers::{EventId, RoomId, UserId};
+use ruma_identifiers::{EventId, RoomId, ServerName, UserId};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
@@ -84,7 +84,7 @@ pub struct RoomV1Pdu {
     pub hashes: EventHash,
 
     /// Signatures for the PDU.
-    pub signatures: BTreeMap<String, BTreeMap<String, String>>,
+    pub signatures: BTreeMap<Box<ServerName>, BTreeMap<String, String>>,
 }
 
 /// A 'persistent data unit' (event) for room versions 3 and beyond.
@@ -140,7 +140,7 @@ pub struct RoomV3Pdu {
     pub hashes: EventHash,
 
     /// Signatures for the PDU.
-    pub signatures: BTreeMap<String, BTreeMap<String, String>>,
+    pub signatures: BTreeMap<Box<ServerName>, BTreeMap<String, String>>,
 }
 
 /// PDU type without event and room IDs.
@@ -216,7 +216,7 @@ pub struct RoomV1PduStub {
     pub hashes: EventHash,
 
     /// Signatures for the PDU.
-    pub signatures: BTreeMap<String, BTreeMap<String, String>>,
+    pub signatures: BTreeMap<Box<ServerName>, BTreeMap<String, String>>,
 }
 
 impl RoomV1PduStub {
@@ -292,7 +292,7 @@ pub struct RoomV3PduStub {
     pub hashes: EventHash,
 
     /// Signatures for the PDU.
-    pub signatures: BTreeMap<String, BTreeMap<String, String>>,
+    pub signatures: BTreeMap<Box<ServerName>, BTreeMap<String, String>>,
 }
 
 impl RoomV3PduStub {

--- a/ruma-events/tests/pdu.rs
+++ b/ruma-events/tests/pdu.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::BTreeMap,
-    convert::TryFrom,
+    convert::{TryFrom, TryInto},
     time::{Duration, SystemTime},
 };
 
@@ -9,7 +9,7 @@ use ruma_events::{
     pdu::{EventHash, Pdu, PduStub, RoomV1Pdu, RoomV1PduStub, RoomV3Pdu, RoomV3PduStub},
     EventType,
 };
-use ruma_identifiers::{EventId, RoomId, ServerName, UserId};
+use ruma_identifiers::{EventId, RoomId, UserId};
 use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
 #[test]
@@ -18,7 +18,7 @@ fn serialize_stub_as_v1() {
     let mut inner_signature = BTreeMap::new();
     inner_signature
         .insert("ed25519:key_version".into(), "86BytesOfSignatureOfTheRedactedEvent".into());
-    signatures.insert(Box::<ServerName>::try_from("example.com").unwrap(), inner_signature);
+    signatures.insert("example.com".try_into().unwrap(), inner_signature);
 
     let mut unsigned = BTreeMap::new();
     unsigned.insert("somekey".into(), json!({"a": 456}));
@@ -79,7 +79,7 @@ fn serialize_stub_as_v3() {
     let mut inner_signature = BTreeMap::new();
     inner_signature
         .insert("ed25519:key_version".into(), "86BytesOfSignatureOfTheRedactedEvent".into());
-    signatures.insert(Box::<ServerName>::try_from("example.com").unwrap(), inner_signature);
+    signatures.insert("example.com".try_into().unwrap(), inner_signature);
 
     let mut unsigned = BTreeMap::new();
     unsigned.insert("somekey".into(), json!({"a": 456}));
@@ -236,7 +236,7 @@ fn serialize_pdu_as_v1() {
     let mut inner_signature = BTreeMap::new();
     inner_signature
         .insert("ed25519:key_version".into(), "86BytesOfSignatureOfTheRedactedEvent".into());
-    signatures.insert(Box::<ServerName>::try_from("example.com").unwrap(), inner_signature);
+    signatures.insert("example.com".try_into().unwrap(), inner_signature);
 
     let mut unsigned = BTreeMap::new();
     unsigned.insert("somekey".into(), json!({"a": 456}));
@@ -301,7 +301,7 @@ fn serialize_pdu_as_v3() {
     let mut inner_signature = BTreeMap::new();
     inner_signature
         .insert("ed25519:key_version".into(), "86BytesOfSignatureOfTheRedactedEvent".into());
-    signatures.insert(Box::<ServerName>::try_from("example.com").unwrap(), inner_signature);
+    signatures.insert("example.com".try_into().unwrap(), inner_signature);
 
     let mut unsigned = BTreeMap::new();
     unsigned.insert("somekey".into(), json!({"a": 456}));
@@ -463,7 +463,7 @@ fn convert_v1_stub_to_pdu() {
     let mut inner_signature = BTreeMap::new();
     inner_signature
         .insert("ed25519:key_version".into(), "86BytesOfSignatureOfTheRedactedEvent".into());
-    signatures.insert(Box::<ServerName>::try_from("example.com").unwrap(), inner_signature);
+    signatures.insert("example.com".try_into().unwrap(), inner_signature);
 
     let mut unsigned = BTreeMap::new();
     unsigned.insert("somekey".into(), json!({"a": 456}));
@@ -538,8 +538,7 @@ fn convert_v3_stub_to_pdu() {
     inner_signature
         .insert("ed25519:key_version".into(), "86BytesOfSignatureOfTheRedactedEvent".into());
 
-    signatures
-        .insert(Box::<ServerName>::try_from("example.com".to_string()).unwrap(), inner_signature);
+    signatures.insert("example.com".try_into().unwrap(), inner_signature);
 
     let mut unsigned = BTreeMap::new();
     unsigned.insert("somekey".into(), json!({"a": 456}));

--- a/ruma-events/tests/pdu.rs
+++ b/ruma-events/tests/pdu.rs
@@ -9,7 +9,7 @@ use ruma_events::{
     pdu::{EventHash, Pdu, PduStub, RoomV1Pdu, RoomV1PduStub, RoomV3Pdu, RoomV3PduStub},
     EventType,
 };
-use ruma_identifiers::{EventId, RoomId, UserId};
+use ruma_identifiers::{EventId, RoomId, ServerName, UserId};
 use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
 #[test]
@@ -18,7 +18,7 @@ fn serialize_stub_as_v1() {
     let mut inner_signature = BTreeMap::new();
     inner_signature
         .insert("ed25519:key_version".into(), "86BytesOfSignatureOfTheRedactedEvent".into());
-    signatures.insert("example.com".into(), inner_signature);
+    signatures.insert(Box::<ServerName>::try_from("example.com").unwrap(), inner_signature);
 
     let mut unsigned = BTreeMap::new();
     unsigned.insert("somekey".into(), json!({"a": 456}));
@@ -79,7 +79,7 @@ fn serialize_stub_as_v3() {
     let mut inner_signature = BTreeMap::new();
     inner_signature
         .insert("ed25519:key_version".into(), "86BytesOfSignatureOfTheRedactedEvent".into());
-    signatures.insert("example.com".into(), inner_signature);
+    signatures.insert(Box::<ServerName>::try_from("example.com").unwrap(), inner_signature);
 
     let mut unsigned = BTreeMap::new();
     unsigned.insert("somekey".into(), json!({"a": 456}));
@@ -125,7 +125,7 @@ fn serialize_stub_as_v3() {
 }
 
 #[test]
-fn test_deserialize_stub_as_v1() {
+fn deserialize_stub_as_v1() {
     let json = json!({
         "auth_events": [
             [
@@ -236,7 +236,7 @@ fn serialize_pdu_as_v1() {
     let mut inner_signature = BTreeMap::new();
     inner_signature
         .insert("ed25519:key_version".into(), "86BytesOfSignatureOfTheRedactedEvent".into());
-    signatures.insert("example.com".into(), inner_signature);
+    signatures.insert(Box::<ServerName>::try_from("example.com").unwrap(), inner_signature);
 
     let mut unsigned = BTreeMap::new();
     unsigned.insert("somekey".into(), json!({"a": 456}));
@@ -301,7 +301,7 @@ fn serialize_pdu_as_v3() {
     let mut inner_signature = BTreeMap::new();
     inner_signature
         .insert("ed25519:key_version".into(), "86BytesOfSignatureOfTheRedactedEvent".into());
-    signatures.insert("example.com".into(), inner_signature);
+    signatures.insert(Box::<ServerName>::try_from("example.com").unwrap(), inner_signature);
 
     let mut unsigned = BTreeMap::new();
     unsigned.insert("somekey".into(), json!({"a": 456}));
@@ -463,7 +463,7 @@ fn convert_v1_stub_to_pdu() {
     let mut inner_signature = BTreeMap::new();
     inner_signature
         .insert("ed25519:key_version".into(), "86BytesOfSignatureOfTheRedactedEvent".into());
-    signatures.insert("example.com".into(), inner_signature);
+    signatures.insert(Box::<ServerName>::try_from("example.com").unwrap(), inner_signature);
 
     let mut unsigned = BTreeMap::new();
     unsigned.insert("somekey".into(), json!({"a": 456}));
@@ -537,7 +537,9 @@ fn convert_v3_stub_to_pdu() {
     let mut inner_signature = BTreeMap::new();
     inner_signature
         .insert("ed25519:key_version".into(), "86BytesOfSignatureOfTheRedactedEvent".into());
-    signatures.insert("example.com".into(), inner_signature);
+
+    signatures
+        .insert(Box::<ServerName>::try_from("example.com".to_string()).unwrap(), inner_signature);
 
     let mut unsigned = BTreeMap::new();
     unsigned.insert("somekey".into(), json!({"a": 456}));

--- a/ruma-federation-api/src/discovery.rs
+++ b/ruma-federation-api/src/discovery.rs
@@ -2,7 +2,7 @@
 
 use std::{collections::BTreeMap, time::SystemTime};
 
-use ruma_identifiers::ServerKeyId;
+use ruma_identifiers::{ServerKeyId, ServerName};
 use serde::{Deserialize, Serialize};
 
 pub mod discover_homeserver;
@@ -34,14 +34,14 @@ pub struct OldVerifyKey {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ServerKey {
     /// DNS name of the homeserver.
-    pub server_name: String,
+    pub server_name: Box<ServerName>,
     /// Public keys of the homeserver for verifying digital signatures.
     pub verify_keys: BTreeMap<String, VerifyKey>,
     /// Public keys that the homeserver used to use and when it stopped using them.
     pub old_verify_keys: BTreeMap<String, OldVerifyKey>,
     /// Digital signatures of this object signed using the verify_keys. Map of
     /// server name to keys by key ID
-    pub signatures: BTreeMap<String, BTreeMap<ServerKeyId, String>>,
+    pub signatures: BTreeMap<Box<ServerName>, BTreeMap<ServerKeyId, String>>,
     /// Timestamp when the keys should be refreshed. This field MUST be ignored in room
     /// versions 1, 2, 3, and 4.
     #[serde(with = "ruma_serde::time::ms_since_unix_epoch")]

--- a/ruma-federation-api/src/discovery/get_remote_server_keys/v2.rs
+++ b/ruma-federation-api/src/discovery/get_remote_server_keys/v2.rs
@@ -4,6 +4,7 @@ use std::time::SystemTime;
 
 use crate::discovery::ServerKey;
 use ruma_api::ruma_api;
+use ruma_identifiers::ServerName;
 
 ruma_api! {
     metadata: {
@@ -18,7 +19,7 @@ ruma_api! {
     request: {
         /// The server's DNS name to query
         #[ruma_api(path)]
-        pub server_name: String,
+        pub server_name: Box<ServerName>,
 
         /// A millisecond POSIX timestamp in milliseconds indicating when the
         /// returned certificates will need to be valid until to be useful to

--- a/ruma-federation-api/src/discovery/get_remote_server_keys_batch/v2.rs
+++ b/ruma-federation-api/src/discovery/get_remote_server_keys_batch/v2.rs
@@ -4,7 +4,7 @@ use std::{collections::BTreeMap, time::SystemTime};
 
 use crate::discovery::ServerKey;
 use ruma_api::ruma_api;
-use ruma_identifiers::ServerKeyId;
+use ruma_identifiers::{ServerKeyId, ServerName};
 use serde::{Deserialize, Serialize};
 
 ruma_api! {
@@ -28,7 +28,7 @@ ruma_api! {
         /// The notary server may return multiple keys regardless of the Key IDs
         /// given.
         #[ruma_api(body)]
-        pub server_keys: BTreeMap<String, BTreeMap<ServerKeyId, QueryCriteria>>,
+        pub server_keys: BTreeMap<Box<ServerName>, BTreeMap<ServerKeyId, QueryCriteria>>,
 
         /// A millisecond POSIX timestamp in milliseconds indicating when the
         /// returned certificates will need to be valid until to be useful to

--- a/ruma-federation-api/src/transactions/send_transaction_message/v1.rs
+++ b/ruma-federation-api/src/transactions/send_transaction_message/v1.rs
@@ -4,7 +4,7 @@ use std::{collections::BTreeMap, time::SystemTime};
 
 use ruma_api::ruma_api;
 use ruma_events::pdu::Pdu;
-use ruma_identifiers::EventId;
+use ruma_identifiers::{EventId, ServerName};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
@@ -24,7 +24,7 @@ ruma_api! {
         pub transaction_id: String,
 
         /// The server_name of the homeserver sending this transaction.
-        pub origin: String,
+        pub origin: Box<ServerName>,
 
         /// POSIX timestamp in milliseconds on the originating homeserver when this transaction started.
         #[serde(with = "ruma_serde::time::ms_since_unix_epoch")]

--- a/ruma-identifiers/src/server_key_id.rs
+++ b/ruma-identifiers/src/server_key_id.rs
@@ -66,8 +66,7 @@ mod tests {
     #[cfg(feature = "serde")]
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
-    use super::ServerKeyId;
-    use crate::error::Error;
+    use crate::{error::Error, ServerKeyId};
 
     #[cfg(feature = "serde")]
     use crate::key_algorithms::ServerKeyAlgorithm;


### PR DESCRIPTION
This updates a few endpoints to use the correct identifier types (`ServerName`, `DeviceId`, `UserId`).