### PR TITLE
client-api: Make filter associated fn's & methods const

### DIFF
--- a/ruma-client-api/src/r0/filter/lazy_load.rs
+++ b/ruma-client-api/src/r0/filter/lazy_load.rs
@@ -24,7 +24,7 @@ pub enum LazyLoadOptions {
 
 impl LazyLoadOptions {
     /// Returns `true` is `self` is `Disabled`.
-    pub fn is_disabled(&self) -> bool {
+    pub const fn is_disabled(&self) -> bool {
         matches!(self, Self::Disabled)
     }
 }

--- a/ruma-client/examples/message_log.rs
+++ b/ruma-client/examples/message_log.rs
@@ -18,7 +18,6 @@ async fn log_messages(homeserver_url: Uri, username: &str, password: &str) -> an
 
     client.log_in(username, password, None, None).await?;
 
-    // FIXME: Possibly promotable when replacing `.into()` if `ignore_all` is made const.
     let filter = FilterDefinition::ignore_all().into();
     let initial_sync_response = client
         .request(assign!(sync_events::Request::new(), {


### PR DESCRIPTION
This doesn't work with our current MSRV (requires 1.46). We should probably just merge at a later point.