### PR TITLE
Expose ruma serde via monocrate

### DIFF
--- a/ruma-serde/src/lib.rs
+++ b/ruma-serde/src/lib.rs
@@ -39,7 +39,7 @@ pub fn is_true(b: &bool) -> bool {
 /// formulation in the spec.
 ///
 /// To be used like this:
-/// `#[serde(deserialize_with = "empty_string_as_none"]`
+/// `#[serde(deserialize_with = "empty_string_as_none")]`
 /// Relevant serde issue: https://github.com/serde-rs/serde/issues/1425
 pub fn empty_string_as_none<'de, D, T>(de: D) -> Result<Option<T>, D::Error>
 where

--- a/ruma/Cargo.toml
+++ b/ruma/Cargo.toml
@@ -27,6 +27,7 @@ push-gateway-api = ["ruma-api", "ruma-push-gateway-api"]
 [dependencies]
 ruma-common = { version = "0.2.0", path = "../ruma-common" }
 ruma-identifiers = { version = "0.17.4", path = "../ruma-identifiers", features = ["serde"] }
+ruma-serde = { version = "0.2.3", path = "../ruma-serde" }
 
 ruma-events = { version = "=0.22.0-alpha.1", path = "../ruma-events", optional = true }
 ruma-signatures = { version = "0.6.0-dev.1", path = "../ruma-signatures", optional = true }

--- a/ruma/src/lib.rs
+++ b/ruma/src/lib.rs
@@ -16,6 +16,8 @@
 pub use ruma_common::*;
 #[doc(inline)]
 pub use ruma_identifiers as identifiers;
+#[doc(inline)]
+pub use ruma_serde as serde;
 
 pub use ruma_identifiers::{
     device_id, device_key_id, event_id, room_alias_id, room_id, room_version_id, server_key_id,


### PR DESCRIPTION
just ran into this as I tried to use `empty_string_as_none` helper, and seemingly could not do so through the monocrate.
