### PR TITLE
Move new_content and relates_to fields to MessageEventContent struct

### DIFF
--- a/ruma-client/examples/message_log.rs
+++ b/ruma-client/examples/message_log.rs
@@ -5,7 +5,7 @@ use http::Uri;
 use ruma::{
     api::client::r0::{filter::FilterDefinition, sync::sync_events},
     events::{
-        room::message::{MessageEventContent, TextMessageEventContent},
+        room::message::{MessageEventContent, MessageType, TextMessageEventContent},
         AnySyncMessageEvent, AnySyncRoomEvent, SyncMessageEvent,
     },
     presence::PresenceState,
@@ -40,9 +40,13 @@ async fn log_messages(homeserver_url: Uri, username: &str, password: &str) -> an
                 if let AnySyncRoomEvent::Message(AnySyncMessageEvent::RoomMessage(
                     SyncMessageEvent {
                         content:
-                            MessageEventContent::Text(TextMessageEventContent {
-                                body: msg_body, ..
-                            }),
+                            MessageEventContent {
+                                msgtype:
+                                    MessageType::Text(TextMessageEventContent {
+                                        body: msg_body, ..
+                                    }),
+                                ..
+                            },
                         sender,
                         ..
                     },

--- a/ruma-events/src/room/message.rs
+++ b/ruma-events/src/room/message.rs
@@ -67,42 +67,22 @@ impl MessageEventContent {
 
     /// A constructor to create a plain text message.
     pub fn text_plain(body: impl Into<String>) -> Self {
-        Self {
-            msgtype: MessageType::Text(TextMessageEventContent::plain(body)),
-            relates_to: None,
-            #[cfg(feature = "unstable-pre-spec")]
-            new_content: None,
-        }
+        Self::new(MessageType::Text(TextMessageEventContent::plain(body)))
     }
 
     /// A constructor to create an html message.
     pub fn text_html(body: impl Into<String>, html_body: impl Into<String>) -> Self {
-        Self {
-            msgtype: MessageType::Text(TextMessageEventContent::html(body, html_body)),
-            relates_to: None,
-            #[cfg(feature = "unstable-pre-spec")]
-            new_content: None,
-        }
+        Self::new(MessageType::Text(TextMessageEventContent::html(body, html_body)))
     }
 
     /// A constructor to create a plain text notice.
     pub fn notice_plain(body: impl Into<String>) -> Self {
-        Self {
-            msgtype: MessageType::Notice(NoticeMessageEventContent::plain(body)),
-            relates_to: None,
-            #[cfg(feature = "unstable-pre-spec")]
-            new_content: None,
-        }
+        Self::new(MessageType::Notice(NoticeMessageEventContent::plain(body)))
     }
 
     /// A constructor to create an html notice.
     pub fn notice_html(body: impl Into<String>, html_body: impl Into<String>) -> Self {
-        Self {
-            msgtype: MessageType::Notice(NoticeMessageEventContent::html(body, html_body)),
-            relates_to: None,
-            #[cfg(feature = "unstable-pre-spec")]
-            new_content: None,
-        }
+        Self::new(MessageType::Notice(NoticeMessageEventContent::html(body, html_body)))
     }
 }
 

--- a/ruma-events/src/room/message.rs
+++ b/ruma-events/src/room/message.rs
@@ -55,8 +55,7 @@ pub struct MessageEventContent {
 }
 
 impl MessageEventContent {
-    /// A convenience constructor to create a `MessageEventContent` with the given
-    /// `MessageType`.
+    /// Create a `MessageEventContent` with the given `MessageType`.
     pub fn new(msgtype: MessageType) -> Self {
         Self {
             msgtype,
@@ -66,7 +65,7 @@ impl MessageEventContent {
         }
     }
 
-    /// A convenience constructor to create a plain text message.
+    /// A constructor to create a plain text message.
     pub fn text_plain(body: impl Into<String>) -> Self {
         Self {
             msgtype: MessageType::Text(TextMessageEventContent::plain(body)),
@@ -76,7 +75,7 @@ impl MessageEventContent {
         }
     }
 
-    /// A convenience constructor to create an html message.
+    /// A constructor to create an html message.
     pub fn text_html(body: impl Into<String>, html_body: impl Into<String>) -> Self {
         Self {
             msgtype: MessageType::Text(TextMessageEventContent::html(body, html_body)),
@@ -86,7 +85,7 @@ impl MessageEventContent {
         }
     }
 
-    /// A convenience constructor to create a plain text notice.
+    /// A constructor to create a plain text notice.
     pub fn notice_plain(body: impl Into<String>) -> Self {
         Self {
             msgtype: MessageType::Notice(NoticeMessageEventContent::plain(body)),
@@ -96,7 +95,7 @@ impl MessageEventContent {
         }
     }
 
-    /// A convenience constructor to create an html notice.
+    /// A constructor to create an html notice.
     pub fn notice_html(body: impl Into<String>, html_body: impl Into<String>) -> Self {
         Self {
             msgtype: MessageType::Notice(NoticeMessageEventContent::html(body, html_body)),
@@ -150,12 +149,7 @@ pub enum MessageType {
 
 impl From<MessageType> for MessageEventContent {
     fn from(msgtype: MessageType) -> Self {
-        Self {
-            msgtype,
-            relates_to: None,
-            #[cfg(feature = "unstable-pre-spec")]
-            new_content: None,
-        }
+        Self::new(msgtype)
     }
 }
 

--- a/ruma-events/src/room/message/content_serde.rs
+++ b/ruma-events/src/room/message/content_serde.rs
@@ -5,21 +5,19 @@ use serde_json::value::RawValue as RawJsonValue;
 
 use crate::{
     from_raw_json_value,
-    room::message::{MessageEventContent, MessageType},
+    room::message::{MessageEventContent, MessageType, Relation},
 };
 
 /// Helper struct to determine the msgtype, relates_to and new_content fields
 /// from a `serde_json::value::RawValue`
 #[derive(Debug, Deserialize)]
 struct MessageContentDeHelper {
-    msgtype: String,
-
     #[serde(rename = "m.relates_to")]
-    relates_to: Option<Box<RawJsonValue>>,
+    relates_to: Option<Relation>,
 
     #[cfg(feature = "unstable-pre-spec")]
     #[serde(rename = "m.new_content")]
-    new_content: Option<Box<RawJsonValue>>,
+    new_content: Option<MessageEventContent>,
 }
 
 impl<'de> de::Deserialize<'de> for MessageEventContent {
@@ -28,80 +26,13 @@ impl<'de> de::Deserialize<'de> for MessageEventContent {
         D: de::Deserializer<'de>,
     {
         let json = Box::<RawJsonValue>::deserialize(deserializer)?;
-        #[cfg(feature = "unstable-pre-spec")]
-        let MessageContentDeHelper { msgtype, relates_to, new_content } =
-            from_raw_json_value(&json)?;
-        #[cfg(not(feature = "unstable-pre-spec"))]
-        let MessageContentDeHelper { msgtype, relates_to } = from_raw_json_value(&json)?;
+        let helper = from_raw_json_value::<MessageContentDeHelper, D::Error>(&json)?;
 
-        Ok(match msgtype.as_str() {
-            "m.audio" => Self {
-                msgtype: MessageType::Audio(from_raw_json_value(&json)?),
-                relates_to: relates_to.map(|json| from_raw_json_value(&json)).transpose()?,
-                #[cfg(feature = "unstable-pre-spec")]
-                new_content: new_content.map(|json| from_raw_json_value(&json)).transpose()?,
-            },
-            "m.emote" => Self {
-                msgtype: MessageType::Emote(from_raw_json_value(&json)?),
-                relates_to: relates_to.map(|json| from_raw_json_value(&json)).transpose()?,
-                #[cfg(feature = "unstable-pre-spec")]
-                new_content: new_content.map(|json| from_raw_json_value(&json)).transpose()?,
-            },
-            "m.file" => Self {
-                msgtype: MessageType::File(from_raw_json_value(&json)?),
-                relates_to: relates_to.map(|json| from_raw_json_value(&json)).transpose()?,
-                #[cfg(feature = "unstable-pre-spec")]
-                new_content: new_content.map(|json| from_raw_json_value(&json)).transpose()?,
-            },
-            "m.image" => Self {
-                msgtype: MessageType::Image(from_raw_json_value(&json)?),
-                relates_to: relates_to.map(|json| from_raw_json_value(&json)).transpose()?,
-                #[cfg(feature = "unstable-pre-spec")]
-                new_content: new_content.map(|json| from_raw_json_value(&json)).transpose()?,
-            },
-            "m.location" => Self {
-                msgtype: MessageType::Location(from_raw_json_value(&json)?),
-                relates_to: relates_to.map(|json| from_raw_json_value(&json)).transpose()?,
-                #[cfg(feature = "unstable-pre-spec")]
-                new_content: new_content.map(|json| from_raw_json_value(&json)).transpose()?,
-            },
-            "m.notice" => Self {
-                msgtype: MessageType::Notice(from_raw_json_value(&json)?),
-                relates_to: relates_to.map(|json| from_raw_json_value(&json)).transpose()?,
-                #[cfg(feature = "unstable-pre-spec")]
-                new_content: new_content.map(|json| from_raw_json_value(&json)).transpose()?,
-            },
-            "m.server_notice" => Self {
-                msgtype: MessageType::ServerNotice(from_raw_json_value(&json)?),
-                relates_to: relates_to.map(|json| from_raw_json_value(&json)).transpose()?,
-                #[cfg(feature = "unstable-pre-spec")]
-                new_content: new_content.map(|json| from_raw_json_value(&json)).transpose()?,
-            },
-            "m.text" => Self {
-                msgtype: MessageType::Text(from_raw_json_value(&json)?),
-                relates_to: relates_to.map(|json| from_raw_json_value(&json)).transpose()?,
-                #[cfg(feature = "unstable-pre-spec")]
-                new_content: new_content.map(|json| from_raw_json_value(&json)).transpose()?,
-            },
-            "m.video" => Self {
-                msgtype: MessageType::Video(from_raw_json_value(&json)?),
-                relates_to: relates_to.map(|json| from_raw_json_value(&json)).transpose()?,
-                #[cfg(feature = "unstable-pre-spec")]
-                new_content: new_content.map(|json| from_raw_json_value(&json)).transpose()?,
-            },
+        Ok(Self {
+            msgtype: from_raw_json_value(&json)?,
+            relates_to: helper.relates_to,
             #[cfg(feature = "unstable-pre-spec")]
-            "m.key.verification.request" => Self {
-                msgtype: MessageType::VerificationRequest(from_raw_json_value(&json)?),
-                relates_to: relates_to.map(|json| from_raw_json_value(&json)).transpose()?,
-                #[cfg(feature = "unstable-pre-spec")]
-                new_content: new_content.map(|json| from_raw_json_value(&json)).transpose()?,
-            },
-            _ => Self {
-                msgtype: MessageType::_Custom(from_raw_json_value(&json)?),
-                relates_to: relates_to.map(|json| from_raw_json_value(&json)).transpose()?,
-                #[cfg(feature = "unstable-pre-spec")]
-                new_content: new_content.map(|json| from_raw_json_value(&json)).transpose()?,
-            },
+            new_content: helper.relates_to,
         })
     }
 }

--- a/ruma-events/src/room/message/content_serde.rs
+++ b/ruma-events/src/room/message/content_serde.rs
@@ -1,15 +1,25 @@
-//! `Deserialize` implementation for MessageEventContent
+// //! `Deserialize` implementation for MessageEventContent
 
 use serde::{de, Deserialize};
 use serde_json::value::RawValue as RawJsonValue;
 
-use crate::{from_raw_json_value, room::message::MessageEventContent};
+use crate::{
+    from_raw_json_value,
+    room::message::{MessageEventContent, MessageType},
+};
 
-/// Helper struct to determine the msgtype from a `serde_json::value::RawValue`
+/// Helper struct to determine the msgtype, relates_to and new_content fields
+/// from a `serde_json::value::RawValue`
 #[derive(Debug, Deserialize)]
-struct MessageDeHelper {
-    /// The message type field
+struct MessageContentDeHelper {
     msgtype: String,
+
+    #[serde(rename = "m.relates_to")]
+    relates_to: Option<Box<RawJsonValue>>,
+
+    #[cfg(feature = "unstable-pre-spec")]
+    #[serde(rename = "m.new_content")]
+    new_content: Option<Box<RawJsonValue>>,
 }
 
 impl<'de> de::Deserialize<'de> for MessageEventContent {
@@ -18,7 +28,98 @@ impl<'de> de::Deserialize<'de> for MessageEventContent {
         D: de::Deserializer<'de>,
     {
         let json = Box::<RawJsonValue>::deserialize(deserializer)?;
-        let MessageDeHelper { msgtype } = from_raw_json_value(&json)?;
+        #[cfg(feature = "unstable-pre-spec")]
+        let MessageContentDeHelper { msgtype, relates_to, new_content } =
+            from_raw_json_value(&json)?;
+        #[cfg(not(feature = "unstable-pre-spec"))]
+        let MessageContentDeHelper { msgtype, relates_to } = from_raw_json_value(&json)?;
+
+        Ok(match msgtype.as_str() {
+            "m.audio" => Self {
+                msgtype: MessageType::Audio(from_raw_json_value(&json)?),
+                relates_to: relates_to.map(|json| from_raw_json_value(&json)).transpose()?,
+                #[cfg(feature = "unstable-pre-spec")]
+                new_content: new_content.map(|json| from_raw_json_value(&json)).transpose()?,
+            },
+            "m.emote" => Self {
+                msgtype: MessageType::Emote(from_raw_json_value(&json)?),
+                relates_to: relates_to.map(|json| from_raw_json_value(&json)).transpose()?,
+                #[cfg(feature = "unstable-pre-spec")]
+                new_content: new_content.map(|json| from_raw_json_value(&json)).transpose()?,
+            },
+            "m.file" => Self {
+                msgtype: MessageType::File(from_raw_json_value(&json)?),
+                relates_to: relates_to.map(|json| from_raw_json_value(&json)).transpose()?,
+                #[cfg(feature = "unstable-pre-spec")]
+                new_content: new_content.map(|json| from_raw_json_value(&json)).transpose()?,
+            },
+            "m.image" => Self {
+                msgtype: MessageType::Image(from_raw_json_value(&json)?),
+                relates_to: relates_to.map(|json| from_raw_json_value(&json)).transpose()?,
+                #[cfg(feature = "unstable-pre-spec")]
+                new_content: new_content.map(|json| from_raw_json_value(&json)).transpose()?,
+            },
+            "m.location" => Self {
+                msgtype: MessageType::Location(from_raw_json_value(&json)?),
+                relates_to: relates_to.map(|json| from_raw_json_value(&json)).transpose()?,
+                #[cfg(feature = "unstable-pre-spec")]
+                new_content: new_content.map(|json| from_raw_json_value(&json)).transpose()?,
+            },
+            "m.notice" => Self {
+                msgtype: MessageType::Notice(from_raw_json_value(&json)?),
+                relates_to: relates_to.map(|json| from_raw_json_value(&json)).transpose()?,
+                #[cfg(feature = "unstable-pre-spec")]
+                new_content: new_content.map(|json| from_raw_json_value(&json)).transpose()?,
+            },
+            "m.server_notice" => Self {
+                msgtype: MessageType::ServerNotice(from_raw_json_value(&json)?),
+                relates_to: relates_to.map(|json| from_raw_json_value(&json)).transpose()?,
+                #[cfg(feature = "unstable-pre-spec")]
+                new_content: new_content.map(|json| from_raw_json_value(&json)).transpose()?,
+            },
+            "m.text" => Self {
+                msgtype: MessageType::Text(from_raw_json_value(&json)?),
+                relates_to: relates_to.map(|json| from_raw_json_value(&json)).transpose()?,
+                #[cfg(feature = "unstable-pre-spec")]
+                new_content: new_content.map(|json| from_raw_json_value(&json)).transpose()?,
+            },
+            "m.video" => Self {
+                msgtype: MessageType::Video(from_raw_json_value(&json)?),
+                relates_to: relates_to.map(|json| from_raw_json_value(&json)).transpose()?,
+                #[cfg(feature = "unstable-pre-spec")]
+                new_content: new_content.map(|json| from_raw_json_value(&json)).transpose()?,
+            },
+            #[cfg(feature = "unstable-pre-spec")]
+            "m.key.verification.request" => Self {
+                msgtype: MessageType::VerificationRequest(from_raw_json_value(&json)?),
+                relates_to: relates_to.map(|json| from_raw_json_value(&json)).transpose()?,
+                #[cfg(feature = "unstable-pre-spec")]
+                new_content: new_content.map(|json| from_raw_json_value(&json)).transpose()?,
+            },
+            _ => Self {
+                msgtype: MessageType::_Custom(from_raw_json_value(&json)?),
+                relates_to: relates_to.map(|json| from_raw_json_value(&json)).transpose()?,
+                #[cfg(feature = "unstable-pre-spec")]
+                new_content: new_content.map(|json| from_raw_json_value(&json)).transpose()?,
+            },
+        })
+    }
+}
+
+/// Helper struct to determine the msgtype from a `serde_json::value::RawValue`
+#[derive(Debug, Deserialize)]
+struct MessageTypeDeHelper {
+    /// The message type field
+    msgtype: String,
+}
+
+impl<'de> de::Deserialize<'de> for MessageType {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        let json = Box::<RawJsonValue>::deserialize(deserializer)?;
+        let MessageTypeDeHelper { msgtype } = from_raw_json_value(&json)?;
 
         Ok(match msgtype.as_ref() {
             "m.audio" => Self::Audio(from_raw_json_value(&json)?),

--- a/ruma-events/src/room/message/content_serde.rs
+++ b/ruma-events/src/room/message/content_serde.rs
@@ -1,4 +1,4 @@
-// //! `Deserialize` implementation for MessageEventContent
+//! `Deserialize` implementation for MessageEventContent and MessageType.
 
 use serde::{de, Deserialize};
 use serde_json::value::RawValue as RawJsonValue;
@@ -17,7 +17,7 @@ struct MessageContentDeHelper {
 
     #[cfg(feature = "unstable-pre-spec")]
     #[serde(rename = "m.new_content")]
-    new_content: Option<MessageEventContent>,
+    new_content: Option<Box<MessageEventContent>>,
 }
 
 impl<'de> de::Deserialize<'de> for MessageEventContent {
@@ -32,7 +32,7 @@ impl<'de> de::Deserialize<'de> for MessageEventContent {
             msgtype: from_raw_json_value(&json)?,
             relates_to: helper.relates_to,
             #[cfg(feature = "unstable-pre-spec")]
-            new_content: helper.relates_to,
+            new_content: helper.new_content,
         })
     }
 }

--- a/ruma-events/tests/enums.rs
+++ b/ruma-events/tests/enums.rs
@@ -5,7 +5,7 @@ use serde_json::{from_value as from_json_value, json, Value as JsonValue};
 use ruma_events::{
     room::{
         aliases::AliasesEventContent,
-        message::{MessageEventContent, TextMessageEventContent},
+        message::{MessageEventContent, MessageType, TextMessageEventContent},
         power_levels::PowerLevelsEventContent,
     },
     AnyEvent, AnyMessageEvent, AnyRoomEvent, AnyStateEvent, AnyStateEventContent,
@@ -137,12 +137,14 @@ fn message_event_sync_deserialization() {
         from_json_value::<AnySyncRoomEvent>(json_data),
         Ok(AnySyncRoomEvent::Message(
             AnySyncMessageEvent::RoomMessage(SyncMessageEvent {
-                content: MessageEventContent::Text(TextMessageEventContent {
-                    body,
-                    formatted: Some(formatted),
-                    relates_to: None,
+                content: MessageEventContent {
+                    msgtype: MessageType::Text(TextMessageEventContent {
+                        body,
+                        formatted: Some(formatted),
+                        ..
+                    }),
                     ..
-                }),
+                },
                 ..
             })
         ))
@@ -177,12 +179,14 @@ fn message_room_event_deserialization() {
         from_json_value::<AnyRoomEvent>(json_data),
         Ok(AnyRoomEvent::Message(
             AnyMessageEvent::RoomMessage(MessageEvent {
-                content: MessageEventContent::Text(TextMessageEventContent {
-                    body,
-                    formatted: Some(formatted),
-                    relates_to: None,
+                content: MessageEventContent {
+                    msgtype: MessageType::Text(TextMessageEventContent {
+                        body,
+                        formatted: Some(formatted),
+                        ..
+                    }),
                     ..
-                }),
+                },
                 ..
             })
         ))
@@ -217,12 +221,14 @@ fn message_event_deserialization() {
         from_json_value::<AnyEvent>(json_data),
         Ok(AnyEvent::Message(
             AnyMessageEvent::RoomMessage(MessageEvent {
-                content: MessageEventContent::Text(TextMessageEventContent {
-                    body,
-                    formatted: Some(formatted),
-                    relates_to: None,
+                content: MessageEventContent {
+                    msgtype: MessageType::Text(TextMessageEventContent {
+                        body,
+                        formatted: Some(formatted),
+                        ..
+                    }),
                     ..
-                }),
+                },
                 ..
             })
         ))

--- a/ruma-events/tests/room_message.rs
+++ b/ruma-events/tests/room_message.rs
@@ -26,16 +26,12 @@ use serde_json::{from_value as from_json_value, json, to_value as to_json_value}
 #[test]
 fn serialization() {
     let ev = MessageEvent {
-        content: assign!(MessageEventContent::new(
-            MessageType::Audio(AudioMessageEventContent {
-                body: "test".into(),
-                info: None,
-                url: Some("http://example.com/audio.mp3".into()),
-                file: None,
-            }),
-        ), {
-            relates_to: None,
-        }),
+        content: MessageEventContent::new(MessageType::Audio(AudioMessageEventContent {
+            body: "test".into(),
+            info: None,
+            url: Some("http://example.com/audio.mp3".into()),
+            file: None,
+        })),
         event_id: event_id!("$143273582443PhrSn:example.org"),
         origin_server_ts: UNIX_EPOCH + Duration::from_millis(10_000),
         room_id: room_id!("!testroomid:example.org"),
@@ -62,16 +58,13 @@ fn serialization() {
 
 #[test]
 fn content_serialization() {
-    let message_event_content = assign!(MessageEventContent::new(
-        MessageType::Audio(AudioMessageEventContent {
+    let message_event_content =
+        MessageEventContent::new(MessageType::Audio(AudioMessageEventContent {
             body: "test".into(),
             info: None,
             url: Some("http://example.com/audio.mp3".into()),
             file: None,
-        }),
-    ), {
-        relates_to: None,
-    });
+        }));
 
     assert_eq!(
         to_json_value(&message_event_content).unwrap(),
@@ -164,10 +157,10 @@ fn plain_text_content_serialization() {
 fn relates_to_content_serialization() {
     let message_event_content =
         assign!(MessageEventContent::text_plain("> <@test:example.com> test\n\ntest reply"), {
-        relates_to: Some(Relation::Reply {
-            in_reply_to: InReplyTo { event_id: event_id!("$15827405538098VGFWH:example.com") },
-        }),
-    });
+            relates_to: Some(Relation::Reply {
+                in_reply_to: InReplyTo { event_id: event_id!("$15827405538098VGFWH:example.com") },
+            }),
+        });
 
     let json_data = json!({
         "body": "> <@test:example.com> test\n\ntest reply",

--- a/ruma-events/tests/room_message.rs
+++ b/ruma-events/tests/room_message.rs
@@ -229,17 +229,23 @@ fn edit_deserialization_future() {
             msgtype: MessageType::Text(TextMessageEventContent {
                 body,
                 formatted: None,
+                ..
             }),
             relates_to: Some(Relation::Replacement(Replacement { event_id })),
             new_content: Some(new_content),
+            ..
         } if body == "s/foo/bar"
             && event_id == ev_id
             && matches!(
                 &*new_content,
-                MessageEventContent::Text(TextMessageEventContent {
-                    body,
-                    formatted: None,
-                }) if body == "bar"
+                MessageEventContent {
+                    msgtype: MessageType::Text(TextMessageEventContent {
+                        body,
+                        formatted: None,
+                        ..
+                    }),
+                    ..
+                } if body == "bar"
             )
     );
 }
@@ -264,12 +270,15 @@ fn verification_request_deserialization() {
 
     assert_matches!(
         from_json_value::<MessageEventContent>(json_data).unwrap(),
-        MessageEventContent::VerificationRequest(KeyVerificationRequestEventContent {
-            body,
-            to,
-            from_device,
-            methods,
-        }) if body == "@example:localhost is requesting to verify your key, ..."
+        MessageEventContent {
+            msgtype: MessageType::VerificationRequest(KeyVerificationRequestEventContent {
+                body,
+                to,
+                from_device,
+                methods,
+            }),
+            ..
+        } if body == "@example:localhost is requesting to verify your key, ..."
             && to == user_id
             && from_device == device_id
             && methods.contains(&VerificationMethod::MSasV1)
@@ -297,7 +306,7 @@ fn verification_request_serialization() {
         "methods": methods
     });
 
-    let content = MessageEventContent::VerificationRequest(KeyVerificationRequestEventContent {
+    let content = MessageType::VerificationRequest(KeyVerificationRequestEventContent {
         to: user_id,
         from_device: device_id,
         body,

--- a/ruma-events/tests/room_message.rs
+++ b/ruma-events/tests/room_message.rs
@@ -26,13 +26,14 @@ use serde_json::{from_value as from_json_value, json, to_value as to_json_value}
 #[test]
 fn serialization() {
     let ev = MessageEvent {
-        content: assign!(MessageEventContent::text_plain(""), {
-            msgtype: MessageType::Audio(AudioMessageEventContent {
+        content: assign!(MessageEventContent::new(
+            MessageType::Audio(AudioMessageEventContent {
                 body: "test".into(),
                 info: None,
                 url: Some("http://example.com/audio.mp3".into()),
                 file: None,
             }),
+        ), {
             relates_to: None,
         }),
         event_id: event_id!("$143273582443PhrSn:example.org"),
@@ -61,13 +62,14 @@ fn serialization() {
 
 #[test]
 fn content_serialization() {
-    let message_event_content = assign!(MessageEventContent::text_plain(""), {
-        msgtype: MessageType::Audio(AudioMessageEventContent {
+    let message_event_content = assign!(MessageEventContent::new(
+        MessageType::Audio(AudioMessageEventContent {
             body: "test".into(),
             info: None,
             url: Some("http://example.com/audio.mp3".into()),
             file: None,
         }),
+    ), {
         relates_to: None,
     });
 
@@ -87,7 +89,7 @@ fn custom_content_serialization() {
         "custom_field".into() => json!("baba"),
         "another_one".into() => json!("abab"),
     };
-    let custom_event_content = MessageEventContent::_Custom(CustomEventContent {
+    let custom_event_content = MessageType::_Custom(CustomEventContent {
         msgtype: "my_custom_msgtype".into(),
         data: json_data,
     });
@@ -116,11 +118,11 @@ fn custom_content_deserialization() {
     };
 
     assert_matches!(
-        from_json_value::<Raw<MessageEventContent>>(json_data)
+        from_json_value::<Raw<MessageType>>(json_data)
             .unwrap()
             .deserialize()
             .unwrap(),
-        MessageEventContent::_Custom(CustomEventContent {
+        MessageType::_Custom(CustomEventContent {
             msgtype,
             data
         }) if msgtype == "my_custom_msgtype"
@@ -160,7 +162,6 @@ fn plain_text_content_serialization() {
 
 #[test]
 fn relates_to_content_serialization() {
-    // TODO: this should fail once relates_to + new_content are merged, then fix test
     let message_event_content =
         assign!(MessageEventContent::text_plain("> <@test:example.com> test\n\ntest reply"), {
         relates_to: Some(Relation::Reply {


### PR DESCRIPTION
resolves #405 or at least get it going.

`MessageEventContent` used to be an enum, it now has a `msgtype` field where the enum (now called `MessageType`) sits.