### PR TITLE
Disable unresolved import lints for VSCode + ra users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.vscode
 target
 Cargo.lock

--- a/contrib/ide/vscode/settings.json
+++ b/contrib/ide/vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    // rust-analyzer can't currently handle macro-generated types
+    "rust-analyzer.diagnostics.disabled": [
+        "unresolved-import"
+    ]
+}


### PR DESCRIPTION
If we do this, could also add some other things such that VSCode users don't need the editorconfig plugin installed to automatically follow some conventions (mainly final newlines).