### PR TITLE
Canonical helper methods for Map<> -> CanonicalJsonObject conversion

### DIFF
--- a/ruma-serde/src/canonical_json.rs
+++ b/ruma-serde/src/canonical_json.rs
@@ -1,9 +1,11 @@
-use std::fmt;
+use std::{collections::BTreeMap, convert::TryInto, fmt};
 
-use serde::Serialize;
-use serde_json::Error as JsonError;
+use serde::{ser::Error as _, Serialize};
+use serde_json::{Error as JsonError, Map as JsonObject, Value as JsonValue};
 
 pub mod value;
+
+pub type CanonicalJsonObject = BTreeMap<String, value::CanonicalJsonValue>;
 
 /// Returns a canonical JSON string according to Matrix specification.
 ///
@@ -45,11 +47,26 @@ impl fmt::Display for Error {
 
 impl std::error::Error for Error {}
 
+pub fn try_from_json_map(
+    json: JsonObject<String, JsonValue>,
+) -> Result<CanonicalJsonObject, Error> {
+    json.into_iter().map(|(k, v)| Ok((k, v.try_into()?))).collect()
+}
+
+pub fn to_canonical_obj<T: Serialize>(value: T) -> Result<CanonicalJsonObject, Error> {
+    match serde_json::to_value(value).map_err(Error::SerDe)? {
+        JsonValue::Object(map) => try_from_json_map(map),
+        _ => Err(Error::SerDe(JsonError::custom("`value` must be an object"))),
+    }
+}
+
 #[cfg(test)]
 mod test {
-    use std::convert::TryInto;
+    use std::{collections::BTreeMap, convert::TryInto};
 
-    use super::{to_string as to_canonical_json_string, value::CanonicalJsonValue};
+    use super::{
+        to_canonical_obj, to_string as to_canonical_json_string, value::CanonicalJsonValue,
+    };
     use serde_json::{from_str as from_json_str, json, to_string as to_json_string};
 
     #[test]
@@ -96,5 +113,28 @@ mod test {
             to_json_string(&json).unwrap(),
             r#"{"auth":{"mxid":"@john.doe:example.com","profile":{"display_name":"John Doe","three_pids":[{"address":"john.doe@example.org","medium":"email"},{"address":"123456789","medium":"msisdn"}]},"success":true}}"#
         )
+    }
+
+    #[test]
+    fn check_serialize_to_canonical() {
+        #[derive(Debug, serde::Serialize)]
+        struct Thing {
+            foo: String,
+            bar: Vec<u8>,
+        }
+        let t = Thing { foo: "foo".into(), bar: vec![0, 1, 2] };
+
+        let mut expected = BTreeMap::new();
+        expected.insert("foo".into(), CanonicalJsonValue::String("foo".into()));
+        expected.insert(
+            "bar".into(),
+            CanonicalJsonValue::Array(vec![
+                CanonicalJsonValue::Integer(js_int::int!(0)),
+                CanonicalJsonValue::Integer(js_int::int!(1)),
+                CanonicalJsonValue::Integer(js_int::int!(2)),
+            ]),
+        );
+
+        assert_eq!(to_canonical_obj(t).unwrap(), expected)
     }
 }

--- a/ruma-serde/src/canonical_json.rs
+++ b/ruma-serde/src/canonical_json.rs
@@ -1,11 +1,11 @@
-use std::{collections::BTreeMap, convert::TryInto, fmt};
+use std::{convert::TryInto, fmt};
 
 use serde::Serialize;
 use serde_json::{Error as JsonError, Map as JsonObject, Value as JsonValue};
 
 pub mod value;
 
-pub type CanonicalJsonObject = BTreeMap<String, value::CanonicalJsonValue>;
+use value::Object as CanonicalJsonObject;
 
 /// Returns a canonical JSON string according to Matrix specification.
 ///
@@ -67,6 +67,8 @@ mod test {
         to_canonical_value, to_string as to_canonical_json_string, try_from_json_map,
         value::CanonicalJsonValue,
     };
+
+    use js_int::int;
     use serde_json::{from_str as from_json_str, json, to_string as to_json_string, Map};
 
     #[test]
@@ -116,7 +118,7 @@ mod test {
     }
 
     #[test]
-    fn check_serialize_map_to_canonical() {
+    fn serialize_map_to_canonical() {
         let mut expected = BTreeMap::new();
         expected.insert("foo".into(), CanonicalJsonValue::String("string".into()));
         expected.insert(
@@ -132,11 +134,11 @@ mod test {
         map.insert("foo".into(), json!("string"));
         map.insert("bar".into(), json!(vec![0, 1, 2,]));
 
-        assert_eq!(try_from_json_map(map).unwrap(), expected)
+        assert_eq!(try_from_json_map(map).unwrap(), expected);
     }
 
     #[test]
-    fn check_to_canonical() {
+    fn to_canonical() {
         #[derive(Debug, serde::Serialize)]
         struct Thing {
             foo: String,
@@ -149,12 +151,12 @@ mod test {
         expected.insert(
             "bar".into(),
             CanonicalJsonValue::Array(vec![
-                CanonicalJsonValue::Integer(js_int::int!(0)),
-                CanonicalJsonValue::Integer(js_int::int!(1)),
-                CanonicalJsonValue::Integer(js_int::int!(2)),
+                CanonicalJsonValue::Integer(int!(0)),
+                CanonicalJsonValue::Integer(int!(1)),
+                CanonicalJsonValue::Integer(int!(2)),
             ]),
         );
 
-        assert_eq!(to_canonical_value(t).unwrap(), CanonicalJsonValue::Object(expected))
+        assert_eq!(to_canonical_value(t).unwrap(), CanonicalJsonValue::Object(expected));
     }
 }

--- a/ruma-serde/src/canonical_json.rs
+++ b/ruma-serde/src/canonical_json.rs
@@ -124,9 +124,9 @@ mod test {
         expected.insert(
             "bar".into(),
             CanonicalJsonValue::Array(vec![
-                CanonicalJsonValue::Integer(js_int::int!(0)),
-                CanonicalJsonValue::Integer(js_int::int!(1)),
-                CanonicalJsonValue::Integer(js_int::int!(2)),
+                CanonicalJsonValue::Integer(int!(0)),
+                CanonicalJsonValue::Integer(int!(1)),
+                CanonicalJsonValue::Integer(int!(2)),
             ]),
         );
 

--- a/ruma-serde/src/canonical_json/value.rs
+++ b/ruma-serde/src/canonical_json/value.rs
@@ -75,7 +75,7 @@ pub enum CanonicalJsonValue {
     /// # use ruma_serde::CanonicalJsonValue;
     /// let v: CanonicalJsonValue = json!({ "an": "object" }).try_into().unwrap();
     /// ```
-    Object(BTreeMap<String, CanonicalJsonValue>),
+    Object(Object),
 }
 
 impl Default for CanonicalJsonValue {

--- a/ruma-serde/src/canonical_json/value.rs
+++ b/ruma-serde/src/canonical_json/value.rs
@@ -136,7 +136,7 @@ impl TryFrom<JsonValue> for CanonicalJsonValue {
             JsonValue::Object(obj) => Self::Object(
                 obj.into_iter()
                     .map(|(k, v)| Ok((k, v.try_into()?)))
-                    .collect::<Result<BTreeMap<_, _>, _>>()?,
+                    .collect::<Result<Object, _>>()?,
             ),
             JsonValue::Null => Self::Null,
         })

--- a/ruma-serde/src/canonical_json/value.rs
+++ b/ruma-serde/src/canonical_json/value.rs
@@ -10,6 +10,9 @@ use serde_json::{to_string as to_json_string, Value as JsonValue};
 
 use super::Error;
 
+/// The inner type of `CanonicalJsonValue::Object`.
+pub type Object = BTreeMap<String, CanonicalJsonValue>;
+
 #[derive(Clone, Eq, PartialEq)]
 pub enum CanonicalJsonValue {
     /// Represents a JSON null value.

--- a/ruma-serde/src/lib.rs
+++ b/ruma-serde/src/lib.rs
@@ -16,7 +16,8 @@ pub mod urlencoded;
 pub use can_be_empty::{is_empty, CanBeEmpty};
 pub use canonical_json::{
     to_canonical_value, to_string as to_canonical_json_string, try_from_json_map,
-    value::CanonicalJsonValue, Error as CanonicalJsonError,
+    value::{CanonicalJsonValue, Object as CanonicalJsonObject},
+    Error as CanonicalJsonError,
 };
 pub use cow::deserialize_cow_str;
 pub use empty::vec_as_map_of_empty;

--- a/ruma-serde/src/lib.rs
+++ b/ruma-serde/src/lib.rs
@@ -15,7 +15,7 @@ pub mod urlencoded;
 
 pub use can_be_empty::{is_empty, CanBeEmpty};
 pub use canonical_json::{
-    to_canonical_obj, to_string as to_canonical_json_string, try_from_json_map,
+    to_canonical_value, to_string as to_canonical_json_string, try_from_json_map,
     value::CanonicalJsonValue, Error as CanonicalJsonError,
 };
 pub use cow::deserialize_cow_str;

--- a/ruma-serde/src/lib.rs
+++ b/ruma-serde/src/lib.rs
@@ -15,7 +15,8 @@ pub mod urlencoded;
 
 pub use can_be_empty::{is_empty, CanBeEmpty};
 pub use canonical_json::{
-    to_string as to_canonical_json_string, value::CanonicalJsonValue, Error as CanonicalJsonError,
+    to_canonical_obj, to_string as to_canonical_json_string, try_from_json_map,
+    value::CanonicalJsonValue, Error as CanonicalJsonError,
 };
 pub use cow::deserialize_cow_str;
 pub use empty::vec_as_map_of_empty;

--- a/ruma-signatures/src/functions.rs
+++ b/ruma-signatures/src/functions.rs
@@ -5,7 +5,7 @@ use std::{collections::BTreeMap, mem};
 use base64::{decode_config, encode_config, STANDARD_NO_PAD, URL_SAFE_NO_PAD};
 use ring::digest::{digest, SHA256};
 use ruma_identifiers::RoomVersionId;
-use ruma_serde::{to_canonical_json_string, CanonicalJsonValue};
+use ruma_serde::{to_canonical_json_string, CanonicalJsonObject, CanonicalJsonValue};
 use serde_json::from_str as from_json_str;
 
 use crate::{
@@ -72,9 +72,6 @@ static CONTENT_HASH_FIELDS_TO_REMOVE: &[&str] = &["hashes", "signatures", "unsig
 
 /// The fields to remove from a JSON object when creating a reference hash of an event.
 static REFERENCE_HASH_FIELDS_TO_REMOVE: &[&str] = &["age_ts", "signatures", "unsigned"];
-
-/// The inner type of `CanonicalJsonValue::Object`.
-pub type CanonicalJsonObject = BTreeMap<String, CanonicalJsonValue>;
 
 /// Signs an arbitrary JSON object and adds the signature to an object under the key `signatures`.
 ///

--- a/ruma-signatures/src/lib.rs
+++ b/ruma-signatures/src/lib.rs
@@ -51,7 +51,7 @@ use std::{
 
 pub use functions::{
     canonical_json, content_hash, hash_and_sign_event, redact, reference_hash, sign_json,
-    verify_event, verify_json, CanonicalJsonObject,
+    verify_event, verify_json,
 };
 pub use keys::{Ed25519KeyPair, KeyPair, PublicKeyMap, PublicKeySet};
 pub use signatures::Signature;


### PR DESCRIPTION
Resolves #336 

Not sure which way would make the most sense for the names (to/from...).

I added the `to_canonical_value` to simplify, in conduit going from a `T: Serialize` (mostly ruma types) to `CanonicalJsonValue`, to insert directly into the `CanonicalJsonObject`. Not sure what would make more sense, create a `Map` and insert into then convert or use the `CanonicalJsonObject` and insert into that directly? I have helpers for each way.