### PR TITLE
Use proc-macro-crate to allow exporting ruma-events-macro from ruma-events

### DIFF
--- a/ruma-events-macros/Cargo.toml
+++ b/ruma-events-macros/Cargo.toml
@@ -16,6 +16,7 @@ version = "0.22.0-alpha.1"
 syn = { version = "1.0.38", features = ["full"] }
 quote = "1.0.7"
 proc-macro2 = "1.0.19"
+proc-macro-crate = "0.1.5"
 
 [lib]
 proc-macro = true

--- a/ruma-events-macros/src/event.rs
+++ b/ruma-events-macros/src/event.rs
@@ -40,7 +40,7 @@ pub fn expand_event(input: DeriveInput) -> syn::Result<TokenStream> {
 
     let deserialize_impl = expand_deserialize_event(&input, &var, &fields)?;
 
-    let conversion_impl = expand_from_into(&input, &kind, &var, &fields);
+    let conversion_impl = expand_from_into(&input, &kind, &var, &fields, &import_path);
 
     let eq_impl = expand_eq_ord_event(&input, &fields);
 
@@ -345,6 +345,7 @@ fn expand_from_into(
     kind: &EventKind,
     var: &EventKindVariation,
     fields: &[Field],
+    import_path: &TokenStream,
 ) -> Option<TokenStream> {
     let ident = &input.ident;
 
@@ -379,7 +380,7 @@ fn expand_from_into(
                 /// Convert this sync event into a full event, one with a room_id field.
                 pub fn into_full_event(
                     self,
-                    room_id: ::ruma_identifiers::RoomId,
+                    room_id: #import_path::exports::ruma_identifiers::RoomId,
                 ) -> #full_struct #ty_gen {
                     let Self { #( #fields, )* } = self;
                     #full_struct {

--- a/ruma-events-macros/src/event_content.rs
+++ b/ruma-events-macros/src/event_content.rs
@@ -172,7 +172,7 @@ pub fn expand_event_content(input: &DeriveInput, emit_redacted: bool) -> syn::Re
             // this is the non redacted event content's impl
             impl #ident {
                 /// Transforms the full event content into a redacted content according to spec.
-                pub fn redact(self, version: ::ruma_identifiers::RoomVersionId) -> #redacted_ident {
+                pub fn redact(self, version: #import_path::exports::ruma_identifiers::RoomVersionId) -> #redacted_ident {
                     #redacted_ident { #( #redaction_struct_fields: self.#redaction_struct_fields, )* }
                 }
             }

--- a/ruma-events-macros/src/event_enum.rs
+++ b/ruma-events-macros/src/event_enum.rs
@@ -226,7 +226,7 @@ fn expand_conversion_impl(
             Some(quote! {
                 impl #ident {
                     /// Convert this sync event into a full event, one with a room_id field.
-                    pub fn into_full_event(self, room_id: ::ruma_identifiers::RoomId) -> #full {
+                    pub fn into_full_event(self, room_id: #import_path::exports::ruma_identifiers::RoomId) -> #full {
                         match self {
                             #(
                                 Self::#variants(event) => {
@@ -401,7 +401,7 @@ fn expand_redact(
                 pub fn redact(
                     self,
                     redaction: #param,
-                    version: ::ruma_identifiers::RoomVersionId,
+                    version: #import_path::exports::ruma_identifiers::RoomVersionId,
                 ) -> #redaction_enum {
                     match self {
                         #(
@@ -788,9 +788,9 @@ fn generate_accessor(
 fn field_return_type(name: &str, var: &EventKindVariation) -> TokenStream {
     match name {
         "origin_server_ts" => quote! { ::std::time::SystemTime },
-        "room_id" => quote! { ::ruma_identifiers::RoomId },
-        "event_id" => quote! { ::ruma_identifiers::EventId },
-        "sender" => quote! { ::ruma_identifiers::UserId },
+        "room_id" => quote! { #import_path::exports::ruma_identifiers::RoomId },
+        "event_id" => quote! { #import_path::exports::ruma_identifiers::EventId },
+        "sender" => quote! { #import_path::exports::ruma_identifiers::UserId },
         "state_key" => quote! { str },
         "unsigned" if &EventKindVariation::RedactedSync == var => {
             quote! { ::ruma_events::RedactedSyncUnsigned }

--- a/ruma-events-macros/src/lib.rs
+++ b/ruma-events-macros/src/lib.rs
@@ -52,43 +52,67 @@ pub fn event_enum(input: TokenStream) -> TokenStream {
 /// Generates an implementation of `ruma_events::EventContent`.
 #[proc_macro_derive(EventContent, attributes(ruma_event))]
 pub fn derive_event_content(input: TokenStream) -> TokenStream {
+    let import_path = import_ruma_events();
     let input = parse_macro_input!(input as DeriveInput);
-    expand_event_content(&input, true).unwrap_or_else(|err| err.to_compile_error()).into()
+
+    expand_event_content(&input, true, &import_path)
+        .unwrap_or_else(|err| err.to_compile_error())
+        .into()
 }
 
 /// Generates an implementation of `ruma_events::BasicEventContent` and it's super traits.
 #[proc_macro_derive(BasicEventContent, attributes(ruma_event))]
 pub fn derive_basic_event_content(input: TokenStream) -> TokenStream {
+    let import_path = import_ruma_events();
     let input = parse_macro_input!(input as DeriveInput);
-    expand_basic_event_content(&input).unwrap_or_else(|err| err.to_compile_error()).into()
+
+    expand_basic_event_content(&input, &import_path)
+        .unwrap_or_else(|err| err.to_compile_error())
+        .into()
 }
 
 /// Generates an implementation of `ruma_events::RoomEventContent` and it's super traits.
 #[proc_macro_derive(RoomEventContent, attributes(ruma_event))]
 pub fn derive_room_event_content(input: TokenStream) -> TokenStream {
+    let import_path = import_ruma_events();
     let input = parse_macro_input!(input as DeriveInput);
-    expand_room_event_content(&input).unwrap_or_else(|err| err.to_compile_error()).into()
+
+    expand_room_event_content(&input, &import_path)
+        .unwrap_or_else(|err| err.to_compile_error())
+        .into()
 }
 
 /// Generates an implementation of `ruma_events::MessageEventContent` and it's super traits.
 #[proc_macro_derive(MessageEventContent, attributes(ruma_event))]
 pub fn derive_message_event_content(input: TokenStream) -> TokenStream {
+    let import_path = import_ruma_events();
     let input = parse_macro_input!(input as DeriveInput);
-    expand_message_event_content(&input).unwrap_or_else(|err| err.to_compile_error()).into()
+
+    expand_message_event_content(&input, &import_path)
+        .unwrap_or_else(|err| err.to_compile_error())
+        .into()
 }
 
 /// Generates an implementation of `ruma_events::StateEventContent` and it's super traits.
 #[proc_macro_derive(StateEventContent, attributes(ruma_event))]
 pub fn derive_state_event_content(input: TokenStream) -> TokenStream {
+    let import_path = import_ruma_events();
     let input = parse_macro_input!(input as DeriveInput);
-    expand_state_event_content(&input).unwrap_or_else(|err| err.to_compile_error()).into()
+
+    expand_state_event_content(&input, &import_path)
+        .unwrap_or_else(|err| err.to_compile_error())
+        .into()
 }
 
 /// Generates an implementation of `ruma_events::EphemeralRoomEventContent` and it's super traits.
 #[proc_macro_derive(EphemeralRoomEventContent, attributes(ruma_event))]
 pub fn derive_ephemeral_room_event_content(input: TokenStream) -> TokenStream {
+    let import_path = import_ruma_events();
     let input = parse_macro_input!(input as DeriveInput);
-    expand_ephemeral_room_event_content(&input).unwrap_or_else(|err| err.to_compile_error()).into()
+
+    expand_ephemeral_room_event_content(&input, &import_path)
+        .unwrap_or_else(|err| err.to_compile_error())
+        .into()
 }
 
 /// Generates implementations needed to serialize and deserialize Matrix events.

--- a/ruma-events/src/lib.rs
+++ b/ruma-events/src/lib.rs
@@ -139,6 +139,25 @@ mod event_type;
 // that expect `ruma_events` to exist in the prelude.
 extern crate self as ruma_events;
 
+/// Re-exports to allow users to declare their own event types using the
+/// macros used internally.
+///
+/// It is not considered part of ruma-events' public API.
+#[doc(hidden)]
+pub mod exports {
+    pub use js_int;
+    pub use ruma_identifiers;
+    pub use serde;
+    pub use serde_json;
+}
+
+/// Re-export of all the derives needed to create your own event types.
+pub mod macros {
+    pub use ruma_events_macros::{
+        BasicEventContent, EphemeralRoomEventContent, Event, MessageEventContent, StateEventContent,
+    };
+}
+
 pub mod call;
 pub mod custom;
 pub mod direct;


### PR DESCRIPTION
Resolves #124

I left `::ruma_identifiers::SomeId` as it was I wasn't sure exactly how to deal with that. 