### PR TITLE
Set Content-Type to `application/json` in all manual endpoint trait implementations

### DIFF
--- a/ruma-client-api/src/r0/message/send_message_event.rs
+++ b/ruma-client-api/src/r0/message/send_message_event.rs
@@ -121,7 +121,7 @@ impl<'a> ruma_api::OutgoingRequest for Request<'a> {
         base_url: &str,
         access_token: Option<&str>,
     ) -> Result<http::Request<Vec<u8>>, IntoHttpError> {
-        use http::header::{HeaderValue, AUTHORIZATION};
+        use http::header::{HeaderValue, AUTHORIZATION, CONTENT_TYPE};
         use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 
         let http_request = http::Request::builder()
@@ -145,6 +145,7 @@ impl<'a> ruma_api::OutgoingRequest for Request<'a> {
                     access_token.ok_or(IntoHttpError::NeedsAuthentication)?
                 ))?,
             )
+            .header(CONTENT_TYPE, "application/json")
             .body(serde_json::to_vec(&self.content)?)?;
 
         Ok(http_request)

--- a/ruma-client-api/src/r0/state/send_state_event_for_empty_key.rs
+++ b/ruma-client-api/src/r0/state/send_state_event_for_empty_key.rs
@@ -114,7 +114,7 @@ impl<'a> ruma_api::OutgoingRequest for Request<'a> {
         base_url: &str,
         access_token: Option<&str>,
     ) -> Result<http::Request<Vec<u8>>, IntoHttpError> {
-        use http::header::{HeaderValue, AUTHORIZATION};
+        use http::header::{HeaderValue, AUTHORIZATION, CONTENT_TYPE};
         use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 
         let http_request = http::Request::builder()
@@ -137,6 +137,7 @@ impl<'a> ruma_api::OutgoingRequest for Request<'a> {
                     access_token.ok_or(IntoHttpError::NeedsAuthentication)?
                 ))?,
             )
+            .header(CONTENT_TYPE, "application/json")
             .body(serde_json::to_vec(&self.content)?)?;
 
         Ok(http_request)

--- a/ruma-client-api/src/r0/state/send_state_event_for_key.rs
+++ b/ruma-client-api/src/r0/state/send_state_event_for_key.rs
@@ -117,7 +117,7 @@ impl<'a> ruma_api::OutgoingRequest for Request<'a> {
         base_url: &str,
         access_token: Option<&str>,
     ) -> Result<http::Request<Vec<u8>>, IntoHttpError> {
-        use http::header::{HeaderValue, AUTHORIZATION};
+        use http::header::{HeaderValue, AUTHORIZATION, CONTENT_TYPE};
         use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 
         let http_request = http::Request::builder()
@@ -141,6 +141,7 @@ impl<'a> ruma_api::OutgoingRequest for Request<'a> {
                     access_token.ok_or(IntoHttpError::NeedsAuthentication)?
                 ))?,
             )
+            .header(CONTENT_TYPE, "application/json")
             .body(serde_json::to_vec(&self.content)?)?;
 
         Ok(http_request)


### PR DESCRIPTION
Closes #431.