### PR TITLE
Use Box instead of Raw for the redacted Unsigned types redacted_because

### DIFF
--- a/ruma-events-macros/src/event_enum.rs
+++ b/ruma-events-macros/src/event_enum.rs
@@ -379,7 +379,7 @@ fn generate_redacted_fields(
 
             quote! {
                 unsigned: ::ruma_events::#redaction_type {
-                    redacted_because: Some(::ruma_events::EventJson::from(redaction)),
+                    redacted_because: Some(::std::boxed::Box::new(redaction)),
                 },
             }
         } else {

--- a/ruma-events/src/lib.rs
+++ b/ruma-events/src/lib.rs
@@ -222,7 +222,7 @@ impl Unsigned {
 pub struct RedactedUnsigned {
     /// The event that redacted this event, if any.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub redacted_because: Option<Raw<RedactionEvent>>,
+    pub redacted_because: Option<Box<RedactionEvent>>,
 }
 
 impl RedactedUnsigned {
@@ -243,7 +243,7 @@ impl RedactedUnsigned {
 pub struct RedactedSyncUnsigned {
     /// The event that redacted this event, if any.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub redacted_because: Option<Raw<SyncRedactionEvent>>,
+    pub redacted_because: Option<Box<SyncRedactionEvent>>,
 }
 
 impl RedactedSyncUnsigned {


### PR DESCRIPTION
I had to add the `full_unsigned` helper function because this change caught that we were using sync redaction event in a full event in the `redacted.rs` test.