### PR TITLE
Convert alias mod and get_public_rooms to use Outgoing trait

### DIFF
--- a/ruma-client-api/src/r0/account/add_3pid.rs
+++ b/ruma-client-api/src/r0/account/add_3pid.rs
@@ -17,7 +17,7 @@ ruma_api! {
     request: {
         /// Additional information for the User-Interactive Authentication API.
         #[serde(skip_serializing_if = "Option::is_none")]
-        pub auth: Option<&'a AuthData>,
+        pub auth: Option<AuthData>,
 
         /// Client-generated secret string used to protect this session.
         pub client_secret: &'a str,

--- a/ruma-client-api/src/r0/account/add_3pid.rs
+++ b/ruma-client-api/src/r0/account/add_3pid.rs
@@ -17,13 +17,13 @@ ruma_api! {
     request: {
         /// Additional information for the User-Interactive Authentication API.
         #[serde(skip_serializing_if = "Option::is_none")]
-        pub auth: Option<AuthData>,
+        pub auth: Option<&'a AuthData>,
 
         /// Client-generated secret string used to protect this session.
-        pub client_secret: String,
+        pub client_secret: &'a str,
 
         /// The session identifier given by the identity server.
-        pub sid: String,
+        pub sid: &'a str,
     }
 
     response: {}

--- a/ruma-client-api/src/r0/alias/create_alias.rs
+++ b/ruma-client-api/src/r0/alias/create_alias.rs
@@ -16,10 +16,10 @@ ruma_api! {
     request: {
         /// The room alias to set.
         #[ruma_api(path)]
-        pub room_alias: RoomAliasId,
+        pub room_alias: &'a RoomAliasId,
 
         /// The room ID to set.
-        pub room_id: RoomId,
+        pub room_id: &'a RoomId,
     }
 
     response: {}

--- a/ruma-client-api/src/r0/alias/delete_alias.rs
+++ b/ruma-client-api/src/r0/alias/delete_alias.rs
@@ -16,7 +16,7 @@ ruma_api! {
     request: {
         /// The room alias to remove.
         #[ruma_api(path)]
-        pub room_alias: RoomAliasId,
+        pub room_alias: &'a RoomAliasId,
     }
 
     response: {}

--- a/ruma-client-api/src/r0/alias/get_alias.rs
+++ b/ruma-client-api/src/r0/alias/get_alias.rs
@@ -16,15 +16,15 @@ ruma_api! {
     request: {
         /// The room alias.
         #[ruma_api(path)]
-        pub room_alias: RoomAliasId,
+        pub room_alias: &'a RoomAliasId,
     }
 
     response: {
         /// The room ID for this room alias.
-        pub room_id: RoomId,
+        pub room_id: &'a RoomId,
 
         /// A list of servers that are aware of this room ID.
-        pub servers: Vec<String>,
+        pub servers: &'a [String],
     }
 
     error: crate::Error

--- a/ruma-client-api/src/r0/directory.rs
+++ b/ruma-client-api/src/r0/directory.rs
@@ -6,33 +6,34 @@ pub mod get_room_visibility;
 pub mod set_room_visibility;
 
 use js_int::UInt;
+use ruma_api::Outgoing;
 use ruma_identifiers::{RoomAliasId, RoomId};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 /// A chunk of a room list response, describing one room
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct PublicRoomsChunk {
+#[derive(Clone, Debug, Outgoing, Serialize)]
+pub struct PublicRoomsChunk<'a> {
     /// Aliases of the room.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub aliases: Vec<RoomAliasId>,
+    pub aliases: Vec<&'a RoomAliasId>,
 
     /// The canonical alias of the room, if any.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub canonical_alias: Option<RoomAliasId>,
+    pub canonical_alias: Option<&'a RoomAliasId>,
 
     /// The name of the room, if any.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
+    pub name: Option<&'a str>,
 
     /// The number of members joined to the room.
     pub num_joined_members: UInt,
 
     /// The ID of the room.
-    pub room_id: RoomId,
+    pub room_id: &'a RoomId,
 
     /// The topic of the room, if any.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub topic: Option<String>,
+    pub topic: Option<&'a str>,
 
     /// Whether the room may be viewed by guest users without joining.
     pub world_readable: bool,
@@ -44,5 +45,5 @@ pub struct PublicRoomsChunk {
 
     /// The URL for the room's avatar, if one is set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub avatar_url: Option<String>,
+    pub avatar_url: Option<&'a str>,
 }

--- a/ruma-client-api/src/r0/directory/get_public_rooms_filtered.rs
+++ b/ruma-client-api/src/r0/directory/get_public_rooms_filtered.rs
@@ -12,7 +12,7 @@ use serde::{
 
 use serde_json::Value as JsonValue;
 
-use super::PublicRoomsChunk;
+use super::{IncomingPublicRoomsChunk, PublicRoomsChunk};
 
 ruma_api! {
     metadata: {
@@ -30,7 +30,7 @@ ruma_api! {
         /// `None` means the server this request is sent to.
         #[serde(skip_serializing_if = "Option::is_none")]
         #[ruma_api(query)]
-        pub server: Option<String>,
+        pub server: Option<&'a str>,
 
         /// Limit for the number of results to return.
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -38,7 +38,7 @@ ruma_api! {
 
         /// Pagination token from a previous request.
         #[serde(skip_serializing_if = "Option::is_none")]
-        pub since: Option<String>,
+        pub since: Option<&'a str>,
 
         /// Filter to apply to the results.
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -51,13 +51,13 @@ ruma_api! {
 
     response: {
         /// A paginated chunk of public rooms.
-        pub chunk: Vec<PublicRoomsChunk>,
+        pub chunk: Vec<PublicRoomsChunk<'a>>,
 
         /// A pagination token for the response.
-        pub next_batch: Option<String>,
+        pub next_batch: Option<&'a str>,
 
         /// A pagination token that allows fetching previous results.
-        pub prev_batch: Option<String>,
+        pub prev_batch: Option<&'a str>,
 
         /// An estimate on the total number of public rooms, if the server has an estimate.
         pub total_room_count_estimate: Option<UInt>,


### PR DESCRIPTION
When should we use the `Outgoing` trait on a type turning it into `Type<'a>` and when should we just `&'a Type` (`PublicRoomsChunk` -> `PublicRoomsChunk<'a>` or `AuthData` -> `&'a AuthData`). Ideally we will convert everything to `Type<'a>` right?