### PR TITLE
Make pdus of transactions optional

### DIFF
--- a/ruma-federation-api/src/transactions/send_transaction_message/v1.rs
+++ b/ruma-federation-api/src/transactions/send_transaction_message/v1.rs
@@ -35,6 +35,7 @@ ruma_api! {
         /// List of persistent updates to rooms.
         ///
         /// Must not be more than 50 items.
+        #[cfg_attr(feature = "unstable-pre-spec", serde(default, skip_serializing_if = "<[_]>::is_empty"))]
         pub pdus: &'a [Raw<Pdu>],
 
         /// List of ephemeral messages.


### PR DESCRIPTION
I think this is a bug in the spec, as servers should be able to send EDUs even if they have no new PDUs

https://matrix.org/docs/spec/server_server/r0.1.4#put-matrix-federation-v1-send-txnid