### PR TITLE
require std::error::Error for EndpointError

### DIFF
--- a/ruma-api/CHANGELOG.md
+++ b/ruma-api/CHANGELOG.md
@@ -3,6 +3,12 @@
 Breaking changes:
 
 * Update strum dependency to 0.19
+* The `EndpointError` trait now requires `std::error::Error`. This allows integrating `EndpointError`s in the common
+  rust error ecosystem like `thiserror` and `anyhow`.
+
+Improvements:
+
+* The `EndpointError`s that come with ruma crates now implement `std::errror::Error`.
 
 # 0.17.0
 

--- a/ruma-api/src/error.rs
+++ b/ruma-api/src/error.rs
@@ -19,7 +19,7 @@ impl crate::EndpointError for Void {
 
 impl Display for Void {
     fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
-        unreachable!()
+        match self {}
     }
 }
 

--- a/ruma-api/src/error.rs
+++ b/ruma-api/src/error.rs
@@ -17,6 +17,14 @@ impl crate::EndpointError for Void {
     }
 }
 
+impl Display for Void {
+    fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
+        unreachable!()
+    }
+}
+
+impl std::error::Error for Void {}
+
 /// An error when converting one of ruma's endpoint-specific request or response
 /// types to the corresponding http type.
 #[derive(Debug)]
@@ -161,6 +169,8 @@ impl<E> From<ResponseDeserializationError> for FromHttpResponseError<E> {
         Self::Deserialization(err)
     }
 }
+
+impl<E: std::error::Error> std::error::Error for FromHttpResponseError<E> {}
 
 /// An error that occurred when trying to deserialize a response.
 #[derive(Debug)]

--- a/ruma-api/src/lib.rs
+++ b/ruma-api/src/lib.rs
@@ -232,7 +232,7 @@ pub trait Outgoing {
 }
 
 /// Gives users the ability to define their own serializable/deserializable errors.
-pub trait EndpointError: Sized {
+pub trait EndpointError: std::error::Error + Sized {
     /// Tries to construct `Self` from an `http::Response`.
     ///
     /// This will always return `Err` variant when no `error` field is defined in

--- a/ruma-client-api/src/r0/uiaa.rs
+++ b/ruma-client-api/src/r0/uiaa.rs
@@ -119,6 +119,8 @@ impl EndpointError for UiaaResponse {
     }
 }
 
+impl std::error::Error for UiaaResponse {}
+
 impl From<UiaaResponse> for http::Response<Vec<u8>> {
     fn from(uiaa_response: UiaaResponse) -> http::Response<Vec<u8>> {
         match uiaa_response {


### PR DESCRIPTION
and implement it for ruma_api::error::FromHttpResponseError and Void.
This allows integrating EndpointErrors in the common rust error
ecosystem like thiserror and anyhow.

This came up while wrapping the ruma errors in a custom error using the `thiserror` crate.
As almost everything was already implementing Display & Debug, this hopefully should just work™ for everyone.