### PR TITLE
Feature gate non-exhaustive type attributes

### DIFF
--- a/ruma-appservice-api/Cargo.toml
+++ b/ruma-appservice-api/Cargo.toml
@@ -18,3 +18,6 @@ ruma-events = { version = "=0.22.0-alpha.1", path = "../ruma-events" }
 ruma-identifiers = { version = "0.17.4", path = "../ruma-identifiers" }
 serde = { version = "1.0.114", features = ["derive"] }
 serde_json = "1.0.57"
+
+[features]
+unstable-exhaustive-types = []

--- a/ruma-appservice-api/src/event/push_events/v1.rs
+++ b/ruma-appservice-api/src/event/push_events/v1.rs
@@ -14,7 +14,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The transaction ID for this set of events.
         ///
@@ -28,7 +28,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {}
 }
 

--- a/ruma-appservice-api/src/query/query_room_alias/v1.rs
+++ b/ruma-appservice-api/src/query/query_room_alias/v1.rs
@@ -13,7 +13,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The room alias being queried.
         #[ruma_api(path)]
@@ -21,7 +21,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {}
 }
 

--- a/ruma-appservice-api/src/query/query_user_id/v1.rs
+++ b/ruma-appservice-api/src/query/query_user_id/v1.rs
@@ -13,7 +13,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The user ID being queried.
         #[ruma_api(path)]
@@ -21,7 +21,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {}
 }
 

--- a/ruma-appservice-api/src/thirdparty/get_location_for_protocol/v1.rs
+++ b/ruma-appservice-api/src/thirdparty/get_location_for_protocol/v1.rs
@@ -15,7 +15,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The protocol used to communicate to the third party network.
         #[ruma_api(path)]
@@ -27,7 +27,7 @@ ruma_api! {
         pub fields: BTreeMap<String, String>,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// List of matched third party locations.
         #[ruma_api(body)]

--- a/ruma-appservice-api/src/thirdparty/get_location_for_room_alias/v1.rs
+++ b/ruma-appservice-api/src/thirdparty/get_location_for_room_alias/v1.rs
@@ -14,14 +14,14 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The Matrix room alias to look up.
         #[ruma_api(query)]
         pub alias: &'a RoomAliasId,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// List of matched third party locations.
         #[ruma_api(body)]

--- a/ruma-appservice-api/src/thirdparty/get_protocol/v1.rs
+++ b/ruma-appservice-api/src/thirdparty/get_protocol/v1.rs
@@ -13,14 +13,14 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The name of the protocol.
         #[ruma_api(path)]
         pub protocol: &'a str,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// Metadata about the protocol.
         #[ruma_api(body)]

--- a/ruma-appservice-api/src/thirdparty/get_user_for_protocol/v1.rs
+++ b/ruma-appservice-api/src/thirdparty/get_user_for_protocol/v1.rs
@@ -15,7 +15,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The protocol used to communicate to the third party network.
         #[ruma_api(path)]
@@ -27,7 +27,7 @@ ruma_api! {
         pub fields: BTreeMap<String, String>,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// List of matched third party users.
         #[ruma_api(body)]

--- a/ruma-appservice-api/src/thirdparty/get_user_for_user_id/v1.rs
+++ b/ruma-appservice-api/src/thirdparty/get_user_for_user_id/v1.rs
@@ -14,14 +14,14 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The Matrix User ID to look up.
         #[ruma_api(query)]
         pub userid: &'a UserId,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// List of matched third party users.
         #[ruma_api(body)]

--- a/ruma-client-api/Cargo.toml
+++ b/ruma-client-api/Cargo.toml
@@ -35,5 +35,6 @@ maplit = "1.0.2"
 matches = "0.1.8"
 
 [features]
+unstable-exhaustive-types = []
 unstable-pre-spec = []
 unstable-synapse-quirks = []

--- a/ruma-client-api/src/r0/account.rs
+++ b/ruma-client-api/src/r0/account.rs
@@ -23,7 +23,7 @@ use serde::{Deserialize, Serialize};
 
 /// Additional authentication information for requestToken endpoints.
 #[derive(Clone, Debug, Outgoing, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct IdentityServerInfo<'a> {
     /// The ID server to send the onward request to as a hostname with an
     /// appended colon and port number if the port is not the default.

--- a/ruma-client-api/src/r0/account/add_3pid.rs
+++ b/ruma-client-api/src/r0/account/add_3pid.rs
@@ -14,7 +14,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// Additional information for the User-Interactive Authentication API.
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -28,7 +28,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {}
 
     error: UiaaResponse

--- a/ruma-client-api/src/r0/account/bind_3pid.rs
+++ b/ruma-client-api/src/r0/account/bind_3pid.rs
@@ -14,7 +14,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// Client-generated secret string used to protect this session.
         pub client_secret: &'a str,
@@ -29,7 +29,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {}
 
     error: crate::Error

--- a/ruma-client-api/src/r0/account/change_password.rs
+++ b/ruma-client-api/src/r0/account/change_password.rs
@@ -14,7 +14,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The new password for the account.
         pub new_password: &'a str,
@@ -35,7 +35,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {}
 
     error: UiaaResponse

--- a/ruma-client-api/src/r0/account/deactivate.rs
+++ b/ruma-client-api/src/r0/account/deactivate.rs
@@ -17,7 +17,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// Additional authentication information for the user-interactive authentication API.
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -29,7 +29,7 @@ ruma_api! {
         pub id_server: Option<&'a str>,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// Result of unbind operation.
         pub id_server_unbind_result: ThirdPartyIdRemovalStatus,

--- a/ruma-client-api/src/r0/account/delete_3pid.rs
+++ b/ruma-client-api/src/r0/account/delete_3pid.rs
@@ -15,7 +15,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// Identity server to delete from.
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -28,7 +28,7 @@ ruma_api! {
         pub address: &'a str,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// Result of unbind operation.
         pub id_server_unbind_result: ThirdPartyIdRemovalStatus,

--- a/ruma-client-api/src/r0/account/get_username_availability.rs
+++ b/ruma-client-api/src/r0/account/get_username_availability.rs
@@ -12,14 +12,14 @@ ruma_api! {
         requires_authentication: false,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The username to check the availability of.
         #[ruma_api(query)]
         pub username: &'a str,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// A flag to indicate that the username is available.
         /// This should always be true when the server replies with 200 OK.

--- a/ruma-client-api/src/r0/account/register.rs
+++ b/ruma-client-api/src/r0/account/register.rs
@@ -17,7 +17,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The desired password for the account.
         ///
@@ -67,7 +67,7 @@ ruma_api! {
         pub inhibit_login: bool,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// An access token for the account.
         ///

--- a/ruma-client-api/src/r0/account/request_3pid_management_token_via_email.rs
+++ b/ruma-client-api/src/r0/account/request_3pid_management_token_via_email.rs
@@ -15,7 +15,7 @@ ruma_api! {
         requires_authentication: false,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// Client-generated secret string used to protect this session.
         pub client_secret: &'a str,
@@ -36,7 +36,7 @@ ruma_api! {
         pub identity_server_info: Option<IdentityServerInfo<'a>>,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// The session identifier given by the identity server.
         pub sid: String,

--- a/ruma-client-api/src/r0/account/request_3pid_management_token_via_msisdn.rs
+++ b/ruma-client-api/src/r0/account/request_3pid_management_token_via_msisdn.rs
@@ -15,7 +15,7 @@ ruma_api! {
         requires_authentication: false,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// Client-generated secret string used to protect this session.
         pub client_secret: &'a str,
@@ -39,7 +39,7 @@ ruma_api! {
         pub identity_server_info: Option<IdentityServerInfo<'a>>,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// The session identifier given by the identity server.
         pub sid: String,

--- a/ruma-client-api/src/r0/account/request_openid_token.rs
+++ b/ruma-client-api/src/r0/account/request_openid_token.rs
@@ -16,14 +16,14 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// User ID of authenticated user.
         #[ruma_api(path)]
         pub user_id: &'a UserId,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// Access token for verifying user's identity.
         pub access_token: String,
@@ -64,7 +64,7 @@ impl Response {
 
 /// Access token types.
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub enum TokenType {
     /// Bearer token type
     Bearer,

--- a/ruma-client-api/src/r0/account/request_password_change_token_via_email.rs
+++ b/ruma-client-api/src/r0/account/request_password_change_token_via_email.rs
@@ -15,7 +15,7 @@ ruma_api! {
         requires_authentication: false,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// Client-generated secret string used to protect this session.
         pub client_secret: &'a str,
@@ -36,7 +36,7 @@ ruma_api! {
         pub identity_server_info: Option<IdentityServerInfo<'a>>,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// The session identifier given by the identity server.
         pub sid: String,

--- a/ruma-client-api/src/r0/account/request_password_change_token_via_msisdn.rs
+++ b/ruma-client-api/src/r0/account/request_password_change_token_via_msisdn.rs
@@ -13,7 +13,7 @@ ruma_api! {
         requires_authentication: false,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// Client-generated secret string used to protect this session.
         pub client_secret: &'a str,
@@ -32,7 +32,7 @@ ruma_api! {
         pub next_link: Option<&'a str>,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// The session identifier given by the identity server.
         pub sid: String,

--- a/ruma-client-api/src/r0/account/request_registration_token_via_email.rs
+++ b/ruma-client-api/src/r0/account/request_registration_token_via_email.rs
@@ -15,7 +15,7 @@ ruma_api! {
         requires_authentication: false,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// Client-generated secret string used to protect this session.
         pub client_secret: &'a str,
@@ -36,7 +36,7 @@ ruma_api! {
         pub identity_server_info: Option<IdentityServerInfo<'a>>,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// The session identifier given by the identity server.
         pub sid: String,

--- a/ruma-client-api/src/r0/account/request_registration_token_via_msisdn.rs
+++ b/ruma-client-api/src/r0/account/request_registration_token_via_msisdn.rs
@@ -15,7 +15,7 @@ ruma_api! {
         requires_authentication: false,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// Client-generated secret string used to protect this session.
         pub client_secret: &'a str,
@@ -39,7 +39,7 @@ ruma_api! {
         pub identity_server_info: Option<IdentityServerInfo<'a>>,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// The session identifier given by the identity server.
         pub sid: String,

--- a/ruma-client-api/src/r0/account/unbind_3pid.rs
+++ b/ruma-client-api/src/r0/account/unbind_3pid.rs
@@ -15,7 +15,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// Identity server to unbind from.
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -28,7 +28,7 @@ ruma_api! {
         pub address: &'a str,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// Result of unbind operation.
         pub id_server_unbind_result: ThirdPartyIdRemovalStatus,

--- a/ruma-client-api/src/r0/account/whoami.rs
+++ b/ruma-client-api/src/r0/account/whoami.rs
@@ -14,10 +14,10 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {}
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// The id of the user that owns the access token.
         pub user_id: UserId,

--- a/ruma-client-api/src/r0/alias/create_alias.rs
+++ b/ruma-client-api/src/r0/alias/create_alias.rs
@@ -13,7 +13,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The room alias to set.
         #[ruma_api(path)]
@@ -24,7 +24,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {}
 
     error: crate::Error

--- a/ruma-client-api/src/r0/alias/delete_alias.rs
+++ b/ruma-client-api/src/r0/alias/delete_alias.rs
@@ -13,7 +13,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The room alias to remove.
         #[ruma_api(path)]
@@ -21,7 +21,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {}
 
     error: crate::Error

--- a/ruma-client-api/src/r0/alias/get_alias.rs
+++ b/ruma-client-api/src/r0/alias/get_alias.rs
@@ -13,14 +13,14 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The room alias.
         #[ruma_api(path)]
         pub room_alias: &'a RoomAliasId,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// The room ID for this room alias.
         pub room_id: RoomId,

--- a/ruma-client-api/src/r0/appservice/set_room_visibility.rs
+++ b/ruma-client-api/src/r0/appservice/set_room_visibility.rs
@@ -15,7 +15,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The protocol (network) ID to update the room list for.
         #[ruma_api(path)]
@@ -30,7 +30,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {}
 
     error: crate::Error

--- a/ruma-client-api/src/r0/backup/add_backup_keys.rs
+++ b/ruma-client-api/src/r0/backup/add_backup_keys.rs
@@ -15,7 +15,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The backup version. Must be the current backup.
         #[ruma_api(query)]
@@ -27,7 +27,7 @@ ruma_api! {
         pub rooms: Rooms,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// An opaque string representing stored keys in the backup. Clients can compare it with
         /// the etag value they received in the request of their last key storage request.

--- a/ruma-client-api/src/r0/backup/create_backup.rs
+++ b/ruma-client-api/src/r0/backup/create_backup.rs
@@ -14,14 +14,14 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The algorithm used for storing backups.
         #[serde(flatten)]
         pub algorithm: BackupAlgorithm,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// The backup version. This is an opaque string.
         pub version: String,

--- a/ruma-client-api/src/r0/backup/get_backup.rs
+++ b/ruma-client-api/src/r0/backup/get_backup.rs
@@ -15,14 +15,14 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The backup version.
         #[ruma_api(path)]
         pub version: &'a str,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// The algorithm used for storing backups.
         #[serde(flatten)]

--- a/ruma-client-api/src/r0/backup/get_backup_keys.rs
+++ b/ruma-client-api/src/r0/backup/get_backup_keys.rs
@@ -14,14 +14,14 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The backup version. Must be the current backup.
         #[ruma_api(query)]
         pub version: &'a str,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// A map from room IDs to session IDs to key data.
         ///

--- a/ruma-client-api/src/r0/backup/get_latest_backup.rs
+++ b/ruma-client-api/src/r0/backup/get_latest_backup.rs
@@ -16,10 +16,10 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {}
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// The algorithm used for storing backups.
         #[serde(flatten)]

--- a/ruma-client-api/src/r0/backup/update_backup.rs
+++ b/ruma-client-api/src/r0/backup/update_backup.rs
@@ -14,7 +14,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The backup version.
         #[ruma_api(path)]
@@ -26,7 +26,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {}
 
     error: crate::Error

--- a/ruma-client-api/src/r0/capabilities/get_capabilities.rs
+++ b/ruma-client-api/src/r0/capabilities/get_capabilities.rs
@@ -17,10 +17,10 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {}
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// The capabilities the server supports
         pub capabilities: Capabilities,

--- a/ruma-client-api/src/r0/config/get_global_account_data.rs
+++ b/ruma-client-api/src/r0/config/get_global_account_data.rs
@@ -15,7 +15,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// User ID of user for whom to retrieve data.
         #[ruma_api(path)]
@@ -26,7 +26,7 @@ ruma_api! {
         pub event_type: &'a str,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// Account data content for the given type.
         #[ruma_api(body)]

--- a/ruma-client-api/src/r0/config/get_room_account_data.rs
+++ b/ruma-client-api/src/r0/config/get_room_account_data.rs
@@ -15,7 +15,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// User ID of user for whom to retrieve data.
         #[ruma_api(path)]
@@ -30,7 +30,7 @@ ruma_api! {
         pub event_type: &'a str,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// Account data content for the given type.
         #[ruma_api(body)]

--- a/ruma-client-api/src/r0/config/set_global_account_data.rs
+++ b/ruma-client-api/src/r0/config/set_global_account_data.rs
@@ -14,7 +14,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// Arbitrary JSON to store as config data.
         ///
@@ -36,7 +36,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {}
 
     error: crate::Error

--- a/ruma-client-api/src/r0/config/set_room_account_data.rs
+++ b/ruma-client-api/src/r0/config/set_room_account_data.rs
@@ -14,7 +14,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// Arbitrary JSON to store as config data.
         ///
@@ -40,7 +40,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {}
 
     error: crate::Error

--- a/ruma-client-api/src/r0/contact/get_contacts.rs
+++ b/ruma-client-api/src/r0/contact/get_contacts.rs
@@ -17,10 +17,10 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {}
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// A list of third party identifiers the homeserver has associated with the user's
         /// account.
@@ -50,7 +50,7 @@ impl Response {
 /// To create an instance of this type, first create a `ThirdPartyIdentifierInit` and convert it to
 /// this type using `ThirdPartyIdentifier::Init` / `.into()`.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct ThirdPartyIdentifier {
     /// The third party identifier address.

--- a/ruma-client-api/src/r0/contact/request_contact_verification_token.rs
+++ b/ruma-client-api/src/r0/contact/request_contact_verification_token.rs
@@ -13,7 +13,7 @@ ruma_api! {
         requires_authentication: false,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// Client-generated secret string used to protect this session.
         pub client_secret: &'a str,
@@ -43,7 +43,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {}
 
     error: crate::Error

--- a/ruma-client-api/src/r0/context/get_context.rs
+++ b/ruma-client-api/src/r0/context/get_context.rs
@@ -18,7 +18,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The room to get events from.
         #[ruma_api(path)]
@@ -46,7 +46,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// A token that can be used to paginate backwards with.
         #[serde(skip_serializing_if = "Option::is_none")]

--- a/ruma-client-api/src/r0/device/delete_device.rs
+++ b/ruma-client-api/src/r0/device/delete_device.rs
@@ -15,7 +15,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The device to delete.
         #[ruma_api(path)]
@@ -27,7 +27,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {}
 
     error: UiaaResponse

--- a/ruma-client-api/src/r0/device/delete_devices.rs
+++ b/ruma-client-api/src/r0/device/delete_devices.rs
@@ -15,7 +15,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// List of devices to delete.
         pub devices: &'a [DeviceIdBox],
@@ -26,7 +26,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {}
 
     error: UiaaResponse

--- a/ruma-client-api/src/r0/device/get_device.rs
+++ b/ruma-client-api/src/r0/device/get_device.rs
@@ -14,14 +14,14 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The device to retrieve.
         #[ruma_api(path)]
         pub device_id: &'a DeviceId,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// Information about the device.
         #[ruma_api(body)]

--- a/ruma-client-api/src/r0/device/get_devices.rs
+++ b/ruma-client-api/src/r0/device/get_devices.rs
@@ -14,10 +14,10 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {}
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// A list of all registered devices for this user
         pub devices: Vec<Device>,

--- a/ruma-client-api/src/r0/device/update_device.rs
+++ b/ruma-client-api/src/r0/device/update_device.rs
@@ -13,7 +13,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The device to update.
         #[ruma_api(path)]
@@ -26,7 +26,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {}
 
     error: crate::Error

--- a/ruma-client-api/src/r0/directory/get_public_rooms.rs
+++ b/ruma-client-api/src/r0/directory/get_public_rooms.rs
@@ -15,7 +15,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// Limit for the number of results to return.
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -35,7 +35,7 @@ ruma_api! {
         pub server: Option<&'a str>,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// A paginated chunk of public rooms.
         pub chunk: Vec<PublicRoomsChunk>,

--- a/ruma-client-api/src/r0/directory/get_public_rooms_filtered.rs
+++ b/ruma-client-api/src/r0/directory/get_public_rooms_filtered.rs
@@ -17,7 +17,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The server to fetch the public room lists from.
         ///
@@ -44,7 +44,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// A paginated chunk of public rooms.
         pub chunk: Vec<PublicRoomsChunk>,

--- a/ruma-client-api/src/r0/directory/get_room_visibility.rs
+++ b/ruma-client-api/src/r0/directory/get_room_visibility.rs
@@ -15,14 +15,14 @@ ruma_api! {
         requires_authentication: false,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The ID of the room of which to request the visibility.
         #[ruma_api(path)]
         pub room_id: &'a RoomId,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// Visibility of the room.
         pub visibility: Visibility,

--- a/ruma-client-api/src/r0/directory/set_room_visibility.rs
+++ b/ruma-client-api/src/r0/directory/set_room_visibility.rs
@@ -15,7 +15,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The ID of the room of which to set the visibility.
         #[ruma_api(path)]
@@ -26,7 +26,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {}
 
     error: crate::Error

--- a/ruma-client-api/src/r0/filter/create_filter.rs
+++ b/ruma-client-api/src/r0/filter/create_filter.rs
@@ -15,7 +15,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The ID of the user uploading the filter.
         ///
@@ -28,7 +28,7 @@ ruma_api! {
         pub filter: FilterDefinition<'a>,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// The ID of the filter that was created.
         pub filter_id: String,

--- a/ruma-client-api/src/r0/filter/get_filter.rs
+++ b/ruma-client-api/src/r0/filter/get_filter.rs
@@ -15,7 +15,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The user ID to download a filter for.
         #[ruma_api(path)]
@@ -26,7 +26,7 @@ ruma_api! {
         pub filter_id: &'a str,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// The filter definition.
         #[ruma_api(body)]

--- a/ruma-client-api/src/r0/keys/claim_keys.rs
+++ b/ruma-client-api/src/r0/keys/claim_keys.rs
@@ -20,7 +20,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The time (in milliseconds) to wait when downloading keys from remote servers.
         /// 10 seconds is the recommended default.
@@ -35,7 +35,7 @@ ruma_api! {
         pub one_time_keys: BTreeMap<UserId, BTreeMap<DeviceIdBox, DeviceKeyAlgorithm>>,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// If any remote homeservers could not be reached, they are recorded here.
         /// The names of the properties are the names of the unreachable servers.

--- a/ruma-client-api/src/r0/keys/get_key_changes.rs
+++ b/ruma-client-api/src/r0/keys/get_key_changes.rs
@@ -13,7 +13,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The desired start point of the list.
         ///
@@ -29,7 +29,7 @@ ruma_api! {
         pub to: &'a str,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// The Matrix User IDs of all users who updated their device identity keys.
         pub changed: Vec<UserId>,

--- a/ruma-client-api/src/r0/keys/get_keys.rs
+++ b/ruma-client-api/src/r0/keys/get_keys.rs
@@ -21,7 +21,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The time (in milliseconds) to wait when downloading keys from remote
         /// servers. 10 seconds is the recommended default.
@@ -46,7 +46,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// If any remote homeservers could not be reached, they are recorded
         /// here. The names of the properties are the names of the unreachable

--- a/ruma-client-api/src/r0/keys/upload_keys.rs
+++ b/ruma-client-api/src/r0/keys/upload_keys.rs
@@ -20,7 +20,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// Identity keys for the device. May be absent if no new identity keys are required.
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -31,7 +31,7 @@ ruma_api! {
         pub one_time_keys: Option<BTreeMap<DeviceKeyId, OneTimeKey>>,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// For each key algorithm, the number of unclaimed one-time keys of that
         /// type currently held on the server for this device.

--- a/ruma-client-api/src/r0/keys/upload_signatures.rs
+++ b/ruma-client-api/src/r0/keys/upload_signatures.rs
@@ -15,7 +15,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// Signed keys.
         #[ruma_api(body)]
@@ -23,7 +23,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {}
 
     error: crate::Error

--- a/ruma-client-api/src/r0/keys/upload_signing_keys.rs
+++ b/ruma-client-api/src/r0/keys/upload_signing_keys.rs
@@ -16,7 +16,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// Additional authentication information for the user-interactive authentication API.
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -38,7 +38,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {}
 
     error: crate::Error

--- a/ruma-client-api/src/r0/membership/ban_user.rs
+++ b/ruma-client-api/src/r0/membership/ban_user.rs
@@ -13,7 +13,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The room to kick the user from.
         #[ruma_api(path)]
@@ -28,7 +28,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {}
 
     error: crate::Error

--- a/ruma-client-api/src/r0/membership/forget_room.rs
+++ b/ruma-client-api/src/r0/membership/forget_room.rs
@@ -13,7 +13,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The room to forget.
         #[ruma_api(path)]
@@ -21,7 +21,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {}
 
     error: crate::Error

--- a/ruma-client-api/src/r0/membership/invite_user.rs
+++ b/ruma-client-api/src/r0/membership/invite_user.rs
@@ -23,7 +23,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The room where the user should be invited.
         #[ruma_api(path)]
@@ -35,7 +35,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {}
 
     error: crate::Error
@@ -57,7 +57,7 @@ impl Response {
 
 /// Distinguishes between invititations by Matrix or third party identifiers.
 #[derive(Clone, Debug, PartialEq, Outgoing, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[incoming_derive(PartialEq)]
 #[serde(untagged)]
 pub enum InvitationRecipient<'a> {

--- a/ruma-client-api/src/r0/membership/join_room_by_id.rs
+++ b/ruma-client-api/src/r0/membership/join_room_by_id.rs
@@ -15,7 +15,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The room where the user should be invited.
         #[ruma_api(path)]
@@ -27,7 +27,7 @@ ruma_api! {
         pub third_party_signed: Option<ThirdPartySigned<'a>>,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// The room that the user joined.
         pub room_id: RoomId,

--- a/ruma-client-api/src/r0/membership/join_room_by_id_or_alias.rs
+++ b/ruma-client-api/src/r0/membership/join_room_by_id_or_alias.rs
@@ -15,7 +15,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The room where the user should be invited.
         #[ruma_api(path)]
@@ -33,7 +33,7 @@ ruma_api! {
         pub third_party_signed: Option<ThirdPartySigned<'a>>,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// The room that the user joined.
         pub room_id: RoomId,

--- a/ruma-client-api/src/r0/membership/kick_user.rs
+++ b/ruma-client-api/src/r0/membership/kick_user.rs
@@ -13,7 +13,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The room to kick the user from.
         #[ruma_api(path)]
@@ -28,7 +28,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {}
 
     error: crate::Error

--- a/ruma-client-api/src/r0/membership/leave_room.rs
+++ b/ruma-client-api/src/r0/membership/leave_room.rs
@@ -13,7 +13,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The room to leave.
         #[ruma_api(path)]
@@ -21,7 +21,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {}
 
     error: crate::Error

--- a/ruma-client-api/src/r0/membership/unban_user.rs
+++ b/ruma-client-api/src/r0/membership/unban_user.rs
@@ -13,7 +13,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The room to unban the user from.
         #[ruma_api(path)]
@@ -24,7 +24,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {}
 
     error: crate::Error

--- a/ruma-client-api/src/r0/message/get_message_events.rs
+++ b/ruma-client-api/src/r0/message/get_message_events.rs
@@ -19,7 +19,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The room to get events from.
         #[ruma_api(path)]
@@ -64,7 +64,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// The token the pagination starts from.
         #[serde(skip_serializing_if = "Option::is_none")]

--- a/ruma-client-api/src/r0/message/send_message_event.rs
+++ b/ruma-client-api/src/r0/message/send_message_event.rs
@@ -18,7 +18,7 @@ use serde_json::value::RawValue as RawJsonValue;
 ///
 /// Send a message event to a room.
 #[derive(Clone, Debug, Outgoing)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[incoming_derive(!Deserialize)]
 pub struct Request<'a> {
     /// The room to send the event to.
@@ -44,7 +44,7 @@ impl<'a> Request<'a> {
 
 /// Data in the response from the `send_message_event` API endpoint.
 #[derive(Clone, Debug, Outgoing)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[incoming_derive(!Deserialize)]
 pub struct Response {
     /// A unique identifier for the event.

--- a/ruma-client-api/src/r0/push.rs
+++ b/ruma-client-api/src/r0/push.rs
@@ -22,7 +22,7 @@ pub mod set_pushrule_enabled;
 #[derive(
     Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Display, EnumString,
 )]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum RuleKind {

--- a/ruma-client-api/src/r0/read_marker/set_read_marker.rs
+++ b/ruma-client-api/src/r0/read_marker/set_read_marker.rs
@@ -13,7 +13,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The room ID to set the read marker in for the user.
         #[ruma_api(path)]
@@ -33,7 +33,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {}
 
     error: crate::Error

--- a/ruma-client-api/src/r0/receipt/create_receipt.rs
+++ b/ruma-client-api/src/r0/receipt/create_receipt.rs
@@ -16,7 +16,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The room in which to send the event.
         #[ruma_api(path)]
@@ -32,7 +32,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {}
 
     error: crate::Error
@@ -54,7 +54,7 @@ impl Response {
 
 /// The type of receipt.
 #[derive(Clone, Copy, Debug, Display, EnumString)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub enum ReceiptType {
     /// m.read
     #[strum(serialize = "m.read")]

--- a/ruma-client-api/src/r0/redact/redact_event.rs
+++ b/ruma-client-api/src/r0/redact/redact_event.rs
@@ -13,7 +13,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The ID of the room of the event to redact.
         #[ruma_api(path)]
@@ -35,7 +35,7 @@ ruma_api! {
         pub reason: Option<&'a str>,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// The ID of the redacted event.
         pub event_id: EventId,

--- a/ruma-client-api/src/r0/room.rs
+++ b/ruma-client-api/src/r0/room.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 /// Whether or not a newly created room will be listed in the room directory.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[serde(rename_all = "snake_case")]
 pub enum Visibility {
     /// Indicates that the room will be shown in the published room list.

--- a/ruma-client-api/src/r0/room/create_room.rs
+++ b/ruma-client-api/src/r0/room/create_room.rs
@@ -27,7 +27,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// Extra keys to be added to the content of the `m.room.create`.
         #[serde(default, skip_serializing_if = "CreationContent::is_empty")]
@@ -88,7 +88,7 @@ ruma_api! {
         pub visibility: Visibility,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// The created room's ID.
         pub room_id: RoomId,
@@ -116,7 +116,7 @@ impl Response {
 /// This is the same as the event content struct for `m.room.create`, but without some fields that
 /// servers are supposed to ignore.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct CreationContent {
     /// Whether users on other servers can join this room.
     ///
@@ -163,7 +163,7 @@ impl Default for CreationContent {
 
 /// A convenience parameter for setting a few default state events.
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[serde(rename_all = "snake_case")]
 pub enum RoomPreset {
     /// `join_rules` is set to `invite` and `history_visibility` is set to `shared`.

--- a/ruma-client-api/src/r0/search/search_events.rs
+++ b/ruma-client-api/src/r0/search/search_events.rs
@@ -21,7 +21,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The point to return events from.
         ///
@@ -33,7 +33,7 @@ ruma_api! {
         pub search_categories: Categories<'a>,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// A grouping of search results by category.
         pub search_categories: ResultCategories,
@@ -58,7 +58,7 @@ impl Response {
 
 /// Categories of events that can be searched for.
 #[derive(Clone, Debug, Default, Outgoing, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct Categories<'a> {
     /// Criteria for searching room events.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -74,7 +74,7 @@ impl Categories<'_> {
 
 /// Criteria for searching a category of events.
 #[derive(Clone, Copy, Debug, Outgoing, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct Criteria<'a> {
     /// The string to search events for.
     pub search_term: &'a str,
@@ -121,7 +121,7 @@ impl<'a> Criteria<'a> {
 
 /// Configures whether any context for the events returned are included in the response.
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct EventContext {
     /// How many events before the result are returned.
     #[serde(
@@ -178,7 +178,7 @@ impl Default for EventContext {
 
 /// Context for search results, if requested.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct EventContextResult {
     /// Pagination token for the end of the chunk.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -219,7 +219,7 @@ impl EventContextResult {
 
 /// A grouping for partioning the result set.
 #[derive(Clone, Copy, Default, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct Grouping {
     /// The key within events to use for this grouping.
     pub key: Option<GroupingKey>,
@@ -239,7 +239,7 @@ impl Grouping {
 
 /// The key within events to use for this grouping.
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, PartialOrd, Ord, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[serde(rename_all = "snake_case")]
 pub enum GroupingKey {
     /// `room_id`
@@ -252,7 +252,7 @@ pub enum GroupingKey {
 /// Requests that the server partitions the result set based on the provided list of keys.
 #[derive(Clone, Copy, Default, Debug, Outgoing, Serialize)]
 #[incoming_derive(Default)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct Groupings<'a> {
     /// List of groups to request.
     #[serde(default, skip_serializing_if = "<[_]>::is_empty")]
@@ -273,7 +273,7 @@ impl Groupings<'_> {
 
 /// The keys to search for.
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub enum SearchKeys {
     /// content.body
     #[serde(rename = "content.body")]
@@ -290,7 +290,7 @@ pub enum SearchKeys {
 
 /// The order in which to search for results.
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[serde(rename_all = "snake_case")]
 pub enum OrderBy {
     /// Prioritize recent events.
@@ -303,7 +303,7 @@ pub enum OrderBy {
 
 /// Categories of events that can be searched for.
 #[derive(Clone, Default, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct ResultCategories {
     /// Room event results.
     #[serde(default, skip_serializing_if = "ResultRoomEvents::is_empty")]
@@ -319,7 +319,7 @@ impl ResultCategories {
 
 /// Categories of events that can be searched for.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct ResultRoomEvents {
     /// An approximate count of the total number of results found.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -368,7 +368,7 @@ impl ResultRoomEvents {
 
 /// A grouping of results, if requested.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct ResultGroup {
     /// Token that can be used to get the next batch of results in the group, by passing as the
     /// `next_batch` parameter to the next call. If this field is absent, there are no more
@@ -399,7 +399,7 @@ impl ResultGroup {
 
 /// A search result.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct SearchResult {
     /// Context for result, if requested.
     #[serde(skip_serializing_if = "EventContextResult::is_empty")]
@@ -428,7 +428,7 @@ impl SearchResult {
 
 /// A user profile.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct UserProfile {
     /// The user's avatar URL, if set.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/ruma-client-api/src/r0/server/get_user_info.rs
+++ b/ruma-client-api/src/r0/server/get_user_info.rs
@@ -16,7 +16,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The user to look up.
         #[ruma_api(path)]
@@ -24,7 +24,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// The Matrix user ID of the user.
         #[serde(skip_serializing_if = "Option::is_none")]

--- a/ruma-client-api/src/r0/session/get_login_types.rs
+++ b/ruma-client-api/src/r0/session/get_login_types.rs
@@ -14,10 +14,10 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {}
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// The homeserver's supported login types.
         pub flows: Vec<LoginType>

--- a/ruma-client-api/src/r0/session/login.rs
+++ b/ruma-client-api/src/r0/session/login.rs
@@ -15,7 +15,7 @@ ruma_api! {
         requires_authentication: false,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// Identification information for the user.
         #[serde(flatten)]
@@ -35,7 +35,7 @@ ruma_api! {
         pub initial_device_display_name: Option<&'a str>,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// The fully-qualified Matrix ID that has been registered.
         pub user_id: UserId,

--- a/ruma-client-api/src/r0/session/logout.rs
+++ b/ruma-client-api/src/r0/session/logout.rs
@@ -13,11 +13,11 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {}
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {}
 
     error: crate::Error

--- a/ruma-client-api/src/r0/session/logout_all.rs
+++ b/ruma-client-api/src/r0/session/logout_all.rs
@@ -13,11 +13,11 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {}
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {}
 
     error: crate::Error

--- a/ruma-client-api/src/r0/session/sso_login.rs
+++ b/ruma-client-api/src/r0/session/sso_login.rs
@@ -13,7 +13,7 @@ ruma_api! {
 
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// URL to which the homeserver should return the user after completing
         /// authentication with the SSO identity provider.
@@ -21,7 +21,7 @@ ruma_api! {
         pub redirect_url: &'a str,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// Redirect URL to the SSO identity provider.
         #[ruma_api(header = LOCATION)]

--- a/ruma-client-api/src/r0/state/send_state_event_for_empty_key.rs
+++ b/ruma-client-api/src/r0/state/send_state_event_for_empty_key.rs
@@ -18,7 +18,7 @@ use serde_json::value::RawValue as RawJsonValue;
 ///
 /// Send a state event to a room associated with the empty state key.
 #[derive(Clone, Debug, Outgoing)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[incoming_derive(!Deserialize)]
 pub struct Request<'a> {
     /// The room to set the state in.
@@ -37,7 +37,7 @@ impl<'a> Request<'a> {
 
 /// Data in the response from the `send_state_event_for_empty_key` API endpoint.
 #[derive(Clone, Debug, Outgoing)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[incoming_derive(!Deserialize)]
 pub struct Response {
     /// A unique identifier for the event.

--- a/ruma-client-api/src/r0/state/send_state_event_for_key.rs
+++ b/ruma-client-api/src/r0/state/send_state_event_for_key.rs
@@ -18,7 +18,7 @@ use serde_json::value::RawValue as RawJsonValue;
 ///
 /// Send a state event to a room associated with a given state key.
 #[derive(Clone, Debug, Outgoing)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[incoming_derive(!Deserialize)]
 pub struct Request<'a> {
     /// The room to set the state in.
@@ -40,7 +40,7 @@ impl<'a> Request<'a> {
 
 /// Data in the response from the `send_message_event` API endpoint.
 #[derive(Clone, Debug, Outgoing)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[incoming_derive(!Deserialize)]
 pub struct Response {
     /// A unique identifier for the event.

--- a/ruma-client-api/src/r0/sync/sync_events.rs
+++ b/ruma-client-api/src/r0/sync/sync_events.rs
@@ -25,7 +25,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// A filter represented either as its full JSON definition or the ID of a saved filter.
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -60,7 +60,7 @@ ruma_api! {
         pub timeout: Option<Duration>,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// The batch token to supply in the `since` param of the next `/sync` request.
         pub next_batch: String,
@@ -155,7 +155,7 @@ impl<'a> From<&'a str> for Filter<'a> {
 
 /// Updates to rooms.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct Rooms {
     /// The rooms that the user has left or been banned from.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
@@ -184,7 +184,7 @@ impl Rooms {
 
 /// Historical updates to left rooms.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct LeftRoom {
     /// The timeline of messages and state changes in the room up to the point when the user
     /// left.
@@ -214,7 +214,7 @@ impl LeftRoom {
 
 /// Updates to joined rooms.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct JoinedRoom {
     /// Information about the room which clients may need to correctly render it
     /// to users.
@@ -264,7 +264,7 @@ impl JoinedRoom {
 
 /// unread notifications count
 #[derive(Clone, Copy, Default, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct UnreadNotificationsCount {
     /// The number of unread notifications for this room with the highlight flag set.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -289,7 +289,7 @@ impl UnreadNotificationsCount {
 
 /// Events in the room.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct Timeline {
     /// True if the number of events returned was limited by the `limit` on the filter.
     #[serde(default, skip_serializing_if = "ruma_serde::is_default")]
@@ -319,7 +319,7 @@ impl Timeline {
 
 /// State events in the room.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct State {
     /// A list of state events.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -340,7 +340,7 @@ impl State {
 
 /// The private data that this user has attached to this room.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct AccountData {
     /// A list of events.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -361,7 +361,7 @@ impl AccountData {
 
 /// Ephemeral events not recorded in the timeline or state of the room.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct Ephemeral {
     /// A list of events.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -382,7 +382,7 @@ impl Ephemeral {
 
 /// Information about room for rendering to clients.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct RoomSummary {
     /// Users which can be used to generate a room name if the room does not have
     /// one. Required if room name or canonical aliases are not set or empty.
@@ -418,7 +418,7 @@ impl RoomSummary {
 
 /// Updates to the rooms that the user has been invited to.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct InvitedRoom {
     /// The state of a room that the user has been invited to.
     #[serde(default, skip_serializing_if = "InviteState::is_empty")]
@@ -439,7 +439,7 @@ impl InvitedRoom {
 
 /// The state of a room that the user has been invited to.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct InviteState {
     /// A list of state events.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -460,7 +460,7 @@ impl InviteState {
 
 /// Updates to the presence status of other users.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct Presence {
     /// A list of events.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -481,7 +481,7 @@ impl Presence {
 
 /// Messages sent dirrectly between devices.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct ToDevice {
     /// A list of to-device events.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -502,7 +502,7 @@ impl ToDevice {
 
 /// Information on E2E device udpates.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct DeviceLists {
     /// List of users who have updated their device identity keys or who now
     /// share an encrypted room with the client since the previous sync

--- a/ruma-client-api/src/r0/tag/create_tag.rs
+++ b/ruma-client-api/src/r0/tag/create_tag.rs
@@ -14,7 +14,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The ID of the user creating the tag.
         #[ruma_api(path)]
@@ -34,7 +34,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {}
 
     error: crate::Error

--- a/ruma-client-api/src/r0/tag/delete_tag.rs
+++ b/ruma-client-api/src/r0/tag/delete_tag.rs
@@ -13,7 +13,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The user whose tag will be deleted.
         #[ruma_api(path)]
@@ -29,7 +29,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {}
 
     error: crate::Error

--- a/ruma-client-api/src/r0/tag/get_tags.rs
+++ b/ruma-client-api/src/r0/tag/get_tags.rs
@@ -14,7 +14,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The user whose tags will be retrieved.
         #[ruma_api(path)]
@@ -25,7 +25,7 @@ ruma_api! {
         pub room_id: &'a RoomId,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// The user's tags for the room.
         pub tags: Tags,

--- a/ruma-client-api/src/r0/thirdparty/get_location_for_protocol.rs
+++ b/ruma-client-api/src/r0/thirdparty/get_location_for_protocol.rs
@@ -15,7 +15,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The protocol used to communicate to the third party network.
         #[ruma_api(path)]
@@ -27,7 +27,7 @@ ruma_api! {
         pub fields: BTreeMap<String, String>,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// List of matched third party locations.
         #[ruma_api(body)]

--- a/ruma-client-api/src/r0/thirdparty/get_location_for_room_alias.rs
+++ b/ruma-client-api/src/r0/thirdparty/get_location_for_room_alias.rs
@@ -14,14 +14,14 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The Matrix room alias to look up.
         #[ruma_api(query)]
         pub alias: &'a RoomAliasId,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// List of matched third party locations.
         #[ruma_api(body)]

--- a/ruma-client-api/src/r0/thirdparty/get_protocol.rs
+++ b/ruma-client-api/src/r0/thirdparty/get_protocol.rs
@@ -13,14 +13,14 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The name of the protocol.
         #[ruma_api(path)]
         pub protocol: &'a str,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// Metadata about the protocol.
         #[ruma_api(body)]

--- a/ruma-client-api/src/r0/thirdparty/get_protocols.rs
+++ b/ruma-client-api/src/r0/thirdparty/get_protocols.rs
@@ -16,10 +16,10 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {}
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// Metadata about protocols supported by the homeserver.
         #[ruma_api(body)]

--- a/ruma-client-api/src/r0/thirdparty/get_user_for_protocol.rs
+++ b/ruma-client-api/src/r0/thirdparty/get_user_for_protocol.rs
@@ -15,7 +15,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The protocol used to communicate to the third party network.
         #[ruma_api(path)]
@@ -27,7 +27,7 @@ ruma_api! {
         pub fields: BTreeMap<String, String>,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// List of matched third party users.
         #[ruma_api(body)]

--- a/ruma-client-api/src/r0/thirdparty/get_user_for_user_id.rs
+++ b/ruma-client-api/src/r0/thirdparty/get_user_for_user_id.rs
@@ -14,14 +14,14 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The Matrix User ID to look up.
         #[ruma_api(query)]
         pub userid: &'a UserId,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// List of matched third party users.
         #[ruma_api(body)]

--- a/ruma-client-api/src/r0/to_device/send_event_to_device.rs
+++ b/ruma-client-api/src/r0/to_device/send_event_to_device.rs
@@ -19,7 +19,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// Type of event being sent to each device.
         #[ruma_api(path)]
@@ -39,7 +39,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {}
 
     error: crate::Error

--- a/ruma-client-api/src/r0/typing/create_typing_event.rs
+++ b/ruma-client-api/src/r0/typing/create_typing_event.rs
@@ -16,7 +16,7 @@ ruma_api! {
         rate_limited: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The user who has started to type.
         #[ruma_api(path)]
@@ -32,7 +32,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {}
 
     error: crate::Error

--- a/ruma-client-api/src/r0/user_directory/search_users.rs
+++ b/ruma-client-api/src/r0/user_directory/search_users.rs
@@ -15,7 +15,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The term to search for.
         pub search_term: &'a str,
@@ -35,7 +35,7 @@ ruma_api! {
         pub language: Option<String>,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// Ordered by rank and then whether or not profile info is available.
         pub results: Vec<User>,

--- a/ruma-client-api/src/r0/voip/get_turn_server_info.rs
+++ b/ruma-client-api/src/r0/voip/get_turn_server_info.rs
@@ -15,10 +15,10 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {}
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// The username to use.
         pub username: String,

--- a/ruma-client-api/src/unversioned/discover_homeserver.rs
+++ b/ruma-client-api/src/unversioned/discover_homeserver.rs
@@ -14,10 +14,10 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {}
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// Information about the homeserver to connect to.
         #[serde(rename = "m.homeserver")]
@@ -47,7 +47,7 @@ impl Response {
 
 /// Information about a discovered homeserver.
 #[derive(Clone, Debug, Deserialize, Hash, PartialEq, PartialOrd, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct HomeserverInfo {
     /// The base URL for the homeserver for client-server connections.
     pub base_url: String,
@@ -62,7 +62,7 @@ impl HomeserverInfo {
 
 /// Information about a discovered identity server.
 #[derive(Clone, Debug, Deserialize, Hash, PartialEq, PartialOrd, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct IdentityServerInfo {
     /// The base URL for the identity server for client-server connections.
     pub base_url: String,

--- a/ruma-client-api/src/unversioned/get_supported_versions.rs
+++ b/ruma-client-api/src/unversioned/get_supported_versions.rs
@@ -15,10 +15,10 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {}
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// A list of Matrix client API protocol versions supported by the homeserver.
         pub versions: Vec<String>,

--- a/ruma-client/src/error.rs
+++ b/ruma-client/src/error.rs
@@ -6,7 +6,7 @@ use ruma_api::error::{FromHttpResponseError, IntoHttpError};
 
 /// An error that can occur during client operations.
 #[derive(Debug)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub enum Error<E> {
     /// Queried endpoint requires authentication but was called on an anonymous client.
     AuthenticationRequired,

--- a/ruma-events/Cargo.toml
+++ b/ruma-events/Cargo.toml
@@ -29,6 +29,9 @@ matches = "0.1.8"
 ruma-identifiers = { version = "0.17.4", path = "../ruma-identifiers", features = ["rand"] }
 trybuild = "1.0.31"
 
+[features]
+unstable-exhaustive-types = []
+
 [[bench]]
 name = "event_deserialize"
 harness = false

--- a/ruma-events/src/call.rs
+++ b/ruma-events/src/call.rs
@@ -23,7 +23,7 @@ pub struct SessionDescription {
 
 /// The type of VoIP session description.
 #[derive(Clone, Copy, Debug, PartialEq, Display, EnumString, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum SessionDescriptionType {

--- a/ruma-events/src/call/hangup.rs
+++ b/ruma-events/src/call/hangup.rs
@@ -32,7 +32,7 @@ pub struct HangupEventContent {
 /// error in the call negotiation, this should be `ice_failed` for when ICE negotiation fails or
 /// `invite_timeout` for when the other party did not answer in time.
 #[derive(Clone, Copy, Debug, PartialEq, Display, EnumString, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum Reason {

--- a/ruma-events/src/event_type.rs
+++ b/ruma-events/src/event_type.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 /// This type can hold an arbitrary string. To check for events that are not available as a
 /// documented variant here, use its string representation, obtained through `.as_str()`.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[serde(from = "String", into = "String")]
 pub enum EventType {
     /// m.call.answer

--- a/ruma-events/src/key/verification.rs
+++ b/ruma-events/src/key/verification.rs
@@ -14,7 +14,7 @@ pub mod start;
 
 /// A hash algorithm.
 #[derive(Clone, Copy, Debug, PartialEq, Display, EnumString, Serialize, Deserialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum HashAlgorithm {
@@ -24,7 +24,7 @@ pub enum HashAlgorithm {
 
 /// A key agreement protocol.
 #[derive(Clone, Copy, Debug, PartialEq, Display, EnumString, Serialize, Deserialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[serde(rename_all = "kebab-case")]
 #[strum(serialize_all = "kebab-case")]
 pub enum KeyAgreementProtocol {
@@ -36,7 +36,7 @@ pub enum KeyAgreementProtocol {
 
 /// A message authentication code algorithm.
 #[derive(Clone, Copy, Debug, PartialEq, Display, EnumString, Serialize, Deserialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[serde(rename_all = "kebab-case")]
 #[strum(serialize_all = "kebab-case")]
 pub enum MessageAuthenticationCode {
@@ -48,7 +48,7 @@ pub enum MessageAuthenticationCode {
 
 /// A Short Authentication String method.
 #[derive(Clone, Copy, Debug, PartialEq, Display, EnumString, Serialize, Deserialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum ShortAuthenticationString {
@@ -61,7 +61,7 @@ pub enum ShortAuthenticationString {
 
 /// A Short Authentication String (SAS) verification method.
 #[derive(Clone, Copy, Debug, PartialEq, Display, EnumString, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub enum VerificationMethod {
     /// The *m.sas.v1* verification method.
     #[serde(rename = "m.sas.v1")]

--- a/ruma-events/src/key/verification/accept.rs
+++ b/ruma-events/src/key/verification/accept.rs
@@ -34,7 +34,7 @@ pub struct AcceptEventContent {
 /// An enum representing the different method specific
 /// *m.key.verification.accept* content.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[serde(untagged)]
 pub enum AcceptMethod {
     /// The *m.sas.v1* verification method.
@@ -57,7 +57,7 @@ pub struct CustomContent {
 
 /// The payload of an *m.key.verification.accept* event using the *m.sas.v1* method.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[serde(rename = "m.sas.v1", tag = "method")]
 pub struct MSasV1Content {
     /// The key agreement protocol the device is choosing to use, out of the

--- a/ruma-events/src/key/verification/cancel.rs
+++ b/ruma-events/src/key/verification/cancel.rs
@@ -32,7 +32,7 @@ pub struct CancelEventContent {
 ///
 /// Custom error codes should use the Java package naming convention.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[serde(from = "String", into = "String")]
 pub enum CancelCode {
     /// The user cancelled the verification.

--- a/ruma-events/src/key/verification/start.rs
+++ b/ruma-events/src/key/verification/start.rs
@@ -39,7 +39,7 @@ pub struct StartEventContent {
 /// An enum representing the different method specific
 /// *m.key.verification.start* content.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[serde(untagged)]
 pub enum StartMethod {
     /// The *m.sas.v1* verification method.
@@ -62,7 +62,7 @@ pub struct CustomContent {
 
 /// The payload of an *m.key.verification.start* event using the *m.sas.v1* method.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[serde(rename = "m.sas.v1", tag = "method")]
 pub struct MSasV1Content {
     /// The key agreement protocols the sending device understands.

--- a/ruma-events/src/room/aliases.rs
+++ b/ruma-events/src/room/aliases.rs
@@ -14,7 +14,7 @@ pub type AliasesEvent = StateEvent<AliasesEventContent>;
 
 /// The payload for `AliasesEvent`.
 #[derive(Clone, Debug, Deserialize, Serialize, StateEventContent)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[ruma_event(type = "m.room.aliases", custom_redacted)]
 pub struct AliasesEventContent {
     /// A list of room aliases.

--- a/ruma-events/src/room/avatar.rs
+++ b/ruma-events/src/room/avatar.rs
@@ -13,7 +13,7 @@ pub type AvatarEvent = StateEvent<AvatarEventContent>;
 
 /// The payload for `AvatarEvent`.
 #[derive(Clone, Debug, Deserialize, Serialize, StateEventContent)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[ruma_event(type = "m.room.avatar")]
 pub struct AvatarEventContent {
     /// Information about the avatar image.

--- a/ruma-events/src/room/canonical_alias.rs
+++ b/ruma-events/src/room/canonical_alias.rs
@@ -11,7 +11,7 @@ pub type CanonicalAliasEvent = StateEvent<CanonicalAliasEventContent>;
 
 /// The payload for `CanonicalAliasEvent`.
 #[derive(Clone, Debug, Deserialize, Serialize, StateEventContent)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[ruma_event(type = "m.room.canonical_alias")]
 pub struct CanonicalAliasEventContent {
     /// The canonical alias.

--- a/ruma-events/src/room/create.rs
+++ b/ruma-events/src/room/create.rs
@@ -12,7 +12,7 @@ pub type CreateEvent = StateEvent<CreateEventContent>;
 
 /// The payload for `CreateEvent`.
 #[derive(Clone, Debug, Deserialize, Serialize, StateEventContent)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[ruma_event(type = "m.room.create")]
 pub struct CreateEventContent {
     /// The `user_id` of the room creator. This is set by the homeserver.
@@ -45,7 +45,7 @@ impl CreateEventContent {
 
 /// A reference to an old room replaced during a room version upgrade.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct PreviousRoom {
     /// The ID of the old room.
     pub room_id: RoomId,

--- a/ruma-events/src/room/encrypted.rs
+++ b/ruma-events/src/room/encrypted.rs
@@ -14,7 +14,7 @@ pub type EncryptedEvent = MessageEvent<EncryptedEventContent>;
 
 /// The payload for `EncryptedEvent`.
 #[derive(Clone, Debug, Deserialize, Serialize, MessageEventContent)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[ruma_event(type = "m.room.encrypted")]
 #[serde(tag = "algorithm")]
 pub enum EncryptedEventContent {
@@ -29,7 +29,7 @@ pub enum EncryptedEventContent {
 
 /// The payload for `EncryptedEvent` using the *m.olm.v1.curve25519-aes-sha2* algorithm.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct OlmV1Curve25519AesSha2Content {
     /// A map from the recipient Curve25519 identity key to ciphertext information.
     pub ciphertext: BTreeMap<String, CiphertextInfo>,
@@ -49,7 +49,7 @@ impl OlmV1Curve25519AesSha2Content {
 ///
 /// Used for messages encrypted with the *m.olm.v1.curve25519-aes-sha2* algorithm.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct CiphertextInfo {
     /// The encrypted payload.
     pub body: String,
@@ -71,7 +71,7 @@ impl CiphertextInfo {
 /// To create an instance of this type, first create a `MegolmV1AesSha2ContentInit` and convert it
 /// via `MegolmV1AesSha2Content::from` / `.into()`.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct MegolmV1AesSha2Content {
     /// The encrypted content of the event.
     pub ciphertext: String,

--- a/ruma-events/src/room/encryption.rs
+++ b/ruma-events/src/room/encryption.rs
@@ -11,7 +11,7 @@ pub type EncryptionEvent = StateEvent<EncryptionEventContent>;
 
 /// The payload for `EncryptionEvent`.
 #[derive(Clone, Debug, Deserialize, Serialize, StateEventContent)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[ruma_event(type = "m.room.encryption")]
 pub struct EncryptionEventContent {
     /// The encryption algorithm to be used to encrypt messages sent in this room.

--- a/ruma-events/src/room/guest_access.rs
+++ b/ruma-events/src/room/guest_access.rs
@@ -14,7 +14,7 @@ pub type GuestAccessEvent = StateEvent<GuestAccessEventContent>;
 
 /// The payload for `GuestAccessEvent`.
 #[derive(Clone, Debug, Deserialize, Serialize, StateEventContent)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[ruma_event(type = "m.room.guest_access")]
 pub struct GuestAccessEventContent {
     /// A policy for guest user access to a room.
@@ -30,7 +30,7 @@ impl GuestAccessEventContent {
 
 /// A policy for guest user access to a room.
 #[derive(Clone, Copy, Debug, PartialEq, Display, EnumString, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum GuestAccess {

--- a/ruma-events/src/room/history_visibility.rs
+++ b/ruma-events/src/room/history_visibility.rs
@@ -12,7 +12,7 @@ pub type HistoryVisibilityEvent = StateEvent<HistoryVisibilityEventContent>;
 
 /// The payload for `HistoryVisibilityEvent`.
 #[derive(Clone, Debug, Deserialize, Serialize, StateEventContent)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[ruma_event(type = "m.room.history_visibility")]
 pub struct HistoryVisibilityEventContent {
     /// Who can see the room history.
@@ -29,7 +29,7 @@ impl HistoryVisibilityEventContent {
 
 /// Who can see a room's history.
 #[derive(Clone, Copy, Debug, PartialEq, Display, EnumString, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum HistoryVisibility {

--- a/ruma-events/src/room/join_rules.rs
+++ b/ruma-events/src/room/join_rules.rs
@@ -11,7 +11,7 @@ pub type JoinRulesEvent = StateEvent<JoinRulesEventContent>;
 
 /// The payload for `JoinRulesEvent`.
 #[derive(Clone, Debug, Deserialize, Serialize, StateEventContent)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[ruma_event(type = "m.room.join_rules")]
 pub struct JoinRulesEventContent {
     /// The type of rules used for users wishing to join this room.
@@ -28,7 +28,7 @@ impl JoinRulesEventContent {
 
 /// The rule used for users wishing to join this room.
 #[derive(Clone, Copy, Debug, PartialEq, Display, EnumString, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[serde(rename_all = "lowercase")]
 #[strum(serialize_all = "lowercase")]
 pub enum JoinRule {

--- a/ruma-events/src/room/member.rs
+++ b/ruma-events/src/room/member.rs
@@ -65,7 +65,7 @@ pub struct MemberEventContent {
 
 /// The membership state of a user.
 #[derive(Clone, Copy, Debug, PartialEq, Display, EnumString, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[serde(rename_all = "lowercase")]
 #[strum(serialize_all = "lowercase")]
 pub enum MembershipState {
@@ -116,7 +116,7 @@ pub struct SignedContent {
 
 /// Translation of the membership change in `m.room.member` event.
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub enum MembershipChange {
     /// No change.
     None,

--- a/ruma-events/src/room/message.rs
+++ b/ruma-events/src/room/message.rs
@@ -20,7 +20,7 @@ pub type MessageEvent = OuterMessageEvent<MessageEventContent>;
 
 /// The payload for `MessageEvent`.
 #[derive(Clone, Debug, Deserialize, Serialize, MessageEventContent)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[ruma_event(type = "m.room.message")]
 #[serde(tag = "msgtype")]
 pub enum MessageEventContent {
@@ -289,7 +289,7 @@ pub struct ServerNoticeMessageEventContent {
 
 /// Types of server notices.
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub enum ServerNoticeType {
     /// The server has exceeded some limit which requires the server administrator to intervene.
     #[serde(rename = "m.server_notice.usage_limit_reached")]
@@ -298,7 +298,7 @@ pub enum ServerNoticeType {
 
 /// Types of usage limits.
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[serde(rename_all = "snake_case")]
 pub enum LimitType {
     /// The server's number of active users in the last 30 days has exceeded the maximum.
@@ -310,7 +310,7 @@ pub enum LimitType {
 
 /// The format for the formatted representation of a message body.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub enum MessageFormat {
     /// HTML.
     #[serde(rename = "org.matrix.custom.html")]

--- a/ruma-events/src/room/message/feedback.rs
+++ b/ruma-events/src/room/message/feedback.rs
@@ -15,7 +15,7 @@ pub type FeedbackEvent = MessageEvent<FeedbackEventContent>;
 
 /// The payload for `FeedbackEvent`.
 #[derive(Clone, Debug, Deserialize, Serialize, MessageEventContent)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[ruma_event(type = "m.room.message.feedback")]
 pub struct FeedbackEventContent {
     /// The event that this feedback is related to.
@@ -35,7 +35,7 @@ impl FeedbackEventContent {
 
 /// A type of feedback.
 #[derive(Clone, Copy, Debug, PartialEq, Display, EnumString, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum FeedbackType {

--- a/ruma-events/src/room/pinned_events.rs
+++ b/ruma-events/src/room/pinned_events.rs
@@ -11,7 +11,7 @@ pub type PinnedEventsEvent = StateEvent<PinnedEventsEventContent>;
 
 /// The payload for `PinnedEventsEvent`.
 #[derive(Clone, Debug, Deserialize, Serialize, StateEventContent)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[ruma_event(type = "m.room.pinned_events")]
 pub struct PinnedEventsEventContent {
     /// An ordered list of event IDs to pin.

--- a/ruma-events/src/room_key_request.rs
+++ b/ruma-events/src/room_key_request.rs
@@ -36,7 +36,7 @@ pub struct RoomKeyRequestEventContent {
 
 /// A new key request or a cancellation of a previous request.
 #[derive(Clone, Copy, Debug, PartialEq, Display, EnumString, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 pub enum Action {

--- a/ruma-events/src/tag.rs
+++ b/ruma-events/src/tag.rs
@@ -15,7 +15,7 @@ pub type Tags = BTreeMap<String, TagInfo>;
 
 /// The payload for `TagEvent`.
 #[derive(Clone, Debug, Deserialize, Serialize, BasicEventContent)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[ruma_event(type = "m.tag")]
 pub struct TagEventContent {
     /// A map of tag names to tag info.
@@ -37,7 +37,7 @@ impl From<Tags> for TagEventContent {
 
 /// Information about a tag.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct TagInfo {
     /// Value to use for lexicographically ordering rooms with this tag.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/ruma-federation-api/Cargo.toml
+++ b/ruma-federation-api/Cargo.toml
@@ -27,3 +27,6 @@ serde_json = "1.0.57"
 
 [dev-dependencies]
 matches = "0.1.8"
+
+[features]
+unstable-exhaustive-types = []

--- a/ruma-federation-api/src/authorization/get_event_authorization/v1.rs
+++ b/ruma-federation-api/src/authorization/get_event_authorization/v1.rs
@@ -15,7 +15,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The room ID to get the auth chain for.
         #[ruma_api(path)]
@@ -26,7 +26,7 @@ ruma_api! {
         pub event_id: &'a EventId,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// The full set of authorization events that make up the state of the room,
         /// and their authorization events, recursively.

--- a/ruma-federation-api/src/backfill/get_backfill/v1.rs
+++ b/ruma-federation-api/src/backfill/get_backfill/v1.rs
@@ -17,7 +17,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The room ID to backfill.
         #[ruma_api(path)]
@@ -32,7 +32,7 @@ ruma_api! {
         pub limit: UInt,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// The `server_name` of the homeserver sending this transaction.
         pub origin: ServerNameBox,

--- a/ruma-federation-api/src/device/get_devices/v1.rs
+++ b/ruma-federation-api/src/device/get_devices/v1.rs
@@ -16,14 +16,14 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The user ID to retrieve devices for. Must be a user local to the receiving homeserver.
         #[ruma_api(path)]
         pub user_id: &'a UserId,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// The user ID devices were requested for.
         pub user_id: UserId,
@@ -56,7 +56,7 @@ impl Response {
 
 /// Information about a user's device.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct UserDevice {
     /// The device ID.
     pub device_id: DeviceIdBox,

--- a/ruma-federation-api/src/directory/get_public_rooms/v1.rs
+++ b/ruma-federation-api/src/directory/get_public_rooms/v1.rs
@@ -15,7 +15,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// Limit for the number of results to return.
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -34,7 +34,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// A paginated chunk of public rooms.
         pub chunk: Vec<PublicRoomsChunk>,

--- a/ruma-federation-api/src/directory/get_public_rooms_filtered/v1.rs
+++ b/ruma-federation-api/src/directory/get_public_rooms_filtered/v1.rs
@@ -17,7 +17,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// Limit for the number of results to return.
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -37,7 +37,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// A paginated chunk of public rooms.
         pub chunk: Vec<PublicRoomsChunk>,

--- a/ruma-federation-api/src/discovery.rs
+++ b/ruma-federation-api/src/discovery.rs
@@ -13,7 +13,7 @@ pub mod get_server_version;
 
 /// Public key of the homeserver for verifying digital signatures.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct VerifyKey {
     /// The Unpadded Base64 encoded key.
     pub key: String,
@@ -28,7 +28,7 @@ impl VerifyKey {
 
 /// A key the server used to use, but stopped using.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct OldVerifyKey {
     /// Timestamp when this key expired.
     #[serde(with = "ruma_serde::time::ms_since_unix_epoch")]
@@ -47,7 +47,7 @@ impl OldVerifyKey {
 // Spec is wrong, all fields are required (see https://github.com/matrix-org/matrix-doc/issues/2508)
 /// Queried server key, signed by the notary server.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct ServerKey {
     /// DNS name of the homeserver.
     pub server_name: ServerNameBox,

--- a/ruma-federation-api/src/discovery/discover_homeserver.rs
+++ b/ruma-federation-api/src/discovery/discover_homeserver.rs
@@ -14,10 +14,10 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {}
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// The server name to delegate server-server communciations to, with optional port.
         #[serde(rename = "m.homeserver")]

--- a/ruma-federation-api/src/discovery/get_remote_server_keys/v2.rs
+++ b/ruma-federation-api/src/discovery/get_remote_server_keys/v2.rs
@@ -18,7 +18,7 @@ ruma_api! {
         requires_authentication: false,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The server's DNS name to query
         #[ruma_api(path)]
@@ -33,7 +33,7 @@ ruma_api! {
         pub minimum_valid_until_ts: SystemTime,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// The queried server's keys, signed by the notary server.
         pub server_keys: Vec<ServerKey>,

--- a/ruma-federation-api/src/discovery/get_remote_server_keys_batch/v2.rs
+++ b/ruma-federation-api/src/discovery/get_remote_server_keys_batch/v2.rs
@@ -17,7 +17,7 @@ ruma_api! {
         requires_authentication: false,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The query criteria. The outer string key on the object is the server
         /// name (eg: matrix.org). The inner string key is the Key ID to query
@@ -42,7 +42,7 @@ ruma_api! {
         pub minimum_valid_until_ts: SystemTime,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// The queried server's keys, signed by the notary server.
         pub server_keys: Vec<ServerKey>,
@@ -68,7 +68,7 @@ impl Response {
 
 /// The query criteria.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct QueryCriteria {
     /// A millisecond POSIX timestamp in milliseconds indicating when the
     /// returned certificates will need to be valid until to be useful to the

--- a/ruma-federation-api/src/discovery/get_server_keys/v2.rs
+++ b/ruma-federation-api/src/discovery/get_server_keys/v2.rs
@@ -14,10 +14,10 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {}
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// Queried server key, signed by the notary server.
         #[ruma_api(body)]

--- a/ruma-federation-api/src/discovery/get_server_version/v1.rs
+++ b/ruma-federation-api/src/discovery/get_server_version/v1.rs
@@ -14,11 +14,11 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {}
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// Information about the homeserver implementation
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -42,7 +42,7 @@ impl Response {
 
 /// Arbitrary values that identify this implementation.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct Server {
     /// Arbitrary name that identifies this implementation.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/ruma-federation-api/src/event/get_missing_events/v1.rs
+++ b/ruma-federation-api/src/event/get_missing_events/v1.rs
@@ -15,7 +15,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The room ID to search in.
         #[ruma_api(path)]
@@ -37,7 +37,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// The missing PDUs.
         events: Vec<Pdu>

--- a/ruma-federation-api/src/keys/claim_keys/v1.rs
+++ b/ruma-federation-api/src/keys/claim_keys/v1.rs
@@ -17,13 +17,13 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The keys to be claimed.
         pub one_time_keys: OneTimeKeyClaims,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// One-time keys for the queried devices
         pub one_time_keys: OneTimeKeys,
@@ -52,7 +52,7 @@ pub type OneTimeKeys = BTreeMap<UserId, BTreeMap<DeviceIdBox, BTreeMap<DeviceKey
 
 /// A key and its signature
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct KeyObject {
     /// The key, encoded using unpadded base64.
     pub key: String,

--- a/ruma-federation-api/src/keys/get_keys/v1.rs
+++ b/ruma-federation-api/src/keys/get_keys/v1.rs
@@ -16,14 +16,14 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The keys to be downloaded. Gives all keys for a given user if the list of device ids is
         /// empty.
         pub device_keys: BTreeMap<UserId, Vec<DeviceIdBox>>,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// Keys from the queried devices.
         pub device_keys: BTreeMap<UserId, BTreeMap<DeviceIdBox, IncomingDeviceKeys>>,

--- a/ruma-federation-api/src/membership/create_invite.rs
+++ b/ruma-federation-api/src/membership/create_invite.rs
@@ -28,7 +28,7 @@ pub struct StrippedState {
 
 /// The invite event sent as a response.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct InviteEvent {
     /// The matrix ID of the user who sent the original `m.room.third_party_invite`.
     pub sender: UserId,

--- a/ruma-federation-api/src/membership/create_invite/v1.rs
+++ b/ruma-federation-api/src/membership/create_invite/v1.rs
@@ -18,7 +18,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The room ID that the user is being invited to.
         #[ruma_api(path)]
@@ -52,7 +52,7 @@ ruma_api! {
         pub unsigned: UnsignedEventContent,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// The response invite event
         #[ruma_api(body)]
@@ -63,7 +63,7 @@ ruma_api! {
 
 /// Information included alongside an event that is not signed.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct UnsignedEventContent {
     /// An optional list of simplified events to help the receiver of the invite identify the room.
     /// The recommended events to include are the join rules, canonical alias, avatar, and name of

--- a/ruma-federation-api/src/membership/create_invite/v2.rs
+++ b/ruma-federation-api/src/membership/create_invite/v2.rs
@@ -15,7 +15,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The room ID that the user is being invited to.
         #[ruma_api(path)]
@@ -35,7 +35,7 @@ ruma_api! {
         pub invite_room_state: StrippedState,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// An invite event.
         pub event: InviteEvent,

--- a/ruma-federation-api/src/membership/create_join_event.rs
+++ b/ruma-federation-api/src/membership/create_join_event.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 /// Full state of the room.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[non_exhaustive]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct RoomState {
     /// The resident server's DNS name.
     pub origin: String,

--- a/ruma-federation-api/src/membership/create_join_event/v1.rs
+++ b/ruma-federation-api/src/membership/create_join_event/v1.rs
@@ -17,7 +17,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The room ID that is about to be joined.
         #[ruma_api(path)]
@@ -32,7 +32,7 @@ ruma_api! {
         pub pdu_stub: Raw<PduStub>,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// Full state and auth chain of the room prior to the join event.
         #[ruma_api(body)]

--- a/ruma-federation-api/src/membership/create_join_event/v2.rs
+++ b/ruma-federation-api/src/membership/create_join_event/v2.rs
@@ -17,7 +17,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The room ID that is about to be joined.
         #[ruma_api(path)]
@@ -32,7 +32,7 @@ ruma_api! {
         pub pdu_stub: Raw<PduStub>,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// Full state of the room.
         #[ruma_api(body)]

--- a/ruma-federation-api/src/membership/create_join_event_template/v1.rs
+++ b/ruma-federation-api/src/membership/create_join_event_template/v1.rs
@@ -15,7 +15,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The room ID that is about to be joined.
         #[ruma_api(path)]
@@ -33,7 +33,7 @@ ruma_api! {
         pub ver: &'a [RoomVersionId],
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// The version of the room where the server is trying to join.
         #[serde(skip_serializing_if = "Option::is_none")]

--- a/ruma-federation-api/src/openid/get_openid_userinfo/v1.rs
+++ b/ruma-federation-api/src/openid/get_openid_userinfo/v1.rs
@@ -13,14 +13,14 @@ ruma_api! {
         requires_authentication: false,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// The OpenID access token to get information about the owner for.
         #[ruma_api(query)]
         pub access_token: &'a str,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// The Matrix User ID who generated the token.
         pub sub: UserId,

--- a/ruma-federation-api/src/query/get_profile_information/v1.rs
+++ b/ruma-federation-api/src/query/get_profile_information/v1.rs
@@ -14,7 +14,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// User ID to query.
         #[ruma_api(query)]
@@ -27,7 +27,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// Display name of the user.
         #[serde(skip_serializing_if = "Option::is_none")]

--- a/ruma-federation-api/src/query/get_room_information/v1.rs
+++ b/ruma-federation-api/src/query/get_room_information/v1.rs
@@ -13,14 +13,14 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// Room alias to query.
         #[ruma_api(query)]
         pub room_alias: &'a RoomAliasId,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// Room ID mapped to queried alias.
         pub room_id: RoomId,

--- a/ruma-federation-api/src/transactions/send_transaction_message/v1.rs
+++ b/ruma-federation-api/src/transactions/send_transaction_message/v1.rs
@@ -18,7 +18,7 @@ ruma_api! {
         requires_authentication: true,
     }
 
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     request: {
         /// A transaction ID unique between sending and receiving homeservers.
         #[ruma_api(path)]
@@ -45,7 +45,7 @@ ruma_api! {
     }
 
     #[derive(Default)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// Map of event IDs and response for each PDU given in the request.
         #[serde(with = "crate::serde::pdu_process_response")]

--- a/ruma/Cargo.toml
+++ b/ruma/Cargo.toml
@@ -15,6 +15,12 @@ edition = "2018"
 [features]
 either = ["ruma-identifiers/either"]
 rand = ["ruma-identifiers/rand"]
+unstable-exhaustive-types = [
+  "ruma-events/unstable-exhaustive-types",
+  "ruma-appservice-api/unstable-exhaustive-types",
+  "ruma-client-api/unstable-exhaustive-types",
+  "ruma-federation-api/unstable-exhaustive-types",
+]
 unstable-pre-spec = ["ruma-client-api/unstable-pre-spec"]
 unstable-synapse-quirks = ["ruma-client-api/unstable-synapse-quirks"]
 


### PR DESCRIPTION
This PR makes the changes suggested in #215, allowing certain users to opt-in to exhaustive types with the `unstable-exhaustive-types` feature flag (set either on the independent crates affected, or primary `ruma` crate itself).