### PR TITLE
Add Raw wrapper to get_room_state endpoint and optional PDU eventId

### DIFF
--- a/ruma-events/src/pdu.rs
+++ b/ruma-events/src/pdu.rs
@@ -91,6 +91,10 @@ pub struct RoomV1Pdu {
 /// A 'persistent data unit' (event) for room versions 3 and beyond.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RoomV3Pdu {
+    /// Event ID for the PDU.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub event_id: Option<EventId>,
+
     /// The room this event belongs to.
     pub room_id: RoomId,
 
@@ -304,6 +308,7 @@ impl RoomV3PduStub {
     /// Converts a V3 PDU stub into a full V3 PDU.
     pub fn into_v3_pdu(self, room_id: RoomId) -> RoomV3Pdu {
         RoomV3Pdu {
+            event_id: None,
             room_id,
             sender: self.sender,
             #[cfg(not(feature = "unstable-pre-spec"))]

--- a/ruma-federation-api/src/event/get_room_state/v1.rs
+++ b/ruma-federation-api/src/event/get_room_state/v1.rs
@@ -1,6 +1,7 @@
 //! [GET /_matrix/federation/v1/state/{roomId}](https://matrix.org/docs/spec/server_server/r0.1.4#get-matrix-federation-v1-state-roomid)
 
 use ruma_api::ruma_api;
+use ruma_common::Raw;
 use ruma_events::pdu::Pdu;
 use ruma_identifiers::{EventId, RoomId};
 
@@ -27,10 +28,10 @@ ruma_api! {
     response: {
         /// The full set of authorization events that make up the state of the
         /// room, and their authorization events, recursively.
-        pub auth_chain: Vec<Pdu>,
+        pub auth_chain: Vec<Raw<Pdu>>,
 
         /// The fully resolved state of the room at the given event.
-        pub pdus: Vec<Pdu>,
+        pub pdus: Vec<Raw<Pdu>>,
     }
 }
 
@@ -43,7 +44,7 @@ impl<'a> Request<'a> {
 
 impl Response {
     /// Creates a new `Response` with the given auth chain and room state.
-    pub fn new(auth_chain: Vec<Pdu>, pdus: Vec<Pdu>) -> Self {
+    pub fn new(auth_chain: Vec<Raw<Pdu>>, pdus: Vec<Raw<Pdu>>) -> Self {
         Self { auth_chain, pdus }
     }
 }


### PR DESCRIPTION
I made them 2 commits as I'm not sure about the optional EventId commit...

The `state-res` crate needs to have a consitent and reliable way to get at the event_id of PDU's during resolution but it is not valid for any federation endpoint to send PDU's with event_ids (if they do you should rehash on the receiving end anyway). I wonder if it would make more sense to have a wrapper type in the state-res crate like

```rust
pub struct SignedPdu<T>(T, EventId);
```
where `T` is somehow constrained to always be a PDU?