### PR TITLE
Remove .expect panic when converting header <-> string values

### DIFF
--- a/ruma-api-macros/src/api/request.rs
+++ b/ruma-api-macros/src/api/request.rs
@@ -34,8 +34,7 @@ impl Request {
             quote! {
                 headers.append(
                     ruma_api::exports::http::header::#header_name,
-                    ruma_api::exports::http::header::HeaderValue::from_str(request.#field_name.as_ref())
-                        .expect("failed to convert value into HeaderValue"),
+                    ruma_api::exports::http::header::HeaderValue::from_str(request.#field_name.as_ref())?,
                 );
             }
         });

--- a/ruma-api-macros/src/api/response.rs
+++ b/ruma-api-macros/src/api/response.rs
@@ -56,10 +56,12 @@ impl Response {
                 }
                 ResponseField::Header(_, header_name) => {
                     quote_spanned! {span=>
-                        #field_name: headers.remove(ruma_api::exports::http::header::#header_name)
-                            .expect("response missing expected header")
-                            .to_str()
-                            .expect("failed to convert HeaderValue to str")
+                        #field_name: ruma_api::try_deserialize!(
+                            response,
+                            headers.remove(ruma_api::exports::http::header::#header_name)
+                                .expect("response missing expected header")
+                                .to_str()
+                            )
                             .to_owned()
                     }
                 }

--- a/ruma-api/tests/ruma_api.rs
+++ b/ruma-api/tests/ruma_api.rs
@@ -3,4 +3,5 @@ fn ui() {
     let t = trybuild::TestCases::new();
     t.pass("tests/ui/01-api-sanity-check.rs");
     t.compile_fail("tests/ui/02-invalid-path.rs");
+    t.pass("tests/ui/03-move-value.rs");
 }

--- a/ruma-api/tests/ui/03-move-value.rs
+++ b/ruma-api/tests/ui/03-move-value.rs
@@ -1,0 +1,37 @@
+use ruma_api::ruma_api;
+use ruma_identifiers::UserId;
+
+ruma_api! {
+    metadata: {
+        description: "Does something.",
+        method: POST,
+        name: "my_endpoint",
+        path: "/_matrix/foo/:bar/",
+        rate_limited: false,
+        requires_authentication: false,
+    }
+
+    request: {
+        #[ruma_api(body)]
+        pub q2: Vec<u8>,
+
+        #[ruma_api(path)]
+        pub bar: String,
+
+        #[ruma_api(query)]
+        pub baz: UserId,
+
+        #[ruma_api(header = CONTENT_TYPE)]
+        pub world: String,
+    }
+
+    response: {
+        #[ruma_api(body)]
+        pub q2: Vec<u8>,
+
+        #[ruma_api(header = CONTENT_TYPE)]
+        pub world: String,
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
In order to avoid `use of moved value "response"` compiler errors, I sort the fields so the header fields are first. This seemed better than emitting an error dependant on field ordering. Then use the `try_deserialize!` macro to bail in the error case.

Resolves #4