### PR TITLE
Support for in-room verification events.

### DIFF
--- a/ruma-events/src/dummy.rs
+++ b/ruma-events/src/dummy.rs
@@ -24,6 +24,9 @@ pub type DummyEvent = BasicEvent<DummyEventContent>;
 #[ruma_event(type = "m.dummy")]
 pub struct DummyEventContent(pub Empty);
 
+/// The to-device version of the payload for the `DummyEvent`.
+pub type DummyToDeviceEventContent = DummyEventContent;
+
 impl Deref for DummyEventContent {
     type Target = Empty;
 

--- a/ruma-events/src/enums.rs
+++ b/ruma-events/src/enums.rs
@@ -37,6 +37,16 @@ event_enum! {
         "m.call.hangup",
         "m.call.candidates",
         #[cfg(feature = "unstable-pre-spec")]
+        "m.key.verification.start",
+        #[cfg(feature = "unstable-pre-spec")]
+        "m.key.verification.cancel",
+        #[cfg(feature = "unstable-pre-spec")]
+        "m.key.verification.accept",
+        #[cfg(feature = "unstable-pre-spec")]
+        "m.key.verification.key",
+        #[cfg(feature = "unstable-pre-spec")]
+        "m.key.verification.mac",
+        #[cfg(feature = "unstable-pre-spec")]
         "m.reaction",
         "m.room.encrypted",
         "m.room.message",

--- a/ruma-events/src/enums.rs
+++ b/ruma-events/src/enums.rs
@@ -49,6 +49,8 @@ event_enum! {
         #[cfg(feature = "unstable-pre-spec")]
         "m.key.verification.mac",
         #[cfg(feature = "unstable-pre-spec")]
+        "m.key.verification.done",
+        #[cfg(feature = "unstable-pre-spec")]
         "m.reaction",
         "m.room.encrypted",
         "m.room.message",

--- a/ruma-events/src/enums.rs
+++ b/ruma-events/src/enums.rs
@@ -37,6 +37,8 @@ event_enum! {
         "m.call.hangup",
         "m.call.candidates",
         #[cfg(feature = "unstable-pre-spec")]
+        "m.key.verification.ready",
+        #[cfg(feature = "unstable-pre-spec")]
         "m.key.verification.start",
         #[cfg(feature = "unstable-pre-spec")]
         "m.key.verification.cancel",

--- a/ruma-events/src/forwarded_room_key.rs
+++ b/ruma-events/src/forwarded_room_key.rs
@@ -4,17 +4,10 @@ use ruma_events_macros::BasicEventContent;
 use ruma_identifiers::{EventEncryptionAlgorithm, RoomId};
 use serde::{Deserialize, Serialize};
 
-use crate::BasicEvent;
-
-/// This event type is used to forward keys for end-to-end encryption.
-///
-/// Typically it is encrypted as an *m.room.encrypted* event, then sent as a to-device event.
-pub type ForwardedRoomKeyEvent = BasicEvent<ForwardedRoomKeyEventContent>;
-
 /// The payload for `ForwardedRoomKeyEvent`.
 #[derive(Clone, Debug, Deserialize, Serialize, BasicEventContent)]
 #[ruma_event(type = "m.forwarded_room_key")]
-pub struct ForwardedRoomKeyEventContent {
+pub struct ForwardedRoomKeyToDeviceEventContent {
     /// The encryption algorithm the key in this event is to be used with.
     pub algorithm: EventEncryptionAlgorithm,
 

--- a/ruma-events/src/key/verification.rs
+++ b/ruma-events/src/key/verification.rs
@@ -21,6 +21,8 @@ pub mod accept;
 pub mod cancel;
 pub mod key;
 pub mod mac;
+#[cfg(feature = "unstable-pre-spec")]
+pub mod ready;
 pub mod request;
 pub mod start;
 

--- a/ruma-events/src/key/verification.rs
+++ b/ruma-events/src/key/verification.rs
@@ -1,8 +1,21 @@
 //! Modules for events in the *m.key.verification* namespace.
 //!
 //! This module also contains types shared by events in its child namespaces.
+//!
+//! MSC for the in-room variants of the `m.key.verification.*` events can be
+//! found [here](https://github.com/matrix-org/matrix-doc/pull/2241).
 
+#[cfg(feature = "unstable-pre-spec")]
+use serde::{Deserialize, Serialize};
+#[cfg(feature = "unstable-pre-spec")]
+use std::convert::TryFrom;
+
+#[cfg(feature = "unstable-pre-spec")]
+use ruma_identifiers::EventId;
 use ruma_serde::StringEnum;
+
+#[cfg(feature = "unstable-pre-spec")]
+use crate::room::relationships::{Reference, RelatesToJsonRepr, RelationJsonRepr};
 
 pub mod accept;
 pub mod cancel;
@@ -62,6 +75,37 @@ pub enum ShortAuthenticationString {
 
     #[doc(hidden)]
     _Custom(String),
+}
+
+/// The relation that contains info which event the reaction is applying to.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(try_from = "RelatesToJsonRepr", into = "RelatesToJsonRepr")]
+#[cfg(feature = "unstable-pre-spec")]
+pub struct Relation {
+    /// The event that is being referenced.
+    pub event_id: EventId,
+}
+
+#[cfg(feature = "unstable-pre-spec")]
+impl From<Relation> for RelatesToJsonRepr {
+    fn from(relation: Relation) -> Self {
+        RelatesToJsonRepr::Relation(RelationJsonRepr::Reference(Reference {
+            event_id: relation.event_id,
+        }))
+    }
+}
+
+#[cfg(feature = "unstable-pre-spec")]
+impl TryFrom<RelatesToJsonRepr> for Relation {
+    type Error = &'static str;
+
+    fn try_from(value: RelatesToJsonRepr) -> Result<Self, Self::Error> {
+        if let RelatesToJsonRepr::Relation(RelationJsonRepr::Reference(r)) = value {
+            Ok(Relation { event_id: r.event_id })
+        } else {
+            Err("Expected a relation with a rel_type of `reference`")
+        }
+    }
 }
 
 /// A Short Authentication String (SAS) verification method.

--- a/ruma-events/src/key/verification.rs
+++ b/ruma-events/src/key/verification.rs
@@ -19,6 +19,8 @@ use crate::room::relationships::{Reference, RelatesToJsonRepr, RelationJsonRepr}
 
 pub mod accept;
 pub mod cancel;
+#[cfg(feature = "unstable-pre-spec")]
+pub mod done;
 pub mod key;
 pub mod mac;
 #[cfg(feature = "unstable-pre-spec")]

--- a/ruma-events/src/key/verification/cancel.rs
+++ b/ruma-events/src/key/verification/cancel.rs
@@ -1,10 +1,22 @@
 //! Types for the *m.key.verification.cancel* event.
 
 use ruma_events_macros::BasicEventContent;
+#[cfg(feature = "unstable-pre-spec")]
+use ruma_events_macros::MessageEventContent;
 use ruma_serde::StringEnum;
 use serde::{Deserialize, Serialize};
 
-/// The payload for `CancelEvent`.
+#[cfg(feature = "unstable-pre-spec")]
+use crate::MessageEvent;
+
+#[cfg(feature = "unstable-pre-spec")]
+use super::Relation;
+
+/// Cancels a key verification process/request.
+#[cfg(feature = "unstable-pre-spec")]
+pub type CancelEvent = MessageEvent<CancelEventContent>;
+
+/// The payload for a to-device `CancelEvent`.
 #[derive(Clone, Debug, Deserialize, Serialize, BasicEventContent)]
 #[ruma_event(type = "m.key.verification.cancel")]
 pub struct CancelToDeviceEventContent {
@@ -18,6 +30,24 @@ pub struct CancelToDeviceEventContent {
 
     /// The error code for why the process/request was cancelled by the user.
     pub code: CancelCode,
+}
+
+/// The payload for an in-room `CancelEvent`.
+#[derive(Clone, Debug, Deserialize, Serialize, MessageEventContent)]
+#[ruma_event(type = "m.key.verification.cancel")]
+#[cfg(feature = "unstable-pre-spec")]
+pub struct CancelEventContent {
+    /// A human readable description of the `code`.
+    ///
+    /// The client should only rely on this string if it does not understand the `code`.
+    pub reason: String,
+
+    /// The error code for why the process/request was cancelled by the user.
+    pub code: CancelCode,
+
+    /// Information about the related event.
+    #[serde(rename = "m.relates_to")]
+    pub relation: Relation,
 }
 
 /// An error code for why the process/request was cancelled by the user.

--- a/ruma-events/src/key/verification/cancel.rs
+++ b/ruma-events/src/key/verification/cancel.rs
@@ -4,17 +4,10 @@ use ruma_events_macros::BasicEventContent;
 use ruma_serde::StringEnum;
 use serde::{Deserialize, Serialize};
 
-use crate::BasicEvent;
-
-/// Cancels a key verification process/request.
-///
-/// Typically sent as a to-device event.
-pub type CancelEvent = BasicEvent<CancelEventContent>;
-
 /// The payload for `CancelEvent`.
 #[derive(Clone, Debug, Deserialize, Serialize, BasicEventContent)]
 #[ruma_event(type = "m.key.verification.cancel")]
-pub struct CancelEventContent {
+pub struct CancelToDeviceEventContent {
     /// The opaque identifier for the verification process/request.
     pub transaction_id: String,
 

--- a/ruma-events/src/key/verification/done.rs
+++ b/ruma-events/src/key/verification/done.rs
@@ -40,7 +40,7 @@ mod tests {
             }
         });
 
-        let content = DoneEventContent { relation: Relation { event_id: event_id.clone() } };
+        let content = DoneEventContent { relation: Relation { event_id } };
 
         assert_eq!(to_json_value(&content).unwrap(), json_data);
     }

--- a/ruma-events/src/key/verification/done.rs
+++ b/ruma-events/src/key/verification/done.rs
@@ -1,0 +1,71 @@
+//! Types for the *m.key.verification.done* event.
+
+use ruma_events_macros::MessageEventContent;
+use serde::{Deserialize, Serialize};
+
+use super::Relation;
+use crate::MessageEvent;
+
+/// Event signaling that the interactive key verification has successfully
+/// concluded.
+pub type DoneEvent = MessageEvent<DoneEventContent>;
+
+/// The payload for `DoneEvent`.
+#[derive(Clone, Debug, Deserialize, Serialize, MessageEventContent)]
+#[ruma_event(type = "m.key.verification.done")]
+pub struct DoneEventContent {
+    /// Relation signaling which verification request this event is responding
+    /// to.
+    #[serde(rename = "m.relates_to")]
+    pub relation: Relation,
+}
+
+#[cfg(test)]
+mod tests {
+    use matches::assert_matches;
+    use ruma_identifiers::event_id;
+    use ruma_serde::Raw;
+    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+
+    use super::{DoneEventContent, Relation};
+
+    #[test]
+    fn serialization() {
+        let event_id = event_id!("$1598361704261elfgc:localhost");
+
+        let json_data = json!({
+            "m.relates_to": {
+                "rel_type": "m.reference",
+                "event_id": event_id,
+            }
+        });
+
+        let content = DoneEventContent { relation: Relation { event_id: event_id.clone() } };
+
+        assert_eq!(to_json_value(&content).unwrap(), json_data);
+    }
+
+    #[test]
+    fn deserialization() {
+        let id = event_id!("$1598361704261elfgc:localhost");
+
+        let json_data = json!({
+            "m.relates_to": {
+                "rel_type": "m.reference",
+                "event_id": id,
+            }
+        });
+
+        assert_matches!(
+            from_json_value::<Raw<DoneEventContent>>(json_data)
+                .unwrap()
+                .deserialize()
+                .unwrap(),
+            DoneEventContent {
+                relation: Relation {
+                    event_id
+                },
+            } if event_id == id
+        );
+    }
+}

--- a/ruma-events/src/key/verification/key.rs
+++ b/ruma-events/src/key/verification/key.rs
@@ -3,17 +3,10 @@
 use ruma_events_macros::BasicEventContent;
 use serde::{Deserialize, Serialize};
 
-use crate::BasicEvent;
-
-/// Sends the ephemeral public key for a device to the partner device.
-///
-/// Typically sent as a to-device event.
-pub type KeyEvent = BasicEvent<KeyEventContent>;
-
 /// The payload for `KeyEvent`.
 #[derive(Clone, Debug, Deserialize, Serialize, BasicEventContent)]
 #[ruma_event(type = "m.key.verification.key")]
-pub struct KeyEventContent {
+pub struct KeyToDeviceEventContent {
     /// An opaque identifier for the verification process.
     ///
     /// Must be the same as the one used for the *m.key.verification.start* message.

--- a/ruma-events/src/key/verification/key.rs
+++ b/ruma-events/src/key/verification/key.rs
@@ -1,9 +1,21 @@
 //! Types for the *m.key.verification.key* event.
 
 use ruma_events_macros::BasicEventContent;
+#[cfg(feature = "unstable-pre-spec")]
+use ruma_events_macros::MessageEventContent;
 use serde::{Deserialize, Serialize};
 
-/// The payload for `KeyEvent`.
+#[cfg(feature = "unstable-pre-spec")]
+use super::Relation;
+
+#[cfg(feature = "unstable-pre-spec")]
+use crate::MessageEvent;
+
+/// Sends the ephemeral public key for a device to the partner device.
+#[cfg(feature = "unstable-pre-spec")]
+pub type KeyEvent = MessageEvent<KeyEventContent>;
+
+/// The payload for a to-device `KeyEvent`.
 #[derive(Clone, Debug, Deserialize, Serialize, BasicEventContent)]
 #[ruma_event(type = "m.key.verification.key")]
 pub struct KeyToDeviceEventContent {
@@ -14,4 +26,17 @@ pub struct KeyToDeviceEventContent {
 
     /// The device's ephemeral public key, encoded as unpadded Base64.
     pub key: String,
+}
+
+/// The payload for in-room `KeyEvent`.
+#[derive(Clone, Debug, Deserialize, Serialize, MessageEventContent)]
+#[ruma_event(type = "m.key.verification.key")]
+#[cfg(feature = "unstable-pre-spec")]
+pub struct KeyEventContent {
+    /// The device's ephemeral public key, encoded as unpadded Base64.
+    pub key: String,
+
+    /// Information about the related event.
+    #[serde(rename = "m.relates_to")]
+    pub relation: Relation,
 }

--- a/ruma-events/src/key/verification/mac.rs
+++ b/ruma-events/src/key/verification/mac.rs
@@ -3,9 +3,21 @@
 use std::collections::BTreeMap;
 
 use ruma_events_macros::BasicEventContent;
+#[cfg(feature = "unstable-pre-spec")]
+use ruma_events_macros::MessageEventContent;
 use serde::{Deserialize, Serialize};
 
-/// The payload for `MacEvent`.
+#[cfg(feature = "unstable-pre-spec")]
+use super::Relation;
+
+#[cfg(feature = "unstable-pre-spec")]
+use crate::MessageEvent;
+
+/// Sends the MAC of a device's key to the partner device.
+#[cfg(feature = "unstable-pre-spec")]
+pub type MacEvent = MessageEvent<MacEventContent>;
+
+/// The payload for a to-device `MacEvent`.
 #[derive(Clone, Debug, Deserialize, Serialize, BasicEventContent)]
 #[ruma_event(type = "m.key.verification.mac")]
 pub struct MacToDeviceEventContent {
@@ -22,4 +34,23 @@ pub struct MacToDeviceEventContent {
     /// The MAC of the comma-separated, sorted, list of key IDs given in the `mac` property,
     /// encoded as unpadded Base64.
     pub keys: String,
+}
+
+/// The payload for an in-room `MacEvent`.
+#[derive(Clone, Debug, Deserialize, Serialize, MessageEventContent)]
+#[ruma_event(type = "m.key.verification.mac")]
+#[cfg(feature = "unstable-pre-spec")]
+pub struct MacEventContent {
+    /// A map of the key ID to the MAC of the key, using the algorithm in the verification process.
+    ///
+    /// The MAC is encoded as unpadded Base64.
+    pub mac: BTreeMap<String, String>,
+
+    /// The MAC of the comma-separated, sorted, list of key IDs given in the `mac` property,
+    /// encoded as unpadded Base64.
+    pub keys: String,
+
+    /// Information about the related event.
+    #[serde(rename = "m.relates_to")]
+    pub relation: Relation,
 }

--- a/ruma-events/src/key/verification/mac.rs
+++ b/ruma-events/src/key/verification/mac.rs
@@ -5,17 +5,10 @@ use std::collections::BTreeMap;
 use ruma_events_macros::BasicEventContent;
 use serde::{Deserialize, Serialize};
 
-use crate::BasicEvent;
-
-/// Sends the MAC of a device's key to the partner device.
-///
-/// Typically sent as a to-device event.
-pub type MacEvent = BasicEvent<MacEventContent>;
-
 /// The payload for `MacEvent`.
 #[derive(Clone, Debug, Deserialize, Serialize, BasicEventContent)]
 #[ruma_event(type = "m.key.verification.mac")]
-pub struct MacEventContent {
+pub struct MacToDeviceEventContent {
     /// An opaque identifier for the verification process.
     ///
     /// Must be the same as the one used for the *m.key.verification.start* message.

--- a/ruma-events/src/key/verification/ready.rs
+++ b/ruma-events/src/key/verification/ready.rs
@@ -51,7 +51,7 @@ mod tests {
 
         let content = ReadyEventContent {
             from_device: device,
-            relation: Relation { event_id: event_id.clone() },
+            relation: Relation { event_id },
             methods: vec![VerificationMethod::MSasV1],
         };
 

--- a/ruma-events/src/key/verification/ready.rs
+++ b/ruma-events/src/key/verification/ready.rs
@@ -1,0 +1,91 @@
+//! Types for the *m.key.verification.ready* event.
+
+use ruma_events_macros::MessageEventContent;
+use ruma_identifiers::DeviceIdBox;
+use serde::{Deserialize, Serialize};
+
+use super::{Relation, VerificationMethod};
+use crate::MessageEvent;
+
+/// Response to a previously sent *m.key.verification.request* message.
+pub type ReadyEvent = MessageEvent<ReadyEventContent>;
+
+/// The payload for `ReadyEvent`.
+#[derive(Clone, Debug, Deserialize, Serialize, MessageEventContent)]
+#[ruma_event(type = "m.key.verification.ready")]
+pub struct ReadyEventContent {
+    /// The device ID which is initiating the request.
+    pub from_device: DeviceIdBox,
+
+    /// The verification methods supported by the sender.
+    pub methods: Vec<VerificationMethod>,
+
+    /// Relation signaling which verification request this event is responding
+    /// to.
+    #[serde(rename = "m.relates_to")]
+    pub relation: Relation,
+}
+
+#[cfg(test)]
+mod tests {
+    use matches::assert_matches;
+    use ruma_identifiers::{event_id, DeviceIdBox};
+    use ruma_serde::Raw;
+    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+
+    use super::{ReadyEventContent, Relation, VerificationMethod};
+
+    #[test]
+    fn serialization() {
+        let event_id = event_id!("$1598361704261elfgc:localhost");
+        let device: DeviceIdBox = "123".into();
+
+        let json_data = json!({
+            "from_device": device,
+            "methods": ["m.sas.v1"],
+            "m.relates_to": {
+                "rel_type": "m.reference",
+                "event_id": event_id,
+            }
+        });
+
+        let content = ReadyEventContent {
+            from_device: device,
+            relation: Relation { event_id: event_id.clone() },
+            methods: vec![VerificationMethod::MSasV1],
+        };
+
+        assert_eq!(to_json_value(&content).unwrap(), json_data);
+    }
+
+    #[test]
+    fn deserialization() {
+        let id = event_id!("$1598361704261elfgc:localhost");
+        let device: DeviceIdBox = "123".into();
+
+        let json_data = json!({
+            "from_device": device,
+            "methods": ["m.sas.v1"],
+            "m.relates_to": {
+                "rel_type": "m.reference",
+                "event_id": id,
+            }
+        });
+
+        assert_matches!(
+            from_json_value::<Raw<ReadyEventContent>>(json_data)
+                .unwrap()
+                .deserialize()
+                .unwrap(),
+            ReadyEventContent {
+                from_device,
+                relation: Relation {
+                    event_id
+                },
+                methods,
+            } if from_device == device
+                && methods == vec![VerificationMethod::MSasV1]
+                && event_id == id
+        );
+    }
+}

--- a/ruma-events/src/key/verification/request.rs
+++ b/ruma-events/src/key/verification/request.rs
@@ -7,17 +7,11 @@ use ruma_identifiers::DeviceIdBox;
 use serde::{Deserialize, Serialize};
 
 use super::VerificationMethod;
-use crate::BasicEvent;
-
-/// Requests a key verification with another user's devices.
-///
-/// Typically sent as a to-device event.
-pub type RequestEvent = BasicEvent<RequestEventContent>;
 
 /// The payload for `RequestEvent`.
 #[derive(Clone, Debug, Deserialize, Serialize, BasicEventContent)]
 #[ruma_event(type = "m.key.verification.request")]
-pub struct RequestEventContent {
+pub struct RequestToDeviceEventContent {
     /// The device ID which is initiating the request.
     pub from_device: DeviceIdBox,
 

--- a/ruma-events/src/key/verification/start.rs
+++ b/ruma-events/src/key/verification/start.rs
@@ -3,16 +3,27 @@
 use std::{collections::BTreeMap, convert::TryFrom};
 
 use ruma_events_macros::BasicEventContent;
+#[cfg(feature = "unstable-pre-spec")]
+use ruma_events_macros::MessageEventContent;
 use ruma_identifiers::DeviceIdBox;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
+#[cfg(feature = "unstable-pre-spec")]
+use super::Relation;
 use super::{
     HashAlgorithm, KeyAgreementProtocol, MessageAuthenticationCode, ShortAuthenticationString,
 };
-use crate::InvalidInput;
 
-/// The payload of an *m.key.verification.start* event.
+use crate::InvalidInput;
+#[cfg(feature = "unstable-pre-spec")]
+use crate::MessageEvent;
+
+/// Begins an SAS key verification process.
+#[cfg(feature = "unstable-pre-spec")]
+pub type StartEvent = MessageEvent<StartEventContent>;
+
+/// The payload of a to-device *m.key.verification.start* event.
 #[derive(Clone, Debug, Deserialize, Serialize, BasicEventContent)]
 #[ruma_event(type = "m.key.verification.start")]
 pub struct StartToDeviceEventContent {
@@ -29,6 +40,23 @@ pub struct StartToDeviceEventContent {
     /// Method specific content.
     #[serde(flatten)]
     pub method: StartMethod,
+}
+
+/// The payload of an in-room *m.key.verification.start* event.
+#[derive(Clone, Debug, Deserialize, Serialize, MessageEventContent)]
+#[ruma_event(type = "m.key.verification.start")]
+#[cfg(feature = "unstable-pre-spec")]
+pub struct StartEventContent {
+    /// The device ID which is initiating the process.
+    pub from_device: DeviceIdBox,
+
+    /// Method specific content.
+    #[serde(flatten)]
+    pub method: StartMethod,
+
+    /// Information about the related event.
+    #[serde(rename = "m.relates_to")]
+    pub relation: Relation,
 }
 
 /// An enum representing the different method specific
@@ -185,6 +213,10 @@ mod tests {
         MessageAuthenticationCode, ShortAuthenticationString, StartMethod,
         StartToDeviceEventContent,
     };
+    #[cfg(feature = "unstable-pre-spec")]
+    use super::{Relation, StartEventContent};
+    #[cfg(feature = "unstable-pre-spec")]
+    use ruma_identifiers::event_id;
     use ruma_identifiers::user_id;
     use ruma_serde::Raw;
 
@@ -312,6 +344,41 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "unstable-pre-spec")]
+    fn in_room_serialization() {
+        let event_id = event_id!("$1598361704261elfgc:localhost");
+
+        let key_verification_start_content = StartEventContent {
+            from_device: "123".into(),
+            relation: Relation { event_id: event_id.clone() },
+            method: StartMethod::MSasV1(
+                MSasV1Content::new(MSasV1ContentInit {
+                    hashes: vec![HashAlgorithm::Sha256],
+                    key_agreement_protocols: vec![KeyAgreementProtocol::Curve25519],
+                    message_authentication_codes: vec![MessageAuthenticationCode::HkdfHmacSha256],
+                    short_authentication_string: vec![ShortAuthenticationString::Decimal],
+                })
+                .unwrap(),
+            ),
+        };
+
+        let json_data = json!({
+            "from_device": "123",
+            "method": "m.sas.v1",
+            "key_agreement_protocols": ["curve25519"],
+            "hashes": ["sha256"],
+            "message_authentication_codes": ["hkdf-hmac-sha256"],
+            "short_authentication_string": ["decimal"],
+            "m.relates_to": {
+                "rel_type": "m.reference",
+                "event_id": event_id,
+            }
+        });
+
+        assert_eq!(to_json_value(&key_verification_start_content).unwrap(), json_data);
+    }
+
+    #[test]
     fn deserialization() {
         let json = json!({
             "from_device": "123",
@@ -421,6 +488,50 @@ mod tests {
                 && transaction_id == "456"
                 && method == "m.sas.custom"
                 && fields.get("test").unwrap() == &JsonValue::from("field")
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "unstable-pre-spec")]
+    fn in_room_deserialization() {
+        let id = event_id!("$1598361704261elfgc:localhost");
+
+        let json = json!({
+            "from_device": "123",
+            "method": "m.sas.v1",
+            "hashes": ["sha256"],
+            "key_agreement_protocols": ["curve25519"],
+            "message_authentication_codes": ["hkdf-hmac-sha256"],
+            "short_authentication_string": ["decimal"],
+            "m.relates_to": {
+                "rel_type": "m.reference",
+                "event_id": id,
+            }
+        });
+
+        // Deserialize the content struct separately to verify `TryFromRaw` is implemented for it.
+        assert_matches!(
+            from_json_value::<Raw<StartEventContent>>(json)
+                .unwrap()
+                .deserialize()
+                .unwrap(),
+            StartEventContent {
+                from_device,
+                relation: Relation {
+                    event_id,
+                },
+                method: StartMethod::MSasV1(MSasV1Content {
+                    hashes,
+                    key_agreement_protocols,
+                    message_authentication_codes,
+                    short_authentication_string,
+                })
+            } if from_device == "123"
+                && event_id == id
+                && hashes == vec![HashAlgorithm::Sha256]
+                && key_agreement_protocols == vec![KeyAgreementProtocol::Curve25519]
+                && message_authentication_codes == vec![MessageAuthenticationCode::HkdfHmacSha256]
+                && short_authentication_string == vec![ShortAuthenticationString::Decimal]
         );
     }
 

--- a/ruma-events/src/key/verification/start.rs
+++ b/ruma-events/src/key/verification/start.rs
@@ -10,17 +10,12 @@ use serde_json::Value as JsonValue;
 use super::{
     HashAlgorithm, KeyAgreementProtocol, MessageAuthenticationCode, ShortAuthenticationString,
 };
-use crate::{BasicEvent, InvalidInput};
-
-/// Begins an SAS key verification process.
-///
-/// Typically sent as a to-device event.
-pub type StartEvent = BasicEvent<StartEventContent>;
+use crate::InvalidInput;
 
 /// The payload of an *m.key.verification.start* event.
 #[derive(Clone, Debug, Deserialize, Serialize, BasicEventContent)]
 #[ruma_event(type = "m.key.verification.start")]
-pub struct StartEventContent {
+pub struct StartToDeviceEventContent {
     /// The device ID which is initiating the process.
     pub from_device: DeviceIdBox,
 
@@ -183,11 +178,14 @@ mod tests {
         from_value as from_json_value, json, to_value as to_json_value, Value as JsonValue,
     };
 
+    use crate::ToDeviceEvent;
+
     use super::{
         CustomContent, HashAlgorithm, KeyAgreementProtocol, MSasV1Content, MSasV1ContentInit,
-        MessageAuthenticationCode, ShortAuthenticationString, StartEvent, StartEventContent,
-        StartMethod,
+        MessageAuthenticationCode, ShortAuthenticationString, StartMethod,
+        StartToDeviceEventContent,
     };
+    use ruma_identifiers::user_id;
     use ruma_serde::Raw;
 
     #[test]
@@ -248,7 +246,7 @@ mod tests {
 
     #[test]
     fn serialization() {
-        let key_verification_start_content = StartEventContent {
+        let key_verification_start_content = StartToDeviceEventContent {
             from_device: "123".into(),
             transaction_id: "456".into(),
             method: StartMethod::MSasV1(
@@ -262,7 +260,7 @@ mod tests {
             ),
         };
 
-        let key_verification_start = StartEvent { content: key_verification_start_content };
+        let sender = user_id!("@example:localhost");
 
         let json_data = json!({
             "content": {
@@ -274,10 +272,16 @@ mod tests {
                 "message_authentication_codes": ["hkdf-hmac-sha256"],
                 "short_authentication_string": ["decimal"]
             },
-            "type": "m.key.verification.start"
+            "type": "m.key.verification.start",
+            "sender": sender
         });
 
+        let key_verification_start =
+            ToDeviceEvent { sender, content: key_verification_start_content };
+
         assert_eq!(to_json_value(&key_verification_start).unwrap(), json_data);
+
+        let sender = user_id!("@example:localhost");
 
         let json_data = json!({
             "content": {
@@ -286,10 +290,11 @@ mod tests {
                 "method": "m.sas.custom",
                 "test": "field",
             },
-            "type": "m.key.verification.start"
+            "type": "m.key.verification.start",
+            "sender": sender
         });
 
-        let key_verification_start_content = StartEventContent {
+        let key_verification_start_content = StartToDeviceEventContent {
             from_device: "123".into(),
             transaction_id: "456".into(),
             method: StartMethod::Custom(CustomContent {
@@ -300,7 +305,8 @@ mod tests {
             }),
         };
 
-        let key_verification_start = StartEvent { content: key_verification_start_content };
+        let key_verification_start =
+            ToDeviceEvent { sender, content: key_verification_start_content };
 
         assert_eq!(to_json_value(&key_verification_start).unwrap(), json_data);
     }
@@ -319,11 +325,11 @@ mod tests {
 
         // Deserialize the content struct separately to verify `TryFromRaw` is implemented for it.
         assert_matches!(
-            from_json_value::<Raw<StartEventContent>>(json)
+            from_json_value::<Raw<StartToDeviceEventContent>>(json)
                 .unwrap()
                 .deserialize()
                 .unwrap(),
-            StartEventContent {
+            StartToDeviceEventContent {
                 from_device,
                 transaction_id,
                 method: StartMethod::MSasV1(MSasV1Content {
@@ -340,6 +346,8 @@ mod tests {
                 && short_authentication_string == vec![ShortAuthenticationString::Decimal]
         );
 
+        let sender = user_id!("@example:localhost");
+
         let json = json!({
             "content": {
                 "from_device": "123",
@@ -350,16 +358,18 @@ mod tests {
                 "message_authentication_codes": ["hkdf-hmac-sha256"],
                 "short_authentication_string": ["decimal"]
             },
-            "type": "m.key.verification.start"
+            "type": "m.key.verification.start",
+            "sender": sender
         });
 
         assert_matches!(
-            from_json_value::<Raw<StartEvent>>(json)
+            from_json_value::<Raw<ToDeviceEvent<StartToDeviceEventContent>>>(json)
                 .unwrap()
                 .deserialize()
                 .unwrap(),
-            StartEvent {
-                content: StartEventContent {
+            ToDeviceEvent {
+                sender,
+                content: StartToDeviceEventContent {
                     from_device,
                     transaction_id,
                     method: StartMethod::MSasV1(MSasV1Content {
@@ -370,12 +380,15 @@ mod tests {
                     })
                 }
             } if from_device == "123"
+                && sender == user_id!("@example:localhost")
                 && transaction_id == "456"
                 && hashes == vec![HashAlgorithm::Sha256]
                 && key_agreement_protocols == vec![KeyAgreementProtocol::Curve25519]
                 && message_authentication_codes == vec![MessageAuthenticationCode::HkdfHmacSha256]
                 && short_authentication_string == vec![ShortAuthenticationString::Decimal]
         );
+
+        let sender = user_id!("@example:localhost");
 
         let json = json!({
             "content": {
@@ -384,16 +397,18 @@ mod tests {
                 "method": "m.sas.custom",
                 "test": "field",
             },
-            "type": "m.key.verification.start"
+            "type": "m.key.verification.start",
+            "sender": sender,
         });
 
         assert_matches!(
-            from_json_value::<Raw<StartEvent>>(json)
+            from_json_value::<Raw<ToDeviceEvent<StartToDeviceEventContent>>>(json)
                 .unwrap()
                 .deserialize()
                 .unwrap(),
-            StartEvent {
-                content: StartEventContent {
+            ToDeviceEvent {
+                sender,
+                content: StartToDeviceEventContent {
                     from_device,
                     transaction_id,
                     method: StartMethod::Custom(CustomContent {
@@ -402,6 +417,7 @@ mod tests {
                     })
                 }
             } if from_device == "123"
+                && sender == user_id!("@example:localhost")
                 && transaction_id == "456"
                 && method == "m.sas.custom"
                 && fields.get("test").unwrap() == &JsonValue::from("field")
@@ -411,7 +427,7 @@ mod tests {
     #[test]
     fn deserialization_failure() {
         // Ensure that invalid JSON  creates a `serde_json::Error` and not `InvalidEvent`
-        assert!(serde_json::from_str::<Raw<StartEventContent>>("{").is_err());
+        assert!(serde_json::from_str::<Raw<StartToDeviceEventContent>>("{").is_err());
     }
 
     // TODO this fails because the error is a Validation error not deserialization?

--- a/ruma-events/src/room/encrypted.rs
+++ b/ruma-events/src/room/encrypted.rs
@@ -27,6 +27,9 @@ pub enum EncryptedEventContent {
     MegolmV1AesSha2(MegolmV1AesSha2Content),
 }
 
+/// The to-device version of the payload for the `EncryptedEvent`.
+pub type EncryptedToDeviceEventContent = EncryptedEventContent;
+
 /// The payload for `EncryptedEvent` using the *m.olm.v1.curve25519-aes-sha2* algorithm.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]

--- a/ruma-events/src/room/encrypted.rs
+++ b/ruma-events/src/room/encrypted.rs
@@ -7,9 +7,9 @@ use ruma_events_macros::MessageEventContent;
 use ruma_identifiers::DeviceIdBox;
 use serde::{Deserialize, Serialize};
 
-use crate::MessageEvent;
+use crate::{room::message::Relation, MessageEvent};
 
-/// An event that defines how messages sent in this room should be encrypted.
+/// An event that has been encrypted.
 pub type EncryptedEvent = MessageEvent<EncryptedEventContent>;
 
 /// The payload for `EncryptedEvent`.
@@ -87,6 +87,11 @@ pub struct MegolmV1AesSha2Content {
 
     /// The ID of the session used to encrypt the message.
     pub session_id: String,
+
+    /// Information about related messages for
+    /// [rich replies](https://matrix.org/docs/spec/client_server/r0.6.1#rich-replies).
+    #[serde(rename = "m.relates_to", skip_serializing_if = "Option::is_none")]
+    pub relates_to: Option<Relation>,
 }
 
 /// Mandatory initial set of fields of `MegolmV1AesSha2Content`.
@@ -112,7 +117,7 @@ impl From<MegolmV1AesSha2ContentInit> for MegolmV1AesSha2Content {
     /// Creates a new `MegolmV1AesSha2Content` from the given init struct.
     fn from(init: MegolmV1AesSha2ContentInit) -> Self {
         let MegolmV1AesSha2ContentInit { ciphertext, sender_key, device_id, session_id } = init;
-        Self { ciphertext, sender_key, device_id, session_id }
+        Self { ciphertext, sender_key, device_id, session_id, relates_to: None }
     }
 }
 
@@ -132,6 +137,7 @@ mod tests {
                 sender_key: "sender_key".into(),
                 device_id: "device_id".into(),
                 session_id: "session_id".into(),
+                relates_to: None,
             });
 
         let json_data = json!({
@@ -165,6 +171,7 @@ mod tests {
                 sender_key,
                 device_id,
                 session_id,
+                relates_to: None,
             }) if ciphertext == "ciphertext"
                 && sender_key == "sender_key"
                 && device_id == "device_id"

--- a/ruma-events/src/room_key.rs
+++ b/ruma-events/src/room_key.rs
@@ -6,8 +6,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::BasicEvent;
 
-/// This event type is used to exchange keys for end-to-end encryption.
-///
 /// Typically it is encrypted as an *m.room.encrypted* event, then sent as a to-device event.
 pub type RoomKeyEvent = BasicEvent<RoomKeyEventContent>;
 
@@ -29,6 +27,9 @@ pub struct RoomKeyEventContent {
     /// The key to be exchanged.
     pub session_key: String,
 }
+
+/// The to-device version of the payload for the `RoomKeyEvent`.
+pub type RoomKeyToDeviceEventContent = RoomKeyEventContent;
 
 #[cfg(test)]
 mod tests {

--- a/ruma-events/src/room_key_request.rs
+++ b/ruma-events/src/room_key_request.rs
@@ -5,17 +5,10 @@ use ruma_identifiers::{DeviceIdBox, EventEncryptionAlgorithm, RoomId};
 use ruma_serde::StringEnum;
 use serde::{Deserialize, Serialize};
 
-use crate::BasicEvent;
-
-/// This event type is used to request keys for end-to-end encryption.
-///
-/// It is sent as an unencrypted to-device event.
-pub type RoomKeyRequestEvent = BasicEvent<RoomKeyRequestEventContent>;
-
 /// The payload for `RoomKeyRequestEvent`.
 #[derive(Clone, Debug, Deserialize, Serialize, BasicEventContent)]
 #[ruma_event(type = "m.room_key_request")]
-pub struct RoomKeyRequestEventContent {
+pub struct RoomKeyRequestToDeviceEventContent {
     /// Whether this is a new key request or a cancellation of a previous request.
     pub action: Action,
 


### PR DESCRIPTION
As previously discussed this PR adds support for in-room verification events.

This implements the `m.key.verification.*` events as described in [MSC2241].

There are two new `m.key.verification.*` event types added, `done` and `reply`. These two are for now only supported as in-room variants. [MSC2366] allows them to be used as to-device events, adding support for [MSC2366] will happen in a separate PR.

The content of the `m.room.encrypted` event has been modified to contain an `m.relates_to` field as well, it's using the `Relation` struct for `m.room.message` events, not sure if we'll want to move that struct somewhere else now that it's shared between them.

This fixes: https://github.com/ruma/ruma/issues/34

[MSC2366]: https://github.com/matrix-org/matrix-doc/pull/2366
[MSC2241]: https://github.com/matrix-org/matrix-doc/pull/2241