### PR TITLE
Add conversion (sync -> full event) methods to enums and event structs

### DIFF
--- a/ruma-events-macros/src/event.rs
+++ b/ruma-events-macros/src/event.rs
@@ -94,7 +94,7 @@ pub fn expand_event(input: DeriveInput) -> syn::Result<TokenStream> {
 
     let deserialize_impl = expand_deserialize_event(is_generic, &input, &fields)?;
 
-    let conversion_impl = expand_from_into(is_generic, &input, &fields);
+    let conversion_impl = expand_from_into(&input, &fields);
 
     Ok(quote! {
         #conversion_impl
@@ -305,30 +305,10 @@ fn expand_deserialize_event(
     })
 }
 
-fn expand_from_into(
-    is_generic: bool,
-    input: &DeriveInput,
-    fields: &[Field],
-) -> Option<TokenStream> {
+fn expand_from_into(input: &DeriveInput, fields: &[Field]) -> Option<TokenStream> {
     let ident = &input.ident;
 
-    // we know there is a content field already
-    let content_type = fields
-        .iter()
-        // we also know that the fields are named and have an ident
-        .find(|f| f.ident.as_ref().unwrap() == "content")
-        .map(|f| f.ty.clone())
-        .unwrap();
-
     let (impl_generics, ty_gen, where_clause) = input.generics.split_for_impl();
-
-    let enum_variants = fields
-        .iter()
-        .map(|field| {
-            let name = field.ident.as_ref().unwrap();
-            to_camel_case(name)
-        })
-        .collect::<Vec<_>>();
 
     let fields = fields.iter().flat_map(|f| &f.ident).collect::<Vec<_>>();
 

--- a/ruma-events-macros/src/event_enum.rs
+++ b/ruma-events-macros/src/event_enum.rs
@@ -261,6 +261,7 @@ fn expand_conversion_impl(
 
             Some(quote! {
                 impl #ident {
+                    /// Convert this sync event into a full event, one with a room_id field.
                     pub fn into_full_event(self, room_id: ::ruma_identifiers::RoomId) -> #full {
                         match self {
                             #(

--- a/ruma-events/src/lib.rs
+++ b/ruma-events/src/lib.rs
@@ -291,6 +291,8 @@ impl RedactedSyncUnsigned {
 }
 
 impl RedactedSyncUnsigned {
+    /// Convert a `RedactedSyncUnsigned` into `RedactedUnsigned`, converting the
+    /// underlying sync redaction event to a full redaction event (with room_id).
     pub fn into_full_event(self, room_id: RoomId) -> RedactedUnsigned {
         if let Some(why) = self.redacted_because {
             let SyncRedactionEvent {


### PR DESCRIPTION
Ok now that I know what has to be emitted tomorrow I can work on refactoring this so it isn't quite so string comparison heavy. I have a few ideas, `generate_conversion_fields` may work by altering the `EVENT_FIELDS` functions so that might be an easy win. I think the `Event` derive needs to use the `EventKind/EventKindVariation` stuff as you were saying a while ago so I'll probably start moving to that. If you see any other low hanging fruit let me know I'll ping the PR when I have something more.

Resolves #115 