### PR TITLE
Create CanonicalJsonValue in ruma-serde

### DIFF
--- a/ruma-serde/src/canonical_json.rs
+++ b/ruma-serde/src/canonical_json.rs
@@ -1,0 +1,1 @@
+pub mod value;

--- a/ruma-serde/src/canonical_json/value.rs
+++ b/ruma-serde/src/canonical_json/value.rs
@@ -4,7 +4,7 @@ use std::{
     fmt,
 };
 
-use js_int::UInt;
+use js_int::Int;
 use serde::de::Error;
 use serde_json::Value as JsonValue;
 
@@ -30,7 +30,7 @@ pub enum CanonicalJsonValue {
     /// ```
     Bool(bool),
 
-    /// Represents a JSON number, whether integer or floating point.
+    /// Represents a JSON integer.
     ///
     /// ```
     /// # use serde_json::json;
@@ -38,7 +38,7 @@ pub enum CanonicalJsonValue {
     /// # use ruma_serde::CanonicalJsonValue;
     /// let v: CanonicalJsonValue = json!(12).try_into().unwrap();
     /// ```
-    Number(UInt),
+    Integer(Int),
 
     /// Represents a JSON string.
     ///
@@ -74,6 +74,11 @@ pub enum CanonicalJsonValue {
 }
 
 impl CanonicalJsonValue {
+    /// Returns a canonical JSON string according to Matrix specification.
+    ///
+    /// The method should be preferred over `serde_json::to_string` since it
+    /// checks the size of the canonical string. Matrix canonical JSON enforces
+    /// a size limit of less than 65,535 when sending PDU's for the server-server protocol.
     pub fn to_canonical_string(&self) -> Result<String, serde_json::Error> {
         Ok(serde_json::to_string(self).and_then(|s| {
             if s.len() > 65_535 {
@@ -84,12 +89,13 @@ impl CanonicalJsonValue {
         })?)
     }
 }
+
 impl fmt::Debug for CanonicalJsonValue {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             CanonicalJsonValue::Null => formatter.debug_tuple("Null").finish(),
             CanonicalJsonValue::Bool(v) => formatter.debug_tuple("Bool").field(&v).finish(),
-            CanonicalJsonValue::Number(ref v) => fmt::Debug::fmt(v, formatter),
+            CanonicalJsonValue::Integer(ref v) => fmt::Debug::fmt(v, formatter),
             CanonicalJsonValue::String(ref v) => formatter.debug_tuple("String").field(v).finish(),
             CanonicalJsonValue::Array(ref v) => {
                 formatter.write_str("Array(")?;
@@ -113,32 +119,14 @@ impl fmt::Display for CanonicalJsonValue {
     /// #
     /// let json = json!({ "city": "London", "street": "10 Downing Street" });
     ///
-    /// // Compact format:
+    /// // Canonical format:
     /// //
     /// // {"city":"London","street":"10 Downing Street"}
     /// let compact = format!("{}", json);
     /// assert_eq!(compact,
     ///     "{\"city\":\"London\",\"street\":\"10 Downing Street\"}");
-    ///
-    /// // Pretty format:
-    /// //
-    /// // {
-    /// //   "city": "London",
-    /// //   "street": "10 Downing Street"
-    /// // }
-    /// let pretty = format!("{:#}", json);
-    /// assert_eq!(pretty,
-    ///     "{\n  \"city\": \"London\",\n  \"street\": \"10 Downing Street\"\n}");
-    /// ```
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let alternate = f.alternate();
-        if alternate {
-            // {:#}
-            write!(f, "{}", serde_json::to_string_pretty(&self).map_err(|_| fmt::Error)?)
-        } else {
-            // {}
-            write!(f, "{}", serde_json::to_string(&self).map_err(|_| fmt::Error)?)
-        }
+        write!(f, "{}", serde_json::to_string(&self).map_err(|_| fmt::Error)?)
     }
 }
 
@@ -147,9 +135,9 @@ impl TryFrom<JsonValue> for CanonicalJsonValue {
     fn try_from(json: JsonValue) -> Result<Self, Self::Error> {
         Ok(match json {
             JsonValue::Bool(b) => Self::Bool(b),
-            JsonValue::Number(num) => Self::Number(
-                UInt::try_from(num.as_u64().ok_or_else(|| {
-                    serde_json::Error::custom("Invalid number found, expected u64")
+            JsonValue::Number(num) => Self::Integer(
+                Int::try_from(num.as_i64().ok_or_else(|| {
+                    serde_json::Error::custom("Invalid number found, expected i64")
                 })?)
                 .map_err(serde_json::Error::custom)?,
             ),
@@ -176,7 +164,7 @@ impl serde::ser::Serialize for CanonicalJsonValue {
         match *self {
             CanonicalJsonValue::Null => serializer.serialize_unit(),
             CanonicalJsonValue::Bool(b) => serializer.serialize_bool(b),
-            CanonicalJsonValue::Number(ref n) => n.serialize(serializer),
+            CanonicalJsonValue::Integer(ref n) => n.serialize(serializer),
             CanonicalJsonValue::String(ref s) => serializer.serialize_str(s),
             CanonicalJsonValue::Array(ref v) => v.serialize(serializer),
             CanonicalJsonValue::Object(ref m) => {
@@ -201,48 +189,56 @@ impl<'de> serde::Deserialize<'de> for CanonicalJsonValue {
         Ok(val.try_into().map_err(serde::de::Error::custom)?)
     }
 }
-#[test]
-fn serialize_canon() {
-    let json: CanonicalJsonValue = serde_json::json!({
-        "a": [1, 2, 3],
-        "other": { "stuff": "hello" },
-        "string": "Thing"
-    })
-    .try_into()
-    .unwrap();
 
-    let ser = json.to_canonical_string().unwrap();
-    let back = serde_json::from_str::<CanonicalJsonValue>(&ser).unwrap();
+#[cfg(test)]
+mod test {
+    use std::convert::TryInto;
 
-    assert_eq!(json, back);
-}
+    use super::CanonicalJsonValue;
 
-#[test]
-fn check_canonical_sorts_keys() {
-    let json: CanonicalJsonValue = serde_json::json!({
-        "auth": {
-            "success": true,
-            "mxid": "@john.doe:example.com",
-            "profile": {
-                "display_name": "John Doe",
-                "three_pids": [
-                    {
-                        "medium": "email",
-                        "address": "john.doe@example.org"
-                    },
-                    {
-                        "medium": "msisdn",
-                        "address": "123456789"
-                    }
-                ]
+    #[test]
+    fn serialize_canon() {
+        let json: CanonicalJsonValue = serde_json::json!({
+            "a": [1, 2, 3],
+            "other": { "stuff": "hello" },
+            "string": "Thing"
+        })
+        .try_into()
+        .unwrap();
+
+        let ser = json.to_canonical_string().unwrap();
+        let back = serde_json::from_str::<CanonicalJsonValue>(&ser).unwrap();
+
+        assert_eq!(json, back);
+    }
+
+    #[test]
+    fn check_canonical_sorts_keys() {
+        let json: CanonicalJsonValue = serde_json::json!({
+            "auth": {
+                "success": true,
+                "mxid": "@john.doe:example.com",
+                "profile": {
+                    "display_name": "John Doe",
+                    "three_pids": [
+                        {
+                            "medium": "email",
+                            "address": "john.doe@example.org"
+                        },
+                        {
+                            "medium": "msisdn",
+                            "address": "123456789"
+                        }
+                    ]
+                }
             }
-        }
-    })
-    .try_into()
-    .unwrap();
+        })
+        .try_into()
+        .unwrap();
 
-    assert_eq!(
-        serde_json::to_string(&json).unwrap(),
-        r#"{"auth":{"mxid":"@john.doe:example.com","profile":{"display_name":"John Doe","three_pids":[{"address":"john.doe@example.org","medium":"email"},{"address":"123456789","medium":"msisdn"}]},"success":true}}"#
-    )
+        assert_eq!(
+            serde_json::to_string(&json).unwrap(),
+            r#"{"auth":{"mxid":"@john.doe:example.com","profile":{"display_name":"John Doe","three_pids":[{"address":"john.doe@example.org","medium":"email"},{"address":"123456789","medium":"msisdn"}]},"success":true}}"#
+        )
+    }
 }

--- a/ruma-serde/src/canonical_json/value.rs
+++ b/ruma-serde/src/canonical_json/value.rs
@@ -1,0 +1,248 @@
+use std::{
+    collections::BTreeMap,
+    convert::{TryFrom, TryInto},
+    fmt,
+};
+
+use js_int::UInt;
+use serde::de::Error;
+use serde_json::Value as JsonValue;
+
+#[derive(Clone, Eq, PartialEq)]
+pub enum CanonicalJsonValue {
+    /// Represents a JSON null value.
+    ///
+    /// ```
+    /// # use serde_json::json;
+    /// # use std::convert::TryInto;
+    /// # use ruma_serde::CanonicalJsonValue;
+    /// let v: CanonicalJsonValue = json!(null).try_into().unwrap();
+    /// ```
+    Null,
+
+    /// Represents a JSON boolean.
+    ///
+    /// ```
+    /// # use serde_json::json;
+    /// # use std::convert::TryInto;
+    /// # use ruma_serde::CanonicalJsonValue;
+    /// let v: CanonicalJsonValue = json!(true).try_into().unwrap();
+    /// ```
+    Bool(bool),
+
+    /// Represents a JSON number, whether integer or floating point.
+    ///
+    /// ```
+    /// # use serde_json::json;
+    /// # use std::convert::TryInto;
+    /// # use ruma_serde::CanonicalJsonValue;
+    /// let v: CanonicalJsonValue = json!(12).try_into().unwrap();
+    /// ```
+    Number(UInt),
+
+    /// Represents a JSON string.
+    ///
+    /// ```
+    /// # use serde_json::json;
+    /// # use std::convert::TryInto;
+    /// # use ruma_serde::CanonicalJsonValue;
+    /// let v: CanonicalJsonValue = json!("a string").try_into().unwrap();
+    /// ```
+    String(String),
+
+    /// Represents a JSON array.
+    ///
+    /// ```
+    /// # use serde_json::json;
+    /// # use std::convert::TryInto;
+    /// # use ruma_serde::CanonicalJsonValue;
+    /// let v: CanonicalJsonValue = json!(["an", "array"]).try_into().unwrap();
+    /// ```
+    Array(Vec<CanonicalJsonValue>),
+
+    /// Represents a JSON object.
+    ///
+    /// The map is backed by a BTreeMap to guarantee the sorting of keys.
+    ///
+    /// ```
+    /// # use serde_json::json;
+    /// # use std::convert::TryInto;
+    /// # use ruma_serde::CanonicalJsonValue;
+    /// let v: CanonicalJsonValue = json!({ "an": "object" }).try_into().unwrap();
+    /// ```
+    Object(BTreeMap<String, CanonicalJsonValue>),
+}
+
+impl CanonicalJsonValue {
+    pub fn to_canonical_string(&self) -> Result<String, serde_json::Error> {
+        Ok(serde_json::to_string(self).and_then(|s| {
+            if s.len() > 65_535 {
+                Err(serde_json::Error::custom("TOO LARGE"))
+            } else {
+                Ok(s)
+            }
+        })?)
+    }
+}
+impl fmt::Debug for CanonicalJsonValue {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            CanonicalJsonValue::Null => formatter.debug_tuple("Null").finish(),
+            CanonicalJsonValue::Bool(v) => formatter.debug_tuple("Bool").field(&v).finish(),
+            CanonicalJsonValue::Number(ref v) => fmt::Debug::fmt(v, formatter),
+            CanonicalJsonValue::String(ref v) => formatter.debug_tuple("String").field(v).finish(),
+            CanonicalJsonValue::Array(ref v) => {
+                formatter.write_str("Array(")?;
+                fmt::Debug::fmt(v, formatter)?;
+                formatter.write_str(")")
+            }
+            CanonicalJsonValue::Object(ref v) => {
+                formatter.write_str("Object(")?;
+                fmt::Debug::fmt(v, formatter)?;
+                formatter.write_str(")")
+            }
+        }
+    }
+}
+
+impl fmt::Display for CanonicalJsonValue {
+    /// Display a JSON value as a string.
+    ///
+    /// ```
+    /// # use serde_json::json;
+    /// #
+    /// let json = json!({ "city": "London", "street": "10 Downing Street" });
+    ///
+    /// // Compact format:
+    /// //
+    /// // {"city":"London","street":"10 Downing Street"}
+    /// let compact = format!("{}", json);
+    /// assert_eq!(compact,
+    ///     "{\"city\":\"London\",\"street\":\"10 Downing Street\"}");
+    ///
+    /// // Pretty format:
+    /// //
+    /// // {
+    /// //   "city": "London",
+    /// //   "street": "10 Downing Street"
+    /// // }
+    /// let pretty = format!("{:#}", json);
+    /// assert_eq!(pretty,
+    ///     "{\n  \"city\": \"London\",\n  \"street\": \"10 Downing Street\"\n}");
+    /// ```
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let alternate = f.alternate();
+        if alternate {
+            // {:#}
+            write!(f, "{}", serde_json::to_string_pretty(&self).map_err(|_| fmt::Error)?)
+        } else {
+            // {}
+            write!(f, "{}", serde_json::to_string(&self).map_err(|_| fmt::Error)?)
+        }
+    }
+}
+
+impl TryFrom<JsonValue> for CanonicalJsonValue {
+    type Error = serde_json::Error;
+    fn try_from(json: JsonValue) -> Result<Self, Self::Error> {
+        Ok(match json {
+            JsonValue::Bool(b) => Self::Bool(b),
+            JsonValue::Number(num) => Self::Number(
+                UInt::try_from(num.as_u64().ok_or_else(|| {
+                    serde_json::Error::custom("Invalid number found, expected u64")
+                })?)
+                .map_err(serde_json::Error::custom)?,
+            ),
+            JsonValue::Array(vec) => {
+                Self::Array(vec.into_iter().map(TryInto::try_into).collect::<Result<Vec<_>, _>>()?)
+            }
+            JsonValue::String(string) => Self::String(string),
+            JsonValue::Object(obj) => Self::Object(
+                obj.into_iter()
+                    .map(|(k, v)| Ok((k, v.try_into()?)))
+                    .collect::<Result<BTreeMap<_, _>, _>>()?,
+            ),
+            JsonValue::Null => Self::Null,
+        })
+    }
+}
+
+impl serde::ser::Serialize for CanonicalJsonValue {
+    #[inline]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: ::serde::Serializer,
+    {
+        match *self {
+            CanonicalJsonValue::Null => serializer.serialize_unit(),
+            CanonicalJsonValue::Bool(b) => serializer.serialize_bool(b),
+            CanonicalJsonValue::Number(ref n) => n.serialize(serializer),
+            CanonicalJsonValue::String(ref s) => serializer.serialize_str(s),
+            CanonicalJsonValue::Array(ref v) => v.serialize(serializer),
+            CanonicalJsonValue::Object(ref m) => {
+                use serde::ser::SerializeMap;
+                let mut map = serializer.serialize_map(Some(m.len()))?;
+                for (k, v) in m {
+                    map.serialize_entry(k, v)?;
+                }
+                map.end()
+            }
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for CanonicalJsonValue {
+    #[inline]
+    fn deserialize<D>(deserializer: D) -> Result<CanonicalJsonValue, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let val = serde_json::Value::deserialize(deserializer)?;
+        Ok(val.try_into().map_err(serde::de::Error::custom)?)
+    }
+}
+#[test]
+fn serialize_canon() {
+    let json: CanonicalJsonValue = serde_json::json!({
+        "a": [1, 2, 3],
+        "other": { "stuff": "hello" },
+        "string": "Thing"
+    })
+    .try_into()
+    .unwrap();
+
+    let ser = json.to_canonical_string().unwrap();
+    let back = serde_json::from_str::<CanonicalJsonValue>(&ser).unwrap();
+
+    assert_eq!(json, back);
+}
+
+#[test]
+fn check_canonical_sorts_keys() {
+    let json: CanonicalJsonValue = serde_json::json!({
+        "auth": {
+            "success": true,
+            "mxid": "@john.doe:example.com",
+            "profile": {
+                "display_name": "John Doe",
+                "three_pids": [
+                    {
+                        "medium": "email",
+                        "address": "john.doe@example.org"
+                    },
+                    {
+                        "medium": "msisdn",
+                        "address": "123456789"
+                    }
+                ]
+            }
+        }
+    })
+    .try_into()
+    .unwrap();
+
+    assert_eq!(
+        serde_json::to_string(&json).unwrap(),
+        r#"{"auth":{"mxid":"@john.doe:example.com","profile":{"display_name":"John Doe","three_pids":[{"address":"john.doe@example.org","medium":"email"},{"address":"123456789","medium":"msisdn"}]},"success":true}}"#
+    )
+}

--- a/ruma-serde/src/lib.rs
+++ b/ruma-serde/src/lib.rs
@@ -13,7 +13,7 @@ pub mod time;
 pub mod urlencoded;
 
 pub use can_be_empty::{is_empty, CanBeEmpty};
-pub use canonical_json::value::{CanonicalError, CanonicalJsonValue};
+pub use canonical_json::value::{CanonicalJsonValue, Error as CanonicalError};
 pub use empty::vec_as_map_of_empty;
 
 /// Check whether a value is equal to its default value.

--- a/ruma-serde/src/lib.rs
+++ b/ruma-serde/src/lib.rs
@@ -3,7 +3,7 @@
 use serde::de::{Deserialize, IntoDeserializer};
 
 pub mod can_be_empty;
-pub mod canonical_json;
+mod canonical_json;
 pub mod duration;
 pub mod empty;
 pub mod json_string;
@@ -13,7 +13,7 @@ pub mod time;
 pub mod urlencoded;
 
 pub use can_be_empty::{is_empty, CanBeEmpty};
-pub use canonical_json::value::CanonicalJsonValue;
+pub use canonical_json::value::{CanonicalError, CanonicalJsonValue};
 pub use empty::vec_as_map_of_empty;
 
 /// Check whether a value is equal to its default value.

--- a/ruma-serde/src/lib.rs
+++ b/ruma-serde/src/lib.rs
@@ -3,6 +3,7 @@
 use serde::de::{Deserialize, IntoDeserializer};
 
 pub mod can_be_empty;
+pub mod canonical_json;
 pub mod duration;
 pub mod empty;
 pub mod json_string;
@@ -12,6 +13,7 @@ pub mod time;
 pub mod urlencoded;
 
 pub use can_be_empty::{is_empty, CanBeEmpty};
+pub use canonical_json::value::CanonicalJsonValue;
 pub use empty::vec_as_map_of_empty;
 
 /// Check whether a value is equal to its default value.


### PR DESCRIPTION
So here's my first crack at it, let me know what you think.

Do you know of a way to privately implement a trait, the `CanonicalJsonValue::to_canonical_string` could be the only way to get a serialized version if we could privately impl `Serialize` inside that function or something? Better errors would be nice (don't just use serde_json::Error::custom all over the place) eventually? 