### PR TITLE
Make /federation/v1/get_missing_events fields public

### DIFF
--- a/ruma-api/tests/optional_headers.rs
+++ b/ruma-api/tests/optional_headers.rs
@@ -12,10 +12,10 @@ ruma_api! {
 
     request: {
         #[ruma_api(header = LOCATION)]
-        location: Option<String>,
+        pub location: Option<String>,
     }
     response: {
         #[ruma_api(header = LOCATION)]
-        stuff: Option<String>,
+        pub stuff: Option<String>,
     }
 }

--- a/ruma-api/tests/ruma_api_lifetime.rs
+++ b/ruma-api/tests/ruma_api_lifetime.rs
@@ -1,8 +1,8 @@
 #[allow(unused)]
 #[derive(Copy, Clone, Debug, ruma_common::Outgoing, serde::Serialize)]
 pub struct OtherThing<'t> {
-    some: &'t str,
-    t: &'t [u8],
+    pub some: &'t str,
+    pub t: &'t [u8],
 }
 
 mod empty_response {

--- a/ruma-common-macros/src/outgoing.rs
+++ b/ruma-common-macros/src/outgoing.rs
@@ -106,6 +106,9 @@ pub fn expand_derive_outgoing(input: DeriveInput) -> syn::Result<TokenStream> {
         DataKind::Struct(mut fields, struct_kind) => {
             let mut found_lifetime = false;
             for field in &mut fields {
+                if !matches!(field.vis, syn::Visibility::Public(_)) {
+                    return Err(syn::Error::new_spanned(field, "All fields must be marked `pub`"));
+                }
                 if strip_lifetimes(&mut field.ty) {
                     found_lifetime = true;
                 }

--- a/ruma-common/tests/outgoing.rs
+++ b/ruma-common/tests/outgoing.rs
@@ -16,8 +16,8 @@ pub struct IncomingThing<T> {
 #[allow(unused)]
 #[derive(Copy, Clone, Debug, Outgoing, serde::Serialize)]
 pub struct OtherThing<'t> {
-    some: &'t str,
-    t: &'t [u8],
+    pub some: &'t str,
+    pub t: &'t [u8],
 }
 
 #[derive(Outgoing)]


### PR DESCRIPTION
I also added a check to the RawRequest/Response TryFrom::try_from of the ruma_api macro, not sure if this is needed they are all seperate commits so shouldn't be bad cherry picking.