### PR TITLE
Deserialize empty strings to none for some URLs

### DIFF
--- a/ruma-client-api/src/r0/account/request_3pid_management_token_via_email.rs
+++ b/ruma-client-api/src/r0/account/request_3pid_management_token_via_email.rs
@@ -41,6 +41,10 @@ ruma_api! {
 
         /// URL to submit validation token to. If omitted, verification happens without client.
         #[serde(skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(
+            feature = "compat",
+            serde(default, deserialize_with = "ruma_serde::empty_string_as_none")
+        )]
         pub submit_url: Option<String>
     }
 

--- a/ruma-client-api/src/r0/account/request_3pid_management_token_via_msisdn.rs
+++ b/ruma-client-api/src/r0/account/request_3pid_management_token_via_msisdn.rs
@@ -44,6 +44,10 @@ ruma_api! {
 
         /// URL to submit validation token to. If omitted, verification happens without client.
         #[serde(skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(
+            feature = "compat",
+            serde(default, deserialize_with = "ruma_serde::empty_string_as_none")
+        )]
         pub submit_url: Option<String>
     }
 

--- a/ruma-client-api/src/r0/account/request_password_change_token_via_email.rs
+++ b/ruma-client-api/src/r0/account/request_password_change_token_via_email.rs
@@ -41,6 +41,10 @@ ruma_api! {
 
         /// URL to submit validation token to. If omitted, verification happens without client.
         #[serde(skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(
+            feature = "compat",
+            serde(default, deserialize_with = "ruma_serde::empty_string_as_none")
+        )]
         pub submit_url: Option<String>
     }
 

--- a/ruma-client-api/src/r0/account/request_password_change_token_via_msisdn.rs
+++ b/ruma-client-api/src/r0/account/request_password_change_token_via_msisdn.rs
@@ -37,6 +37,10 @@ ruma_api! {
 
         /// URL to submit validation token to. If omitted, verification happens without client.
         #[serde(skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(
+            feature = "compat",
+            serde(default, deserialize_with = "ruma_serde::empty_string_as_none")
+        )]
         pub submit_url: Option<String>
     }
 

--- a/ruma-client-api/src/r0/account/request_registration_token_via_email.rs
+++ b/ruma-client-api/src/r0/account/request_registration_token_via_email.rs
@@ -41,6 +41,10 @@ ruma_api! {
 
         /// URL to submit validation token to. If omitted, verification happens without client.
         #[serde(skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(
+            feature = "compat",
+            serde(default, deserialize_with = "ruma_serde::empty_string_as_none")
+        )]
         pub submit_url: Option<String>
     }
 

--- a/ruma-client-api/src/r0/account/request_registration_token_via_msisdn.rs
+++ b/ruma-client-api/src/r0/account/request_registration_token_via_msisdn.rs
@@ -44,6 +44,10 @@ ruma_api! {
 
         /// URL to submit validation token to. If omitted, verification happens without client.
         #[serde(skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(
+            feature = "compat",
+            serde(default, deserialize_with = "ruma_serde::empty_string_as_none")
+        )]
         pub submit_url: Option<String>
     }
 

--- a/ruma-client-api/src/r0/directory.rs
+++ b/ruma-client-api/src/r0/directory.rs
@@ -45,6 +45,10 @@ pub struct PublicRoomsChunk {
 
     /// The URL for the room's avatar, if one is set.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(
+        feature = "compat",
+        serde(default, deserialize_with = "ruma_serde::empty_string_as_none")
+    )]
     pub avatar_url: Option<String>,
 }
 

--- a/ruma-client-api/src/r0/membership/joined_members.rs
+++ b/ruma-client-api/src/r0/membership/joined_members.rs
@@ -68,3 +68,37 @@ impl RoomMember {
         Default::default()
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::RoomMember;
+    use matches::assert_matches;
+    use serde_json::{from_value as from_json_value, json};
+
+    #[test]
+    fn deserialize_room_member() {
+        assert_matches!(
+            from_json_value::<RoomMember>(json!({
+                "display_name": "alice",
+                "avatar_url": "mxc://localhost:wefuiwegh8742w",
+            })).unwrap(),
+            RoomMember {
+                display_name: Some(display_name),
+                avatar_url: Some(avatar_url),
+            } if display_name == "alice"
+                && avatar_url == "mxc://localhost:wefuiwegh8742w"
+        );
+
+        #[cfg(feature = "compat")]
+        assert_matches!(
+            from_json_value::<RoomMember>(json!({
+                "display_name": "alice",
+                "avatar_url": "",
+            })).unwrap(),
+            RoomMember {
+                display_name: Some(display_name),
+                avatar_url: None,
+            } if display_name == "alice"
+        );
+    }
+}

--- a/ruma-client-api/src/r0/membership/joined_members.rs
+++ b/ruma-client-api/src/r0/membership/joined_members.rs
@@ -55,6 +55,10 @@ pub struct RoomMember {
 
     /// The mxc avatar url of the user.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(
+        feature = "compat",
+        serde(default, deserialize_with = "ruma_serde::empty_string_as_none")
+    )]
     pub avatar_url: Option<String>,
 }
 

--- a/ruma-client-api/src/r0/profile/get_avatar_url.rs
+++ b/ruma-client-api/src/r0/profile/get_avatar_url.rs
@@ -26,6 +26,10 @@ ruma_api! {
     response: {
         /// The user's avatar URL, if set.
         #[serde(skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(
+            feature = "compat",
+            serde(default, deserialize_with = "ruma_serde::empty_string_as_none")
+        )]
         pub avatar_url: Option<String>
     }
 

--- a/ruma-client-api/src/r0/profile/get_profile.rs
+++ b/ruma-client-api/src/r0/profile/get_profile.rs
@@ -26,6 +26,10 @@ ruma_api! {
     response: {
         /// The user's avatar URL, if set.
         #[serde(skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(
+            feature = "compat",
+            serde(default, deserialize_with = "ruma_serde::empty_string_as_none")
+        )]
         pub avatar_url: Option<String>,
 
         /// The user's display name, if set.

--- a/ruma-client-api/src/r0/search/search_events.rs
+++ b/ruma-client-api/src/r0/search/search_events.rs
@@ -437,6 +437,10 @@ impl SearchResult {
 pub struct UserProfile {
     /// The user's avatar URL, if set.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(
+        feature = "compat",
+        serde(default, deserialize_with = "ruma_serde::empty_string_as_none")
+    )]
     pub avatar_url: Option<String>,
 
     /// The user's display name, if set.

--- a/ruma-client-api/src/r0/user_directory/search_users.rs
+++ b/ruma-client-api/src/r0/user_directory/search_users.rs
@@ -79,5 +79,9 @@ pub struct User {
 
     /// The avatar url, as an MXC, if one exists.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(
+        feature = "compat",
+        serde(default, deserialize_with = "ruma_serde::empty_string_as_none")
+    )]
     pub avatar_url: Option<String>,
 }

--- a/ruma-common/src/directory.rs
+++ b/ruma-common/src/directory.rs
@@ -51,6 +51,10 @@ pub struct PublicRoomsChunk {
 
     /// The URL for the room's avatar, if one is set.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(
+        feature = "compat",
+        serde(default, deserialize_with = "ruma_serde::empty_string_as_none")
+    )]
     pub avatar_url: Option<String>,
 }
 

--- a/ruma-federation-api/src/event/get_room_state/v1.rs
+++ b/ruma-federation-api/src/event/get_room_state/v1.rs
@@ -38,7 +38,7 @@ ruma_api! {
 impl<'a> Request<'a> {
     /// Creates a new `Request` with the given event ID and room ID.
     pub fn new(event_id: &'a EventId, room_id: &'a RoomId) -> Self {
-        Self { event_id, room_id }
+        Self { room_id, event_id }
     }
 }
 

--- a/ruma-federation-api/src/event/get_room_state_ids/v1.rs
+++ b/ruma-federation-api/src/event/get_room_state_ids/v1.rs
@@ -36,7 +36,7 @@ ruma_api! {
 impl<'a> Request<'a> {
     /// Creates a new `Request` with the given event id and room id.
     pub fn new(event_id: &'a EventId, room_id: &'a RoomId) -> Self {
-        Self { event_id, room_id }
+        Self { room_id, event_id }
     }
 }
 

--- a/ruma-federation-api/src/query/get_profile_information/v1.rs
+++ b/ruma-federation-api/src/query/get_profile_information/v1.rs
@@ -33,6 +33,10 @@ ruma_api! {
 
         /// Avatar URL for the user's avatar.
         #[serde(skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(
+            feature = "compat",
+            serde(default, deserialize_with = "ruma_serde::empty_string_as_none")
+        )]
         pub avatar_url: Option<String>,
     }
 }


### PR DESCRIPTION
This pull request adds `cfg_attr` for deserializing empty strings to none for all URLs fields and some tests.

fields
- [x] avatar_url
- [x] submit_url

ref https://github.com/ruma/ruma/issues/427