### PR TITLE
Lifetime parameters in the ruma_api! macro

### DIFF
--- a/ruma-api-macros/src/api.rs
+++ b/ruma-api-macros/src/api.rs
@@ -126,7 +126,7 @@ impl ToTokens for Api {
             let field_name = field.ident.as_ref().expect("expected field to have an identifier");
 
             quote! {
-                #field_name: request_query
+                #field_name: request_query,
             }
         } else {
             self.request.request_init_query_fields()
@@ -247,10 +247,10 @@ impl ToTokens for Api {
         let api = quote! {
             // FIXME: These can't conflict with other imports, but it would still be nice not to
             //        bring anything into scope that code outside the macro could then rely on.
-            // use ::std::convert::TryInto as _;
+            use ::std::convert::TryInto as _;
 
             use ::ruma_api::exports::serde::de::Error as _;
-            // use ::ruma_api::exports::serde::Deserialize as _;
+            use ::ruma_api::exports::serde::Deserialize as _;
             use ::ruma_api::Endpoint as _;
 
             #[doc = #request_doc]

--- a/ruma-api-macros/src/api.rs
+++ b/ruma-api-macros/src/api.rs
@@ -160,9 +160,9 @@ impl ToTokens for Api {
         {
             let body_lifetimes = if self.request.has_body_lifetimes() {
                 // duplicate the anonymous lifetime as many times as needed
-                let anon = quote! { '_, };
-                let lifetimes = vec![&anon].repeat(self.request.body_lifetime_count());
-                quote! { < #( #lifetimes )* >}
+                let lifetimes =
+                    std::iter::repeat(quote! { '_ }).take(self.request.body_lifetime_count());
+                quote! { < #( #lifetimes, )* >}
             } else {
                 TokenStream::new()
             };
@@ -200,9 +200,9 @@ impl ToTokens for Api {
         {
             let body_lifetimes = if self.response.has_body_lifetimes() {
                 // duplicate the anonymous lifetime as many times as needed
-                let anon = quote! { '_, };
-                let lifetimes = vec![&anon].repeat(self.response.body_lifetime_count());
-                quote! { < #( #lifetimes )* >}
+                let lifetimes =
+                    std::iter::repeat(quote! { '_ }).take(self.response.body_lifetime_count());
+                quote! { < #( #lifetimes, )* >}
             } else {
                 TokenStream::new()
             };

--- a/ruma-api-macros/src/api/request.rs
+++ b/ruma-api-macros/src/api/request.rs
@@ -356,6 +356,14 @@ impl TryFrom<RawRequest> for Request {
             ));
         }
 
+        // TODO when/if `&[(&str, &str)]` is supported remove this
+        if query_map_field.is_some() && !lifetimes.query.is_empty() {
+            return Err(syn::Error::new_spanned(
+                raw.request_kw,
+                "Lifetimes are not allowed for query_map fields",
+            ));
+        }
+
         Ok(Self { fields, lifetimes })
     }
 }

--- a/ruma-api-macros/src/api/request.rs
+++ b/ruma-api-macros/src/api/request.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 #[derive(Debug, Default)]
-pub struct RequetLifetimes {
+pub struct RequestLifetimes {
     body: BTreeSet<Lifetime>,
     path: BTreeSet<Lifetime>,
     query: BTreeSet<Lifetime>,
@@ -28,7 +28,7 @@ pub struct Request {
     fields: Vec<RequestField>,
 
     /// The collected lifetime identifiers from the declared fields.
-    lifetimes: RequetLifetimes,
+    lifetimes: RequestLifetimes,
 }
 
 impl Request {
@@ -252,7 +252,7 @@ impl TryFrom<RawRequest> for Request {
     fn try_from(raw: RawRequest) -> syn::Result<Self> {
         let mut newtype_body_field = None;
         let mut query_map_field = None;
-        let mut lifetimes = RequetLifetimes::default();
+        let mut lifetimes = RequestLifetimes::default();
 
         let fields = raw
             .fields
@@ -323,13 +323,13 @@ impl TryFrom<RawRequest> for Request {
                 }
 
                 match field_kind.unwrap_or(RequestFieldKind::Body) {
-                    RequestFieldKind::Header => util::copy_lifetime_ident(&mut lifetimes.header, &field.ty),
-                    RequestFieldKind::Body => util::copy_lifetime_ident(&mut lifetimes.body, &field.ty),
-                    RequestFieldKind::NewtypeBody => util::copy_lifetime_ident(&mut lifetimes.body, &field.ty),
-                    RequestFieldKind::NewtypeRawBody => util::copy_lifetime_ident(&mut lifetimes.body, &field.ty),
-                    RequestFieldKind::Path => util::copy_lifetime_ident(&mut lifetimes.path, &field.ty),
-                    RequestFieldKind::Query => util::copy_lifetime_ident(&mut lifetimes.query, &field.ty),
-                    RequestFieldKind::QueryMap => util::copy_lifetime_ident(&mut lifetimes.query, &field.ty),
+                    RequestFieldKind::Header => util::collect_lifetime_ident(&mut lifetimes.header, &field.ty),
+                    RequestFieldKind::Body => util::collect_lifetime_ident(&mut lifetimes.body, &field.ty),
+                    RequestFieldKind::NewtypeBody => util::collect_lifetime_ident(&mut lifetimes.body, &field.ty),
+                    RequestFieldKind::NewtypeRawBody => util::collect_lifetime_ident(&mut lifetimes.body, &field.ty),
+                    RequestFieldKind::Path => util::collect_lifetime_ident(&mut lifetimes.path, &field.ty),
+                    RequestFieldKind::Query => util::collect_lifetime_ident(&mut lifetimes.query, &field.ty),
+                    RequestFieldKind::QueryMap => util::collect_lifetime_ident(&mut lifetimes.query, &field.ty),
                 }
 
                 Ok(RequestField::new(

--- a/ruma-api-macros/src/api/response.rs
+++ b/ruma-api-macros/src/api/response.rs
@@ -248,19 +248,19 @@ impl TryFrom<RawResponse> for Response {
 
                 Ok(match field_kind.unwrap_or(ResponseFieldKind::Body) {
                     ResponseFieldKind::Body => {
-                        util::copy_lifetime_ident(&mut lifetimes.body, &field.ty);
+                        util::collect_lifetime_ident(&mut lifetimes.body, &field.ty);
                         ResponseField::Body(field)
                     }
                     ResponseFieldKind::Header => {
-                        util::copy_lifetime_ident(&mut lifetimes.header, &field.ty);
+                        util::collect_lifetime_ident(&mut lifetimes.header, &field.ty);
                         ResponseField::Header(field, header.expect("missing header name"))
                     }
                     ResponseFieldKind::NewtypeBody => {
-                        util::copy_lifetime_ident(&mut lifetimes.body, &field.ty);
+                        util::collect_lifetime_ident(&mut lifetimes.body, &field.ty);
                         ResponseField::NewtypeBody(field)
                     }
                     ResponseFieldKind::NewtypeRawBody => {
-                        util::copy_lifetime_ident(&mut lifetimes.body, &field.ty);
+                        util::collect_lifetime_ident(&mut lifetimes.body, &field.ty);
                         ResponseField::NewtypeRawBody(field)
                     }
                 })

--- a/ruma-api-macros/src/derive_outgoing.rs
+++ b/ruma-api-macros/src/derive_outgoing.rs
@@ -147,7 +147,7 @@ fn strip_lifetimes(field_type: &mut Type) -> bool {
         // The IncomingT has to be declared by the user of this derive macro.
         Type::Path(TypePath { path, .. }) => {
             let mut has_lifetimes = false;
-            let mut generic_lifetime = false;
+            let mut is_lifetime_generic = false;
 
             for seg in &mut path.segments {
                 // strip generic lifetimes
@@ -168,7 +168,7 @@ fn strip_lifetimes(field_type: &mut Type) -> bool {
                             })
                             .filter(|arg| {
                                 if let GenericArgument::Lifetime(_) = arg {
-                                    generic_lifetime = true;
+                                    is_lifetime_generic = true;
                                     false
                                 } else {
                                     true
@@ -195,14 +195,14 @@ fn strip_lifetimes(field_type: &mut Type) -> bool {
             }
 
             // If a type has a generic lifetime parameter there must be an `Incoming` variant of that type.
-            if generic_lifetime {
+            if is_lifetime_generic {
                 if let Some(name) = path.segments.last_mut() {
                     let incoming_ty_ident = format_ident!("Incoming{}", name.ident);
                     name.ident = incoming_ty_ident;
                 }
             }
 
-            has_lifetimes || generic_lifetime
+            has_lifetimes || is_lifetime_generic
         }
         Type::Reference(TypeReference { elem, .. }) => match &mut **elem {
             Type::Path(ty_path) => {

--- a/ruma-api-macros/src/derive_outgoing.rs
+++ b/ruma-api-macros/src/derive_outgoing.rs
@@ -227,6 +227,15 @@ fn strip_lifetimes(field_type: &mut Type) -> bool {
             }
             _ => false,
         },
+        Type::Tuple(syn::TypeTuple { elems, .. }) => {
+            let mut has_lifetime = false;
+            for elem in elems {
+                if strip_lifetimes(elem) {
+                    has_lifetime = true;
+                }
+            }
+            has_lifetime
+        }
         _ => false,
     }
 }

--- a/ruma-api-macros/src/util.rs
+++ b/ruma-api-macros/src/util.rs
@@ -43,6 +43,11 @@ pub fn collect_lifetime_ident(lifetimes: &mut BTreeSet<Lifetime>, ty: &Type) {
                 lifetimes.insert(lt.clone());
             }
         }
+        Type::Tuple(syn::TypeTuple { elems, .. }) => {
+            for ty in elems {
+                collect_lifetime_ident(lifetimes, ty)
+            }
+        }
         _ => {}
     }
 }

--- a/ruma-api-macros/src/util.rs
+++ b/ruma-api-macros/src/util.rs
@@ -10,7 +10,7 @@ use syn::{
 
 use crate::api::{metadata::Metadata, request::Request};
 
-pub fn copy_lifetime_ident(lifetimes: &mut BTreeSet<Lifetime>, ty: &Type) {
+pub fn collect_lifetime_ident(lifetimes: &mut BTreeSet<Lifetime>, ty: &Type) {
     match ty {
         Type::Path(TypePath { path, .. }) => {
             for seg in &path.segments {
@@ -20,7 +20,7 @@ pub fn copy_lifetime_ident(lifetimes: &mut BTreeSet<Lifetime>, ty: &Type) {
                     }) => {
                         for gen in args {
                             if let GenericArgument::Type(ty) = gen {
-                                copy_lifetime_ident(lifetimes, &ty)
+                                collect_lifetime_ident(lifetimes, &ty)
                             } else if let GenericArgument::Lifetime(lt) = gen {
                                 lifetimes.insert(lt.clone());
                             }
@@ -30,7 +30,7 @@ pub fn copy_lifetime_ident(lifetimes: &mut BTreeSet<Lifetime>, ty: &Type) {
                         inputs, ..
                     }) => {
                         for ty in inputs {
-                            copy_lifetime_ident(lifetimes, ty)
+                            collect_lifetime_ident(lifetimes, ty)
                         }
                     }
                     _ => {}
@@ -38,7 +38,7 @@ pub fn copy_lifetime_ident(lifetimes: &mut BTreeSet<Lifetime>, ty: &Type) {
             }
         }
         Type::Reference(TypeReference { elem, lifetime, .. }) => {
-            copy_lifetime_ident(lifetimes, &*elem);
+            collect_lifetime_ident(lifetimes, &*elem);
             if let Some(lt) = lifetime {
                 lifetimes.insert(lt.clone());
             }

--- a/ruma-api-macros/src/util.rs
+++ b/ruma-api-macros/src/util.rs
@@ -218,13 +218,8 @@ pub(crate) fn extract_request_query(request: &Request) -> TokenStream {
             );
         }
     } else if request.has_query_fields() {
-        let request_query_type = if request.has_query_lifetimes() {
-            quote! { IncomingRequestQuery }
-        } else {
-            quote! { RequestQuery }
-        };
         quote! {
-            let request_query: #request_query_type = ::ruma_api::try_deserialize!(
+            let request_query: <RequestQuery as ::ruma_api::Outgoing>::Incoming = ::ruma_api::try_deserialize!(
                 request,
                 ::ruma_api::exports::ruma_serde::urlencoded::from_str(
                     &request.uri().query().unwrap_or("")

--- a/ruma-api-macros/src/util.rs
+++ b/ruma-api-macros/src/util.rs
@@ -5,8 +5,8 @@ use quote::quote;
 use std::collections::BTreeSet;
 use syn::{
     AngleBracketedGenericArguments, GenericArgument, Ident, Lifetime,
-    ParenthesizedGenericArguments, PathArguments, Type, TypeGroup, TypeParen, TypePath,
-    TypeReference, TypeTuple,
+    ParenthesizedGenericArguments, PathArguments, Type, TypeArray, TypeBareFn, TypeGroup,
+    TypeParen, TypePath, TypePtr, TypeReference, TypeSlice, TypeTuple,
 };
 
 use crate::api::{metadata::Metadata, request::Request};
@@ -51,6 +51,18 @@ pub fn collect_lifetime_ident(lifetimes: &mut BTreeSet<Lifetime>, ty: &Type) {
         }
         Type::Paren(TypeParen { elem, .. }) => collect_lifetime_ident(lifetimes, &*elem),
         Type::Group(TypeGroup { elem, .. }) => collect_lifetime_ident(lifetimes, &*elem),
+        Type::Ptr(TypePtr { elem, .. }) => collect_lifetime_ident(lifetimes, &*elem),
+        Type::Slice(TypeSlice { elem, .. }) => collect_lifetime_ident(lifetimes, &*elem),
+        Type::Array(TypeArray { elem, .. }) => collect_lifetime_ident(lifetimes, &*elem),
+        Type::BareFn(TypeBareFn {
+            lifetimes: Some(syn::BoundLifetimes { lifetimes: fn_lifetimes, .. }),
+            ..
+        }) => {
+            for lt in fn_lifetimes {
+                let syn::LifetimeDef { lifetime, .. } = lt;
+                lifetimes.insert(lifetime.clone());
+            }
+        }
         _ => {}
     }
 }

--- a/ruma-api-macros/src/util.rs
+++ b/ruma-api-macros/src/util.rs
@@ -47,16 +47,6 @@ pub fn copy_lifetime_ident(lifetimes: &mut BTreeSet<Lifetime>, ty: &Type) {
     }
 }
 
-/// Collects the unique lifetime identifiers from the struct declaration.
-pub fn collect_generic_idents<'a, I: Iterator<Item = &'a Type>>(iter: I) -> TokenStream {
-    let mut lifetimes = BTreeSet::new();
-
-    for ty in iter {
-        copy_lifetime_ident(&mut lifetimes, &ty);
-    }
-    generics_to_tokens(lifetimes.iter())
-}
-
 /// Generates a `TokenStream` of lifetime identifiers `<'lifetime>`.
 pub fn generics_to_tokens<'a, I: Iterator<Item = &'a Lifetime>>(lifetimes: I) -> TokenStream {
     let lifetimes = lifetimes.collect::<Vec<_>>();

--- a/ruma-api/tests/outgoing.rs
+++ b/ruma-api/tests/outgoing.rs
@@ -26,34 +26,6 @@ pub struct IncomingOtherThing {
     t: Vec<u8>,
 }
 
-use ruma_api::ruma_api;
-
-ruma_api! {
-    metadata: {
-        description: "Does something.",
-        method: GET,
-        name: "no_fields",
-        path: "/_matrix/my/endpoint/:thing",
-        rate_limited: false,
-        requires_authentication: false,
-    }
-
-    request: {
-        #[ruma_api(query)]
-        pub abc: &'a str,
-        #[ruma_api(path)]
-        pub thing: &'a str,
-        #[ruma_api(header = CONTENT_TYPE)]
-        pub stuff: &'a str,
-    }
-
-    response: {
-        pub body: &'a str,
-        pub thing: OtherThing<'a>,
-        pub stuff: &'a [u8],
-    }
-}
-
 #[derive(Outgoing)]
 #[incoming_no_deserialize]
 pub struct FakeRequest<'a, T> {

--- a/ruma-api/tests/outgoing.rs
+++ b/ruma-api/tests/outgoing.rs
@@ -54,24 +54,24 @@ ruma_api! {
     }
 }
 
-// #[derive(Outgoing)]
-// #[incoming_no_deserialize]
-// pub struct Request<'a, T> {
-//     pub abc: &'a str,
-//     pub thing: Thing<'a, T>,
-//     pub device_id: &'a ::ruma_identifiers::DeviceId,
-//     pub user_id: &'a UserId,
-//     pub bytes: &'a [u8],
-//     pub recursive: &'a [Thing<'a, T>],
-//     pub option: Option<&'a [u8]>,
-// }
+#[derive(Outgoing)]
+#[incoming_no_deserialize]
+pub struct FakeRequest<'a, T> {
+    pub abc: &'a str,
+    pub thing: Thing<'a, T>,
+    pub device_id: &'a ::ruma_identifiers::DeviceId,
+    pub user_id: &'a UserId,
+    pub bytes: &'a [u8],
+    pub recursive: &'a [Thing<'a, T>],
+    pub option: Option<&'a [u8]>,
+}
 
-// #[derive(Outgoing)]
-// #[incoming_no_deserialize]
-// pub enum EnumThing<'a, T> {
-//     Abc(&'a str),
-//     Stuff(Thing<'a, T>),
-//     Boxy(&'a ::ruma_identifiers::DeviceId),
-//     Other(Option<&'a str>),
-//     StructVar { stuff: &'a str, more: &'a ::ruma_identifiers::ServerName },
-// }
+#[derive(Outgoing)]
+#[incoming_no_deserialize]
+pub enum EnumThing<'a, T> {
+    Abc(&'a str),
+    Stuff(Thing<'a, T>),
+    Boxy(&'a ::ruma_identifiers::DeviceId),
+    Other(Option<&'a str>),
+    StructVar { stuff: &'a str, more: &'a ::ruma_identifiers::ServerName },
+}

--- a/ruma-api/tests/outgoing.rs
+++ b/ruma-api/tests/outgoing.rs
@@ -36,6 +36,7 @@ pub struct FakeRequest<'a, T> {
     pub bytes: &'a [u8],
     pub recursive: &'a [Thing<'a, T>],
     pub option: Option<&'a [u8]>,
+    pub depth: Option<&'a [(&'a str, &'a str)]>,
 }
 
 #[derive(Outgoing)]

--- a/ruma-api/tests/outgoing.rs
+++ b/ruma-api/tests/outgoing.rs
@@ -13,24 +13,65 @@ pub struct IncomingThing<T> {
     t: T,
 }
 
-#[derive(Outgoing)]
-#[incoming_no_deserialize]
-pub struct Request<'a, T> {
-    pub abc: &'a str,
-    pub thing: Thing<'a, T>,
-    pub device_id: &'a ::ruma_identifiers::DeviceId,
-    pub user_id: &'a UserId,
-    pub bytes: &'a [u8],
-    pub recursive: &'a [Thing<'a, T>],
-    pub option: Option<&'a [u8]>,
+#[allow(unused)]
+#[derive(Copy, Clone, Debug, serde::Deserialize, serde::Serialize)]
+pub struct OtherThing<'t> {
+    some: &'t str,
+    t: &'t [u8],
 }
 
-#[derive(Outgoing)]
-#[incoming_no_deserialize]
-pub enum EnumThing<'a, T> {
-    Abc(&'a str),
-    Stuff(Thing<'a, T>),
-    Boxy(&'a ::ruma_identifiers::DeviceId),
-    Other(Option<&'a str>),
-    StructVar { stuff: &'a str, more: &'a ::ruma_identifiers::ServerName },
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+pub struct IncomingOtherThing {
+    some: String,
+    t: Vec<u8>,
 }
+
+use ruma_api::ruma_api;
+
+ruma_api! {
+    metadata: {
+        description: "Does something.",
+        method: GET,
+        name: "no_fields",
+        path: "/_matrix/my/endpoint/:thing",
+        rate_limited: false,
+        requires_authentication: false,
+    }
+
+    request: {
+        #[ruma_api(query)]
+        pub abc: &'a str,
+        #[ruma_api(path)]
+        pub thing: &'a str,
+        #[ruma_api(header = CONTENT_TYPE)]
+        pub stuff: &'a str,
+    }
+
+    response: {
+        pub body: &'a str,
+        pub thing: OtherThing<'a>,
+        pub stuff: &'a [u8],
+    }
+}
+
+// #[derive(Outgoing)]
+// #[incoming_no_deserialize]
+// pub struct Request<'a, T> {
+//     pub abc: &'a str,
+//     pub thing: Thing<'a, T>,
+//     pub device_id: &'a ::ruma_identifiers::DeviceId,
+//     pub user_id: &'a UserId,
+//     pub bytes: &'a [u8],
+//     pub recursive: &'a [Thing<'a, T>],
+//     pub option: Option<&'a [u8]>,
+// }
+
+// #[derive(Outgoing)]
+// #[incoming_no_deserialize]
+// pub enum EnumThing<'a, T> {
+//     Abc(&'a str),
+//     Stuff(Thing<'a, T>),
+//     Boxy(&'a ::ruma_identifiers::DeviceId),
+//     Other(Option<&'a str>),
+//     StructVar { stuff: &'a str, more: &'a ::ruma_identifiers::ServerName },
+// }

--- a/ruma-api/tests/outgoing.rs
+++ b/ruma-api/tests/outgoing.rs
@@ -14,16 +14,10 @@ pub struct IncomingThing<T> {
 }
 
 #[allow(unused)]
-#[derive(Copy, Clone, Debug, serde::Deserialize, serde::Serialize)]
+#[derive(Copy, Clone, Debug, Outgoing, serde::Serialize)]
 pub struct OtherThing<'t> {
     some: &'t str,
     t: &'t [u8],
-}
-
-#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
-pub struct IncomingOtherThing {
-    some: String,
-    t: Vec<u8>,
 }
 
 #[derive(Outgoing)]
@@ -37,6 +31,7 @@ pub struct FakeRequest<'a, T> {
     pub recursive: &'a [Thing<'a, T>],
     pub option: Option<&'a [u8]>,
     pub depth: Option<&'a [(&'a str, &'a str)]>,
+    pub arc_type: std::sync::Arc<&'a str>,
 }
 
 #[derive(Outgoing)]

--- a/ruma-api/tests/ruma_api_lifetime.rs
+++ b/ruma-api/tests/ruma_api_lifetime.rs
@@ -1,0 +1,139 @@
+use ruma_identifiers::{RoomAliasId, RoomId};
+
+mod empty_response {
+    use super::*;
+
+    ruma_api::ruma_api! {
+        metadata: {
+            description: "Add an alias to a room.",
+            method: PUT,
+            name: "create_alias",
+            path: "/_matrix/client/r0/directory/room/:room_alias",
+            rate_limited: false,
+            requires_authentication: true,
+        }
+
+        request: {
+            /// The room alias to set.
+            #[ruma_api(path)]
+            pub room_alias: &'a RoomAliasId,
+
+            /// The room ID to set.
+            pub room_id: &'a RoomId,
+        }
+
+        response: {}
+
+    }
+}
+
+mod nested_types {
+    use super::*;
+
+    ruma_api::ruma_api! {
+        metadata: {
+            description: "Add an alias to a room.",
+            method: PUT,
+            name: "create_alias",
+            path: "/_matrix/client/r0/directory/room/:room_alias",
+            rate_limited: false,
+            requires_authentication: true,
+        }
+
+        request: {
+            /// The room alias to set.
+            pub room_alias: &'a [Option<&'a RoomAliasId>],
+
+            /// The room ID to set.
+            pub room_id: &'b [Option<Option<&'a ruma_identifiers::DeviceId>>],
+        }
+
+        response: {}
+
+    }
+}
+
+mod full_request_response {
+    #[allow(unused)]
+    #[derive(Copy, Clone, Debug, serde::Deserialize, serde::Serialize)]
+    pub struct OtherThing<'t> {
+        some: &'t str,
+        t: &'t [u8],
+    }
+
+    #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+    pub struct IncomingOtherThing {
+        some: String,
+        t: Vec<u8>,
+    }
+
+    ruma_api::ruma_api! {
+        metadata: {
+            description: "Does something.",
+            method: GET,
+            name: "no_fields",
+            path: "/_matrix/my/endpoint/:thing",
+            rate_limited: false,
+            requires_authentication: false,
+        }
+
+        request: {
+            #[ruma_api(query)]
+            pub abc: &'a str,
+            #[ruma_api(path)]
+            pub thing: &'a str,
+            #[ruma_api(header = CONTENT_TYPE)]
+            pub stuff: &'a str,
+        }
+
+        response: {
+            #[ruma_api(body)]
+            pub thing: OtherThing<'a>,
+            #[ruma_api(header = CONTENT_TYPE)]
+            pub stuff: &'a str,
+        }
+    }
+}
+
+mod full_request_response_with_query_map {
+    #[allow(unused)]
+    #[derive(Copy, Clone, Debug, serde::Deserialize, serde::Serialize)]
+    pub struct OtherThing<'t> {
+        some: &'t str,
+        t: &'t [u8],
+    }
+
+    #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+    pub struct IncomingOtherThing {
+        some: String,
+        t: Vec<u8>,
+    }
+
+    ruma_api::ruma_api! {
+        metadata: {
+            description: "Does something.",
+            method: GET,
+            name: "no_fields",
+            path: "/_matrix/my/endpoint/:thing",
+            rate_limited: false,
+            requires_authentication: false,
+        }
+
+        request: {
+            #[ruma_api(query_map)]
+            // pub abc: &'a [(&'a str, &'a str)],
+            pub abc: &'a [(String, String)],
+            #[ruma_api(path)]
+            pub thing: &'a str,
+            #[ruma_api(header = CONTENT_TYPE)]
+            pub stuff: &'a str,
+        }
+
+        response: {
+            #[ruma_api(body)]
+            pub thing: OtherThing<'a>,
+            #[ruma_api(header = CONTENT_TYPE)]
+            pub stuff: &'a str,
+        }
+    }
+}

--- a/ruma-api/tests/ruma_api_lifetime.rs
+++ b/ruma-api/tests/ruma_api_lifetime.rs
@@ -30,7 +30,6 @@ mod empty_response {
         }
 
         response: {}
-
     }
 }
 
@@ -56,7 +55,6 @@ mod nested_types {
         }
 
         response: {}
-
     }
 }
 

--- a/ruma-api/tests/ruma_api_lifetime.rs
+++ b/ruma-api/tests/ruma_api_lifetime.rs
@@ -1,5 +1,12 @@
 use ruma_identifiers::{RoomAliasId, RoomId};
 
+#[allow(unused)]
+#[derive(Copy, Clone, Debug, ruma_api::Outgoing, serde::Serialize)]
+pub struct OtherThing<'t> {
+    some: &'t str,
+    t: &'t [u8],
+}
+
 mod empty_response {
     use super::*;
 
@@ -54,18 +61,7 @@ mod nested_types {
 }
 
 mod full_request_response {
-    #[allow(unused)]
-    #[derive(Copy, Clone, Debug, serde::Deserialize, serde::Serialize)]
-    pub struct OtherThing<'t> {
-        some: &'t str,
-        t: &'t [u8],
-    }
-
-    #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
-    pub struct IncomingOtherThing {
-        some: String,
-        t: Vec<u8>,
-    }
+    use super::*;
 
     ruma_api::ruma_api! {
         metadata: {
@@ -97,18 +93,7 @@ mod full_request_response {
 }
 
 mod full_request_response_with_query_map {
-    #[allow(unused)]
-    #[derive(Copy, Clone, Debug, serde::Deserialize, serde::Serialize)]
-    pub struct OtherThing<'t> {
-        some: &'t str,
-        t: &'t [u8],
-    }
-
-    #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
-    pub struct IncomingOtherThing {
-        some: String,
-        t: Vec<u8>,
-    }
+    use super::*;
 
     ruma_api::ruma_api! {
         metadata: {
@@ -122,7 +107,7 @@ mod full_request_response_with_query_map {
 
         request: {
             #[ruma_api(query_map)]
-            // pub abc: &'a [(&'a str, &'a str)], // TODO This does not impl Deserialize
+            // pub abc: &'a [(&'a str, &'a str)], // TODO handle this use case
             pub abc: Vec<(String, String)>,
             #[ruma_api(path)]
             pub thing: &'a str,

--- a/ruma-api/tests/ruma_api_lifetime.rs
+++ b/ruma-api/tests/ruma_api_lifetime.rs
@@ -70,7 +70,7 @@ mod full_request_response {
     ruma_api::ruma_api! {
         metadata: {
             description: "Does something.",
-            method: GET,
+            method: POST,
             name: "no_fields",
             path: "/_matrix/my/endpoint/:thing",
             rate_limited: false,
@@ -84,6 +84,7 @@ mod full_request_response {
             pub thing: &'a str,
             #[ruma_api(header = CONTENT_TYPE)]
             pub stuff: &'a str,
+            pub more: OtherThing<'t>,
         }
 
         response: {
@@ -121,8 +122,8 @@ mod full_request_response_with_query_map {
 
         request: {
             #[ruma_api(query_map)]
-            // pub abc: &'a [(&'a str, &'a str)],
-            pub abc: &'a [(String, String)],
+            // pub abc: &'a [(&'a str, &'a str)], // TODO This does not impl Deserialize
+            pub abc: Vec<(String, String)>,
             #[ruma_api(path)]
             pub thing: &'a str,
             #[ruma_api(header = CONTENT_TYPE)]

--- a/ruma-api/tests/ruma_api_lifetime.rs
+++ b/ruma-api/tests/ruma_api_lifetime.rs
@@ -121,3 +121,37 @@ mod full_request_response_with_query_map {
         }
     }
 }
+
+mod query_fields {
+    ruma_api::ruma_api! {
+        metadata: {
+            description: "Get the list of rooms in this homeserver's public directory.",
+            method: GET,
+            name: "get_public_rooms",
+            path: "/_matrix/client/r0/publicRooms",
+            rate_limited: false,
+            requires_authentication: false,
+        }
+
+        request: {
+            /// Limit for the number of results to return.
+            #[serde(skip_serializing_if = "Option::is_none")]
+            #[ruma_api(query)]
+            pub limit: Option<usize>,
+
+            /// Pagination token from a previous request.
+            #[serde(skip_serializing_if = "Option::is_none")]
+            #[ruma_api(query)]
+            pub since: Option<&'a str>,
+
+            /// The server to fetch the public room lists from.
+            ///
+            /// `None` means the server this request is sent to.
+            #[serde(skip_serializing_if = "Option::is_none")]
+            #[ruma_api(query)]
+            pub server: Option<&'a str>,
+        }
+
+        response: { }
+    }
+}


### PR DESCRIPTION
My last commit mentions about conversion between the fields of a `Response/Request` that are `&str` or some other type that needs to be converted, will we use `From/Into` or is there another way you were thinking for converting `Request<'a>/Response<'a>` into `IncomingRequest/Response`?