### PR TITLE
Fix `push_events::v1::Request` serialization

### DIFF
--- a/ruma-appservice-api/CHANGELOG.md
+++ b/ruma-appservice-api/CHANGELOG.md
@@ -8,6 +8,10 @@ Breaking changes:
 
 * Fix endpoint versioning
 
+Bug fixes:
+
+* Fix `push_events::v1::Request` serialization by sending a dictionary instead of an array on request body
+
 # 0.2.0
 
 Improvements:


### PR DESCRIPTION
Change `push_events::v1::Request` serialization to prevent flattening
of the event property into the request body.

Spec:
https://matrix.org/docs/spec/application_service/r0.1.2#put-matrix-app-v1-transactions-txnid