### PR TITLE
Allow cfg attribute macros on metadata fields

### DIFF
--- a/ruma-api-macros/src/api.rs
+++ b/ruma-api-macros/src/api.rs
@@ -83,8 +83,32 @@ pub fn expand_all(api: Api) -> syn::Result<TokenStream> {
     // with only the literal's value from here on.
     let name = &api.metadata.name.value();
     let path = &api.metadata.path;
-    let rate_limited = &api.metadata.rate_limited;
-    let authentication = &api.metadata.authentication;
+    let rate_limited = &api
+        .metadata
+        .rate_limited
+        .iter()
+        .map(|r| {
+            let attrs = &r.attrs;
+            let value = &r.value;
+            quote! {
+                #( #attrs )*
+                rate_limited: #value,
+            }
+        })
+        .collect::<Vec<_>>();
+    let authentication = &api
+        .metadata
+        .authentication
+        .iter()
+        .map(|r| {
+            let attrs = &r.attrs;
+            let value = &r.value;
+            quote! {
+                #( #attrs )*
+                authentication: #ruma_api::AuthScheme::#value,
+            }
+        })
+        .collect::<Vec<_>>();
 
     let request_type = &api.request;
     let response_type = &api.response;
@@ -133,6 +157,21 @@ pub fn expand_all(api: Api) -> syn::Result<TokenStream> {
             );
         });
     }
+    // if authentication == "AccessToken" {
+    //     header_kvs.extend(quote! {
+    //         req_headers.insert(
+    //             #http::header::AUTHORIZATION,
+    //             #http::header::HeaderValue::from_str(
+    //                 &::std::format!(
+    //                     "Bearer {}",
+    //                     access_token.ok_or(
+    //                         #ruma_api::error::IntoHttpError::NeedsAuthentication
+    //                     )?
+    //                 )
+    //             )?
+    //         );
+    //     });
+    // }
 
     let extract_request_headers = if api.request.has_header_fields() {
         quote! {
@@ -227,19 +266,19 @@ pub fn expand_all(api: Api) -> syn::Result<TokenStream> {
     let error = &api.error_ty;
     let request_lifetimes = api.request.combine_lifetimes();
 
-    let non_auth_endpoint_impls = if authentication != "None" {
-        TokenStream::new()
-    } else {
-        quote! {
-            #[automatically_derived]
-            impl #request_lifetimes #ruma_api::OutgoingNonAuthRequest
-                for Request #request_lifetimes
-            {}
+    // let non_auth_endpoint_impls = if authentication != "None" {
+    //     TokenStream::new()
+    // } else {
+    //     quote! {
+    //         #[automatically_derived]
+    //         impl #request_lifetimes #ruma_api::OutgoingNonAuthRequest
+    //             for Request #request_lifetimes
+    //         {}
 
-            #[automatically_derived]
-            impl #ruma_api::IncomingNonAuthRequest for #incoming_request_type {}
-        }
-    };
+    //         #[automatically_derived]
+    //         impl #ruma_api::IncomingNonAuthRequest for #incoming_request_type {}
+    //     }
+    // };
 
     Ok(quote! {
         #[doc = #request_doc]
@@ -301,8 +340,8 @@ pub fn expand_all(api: Api) -> syn::Result<TokenStream> {
             method: #http::Method::#method,
             name: #name,
             path: #path,
-            rate_limited: #rate_limited,
-            authentication: #ruma_api::AuthScheme::#authentication,
+            #( #rate_limited )*
+            #( #authentication )*
         };
 
         #[automatically_derived]
@@ -367,7 +406,7 @@ pub fn expand_all(api: Api) -> syn::Result<TokenStream> {
             }
         }
 
-        #non_auth_endpoint_impls
+        // #non_auth_endpoint_impls
     })
 }
 

--- a/ruma-api-macros/src/api/metadata.rs
+++ b/ruma-api-macros/src/api/metadata.rs
@@ -63,13 +63,8 @@ fn set_field<T: ToTokens>(field: &mut Option<T>, value: T) -> syn::Result<()> {
     }
 }
 
-fn add_field<T: ToTokens>(
-    field: &mut Vec<MetadataField<T>>,
-    value: T,
-    attrs: Vec<Attribute>,
-) -> syn::Result<()> {
+fn add_field<T: ToTokens>(field: &mut Vec<MetadataField<T>>, value: T, attrs: Vec<Attribute>) {
     field.push(MetadataField { value, attrs });
-    Ok(())
 }
 
 impl Parse for Metadata {
@@ -96,8 +91,8 @@ impl Parse for Metadata {
                 FieldValue::Method(m) => set_field(&mut method, m)?,
                 FieldValue::Name(n) => set_field(&mut name, n)?,
                 FieldValue::Path(p) => set_field(&mut path, p)?,
-                FieldValue::RateLimited(rl, attrs) => add_field(&mut rate_limited, rl, attrs)?,
-                FieldValue::Authentication(a, attrs) => add_field(&mut authentication, a, attrs)?,
+                FieldValue::RateLimited(rl, attrs) => add_field(&mut rate_limited, rl, attrs),
+                FieldValue::Authentication(a, attrs) => add_field(&mut authentication, a, attrs),
             }
         }
 

--- a/ruma-api-macros/src/api/metadata.rs
+++ b/ruma-api-macros/src/api/metadata.rs
@@ -172,6 +172,14 @@ enum FieldValue {
 impl Parse for FieldValue {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let attrs: Vec<Attribute> = input.call(Attribute::parse_outer)?;
+        for attr in attrs.iter() {
+            if !util::is_cfg_attribute(attr) {
+                return Err(syn::Error::new_spanned(
+                    &attr,
+                    "attributes may only be `cfg` attributes",
+                ));
+            }
+        }
         let field: Field = input.parse()?;
         let _: Token![:] = input.parse()?;
 

--- a/ruma-api-macros/src/util.rs
+++ b/ruma-api-macros/src/util.rs
@@ -5,7 +5,7 @@ use proc_macro_crate::crate_name;
 use quote::quote;
 use std::collections::BTreeSet;
 use syn::{
-    AngleBracketedGenericArguments, GenericArgument, Ident, Lifetime,
+    AngleBracketedGenericArguments, AttrStyle, Attribute, GenericArgument, Ident, Lifetime,
     ParenthesizedGenericArguments, PathArguments, Type, TypeArray, TypeBareFn, TypeGroup,
     TypeParen, TypePath, TypePtr, TypeReference, TypeSlice, TypeTuple,
 };
@@ -401,4 +401,8 @@ pub fn import_ruma_api() -> TokenStream {
     } else {
         quote! { ::ruma_api }
     }
+}
+
+pub(crate) fn is_cfg_attribute(attr: &Attribute) -> bool {
+    attr.style == AttrStyle::Outer && attr.path.is_ident("cfg")
 }

--- a/ruma-api/tests/ruma_api_macros.rs
+++ b/ruma-api/tests/ruma_api_macros.rs
@@ -9,7 +9,15 @@ pub mod some_endpoint {
             method: POST, // An `http::Method` constant. No imports required.
             name: "some_endpoint",
             path: "/_matrix/some/endpoint/:baz",
+
+            #[cfg(all())]
+            rate_limited: true,
+            #[cfg(any())]
             rate_limited: false,
+
+            #[cfg(all())]
+            authentication: AccessToken,
+            #[cfg(any())]
             authentication: None,
         }
 


### PR DESCRIPTION
This PR should fix #381.

TODO:

 - [x] add tests (I am not sure how this is done)
 ~emit correct error message on duplicate field declaration~