### PR TITLE
Make sure we override any default header values with Response fields

### DIFF
--- a/ruma-api-macros/src/api.rs
+++ b/ruma-api-macros/src/api.rs
@@ -289,6 +289,8 @@ impl ToTokens for Api {
                     let mut resp_builder = #ruma_api_import::exports::http::Response::builder()
                         .header(#ruma_api_import::exports::http::header::CONTENT_TYPE, "application/json");
 
+                    let mut headers =
+                        resp_builder.headers_mut().expect("`http::ResponseBuilder` is in unusable state");
                     #serialize_response_headers
 
                     // Since we require header names to come from the `http::header` module,

--- a/ruma-api-macros/src/api.rs
+++ b/ruma-api-macros/src/api.rs
@@ -293,8 +293,9 @@ impl ToTokens for Api {
                         resp_builder.headers_mut().expect("`http::ResponseBuilder` is in unusable state");
                     #serialize_response_headers
 
-                    // Since we require header names to come from the `http::header` module,
-                    // this cannot fail.
+                    // This cannot fail because we parse each header value
+                    // checking for errors as each value is inserted and
+                    // we only allow keys from the `http::header` module.
                     let response = resp_builder.body(#body).unwrap();
                     Ok(response)
                 }

--- a/ruma-api-macros/src/api/response.rs
+++ b/ruma-api-macros/src/api/response.rs
@@ -126,7 +126,7 @@ impl Response {
                                 headers
                                     .insert(
                                         #import_path::exports::http::header::#header_name,
-                                        header.parse().unwrap(),
+                                        header.parse()?,
                                     );
                             }
                         }
@@ -135,7 +135,7 @@ impl Response {
                         headers
                             .insert(
                                 #import_path::exports::http::header::#header_name,
-                                response.#field_name.parse().unwrap(),
+                                response.#field_name.parse()?,
                             );
                     },
                 };

--- a/ruma-api-macros/src/api/response.rs
+++ b/ruma-api-macros/src/api/response.rs
@@ -123,25 +123,20 @@ impl Response {
                     {
                         quote! {
                             if let Some(header) = response.#field_name {
-                                resp_builder = resp_builder.header(
-                                    #import_path::exports::http::header::#header_name,
-                                    header,
-                                );
+                                headers
+                                    .insert(
+                                        #import_path::exports::http::header::#header_name,
+                                        header.parse().unwrap(),
+                                    );
                             }
                         }
                     }
                     _ => quote! {
-                        resp_builder.headers_mut()
-                            .map(|map| {
-                                match map.entry(#import_path::exports::http::header::#header_name) {
-                                    #import_path::exports::http::header::Entry::Occupied(mut occ) => {
-                                        occ.insert(response.#field_name.parse().unwrap());
-                                    },
-                                    #import_path::exports::http::header::Entry::Vacant(vac) => {
-                                        vac.insert(response.#field_name.parse().unwrap());
-                                    },
-                                };
-                            });
+                        headers
+                            .insert(
+                                #import_path::exports::http::header::#header_name,
+                                response.#field_name.parse().unwrap(),
+                            );
                     },
                 };
 

--- a/ruma-api-macros/src/api/response.rs
+++ b/ruma-api-macros/src/api/response.rs
@@ -131,10 +131,17 @@ impl Response {
                         }
                     }
                     _ => quote! {
-                        resp_builder = resp_builder.header(
-                            #import_path::exports::http::header::#header_name,
-                            response.#field_name,
-                        );
+                        resp_builder.headers_mut()
+                            .map(|map| {
+                                match map.entry(#import_path::exports::http::header::#header_name) {
+                                    #import_path::exports::http::header::Entry::Occupied(mut occ) => {
+                                        occ.insert(response.#field_name.parse().unwrap());
+                                    },
+                                    #import_path::exports::http::header::Entry::Vacant(vac) => {
+                                        vac.insert(response.#field_name.parse().unwrap());
+                                    },
+                                };
+                            });
                     },
                 };
 

--- a/ruma-api/tests/header_override.rs
+++ b/ruma-api/tests/header_override.rs
@@ -17,6 +17,7 @@ ruma_api! {
         #[ruma_api(header = LOCATION)]
         pub location: Option<String>,
     }
+
     response: {
         #[ruma_api(header = CONTENT_TYPE)]
         pub stuff: String,

--- a/ruma-api/tests/header_override.rs
+++ b/ruma-api/tests/header_override.rs
@@ -1,0 +1,41 @@
+use std::convert::TryFrom;
+
+use http::header::{Entry, CONTENT_TYPE};
+use ruma_api::ruma_api;
+
+ruma_api! {
+    metadata: {
+        description: "Does something.",
+        method: GET,
+        name: "no_fields",
+        path: "/_matrix/my/endpoint",
+        rate_limited: false,
+        authentication: None,
+    }
+
+    request: {
+        #[ruma_api(header = LOCATION)]
+        pub location: Option<String>,
+    }
+    response: {
+        #[ruma_api(header = CONTENT_TYPE)]
+        pub stuff: String,
+    }
+}
+
+#[test]
+fn content_type_override() {
+    let res = Response { stuff: "magic".into() };
+    let mut http_res = http::Response::<Vec<u8>>::try_from(res).unwrap();
+
+    // Test that we correctly replaced the default content type,
+    // not adding another content-type header.
+    assert_eq!(
+        match http_res.headers_mut().entry(CONTENT_TYPE) {
+            Entry::Occupied(occ) => occ.iter().count(),
+            _ => 0,
+        },
+        1
+    );
+    assert_eq!(http_res.headers().get("content-type").unwrap(), "magic");
+}

--- a/ruma-api/tests/optional_headers.rs
+++ b/ruma-api/tests/optional_headers.rs
@@ -14,6 +14,7 @@ ruma_api! {
         #[ruma_api(header = LOCATION)]
         pub location: Option<String>,
     }
+
     response: {
         #[ruma_api(header = LOCATION)]
         pub stuff: Option<String>,


### PR DESCRIPTION
Resolves #313 

Just wanted to see what you thought of doing it this way before I convert the optional header code block (if that is even needed?). According to the issue, we don't have to worry about `Request`s yet?