### PR TITLE
Create ImageInfo struct specific to AvatarEventContent

### DIFF
--- a/ruma-events/src/room/avatar.rs
+++ b/ruma-events/src/room/avatar.rs
@@ -1,9 +1,10 @@
 //! Types for the *m.room.avatar* event.
 
+use js_int::UInt;
 use ruma_events_macros::StateEventContent;
 use serde::{Deserialize, Serialize};
 
-use super::ImageInfo;
+use super::ThumbnailInfo;
 use crate::StateEvent;
 
 /// A picture that is associated with the room.
@@ -42,4 +43,41 @@ impl AvatarEventContent {
     pub fn new() -> Self {
         Self::default()
     }
+}
+
+/// Metadata about an image (specific to avatars).
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ImageInfo {
+    /// The height of the image in pixels.
+    #[serde(rename = "h", skip_serializing_if = "Option::is_none")]
+    pub height: Option<UInt>,
+
+    /// The width of the image in pixels.
+    #[serde(rename = "w", skip_serializing_if = "Option::is_none")]
+    pub width: Option<UInt>,
+
+    /// The MIME type of the image, e.g. "image/png."
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mimetype: Option<String>,
+
+    /// The file size of the image in bytes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub size: Option<UInt>,
+
+    /// Metadata about the image referred to in `thumbnail_url`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thumbnail_info: Option<Box<ThumbnailInfo>>,
+
+    /// The URL to the thumbnail of the image.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thumbnail_url: Option<String>,
+
+    /// The [BlurHash](https://blurha.sh) for this image.
+    ///
+    /// This uses the unstable prefix in
+    /// [MSC2448](https://github.com/matrix-org/matrix-doc/pull/2448).
+    #[cfg(feature = "unstable-pre-spec")]
+    #[serde(rename = "xyz.amorgan.blurhash")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blurhash: Option<String>,
 }

--- a/ruma-events/tests/state_event.rs
+++ b/ruma-events/tests/state_event.rs
@@ -3,7 +3,11 @@ use std::time::{Duration, UNIX_EPOCH};
 use js_int::UInt;
 use matches::assert_matches;
 use ruma_events::{
-    room::{aliases::AliasesEventContent, avatar::AvatarEventContent, ImageInfo, ThumbnailInfo},
+    room::{
+        aliases::AliasesEventContent,
+        avatar::{AvatarEventContent, ImageInfo},
+        ThumbnailInfo,
+    },
     AnyRoomEvent, AnyStateEvent, AnyStateEventContent, AnySyncStateEvent, RawExt, StateEvent,
     SyncStateEvent, Unsigned,
 };
@@ -219,7 +223,6 @@ fn deserialize_avatar_without_prev_content() {
                     size,
                     thumbnail_info: Some(thumbnail_info),
                     thumbnail_url: Some(thumbnail_url),
-                    thumbnail_file: None,
                     #[cfg(feature = "unstable-pre-spec")]
                     blurhash: None,
                 } if *height == UInt::new(423)


### PR DESCRIPTION
Add a new specific ImageInfo struct, with all the same fields,
except for `thumbnail_file`, to disallow encrypted room avatars.

Resolves: #397