### PR TITLE
federation-api: Update ts format for create_invite

### DIFF
--- a/ruma-federation-api/src/membership/create_invite.rs
+++ b/ruma-federation-api/src/membership/create_invite.rs
@@ -1,10 +1,10 @@
 //! Endpoint for inviting a remote user to a room
 
-use js_int::UInt;
 use ruma_events::{room::member::MemberEventContent, EventType};
 use ruma_identifiers::{ServerName, UserId};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
+use std::time::SystemTime;
 
 pub mod v1;
 pub mod v2;
@@ -37,7 +37,8 @@ pub struct InviteEvent {
     pub origin: Box<ServerName>,
 
     /// A timestamp added by the inviting homeserver.
-    pub origin_server_ts: UInt,
+    #[serde(with = "ruma_serde::time::ms_since_unix_epoch")]
+    pub origin_server_ts: SystemTime,
 
     /// The event type (should always be `m.room.member`).
     #[serde(rename = "type")]
@@ -59,7 +60,7 @@ pub struct InviteEventInit {
     pub origin: Box<ServerName>,
 
     /// A timestamp added by the inviting homeserver.
-    pub origin_server_ts: UInt,
+    pub origin_server_ts: SystemTime,
 
     /// The user ID of the invited member.
     pub state_key: UserId,

--- a/ruma-federation-api/src/membership/create_invite/v1.rs
+++ b/ruma-federation-api/src/membership/create_invite/v1.rs
@@ -1,10 +1,10 @@
 //! [PUT /_matrix/federation/v1/invite/{roomId}/{eventId}](https://matrix.org/docs/spec/server_server/r0.1.4#put-matrix-federation-v1-invite-roomid-eventid)
 
-use js_int::UInt;
 use ruma_api::ruma_api;
 use ruma_events::{room::member::MemberEventContent, EventType};
 use ruma_identifiers::{EventId, RoomId, ServerName, UserId};
 use serde::{Deserialize, Serialize};
+use std::time::SystemTime;
 
 use super::{InviteEvent, StrippedState};
 
@@ -35,7 +35,8 @@ ruma_api! {
         pub origin: &'a ServerName,
 
         /// A timestamp added by the inviting homeserver.
-        pub origin_server_ts: UInt,
+        #[serde(with = "ruma_serde::time::ms_since_unix_epoch")]
+        pub origin_server_ts: SystemTime,
 
         /// The value `m.room.member`.
         #[serde(rename = "type")]
@@ -99,7 +100,7 @@ pub struct RequestInit<'a> {
     pub origin: &'a ServerName,
 
     /// A timestamp added by the inviting homeserver.
-    pub origin_server_ts: UInt,
+    pub origin_server_ts: SystemTime,
 
     /// The user ID of the invited member.
     pub state_key: &'a UserId,


### PR DESCRIPTION
Update create invite's timestamp types from `UInt` to `SystemTime` to match other APIs.