### PR TITLE
Move PushRule from ruma_client_api to ruma_common

### DIFF
--- a/ruma-client-api/src/r0/push.rs
+++ b/ruma-client-api/src/r0/push.rs
@@ -53,31 +53,6 @@ impl TryFrom<&'_ str> for RuleKind {
     }
 }
 
-/// A push rule
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct PushRule {
-    /// The actions to perform when this rule is matched.
-    pub actions: Vec<Action>,
-
-    /// Whether this is a default rule, or has been set explicitly.
-    pub default: bool,
-
-    /// Whether the push rule is enabled or not.
-    pub enabled: bool,
-
-    /// The ID of this rule.
-    pub rule_id: String,
-
-    /// The conditions that must hold true for an event in order for a rule to be applied to an event. A rule with no conditions always matches.
-    /// Only applicable to underride and override rules.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub conditions: Option<Vec<PushCondition>>,
-
-    /// The glob-style pattern to match against. Only applicable to content rules.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub pattern: Option<String>,
-}
-
 /// Defines a pusher
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Pusher {

--- a/ruma-client-api/src/r0/push/get_pushrule.rs
+++ b/ruma-client-api/src/r0/push/get_pushrule.rs
@@ -32,7 +32,7 @@ ruma_api! {
     response: {
         /// The specific push rule.
         #[ruma_api(body)]
-        pub rule: AnyPushRule
+        pub rule: AnyPushRule,
     }
 
     error: crate::Error

--- a/ruma-client-api/src/r0/push/get_pushrule.rs
+++ b/ruma-client-api/src/r0/push/get_pushrule.rs
@@ -1,8 +1,9 @@
 //! [GET /_matrix/client/r0/pushrules/{scope}/{kind}/{ruleId}](https://matrix.org/docs/spec/client_server/r0.6.0#get-matrix-client-r0-pushrules-scope-kind-ruleid)
 
 use ruma_api::ruma_api;
+use ruma_common::push::AnyPushRule;
 
-use super::{PushRule, RuleKind};
+use super::RuleKind;
 
 ruma_api! {
     metadata: {
@@ -31,7 +32,7 @@ ruma_api! {
     response: {
         /// The specific push rule.
         #[ruma_api(body)]
-        pub rule: PushRule
+        pub rule: AnyPushRule
     }
 
     error: crate::Error

--- a/ruma-common/src/push.rs
+++ b/ruma-common/src/push.rs
@@ -103,6 +103,31 @@ pub struct PatternedPushRule {
     pub pattern: String,
 }
 
+/// A push rule
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AnyPushRule {
+    /// The actions to perform when this rule is matched.
+    pub actions: Vec<Action>,
+
+    /// Whether this is a default rule, or has been set explicitly.
+    pub default: bool,
+
+    /// Whether the push rule is enabled or not.
+    pub enabled: bool,
+
+    /// The ID of this rule.
+    pub rule_id: String,
+
+    /// The conditions that must hold true for an event in order for a rule to be applied to an event. A rule with no conditions always matches.
+    /// Only applicable to underride and override rules.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub conditions: Option<Vec<PushCondition>>,
+
+    /// The glob-style pattern to match against. Only applicable to content rules.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pattern: Option<String>,
+}
+
 /// This represents the different actions that should be taken when a rule is matched, and
 /// controls how notifications are delivered to the client.
 ///

--- a/ruma-common/src/push.rs
+++ b/ruma-common/src/push.rs
@@ -106,7 +106,8 @@ pub struct PatternedPushRule {
     pub pattern: String,
 }
 
-/// A push rule
+/// Like `PushRule`, but may represent any kind of push rule
+/// thanks to `pattern` and `conditions` being optional.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AnyPushRule {
     /// The actions to perform when this rule is matched.


### PR DESCRIPTION
Move `ruma_client_api::r0::PushRule` to `ruma_common::push::AnyPushRule` and add `From` and `TryFrom` implementations for converting to and from `PushRule`, `PatternedPushRule` and `ConditionalPushRule`.

Closes #53 