### PR TITLE
Add push rule for `.m.rule.reaction`

### DIFF
--- a/ruma-client-api/Cargo.toml
+++ b/ruma-client-api/Cargo.toml
@@ -35,7 +35,7 @@ matches = "0.1.8"
 
 [features]
 unstable-exhaustive-types = []
-unstable-pre-spec = []
+unstable-pre-spec = ["ruma-common/unstable-pre-spec"]
 unstable-synapse-quirks = [
     "ruma-common/unstable-synapse-quirks",
     "ruma-events/unstable-synapse-quirks",

--- a/ruma-common/Cargo.toml
+++ b/ruma-common/Cargo.toml
@@ -24,3 +24,4 @@ matches = "0.1.8"
 [features]
 unstable-exhaustive-types = []
 unstable-synapse-quirks = []
+unstable-pre-spec = []

--- a/ruma-common/src/push/predefined.rs
+++ b/ruma-common/src/push/predefined.rs
@@ -21,6 +21,18 @@ impl Ruleset {
     pub fn server_default(user_id: &UserId) -> Self {
         Self {
             content: btreeset![ContentPushRule::contains_user_name(user_id)],
+            #[cfg(feature = "unstable-pre-spec")]
+            override_: btreeset![
+                OverridePushRule::master(),
+                OverridePushRule::suppress_notices(),
+                OverridePushRule::invite_for_me(user_id),
+                OverridePushRule::member_event(),
+                OverridePushRule::contains_display_name(),
+                OverridePushRule::tombstone(),
+                OverridePushRule::roomnotif(),
+                OverridePushRule::reaction(),
+            ],
+            #[cfg(not(feature = "unstable-pre-spec"))]
             override_: btreeset![
                 OverridePushRule::master(),
                 OverridePushRule::suppress_notices(),
@@ -147,6 +159,7 @@ impl OverridePushRule {
         })
     }
 
+    /// Matches emoji reactions to a message
     /// MSC2677: Annotations and Reactions
     #[cfg(feature = "unstable-pre-spec")]
     pub fn reaction() -> Self {

--- a/ruma-common/src/push/predefined.rs
+++ b/ruma-common/src/push/predefined.rs
@@ -146,6 +146,18 @@ impl OverridePushRule {
             ],
         })
     }
+
+    /// MSC2677: Annotations and Reactions
+    #[cfg(feature = "unstable-pre-spec")]
+    pub fn reaction() -> Self {
+        Self(ConditionalPushRule {
+            actions: vec![DontNotify],
+            default: true,
+            enabled: true,
+            rule_id: ".m.rule.reaction".into(),
+            conditions: vec![EventMatch { key: "type".into(), pattern: "m.reaction".into() }],
+        })
+    }
 }
 
 /// Default content push rules

--- a/ruma-events/Cargo.toml
+++ b/ruma-events/Cargo.toml
@@ -30,7 +30,7 @@ trybuild = "1.0.38"
 
 [features]
 unstable-exhaustive-types = []
-unstable-pre-spec = []
+unstable-pre-spec = ["ruma-common/unstable-pre-spec"]
 unstable-synapse-quirks = []
 markdown = ["pulldown-cmark"]
 

--- a/ruma-federation-api/Cargo.toml
+++ b/ruma-federation-api/Cargo.toml
@@ -29,5 +29,5 @@ matches = "0.1.8"
 
 [features]
 unstable-exhaustive-types = []
-unstable-pre-spec = []
+unstable-pre-spec = ["ruma-common/unstable-pre-spec"]
 unstable-synapse-quirks = ["ruma-events/unstable-synapse-quirks"]

--- a/ruma/Cargo.toml
+++ b/ruma/Cargo.toml
@@ -57,6 +57,7 @@ unstable-pre-spec = [
     "ruma-client-api/unstable-pre-spec",
     "ruma-events/unstable-pre-spec",
     "ruma-federation-api/unstable-pre-spec",
+    "ruma-common/unstable-pre-spec",
 ]
 unstable-synapse-quirks = [
     "ruma-client-api/unstable-synapse-quirks",


### PR DESCRIPTION
 - resides behind the feature flag `unstable-pre-spec`
 - fixes #371 

I would like to know if the doc comment is appropriate.