### PR TITLE
Remove outdated line from vscode settings.json

### DIFF
--- a/contrib/ide/vscode/settings.json
+++ b/contrib/ide/vscode/settings.json
@@ -1,5 +1,4 @@
 {
     // enable proc-macro support in rust-analyzer
-    "rust-analyzer.cargo.loadOutDirsFromCheck": true,
     "rust-analyzer.procMacro.enable": true
 }


### PR DESCRIPTION
`rust-analyzer.cargo.loadOutDirsFromCheck` seems to be "greyed out" on the latest version of rust-analyzer, meaning its an outdated setting.

Trying to manually "type" it also doesn't seem to auto-complete it. But running vscode with just the other line seems to make ruma work nicely anyway, so no need to keep it.