### PR TITLE
Updates to main branch

### DIFF
--- a/ruma-api-macros/README.md
+++ b/ruma-api-macros/README.md
@@ -3,7 +3,7 @@
 **ruma-api-macros** provides a procedural macro for easily generating [ruma-api]-compatible API endpoints.
 You define the endpoint's metadata, request fields, and response fields, and the macro generates all the necessary types and implements all the necessary traits.
 
-[ruma-api]: https://github.com/ruma/ruma/tree/master/ruma-api
+[ruma-api]: https://github.com/ruma/ruma/tree/main/ruma-api
 
 ## Usage
 

--- a/ruma-api-macros/src/lib.rs
+++ b/ruma-api-macros/src/lib.rs
@@ -5,7 +5,7 @@
 //! re-exports in ruma-api. Also note that for technical reasons, the
 //! `ruma_api!` macro is only documented in ruma-api, not here.
 //!
-//! [ruma-api]: https://github.com/ruma/ruma/tree/master/ruma-api
+//! [ruma-api]: https://github.com/ruma/ruma/tree/main/ruma-api
 
 #![allow(clippy::cognitive_complexity)]
 // Remove this once https://github.com/rust-lang/rust/issues/54883 becomes stable

--- a/ruma-api/CHANGELOG.md
+++ b/ruma-api/CHANGELOG.md
@@ -183,7 +183,7 @@ Breaking changes:
 
 The crate has been redesign to focus on conversions between an endpoint's request and response types and Hyper request and response types. Implementations are expected to be generated via [ruma-api-macros].
 
-[ruma-api-macros]: https://github.com/ruma/ruma/tree/master/ruma-api-macros
+[ruma-api-macros]: https://github.com/ruma/ruma/tree/main/ruma-api-macros
 
 # 0.3.0
 

--- a/ruma-events-macros/README.md
+++ b/ruma-events-macros/README.md
@@ -2,4 +2,4 @@
 
 **ruma-events-macros** provides a procedural macro for easily generating event types for [ruma-events].
 
-[ruma-events]: https://github.com/ruma/ruma/tree/master/ruma-events
+[ruma-events]: https://github.com/ruma/ruma/tree/main/ruma-events

--- a/ruma-events-macros/src/lib.rs
+++ b/ruma-events-macros/src/lib.rs
@@ -3,7 +3,7 @@
 //!
 //! See the documentation for the individual macros for usage details.
 //!
-//! [ruma-events]: https://github.com/ruma/ruma/tree/master/ruma-events
+//! [ruma-events]: https://github.com/ruma/ruma/tree/main/ruma-events
 
 #![deny(missing_copy_implementations, missing_debug_implementations, missing_docs)]
 


### PR DESCRIPTION
I noticed some old references to master left in Markdown files and comments. This simply updates to the new default branch.