### PR TITLE
ruma-events-macros: Add extra-traits feature to syn explicitly

### DIFF
--- a/ruma-events-macros/Cargo.toml
+++ b/ruma-events-macros/Cargo.toml
@@ -17,7 +17,7 @@ repository = "https://github.com/ruma/ruma"
 version = "0.22.0-alpha.2"
 
 [dependencies]
-syn = { version = "1.0.57", features = ["full"] }
+syn = { version = "1.0.57", features = ["full", "extra-traits"] }
 quote = "1.0.8"
 proc-macro2 = "1.0.24"
 proc-macro-crate = "0.1.5"


### PR DESCRIPTION
`std::cmp::Eq` is implemented for `syn::LitStr` only with `extra-traits` feature flag.
It is pulled implicitly but not with -Zavoid-dev-deps. And it is better to be explicit.