### PR TITLE
ruma: add unstable-synapse-quirks

### DIFF
--- a/ruma/Cargo.toml
+++ b/ruma/Cargo.toml
@@ -74,3 +74,6 @@ unstable-pre-spec = [
     #"ruma-identity-service-api/unstable-pre-spec",
     #"ruma-push-gateway-api/unstable-pre-spec",
 ]
+unstable-synapse-quirks = [
+    "ruma-client-api/unstable-synapse-quirks",
+]


### PR DESCRIPTION
This feature is used in ruma-client-api.

Without the feature in ruma it's not possible to set it if a crate doesn't directly depend on ruma-client-api. 