### PR TITLE
Use a dedicated method for conversion from Ruma request type to http::Request

### DIFF
--- a/ruma-api-macros/src/derive_outgoing.rs
+++ b/ruma-api-macros/src/derive_outgoing.rs
@@ -138,10 +138,10 @@ fn strip_lifetimes(field_type: &mut Type) -> bool {
 
                 if path.is_ident("str") {
                     // &str -> String
-                    *field_type = parse_quote! { String };
+                    *field_type = parse_quote! { ::std::string::String };
                 } else if segs.contains(&"DeviceId".into()) || segs.contains(&"ServerName".into()) {
                     // The identifiers that need to be boxed `Box<T>` since they are DST's.
-                    *field_type = parse_quote! { Box<#path> };
+                    *field_type = parse_quote! { ::std::boxed::Box<#path> };
                 } else {
                     // &T -> T
                     *field_type = Type::Path(ty_path.clone());

--- a/ruma-api-macros/src/util.rs
+++ b/ruma-api-macros/src/util.rs
@@ -12,7 +12,8 @@ use crate::api::{metadata::Metadata, request::Request};
 /// of the path that start with ":".
 ///
 /// The first `TokenStream` returned is the constructed url path. The second `TokenStream` is
-/// used for implementing `TryFrom<http::Request<Vec<u8>>>`, from path strings deserialized to ruma types.
+/// used for implementing `TryFrom<http::Request<Vec<u8>>>`, from path strings deserialized to Ruma
+/// types.
 pub(crate) fn request_path_string_and_parse(
     request: &Request,
     metadata: &Metadata,

--- a/ruma-api-macros/src/util.rs
+++ b/ruma-api-macros/src/util.rs
@@ -45,9 +45,9 @@ pub(crate) fn request_path_string_and_parse(
                     Span::call_site(),
                 );
                 format_args.push(quote! {
-                    ruma_api::exports::percent_encoding::utf8_percent_encode(
+                    ::ruma_api::exports::percent_encoding::utf8_percent_encode(
                         &self.#path_var.to_string(),
-                        ruma_api::exports::percent_encoding::NON_ALPHANUMERIC,
+                        ::ruma_api::exports::percent_encoding::NON_ALPHANUMERIC,
                     )
                 });
                 format_string.replace_range(start_of_segment..end_of_segment, "{}");
@@ -65,17 +65,16 @@ pub(crate) fn request_path_string_and_parse(
                     let path_var_ident = Ident::new(path_var, Span::call_site());
                     quote! {
                         #path_var_ident: {
-                            use std::ops::Deref as _;
-                            use ruma_api::error::RequestDeserializationError;
+                            use ::ruma_api::error::RequestDeserializationError;
 
                             let segment = path_segments.get(#i).unwrap().as_bytes();
                             let decoded = ::ruma_api::try_deserialize!(
                                 request,
-                                ruma_api::exports::percent_encoding::percent_decode(segment)
+                                ::ruma_api::exports::percent_encoding::percent_decode(segment)
                                     .decode_utf8(),
                             );
 
-                            ::ruma_api::try_deserialize!(request, std::convert::TryFrom::try_from(decoded.deref()))
+                            ::ruma_api::try_deserialize!(request, ::std::convert::TryFrom::try_from(&*decoded))
                         }
                     }
                 },
@@ -107,14 +106,14 @@ pub(crate) fn build_query_string(request: &Request) -> TokenStream {
             // ensure that it won't fail.
             fn assert_trait_impl<T>()
             where
-                T: std::iter::IntoIterator<Item = (std::string::String, std::string::String)>,
+                T: ::std::iter::IntoIterator<Item = (::std::string::String, ::std::string::String)>,
             {}
             assert_trait_impl::<#field_type>();
 
             let request_query = RequestQuery(self.#field_name);
             format_args!(
                 "?{}",
-                ruma_api::exports::ruma_serde::urlencoded::to_string(request_query)?
+                ::ruma_api::exports::ruma_serde::urlencoded::to_string(request_query)?
             )
         })
     } else if request.has_query_fields() {
@@ -127,7 +126,7 @@ pub(crate) fn build_query_string(request: &Request) -> TokenStream {
 
             format_args!(
                 "?{}",
-                ruma_api::exports::ruma_serde::urlencoded::to_string(request_query)?
+                ::ruma_api::exports::ruma_serde::urlencoded::to_string(request_query)?
             )
         })
     } else {
@@ -179,7 +178,7 @@ pub(crate) fn build_request_body(request: &Request) -> TokenStream {
         quote! {
             {
                 let request_body = RequestBody #request_body_initializers;
-                ruma_api::exports::serde_json::to_vec(&request_body)?
+                ::ruma_api::exports::serde_json::to_vec(&request_body)?
             }
         }
     } else {

--- a/ruma-api/tests/conversions.rs
+++ b/ruma-api/tests/conversions.rs
@@ -47,7 +47,7 @@ fn request_serde() -> Result<(), Box<dyn std::error::Error + 'static>> {
         baz: UserId::try_from("@bazme:ruma.io")?,
     };
 
-    let http_req = http::Request::<Vec<u8>>::try_from(req.clone())?;
+    let http_req = req.clone().try_into_http_request("https://homeserver.tld", None)?;
     let req2 = Request::try_from(http_req)?;
 
     assert_eq!(req.hello, req2.hello);

--- a/ruma-api/tests/no_fields.rs
+++ b/ruma-api/tests/no_fields.rs
@@ -1,6 +1,6 @@
 use std::convert::TryFrom;
 
-use ruma_api::ruma_api;
+use ruma_api::{ruma_api, Endpoint};
 
 ruma_api! {
     metadata: {
@@ -19,7 +19,7 @@ ruma_api! {
 #[test]
 fn empty_request_http_repr() {
     let req = Request {};
-    let http_req = http::Request::<Vec<u8>>::try_from(req).unwrap();
+    let http_req = req.try_into_http_request("https://homeserver.tld", None).unwrap();
 
     assert!(http_req.body().is_empty());
 }

--- a/ruma-client-api/src/r0/message/get_message_events.rs
+++ b/ruma-client-api/src/r0/message/get_message_events.rs
@@ -117,9 +117,10 @@ pub enum Direction {
 mod tests {
     use super::{Direction, Request};
 
-    use std::convert::{TryFrom, TryInto};
+    use std::convert::TryFrom;
 
     use js_int::uint;
+    use ruma_api::Endpoint;
     use ruma_identifiers::RoomId;
 
     use crate::r0::filter::{LazyLoadOptions, RoomEventFilter};
@@ -143,7 +144,8 @@ mod tests {
             filter: Some(filter),
         };
 
-        let request: http::Request<Vec<u8>> = req.try_into().unwrap();
+        let request: http::Request<Vec<u8>> =
+            req.try_into_http_request("https://homeserver.tld", Some("auth_tok")).unwrap();
         assert_eq!(
             "from=token&to=token2&dir=b&limit=0&filter=%7B%22not_types%22%3A%5B%22type%22%5D%2C%22not_rooms%22%3A%5B%22room%22%2C%22room2%22%2C%22room3%22%5D%2C%22rooms%22%3A%5B%22%21roomid%3Aexample.org%22%5D%2C%22lazy_load_members%22%3Atrue%2C%22include_redundant_members%22%3Atrue%7D",
             request.uri().query().unwrap()
@@ -162,7 +164,8 @@ mod tests {
             filter: None,
         };
 
-        let request: http::Request<Vec<u8>> = req.try_into().unwrap();
+        let request =
+            req.try_into_http_request("https://homeserver.tld", Some("auth_tok")).unwrap();
         assert_eq!("from=token&to=token2&dir=b&limit=0", request.uri().query().unwrap(),);
     }
 
@@ -178,7 +181,8 @@ mod tests {
             filter: Some(RoomEventFilter::default()),
         };
 
-        let request: http::Request<Vec<u8>> = req.try_into().unwrap();
+        let request: http::Request<Vec<u8>> =
+            req.try_into_http_request("https://homeserver.tld", Some("auth_tok")).unwrap();
         assert_eq!(
             "from=token&to=token2&dir=b&limit=0&filter=%7B%7D",
             request.uri().query().unwrap(),

--- a/ruma-client-api/src/r0/session/login.rs
+++ b/ruma-client-api/src/r0/session/login.rs
@@ -141,8 +141,7 @@ mod user_serde;
 
 #[cfg(test)]
 mod tests {
-    use std::convert::TryInto;
-
+    use ruma_api::Endpoint;
     use serde_json::{from_value as from_json_value, json, Value as JsonValue};
 
     use super::{LoginInfo, Medium, Request, UserInfo};
@@ -193,7 +192,7 @@ mod tests {
             device_id: None,
             initial_device_display_name: Some("test".into()),
         }
-        .try_into()
+        .try_into_http_request("https://homeserver.tld", None)
         .unwrap();
 
         let req_body_value: JsonValue = serde_json::from_slice(req.body()).unwrap();

--- a/ruma-client-api/src/r0/sync/sync_events.rs
+++ b/ruma-client-api/src/r0/sync/sync_events.rs
@@ -403,6 +403,7 @@ impl DeviceLists {
 mod tests {
     use std::{convert::TryInto, time::Duration};
 
+    use ruma_api::Endpoint;
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     use matches::assert_matches;
@@ -418,7 +419,7 @@ mod tests {
             set_presence: PresenceState::Offline,
             timeout: Some(Duration::from_millis(30000)),
         }
-        .try_into()
+        .try_into_http_request("https://homeserver.tld", Some("auth_tok"))
         .unwrap();
 
         let uri = req.uri();


### PR DESCRIPTION
The opposite conversion should probably also receive a dedicated conversion function that returns an `Option<String>` access token on success and fails if an access token is required but missing.