### PR TITLE
Add claim_keys endpoint and changelog entry

### DIFF
--- a/ruma-federation-api/CHANGELOG.md
+++ b/ruma-federation-api/CHANGELOG.md
@@ -6,6 +6,7 @@ Improvements:
 
   ```
   device::get_devices::v1,
+  keys::claim_keys::v1,
   ```
 
 # 0.0.3

--- a/ruma-federation-api/src/keys.rs
+++ b/ruma-federation-api/src/keys.rs
@@ -1,0 +1,3 @@
+//! Endpoints for handling keys for end-to-end encryption
+
+pub mod claim_keys;

--- a/ruma-federation-api/src/keys/claim_keys/mod.rs
+++ b/ruma-federation-api/src/keys/claim_keys/mod.rs
@@ -1,0 +1,3 @@
+//! Endpoint to claim one-time keys for use in pre-key messages
+
+pub mod v1;

--- a/ruma-federation-api/src/keys/claim_keys/v1.rs
+++ b/ruma-federation-api/src/keys/claim_keys/v1.rs
@@ -1,0 +1,59 @@
+//! [POST
+//! /_matrix/federation/v1/user/keys/claim](https://matrix.org/docs/spec/server_server/r0.1.4#post-matrix-federation-v1-user-keys-claim)
+
+use std::collections::BTreeMap;
+
+use ruma_api::ruma_api;
+use ruma_identifiers::{DeviceId, DeviceKeyAlgorithm, DeviceKeyId, UserId};
+use serde::{Deserialize, Serialize};
+
+ruma_api! {
+    metadata: {
+        description: "Claims one-time keys for use in pre-key messages.",
+        method: POST,
+        name: "claim_keys",
+        path: "/_matrix/federation/v1/user/keys/claim",
+        rate_limited: false,
+        requires_authentication: true,
+    }
+
+    request: {
+        /// The keys to be claimed.
+        one_time_keys: OneTimeKeyClaims,
+    }
+
+    response: {
+        /// One-time keys for the queried devices
+        one_time_keys: OneTimeKeys,
+    }
+}
+
+/// A claim for one time keys
+pub type OneTimeKeyClaims = BTreeMap<UserId, BTreeMap<Box<DeviceId>, DeviceKeyAlgorithm>>;
+
+/// One time keys for use in pre-key messages
+pub type OneTimeKeys = BTreeMap<UserId, BTreeMap<Box<DeviceId>, BTreeMap<DeviceKeyId, KeyObject>>>;
+
+/// A key and its signature
+#[non_exhaustive]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KeyObject {
+    /// The key, encoded using unpadded base64.
+    key: String,
+    /// Signature of the key object.
+    signatures: BTreeMap<UserId, BTreeMap<DeviceKeyId, String>>,
+}
+
+impl Request {
+    /// Creates a new `Request` with the given one time key claims.
+    pub fn new(one_time_keys: OneTimeKeyClaims) -> Self {
+        Self { one_time_keys }
+    }
+}
+
+impl Response {
+    /// Creates a new `Response` with the given one time keys.
+    pub fn new(one_time_keys: OneTimeKeys) -> Self {
+        Self { one_time_keys }
+    }
+}

--- a/ruma-federation-api/src/lib.rs
+++ b/ruma-federation-api/src/lib.rs
@@ -8,6 +8,7 @@ pub mod authorization;
 pub mod device;
 pub mod directory;
 pub mod discovery;
+pub mod keys;
 pub mod membership;
 pub mod openid;
 pub mod query;


### PR DESCRIPTION
I wasn't quite sure what to name the module, but figured 22.1 (this endpoint) and 22.2 (query keys) would fit well together under a `keys` module.

Should close #82.