### PR TITLE
Allow custom 'msgtype's for MessageEventContent 

### DIFF
--- a/ruma-events/src/lib.rs
+++ b/ruma-events/src/lib.rs
@@ -190,7 +190,7 @@ use serde::{
     de::{self, IgnoredAny},
     Deserialize, Serialize,
 };
-use serde_json::value::{Map as JsonObject, RawValue as RawJsonValue, Value as JsonValue};
+use serde_json::value::RawValue as RawJsonValue;
 
 use self::room::redaction::{RedactionEvent, SyncRedactionEvent};
 
@@ -518,18 +518,6 @@ pub struct EventDeHelper {
     /// If this `UnsignedData` contains a `redacted_because` key the event is
     /// immediately deserialized as a redacted event.
     pub unsigned: Option<UnsignedDeHelper>,
-}
-
-/// Helper struct to determine the msgtype from a `serde_json::value::RawValue`
-#[doc(hidden)]
-#[derive(Debug, Deserialize)]
-pub struct MessageDeHelper {
-    /// The message type field
-    pub msgtype: String,
-
-    /// Everything else in the json object
-    #[serde(flatten)]
-    pub remaining: JsonObject<String, JsonValue>,
 }
 
 /// Helper function for `serde_json::value::RawValue` deserialization.

--- a/ruma-events/src/lib.rs
+++ b/ruma-events/src/lib.rs
@@ -181,6 +181,7 @@
 // Remove this once https://github.com/rust-lang/rust/issues/54883 becomes stable
 #![allow(clippy::unnested_or_patterns)]
 
+use std::collections::HashMap;
 use std::fmt::Debug;
 
 use js_int::Int;
@@ -190,7 +191,7 @@ use serde::{
     de::{self, IgnoredAny},
     Deserialize, Serialize,
 };
-use serde_json::value::RawValue as RawJsonValue;
+use serde_json::value::{RawValue as RawJsonValue, Value as JsonValue};
 
 use self::room::redaction::{RedactionEvent, SyncRedactionEvent};
 
@@ -518,6 +519,18 @@ pub struct EventDeHelper {
     /// If this `UnsignedData` contains a `redacted_because` key the event is
     /// immediately deserialized as a redacted event.
     pub unsigned: Option<UnsignedDeHelper>,
+}
+
+/// Helper struct to determine the msgtype from a `serde_json::value::RawValue`
+#[doc(hidden)]
+#[derive(Debug, Deserialize)]
+pub struct MessageDeHelper {
+    /// The message type field
+    pub msgtype: String,
+
+    /// Everything else in the json object
+    #[serde(flatten)]
+    pub remaining: HashMap<String, JsonValue>,
 }
 
 /// Helper function for `serde_json::value::RawValue` deserialization.

--- a/ruma-events/src/lib.rs
+++ b/ruma-events/src/lib.rs
@@ -181,7 +181,6 @@
 // Remove this once https://github.com/rust-lang/rust/issues/54883 becomes stable
 #![allow(clippy::unnested_or_patterns)]
 
-use std::collections::BTreeMap;
 use std::fmt::Debug;
 
 use js_int::Int;
@@ -191,7 +190,7 @@ use serde::{
     de::{self, IgnoredAny},
     Deserialize, Serialize,
 };
-use serde_json::value::{RawValue as RawJsonValue, Value as JsonValue};
+use serde_json::value::{Map as JsonObject, RawValue as RawJsonValue, Value as JsonValue};
 
 use self::room::redaction::{RedactionEvent, SyncRedactionEvent};
 
@@ -530,7 +529,7 @@ pub struct MessageDeHelper {
 
     /// Everything else in the json object
     #[serde(flatten)]
-    pub remaining: BTreeMap<String, JsonValue>,
+    pub remaining: JsonObject<String, JsonValue>,
 }
 
 /// Helper function for `serde_json::value::RawValue` deserialization.

--- a/ruma-events/src/lib.rs
+++ b/ruma-events/src/lib.rs
@@ -181,7 +181,7 @@
 // Remove this once https://github.com/rust-lang/rust/issues/54883 becomes stable
 #![allow(clippy::unnested_or_patterns)]
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::fmt::Debug;
 
 use js_int::Int;
@@ -530,7 +530,7 @@ pub struct MessageDeHelper {
 
     /// Everything else in the json object
     #[serde(flatten)]
-    pub remaining: HashMap<String, JsonValue>,
+    pub remaining: BTreeMap<String, JsonValue>,
 }
 
 /// Helper function for `serde_json::value::RawValue` deserialization.

--- a/ruma-events/src/room/message.rs
+++ b/ruma-events/src/room/message.rs
@@ -1,5 +1,7 @@
 //! Types for the *m.room.message* event.
 
+use std::collections::BTreeMap;
+
 use js_int::UInt;
 use ruma_events_macros::MessageEventContent;
 #[cfg(feature = "unstable-pre-spec")]
@@ -18,6 +20,7 @@ use super::{relationships::RelatesToJsonRepr, EncryptedFile, ImageInfo, Thumbnai
 // FIXME: Do we want to keep re-exporting this?
 pub use super::relationships::InReplyTo;
 
+#[doc(hidden)]
 pub mod content_serde;
 pub mod feedback;
 
@@ -600,5 +603,5 @@ pub struct CustomEventContent {
 
     /// Remaining event content
     #[serde(flatten)]
-    pub data: serde_json::Map<String, JsonValue>,
+    pub data: BTreeMap<String, JsonValue>,
 }

--- a/ruma-events/src/room/message.rs
+++ b/ruma-events/src/room/message.rs
@@ -29,7 +29,7 @@ use crate::{from_raw_json_value, MessageDeHelper};
 pub type MessageEvent = OuterMessageEvent<MessageEventContent>;
 
 /// The payload for `MessageEvent`.
-#[derive(Clone, Debug, MessageEventContent, Serialize)]
+#[derive(Clone, Debug, Serialize, MessageEventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[ruma_event(type = "m.room.message")]
 #[serde(untagged)]

--- a/ruma-events/src/room/message/content_serde.rs
+++ b/ruma-events/src/room/message/content_serde.rs
@@ -1,0 +1,50 @@
+//! `Deserialize` implementation for MessageEventContent
+use std::collections::BTreeMap;
+
+use serde::{de, Deserialize};
+use serde_json::value::{RawValue as RawJsonValue, Value as JsonValue};
+
+use crate::{
+    from_raw_json_value,
+    room::message::{CustomEventContent, MessageEventContent},
+};
+
+/// Helper struct to determine the msgtype from a `serde_json::value::RawValue`
+#[doc(hidden)]
+#[derive(Debug, Deserialize)]
+pub struct MessageDeHelper {
+    /// The message type field
+    msgtype: String,
+
+    /// Everything else in the json object
+    #[serde(flatten)]
+    remaining: BTreeMap<String, JsonValue>,
+}
+
+impl<'de> de::Deserialize<'de> for MessageEventContent {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        use MessageEventContent::*;
+        let json = Box::<RawJsonValue>::deserialize(deserializer)?;
+        let MessageDeHelper { msgtype, remaining } = from_raw_json_value(&json)?;
+        Ok(match msgtype.as_ref() {
+            "m.audio" => Audio(from_raw_json_value(&json)?),
+            "m.emote" => Emote(from_raw_json_value(&json)?),
+            "m.file" => File(from_raw_json_value(&json)?),
+            "m.image" => Image(from_raw_json_value(&json)?),
+            "m.location" => Location(from_raw_json_value(&json)?),
+            "m.notice" => Notice(from_raw_json_value(&json)?),
+            "m.server_notice" => ServerNotice(from_raw_json_value(&json)?),
+            "m.text" => Text(from_raw_json_value(&json)?),
+            "m.video" => Video(from_raw_json_value(&json)?),
+            #[cfg(feature = "unstable-pre-spec")]
+            "m.key.verification.request" => VerificationRequest(from_raw_json_value(&json)?),
+            s => {
+                let remaining = remaining.into_iter().collect::<serde_json::Map<_, _>>();
+                _Custom(CustomEventContent { msgtype: s.to_string(), data: remaining })
+            }
+        })
+    }
+}

--- a/ruma-events/src/room/message/content_serde.rs
+++ b/ruma-events/src/room/message/content_serde.rs
@@ -1,4 +1,5 @@
 //! `Deserialize` implementation for MessageEventContent
+
 use std::collections::BTreeMap;
 
 use serde::{de, Deserialize};
@@ -12,7 +13,7 @@ use crate::{
 /// Helper struct to determine the msgtype from a `serde_json::value::RawValue`
 #[doc(hidden)]
 #[derive(Debug, Deserialize)]
-pub struct MessageDeHelper {
+struct MessageDeHelper {
     /// The message type field
     msgtype: String,
 
@@ -41,10 +42,7 @@ impl<'de> de::Deserialize<'de> for MessageEventContent {
             "m.video" => Video(from_raw_json_value(&json)?),
             #[cfg(feature = "unstable-pre-spec")]
             "m.key.verification.request" => VerificationRequest(from_raw_json_value(&json)?),
-            s => {
-                let remaining = remaining.into_iter().collect::<serde_json::Map<_, _>>();
-                _Custom(CustomEventContent { msgtype: s.to_string(), data: remaining })
-            }
+            s => _Custom(CustomEventContent { msgtype: s.to_string(), data: remaining }),
         })
     }
 }

--- a/ruma-events/tests/room_message.rs
+++ b/ruma-events/tests/room_message.rs
@@ -1,6 +1,7 @@
 use std::time::{Duration, UNIX_EPOCH};
 
 use assign::assign;
+use maplit::btreemap;
 use matches::assert_matches;
 #[cfg(feature = "unstable-pre-spec")]
 use ruma_events::{
@@ -76,10 +77,12 @@ fn content_serialization() {
 
 #[test]
 fn custom_content_serialization() {
-    let json_data = vec![("custom_field", "baba"), ("another_one", "abab")]
-        .into_iter()
-        .map(|(k, v)| (k.to_string(), json!(v)))
-        .collect();
+    let json_data = btreemap! {
+        "custom_field".into() => json!("baba"),
+        "another_one".into() => json!("abab"),
+    }
+    .into_iter()
+    .collect();
     let custom_event_content = MessageEventContent::_Custom(CustomEventContent {
         msgtype: "my_custom_msgtype".into(),
         data: json_data,
@@ -103,10 +106,12 @@ fn custom_content_deserialization() {
         "another_one": "abab",
     });
 
-    let expected_json_data = vec![("custom_field", "baba"), ("another_one", "abab")]
-        .into_iter()
-        .map(|(k, v)| (k.to_string(), json!(v)))
-        .collect();
+    let expected_json_data = btreemap! {
+        "custom_field".into() => json!("baba"),
+        "another_one".into() => json!("abab"),
+    }
+    .into_iter()
+    .collect();
 
     assert_matches!(
         from_json_value::<Raw<MessageEventContent>>(json_data)

--- a/ruma-events/tests/room_message.rs
+++ b/ruma-events/tests/room_message.rs
@@ -80,9 +80,7 @@ fn custom_content_serialization() {
     let json_data = btreemap! {
         "custom_field".into() => json!("baba"),
         "another_one".into() => json!("abab"),
-    }
-    .into_iter()
-    .collect();
+    };
     let custom_event_content = MessageEventContent::_Custom(CustomEventContent {
         msgtype: "my_custom_msgtype".into(),
         data: json_data,
@@ -109,9 +107,7 @@ fn custom_content_deserialization() {
     let expected_json_data = btreemap! {
         "custom_field".into() => json!("baba"),
         "another_one".into() => json!("abab"),
-    }
-    .into_iter()
-    .collect();
+    };
 
     assert_matches!(
         from_json_value::<Raw<MessageEventContent>>(json_data)

--- a/ruma-events/tests/room_message.rs
+++ b/ruma-events/tests/room_message.rs
@@ -9,7 +9,8 @@ use ruma_events::{
 use ruma_events::{
     room::{
         message::{
-            AudioMessageEventContent, MessageEventContent, Relation, TextMessageEventContent,
+            AudioMessageEventContent, CustomEventContent, MessageEventContent, Relation,
+            TextMessageEventContent,
         },
         relationships::InReplyTo,
     },
@@ -70,6 +71,52 @@ fn content_serialization() {
             "msgtype": "m.audio",
             "url": "http://example.com/audio.mp3"
         })
+    );
+}
+
+#[test]
+fn custom_content_serialization() {
+    let json_data = vec![("custom_field", "baba"), ("another_one", "abab")]
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), json!(v)))
+        .collect();
+    let custom_event_content = MessageEventContent::_Custom(CustomEventContent {
+        msgtype: "my_custom_msgtype".into(),
+        data: json_data,
+    });
+
+    assert_eq!(
+        to_json_value(&custom_event_content).unwrap(),
+        json!({
+            "msgtype": "my_custom_msgtype",
+            "custom_field": "baba",
+            "another_one": "abab",
+        })
+    );
+}
+
+#[test]
+fn custom_content_deserialization() {
+    let json_data = json!({
+        "msgtype": "my_custom_msgtype",
+        "custom_field": "baba",
+        "another_one": "abab",
+    });
+
+    let expected_json_data = vec![("custom_field", "baba"), ("another_one", "abab")]
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), json!(v)))
+        .collect();
+
+    assert_matches!(
+        from_json_value::<Raw<MessageEventContent>>(json_data)
+            .unwrap()
+            .deserialize()
+            .unwrap(),
+        MessageEventContent::_Custom(CustomEventContent {
+            msgtype,
+            data
+        }) if msgtype == "my_custom_msgtype" && data == expected_json_data
     );
 }
 


### PR DESCRIPTION
 - [x] write custom `Deserialize` implementation
 - [x] work without `serde(tag)`
 - [x] include `_Custom(...)` variant in `MessageEventContent`
 ~Public API / Accessor methods~
~Tests~

Implements most of #406.