### PR TITLE
Verify only the required signatures on `verify_event`

### DIFF
--- a/ruma-signatures/CHANGELOG.md
+++ b/ruma-signatures/CHANGELOG.md
@@ -5,3 +5,7 @@ Breaking changes:
 * Remove `Copy` implementation for `Algorithm`
 * Remove `Copy` and `Clone` implementations for `Ed25519Verifier`
 * Upgrade ruma-identifiers
+
+Bug fixes:
+
+* Verify only the required signatures on `verify_event`

--- a/ruma-signatures/src/functions.rs
+++ b/ruma-signatures/src/functions.rs
@@ -513,9 +513,9 @@ where
 /// Verifies that the signed event contains all the required valid signatures.
 ///
 /// Some room versions may require signatures from multiple homeservers, so this function takes a
-/// map from servers to sets of public keys. For each required homeserver, this function will
-/// require a valid signature. All known public keys for a homeserver should be provided. The
-/// first one found on the given event will be used.
+/// map from servers to sets of public keys. Signatures are verified for each required homeserver.
+/// All known public keys for a homeserver should be provided. The first one found on the given
+/// event will be used.
 ///
 /// If the `Ok` variant is returned by this function, it will contain a `Verified` value which
 /// distinguishes an event with valid signatures and a matching content hash with an event with


### PR DESCRIPTION
The spec says that the required signatures for a signed event is the
signature of sender's server (unless is a third party invite) and the
`event_id` server (in v1 and v2 room versions).

This changes the previous behaviour, which tried to verify the
signatures for all the servers in the `PublicKeyMap`, instead of
checking only the required signatures.

Relevant spec section:
https://matrix.org/docs/spec/server_server/r0.1.4#validating-hashes-and-signatures-on-received-events