### PR TITLE
Use event content enums for event sending endpoints

### DIFF
--- a/ruma-client-api/Cargo.toml
+++ b/ruma-client-api/Cargo.toml
@@ -20,6 +20,7 @@ edition = "2018"
 assign = "1.1.0"
 http = "0.2.1"
 js_int = { version = "0.1.9", features = ["serde"] }
+percent-encoding = "2.1.0"
 ruma-api = { version = "=0.17.0-alpha.1", path = "../ruma-api" }
 ruma-common = { version = "0.2.0", path = "../ruma-common" }
 ruma-events = { version = "=0.22.0-alpha.1", path = "../ruma-events" }

--- a/ruma-client-api/src/r0/message/send_message_event.rs
+++ b/ruma-client-api/src/r0/message/send_message_event.rs
@@ -1,48 +1,203 @@
 //! [PUT /_matrix/client/r0/rooms/{roomId}/send/{eventType}/{txnId}](https://matrix.org/docs/spec/client_server/r0.6.1#put-matrix-client-r0-rooms-roomid-send-eventtype-txnid)
 
-use ruma_api::ruma_api;
-use ruma_events::EventType;
+use std::convert::TryFrom;
+
+use ruma_api::{
+    error::{
+        FromHttpRequestError, FromHttpResponseError, IntoHttpError, RequestDeserializationError,
+        ResponseDeserializationError, ServerError,
+    },
+    EndpointError, Metadata, Outgoing,
+};
+use ruma_events::{AnyMessageEventContent, EventContent as _};
 use ruma_identifiers::{EventId, RoomId};
+use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue as RawJsonValue;
 
-ruma_api! {
-    metadata: {
-        description: "Send a message event to a room.",
-        method: PUT,
-        name: "create_message_event",
-        path: "/_matrix/client/r0/rooms/:room_id/send/:event_type/:txn_id",
-        rate_limited: false,
-        requires_authentication: true,
+/// Data for a request to the `send_message_event` API endpoint.
+///
+/// Send a message event to a room.
+#[derive(Clone, Debug, Outgoing)]
+#[non_exhaustive]
+#[incoming_no_deserialize]
+pub struct Request<'a> {
+    /// The room to send the event to.
+    pub room_id: &'a RoomId,
+
+    /// The transaction ID for this event.
+    ///
+    /// Clients should generate an ID unique across requests with the
+    /// same access token; it will be used by the server to ensure
+    /// idempotency of requests.
+    pub txn_id: &'a str,
+
+    /// The event content to send.
+    pub content: &'a AnyMessageEventContent,
+}
+
+impl<'a> Request<'a> {
+    /// Creates a new `Request` with the given room id, transaction id and event content.
+    pub fn new(room_id: &'a RoomId, txn_id: &'a str, content: &'a AnyMessageEventContent) -> Self {
+        Self { room_id, txn_id, content }
     }
+}
 
-    request: {
-        /// The room to send the event to.
-        #[ruma_api(path)]
-        pub room_id: &'a RoomId,
+/// Data in the response from the `send_message_event` API endpoint.
+#[derive(Clone, Debug, Outgoing)]
+#[non_exhaustive]
+#[incoming_no_deserialize]
+pub struct Response {
+    /// A unique identifier for the event.
+    pub event_id: EventId,
+}
 
-        /// The type of event to send.
-        #[ruma_api(path)]
-        pub event_type: EventType,
-
-        /// The transaction ID for this event.
-        ///
-        /// Clients should generate an ID unique across requests with the
-        /// same access token; it will be used by the server to ensure
-        /// idempotency of requests.
-        #[ruma_api(path)]
-        pub txn_id: &'a str,
-
-        /// The event's content. The type for this field will be updated in a
-        /// future release, until then you can create a value using
-        /// `serde_json::value::to_raw_value`.
-        #[ruma_api(body)]
-        pub data: Box<RawJsonValue>,
+impl Response {
+    /// Creates a new `Response` with the given event id.
+    pub fn new(event_id: EventId) -> Self {
+        Self { event_id }
     }
+}
 
-    response: {
-        /// A unique identifier for the event.
-        pub event_id: EventId,
+const METADATA: Metadata = Metadata {
+    description: "Send a message event to a room.",
+    method: http::Method::PUT,
+    name: "send_message_event",
+    path: "/_matrix/client/r0/rooms/:room_id/send/:event_type/:txn_id",
+    rate_limited: false,
+    requires_authentication: true,
+};
+
+impl TryFrom<http::Request<Vec<u8>>> for IncomingRequest {
+    type Error = FromHttpRequestError;
+
+    fn try_from(request: http::Request<Vec<u8>>) -> Result<Self, Self::Error> {
+        let path_segments: Vec<&str> = request.uri().path()[1..].split('/').collect();
+
+        let room_id = {
+            let decoded =
+                match percent_encoding::percent_decode(path_segments[4].as_bytes()).decode_utf8() {
+                    Ok(val) => val,
+                    Err(err) => return Err(RequestDeserializationError::new(err, request).into()),
+                };
+
+            match RoomId::try_from(&*decoded) {
+                Ok(val) => val,
+                Err(err) => return Err(RequestDeserializationError::new(err, request).into()),
+            }
+        };
+
+        let txn_id =
+            match percent_encoding::percent_decode(path_segments[7].as_bytes()).decode_utf8() {
+                Ok(val) => val.into_owned(),
+                Err(err) => return Err(RequestDeserializationError::new(err, request).into()),
+            };
+
+        let content = {
+            let request_body: Box<RawJsonValue> =
+                match serde_json::from_slice(request.body().as_slice()) {
+                    Ok(val) => val,
+                    Err(err) => return Err(RequestDeserializationError::new(err, request).into()),
+                };
+
+            let event_type = {
+                match percent_encoding::percent_decode(path_segments[6].as_bytes()).decode_utf8() {
+                    Ok(val) => val,
+                    Err(err) => return Err(RequestDeserializationError::new(err, request).into()),
+                }
+            };
+
+            match AnyMessageEventContent::from_parts(&event_type, request_body) {
+                Ok(content) => content,
+                Err(err) => return Err(RequestDeserializationError::new(err, request).into()),
+            }
+        };
+
+        Ok(Self { room_id, txn_id, content })
     }
+}
 
-    error: crate::Error
+/// Data in the response body.
+#[derive(Debug, Deserialize, Serialize)]
+struct ResponseBody {
+    /// A unique identifier for the event.
+    event_id: EventId,
+}
+
+impl TryFrom<Response> for http::Response<Vec<u8>> {
+    type Error = IntoHttpError;
+
+    fn try_from(response: Response) -> Result<Self, Self::Error> {
+        let response = http::Response::builder()
+            .header(http::header::CONTENT_TYPE, "application/json")
+            .body(serde_json::to_vec(&ResponseBody { event_id: response.event_id })?)
+            .unwrap();
+
+        Ok(response)
+    }
+}
+
+impl TryFrom<http::Response<Vec<u8>>> for Response {
+    type Error = FromHttpResponseError<crate::Error>;
+
+    fn try_from(response: http::Response<Vec<u8>>) -> Result<Self, Self::Error> {
+        if response.status().as_u16() < 400 {
+            let response_body: ResponseBody =
+                match serde_json::from_slice(response.body().as_slice()) {
+                    Ok(val) => val,
+                    Err(err) => return Err(ResponseDeserializationError::new(err, response).into()),
+                };
+
+            Ok(Self { event_id: response_body.event_id })
+        } else {
+            match <crate::Error as EndpointError>::try_from_response(response) {
+                Ok(err) => Err(ServerError::Known(err).into()),
+                Err(response_err) => Err(ServerError::Unknown(response_err).into()),
+            }
+        }
+    }
+}
+
+impl<'a> ruma_api::OutgoingRequest for Request<'a> {
+    type EndpointError = crate::Error;
+    type IncomingResponse = Response;
+
+    /// Metadata for the `send_message_event` endpoint.
+    const METADATA: Metadata = METADATA;
+
+    fn try_into_http_request(
+        self,
+        base_url: &str,
+        access_token: Option<&str>,
+    ) -> Result<http::Request<Vec<u8>>, IntoHttpError> {
+        use http::header::{HeaderValue, AUTHORIZATION};
+        use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
+
+        let http_request = http::Request::builder()
+            .method(http::Method::PUT)
+            .uri(format!(
+                "{}/_matrix/client/r0/rooms/{}/send/{}/{}",
+                base_url.strip_suffix("/").unwrap_or(base_url),
+                utf8_percent_encode(self.room_id.as_str(), NON_ALPHANUMERIC),
+                utf8_percent_encode(self.content.event_type(), NON_ALPHANUMERIC),
+                utf8_percent_encode(&self.txn_id, NON_ALPHANUMERIC),
+            ))
+            .header(
+                AUTHORIZATION,
+                HeaderValue::from_str(&format!(
+                    "Bearer {}",
+                    access_token.ok_or(IntoHttpError::NeedsAuthentication)?
+                ))?,
+            )
+            .body(serde_json::to_vec(&self.content)?)?;
+
+        Ok(http_request)
+    }
+}
+
+impl ruma_api::IncomingRequest for IncomingRequest {
+    type EndpointError = crate::Error;
+    type OutgoingResponse = Response;
+
+    /// Metadata for the `send_message_event` endpoint.
+    const METADATA: Metadata = METADATA;
 }

--- a/ruma-client-api/src/r0/state/send_state_event_for_empty_key.rs
+++ b/ruma-client-api/src/r0/state/send_state_event_for_empty_key.rs
@@ -1,40 +1,189 @@
 //! [PUT /_matrix/client/r0/rooms/{roomId}/state/{eventType}](https://matrix.org/docs/spec/client_server/r0.6.1#put-matrix-client-r0-rooms-roomid-state-eventtype)
 
-use ruma_api::ruma_api;
-use ruma_events::EventType;
+use std::convert::TryFrom;
+
+use ruma_api::{
+    error::{
+        FromHttpRequestError, FromHttpResponseError, IntoHttpError, RequestDeserializationError,
+        ResponseDeserializationError, ServerError,
+    },
+    EndpointError, Metadata, Outgoing,
+};
+use ruma_events::{AnyStateEventContent, EventContent as _};
 use ruma_identifiers::{EventId, RoomId};
+use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue as RawJsonValue;
 
-ruma_api! {
-    metadata: {
-        description: "Send a state event to a room associated with the empty state key.",
-        method: PUT,
-        name: "create_state_event_for_empty_key",
-        path: "/_matrix/client/r0/rooms/:room_id/state/:event_type",
-        rate_limited: false,
-        requires_authentication: true,
+/// Data for a request to the `send_state_event_for_empty_key` API endpoint.
+///
+/// Send a state event to a room associated with the empty state key.
+#[derive(Clone, Debug, Outgoing)]
+#[non_exhaustive]
+#[incoming_no_deserialize]
+pub struct Request<'a> {
+    /// The room to set the state in.
+    pub room_id: &'a RoomId,
+
+    /// The event content to send.
+    pub content: &'a AnyStateEventContent,
+}
+
+impl<'a> Request<'a> {
+    /// Creates a new `Request` with the given room id and event content.
+    pub fn new(room_id: &'a RoomId, content: &'a AnyStateEventContent) -> Self {
+        Self { room_id, content }
     }
+}
 
-    request: {
-        /// The room to set the state in.
-        #[ruma_api(path)]
-        pub room_id: &'a RoomId,
+/// Data in the response from the `send_state_event_for_empty_key` API endpoint.
+#[derive(Clone, Debug, Outgoing)]
+#[non_exhaustive]
+#[incoming_no_deserialize]
+pub struct Response {
+    /// A unique identifier for the event.
+    pub event_id: EventId,
+}
 
-        /// The type of event to send.
-        #[ruma_api(path)]
-        pub event_type: EventType,
-
-        /// The event's content. The type for this field will be updated in a
-        /// future release, until then you can create a value using
-        /// `serde_json::value::to_raw_value`.
-        #[ruma_api(body)]
-        pub data: Box<RawJsonValue>,
+impl Response {
+    /// Creates a new `Response` with the given event id.
+    pub fn new(event_id: EventId) -> Self {
+        Self { event_id }
     }
+}
 
-    response: {
-        /// A unique identifier for the event.
-        pub event_id: EventId,
+const METADATA: Metadata = Metadata {
+    description: "Send a state event to a room associated with the empty state key.",
+    method: http::Method::PUT,
+    name: "send_state_event_for_empty_key",
+    path: "/_matrix/client/r0/rooms/:room_id/state/:event_type",
+    rate_limited: false,
+    requires_authentication: true,
+};
+
+impl TryFrom<http::Request<Vec<u8>>> for IncomingRequest {
+    type Error = FromHttpRequestError;
+
+    fn try_from(request: http::Request<Vec<u8>>) -> Result<Self, Self::Error> {
+        let path_segments: Vec<&str> = request.uri().path()[1..].split('/').collect();
+
+        let room_id = {
+            let decoded =
+                match percent_encoding::percent_decode(path_segments[4].as_bytes()).decode_utf8() {
+                    Ok(val) => val,
+                    Err(err) => return Err(RequestDeserializationError::new(err, request).into()),
+                };
+
+            match RoomId::try_from(&*decoded) {
+                Ok(val) => val,
+                Err(err) => return Err(RequestDeserializationError::new(err, request).into()),
+            }
+        };
+
+        let content = {
+            let request_body: Box<RawJsonValue> =
+                match serde_json::from_slice(request.body().as_slice()) {
+                    Ok(val) => val,
+                    Err(err) => return Err(RequestDeserializationError::new(err, request).into()),
+                };
+
+            let event_type = {
+                match percent_encoding::percent_decode(path_segments[6].as_bytes()).decode_utf8() {
+                    Ok(val) => val,
+                    Err(err) => return Err(RequestDeserializationError::new(err, request).into()),
+                }
+            };
+
+            match AnyStateEventContent::from_parts(&event_type, request_body) {
+                Ok(content) => content,
+                Err(err) => return Err(RequestDeserializationError::new(err, request).into()),
+            }
+        };
+
+        Ok(Self { room_id, content })
     }
+}
 
-    error: crate::Error
+/// Data in the response body.
+#[derive(Debug, Deserialize, Serialize)]
+struct ResponseBody {
+    /// A unique identifier for the event.
+    event_id: EventId,
+}
+
+impl TryFrom<Response> for http::Response<Vec<u8>> {
+    type Error = IntoHttpError;
+
+    fn try_from(response: Response) -> Result<Self, Self::Error> {
+        let response = http::Response::builder()
+            .header(http::header::CONTENT_TYPE, "application/json")
+            .body(serde_json::to_vec(&ResponseBody { event_id: response.event_id })?)
+            .unwrap();
+
+        Ok(response)
+    }
+}
+
+impl TryFrom<http::Response<Vec<u8>>> for Response {
+    type Error = FromHttpResponseError<crate::Error>;
+
+    fn try_from(response: http::Response<Vec<u8>>) -> Result<Self, Self::Error> {
+        if response.status().as_u16() < 400 {
+            let response_body: ResponseBody =
+                match serde_json::from_slice(response.body().as_slice()) {
+                    Ok(val) => val,
+                    Err(err) => return Err(ResponseDeserializationError::new(err, response).into()),
+                };
+
+            Ok(Self { event_id: response_body.event_id })
+        } else {
+            match <crate::Error as EndpointError>::try_from_response(response) {
+                Ok(err) => Err(ServerError::Known(err).into()),
+                Err(response_err) => Err(ServerError::Unknown(response_err).into()),
+            }
+        }
+    }
+}
+
+impl<'a> ruma_api::OutgoingRequest for Request<'a> {
+    type EndpointError = crate::Error;
+    type IncomingResponse = Response;
+
+    /// Metadata for the `send_message_event` endpoint.
+    const METADATA: Metadata = METADATA;
+
+    fn try_into_http_request(
+        self,
+        base_url: &str,
+        access_token: Option<&str>,
+    ) -> Result<http::Request<Vec<u8>>, IntoHttpError> {
+        use http::header::{HeaderValue, AUTHORIZATION};
+        use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
+
+        let http_request = http::Request::builder()
+            .method(http::Method::PUT)
+            .uri(format!(
+                "{}/_matrix/client/r0/rooms/{}/state/{}",
+                base_url.strip_suffix("/").unwrap_or(base_url),
+                utf8_percent_encode(self.room_id.as_str(), NON_ALPHANUMERIC),
+                utf8_percent_encode(self.content.event_type(), NON_ALPHANUMERIC),
+            ))
+            .header(
+                AUTHORIZATION,
+                HeaderValue::from_str(&format!(
+                    "Bearer {}",
+                    access_token.ok_or(IntoHttpError::NeedsAuthentication)?
+                ))?,
+            )
+            .body(serde_json::to_vec(&self.content)?)?;
+
+        Ok(http_request)
+    }
+}
+
+impl ruma_api::IncomingRequest for IncomingRequest {
+    type EndpointError = crate::Error;
+    type OutgoingResponse = Response;
+
+    /// Metadata for the `send_message_event` endpoint.
+    const METADATA: Metadata = METADATA;
 }

--- a/ruma-client-api/src/r0/state/send_state_event_for_key.rs
+++ b/ruma-client-api/src/r0/state/send_state_event_for_key.rs
@@ -1,44 +1,199 @@
 //! [PUT /_matrix/client/r0/rooms/{roomId}/state/{eventType}/{stateKey}](https://matrix.org/docs/spec/client_server/r0.6.1#put-matrix-client-r0-rooms-roomid-state-eventtype-statekey)
 
-use ruma_api::ruma_api;
-use ruma_events::EventType;
+use std::convert::TryFrom;
+
+use ruma_api::{
+    error::{
+        FromHttpRequestError, FromHttpResponseError, IntoHttpError, RequestDeserializationError,
+        ResponseDeserializationError, ServerError,
+    },
+    EndpointError, Metadata, Outgoing,
+};
+use ruma_events::{AnyStateEventContent, EventContent as _};
 use ruma_identifiers::{EventId, RoomId};
+use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue as RawJsonValue;
 
-ruma_api! {
-    metadata: {
-        description: "Send a state event to a room associated with a given state key.",
-        method: PUT,
-        name: "create_state_event_for_key",
-        path: "/_matrix/client/r0/rooms/:room_id/state/:event_type/:state_key",
-        rate_limited: false,
-        requires_authentication: true,
+/// Data for a request to the `send_state_event_for_key` API endpoint.
+///
+/// Send a state event to a room associated with a given state key.
+#[derive(Clone, Debug, Outgoing)]
+#[non_exhaustive]
+#[incoming_no_deserialize]
+pub struct Request<'a> {
+    /// The room to set the state in.
+    pub room_id: &'a RoomId,
+
+    /// The state_key for the state to send. Defaults to the empty string.
+    pub state_key: &'a str,
+
+    /// The event content to send.
+    pub content: &'a AnyStateEventContent,
+}
+
+impl<'a> Request<'a> {
+    /// Creates a new `Request` with the given room id, state key and event content.
+    pub fn new(room_id: &'a RoomId, state_key: &'a str, content: &'a AnyStateEventContent) -> Self {
+        Self { room_id, state_key, content }
     }
+}
 
-    request: {
-        /// The room to set the state in.
-        #[ruma_api(path)]
-        pub room_id: &'a RoomId,
+/// Data in the response from the `send_message_event` API endpoint.
+#[derive(Clone, Debug, Outgoing)]
+#[non_exhaustive]
+#[incoming_no_deserialize]
+pub struct Response {
+    /// A unique identifier for the event.
+    pub event_id: EventId,
+}
 
-        /// The type of event to send.
-        #[ruma_api(path)]
-        pub event_type: EventType,
-
-        /// The state_key for the state to send. Defaults to the empty string.
-        #[ruma_api(path)]
-        pub state_key: &'a str,
-
-        /// The event's content. The type for this field will be updated in a
-        /// future release, until then you can create a value using
-        /// `serde_json::value::to_raw_value`.
-        #[ruma_api(body)]
-        pub data: Box<RawJsonValue>,
+impl Response {
+    /// Creates a new `Response` with the given event id.
+    pub fn new(event_id: EventId) -> Self {
+        Self { event_id }
     }
+}
 
-    response: {
-        /// A unique identifier for the event.
-        pub event_id: EventId,
+const METADATA: Metadata = Metadata {
+    description: "Send a state event to a room associated with a given state key.",
+    method: http::Method::PUT,
+    name: "send_state_event_for_key",
+    path: "/_matrix/client/r0/rooms/:room_id/state/:event_type/:state_key",
+    rate_limited: false,
+    requires_authentication: true,
+};
+
+impl TryFrom<http::Request<Vec<u8>>> for IncomingRequest {
+    type Error = FromHttpRequestError;
+
+    fn try_from(request: http::Request<Vec<u8>>) -> Result<Self, Self::Error> {
+        let path_segments: Vec<&str> = request.uri().path()[1..].split('/').collect();
+
+        let room_id = {
+            let decoded =
+                match percent_encoding::percent_decode(path_segments[4].as_bytes()).decode_utf8() {
+                    Ok(val) => val,
+                    Err(err) => return Err(RequestDeserializationError::new(err, request).into()),
+                };
+
+            match RoomId::try_from(&*decoded) {
+                Ok(val) => val,
+                Err(err) => return Err(RequestDeserializationError::new(err, request).into()),
+            }
+        };
+
+        let state_key =
+            match percent_encoding::percent_decode(path_segments[7].as_bytes()).decode_utf8() {
+                Ok(val) => val.into_owned(),
+                Err(err) => return Err(RequestDeserializationError::new(err, request).into()),
+            };
+
+        let content = {
+            let request_body: Box<RawJsonValue> =
+                match serde_json::from_slice(request.body().as_slice()) {
+                    Ok(val) => val,
+                    Err(err) => return Err(RequestDeserializationError::new(err, request).into()),
+                };
+
+            let event_type = {
+                match percent_encoding::percent_decode(path_segments[6].as_bytes()).decode_utf8() {
+                    Ok(val) => val,
+                    Err(err) => return Err(RequestDeserializationError::new(err, request).into()),
+                }
+            };
+
+            match AnyStateEventContent::from_parts(&event_type, request_body) {
+                Ok(content) => content,
+                Err(err) => return Err(RequestDeserializationError::new(err, request).into()),
+            }
+        };
+
+        Ok(Self { room_id, state_key, content })
     }
+}
 
-    error: crate::Error
+/// Data in the response body.
+#[derive(Debug, Deserialize, Serialize)]
+struct ResponseBody {
+    /// A unique identifier for the event.
+    event_id: EventId,
+}
+
+impl TryFrom<Response> for http::Response<Vec<u8>> {
+    type Error = IntoHttpError;
+
+    fn try_from(response: Response) -> Result<Self, Self::Error> {
+        let response = http::Response::builder()
+            .header(http::header::CONTENT_TYPE, "application/json")
+            .body(serde_json::to_vec(&ResponseBody { event_id: response.event_id })?)
+            .unwrap();
+
+        Ok(response)
+    }
+}
+
+impl TryFrom<http::Response<Vec<u8>>> for Response {
+    type Error = FromHttpResponseError<crate::Error>;
+
+    fn try_from(response: http::Response<Vec<u8>>) -> Result<Self, Self::Error> {
+        if response.status().as_u16() < 400 {
+            let response_body: ResponseBody =
+                match serde_json::from_slice(response.body().as_slice()) {
+                    Ok(val) => val,
+                    Err(err) => return Err(ResponseDeserializationError::new(err, response).into()),
+                };
+
+            Ok(Self { event_id: response_body.event_id })
+        } else {
+            match <crate::Error as EndpointError>::try_from_response(response) {
+                Ok(err) => Err(ServerError::Known(err).into()),
+                Err(response_err) => Err(ServerError::Unknown(response_err).into()),
+            }
+        }
+    }
+}
+
+impl<'a> ruma_api::OutgoingRequest for Request<'a> {
+    type EndpointError = crate::Error;
+    type IncomingResponse = Response;
+
+    /// Metadata for the `send_message_event` endpoint.
+    const METADATA: Metadata = METADATA;
+
+    fn try_into_http_request(
+        self,
+        base_url: &str,
+        access_token: Option<&str>,
+    ) -> Result<http::Request<Vec<u8>>, IntoHttpError> {
+        use http::header::{HeaderValue, AUTHORIZATION};
+        use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
+
+        let http_request = http::Request::builder()
+            .method(http::Method::PUT)
+            .uri(format!(
+                "{}/_matrix/client/r0/rooms/{}/state/{}/{}",
+                base_url.strip_suffix("/").unwrap_or(base_url),
+                utf8_percent_encode(self.room_id.as_str(), NON_ALPHANUMERIC),
+                utf8_percent_encode(self.content.event_type(), NON_ALPHANUMERIC),
+                utf8_percent_encode(&self.state_key, NON_ALPHANUMERIC),
+            ))
+            .header(
+                AUTHORIZATION,
+                HeaderValue::from_str(&format!(
+                    "Bearer {}",
+                    access_token.ok_or(IntoHttpError::NeedsAuthentication)?
+                ))?,
+            )
+            .body(serde_json::to_vec(&self.content)?)?;
+
+        Ok(http_request)
+    }
+}
+
+impl ruma_api::IncomingRequest for IncomingRequest {
+    type EndpointError = crate::Error;
+    type OutgoingResponse = Response;
+
+    /// Metadata for the `send_message_event` endpoint.
+    const METADATA: Metadata = METADATA;
 }


### PR DESCRIPTION
Fixes #17.

This is just `cargo expand` output, cleaned up and refactored a lot. State and to-device sending endpoints are still todo, which is why this is in draft status. Is the manual `Endpoint` implementation code readable enough?