### PR TITLE
federation-api: Add retrieval endpoints

### DIFF
--- a/ruma-federation-api/src/event.rs
+++ b/ruma-federation-api/src/event.rs
@@ -1,3 +1,6 @@
 //! Endpoints to get general information about events
 
+pub mod get_event;
 pub mod get_missing_events;
+pub mod get_room_state;
+pub mod get_room_state_ids;

--- a/ruma-federation-api/src/event/get_event.rs
+++ b/ruma-federation-api/src/event/get_event.rs
@@ -1,0 +1,3 @@
+//! Retrieves a single event.
+
+pub mod v1;

--- a/ruma-federation-api/src/event/get_event/v1.rs
+++ b/ruma-federation-api/src/event/get_event/v1.rs
@@ -46,10 +46,7 @@ impl<'a> Request<'a> {
 }
 
 impl Response {
-    /// Creates a new `Response` with:
-    /// * the `server_name` of the homeserver.
-    /// * the timestamp in milliseconds of when this transaction started.
-    /// * the requested event
+    /// Creates a new `Response` with the given server name, timestamp, and event.
     pub fn new(origin: ServerNameBox, origin_server_ts: SystemTime, pdu: Pdu) -> Self {
         Self { origin, origin_server_ts, pdu }
     }

--- a/ruma-federation-api/src/event/get_event/v1.rs
+++ b/ruma-federation-api/src/event/get_event/v1.rs
@@ -1,9 +1,9 @@
 //! [GET /_matrix/federation/v1/event/{eventId}](https://matrix.org/docs/spec/server_server/r0.1.4#get-matrix-federation-v1-event-eventid)
 
-use js_int::UInt;
 use ruma_api::ruma_api;
 use ruma_events::pdu::Pdu;
 use ruma_identifiers::{EventId, ServerNameBox};
+use std::time::SystemTime;
 
 ruma_api! {
     metadata: {
@@ -29,9 +29,10 @@ ruma_api! {
 
         /// POSIX timestamp in milliseconds on originating homeserver when this
         /// transaction started.
-        origin_server_ts: UInt,
+        #[serde(with = "ruma_serde::time::ms_since_unix_epoch")]
+        origin_server_ts: SystemTime,
 
-        /// A single PDU.
+        /// An array with a single PDU.
         ///
         /// Note that events have a different format depending on the room
         /// version - check the [room version specification] for precise event
@@ -50,9 +51,11 @@ impl<'a> Request<'a> {
 }
 
 impl Response {
-    /// Creates a new `Response` with the given origin, server timestamp, and
-    /// list containing a single `Pdu`.
-    pub fn new(origin: ServerNameBox, origin_server_ts: UInt, pdus: Vec<Pdu>) -> Self {
+    /// Creates a new `Response` with:
+    /// * the `server_name` of the homeserver.
+    /// * the timestamp in milliseconds of when this transaction started.
+    /// * a list containing the single requested event
+    pub fn new(origin: ServerNameBox, origin_server_ts: SystemTime, pdus: Vec<Pdu>) -> Self {
         Self { origin, origin_server_ts, pdus }
     }
 }

--- a/ruma-federation-api/src/event/get_event/v1.rs
+++ b/ruma-federation-api/src/event/get_event/v1.rs
@@ -19,7 +19,7 @@ ruma_api! {
     request: {
         /// The event ID to get.
         #[ruma_api(path)]
-        event_id: &'a EventId,
+        pub event_id: &'a EventId,
     }
 
     #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
@@ -30,16 +30,17 @@ ruma_api! {
         /// POSIX timestamp in milliseconds on originating homeserver when this
         /// transaction started.
         #[serde(with = "ruma_serde::time::ms_since_unix_epoch")]
-        origin_server_ts: SystemTime,
+        pub origin_server_ts: SystemTime,
 
-        /// An array with a single PDU.
+        /// The event as an array with a single element.
         ///
         /// Note that events have a different format depending on the room
         /// version - check the [room version specification] for precise event
         /// formats.
         ///
         /// [room version specification]: https://matrix.org/docs/spec/index.html#room-versions
-        pdus: Vec<Pdu>
+        #[serde(rename = "pdus", with = "ruma_serde::single_element_seq")]
+        pub pdu: Pdu,
     }
 }
 
@@ -54,8 +55,8 @@ impl Response {
     /// Creates a new `Response` with:
     /// * the `server_name` of the homeserver.
     /// * the timestamp in milliseconds of when this transaction started.
-    /// * a list containing the single requested event
-    pub fn new(origin: ServerNameBox, origin_server_ts: SystemTime, pdus: Vec<Pdu>) -> Self {
-        Self { origin, origin_server_ts, pdus }
+    /// * the requested event
+    pub fn new(origin: ServerNameBox, origin_server_ts: SystemTime, pdu: Pdu) -> Self {
+        Self { origin, origin_server_ts, pdu }
     }
 }

--- a/ruma-federation-api/src/event/get_event/v1.rs
+++ b/ruma-federation-api/src/event/get_event/v1.rs
@@ -25,20 +25,14 @@ ruma_api! {
     #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// The `server_name` of the homeserver sending this transaction.
-        origin: ServerNameBox,
+        pub origin: ServerNameBox,
 
         /// POSIX timestamp in milliseconds on originating homeserver when this
         /// transaction started.
         #[serde(with = "ruma_serde::time::ms_since_unix_epoch")]
         pub origin_server_ts: SystemTime,
 
-        /// The event as an array with a single element.
-        ///
-        /// Note that events have a different format depending on the room
-        /// version - check the [room version specification] for precise event
-        /// formats.
-        ///
-        /// [room version specification]: https://matrix.org/docs/spec/index.html#room-versions
+        /// The event.
         #[serde(rename = "pdus", with = "ruma_serde::single_element_seq")]
         pub pdu: Pdu,
     }

--- a/ruma-federation-api/src/event/get_event/v1.rs
+++ b/ruma-federation-api/src/event/get_event/v1.rs
@@ -1,0 +1,58 @@
+//! [GET /_matrix/federation/v1/event/{eventId}](https://matrix.org/docs/spec/server_server/r0.1.4#get-matrix-federation-v1-event-eventid)
+
+use js_int::UInt;
+use ruma_api::ruma_api;
+use ruma_events::pdu::Pdu;
+use ruma_identifiers::{EventId, ServerNameBox};
+
+ruma_api! {
+    metadata: {
+        description: "Retrieves a single event.",
+        method: GET,
+        name: "get_event",
+        path: "/_matrix/federation/v1/event/:event_id",
+        rate_limited: false,
+        requires_authentication: true,
+    }
+
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+    request: {
+        /// The event ID to get.
+        #[ruma_api(path)]
+        event_id: &'a EventId,
+    }
+
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+    response: {
+        /// The `server_name` of the homeserver sending this transaction.
+        origin: ServerNameBox,
+
+        /// POSIX timestamp in milliseconds on originating homeserver when this
+        /// transaction started.
+        origin_server_ts: UInt,
+
+        /// A single PDU.
+        ///
+        /// Note that events have a different format depending on the room
+        /// version - check the [room version specification] for precise event
+        /// formats.
+        ///
+        /// [room version specification]: https://matrix.org/docs/spec/index.html#room-versions
+        pdus: Vec<Pdu>
+    }
+}
+
+impl<'a> Request<'a> {
+    /// Creates a new `Request` with the given event id.
+    pub fn new(event_id: &'a EventId) -> Self {
+        Self { event_id }
+    }
+}
+
+impl Response {
+    /// Creates a new `Response` with the given origin, server timestamp, and
+    /// list containing a single `Pdu`.
+    pub fn new(origin: ServerNameBox, origin_server_ts: UInt, pdus: Vec<Pdu>) -> Self {
+        Self { origin, origin_server_ts, pdus }
+    }
+}

--- a/ruma-federation-api/src/event/get_event/v1.rs
+++ b/ruma-federation-api/src/event/get_event/v1.rs
@@ -27,8 +27,7 @@ ruma_api! {
         /// The `server_name` of the homeserver sending this transaction.
         pub origin: ServerNameBox,
 
-        /// POSIX timestamp in milliseconds on originating homeserver when this
-        /// transaction started.
+        /// Time on originating homeserver when this transaction started.
         #[serde(with = "ruma_serde::time::ms_since_unix_epoch")]
         pub origin_server_ts: SystemTime,
 

--- a/ruma-federation-api/src/event/get_room_state.rs
+++ b/ruma-federation-api/src/event/get_room_state.rs
@@ -1,0 +1,3 @@
+//! Retrieves a snapshot of a room's state at a given event.
+
+pub mod v1;

--- a/ruma-federation-api/src/event/get_room_state/v1.rs
+++ b/ruma-federation-api/src/event/get_room_state/v1.rs
@@ -29,28 +29,16 @@ ruma_api! {
     response: {
         /// The full set of authorization events that make up the state of the
         /// room, and their authorization events, recursively.
-        ///
-        /// Note that events have a different format depending on the room
-        /// version - check the [room version specification] for precise event
-        /// formats.
-        ///
-        /// [room version specification]: https://matrix.org/docs/spec/index.html#room-versions
         pub auth_chain: Vec<Pdu>,
 
 
         /// The fully resolved state of the room at the given event.
-        ///
-        /// Note that events have a different format depending on the room
-        /// version - check the [room version specification] for precise event
-        /// formats.
-        ///
-        /// [room version specification]: https://matrix.org/docs/spec/index.html#room-versions
         pub pdus: Vec<Pdu>,
     }
 }
 
 impl<'a> Request<'a> {
-    /// Creates a new `Request` with the given event id and room id.
+    /// Creates a new `Request` with the given event ID and room ID.
     pub fn new(event_id: &'a EventId, room_id: &'a RoomId) -> Self {
         Self { event_id, room_id }
     }

--- a/ruma-federation-api/src/event/get_room_state/v1.rs
+++ b/ruma-federation-api/src/event/get_room_state/v1.rs
@@ -1,0 +1,64 @@
+//! [GET /_matrix/federation/v1/state/{roomId}](https://matrix.org/docs/spec/server_server/r0.1.4#get-matrix-federation-v1-state-roomid)
+
+use ruma_api::ruma_api;
+use ruma_events::pdu::Pdu;
+use ruma_identifiers::{EventId, RoomId};
+
+ruma_api! {
+    metadata: {
+        description: "Retrieves a snapshot of a room's state at a given event.",
+        method: GET,
+        name: "get_room_state",
+        path: "/_matrix/federation/v1/state/:room_id",
+        rate_limited: false,
+        requires_authentication: true,
+    }
+
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+    request: {
+        /// The room ID to get state for.
+        #[ruma_api(path)]
+        room_id: &'a RoomId,
+
+        /// An event ID in the room to retrieve the state at.
+        #[ruma_api(query)]
+        event_id: &'a EventId,
+    }
+
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+    response: {
+        /// The full set of authorization events that make up the state of the
+        /// room, and their authorization events, recursively.
+        ///
+        /// Note that events have a different format depending on the room
+        /// version - check the [room version specification] for precise event
+        /// formats.
+        ///
+        /// [room version specification]: https://matrix.org/docs/spec/index.html#room-versions
+        auth_chain: Vec<Pdu>,
+
+
+        /// The fully resolved state of the room at the given event.
+        ///
+        /// Note that events have a different format depending on the room
+        /// version - check the [room version specification] for precise event
+        /// formats.
+        ///
+        /// [room version specification]: https://matrix.org/docs/spec/index.html#room-versions
+        pdus: Vec<Pdu>
+    }
+}
+
+impl<'a> Request<'a> {
+    /// Creates a new `Request` with the given event id and room id.
+    pub fn new(event_id: &'a EventId, room_id: &'a RoomId) -> Self {
+        Self { event_id, room_id }
+    }
+}
+
+impl Response {
+    /// Creates a new `Response` with the given auth chain and room state.
+    pub fn new(auth_chain: Vec<Pdu>, pdus: Vec<Pdu>) -> Self {
+        Self { auth_chain, pdus }
+    }
+}

--- a/ruma-federation-api/src/event/get_room_state/v1.rs
+++ b/ruma-federation-api/src/event/get_room_state/v1.rs
@@ -18,11 +18,11 @@ ruma_api! {
     request: {
         /// The room ID to get state for.
         #[ruma_api(path)]
-        room_id: &'a RoomId,
+        pub room_id: &'a RoomId,
 
         /// An event ID in the room to retrieve the state at.
         #[ruma_api(query)]
-        event_id: &'a EventId,
+        pub event_id: &'a EventId,
     }
 
     #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
@@ -35,7 +35,7 @@ ruma_api! {
         /// formats.
         ///
         /// [room version specification]: https://matrix.org/docs/spec/index.html#room-versions
-        auth_chain: Vec<Pdu>,
+        pub auth_chain: Vec<Pdu>,
 
 
         /// The fully resolved state of the room at the given event.
@@ -45,7 +45,7 @@ ruma_api! {
         /// formats.
         ///
         /// [room version specification]: https://matrix.org/docs/spec/index.html#room-versions
-        pdus: Vec<Pdu>
+        pub pdus: Vec<Pdu>,
     }
 }
 

--- a/ruma-federation-api/src/event/get_room_state/v1.rs
+++ b/ruma-federation-api/src/event/get_room_state/v1.rs
@@ -31,7 +31,6 @@ ruma_api! {
         /// room, and their authorization events, recursively.
         pub auth_chain: Vec<Pdu>,
 
-
         /// The fully resolved state of the room at the given event.
         pub pdus: Vec<Pdu>,
     }

--- a/ruma-federation-api/src/event/get_room_state_ids.rs
+++ b/ruma-federation-api/src/event/get_room_state_ids.rs
@@ -1,0 +1,3 @@
+//! Retrieves a snapshot of a room's state at a given event, in the form of event IDs.
+
+pub mod v1;

--- a/ruma-federation-api/src/event/get_room_state_ids/v1.rs
+++ b/ruma-federation-api/src/event/get_room_state_ids/v1.rs
@@ -1,0 +1,52 @@
+//! [GET /_matrix/federation/v1/state_ids/{roomId}](https://matrix.org/docs/spec/server_server/r0.1.4#get-matrix-federation-v1-state-ids-roomid)
+
+use ruma_api::ruma_api;
+use ruma_identifiers::{EventId, RoomId};
+
+ruma_api! {
+    metadata: {
+        description: "Retrieves a snapshot of a room's state at a given event, in the form of event IDs",
+        method: GET,
+        name: "get_room_state_ids",
+        path: "/_matrix/federation/v1/state_ids/:room_id",
+        rate_limited: false,
+        requires_authentication: true,
+    }
+
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+    request: {
+        /// The room ID to get state for.
+        #[ruma_api(path)]
+        room_id: &'a RoomId,
+
+        /// An event ID in the room to retrieve the state at.
+        #[ruma_api(query)]
+        event_id: &'a EventId,
+    }
+
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+    response: {
+        /// The full set of authorization events that make up the state of the
+        /// room, and their authorization events, recursively.
+        auth_chain_ids: Vec<EventId>,
+
+
+        /// The fully resolved state of the room at the given event.
+        pdu_ids: Vec<EventId>
+    }
+}
+
+impl<'a> Request<'a> {
+    /// Creates a new `Request` with the given event id and room id.
+    pub fn new(event_id: &'a EventId, room_id: &'a RoomId) -> Self {
+        Self { event_id, room_id }
+    }
+}
+
+impl Response {
+    /// Creates a new `Response` with the given auth chain ids and room state
+    /// ids.
+    pub fn new(auth_chain_ids: Vec<EventId>, pdu_ids: Vec<EventId>) -> Self {
+        Self { auth_chain_ids, pdu_ids }
+    }
+}

--- a/ruma-federation-api/src/event/get_room_state_ids/v1.rs
+++ b/ruma-federation-api/src/event/get_room_state_ids/v1.rs
@@ -29,6 +29,7 @@ ruma_api! {
         /// The full set of authorization events that make up the state of the
         /// room, and their authorization events, recursively.
         pub auth_chain_ids: Vec<EventId>,
+
         /// The fully resolved state of the room at the given event.
         pub pdu_ids: Vec<EventId>,
     }

--- a/ruma-federation-api/src/event/get_room_state_ids/v1.rs
+++ b/ruma-federation-api/src/event/get_room_state_ids/v1.rs
@@ -17,22 +17,22 @@ ruma_api! {
     request: {
         /// The room ID to get state for.
         #[ruma_api(path)]
-        room_id: &'a RoomId,
+        pub room_id: &'a RoomId,
 
         /// An event ID in the room to retrieve the state at.
         #[ruma_api(query)]
-        event_id: &'a EventId,
+        pub event_id: &'a EventId,
     }
 
     #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     response: {
         /// The full set of authorization events that make up the state of the
         /// room, and their authorization events, recursively.
-        auth_chain_ids: Vec<EventId>,
+        pub auth_chain_ids: Vec<EventId>,
 
 
         /// The fully resolved state of the room at the given event.
-        pdu_ids: Vec<EventId>
+        pub pdu_ids: Vec<EventId>,
     }
 }
 

--- a/ruma-federation-api/src/event/get_room_state_ids/v1.rs
+++ b/ruma-federation-api/src/event/get_room_state_ids/v1.rs
@@ -29,8 +29,6 @@ ruma_api! {
         /// The full set of authorization events that make up the state of the
         /// room, and their authorization events, recursively.
         pub auth_chain_ids: Vec<EventId>,
-
-
         /// The fully resolved state of the room at the given event.
         pub pdu_ids: Vec<EventId>,
     }
@@ -44,8 +42,7 @@ impl<'a> Request<'a> {
 }
 
 impl Response {
-    /// Creates a new `Response` with the given auth chain ids and room state
-    /// ids.
+    /// Creates a new `Response` with the given auth chain IDs and room state IDs.
     pub fn new(auth_chain_ids: Vec<EventId>, pdu_ids: Vec<EventId>) -> Self {
         Self { auth_chain_ids, pdu_ids }
     }

--- a/ruma-serde/src/lib.rs
+++ b/ruma-serde/src/lib.rs
@@ -6,6 +6,7 @@ pub mod can_be_empty;
 pub mod duration;
 pub mod empty;
 pub mod json_string;
+pub mod single_element_seq;
 pub mod test;
 pub mod time;
 pub mod urlencoded;

--- a/ruma-serde/src/single_element_seq.rs
+++ b/ruma-serde/src/single_element_seq.rs
@@ -1,7 +1,7 @@
 //! De-/serialization functions to and from single element sequences.
 
 use serde::{
-    de::{Deserialize, DeserializeOwned, Deserializer},
+    de::{Deserialize, Deserializer},
     ser::{Serialize, Serializer},
 };
 
@@ -15,7 +15,7 @@ where
 
 pub fn deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>
 where
-    T: DeserializeOwned,
+    T: Deserialize<'de>,
     D: Deserializer<'de>,
 {
     <[_; 1]>::deserialize(deserializer).map(|[first]| first)

--- a/ruma-serde/src/single_element_seq.rs
+++ b/ruma-serde/src/single_element_seq.rs
@@ -1,0 +1,25 @@
+//! De-/serialization functions to and from single element sequences.
+
+use serde::{
+    de::{Deserialize, DeserializeOwned, Deserializer},
+    ser::{Serialize, Serializer},
+};
+
+pub fn serialize<T, S>(element: &T, serializer: S) -> Result<S::Ok, S::Error>
+where
+    T: Serialize,
+    S: Serializer,
+{
+    [element].serialize(serializer)
+}
+
+pub fn deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+where
+    T: DeserializeOwned,
+    D: Deserializer<'de>,
+{
+    <[_; 1]>::deserialize(deserializer).map(|array| {
+        let [first] = array;
+        first
+    })
+}

--- a/ruma-serde/src/single_element_seq.rs
+++ b/ruma-serde/src/single_element_seq.rs
@@ -18,8 +18,5 @@ where
     T: DeserializeOwned,
     D: Deserializer<'de>,
 {
-    <[_; 1]>::deserialize(deserializer).map(|array| {
-        let [first] = array;
-        first
-    })
+    <[_; 1]>::deserialize(deserializer).map(|[first]| first)
 }


### PR DESCRIPTION
Adds support for the following federation endpoints:

* [GET /_matrix/federation/v1/state/{roomId}](https://matrix.org/docs/spec/server_server/r0.1.3#get-matrix-federation-v1-state-roomid)
* [GET /_matrix/federation/v1/state_ids/{roomId}](https://matrix.org/docs/spec/server_server/r0.1.3#get-matrix-federation-v1-state-ids-roomid)
* [GET /_matrix/federation/v1/event/{eventId}](https://matrix.org/docs/spec/server_server/r0.1.4#get-matrix-federation-v1-event-eventid)

Resolves matrix-org/matrix-spec-proposals#72
