### PR TITLE
client-api: Make UIAA types non-exhaustive

### DIFF
--- a/ruma-client-api/src/r0/uiaa.rs
+++ b/ruma-client-api/src/r0/uiaa.rs
@@ -48,6 +48,18 @@ pub enum AuthData<'a> {
     },
 }
 
+impl<'a> AuthData<'a> {
+    /// Creates a new `AuthData::DirectRequest` with the given login type.
+    pub fn direct_request(kind: &'a str) -> Self {
+        Self::DirectRequest { kind, session: None, auth_parameters: BTreeMap::new() }
+    }
+
+    /// Creates a new `AuthData::FallbackAcknowledgement` with the given session key.
+    pub fn fallback_acknowledgement(session: &'a str) -> Self {
+        Self::FallbackAcknowledgement { session }
+    }
+}
+
 /// Information about available authentication flows and status for User-Interactive Authenticiation
 /// API.
 #[derive(Clone, Debug, Deserialize, Serialize)]


### PR DESCRIPTION
Unclear on how to proceed. As-is, one can't easily use `assign!` to assign extra fields on `AuthData::direct_request`. The only solution I can think of is changing the struct variants to be newtype variants containing structs instead, but that doesn't make me super happy.

CC #215