### PR TITLE
ruma-events: Change the structure of key.verification.start events.

### DIFF
--- a/ruma-events/CHANGELOG.md
+++ b/ruma-events/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 Breaking changes:
 
+* Change the structure of `StartEventContent` so that we can access transaction
+  ids without the need to understand the concrete method.
 * Change `get_message_events` limit field type from `Option<UInt>` to `UInt`
 * Add `alt_aliases` to `CanonicalAliasEventContent`
 * Replace `format` and `formatted_body` fields in `TextMessagEventContent`,

--- a/ruma-events/src/key/verification.rs
+++ b/ruma-events/src/key/verification.rs
@@ -42,6 +42,8 @@ pub enum KeyAgreementProtocol {
 pub enum MessageAuthenticationCode {
     /// The HKDF-HMAC-SHA256 MAC.
     HkdfHmacSha256,
+    /// The HMAC-SHA256 MAC.
+    HmacSha256,
 }
 
 /// A Short Authentication String method.
@@ -69,7 +71,9 @@ pub enum VerificationMethod {
 
 #[cfg(test)]
 mod test {
-    use super::KeyAgreementProtocol;
+    use super::{KeyAgreementProtocol, MessageAuthenticationCode};
+
+    use serde_json::{from_value as from_json_value, json};
 
     #[test]
     fn serialize_key_agreement() {
@@ -79,5 +83,26 @@ mod test {
 
         let deserialized: KeyAgreementProtocol = serde_json::from_str(&serialized).unwrap();
         assert_eq!(deserialized, KeyAgreementProtocol::Curve25519HkdfSha256);
+    }
+
+    #[test]
+    fn deserialize_mac_method() {
+        let json = json!(["hkdf-hmac-sha256", "hmac-sha256"]);
+
+        let deserialized: Vec<MessageAuthenticationCode> = from_json_value(json).unwrap();
+        assert!(deserialized.contains(&MessageAuthenticationCode::HkdfHmacSha256));
+    }
+
+    #[test]
+    fn serialize_mac_method() {
+        let serialized = serde_json::to_string(&MessageAuthenticationCode::HkdfHmacSha256).unwrap();
+        let deserialized: MessageAuthenticationCode = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(serialized, "\"hkdf-hmac-sha256\"");
+        assert_eq!(deserialized, MessageAuthenticationCode::HkdfHmacSha256);
+
+        let serialized = serde_json::to_string(&MessageAuthenticationCode::HmacSha256).unwrap();
+        let deserialized: MessageAuthenticationCode = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(serialized, "\"hmac-sha256\"");
+        assert_eq!(deserialized, MessageAuthenticationCode::HmacSha256);
     }
 }

--- a/ruma-events/src/key/verification/accept.rs
+++ b/ruma-events/src/key/verification/accept.rs
@@ -85,6 +85,46 @@ pub struct MSasV1Content {
     pub commitment: String,
 }
 
+/// Mandatory initial set of fields for creating an accept `MSasV1Content`.
+#[derive(Clone, Debug, Deserialize)]
+pub struct MSasV1ContentInit {
+    /// The key agreement protocol the device is choosing to use, out of the
+    /// options in the *m.key.verification.start* message.
+    pub key_agreement_protocol: KeyAgreementProtocol,
+
+    /// The hash method the device is choosing to use, out of the options in the
+    /// *m.key.verification.start* message.
+    pub hash: HashAlgorithm,
+
+    /// The message authentication codes that the accepting device understands.
+    pub message_authentication_code: MessageAuthenticationCode,
+
+    /// The SAS methods both devices involved in the verification process
+    /// understand.
+    ///
+    /// Must be a subset of the options in the *m.key.verification.start*
+    /// message.
+    pub short_authentication_string: Vec<ShortAuthenticationString>,
+
+    /// The hash (encoded as unpadded base64) of the concatenation of the
+    /// device's ephemeral public key (encoded as unpadded base64) and the
+    /// canonical JSON representation of the *m.key.verification.start* message.
+    pub commitment: String,
+}
+
+impl From<MSasV1ContentInit> for MSasV1Content {
+    /// Creates a new `MSasV1Content` from the given init struct.
+    fn from(init: MSasV1ContentInit) -> Self {
+        MSasV1Content {
+            hash: init.hash,
+            key_agreement_protocol: init.key_agreement_protocol,
+            message_authentication_code: init.message_authentication_code,
+            short_authentication_string: init.short_authentication_string,
+            commitment: init.commitment,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;

--- a/ruma-events/src/key/verification/accept.rs
+++ b/ruma-events/src/key/verification/accept.rs
@@ -1,11 +1,13 @@
 //! Types for the *m.key.verification.accept* event.
 
+use std::collections::BTreeMap;
+
 use ruma_events_macros::BasicEventContent;
 use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
 
 use super::{
     HashAlgorithm, KeyAgreementProtocol, MessageAuthenticationCode, ShortAuthenticationString,
-    VerificationMethod,
 };
 use crate::BasicEvent;
 
@@ -20,33 +22,236 @@ pub type AcceptEvent = BasicEvent<AcceptEventContent>;
 pub struct AcceptEventContent {
     /// An opaque identifier for the verification process.
     ///
-    /// Must be the same as the one used for the *m.key.verification.start* message.
+    /// Must be the same as the one used for the *m.key.verification.start*
+    /// message.
     pub transaction_id: String,
 
-    /// The verification method to use.
-    ///
-    /// Must be `m.sas.v1`.
-    pub method: VerificationMethod,
+    /// The method specific content.
+    #[serde(flatten)]
+    pub method: AcceptMethod,
+}
 
-    /// The key agreement protocol the device is choosing to use, out of the options in the
-    /// *m.key.verification.start* message.
+/// An enum representing the different method specific
+/// *m.key.verification.accept* content.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
+#[serde(untagged)]
+pub enum AcceptMethod {
+    /// The *m.sas.v1* verification method.
+    MSasV1(MSasV1Content),
+
+    /// Any unknown accept method.
+    Custom(CustomContent),
+}
+
+/// Method specific content of a unknown key verification method.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct CustomContent {
+    /// The name of the method.
+    pub method: String,
+
+    /// The additional fields that the method contains.
+    #[serde(flatten)]
+    pub fields: BTreeMap<String, JsonValue>,
+}
+
+/// The payload of an *m.key.verification.accept* event using the *m.sas.v1* method.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[non_exhaustive]
+#[serde(rename = "m.sas.v1", tag = "method")]
+pub struct MSasV1Content {
+    /// The key agreement protocol the device is choosing to use, out of the
+    /// options in the *m.key.verification.start* message.
     pub key_agreement_protocol: KeyAgreementProtocol,
 
     /// The hash method the device is choosing to use, out of the options in the
     /// *m.key.verification.start* message.
     pub hash: HashAlgorithm,
 
-    /// The message authentication code the device is choosing to use, out of the options in the
-    /// *m.key.verification.start* message.
+    /// The message authentication code the device is choosing to use, out of
+    /// the options in the *m.key.verification.start* message.
     pub message_authentication_code: MessageAuthenticationCode,
 
-    /// The SAS methods both devices involved in the verification process understand.
+    /// The SAS methods both devices involved in the verification process
+    /// understand.
     ///
-    /// Must be a subset of the options in the *m.key.verification.start* message.
+    /// Must be a subset of the options in the *m.key.verification.start*
+    /// message.
     pub short_authentication_string: Vec<ShortAuthenticationString>,
 
-    /// The hash (encoded as unpadded base64) of the concatenation of the device's ephemeral public
-    /// key (encoded as unpadded base64) and the canonical JSON representation of the
-    /// *m.key.verification.start* message.
+    /// The hash (encoded as unpadded base64) of the concatenation of the
+    /// device's ephemeral public key (encoded as unpadded base64) and the
+    /// canonical JSON representation of the *m.key.verification.start* message.
     pub commitment: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use matches::assert_matches;
+    use serde_json::{
+        from_value as from_json_value, json, to_value as to_json_value, Value as JsonValue,
+    };
+
+    use super::{
+        AcceptEvent, AcceptEventContent, AcceptMethod, CustomContent, HashAlgorithm,
+        KeyAgreementProtocol, MSasV1Content, MessageAuthenticationCode, ShortAuthenticationString,
+    };
+    use ruma_common::Raw;
+
+    #[test]
+    fn serialization() {
+        let key_verification_accept_content = AcceptEventContent {
+            transaction_id: "456".into(),
+            method: AcceptMethod::MSasV1(MSasV1Content {
+                hash: HashAlgorithm::Sha256,
+                key_agreement_protocol: KeyAgreementProtocol::Curve25519,
+                message_authentication_code: MessageAuthenticationCode::HkdfHmacSha256,
+                short_authentication_string: vec![ShortAuthenticationString::Decimal],
+                commitment: "test_commitment".into(),
+            }),
+        };
+
+        let key_verification_accept = AcceptEvent { content: key_verification_accept_content };
+
+        let json_data = json!({
+            "content": {
+                "transaction_id": "456",
+                "method": "m.sas.v1",
+                "commitment": "test_commitment",
+                "key_agreement_protocol": "curve25519",
+                "hash": "sha256",
+                "message_authentication_code": "hkdf-hmac-sha256",
+                "short_authentication_string": ["decimal"]
+            },
+            "type": "m.key.verification.accept"
+        });
+
+        assert_eq!(to_json_value(&key_verification_accept).unwrap(), json_data);
+
+        let json_data = json!({
+            "content": {
+                "transaction_id": "456",
+                "method": "m.sas.custom",
+                "test": "field",
+            },
+            "type": "m.key.verification.accept"
+        });
+
+        let key_verification_accept_content = AcceptEventContent {
+            transaction_id: "456".into(),
+            method: AcceptMethod::Custom(CustomContent {
+                method: "m.sas.custom".to_owned(),
+                fields: vec![("test".to_string(), JsonValue::from("field"))]
+                    .into_iter()
+                    .collect::<BTreeMap<String, JsonValue>>(),
+            }),
+        };
+
+        let key_verification_accept = AcceptEvent { content: key_verification_accept_content };
+
+        assert_eq!(to_json_value(&key_verification_accept).unwrap(), json_data);
+    }
+
+    #[test]
+    fn deserialization() {
+        let json = json!({
+            "transaction_id": "456",
+            "commitment": "test_commitment",
+            "method": "m.sas.v1",
+            "hash": "sha256",
+            "key_agreement_protocol": "curve25519",
+            "message_authentication_code": "hkdf-hmac-sha256",
+            "short_authentication_string": ["decimal"]
+        });
+
+        // Deserialize the content struct separately to verify `TryFromRaw` is implemented for it.
+        assert_matches!(
+            from_json_value::<Raw<AcceptEventContent>>(json)
+                .unwrap()
+                .deserialize()
+                .unwrap(),
+            AcceptEventContent {
+                transaction_id,
+                method: AcceptMethod::MSasV1(MSasV1Content {
+                    commitment,
+                    hash,
+                    key_agreement_protocol,
+                    message_authentication_code,
+                    short_authentication_string,
+                })
+            } if commitment == "test_commitment"
+                && transaction_id == "456"
+                && hash == HashAlgorithm::Sha256
+                && key_agreement_protocol == KeyAgreementProtocol::Curve25519
+                && message_authentication_code == MessageAuthenticationCode::HkdfHmacSha256
+                && short_authentication_string == vec![ShortAuthenticationString::Decimal]
+        );
+
+        let json = json!({
+            "content": {
+                "commitment": "test_commitment",
+                "transaction_id": "456",
+                "method": "m.sas.v1",
+                "key_agreement_protocol": "curve25519",
+                "hash": "sha256",
+                "message_authentication_code": "hkdf-hmac-sha256",
+                "short_authentication_string": ["decimal"]
+            },
+            "type": "m.key.verification.accept"
+        });
+
+        assert_matches!(
+            from_json_value::<Raw<AcceptEvent>>(json)
+                .unwrap()
+                .deserialize()
+                .unwrap(),
+            AcceptEvent {
+                content: AcceptEventContent {
+                    transaction_id,
+                    method: AcceptMethod::MSasV1(MSasV1Content {
+                        commitment,
+                        hash,
+                        key_agreement_protocol,
+                        message_authentication_code,
+                        short_authentication_string,
+                    })
+                }
+            } if commitment == "test_commitment"
+                && transaction_id == "456"
+                && hash == HashAlgorithm::Sha256
+                && key_agreement_protocol == KeyAgreementProtocol::Curve25519
+                && message_authentication_code == MessageAuthenticationCode::HkdfHmacSha256
+                && short_authentication_string == vec![ShortAuthenticationString::Decimal]
+        );
+
+        let json = json!({
+            "content": {
+                "from_device": "123",
+                "transaction_id": "456",
+                "method": "m.sas.custom",
+                "test": "field",
+            },
+            "type": "m.key.verification.accept"
+        });
+
+        assert_matches!(
+            from_json_value::<Raw<AcceptEvent>>(json)
+                .unwrap()
+                .deserialize()
+                .unwrap(),
+            AcceptEvent {
+                content: AcceptEventContent {
+                    transaction_id,
+                    method: AcceptMethod::Custom(CustomContent {
+                        method,
+                        fields,
+                    })
+                }
+            } if transaction_id == "456"
+                && method == "m.sas.custom"
+                && fields.get("test").unwrap() == &JsonValue::from("field")
+        );
+    }
 }

--- a/ruma-events/src/key/verification/start.rs
+++ b/ruma-events/src/key/verification/start.rs
@@ -1,6 +1,6 @@
 //! Types for the *m.key.verification.start* event.
 
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, convert::TryFrom};
 
 use ruma_events_macros::BasicEventContent;
 use ruma_identifiers::DeviceId;
@@ -123,6 +123,15 @@ impl MSasV1Content {
     /// `MessageAuthenticationCode::HkdfHmacSha256`.
     /// * `short_authentication_string` does not include `ShortAuthenticationString::Decimal`.
     pub fn new(options: MSasV1ContentOptions) -> Result<Self, InvalidInput> {
+        MSasV1Content::try_from(options)
+    }
+}
+
+impl TryFrom<MSasV1ContentOptions> for MSasV1Content {
+    type Error = InvalidInput;
+
+    /// Creates a new `MSasV1Content` from the given init struct.
+    fn try_from(options: MSasV1ContentOptions) -> Result<Self, Self::Error> {
         if !options.key_agreement_protocols.contains(&KeyAgreementProtocol::Curve25519)
             && !options
                 .key_agreement_protocols


### PR DESCRIPTION
As promised a pr for #160 is here.

I think we might want to change the accept event to have a similar structure to this, if so we should probably make this part of this PR as well.

edit(jplatte):

* fixes #160 
* fixes #165