### PR TITLE
Fix rooms/{roomId}/aliases and rooms/{roomId}/report endpoint metadata fields

### DIFF
--- a/ruma-client-api/src/r0/room/aliases.rs
+++ b/ruma-client-api/src/r0/room/aliases.rs
@@ -1,15 +1,15 @@
-//! [PUT /_matrix/client/r0/directory/room/{roomAlias}](https://matrix.org/docs/spec/client_server/r0.6.0#put-matrix-client-r0-directory-room-roomalias)
+//! [GET /_matrix/client/r0/rooms/{roomId}/aliases](https://matrix.org/docs/spec/client_server/latest#get-matrix-client-r0-rooms-roomid-aliases)
 
 use ruma_api::ruma_api;
 use ruma_identifiers::{RoomAliasId, RoomId};
 
 ruma_api! {
     metadata: {
-        description: "Get a list of local aliases on a given room.",
-        method: PUT,
+        description: "Get a list of aliases maintained by the local server for the given room.",
+        method: GET,
         name: "create_alias",
-        path: "/_matrix/client/r0/directory/room/:room_id",
-        rate_limited: false,
+        path: "/_matrix/client/r0/rooms/:room_id/aliases",
+        rate_limited: true,
         requires_authentication: true,
     }
 

--- a/ruma-client-api/src/r0/room/aliases.rs
+++ b/ruma-client-api/src/r0/room/aliases.rs
@@ -1,4 +1,4 @@
-//! [GET /_matrix/client/r0/rooms/{roomId}/aliases](https://matrix.org/docs/spec/client_server/latest#get-matrix-client-r0-rooms-roomid-aliases)
+//! [GET /_matrix/client/r0/rooms/{roomId}/aliases](https://matrix.org/docs/spec/client_server/r0.6.1#get-matrix-client-r0-rooms-roomid-aliases)
 
 use ruma_api::ruma_api;
 use ruma_identifiers::{RoomAliasId, RoomId};
@@ -7,7 +7,7 @@ ruma_api! {
     metadata: {
         description: "Get a list of aliases maintained by the local server for the given room.",
         method: GET,
-        name: "create_alias",
+        name: "aliases",
         path: "/_matrix/client/r0/rooms/:room_id/aliases",
         rate_limited: true,
         requires_authentication: true,

--- a/ruma-client-api/src/r0/room/report_content.rs
+++ b/ruma-client-api/src/r0/room/report_content.rs
@@ -9,7 +9,7 @@ ruma_api! {
         description: "Report content as inappropriate.",
         method: POST,
         name: "report_content",
-        path: "/rooms/:room_id/report/:event_id",
+        path: "/_matrix/client/r0/rooms/:room_id/report/:event_id",
         rate_limited:  false,
         requires_authentication: true,
     }


### PR DESCRIPTION
It was pointed out to me that I confused `/directory` and `/rooms` a bit when declaring this endpoint originally. I happened to notice `/report` had no `/_matrix/client/r0`, it does need that part right?