### PR TITLE
Add AnyPushRule

### DIFF
--- a/ruma-client-api/src/r0/push.rs
+++ b/ruma-client-api/src/r0/push.rs
@@ -53,31 +53,6 @@ impl TryFrom<&'_ str> for RuleKind {
     }
 }
 
-/// A push rule
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct PushRule {
-    /// The actions to perform when this rule is matched.
-    pub actions: Vec<Action>,
-
-    /// Whether this is a default rule, or has been set explicitly.
-    pub default: bool,
-
-    /// Whether the push rule is enabled or not.
-    pub enabled: bool,
-
-    /// The ID of this rule.
-    pub rule_id: String,
-
-    /// The conditions that must hold true for an event in order for a rule to be applied to an event. A rule with no conditions always matches.
-    /// Only applicable to underride and override rules.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub conditions: Option<Vec<PushCondition>>,
-
-    /// The glob-style pattern to match against. Only applicable to content rules.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub pattern: Option<String>,
-}
-
 /// Defines a pusher
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Pusher {

--- a/ruma-client-api/src/r0/push/get_pushrule.rs
+++ b/ruma-client-api/src/r0/push/get_pushrule.rs
@@ -1,8 +1,9 @@
 //! [GET /_matrix/client/r0/pushrules/{scope}/{kind}/{ruleId}](https://matrix.org/docs/spec/client_server/r0.6.0#get-matrix-client-r0-pushrules-scope-kind-ruleid)
 
 use ruma_api::ruma_api;
+use ruma_common::push::AnyPushRule;
 
-use super::{PushRule, RuleKind};
+use super::RuleKind;
 
 ruma_api! {
     metadata: {
@@ -31,7 +32,7 @@ ruma_api! {
     response: {
         /// The specific push rule.
         #[ruma_api(body)]
-        pub rule: PushRule
+        pub rule: AnyPushRule,
     }
 
     error: crate::Error

--- a/ruma-common/src/push.rs
+++ b/ruma-common/src/push.rs
@@ -57,6 +57,7 @@ pub enum AnyPushRule {
 /// These rules are stored on the user's homeserver. They are manually configured by the user, who
 /// can create and view them via the Client/Server API.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct PushRule {
     /// Actions to determine if and how a notification is delivered for events matching this rule.
     pub actions: Vec<Action>,
@@ -75,6 +76,7 @@ pub struct PushRule {
 ///
 /// Only applicable to underride and override rules.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ConditionalPushRule {
     /// Actions to determine if and how a notification is delivered for events matching this rule.
     pub actions: Vec<Action>,
@@ -98,6 +100,7 @@ pub struct ConditionalPushRule {
 ///
 /// Only applicable to content rules.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct PatternedPushRule {
     /// Actions to determine if and how a notification is delivered for events matching this rule.
     pub actions: Vec<Action>,

--- a/ruma-common/src/push.rs
+++ b/ruma-common/src/push.rs
@@ -450,7 +450,7 @@ mod tests {
                 default: false,
                 enabled: true,
                 rule_id,
-            }) if actions.is_empty() && rule_id == ".test.rule".to_string()
+            }) if actions.is_empty() && rule_id == *".test.rule"
         );
     }
 

--- a/ruma-common/src/push.rs
+++ b/ruma-common/src/push.rs
@@ -39,6 +39,18 @@ pub struct Ruleset {
     pub underride: Vec<ConditionalPushRule>,
 }
 
+/// An enum that represents a push rule of any shape
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum AnyPushRule {
+    /// A rule with no pattern or conditions
+    Normal(PushRule),
+    /// A rule with a pattern
+    Patterned(PatternedPushRule),
+    /// A rule with conditions
+    Conditional(ConditionalPushRule),
+}
+
 /// A push rule is a single rule that states under what conditions an event should be passed onto a
 /// push gateway and how the notification should be presented.
 ///


### PR DESCRIPTION
`ruma_client_api` had it's own `PushRule` type, separate from `ruma_common`'s three `PushRule`s.

This PR adds `AnyPushRule`, an enumeration of all possible shapes of push rules, and replaces `ruma_client_api`'s own type.

Closes https://github.com/ruma/ruma/issues/53