### PR TITLE
Change requires_authentication field to be an enum

### DIFF
--- a/ruma-api-macros/README.md
+++ b/ruma-api-macros/README.md
@@ -20,7 +20,7 @@ pub mod some_endpoint {
             name: "some_endpoint",
             path: "/_matrix/some/endpoint/:baz", // Variable path components start with a colon.
             rate_limited: false,
-            requires_authentication: false,
+            authentication: None,
         }
 
         request: {

--- a/ruma-api-macros/src/api.rs
+++ b/ruma-api-macros/src/api.rs
@@ -96,7 +96,7 @@ impl ToTokens for Api {
         let name = &self.metadata.name.value();
         let path = &self.metadata.path;
         let rate_limited = &self.metadata.rate_limited;
-        let requires_authentication = &self.metadata.requires_authentication;
+        let authentication = &self.metadata.authentication;
 
         let request_type = &self.request;
         let response_type = &self.response;
@@ -134,7 +134,7 @@ impl ToTokens for Api {
         };
 
         let mut header_kvs = self.request.append_header_kvs();
-        if requires_authentication.value {
+        if authentication == "AccessToken" {
             header_kvs.extend(quote! {
                 req_builder = req_builder.header(
                     #ruma_api_import::exports::http::header::AUTHORIZATION,
@@ -230,7 +230,7 @@ impl ToTokens for Api {
 
         let request_lifetimes = self.request.combine_lifetimes();
 
-        let non_auth_endpoint_impls = if requires_authentication.value {
+        let non_auth_endpoint_impls = if authentication != "None" {
             TokenStream::new()
         } else {
             quote! {
@@ -321,7 +321,7 @@ impl ToTokens for Api {
                 name: #name,
                 path: #path,
                 rate_limited: #rate_limited,
-                requires_authentication: #requires_authentication,
+                authentication: #ruma_api_import::AuthScheme::#authentication,
             };
 
             impl #request_lifetimes #ruma_api_import::OutgoingRequest

--- a/ruma-api-macros/src/api/metadata.rs
+++ b/ruma-api-macros/src/api/metadata.rs
@@ -18,8 +18,8 @@ pub struct Metadata {
     pub path: LitStr,
     /// The rate_limited field.
     pub rate_limited: LitBool,
-    /// The description field.
-    pub requires_authentication: LitBool,
+    /// The authentication field.
+    pub authentication: Ident,
 }
 
 impl TryFrom<RawMetadata> for Metadata {
@@ -31,7 +31,7 @@ impl TryFrom<RawMetadata> for Metadata {
         let mut name = None;
         let mut path = None;
         let mut rate_limited = None;
-        let mut requires_authentication = None;
+        let mut authentication = None;
 
         for field_value in raw.field_values {
             let identifier = match field_value.member.clone() {
@@ -78,11 +78,11 @@ impl TryFrom<RawMetadata> for Metadata {
                     }
                     _ => return Err(syn::Error::new_spanned(expr, "expected a bool literal")),
                 },
-                "requires_authentication" => match expr {
-                    Expr::Lit(ExprLit { lit: Lit::Bool(literal), .. }) => {
-                        requires_authentication = Some(literal);
+                "authentication" => match expr {
+                    Expr::Path(ExprPath { ref path, .. }) if path.segments.len() == 1 => {
+                        authentication = Some(path.segments[0].ident.clone());
                     }
-                    _ => return Err(syn::Error::new_spanned(expr, "expected a bool literal")),
+                    _ => return Err(syn::Error::new_spanned(expr, "expected an identifier")),
                 },
                 _ => return Err(syn::Error::new_spanned(field_value, "unexpected field")),
             }
@@ -98,8 +98,7 @@ impl TryFrom<RawMetadata> for Metadata {
             name: name.ok_or_else(|| missing_field("name"))?,
             path: path.ok_or_else(|| missing_field("path"))?,
             rate_limited: rate_limited.ok_or_else(|| missing_field("rate_limited"))?,
-            requires_authentication: requires_authentication
-                .ok_or_else(|| missing_field("requires_authentication"))?,
+            authentication: authentication.ok_or_else(|| missing_field("authentication"))?,
         })
     }
 }

--- a/ruma-api/CHANGELOG.md
+++ b/ruma-api/CHANGELOG.md
@@ -8,6 +8,9 @@ Breaking changes:
 * The `Endpoint` trait has been replaced by two new traits that each capture a subset of its
   previous functionality: `OutgoingRequest` for sending requests and receiving responses and
   `IncomingRequest` for receiving requests and sending responses.
+* Endpoint authentication is now more granularly defined by an enum `AuthScheme`
+  instead of a boolean. The `ruma_api!` macro has been updated to require
+  `authentication` instead of `requires_authentication`.
 
 Improvements:
 

--- a/ruma-api/src/lib.rs
+++ b/ruma-api/src/lib.rs
@@ -30,7 +30,7 @@ use http::Method;
 ///         name: &'static str,
 ///         path: &'static str,
 ///         rate_limited: bool,
-///         requires_authentication: bool,
+///         authentication: ruma_api::AuthScheme,
 ///     }
 ///
 ///     request: {
@@ -69,7 +69,7 @@ use http::Method;
 ///     A corresponding query string parameter will be expected in the request struct (see below
 ///     for details).
 /// *   `rate_limited`: Whether or not the endpoint enforces rate limiting on requests.
-/// *   `requires_authentication`: Whether or not the endpoint requires a valid access token.
+/// *   `authentication`: What authentication scheme the endpoint uses.
 ///
 /// ## Request
 ///
@@ -139,7 +139,7 @@ use http::Method;
 ///             name: "some_endpoint",
 ///             path: "/_matrix/some/endpoint/:baz",
 ///             rate_limited: false,
-///             requires_authentication: false,
+///             authentication: None,
 ///         }
 ///
 ///         request: {
@@ -180,7 +180,7 @@ use http::Method;
 ///             name: "newtype_body_endpoint",
 ///             path: "/_matrix/some/newtype/body/endpoint",
 ///             rate_limited: false,
-///             requires_authentication: false,
+///             authentication: None,
 ///         }
 ///
 ///         request: {
@@ -290,6 +290,20 @@ pub trait OutgoingNonAuthRequest: OutgoingRequest {}
 /// Marker trait for requests that don't require authentication. (for the server side)
 pub trait IncomingNonAuthRequest: IncomingRequest {}
 
+/// Authentication scheme used by the endpoint.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum AuthScheme {
+    /// No authentication is performed.
+    None,
+    /// Authentication is performed by including an access token in the request headers.
+    AccessToken,
+    /// Authentication is performed by including X-Matrix signatures in the request headers,
+    /// as defined in the federation API.
+    ServerSignatures,
+    /// Authentication is performed by including an access token in the query parameters.
+    QueryOnlyAccessToken,
+}
+
 /// Metadata about an API endpoint.
 #[derive(Clone, Debug)]
 pub struct Metadata {
@@ -309,8 +323,8 @@ pub struct Metadata {
     /// Whether or not this endpoint is rate limited by the server.
     pub rate_limited: bool,
 
-    /// Whether or not the server requires an authenticated user for this endpoint.
-    pub requires_authentication: bool,
+    /// What authentication scheme the server uses for this endpoint.
+    pub authentication: AuthScheme,
 }
 
 #[doc(hidden)]

--- a/ruma-api/tests/conversions.rs
+++ b/ruma-api/tests/conversions.rs
@@ -10,7 +10,7 @@ ruma_api! {
         name: "my_endpoint",
         path: "/_matrix/foo/:bar/:baz",
         rate_limited: false,
-        requires_authentication: false,
+        authentication: None,
     }
 
     request: {

--- a/ruma-api/tests/manual_endpoint_impl.rs
+++ b/ruma-api/tests/manual_endpoint_impl.rs
@@ -11,7 +11,7 @@ use ruma_api::{
         FromHttpRequestError, FromHttpResponseError, IntoHttpError, RequestDeserializationError,
         ResponseDeserializationError, ServerError, Void,
     },
-    IncomingRequest, Metadata, Outgoing, OutgoingRequest,
+    AuthScheme, IncomingRequest, Metadata, Outgoing, OutgoingRequest,
 };
 
 /// A request to create a new room alias.
@@ -31,7 +31,7 @@ const METADATA: Metadata = Metadata {
     name: "create_alias",
     path: "/_matrix/client/r0/directory/room/:room_alias",
     rate_limited: false,
-    requires_authentication: false,
+    authentication: AuthScheme::None,
 };
 
 impl OutgoingRequest for Request {

--- a/ruma-api/tests/no_fields.rs
+++ b/ruma-api/tests/no_fields.rs
@@ -9,7 +9,7 @@ ruma_api! {
         name: "no_fields",
         path: "/_matrix/my/endpoint",
         rate_limited: false,
-        requires_authentication: false,
+        authentication: None,
     }
 
     request: {}

--- a/ruma-api/tests/optional_headers.rs
+++ b/ruma-api/tests/optional_headers.rs
@@ -7,7 +7,7 @@ ruma_api! {
         name: "no_fields",
         path: "/_matrix/my/endpoint",
         rate_limited: false,
-        requires_authentication: false,
+        authentication: None,
     }
 
     request: {

--- a/ruma-api/tests/ruma_api_lifetime.rs
+++ b/ruma-api/tests/ruma_api_lifetime.rs
@@ -16,7 +16,7 @@ mod empty_response {
             name: "create_alias",
             path: "/_matrix/client/r0/directory/room/:room_alias",
             rate_limited: false,
-            requires_authentication: true,
+            authentication: AccessToken,
         }
 
         request: {
@@ -43,7 +43,7 @@ mod nested_types {
             name: "create_alias",
             path: "/_matrix/client/r0/directory/room/:room_alias",
             rate_limited: false,
-            requires_authentication: true,
+            authentication: AccessToken,
         }
 
         request: {
@@ -70,7 +70,7 @@ mod full_request_response {
             name: "no_fields",
             path: "/_matrix/my/endpoint/:thing",
             rate_limited: false,
-            requires_authentication: false,
+            authentication: None,
         }
 
         request: {
@@ -102,7 +102,7 @@ mod full_request_response_with_query_map {
             name: "no_fields",
             path: "/_matrix/my/endpoint/:thing",
             rate_limited: false,
-            requires_authentication: false,
+            authentication: None,
         }
 
         request: {
@@ -134,7 +134,7 @@ mod query_fields {
             name: "get_public_rooms",
             path: "/_matrix/client/r0/publicRooms",
             rate_limited: false,
-            requires_authentication: false,
+            authentication: None,
         }
 
         request: {

--- a/ruma-api/tests/ruma_api_macros.rs
+++ b/ruma-api/tests/ruma_api_macros.rs
@@ -10,7 +10,7 @@ pub mod some_endpoint {
             name: "some_endpoint",
             path: "/_matrix/some/endpoint/:baz",
             rate_limited: false,
-            requires_authentication: false,
+            authentication: None,
         }
 
         request: {
@@ -67,7 +67,7 @@ pub mod newtype_body_endpoint {
             name: "newtype_body_endpoint",
             path: "/_matrix/some/newtype/body/endpoint",
             rate_limited: false,
-            requires_authentication: false,
+            authentication: None,
         }
 
         request: {
@@ -97,7 +97,7 @@ pub mod newtype_raw_body_endpoint {
             name: "newtype_body_endpoint",
             path: "/_matrix/some/newtype/body/endpoint",
             rate_limited: false,
-            requires_authentication: false,
+            authentication: None,
         }
 
         request: {
@@ -122,7 +122,7 @@ pub mod query_map_endpoint {
             name: "newtype_body_endpoint",
             path: "/_matrix/some/query/map/endpoint",
             rate_limited: false,
-            requires_authentication: false,
+            authentication: None,
         }
 
         request: {

--- a/ruma-api/tests/ui/01-api-sanity-check.rs
+++ b/ruma-api/tests/ui/01-api-sanity-check.rs
@@ -9,7 +9,7 @@ ruma_api! {
         name: "some_endpoint",
         path: "/_matrix/some/endpoint/:baz",
         rate_limited: false,
-        requires_authentication: false,
+        authentication: None,
     }
 
     request: {

--- a/ruma-api/tests/ui/02-invalid-path.rs
+++ b/ruma-api/tests/ui/02-invalid-path.rs
@@ -7,7 +7,7 @@ ruma_api! {
         name: "invalid_path",
         path: "µ/°/§/€",
         rate_limited: false,
-        requires_authentication: false,
+        authentication: None,
     }
 
     request: {
@@ -25,7 +25,7 @@ ruma_api! {
         name: "invalid_path",
         path: "path/to/invalid space/endpoint",
         rate_limited: false,
-        requires_authentication: false,
+        authentication: None,
     }
 
     request: {

--- a/ruma-api/tests/ui/03-move-value.rs
+++ b/ruma-api/tests/ui/03-move-value.rs
@@ -15,7 +15,7 @@ mod newtype_body {
             name: "my_endpoint",
             path: "/_matrix/foo/:bar/",
             rate_limited: false,
-            requires_authentication: false,
+            authentication: None,
         }
 
         request: {
@@ -53,7 +53,7 @@ mod newtype_raw_body {
             name: "my_endpoint",
             path: "/_matrix/foo/:bar/",
             rate_limited: false,
-            requires_authentication: false,
+            authentication: None,
         }
 
         request: {
@@ -94,7 +94,7 @@ mod plain {
             name: "my_endpoint",
             path: "/_matrix/foo/:bar/",
             rate_limited: false,
-            requires_authentication: false,
+            authentication: None,
         }
 
         request: {

--- a/ruma-api/tests/ui/04-attributes.rs
+++ b/ruma-api/tests/ui/04-attributes.rs
@@ -7,7 +7,7 @@ ruma_api! {
         name: "some_endpoint",
         path: "/_matrix/some/endpoint/:baz",
         rate_limited: false,
-        requires_authentication: false,
+        authentication: None,
     }
 
     #[not_a_real_attribute_should_fail]

--- a/ruma-appservice-api/src/event/push_events/v1.rs
+++ b/ruma-appservice-api/src/event/push_events/v1.rs
@@ -11,7 +11,7 @@ ruma_api! {
         name: "push_events",
         path: "/_matrix/app/v1/transactions/:txn_id",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: QueryOnlyAccessToken,
     }
 
     request: {

--- a/ruma-appservice-api/src/query/query_room_alias/v1.rs
+++ b/ruma-appservice-api/src/query/query_room_alias/v1.rs
@@ -10,7 +10,7 @@ ruma_api! {
         name: "query_room_alias",
         path: "/_matrix/app/v1/rooms/:room_alias",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: QueryOnlyAccessToken,
     }
 
     request: {

--- a/ruma-appservice-api/src/query/query_user_id/v1.rs
+++ b/ruma-appservice-api/src/query/query_user_id/v1.rs
@@ -10,7 +10,7 @@ ruma_api! {
         name: "query_user_id",
         path: "/_matrix/app/v1/users/:user_id",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: QueryOnlyAccessToken,
     }
 
     request: {

--- a/ruma-appservice-api/src/thirdparty/get_location_for_protocol/v1.rs
+++ b/ruma-appservice-api/src/thirdparty/get_location_for_protocol/v1.rs
@@ -12,7 +12,7 @@ ruma_api! {
         name: "get_location_for_protocol",
         path: "/_matrix/app/v1/thirdparty/location/:protocol",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: QueryOnlyAccessToken,
     }
 
     request: {

--- a/ruma-appservice-api/src/thirdparty/get_location_for_room_alias/v1.rs
+++ b/ruma-appservice-api/src/thirdparty/get_location_for_room_alias/v1.rs
@@ -11,7 +11,7 @@ ruma_api! {
         name: "get_location_for_room_alias",
         path: "/_matrix/app/v1/thirdparty/location",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: QueryOnlyAccessToken,
     }
 
     request: {

--- a/ruma-appservice-api/src/thirdparty/get_protocol/v1.rs
+++ b/ruma-appservice-api/src/thirdparty/get_protocol/v1.rs
@@ -10,7 +10,7 @@ ruma_api! {
         name: "get_protocol",
         path: "/_matrix/app/v1/thirdparty/protocol/:protocol",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: QueryOnlyAccessToken,
     }
 
     request: {

--- a/ruma-appservice-api/src/thirdparty/get_user_for_protocol/v1.rs
+++ b/ruma-appservice-api/src/thirdparty/get_user_for_protocol/v1.rs
@@ -12,7 +12,7 @@ ruma_api! {
         name: "get_user_for_protocol",
         path: "/_matrix/app/v1/thirdparty/user/:protocol",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: QueryOnlyAccessToken,
     }
 
     request: {

--- a/ruma-appservice-api/src/thirdparty/get_user_for_user_id/v1.rs
+++ b/ruma-appservice-api/src/thirdparty/get_user_for_user_id/v1.rs
@@ -11,7 +11,7 @@ ruma_api! {
         name: "get_user_for_user_id",
         path: "/_matrix/app/v1/thirdparty/user",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: QueryOnlyAccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/account/add_3pid.rs
+++ b/ruma-client-api/src/r0/account/add_3pid.rs
@@ -11,7 +11,7 @@ ruma_api! {
         name: "add_3pid",
         path: "/_matrix/client/r0/account/3pid/add",
         rate_limited: true,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/account/bind_3pid.rs
+++ b/ruma-client-api/src/r0/account/bind_3pid.rs
@@ -11,7 +11,7 @@ ruma_api! {
         name: "bind_3pid",
         path: "/_matrix/client/r0/account/3pid/bind",
         rate_limited: true,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/account/change_password.rs
+++ b/ruma-client-api/src/r0/account/change_password.rs
@@ -11,7 +11,7 @@ ruma_api! {
         name: "change_password",
         path: "/_matrix/client/r0/account/password",
         rate_limited: true,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/account/deactivate.rs
+++ b/ruma-client-api/src/r0/account/deactivate.rs
@@ -13,7 +13,7 @@ ruma_api! {
         name: "deactivate",
         path: "/_matrix/client/r0/account/deactivate",
         rate_limited: true,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     #[derive(Default)]

--- a/ruma-client-api/src/r0/account/delete_3pid.rs
+++ b/ruma-client-api/src/r0/account/delete_3pid.rs
@@ -12,7 +12,7 @@ ruma_api! {
         name: "delete_3pid",
         path: "/_matrix/client/r0/account/3pid/delete",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/account/get_username_availability.rs
+++ b/ruma-client-api/src/r0/account/get_username_availability.rs
@@ -9,7 +9,7 @@ ruma_api! {
         name: "get_username_availability",
         path: "/_matrix/client/r0/register/available",
         rate_limited: true,
-        requires_authentication: false,
+        authentication: None,
     }
 
     request: {

--- a/ruma-client-api/src/r0/account/register.rs
+++ b/ruma-client-api/src/r0/account/register.rs
@@ -13,7 +13,7 @@ ruma_api! {
         name: "register",
         path: "/_matrix/client/r0/register",
         rate_limited: true,
-        requires_authentication: false,
+        authentication: None,
     }
 
     #[derive(Default)]

--- a/ruma-client-api/src/r0/account/request_3pid_management_token_via_email.rs
+++ b/ruma-client-api/src/r0/account/request_3pid_management_token_via_email.rs
@@ -12,7 +12,7 @@ ruma_api! {
         name: "request_3pid_association_token_via_email",
         path: "/_matrix/client/r0/account/3pid/email/requestToken",
         rate_limited: false,
-        requires_authentication: false,
+        authentication: None,
     }
 
     request: {

--- a/ruma-client-api/src/r0/account/request_3pid_management_token_via_msisdn.rs
+++ b/ruma-client-api/src/r0/account/request_3pid_management_token_via_msisdn.rs
@@ -12,7 +12,7 @@ ruma_api! {
         name: "request_3pid_association_token_via_msisdn",
         path: "/_matrix/client/r0/account/3pid/msisdn/requestToken",
         rate_limited: false,
-        requires_authentication: false,
+        authentication: None,
     }
 
     request: {

--- a/ruma-client-api/src/r0/account/request_openid_token.rs
+++ b/ruma-client-api/src/r0/account/request_openid_token.rs
@@ -13,7 +13,7 @@ ruma_api! {
         method: POST,
         path: "/_matrix/client/r0/user/:user_id/openid/request_token",
         rate_limited: true,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/account/request_password_change_token_via_email.rs
+++ b/ruma-client-api/src/r0/account/request_password_change_token_via_email.rs
@@ -12,7 +12,7 @@ ruma_api! {
         name: "request_password_change_token_via_email",
         path: "/_matrix/client/r0/account/password/email/requestToken",
         rate_limited: false,
-        requires_authentication: false,
+        authentication: None,
     }
 
     request: {

--- a/ruma-client-api/src/r0/account/request_password_change_token_via_msisdn.rs
+++ b/ruma-client-api/src/r0/account/request_password_change_token_via_msisdn.rs
@@ -10,7 +10,7 @@ ruma_api! {
         name: "request_password_change_token_via_msisdn",
         path: "/_matrix/client/r0/account/password/msisdn/requestToken",
         rate_limited: false,
-        requires_authentication: false,
+        authentication: None,
     }
 
     request: {

--- a/ruma-client-api/src/r0/account/request_registration_token_via_email.rs
+++ b/ruma-client-api/src/r0/account/request_registration_token_via_email.rs
@@ -12,7 +12,7 @@ ruma_api! {
         name: "request_registration_token_via_email",
         path: "/_matrix/client/r0/register/email/requestToken",
         rate_limited: false,
-        requires_authentication: false,
+        authentication: None,
     }
 
     request: {

--- a/ruma-client-api/src/r0/account/request_registration_token_via_msisdn.rs
+++ b/ruma-client-api/src/r0/account/request_registration_token_via_msisdn.rs
@@ -12,7 +12,7 @@ ruma_api! {
         name: "request_registration_token_via_msisdn",
         path: "/_matrix/client/r0/register/msisdn/requestToken",
         rate_limited: false,
-        requires_authentication: false,
+        authentication: None,
     }
 
     request: {

--- a/ruma-client-api/src/r0/account/unbind_3pid.rs
+++ b/ruma-client-api/src/r0/account/unbind_3pid.rs
@@ -12,7 +12,7 @@ ruma_api! {
         name: "unbind_3pid",
         path: "/_matrix/client/r0/account/3pid/unbind",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/account/whoami.rs
+++ b/ruma-client-api/src/r0/account/whoami.rs
@@ -10,7 +10,7 @@ ruma_api! {
         name: "whoami",
         path: "/_matrix/client/r0/account/whoami",
         rate_limited: true,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     #[derive(Default)]

--- a/ruma-client-api/src/r0/alias/create_alias.rs
+++ b/ruma-client-api/src/r0/alias/create_alias.rs
@@ -10,7 +10,7 @@ ruma_api! {
         name: "create_alias",
         path: "/_matrix/client/r0/directory/room/:room_alias",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/alias/delete_alias.rs
+++ b/ruma-client-api/src/r0/alias/delete_alias.rs
@@ -10,7 +10,7 @@ ruma_api! {
         name: "delete_alias",
         path: "/_matrix/client/r0/directory/room/:room_alias",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/alias/get_alias.rs
+++ b/ruma-client-api/src/r0/alias/get_alias.rs
@@ -10,7 +10,7 @@ ruma_api! {
         name: "get_alias",
         path: "/_matrix/client/r0/directory/room/:room_alias",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/appservice/set_room_visibility.rs
+++ b/ruma-client-api/src/r0/appservice/set_room_visibility.rs
@@ -12,7 +12,7 @@ ruma_api! {
         name: "set_room_visibility",
         path: "/_matrix/client/r0/directory/list/appservice/:network_id/:room_id",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/backup/add_backup_keys.rs
+++ b/ruma-client-api/src/r0/backup/add_backup_keys.rs
@@ -12,7 +12,7 @@ ruma_api! {
         name: "add_backup_keys",
         path: "/_matrix/client/r0/room_keys/keys",
         rate_limited: true,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/backup/create_backup.rs
+++ b/ruma-client-api/src/r0/backup/create_backup.rs
@@ -11,7 +11,7 @@ ruma_api! {
         name: "create_backup",
         path: "/_matrix/client/r0/room_keys/version",
         rate_limited: true,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/backup/get_backup.rs
+++ b/ruma-client-api/src/r0/backup/get_backup.rs
@@ -12,7 +12,7 @@ ruma_api! {
         name: "get_backup",
         path: "/_matrix/client/r0/room_keys/version/:version",
         rate_limited: true,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/backup/get_backup_keys.rs
+++ b/ruma-client-api/src/r0/backup/get_backup_keys.rs
@@ -11,7 +11,7 @@ ruma_api! {
         name: "get_backup_keys",
         path: "/_matrix/client/r0/room_keys/keys",
         rate_limited: true,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/backup/get_latest_backup.rs
+++ b/ruma-client-api/src/r0/backup/get_latest_backup.rs
@@ -12,7 +12,7 @@ ruma_api! {
         name: "get_latest_backup",
         path: "/_matrix/client/r0/room_keys/version",
         rate_limited: true,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     #[derive(Default)]

--- a/ruma-client-api/src/r0/backup/update_backup.rs
+++ b/ruma-client-api/src/r0/backup/update_backup.rs
@@ -11,7 +11,7 @@ ruma_api! {
         name: "update_backup",
         path: "/_matrix/client/r0/room_keys/version/:version",
         rate_limited: true,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/capabilities/get_capabilities.rs
+++ b/ruma-client-api/src/r0/capabilities/get_capabilities.rs
@@ -13,7 +13,7 @@ ruma_api! {
         name: "get_capabilities",
         path: "/_matrix/client/r0/capabilities",
         rate_limited: true,
-        requires_authentication: true
+        authentication: AccessToken
     }
 
     #[derive(Default)]

--- a/ruma-client-api/src/r0/config/get_global_account_data.rs
+++ b/ruma-client-api/src/r0/config/get_global_account_data.rs
@@ -12,7 +12,7 @@ ruma_api! {
         method: GET,
         path: "/_matrix/client/r0/user/:user_id/account_data/:event_type",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/config/get_room_account_data.rs
+++ b/ruma-client-api/src/r0/config/get_room_account_data.rs
@@ -12,7 +12,7 @@ ruma_api! {
         method: GET,
         path: "/_matrix/client/r0/user/:user_id/rooms/:room_id/account_data/:event_type",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/config/set_global_account_data.rs
+++ b/ruma-client-api/src/r0/config/set_global_account_data.rs
@@ -11,7 +11,7 @@ ruma_api! {
         name: "set_global_account_data",
         path: "/_matrix/client/r0/user/:user_id/account_data/:event_type",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/config/set_room_account_data.rs
+++ b/ruma-client-api/src/r0/config/set_room_account_data.rs
@@ -11,7 +11,7 @@ ruma_api! {
         name: "set_room_account_data",
         path: "/_matrix/client/r0/user/:user_id/rooms/:room_id/account_data/:event_type",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/contact/get_contacts.rs
+++ b/ruma-client-api/src/r0/contact/get_contacts.rs
@@ -13,7 +13,7 @@ ruma_api! {
         name: "get_contacts",
         path: "/_matrix/client/r0/account/3pid",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     #[derive(Default)]

--- a/ruma-client-api/src/r0/contact/request_contact_verification_token.rs
+++ b/ruma-client-api/src/r0/contact/request_contact_verification_token.rs
@@ -10,7 +10,7 @@ ruma_api! {
         name: "request_contact_verification_token",
         path: "/_matrix/client/r0/account/3pid/email/requestToken",
         rate_limited: false,
-        requires_authentication: false,
+        authentication: None,
     }
 
     request: {

--- a/ruma-client-api/src/r0/context/get_context.rs
+++ b/ruma-client-api/src/r0/context/get_context.rs
@@ -15,7 +15,7 @@ ruma_api! {
         path: "/_matrix/client/r0/rooms/:room_id/context/:event_id",
         name: "get_context",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/device/delete_device.rs
+++ b/ruma-client-api/src/r0/device/delete_device.rs
@@ -12,7 +12,7 @@ ruma_api! {
         name: "delete_device",
         path: "/_matrix/client/r0/devices/:device_id",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/device/delete_devices.rs
+++ b/ruma-client-api/src/r0/device/delete_devices.rs
@@ -12,7 +12,7 @@ ruma_api! {
         path: "/_matrix/client/r0/delete_devices",
         name: "delete_devices",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/device/get_device.rs
+++ b/ruma-client-api/src/r0/device/get_device.rs
@@ -11,7 +11,7 @@ ruma_api! {
         name: "get_device",
         path: "/_matrix/client/r0/devices/:device_id",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/device/get_devices.rs
+++ b/ruma-client-api/src/r0/device/get_devices.rs
@@ -10,7 +10,7 @@ ruma_api! {
         name: "get_devices",
         path: "/_matrix/client/r0/devices",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     #[derive(Default)]

--- a/ruma-client-api/src/r0/device/update_device.rs
+++ b/ruma-client-api/src/r0/device/update_device.rs
@@ -10,7 +10,7 @@ ruma_api! {
         name: "update_device",
         path: "/_matrix/client/r0/devices/:device_id",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/directory/get_public_rooms.rs
+++ b/ruma-client-api/src/r0/directory/get_public_rooms.rs
@@ -11,7 +11,7 @@ ruma_api! {
         name: "get_public_rooms",
         path: "/_matrix/client/r0/publicRooms",
         rate_limited: false,
-        requires_authentication: false,
+        authentication: None,
     }
 
     #[derive(Default)]

--- a/ruma-client-api/src/r0/directory/get_public_rooms_filtered.rs
+++ b/ruma-client-api/src/r0/directory/get_public_rooms_filtered.rs
@@ -13,7 +13,7 @@ ruma_api! {
         name: "get_public_rooms_filtered",
         path: "/_matrix/client/r0/publicRooms",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     #[derive(Default)]

--- a/ruma-client-api/src/r0/directory/get_room_visibility.rs
+++ b/ruma-client-api/src/r0/directory/get_room_visibility.rs
@@ -12,7 +12,7 @@ ruma_api! {
         method: GET,
         path: "/_matrix/client/r0/directory/list/room/:room_id",
         rate_limited: false,
-        requires_authentication: false,
+        authentication: None,
     }
 
     request: {

--- a/ruma-client-api/src/r0/directory/set_room_visibility.rs
+++ b/ruma-client-api/src/r0/directory/set_room_visibility.rs
@@ -12,7 +12,7 @@ ruma_api! {
         method: PUT,
         path: "/_matrix/client/r0/directory/list/room/:room_id",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/filter/create_filter.rs
+++ b/ruma-client-api/src/r0/filter/create_filter.rs
@@ -12,7 +12,7 @@ ruma_api! {
         name: "create_filter",
         path: "/_matrix/client/r0/user/:user_id/filter",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/filter/get_filter.rs
+++ b/ruma-client-api/src/r0/filter/get_filter.rs
@@ -12,7 +12,7 @@ ruma_api! {
         name: "get_filter",
         path: "/_matrix/client/r0/user/:user_id/filter/:filter_id",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/keys/claim_keys.rs
+++ b/ruma-client-api/src/r0/keys/claim_keys.rs
@@ -17,7 +17,7 @@ ruma_api! {
         name: "claim_keys",
         path: "/_matrix/client/r0/keys/claim",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/keys/get_key_changes.rs
+++ b/ruma-client-api/src/r0/keys/get_key_changes.rs
@@ -10,7 +10,7 @@ ruma_api! {
         name: "get_key_changes",
         path: "/_matrix/client/r0/keys/changes",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/keys/get_keys.rs
+++ b/ruma-client-api/src/r0/keys/get_keys.rs
@@ -17,7 +17,7 @@ ruma_api! {
         name: "get_keys",
         path: "/_matrix/client/r0/keys/query",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     #[derive(Default)]

--- a/ruma-client-api/src/r0/keys/upload_keys.rs
+++ b/ruma-client-api/src/r0/keys/upload_keys.rs
@@ -16,7 +16,7 @@ ruma_api! {
         name: "upload_keys",
         path: "/_matrix/client/r0/keys/upload",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     #[derive(Default)]

--- a/ruma-client-api/src/r0/keys/upload_signatures.rs
+++ b/ruma-client-api/src/r0/keys/upload_signatures.rs
@@ -12,7 +12,7 @@ ruma_api! {
         name: "upload_signatures",
         path: "/_matrix/client/r0/keys/signatures/upload",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/keys/upload_signing_keys.rs
+++ b/ruma-client-api/src/r0/keys/upload_signing_keys.rs
@@ -12,7 +12,7 @@ ruma_api! {
         name: "upload_signing_keys",
         path: "/_matrix/client/r0/keys/device_signing/upload",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     #[derive(Default)]

--- a/ruma-client-api/src/r0/media/create_content.rs
+++ b/ruma-client-api/src/r0/media/create_content.rs
@@ -9,7 +9,7 @@ ruma_api! {
         name: "create_media_content",
         path: "/_matrix/media/r0/upload",
         rate_limited: true,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/media/get_content.rs
+++ b/ruma-client-api/src/r0/media/get_content.rs
@@ -10,7 +10,7 @@ ruma_api! {
         name: "get_media_content",
         path: "/_matrix/media/r0/download/:server_name/:media_id",
         rate_limited: false,
-        requires_authentication: false,
+        authentication: None,
     }
 
     request: {

--- a/ruma-client-api/src/r0/media/get_content_as_filename.rs
+++ b/ruma-client-api/src/r0/media/get_content_as_filename.rs
@@ -10,7 +10,7 @@ ruma_api! {
         name: "get_media_content_as_filename",
         path: "/_matrix/media/r0/download/:server_name/:media_id/:filename",
         rate_limited: false,
-        requires_authentication: false,
+        authentication: None,
     }
 
     request: {

--- a/ruma-client-api/src/r0/media/get_content_thumbnail.rs
+++ b/ruma-client-api/src/r0/media/get_content_thumbnail.rs
@@ -23,7 +23,7 @@ ruma_api! {
         name: "get_content_thumbnail",
         path: "/_matrix/media/r0/thumbnail/:server_name/:media_id",
         rate_limited: true,
-        requires_authentication: false,
+        authentication: None,
     }
 
     request: {

--- a/ruma-client-api/src/r0/media/get_media_config.rs
+++ b/ruma-client-api/src/r0/media/get_media_config.rs
@@ -10,7 +10,7 @@ ruma_api! {
         path: "/_matrix/media/r0/config",
         name: "get_media_config",
         rate_limited: true,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     #[derive(Default)]

--- a/ruma-client-api/src/r0/media/get_media_preview.rs
+++ b/ruma-client-api/src/r0/media/get_media_preview.rs
@@ -13,7 +13,7 @@ ruma_api! {
         method: GET,
         path: "/_matrix/media/r0/preview_url",
         rate_limited: true,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/membership/ban_user.rs
+++ b/ruma-client-api/src/r0/membership/ban_user.rs
@@ -10,7 +10,7 @@ ruma_api! {
         name: "ban_user",
         path: "/_matrix/client/r0/rooms/:room_id/ban",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/membership/forget_room.rs
+++ b/ruma-client-api/src/r0/membership/forget_room.rs
@@ -10,7 +10,7 @@ ruma_api! {
         name: "forget_room",
         path: "/_matrix/client/r0/rooms/:room_id/forget",
         rate_limited: true,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/membership/get_member_events.rs
+++ b/ruma-client-api/src/r0/membership/get_member_events.rs
@@ -13,7 +13,7 @@ ruma_api! {
         name: "get_member_events",
         path: "/_matrix/client/r0/rooms/:room_id/members",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/membership/invite_user.rs
+++ b/ruma-client-api/src/r0/membership/invite_user.rs
@@ -20,7 +20,7 @@ ruma_api! {
         name: "invite_user",
         path: "/_matrix/client/r0/rooms/:room_id/invite",
         rate_limited: true,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/membership/join_room_by_id.rs
+++ b/ruma-client-api/src/r0/membership/join_room_by_id.rs
@@ -12,7 +12,7 @@ ruma_api! {
         name: "join_room_by_id",
         path: "/_matrix/client/r0/rooms/:room_id/join",
         rate_limited: true,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/membership/join_room_by_id_or_alias.rs
+++ b/ruma-client-api/src/r0/membership/join_room_by_id_or_alias.rs
@@ -12,7 +12,7 @@ ruma_api! {
         name: "join_room_by_id_or_alias",
         path: "/_matrix/client/r0/join/:room_id_or_alias",
         rate_limited: true,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/membership/joined_members.rs
+++ b/ruma-client-api/src/r0/membership/joined_members.rs
@@ -13,7 +13,7 @@ ruma_api! {
         name: "joined_members",
         path: "/_matrix/client/r0/rooms/:room_id/joined_members",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/membership/joined_rooms.rs
+++ b/ruma-client-api/src/r0/membership/joined_rooms.rs
@@ -10,7 +10,7 @@ ruma_api! {
         name: "joined_rooms",
         path: "/_matrix/client/r0/joined_rooms",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     #[derive(Default)]

--- a/ruma-client-api/src/r0/membership/kick_user.rs
+++ b/ruma-client-api/src/r0/membership/kick_user.rs
@@ -10,7 +10,7 @@ ruma_api! {
         name: "kick_user",
         path: "/_matrix/client/r0/rooms/:room_id/kick",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/membership/leave_room.rs
+++ b/ruma-client-api/src/r0/membership/leave_room.rs
@@ -10,7 +10,7 @@ ruma_api! {
         name: "leave_room",
         path: "/_matrix/client/r0/rooms/:room_id/leave",
         rate_limited: true,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/membership/unban_user.rs
+++ b/ruma-client-api/src/r0/membership/unban_user.rs
@@ -10,7 +10,7 @@ ruma_api! {
         name: "unban_user",
         path: "/_matrix/client/r0/rooms/:room_id/unban",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/message/get_message_events.rs
+++ b/ruma-client-api/src/r0/message/get_message_events.rs
@@ -16,7 +16,7 @@ ruma_api! {
         name: "get_message_events",
         path: "/_matrix/client/r0/rooms/:room_id/messages",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/message/send_message_event.rs
+++ b/ruma-client-api/src/r0/message/send_message_event.rs
@@ -7,7 +7,7 @@ use ruma_api::{
         FromHttpRequestError, FromHttpResponseError, IntoHttpError, RequestDeserializationError,
         ResponseDeserializationError, ServerError,
     },
-    EndpointError, Metadata, Outgoing,
+    AuthScheme, EndpointError, Metadata, Outgoing,
 };
 use ruma_events::{AnyMessageEventContent, EventContent as _};
 use ruma_identifiers::{EventId, RoomId};
@@ -64,7 +64,7 @@ const METADATA: Metadata = Metadata {
     name: "send_message_event",
     path: "/_matrix/client/r0/rooms/:room_id/send/:event_type/:txn_id",
     rate_limited: false,
-    requires_authentication: true,
+    authentication: AuthScheme::AccessToken,
 };
 
 impl TryFrom<http::Request<Vec<u8>>> for IncomingRequest {

--- a/ruma-client-api/src/r0/presence/get_presence.rs
+++ b/ruma-client-api/src/r0/presence/get_presence.rs
@@ -13,7 +13,7 @@ ruma_api! {
         name: "get_presence",
         path: "/_matrix/client/r0/presence/:user_id/status",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/presence/set_presence.rs
+++ b/ruma-client-api/src/r0/presence/set_presence.rs
@@ -11,7 +11,7 @@ ruma_api! {
         name: "set_presence",
         path: "/_matrix/client/r0/presence/:user_id/status",
         rate_limited: true,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/profile/get_avatar_url.rs
+++ b/ruma-client-api/src/r0/profile/get_avatar_url.rs
@@ -10,7 +10,7 @@ ruma_api! {
         name: "get_avatar_url",
         path: "/_matrix/client/r0/profile/:user_id/avatar_url",
         rate_limited: false,
-        requires_authentication: false,
+        authentication: None,
     }
 
     request: {

--- a/ruma-client-api/src/r0/profile/get_display_name.rs
+++ b/ruma-client-api/src/r0/profile/get_display_name.rs
@@ -10,7 +10,7 @@ ruma_api! {
         name: "get_display_name",
         path: "/_matrix/client/r0/profile/:user_id/displayname",
         rate_limited: false,
-        requires_authentication: false,
+        authentication: None,
     }
 
     request: {

--- a/ruma-client-api/src/r0/profile/get_profile.rs
+++ b/ruma-client-api/src/r0/profile/get_profile.rs
@@ -10,7 +10,7 @@ ruma_api! {
         name: "get_profile",
         path: "/_matrix/client/r0/profile/:user_id",
         rate_limited: false,
-        requires_authentication: false,
+        authentication: None,
     }
 
     request: {

--- a/ruma-client-api/src/r0/profile/set_avatar_url.rs
+++ b/ruma-client-api/src/r0/profile/set_avatar_url.rs
@@ -10,7 +10,7 @@ ruma_api! {
         name: "set_avatar_url",
         path: "/_matrix/client/r0/profile/:user_id/avatar_url",
         rate_limited: true,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/profile/set_display_name.rs
+++ b/ruma-client-api/src/r0/profile/set_display_name.rs
@@ -10,7 +10,7 @@ ruma_api! {
         name: "set_display_name",
         path: "/_matrix/client/r0/profile/:user_id/displayname",
         rate_limited: true,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/push/delete_pushrule.rs
+++ b/ruma-client-api/src/r0/push/delete_pushrule.rs
@@ -11,7 +11,7 @@ ruma_api! {
         name: "delete_pushrule",
         path: "/_matrix/client/r0/pushrules/:scope/:kind/:rule_id",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/push/get_notifications.rs
+++ b/ruma-client-api/src/r0/push/get_notifications.rs
@@ -16,7 +16,7 @@ ruma_api! {
         name: "get_notifications",
         path: "/_matrix/client/r0/notifications",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     #[derive(Default)]

--- a/ruma-client-api/src/r0/push/get_pushers.rs
+++ b/ruma-client-api/src/r0/push/get_pushers.rs
@@ -11,7 +11,7 @@ ruma_api! {
         name: "get_pushers",
         path: "/_matrix/client/r0/pushers",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     #[derive(Default)]

--- a/ruma-client-api/src/r0/push/get_pushrule.rs
+++ b/ruma-client-api/src/r0/push/get_pushrule.rs
@@ -12,7 +12,7 @@ ruma_api! {
         name: "get_pushrule",
         path: "/_matrix/client/r0/pushrules/:scope/:kind/:rule_id",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/push/get_pushrule_actions.rs
+++ b/ruma-client-api/src/r0/push/get_pushrule_actions.rs
@@ -12,7 +12,7 @@ ruma_api! {
         name: "get_pushrule_actions",
         path: "/_matrix/client/r0/pushrules/:scope/:kind/:rule_id/actions",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/push/get_pushrule_enabled.rs
+++ b/ruma-client-api/src/r0/push/get_pushrule_enabled.rs
@@ -11,7 +11,7 @@ ruma_api! {
         name: "get_pushrule_enabled",
         path: "/_matrix/client/r0/pushrules/:scope/:kind/:rule_id/enabled",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/push/get_pushrules_all.rs
+++ b/ruma-client-api/src/r0/push/get_pushrules_all.rs
@@ -10,7 +10,7 @@ ruma_api! {
         name: "get_pushrules_all",
         path: "/_matrix/client/r0/pushrules/",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     #[derive(Default)]

--- a/ruma-client-api/src/r0/push/get_pushrules_global_scope.rs
+++ b/ruma-client-api/src/r0/push/get_pushrules_global_scope.rs
@@ -10,7 +10,7 @@ ruma_api! {
         name: "get_pushrules_global_scope",
         path: "/_matrix/client/r0/pushrules/global/",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     #[derive(Default)]

--- a/ruma-client-api/src/r0/push/set_pusher.rs
+++ b/ruma-client-api/src/r0/push/set_pusher.rs
@@ -11,7 +11,7 @@ ruma_api! {
         name: "set_pusher",
         path: "/_matrix/client/r0/pushers/set",
         rate_limited: true,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/push/set_pushrule.rs
+++ b/ruma-client-api/src/r0/push/set_pushrule.rs
@@ -12,7 +12,7 @@ ruma_api! {
         name: "set_pushrule",
         path: "/_matrix/client/r0/pushrules/:scope/:kind/:rule_id",
         rate_limited: true,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/push/set_pushrule_actions.rs
+++ b/ruma-client-api/src/r0/push/set_pushrule_actions.rs
@@ -12,7 +12,7 @@ ruma_api! {
         name: "set_pushrule_actions",
         path: "/_matrix/client/r0/pushrules/:scope/:kind/:rule_id/actions",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/push/set_pushrule_enabled.rs
+++ b/ruma-client-api/src/r0/push/set_pushrule_enabled.rs
@@ -11,7 +11,7 @@ ruma_api! {
         name: "set_pushrule_enabled",
         path: "/_matrix/client/r0/pushrules/:scope/:kind/:rule_id/enabled",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/read_marker/set_read_marker.rs
+++ b/ruma-client-api/src/r0/read_marker/set_read_marker.rs
@@ -10,7 +10,7 @@ ruma_api! {
         name: "set_read_marker",
         path: "/_matrix/client/r0/rooms/:room_id/read_markers",
         rate_limited: true,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/receipt/create_receipt.rs
+++ b/ruma-client-api/src/r0/receipt/create_receipt.rs
@@ -13,7 +13,7 @@ ruma_api! {
         name: "create_receipt",
         path: "/_matrix/client/r0/rooms/:room_id/receipt/:receipt_type/:event_id",
         rate_limited: true,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/redact/redact_event.rs
+++ b/ruma-client-api/src/r0/redact/redact_event.rs
@@ -10,7 +10,7 @@ ruma_api! {
         name: "redact_event",
         path: "/_matrix/client/r0/rooms/:room_id/redact/:event_id/:txn_id",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/room/aliases.rs
+++ b/ruma-client-api/src/r0/room/aliases.rs
@@ -10,7 +10,7 @@ ruma_api! {
         name: "aliases",
         path: "/_matrix/client/r0/rooms/:room_id/aliases",
         rate_limited: true,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/room/create_room.rs
+++ b/ruma-client-api/src/r0/room/create_room.rs
@@ -23,7 +23,7 @@ ruma_api! {
         name: "create_room",
         path: "/_matrix/client/r0/createRoom",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     #[derive(Default)]

--- a/ruma-client-api/src/r0/room/get_room_event.rs
+++ b/ruma-client-api/src/r0/room/get_room_event.rs
@@ -12,7 +12,7 @@ ruma_api! {
         name: "get_room_event",
         path: "/_matrix/client/r0/rooms/:room_id/event/:event_id",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/room/report_content.rs
+++ b/ruma-client-api/src/r0/room/report_content.rs
@@ -11,7 +11,7 @@ ruma_api! {
         name: "report_content",
         path: "/_matrix/client/r0/rooms/:room_id/report/:event_id",
         rate_limited:  false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/room/upgrade_room.rs
+++ b/ruma-client-api/src/r0/room/upgrade_room.rs
@@ -10,7 +10,7 @@ ruma_api! {
         name: "upgrade_room",
         path: "/_matrix/client/r0/rooms/:room_id/upgrade",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/search/search_events.rs
+++ b/ruma-client-api/src/r0/search/search_events.rs
@@ -18,7 +18,7 @@ ruma_api! {
         name: "search",
         path: "/_matrix/client/r0/search",
         rate_limited: true,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/server/get_user_info.rs
+++ b/ruma-client-api/src/r0/server/get_user_info.rs
@@ -13,7 +13,7 @@ ruma_api! {
         name: "get_user_info",
         path: "/_matrix/client/r0/admin/whois/:user_id",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/session/get_login_types.rs
+++ b/ruma-client-api/src/r0/session/get_login_types.rs
@@ -10,7 +10,7 @@ ruma_api! {
         name: "get_login_types",
         path: "/_matrix/client/r0/login",
         rate_limited: true,
-        requires_authentication: false,
+        authentication: None,
     }
 
     #[derive(Default)]

--- a/ruma-client-api/src/r0/session/login.rs
+++ b/ruma-client-api/src/r0/session/login.rs
@@ -12,7 +12,7 @@ ruma_api! {
         name: "login",
         path: "/_matrix/client/r0/login",
         rate_limited: true,
-        requires_authentication: false,
+        authentication: None,
     }
 
     request: {

--- a/ruma-client-api/src/r0/session/logout.rs
+++ b/ruma-client-api/src/r0/session/logout.rs
@@ -9,7 +9,7 @@ ruma_api! {
         name: "logout",
         path: "/_matrix/client/r0/logout",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     #[derive(Default)]

--- a/ruma-client-api/src/r0/session/logout_all.rs
+++ b/ruma-client-api/src/r0/session/logout_all.rs
@@ -9,7 +9,7 @@ ruma_api! {
         name: "logout_all",
         path: "/_matrix/client/r0/logout/all",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     #[derive(Default)]

--- a/ruma-client-api/src/r0/session/sso_login.rs
+++ b/ruma-client-api/src/r0/session/sso_login.rs
@@ -9,7 +9,7 @@ ruma_api! {
         name: "sso_login",
         path: "/_matrix/client/r0/login/sso/redirect",
         rate_limited: false,
-        requires_authentication: false,
+        authentication: None,
 
     }
 

--- a/ruma-client-api/src/r0/state/get_state_events.rs
+++ b/ruma-client-api/src/r0/state/get_state_events.rs
@@ -12,7 +12,7 @@ ruma_api! {
         name: "get_state_events",
         path: "/_matrix/client/r0/rooms/:room_id/state",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/state/get_state_events_for_empty_key.rs
+++ b/ruma-client-api/src/r0/state/get_state_events_for_empty_key.rs
@@ -12,7 +12,7 @@ ruma_api! {
         name: "get_state_events_for_empty_key",
         path: "/_matrix/client/r0/rooms/:room_id/state/:event_type",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/state/get_state_events_for_key.rs
+++ b/ruma-client-api/src/r0/state/get_state_events_for_key.rs
@@ -12,7 +12,7 @@ ruma_api! {
         name: "get_state_events_for_key",
         path: "/_matrix/client/r0/rooms/:room_id/state/:event_type/:state_key",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/state/send_state_event_for_empty_key.rs
+++ b/ruma-client-api/src/r0/state/send_state_event_for_empty_key.rs
@@ -7,7 +7,7 @@ use ruma_api::{
         FromHttpRequestError, FromHttpResponseError, IntoHttpError, RequestDeserializationError,
         ResponseDeserializationError, ServerError,
     },
-    EndpointError, Metadata, Outgoing,
+    AuthScheme, EndpointError, Metadata, Outgoing,
 };
 use ruma_events::{AnyStateEventContent, EventContent as _};
 use ruma_identifiers::{EventId, RoomId};
@@ -57,7 +57,7 @@ const METADATA: Metadata = Metadata {
     name: "send_state_event_for_empty_key",
     path: "/_matrix/client/r0/rooms/:room_id/state/:event_type",
     rate_limited: false,
-    requires_authentication: true,
+    authentication: AuthScheme::AccessToken,
 };
 
 impl TryFrom<http::Request<Vec<u8>>> for IncomingRequest {

--- a/ruma-client-api/src/r0/state/send_state_event_for_key.rs
+++ b/ruma-client-api/src/r0/state/send_state_event_for_key.rs
@@ -7,7 +7,7 @@ use ruma_api::{
         FromHttpRequestError, FromHttpResponseError, IntoHttpError, RequestDeserializationError,
         ResponseDeserializationError, ServerError,
     },
-    EndpointError, Metadata, Outgoing,
+    AuthScheme, EndpointError, Metadata, Outgoing,
 };
 use ruma_events::{AnyStateEventContent, EventContent as _};
 use ruma_identifiers::{EventId, RoomId};
@@ -60,7 +60,7 @@ const METADATA: Metadata = Metadata {
     name: "send_state_event_for_key",
     path: "/_matrix/client/r0/rooms/:room_id/state/:event_type/:state_key",
     rate_limited: false,
-    requires_authentication: true,
+    authentication: AuthScheme::AccessToken,
 };
 
 impl TryFrom<http::Request<Vec<u8>>> for IncomingRequest {

--- a/ruma-client-api/src/r0/sync/sync_events.rs
+++ b/ruma-client-api/src/r0/sync/sync_events.rs
@@ -21,7 +21,7 @@ ruma_api! {
         name: "sync",
         path: "/_matrix/client/r0/sync",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     #[derive(Default)]

--- a/ruma-client-api/src/r0/tag/create_tag.rs
+++ b/ruma-client-api/src/r0/tag/create_tag.rs
@@ -11,7 +11,7 @@ ruma_api! {
         name: "create_tag",
         path: "/_matrix/client/r0/user/:user_id/rooms/:room_id/tags/:tag",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/tag/delete_tag.rs
+++ b/ruma-client-api/src/r0/tag/delete_tag.rs
@@ -10,7 +10,7 @@ ruma_api! {
         name: "delete_tag",
         path: "/_matrix/client/r0/user/:user_id/rooms/:room_id/tags/:tag",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/tag/get_tags.rs
+++ b/ruma-client-api/src/r0/tag/get_tags.rs
@@ -11,7 +11,7 @@ ruma_api! {
         name: "get_tags",
         path: "/_matrix/client/r0/user/:user_id/rooms/:room_id/tags",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/thirdparty/get_location_for_protocol.rs
+++ b/ruma-client-api/src/r0/thirdparty/get_location_for_protocol.rs
@@ -12,7 +12,7 @@ ruma_api! {
         name: "get_location_for_protocol",
         path: "/_matrix/client/r0/thirdparty/location/:protocol",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/thirdparty/get_location_for_room_alias.rs
+++ b/ruma-client-api/src/r0/thirdparty/get_location_for_room_alias.rs
@@ -11,7 +11,7 @@ ruma_api! {
         name: "get_location_for_room_alias",
         path: "/_matrix/client/r0/thirdparty/location",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/thirdparty/get_protocol.rs
+++ b/ruma-client-api/src/r0/thirdparty/get_protocol.rs
@@ -10,7 +10,7 @@ ruma_api! {
         name: "get_protocol",
         path: "/_matrix/client/r0/thirdparty/protocol/:protocol",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/thirdparty/get_protocols.rs
+++ b/ruma-client-api/src/r0/thirdparty/get_protocols.rs
@@ -12,7 +12,7 @@ ruma_api! {
         name: "get_protocols",
         path: "/_matrix/client/r0/thirdparty/protocols",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     #[derive(Default)]

--- a/ruma-client-api/src/r0/thirdparty/get_user_for_protocol.rs
+++ b/ruma-client-api/src/r0/thirdparty/get_user_for_protocol.rs
@@ -12,7 +12,7 @@ ruma_api! {
         name: "get_user_for_protocol",
         path: "/_matrix/client/r0/thirdparty/user/:protocol",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/thirdparty/get_user_for_user_id.rs
+++ b/ruma-client-api/src/r0/thirdparty/get_user_for_user_id.rs
@@ -11,7 +11,7 @@ ruma_api! {
         name: "get_user_for_user_id",
         path: "/_matrix/client/r0/thirdparty/user",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/to_device/send_event_to_device.rs
+++ b/ruma-client-api/src/r0/to_device/send_event_to_device.rs
@@ -16,7 +16,7 @@ ruma_api! {
         name: "send_event_to_device",
         path: "/_matrix/client/r0/sendToDevice/:event_type/:txn_id",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/typing/create_typing_event.rs
+++ b/ruma-client-api/src/r0/typing/create_typing_event.rs
@@ -12,7 +12,7 @@ ruma_api! {
         path: "/_matrix/client/r0/rooms/:room_id/typing/:user_id",
         name: "create_typing_event",
         description: "Send a typing event to a room.",
-        requires_authentication: true,
+        authentication: AccessToken,
         rate_limited: true,
     }
 

--- a/ruma-client-api/src/r0/user_directory/search_users.rs
+++ b/ruma-client-api/src/r0/user_directory/search_users.rs
@@ -12,7 +12,7 @@ ruma_api! {
         name: "search_users",
         path: "/_matrix/client/r0/user_directory/search",
         rate_limited: true,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/voip/get_turn_server_info.rs
+++ b/ruma-client-api/src/r0/voip/get_turn_server_info.rs
@@ -11,7 +11,7 @@ ruma_api! {
         name: "turn_server_info",
         path: "/_matrix/client/r0/voip/turnServer",
         rate_limited: true,
-        requires_authentication: true,
+        authentication: AccessToken,
     }
 
     #[derive(Default)]

--- a/ruma-client-api/src/unversioned/discover_homeserver.rs
+++ b/ruma-client-api/src/unversioned/discover_homeserver.rs
@@ -10,7 +10,7 @@ ruma_api! {
         name: "discover_homeserver",
         path: "/.well-known/matrix/client",
         rate_limited: false,
-        requires_authentication: false,
+        authentication: None,
     }
 
     #[derive(Default)]

--- a/ruma-client-api/src/unversioned/get_supported_versions.rs
+++ b/ruma-client-api/src/unversioned/get_supported_versions.rs
@@ -11,7 +11,7 @@ ruma_api! {
         name: "api_versions",
         path: "/_matrix/client/versions",
         rate_limited: false,
-        requires_authentication: false,
+        authentication: None,
     }
 
     #[derive(Default)]

--- a/ruma-client/src/lib.rs
+++ b/ruma-client/src/lib.rs
@@ -113,7 +113,7 @@ use http::{uri::Uri, Response as HttpResponse};
 use hyper::{client::HttpConnector, Client as HyperClient};
 #[cfg(feature = "hyper-tls")]
 use hyper_tls::HttpsConnector;
-use ruma_api::OutgoingRequest;
+use ruma_api::{AuthScheme, OutgoingRequest};
 use ruma_client_api::r0::sync::sync_events::{
     Filter as SyncFilter, Request as SyncRequest, Response as SyncResponse,
 };
@@ -345,7 +345,7 @@ where
         let client = self.0.clone();
         let mut http_request = {
             let session;
-            let access_token = if Request::METADATA.requires_authentication {
+            let access_token = if Request::METADATA.authentication == AuthScheme::AccessToken {
                 session = client.session.lock().unwrap();
                 if let Some(s) = &*session {
                     Some(s.access_token.as_str())

--- a/ruma-federation-api/src/authorization/get_event_authorization/v1.rs
+++ b/ruma-federation-api/src/authorization/get_event_authorization/v1.rs
@@ -12,7 +12,7 @@ ruma_api! {
         method: GET,
         path: "/_matrix/federation/v1/event_auth/:room_id/:event_id",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: ServerSignatures,
     }
 
     request: {

--- a/ruma-federation-api/src/backfill/get_backfill/v1.rs
+++ b/ruma-federation-api/src/backfill/get_backfill/v1.rs
@@ -14,7 +14,7 @@ ruma_api! {
         method: GET,
         path: "/_matrix/federation/v1/backfill/:room_id",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: ServerSignatures,
     }
 
     request: {

--- a/ruma-federation-api/src/device/get_devices/v1.rs
+++ b/ruma-federation-api/src/device/get_devices/v1.rs
@@ -13,7 +13,7 @@ ruma_api! {
         method: GET,
         path: "/_matrix/federation/v1/user/devices/:user_id",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: ServerSignatures,
     }
 
     request: {

--- a/ruma-federation-api/src/directory/get_public_rooms/v1.rs
+++ b/ruma-federation-api/src/directory/get_public_rooms/v1.rs
@@ -11,7 +11,7 @@ ruma_api! {
         name: "get_public_rooms",
         path: "/_matrix/federation/v1/publicRooms",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: ServerSignatures,
     }
 
     #[derive(Default)]

--- a/ruma-federation-api/src/directory/get_public_rooms_filtered/v1.rs
+++ b/ruma-federation-api/src/directory/get_public_rooms_filtered/v1.rs
@@ -13,7 +13,7 @@ ruma_api! {
         name: "get_public_rooms_filtered",
         path: "/_matrix/federation/v1/publicRooms",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: ServerSignatures,
     }
 
     #[derive(Default)]

--- a/ruma-federation-api/src/discovery/discover_homeserver.rs
+++ b/ruma-federation-api/src/discovery/discover_homeserver.rs
@@ -10,7 +10,7 @@ ruma_api! {
         name: "discover_homeserver",
         path: "/.well-known/matrix/server",
         rate_limited: false,
-        requires_authentication: false,
+        authentication: None,
     }
 
     #[derive(Default)]

--- a/ruma-federation-api/src/discovery/get_remote_server_keys/v2.rs
+++ b/ruma-federation-api/src/discovery/get_remote_server_keys/v2.rs
@@ -15,7 +15,7 @@ ruma_api! {
         // support an additional parameter at the end, even if it is ignored.
         path: "/_matrix/key/v2/query/:server_name",
         rate_limited: false,
-        requires_authentication: false,
+        authentication: None,
     }
 
     request: {

--- a/ruma-federation-api/src/discovery/get_remote_server_keys_batch/v2.rs
+++ b/ruma-federation-api/src/discovery/get_remote_server_keys_batch/v2.rs
@@ -14,7 +14,7 @@ ruma_api! {
         name: "get_remote_server_keys_batch",
         path: "/_matrix/key/v2/query",
         rate_limited: false,
-        requires_authentication: false,
+        authentication: None,
     }
 
     request: {

--- a/ruma-federation-api/src/discovery/get_server_keys/v2.rs
+++ b/ruma-federation-api/src/discovery/get_server_keys/v2.rs
@@ -10,7 +10,7 @@ ruma_api! {
         name: "get_server_keys",
         path: "/_matrix/key/v2/server",
         rate_limited: false,
-        requires_authentication: false,
+        authentication: None,
     }
 
     #[derive(Default)]

--- a/ruma-federation-api/src/discovery/get_server_version/v1.rs
+++ b/ruma-federation-api/src/discovery/get_server_version/v1.rs
@@ -10,7 +10,7 @@ ruma_api! {
         name: "discover_homeserver",
         path: "/.well-known/matrix/server",
         rate_limited: false,
-        requires_authentication: false,
+        authentication: None,
     }
 
     #[derive(Default)]

--- a/ruma-federation-api/src/event/get_event/v1.rs
+++ b/ruma-federation-api/src/event/get_event/v1.rs
@@ -12,7 +12,7 @@ ruma_api! {
         name: "get_event",
         path: "/_matrix/federation/v1/event/:event_id",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: ServerSignatures,
     }
 
     request: {

--- a/ruma-federation-api/src/event/get_missing_events/v1.rs
+++ b/ruma-federation-api/src/event/get_missing_events/v1.rs
@@ -12,7 +12,7 @@ ruma_api! {
         name: "get_missing_events",
         path: "/_matrix/federation/v1/get_missing_events/:room_id",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: ServerSignatures,
     }
 
     request: {

--- a/ruma-federation-api/src/event/get_room_state/v1.rs
+++ b/ruma-federation-api/src/event/get_room_state/v1.rs
@@ -11,7 +11,7 @@ ruma_api! {
         name: "get_room_state",
         path: "/_matrix/federation/v1/state/:room_id",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: ServerSignatures,
     }
 
     request: {

--- a/ruma-federation-api/src/event/get_room_state_ids/v1.rs
+++ b/ruma-federation-api/src/event/get_room_state_ids/v1.rs
@@ -10,7 +10,7 @@ ruma_api! {
         name: "get_room_state_ids",
         path: "/_matrix/federation/v1/state_ids/:room_id",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: ServerSignatures,
     }
 
     request: {

--- a/ruma-federation-api/src/keys/claim_keys/v1.rs
+++ b/ruma-federation-api/src/keys/claim_keys/v1.rs
@@ -14,7 +14,7 @@ ruma_api! {
         name: "claim_keys",
         path: "/_matrix/federation/v1/user/keys/claim",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: ServerSignatures,
     }
 
     request: {

--- a/ruma-federation-api/src/keys/get_keys/v1.rs
+++ b/ruma-federation-api/src/keys/get_keys/v1.rs
@@ -13,7 +13,7 @@ ruma_api! {
         name: "get_keys",
         path: "/_matrix/federation/v1/user/keys/query",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: ServerSignatures,
     }
 
     request: {

--- a/ruma-federation-api/src/membership/create_invite/v1.rs
+++ b/ruma-federation-api/src/membership/create_invite/v1.rs
@@ -15,7 +15,7 @@ ruma_api! {
         name: "create_invite",
         path: "/_matrix/federation/v1/invite/:room_id/:event_id",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: ServerSignatures,
     }
 
     request: {

--- a/ruma-federation-api/src/membership/create_invite/v2.rs
+++ b/ruma-federation-api/src/membership/create_invite/v2.rs
@@ -12,7 +12,7 @@ ruma_api! {
         name: "create_invite",
         path: "/_matrix/federation/v2/invite/:room_id/:event_id",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: ServerSignatures,
     }
 
     request: {

--- a/ruma-federation-api/src/membership/create_join_event/v1.rs
+++ b/ruma-federation-api/src/membership/create_join_event/v1.rs
@@ -14,7 +14,7 @@ ruma_api! {
         method: PUT,
         path: "/_matrix/federation/v1/send_join/:room_id/:event_id",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: ServerSignatures,
     }
 
     request: {

--- a/ruma-federation-api/src/membership/create_join_event/v2.rs
+++ b/ruma-federation-api/src/membership/create_join_event/v2.rs
@@ -14,7 +14,7 @@ ruma_api! {
         method: PUT,
         path: "/_matrix/federation/v2/send_join/:room_id/:event_id",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: ServerSignatures,
     }
 
     request: {

--- a/ruma-federation-api/src/membership/create_join_event_template/v1.rs
+++ b/ruma-federation-api/src/membership/create_join_event_template/v1.rs
@@ -12,7 +12,7 @@ ruma_api! {
         method: GET,
         path: "/_matrix/federation/v1/make_join/:room_id/:user_id",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: ServerSignatures,
     }
 
     request: {

--- a/ruma-federation-api/src/membership/create_leave_event/v1.rs
+++ b/ruma-federation-api/src/membership/create_leave_event/v1.rs
@@ -16,7 +16,7 @@ ruma_api! {
         method: PUT,
         path: "/_matrix/federation/v1/send_leave/:room_id/:event_id",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: ServerSignatures,
     }
 
     request: {

--- a/ruma-federation-api/src/membership/create_leave_event/v2.rs
+++ b/ruma-federation-api/src/membership/create_leave_event/v2.rs
@@ -16,7 +16,7 @@ ruma_api! {
         method: PUT,
         path: "/_matrix/federation/v1/send_leave/:room_id/:event_id",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: ServerSignatures,
     }
 
     request: {

--- a/ruma-federation-api/src/membership/get_leave_event/v1.rs
+++ b/ruma-federation-api/src/membership/get_leave_event/v1.rs
@@ -15,7 +15,7 @@ ruma_api! {
         method: GET,
         path: "/_matrix/federation/v1/make_leave/:room_id/:user_id",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: ServerSignatures,
     }
 
     request: {

--- a/ruma-federation-api/src/openid/get_openid_userinfo/v1.rs
+++ b/ruma-federation-api/src/openid/get_openid_userinfo/v1.rs
@@ -10,7 +10,7 @@ ruma_api! {
         name: "get_openid_userinfo",
         path: "/_matrix/federation/v1/openid/userinfo",
         rate_limited: false,
-        requires_authentication: false,
+        authentication: None,
     }
 
     request: {

--- a/ruma-federation-api/src/query/get_profile_information/v1.rs
+++ b/ruma-federation-api/src/query/get_profile_information/v1.rs
@@ -11,7 +11,7 @@ ruma_api! {
         method: GET,
         path: "/_matrix/federation/v1/query/profile",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: ServerSignatures,
     }
 
     request: {

--- a/ruma-federation-api/src/query/get_room_information/v1.rs
+++ b/ruma-federation-api/src/query/get_room_information/v1.rs
@@ -10,7 +10,7 @@ ruma_api! {
         method: GET,
         path: "/_matrix/federation/v1/query/directory",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: ServerSignatures,
     }
 
     request: {

--- a/ruma-federation-api/src/transactions/send_transaction_message/v1.rs
+++ b/ruma-federation-api/src/transactions/send_transaction_message/v1.rs
@@ -15,7 +15,7 @@ ruma_api! {
         method: PUT,
         path: "/_matrix/federation/v1/send/:transaction_id",
         rate_limited: false,
-        requires_authentication: true,
+        authentication: ServerSignatures,
     }
 
     request: {

--- a/ruma-push-gateway-api/src/send_event_notification/v1.rs
+++ b/ruma-push-gateway-api/src/send_event_notification/v1.rs
@@ -17,7 +17,7 @@ ruma_api! {
         method: POST,
         path: "/_matrix/push/v1/notify",
         rate_limited: false,
-        requires_authentication: false,
+        authentication: None,
     }
 
     request: {


### PR DESCRIPTION
Draft for matrix-org/matrix-spec-proposals#183 

Done:
* Introduce an enum for Authentication Schemes
* Update the proc-macro to account for it

To do:
* Change all ruma_api! invocations to use the right enum value. Some guidance here would be helpful. `false` obviously maps to `None`, but I'm not sure how `true` maps to the two new variants. Is it all just `AccessToken`?
* Compile
* Tests