### PR TITLE
Fix sync ephemeral room events code-gen enum definition

### DIFF
--- a/ruma-events-macros/src/event_enum.rs
+++ b/ruma-events-macros/src/event_enum.rs
@@ -523,7 +523,11 @@ fn to_event_path(name: &LitStr, struct_name: &Ident) -> TokenStream {
             };
             quote! { ::ruma_events::room::redaction::#redaction }
         }
-        "ToDeviceEvent" | "SyncStateEvent" | "StrippedStateEvent" | "SyncMessageEvent" => {
+        "ToDeviceEvent"
+        | "SyncStateEvent"
+        | "StrippedStateEvent"
+        | "SyncMessageEvent"
+        | "SyncEphemeralRoomEvent" => {
             let content = format_ident!("{}EventContent", event);
             quote! { ::ruma_events::#struct_name<::ruma_events::#( #path )::*::#content> }
         }


### PR DESCRIPTION
Fixes code generated by `event_enum!` it was emitting variants for `AnySyncEphemeralRoomEvent` that looked `Typing(ruma_events::typing::TypingEvent)` what is needed is for variants is `Typing(ruma_events::SyncEphemeralRoomEvent<TypingEventContent>)`.