### PR TITLE
Implement MSC2448: BlurHashes for media

### DIFF
--- a/ruma-client-api/src/r0/media/create_content.rs
+++ b/ruma-client-api/src/r0/media/create_content.rs
@@ -30,6 +30,14 @@ ruma_api! {
     response: {
         /// The MXC URI for the uploaded content.
         pub content_uri: String,
+
+        /// The [BlurHash](https://blurha.sh) for the uploaded content.
+        ///
+        /// This uses the unstable prefix in MSC2448.
+        #[cfg(feature = "unstable-pre-spec")]
+        #[serde(rename = "xyz.amorgan.blurhash")]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub blurhash: Option<String>,
     }
 
     error: crate::Error

--- a/ruma-client-api/src/r0/media/create_content.rs
+++ b/ruma-client-api/src/r0/media/create_content.rs
@@ -33,7 +33,8 @@ ruma_api! {
 
         /// The [BlurHash](https://blurha.sh) for the uploaded content.
         ///
-        /// This uses the unstable prefix in MSC2448.
+        /// This uses the unstable prefix in
+        /// [MSC2448](https://github.com/matrix-org/matrix-doc/pull/2448).
         #[cfg(feature = "unstable-pre-spec")]
         #[serde(rename = "xyz.amorgan.blurhash")]
         #[serde(skip_serializing_if = "Option::is_none")]

--- a/ruma-client-api/src/r0/media/create_content.rs
+++ b/ruma-client-api/src/r0/media/create_content.rs
@@ -53,6 +53,10 @@ impl<'a> Request<'a> {
 impl Response {
     /// Creates a new `Response` with the given MXC URI.
     pub fn new(content_uri: String) -> Self {
-        Self { content_uri }
+        Self {
+            content_uri,
+            #[cfg(feature = "unstable-pre-spec")]
+            blurhash: None,
+        }
     }
 }

--- a/ruma-events/src/room.rs
+++ b/ruma-events/src/room.rs
@@ -58,6 +58,14 @@ pub struct ImageInfo {
     /// Information on the encrypted thumbnail image. Only present if the thumbnail is encrypted.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub thumbnail_file: Option<Box<EncryptedFile>>,
+
+    /// The [BlurHash](https://blurha.sh) for this image.
+    ///
+    /// This uses the unstable prefix in MSC2448.
+    #[cfg(feature = "unstable-pre-spec")]
+    #[serde(rename = "xyz.amorgan.blurhash")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blurhash: Option<String>,
 }
 
 /// Metadata about a thumbnail.

--- a/ruma-events/src/room.rs
+++ b/ruma-events/src/room.rs
@@ -61,7 +61,8 @@ pub struct ImageInfo {
 
     /// The [BlurHash](https://blurha.sh) for this image.
     ///
-    /// This uses the unstable prefix in MSC2448.
+    /// This uses the unstable prefix in
+    /// [MSC2448](https://github.com/matrix-org/matrix-doc/pull/2448).
     #[cfg(feature = "unstable-pre-spec")]
     #[serde(rename = "xyz.amorgan.blurhash")]
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/ruma-events/src/room/message.rs
+++ b/ruma-events/src/room/message.rs
@@ -544,6 +544,14 @@ pub struct VideoInfo {
     /// Information on the encrypted thumbnail file.  Only present if the thumbnail is encrypted.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub thumbnail_file: Option<Box<EncryptedFile>>,
+
+    /// The [BlurHash](https://blurha.sh) for this video.
+    ///
+    /// This uses the unstable prefix in MSC2448.
+    #[cfg(feature = "unstable-pre-spec")]
+    #[serde(rename = "xyz.amorgan.blurhash")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blurhash: Option<String>,
 }
 
 /// The payload for a key verification request message.

--- a/ruma-events/src/room/message.rs
+++ b/ruma-events/src/room/message.rs
@@ -547,7 +547,8 @@ pub struct VideoInfo {
 
     /// The [BlurHash](https://blurha.sh) for this video.
     ///
-    /// This uses the unstable prefix in MSC2448.
+    /// This uses the unstable prefix in
+    /// [MSC2448](https://github.com/matrix-org/matrix-doc/pull/2448).
     #[cfg(feature = "unstable-pre-spec")]
     #[serde(rename = "xyz.amorgan.blurhash")]
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/ruma-events/tests/event_enums.rs
+++ b/ruma-events/tests/event_enums.rs
@@ -84,6 +84,8 @@ fn serialize_message_event() {
                 })),
                 thumbnail_url: Some("mxc://matrix.org".into()),
                 thumbnail_file: None,
+                #[cfg(feature = "unstable-pre-spec")]
+                blurhash: None,
             },
             url: "http://www.matrix.org".into(),
         },

--- a/ruma-events/tests/message_event.rs
+++ b/ruma-events/tests/message_event.rs
@@ -30,6 +30,8 @@ fn message_serialize_sticker() {
                 })),
                 thumbnail_url: Some("mxc://matrix.org".into()),
                 thumbnail_file: None,
+                #[cfg(feature = "unstable-pre-spec")]
+                blurhash: None,
             },
             url: "http://www.matrix.org".into(),
         }),
@@ -189,6 +191,8 @@ fn deserialize_message_sticker() {
                     thumbnail_info: Some(thumbnail_info),
                     thumbnail_url: Some(thumbnail_url),
                     thumbnail_file: None,
+                    #[cfg(feature = "unstable-pre-spec")]
+                    blurhash: None,
                 },
                 url,
             }),

--- a/ruma-events/tests/state_event.rs
+++ b/ruma-events/tests/state_event.rs
@@ -220,6 +220,8 @@ fn deserialize_avatar_without_prev_content() {
                     thumbnail_info: Some(thumbnail_info),
                     thumbnail_url: Some(thumbnail_url),
                     thumbnail_file: None,
+                    #[cfg(feature = "unstable-pre-spec")]
+                    blurhash: None,
                 } if *height == UInt::new(423)
                     && *width == UInt::new(1011)
                     && *mimetype == "image/png"


### PR DESCRIPTION
This exposes the pre-FCP unstable prefixed fields in [MSC2448](https://github.com/matrix-org/matrix-doc/pull/2448).