### PR TITLE
Correct metadata for bind_callback endpoint

### DIFF
--- a/ruma-federation-api/src/thirdparty/bind_callback/v1.rs
+++ b/ruma-federation-api/src/thirdparty/bind_callback/v1.rs
@@ -11,7 +11,7 @@ ruma_api! {
     metadata: {
         description: "Used by identity servers to notify the homeserver that one of its users has bound a third party identifier successfully",
         method: PUT,
-        name: "identifier_bound",
+        name: "bind_callback",
         path: "/_matrix/federation/v1/3pid/onbind",
         rate_limited: false,
         authentication: None,


### PR DESCRIPTION
I forgot to correct the `name` metadata field when changing module names while making the PR for this.