### PR TITLE
Add Identity Service authentication module

### DIFF
--- a/ruma-client-api/CHANGELOG.md
+++ b/ruma-client-api/CHANGELOG.md
@@ -62,6 +62,7 @@ Breaking changes:
 * Replace `r0::room::create_room::InitialStateEvent` with `ruma_events::InitialStateEvent`
 * `error::ErrorKind` no longer implements `Copy`, `FromStr`
 * Switch from `AnyEvent` to `AnyRoomEvent` in `r0::search::search_events`
+* Move `r0::account::request_openid_token::TokenType` to `ruma-common` crate
 
 Improvements:
 

--- a/ruma-client-api/src/r0/account/request_openid_token.rs
+++ b/ruma-client-api/src/r0/account/request_openid_token.rs
@@ -3,8 +3,8 @@
 use std::time::Duration;
 
 use ruma_api::ruma_api;
+use ruma_common::authentication::TokenType;
 use ruma_identifiers::{ServerNameBox, UserId};
-use ruma_serde::StringEnum;
 
 ruma_api! {
     metadata: {
@@ -58,14 +58,4 @@ impl Response {
     ) -> Self {
         Self { access_token, token_type, matrix_server_name, expires_in }
     }
-}
-
-/// Access token types.
-#[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
-pub enum TokenType {
-    /// Bearer token type
-    Bearer,
-
-    #[doc(hidden)]
-    _Custom(String),
 }

--- a/ruma-common/CHANGELOG.md
+++ b/ruma-common/CHANGELOG.md
@@ -10,6 +10,8 @@ Improvements:
 * Add `directory::{Filter, PublicRoomsChunk, RoomNetwork}` (moved from
   `ruma_client_api::r0::directory`)
 * Add `push::{PusherData, PushFormat}` (moved from `ruma_client_api::r0::push`)
+* Add `authentication::TokenType` (moved from
+  `ruma_client_api::r0::account:request_openid_token`)
 
 # 0.2.0
 

--- a/ruma-common/src/authentication.rs
+++ b/ruma-common/src/authentication.rs
@@ -1,0 +1,13 @@
+//! Common types for authentication.
+
+use ruma_serde::StringEnum;
+
+/// Access token types.
+#[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
+pub enum TokenType {
+    /// Bearer token type
+    Bearer,
+
+    #[doc(hidden)]
+    _Custom(String),
+}

--- a/ruma-common/src/lib.rs
+++ b/ruma-common/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![warn(missing_docs, missing_debug_implementations)]
 
+pub mod authentication;
 pub mod directory;
 pub mod encryption;
 pub mod presence;

--- a/ruma-identity-service-api/CHANGELOG.md
+++ b/ruma-identity-service-api/CHANGELOG.md
@@ -1,0 +1,5 @@
+# [unreleased]
+
+## Improvements
+
+- Added authentication endpoints: `authentication::{get_account_information::v2, logout::v2, register::v2}`

--- a/ruma-identity-service-api/Cargo.toml
+++ b/ruma-identity-service-api/Cargo.toml
@@ -12,3 +12,8 @@ edition = "2018"
 
 [dependencies]
 ruma-api = { version = "=0.17.0-alpha.1", path = "../ruma-api" }
+ruma-common = { version = "0.2.0", path = "../ruma-common" }
+ruma-identifiers = { version = "0.17.4", path = "../ruma-identifiers" }
+ruma-serde = { version = "0.2.3", path = "../ruma-serde" }
+serde = { version = "1.0.114", features = ["derive"] }
+serde_json = "1.0.57"

--- a/ruma-identity-service-api/src/authentication.rs
+++ b/ruma-identity-service-api/src/authentication.rs
@@ -1,0 +1,5 @@
+//! Endpoints to authenticate with an identity server.
+
+pub mod get_account_information;
+pub mod logout;
+pub mod register;

--- a/ruma-identity-service-api/src/authentication/get_account_information.rs
+++ b/ruma-identity-service-api/src/authentication/get_account_information.rs
@@ -1,0 +1,3 @@
+//! Gets information about what user owns the access token used in the request.
+
+pub mod v2;

--- a/ruma-identity-service-api/src/authentication/get_account_information/v2.rs
+++ b/ruma-identity-service-api/src/authentication/get_account_information/v2.rs
@@ -1,0 +1,37 @@
+//! [GET /_matrix/identity/v2/account](https://matrix.org/docs/spec/identity_service/latest#get-matrix-identity-v2-account)
+
+use ruma_api::ruma_api;
+use ruma_identifiers::UserId;
+
+ruma_api! {
+    metadata: {
+        description: "Gets information about what user owns the access token used in the request.",
+        method: POST,
+        name: "get_account_information",
+        path: "/_matrix/identity/v2/account",
+        authentication: AccessToken,
+        rate_limited: false,
+    }
+
+    #[derive(Default)]
+    request: {}
+
+    response: {
+        /// The user ID which registered the token.
+        pub user_id: UserId,
+    }
+}
+
+impl Request {
+    /// Creates an empty `Request`.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Response {
+    /// Creates a new `Response` with the given `UserId`.
+    pub fn new(user_id: UserId) -> Self {
+        Self { user_id }
+    }
+}

--- a/ruma-identity-service-api/src/authentication/logout.rs
+++ b/ruma-identity-service-api/src/authentication/logout.rs
@@ -1,0 +1,4 @@
+//! Logs out the access token, preventing it from being used to authenticate future requests to the
+//! server.
+
+pub mod v2;

--- a/ruma-identity-service-api/src/authentication/logout/v2.rs
+++ b/ruma-identity-service-api/src/authentication/logout/v2.rs
@@ -1,0 +1,34 @@
+//! [POST /_matrix/identity/v2/account/logout](https://matrix.org/docs/spec/identity_service/r0.3.0#post-matrix-identity-v2-account-logout)
+
+use ruma_api::ruma_api;
+
+ruma_api! {
+    metadata: {
+        description: "Logs out the access token, preventing it from being used to authenticate future requests to the server.",
+        method: POST,
+        name: "logout",
+        path: "/_matrix/identity/v2/account/logout",
+        authentication: AccessToken,
+        rate_limited: false,
+    }
+
+    #[derive(Default)]
+    request: {}
+
+    #[derive(Default)]
+    response: {}
+}
+
+impl Request {
+    /// Creates an empty `Request`.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Response {
+    /// Creates an empty `Response`.
+    pub fn new() -> Self {
+        Self
+    }
+}

--- a/ruma-identity-service-api/src/authentication/register.rs
+++ b/ruma-identity-service-api/src/authentication/register.rs
@@ -1,0 +1,3 @@
+//! Exchanges an OpenID token from the homeserver for an access token to access the identity server.
+
+pub mod v2;

--- a/ruma-identity-service-api/src/authentication/register/v2.rs
+++ b/ruma-identity-service-api/src/authentication/register/v2.rs
@@ -1,0 +1,69 @@
+//! [POST /_matrix/identity/v2/account/register](https://matrix.org/docs/spec/identity_service/r0.3.0#post-matrix-identity-v2-account-register)
+
+use std::time::Duration;
+
+use ruma_api::ruma_api;
+use ruma_common::StringEnum;
+use ruma_identifiers::ServerName;
+
+ruma_api! {
+    metadata: {
+        description: "Exchanges an OpenID token from the homeserver for an access token to access the identity server.",
+        method: POST,
+        name: "register_account",
+        path: "/_matrix/identity/v2/account/register",
+        authentication: None,
+        rate_limited: false,
+    }
+
+    request: {
+        /// An access token the consumer may use to verify the identity of the
+        /// person who generated the token. This is given to the federation API
+        /// GET /openid/userinfo to verify the user's identity.
+        pub access_token: &'a str,
+
+        /// The string `Bearer`.
+        pub token_type: TokenType,
+
+        /// The homeserver domain the consumer should use when attempting to verify the user's identity.
+        pub matrix_server_name: &'a ServerName,
+
+        /// The number of seconds before this token expires and a new one must be generated.
+        #[serde(with = "ruma_serde::duration::secs")]
+        pub expires_in: Duration,
+    }
+
+    response: {
+        /// An opaque string representing the token to authenticate future requests to the identity server with.
+        pub token: String,
+    }
+}
+
+impl<'a> Request<'a> {
+    /// Creates a `Request` with the given parameters.
+    pub fn new(
+        access_token: &'a str,
+        token_type: TokenType,
+        matrix_server_name: &'a ServerName,
+        expires_in: Duration,
+    ) -> Self {
+        Self { access_token, token_type, matrix_server_name, expires_in }
+    }
+}
+
+impl Response {
+    /// Creates an empty `Response`.
+    pub fn new(token: String) -> Self {
+        Self { token }
+    }
+}
+
+/// Access token types.
+#[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
+pub enum TokenType {
+    /// Bearer token type
+    Bearer,
+
+    #[doc(hidden)]
+    _Custom(String),
+}

--- a/ruma-identity-service-api/src/authentication/register/v2.rs
+++ b/ruma-identity-service-api/src/authentication/register/v2.rs
@@ -3,7 +3,7 @@
 use std::time::Duration;
 
 use ruma_api::ruma_api;
-use ruma_common::StringEnum;
+use ruma_common::authentication::TokenType;
 use ruma_identifiers::ServerName;
 
 ruma_api! {
@@ -56,14 +56,4 @@ impl Response {
     pub fn new(token: String) -> Self {
         Self { token }
     }
-}
-
-/// Access token types.
-#[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
-pub enum TokenType {
-    /// Bearer token type
-    Bearer,
-
-    #[doc(hidden)]
-    _Custom(String),
 }

--- a/ruma-identity-service-api/src/lib.rs
+++ b/ruma-identity-service-api/src/lib.rs
@@ -1,1 +1,1 @@
-
+pub mod authentication;


### PR DESCRIPTION
This implements the authentication module. It's called "Authentication" in the spec, but the corresponding module in the CS API is called `account`. Should we stay internally consistent or consistent with the spec?

Fixes #294 
Fixes #295
Fixes #296