### PR TITLE
Using Github Actions to automatically deploy documentation

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,5 +1,5 @@
-[doc.extern-map.registries]
-crates-io = "https://docs.rs/"
-
 [alias]
 xtask = "run --package xtask --"
+
+[doc.extern-map.registries]
+crates-io = "https://docs.rs/"

--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,5 @@
+[doc.extern-map.registries]
+crates-io = "https://docs.rs/"
+
 [alias]
 xtask = "run --package xtask --"

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,27 +1,27 @@
 on:
   push:
-    branches: [main]
+    branches: [main, docs-deployment]
 
 jobs:
   build-deploy:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repo
-      uses: actions/checkout@master
+      uses: actions/checkout@v2
     - name: Install nightly rust toolchain
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        # Needed for use of '-Zunstable-options' since '--enable-index-page' is unstable
+        # Needed for use of unstable options
         toolchain: nightly
         override: true
     - name: Build docs
       uses: actions-rs/cargo@v1
       env:
-       RUSTDOCFLAGS: "--enable-index-page -Zunstable-options"
+       RUSTDOCFLAGS: "--enable-index-page -Zunstable-options -Zrustdoc-map"
       with:
         command: doc
-        args: --no-deps --workspace --exclude xtask --features compat,unstable-pre-spec,unstable-synapse-quirks
+        args: --no-deps --workspace --exclude xtask --features api,events,signatures,appservice-api,client-api,federation-api,identity-service-api,push-gateway-api,either,rand,markdown,compat,unstable-pre-spec
     - name: Deploy to docs branch
       uses: JamesIves/github-pages-deploy-action@4.1.0
       with:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -22,7 +22,7 @@ jobs:
       with:
         command: doc
         args: --no-deps --workspace
-    - name: Deploy to gh-pages branch
+    - name: Deploy to docs branch
       uses: JamesIves/github-pages-deploy-action@4.1.0
       with:
         branch: docs

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,29 @@
+on:
+  push:
+    # docs-deployment is temporary
+    branches: [main, docs-deployment]
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@master
+    - name: Install nightly rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        # Needed for use of '-Zunstable-options' since '--enable-index-page' is unstable
+        toolchain: nightly
+    - name: Build docs
+      uses: actions-rs/cargo@v1
+      env:
+       RUSTDOCFLAGS: "--enable-index-page -Zunstable-options"
+      with:
+        command: doc
+        args: --no-deps --workspace
+    - name: Deploy to gh-pages branch
+      uses: JamesIves/github-pages-deploy-action@4.1.0
+      with:
+        branch: docs
+        folder: target/doc

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,6 +1,7 @@
 on:
   push:
-    branches: [main]
+    # TODO: remove docs-deployment
+    branches: [main, docs-deployment]
 
 jobs:
   build-deploy:
@@ -21,7 +22,7 @@ jobs:
        RUSTDOCFLAGS: "--enable-index-page -Zunstable-options"
       with:
         command: doc
-        args: --no-deps --workspace
+        args: --no-deps --workspace --exclude xtask --features compat,unstable-pre-spec,unstable-synapse-quirks
     - name: Deploy to docs branch
       uses: JamesIves/github-pages-deploy-action@4.1.0
       with:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -18,10 +18,10 @@ jobs:
     - name: Build docs
       uses: actions-rs/cargo@v1
       env:
-       RUSTDOCFLAGS: "--enable-index-page -Zunstable-options -Zrustdoc-map"
+       RUSTDOCFLAGS: "--enable-index-page -Zunstable-options"
       with:
         command: doc
-        args: --no-deps --workspace --exclude xtask --features api,events,signatures,appservice-api,client-api,federation-api,identity-service-api,push-gateway-api,either,rand,markdown,compat,unstable-pre-spec
+        args: --no-deps --workspace --exclude xtask --features api,events,signatures,appservice-api,client-api,federation-api,identity-service-api,push-gateway-api,either,rand,markdown,compat,unstable-pre-spec -Zrustdoc-map
     - name: Deploy to docs branch
       uses: JamesIves/github-pages-deploy-action@4.1.0
       with:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,7 +1,6 @@
 on:
   push:
-    # TODO: remove docs-deployment
-    branches: [main, docs-deployment]
+    branches: [main]
 
 jobs:
   build-deploy:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,7 +1,6 @@
 on:
   push:
-    # docs-deployment is temporary
-    branches: [main, docs-deployment]
+    branches: [main]
 
 jobs:
   build-deploy:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -15,6 +15,7 @@ jobs:
         profile: minimal
         # Needed for use of '-Zunstable-options' since '--enable-index-page' is unstable
         toolchain: nightly
+        override: true
     - name: Build docs
       uses: actions-rs/cargo@v1
       env:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [main, docs-deployment]
+    branches: [main]
 
 jobs:
   build-deploy:


### PR DESCRIPTION
Hi, I thought I'd have a crack at #444 which is to create a Github actions workflow to deploy the documentation on every push to main.

When I was testing I added my development branch `docs-deployment` to the list of branches the the workflow was watching and you can see the automatic deployment here: [https://louisdewar.github.io/ruma/](https://louisdewar.github.io/ruma/) (this branch is now removed from the workflow, only `main` is listed currently).

Right now the flow is push to `main` then this builds the docs and then deploys to a branch called `docs`. In the settings for this repo you can go to `options` -> `GitHub Pages` and then specify the `Source` as the `docs` branch and then specify the root for the folder.
It can take a bit of time but the docs should be visible at https://ruma.github.io/ruma/ once that's complete. If you instead want the URL to be `docs.ruma.io` then that's possible too. I believe it will also be visible at https://ruma.io/ruma because of the way Github pages works but I'm not fully sure.

In https://github.com/matrix-org/matrix-rust-sdk/blob/master/.github/workflows/docs.yml the docs were built for every push to main and for pull requests but only deployed for pushes to main. Is that the behaviour you want to replicate? Currently it does nothing on pull requests but I assume it would be useful for the CI to detect if there are any errors in building docs.