### PR TITLE
Support for new relation types.

### DIFF
--- a/ruma-events/src/enums.rs
+++ b/ruma-events/src/enums.rs
@@ -36,6 +36,7 @@ event_enum! {
         "m.call.invite",
         "m.call.hangup",
         "m.call.candidates",
+        "m.reaction",
         "m.room.encrypted",
         "m.room.message",
         "m.room.message.feedback",

--- a/ruma-events/src/lib.rs
+++ b/ruma-events/src/lib.rs
@@ -170,6 +170,7 @@ pub mod pdu;
 pub mod policy;
 pub mod presence;
 pub mod push_rules;
+pub mod reaction;
 pub mod receipt;
 pub mod room;
 pub mod room_key;

--- a/ruma-events/src/reaction.rs
+++ b/ruma-events/src/reaction.rs
@@ -1,0 +1,67 @@
+//! Types for the *m.reaction* event.
+
+use std::convert::TryFrom;
+
+use crate::{
+    room::relationships::{Annotation, RelatesToJsonRepr, RelationJsonRepr},
+    MessageEvent,
+};
+use ruma_events_macros::MessageEventContent;
+use ruma_identifiers::EventId;
+use serde::{Deserialize, Serialize};
+
+/// A reaction to another event.
+pub type ReactionEvent = MessageEvent<ReactionEventContent>;
+
+/// The payload for a `ReactionEvent`.
+#[derive(Clone, Debug, Deserialize, Serialize, MessageEventContent)]
+#[ruma_event(type = "m.reaction")]
+pub struct ReactionEventContent {
+    /// Information about the related event.
+    #[serde(rename = "m.relates_to")]
+    pub relation: Relation,
+}
+
+/// The relation that contains info which event the reaction is applying to.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(try_from = "RelatesToJsonRepr", into = "RelatesToJsonRepr")]
+pub struct Relation {
+    /// The event that is being reacted to.
+    pub event_id: EventId,
+
+    /// A string that holds the emoji reaction.
+    pub emoji: String,
+}
+
+impl From<Relation> for RelatesToJsonRepr {
+    fn from(relation: Relation) -> Self {
+        RelatesToJsonRepr::Relation(RelationJsonRepr::Annotation(Annotation {
+            event_id: relation.event_id,
+            key: relation.emoji,
+        }))
+    }
+}
+
+impl TryFrom<RelatesToJsonRepr> for Relation {
+    type Error = &'static str;
+
+    fn try_from(value: RelatesToJsonRepr) -> Result<Self, Self::Error> {
+        if let RelatesToJsonRepr::Relation(RelationJsonRepr::Annotation(a)) = value {
+            Ok(Relation { event_id: a.event_id, emoji: a.key })
+        } else {
+            Err("Expected a relation with a rel_type of `annotation`")
+        }
+    }
+}
+
+impl ReactionEventContent {
+    /// Create a new reaction.
+    ///
+    /// # Arguments
+    ///
+    /// * `event_id` - The id of the event we are reacting to.
+    /// * `emoji` - The emoji that indicates the reaction that is being applied.
+    pub fn new(event_id: EventId, emoji: String) -> Self {
+        ReactionEventContent { relation: Relation { event_id, emoji } }
+    }
+}

--- a/ruma-events/src/room.rs
+++ b/ruma-events/src/room.rs
@@ -22,6 +22,7 @@ pub mod name;
 pub mod pinned_events;
 pub mod power_levels;
 pub mod redaction;
+pub(crate) mod relationships;
 pub mod server_acl;
 pub mod third_party_invite;
 pub mod tombstone;

--- a/ruma-events/src/room/relationships.rs
+++ b/ruma-events/src/room/relationships.rs
@@ -1,0 +1,160 @@
+//! Types for event relationships.
+//!
+//! Events in Matrix can relate to one another in a couple of ways, this module
+//! adds types to parse the relationship of an event if any exists.
+//!
+//! MSC for all the relates_to types except replies:
+//!     https://github.com/matrix-org/matrix-doc/pull/2674
+
+use ruma_identifiers::EventId;
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+
+/// Enum modeling the different ways relationships can be expressed in a
+/// `m.relates_to` field of an event.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub(crate) enum RelatesToJsonRepr {
+    /// A relation which contains subtypes indicating the type of the
+    /// relationship with the `rel_type` field.
+    Relation(RelationJsonRepr),
+
+    /// An `m.in_reply_to` relationship indicating that the event is a reply to
+    /// another event.
+    Reply {
+        /// Information about another message being replied to.
+        #[serde(rename = "m.in_reply_to")]
+        in_reply_to: InReplyTo,
+    },
+
+    /// Custom, unsupported relationship.
+    Custom(JsonValue),
+}
+
+/// A relation, which associates new information to an existing event.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "rel_type")]
+pub(crate) enum RelationJsonRepr {
+    /// An annotation to an event.
+    #[serde(rename = "m.annotation")]
+    Annotation(Annotation),
+
+    /// A reference to another event.
+    #[cfg(feature = "unstable-pre-spec")]
+    #[serde(rename = "m.reference")]
+    Reference(Reference),
+
+    /// An event that replaces another event.
+    #[cfg(feature = "unstable-pre-spec")]
+    #[serde(rename = "m.replace")]
+    Replacement(Replacement),
+}
+
+/// Information about the event a "rich reply" is replying to.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct InReplyTo {
+    /// The event being replied to.
+    pub event_id: EventId,
+}
+
+/// A reference to another event.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg(feature = "unstable-pre-spec")]
+pub struct Reference {
+    /// The event we are referencing.
+    pub event_id: EventId,
+}
+
+/// An annotation for an event.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Annotation {
+    /// The event that is being annotated.
+    pub event_id: EventId,
+
+    /// The annotation.
+    pub key: String,
+}
+
+/// An event replacing another event.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg(feature = "unstable-pre-spec")]
+pub struct Replacement {
+    /// The event this event is replacing.
+    pub event_id: EventId,
+}
+
+#[cfg(test)]
+mod test {
+    use crate::room::message::Relation;
+    use matches::assert_matches;
+    use ruma_identifiers::event_id;
+    use serde_json::{from_value as from_json_value, json};
+
+    #[test]
+    fn reply_deserialize() {
+        let event_id = event_id!("$1598361704261elfgc:localhost");
+
+        let json = json!({
+            "m.in_reply_to": {
+                "event_id": event_id,
+            }
+        });
+
+        assert_matches!(
+            from_json_value::<Relation>(json).unwrap(),
+            Relation::Reply { in_reply_to }
+            if in_reply_to.event_id == event_id
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "unstable-pre-spec")]
+    fn reference_deserialize() {
+        let event_id = event_id!("$1598361704261elfgc:localhost");
+
+        let json = json!({
+            "rel_type": "m.reference",
+            "event_id": event_id,
+        });
+
+        assert_matches!(
+            from_json_value::<Relation>(json).unwrap(),
+            Relation::Reference(reference)
+            if reference.event_id == event_id
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "unstable-pre-spec")]
+    fn replacement_deserialization() {
+        let event_id = event_id!("$1598361704261elfgc:localhost");
+
+        let json = json!({
+            "rel_type": "m.replace",
+            "event_id": event_id,
+        });
+
+        assert_matches!(
+            from_json_value::<Relation>(json).unwrap(),
+            Relation::Replacement(replacement)
+            if replacement.event_id == event_id
+        );
+    }
+
+    #[test]
+    fn annotation_deserialize() {
+        let event_id = event_id!("$1598361704261elfgc:localhost");
+
+        let json = json!({
+            "rel_type": "m.annotation",
+            "event_id": event_id,
+            "key": "🦛",
+        });
+
+        assert_matches!(
+            from_json_value::<Relation>(json).unwrap(),
+            Relation::Annotation(annotation)
+            if annotation.event_id == event_id && annotation.key == "🦛"
+        );
+    }
+}


### PR DESCRIPTION
This PR tries to deal with https://github.com/ruma/ruma/issues/248.

The enums for the different types that can end up inside a `m.relates_to` field of an event have been modeled to represent the structure of the json as it is, since we do require this to be serialized as well as deserialized the same way.

This does mean that we can have an old style reply in the form of `m.in_reply_to` as well as a `rel_type` inside the `m.relates_to` map. The `rel_type` style relation takes precedence though. Making this an error would require customized deserialization logic which didn't seem to be worthwhile to pursue.

The new relation types, while being still unspecced, aren't feature gated since the `event_enum!` macro doesn't seem to know how to deal with features. The second commit adds a new event type for reactions, since reactions are send out as an `m.reaction` event while edits and references are sent out as a normal `m.room.message` event.

It's unclear why the relations are sent out in different ways, a reaction could have been an `m.room.message` where the body is set to the emoji that we are attaching to the event equally well, or otherwise edits could have been an `m.edit` event as well. Though the later would likely make the `rel_type` field superfluous.

Sending out a reaction has been tested in the wild and is pleasant enough, though handling one is indeed still annoying since we need to go and destructure all the types and check the `rel_type` and get to the `key`. Helpers to get the `key` and `rel_type` should perhaps be added.

Fixes: https://github.com/ruma/ruma/issues/248