### PR TITLE
Remove circle-artifacts.com links in the documentation

### DIFF
--- a/ruma-client-api/src/r0/keys/upload_signatures.rs
+++ b/ruma-client-api/src/r0/keys/upload_signatures.rs
@@ -1,6 +1,6 @@
 //! POST /_matrix/client/r0/keys/signatures/upload
 //!
-//! Defined in the [MSC 1756](https://github.com/matrix-org/matrix-doc/blob/master/proposals/1756-cross-signing.md#uploading-signing-keys)
+//! Defined in [MSC 1756](https://github.com/matrix-org/matrix-doc/blob/master/proposals/1756-cross-signing.md#uploading-signing-keys)
 
 use std::collections::BTreeMap;
 

--- a/ruma-client-api/src/r0/keys/upload_signatures.rs
+++ b/ruma-client-api/src/r0/keys/upload_signatures.rs
@@ -1,4 +1,6 @@
-//! [POST /_matrix/client/r0/keys/signatures/upload](https://13301-24998719-gh.circle-artifacts.com/0/scripts/gen/client_server/unstable.html#post-matrix-client-r0-keys-signatures-upload)
+//! POST /_matrix/client/r0/keys/signatures/upload
+//!
+//! Defined in the [MSC 1756](https://github.com/matrix-org/matrix-doc/blob/master/proposals/1756-cross-signing.md#uploading-signing-keys)
 
 use std::collections::BTreeMap;
 

--- a/ruma-client-api/src/r0/keys/upload_signing_keys.rs
+++ b/ruma-client-api/src/r0/keys/upload_signing_keys.rs
@@ -1,4 +1,6 @@
-//! [POST /_matrix/client/r0/keys/device_signing/upload](https://13301-24998719-gh.circle-artifacts.com/0/scripts/gen/client_server/unstable.html#post-matrix-client-r0-keys-device-signing-upload)
+//! POST /_matrix/client/r0/keys/device_signing/upload
+//!
+//! Defined in [MSC 1756](https://github.com/matrix-org/matrix-doc/blob/master/proposals/1756-cross-signing.md#uploading-signing-keys)
 
 use ruma_api::ruma_api;
 


### PR DESCRIPTION
And add a link to the MSC that defines these endpoints as they don't seem to be available on the unstable spec yet.

Fixes #317