### PR TITLE
client-api: Move user in login::Request to identifier in login::LoginInfo::Password

### DIFF
--- a/ruma-client-api/CHANGELOG.md
+++ b/ruma-client-api/CHANGELOG.md
@@ -62,6 +62,9 @@ Breaking changes:
 * `error::ErrorKind` no longer implements `Copy`, `FromStr`
 * Switch from `AnyEvent` to `AnyRoomEvent` in `r0::search::search_events`
 * Move `r0::account::request_openid_token::TokenType` to `ruma-common` crate
+* Move `user: UserInfo` in `r0::session::login::Request` to `identifier: UserIdentifier` in
+  `r0::session::login::LoginInfo::Password`
+  * `r0::session::login::Request::new` takes only `login_info: LoginInfo` as a param
 
 Improvements:
 

--- a/ruma-client-api/src/r0/session/login/user_serde.rs
+++ b/ruma-client-api/src/r0/session/login/user_serde.rs
@@ -5,13 +5,8 @@ use ruma_common::thirdparty::Medium;
 use ruma_serde::Outgoing;
 use serde::Serialize;
 
-// The following three structs could just be used in place of the one in the parent module, but
+// The following structs could just be used in place of the one in the parent module, but
 // that one is arguably much easier to deal with.
-#[derive(Clone, Debug, PartialEq, Eq, Outgoing, Serialize)]
-pub(crate) struct UserInfo<'a> {
-    pub identifier: UserIdentifier<'a>,
-}
-
 #[derive(Clone, Debug, PartialEq, Eq, Outgoing, Serialize)]
 #[serde(tag = "type")]
 pub(crate) enum UserIdentifier<'a> {
@@ -23,32 +18,28 @@ pub(crate) enum UserIdentifier<'a> {
     PhoneNumber { country: &'a str, phone: &'a str },
 }
 
-impl<'a> From<super::UserInfo<'a>> for UserInfo<'a> {
-    fn from(info: super::UserInfo<'a>) -> Self {
-        use super::UserInfo as Info;
-        use UserIdentifier as Id;
+impl<'a> From<super::UserIdentifier<'a>> for UserIdentifier<'a> {
+    fn from(id: super::UserIdentifier<'a>) -> Self {
+        use super::UserIdentifier as SuperId;
+        use UserIdentifier as SerdeId;
 
-        match info {
-            Info::MatrixId(user) => UserInfo { identifier: Id::MatrixId { user } },
-            Info::ThirdPartyId { address, medium } => {
-                UserInfo { identifier: Id::ThirdPartyId { address, medium } }
-            }
-            Info::PhoneNumber { country, phone } => {
-                UserInfo { identifier: Id::PhoneNumber { country, phone } }
-            }
+        match id {
+            SuperId::MatrixId(user) => SerdeId::MatrixId { user },
+            SuperId::ThirdPartyId { address, medium } => SerdeId::ThirdPartyId { address, medium },
+            SuperId::PhoneNumber { country, phone } => SerdeId::PhoneNumber { country, phone },
         }
     }
 }
 
-impl From<IncomingUserInfo> for super::IncomingUserInfo {
-    fn from(info: IncomingUserInfo) -> super::IncomingUserInfo {
-        use super::IncomingUserInfo as Info;
-        use IncomingUserIdentifier as Id;
+impl From<IncomingUserIdentifier> for super::IncomingUserIdentifier {
+    fn from(id: IncomingUserIdentifier) -> super::IncomingUserIdentifier {
+        use super::IncomingUserIdentifier as SuperId;
+        use IncomingUserIdentifier as SerdeId;
 
-        match info.identifier {
-            Id::MatrixId { user } => Info::MatrixId(user),
-            Id::ThirdPartyId { address, medium } => Info::ThirdPartyId { address, medium },
-            Id::PhoneNumber { country, phone } => Info::PhoneNumber { country, phone },
+        match id {
+            SerdeId::MatrixId { user } => SuperId::MatrixId(user),
+            SerdeId::ThirdPartyId { address, medium } => SuperId::ThirdPartyId { address, medium },
+            SerdeId::PhoneNumber { country, phone } => SuperId::PhoneNumber { country, phone },
         }
     }
 }

--- a/ruma-client/src/lib.rs
+++ b/ruma-client/src/lib.rs
@@ -214,11 +214,13 @@ impl Client {
         device_id: Option<&DeviceId>,
         initial_device_display_name: Option<&str>,
     ) -> Result<Session, Error<ruma_client_api::Error>> {
-        use ruma_client_api::r0::session::login::{LoginInfo, Request as LoginRequest, UserInfo};
+        use ruma_client_api::r0::session::login::{
+            LoginInfo, Request as LoginRequest, UserIdentifier,
+        };
 
         let response = self
             .request(assign!(
-                LoginRequest::new(UserInfo::MatrixId(user), LoginInfo::Password { password }), {
+                LoginRequest::new(LoginInfo::Password { identifier: UserIdentifier::MatrixId(user), password }), {
                     device_id,
                     initial_device_display_name,
                 }


### PR DESCRIPTION
As discussed in the matrix room. I have updated the changelog and the tests to reflect that change.