### PR TITLE
Add the unstable-pre-spec feature to the federation-api crate

### DIFF
--- a/ruma-federation-api/Cargo.toml
+++ b/ruma-federation-api/Cargo.toml
@@ -30,3 +30,4 @@ matches = "0.1.8"
 
 [features]
 unstable-exhaustive-types = []
+unstable-pre-spec = []

--- a/ruma-federation-api/src/membership/create_join_event.rs
+++ b/ruma-federation-api/src/membership/create_join_event.rs
@@ -23,9 +23,23 @@ pub struct RoomState {
     pub state: Vec<Raw<Pdu>>,
 }
 
+#[cfg(feature = "unstable-pre-spec")]
+impl Default for RoomState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl RoomState {
+    #[cfg(not(feature = "unstable-pre-spec"))]
     /// Creates an empty `RoomState` with the given `origin`.
     pub fn new(origin: String) -> Self {
         Self { origin, auth_chain: Vec::new(), state: Vec::new() }
+    }
+
+    #[cfg(feature = "unstable-pre-spec")]
+    /// Creates an empty `RoomState` with the given `origin`.
+    pub fn new() -> Self {
+        Self { auth_chain: Vec::new(), state: Vec::new() }
     }
 }

--- a/ruma/Cargo.toml
+++ b/ruma/Cargo.toml
@@ -22,7 +22,7 @@ unstable-exhaustive-types = [
   "ruma-federation-api/unstable-exhaustive-types",
   "ruma-common/unstable-exhaustive-types",
 ]
-unstable-pre-spec = ["ruma-client-api/unstable-pre-spec", "ruma-events/unstable-pre-spec"]
+unstable-pre-spec = ["ruma-client-api/unstable-pre-spec", "ruma-events/unstable-pre-spec", "ruma-federation-api/unstable-pre-spec"]
 unstable-synapse-quirks = [
   "ruma-client-api/unstable-synapse-quirks",
   "ruma-common/unstable-synapse-quirks",


### PR DESCRIPTION
While working on some federation stuff I noticed that this wasn't actually enable-able. I added the feature the the `ruma-federation-api` crate and enabled it in `ruma`.