### PR TITLE
Make `get_public_rooms` use AccessToken authentication

### DIFF
--- a/ruma-client-api/src/r0/directory/get_public_rooms.rs
+++ b/ruma-client-api/src/r0/directory/get_public_rooms.rs
@@ -12,7 +12,7 @@ ruma_api! {
         name: "get_public_rooms",
         path: "/_matrix/client/r0/publicRooms",
         rate_limited: false,
-        authentication: None,
+        authentication: AccessToken,
     }
 
     #[derive(Default)]


### PR DESCRIPTION
When using this function, I get a `Http(Known(Error { kind: MissingToken, message: "Missing access token", status_code: 401 }))` error. I think this small change fixes it.