### PR TITLE
Use MxcUri instead of String for media URLs 

### DIFF
--- a/ruma-client-api/CHANGELOG.md
+++ b/ruma-client-api/CHANGELOG.md
@@ -67,6 +67,17 @@ Breaking changes:
   * `r0::session::login::Request::new` takes only `login_info: LoginInfo` as a param
 * Change `ruma_events::AnyEvent` to `ruma_events::AnySyncRoomEvent` in
   `push::get_notifications::Notification`
+* Use `ruma_identifiers::MxcUri` instead of `String` for `avatar_url` fields in the following
+  endpoints:
+  ```rust
+  r0::{
+      directory,
+      media::create_content,
+      membership::joined_members,
+      profile::{get_avatar_url, get_profile, set_avatar_url},
+      search::{search_events, search_users}
+  }
+  ```
 
 Improvements:
 

--- a/ruma-client-api/src/r0/profile/get_profile.rs
+++ b/ruma-client-api/src/r0/profile/get_profile.rs
@@ -1,7 +1,7 @@
 //! [GET /_matrix/client/r0/profile/{userId}](https://matrix.org/docs/spec/client_server/r0.6.0#get-matrix-client-r0-profile-userid)
 
 use ruma_api::ruma_api;
-use ruma_identifiers::UserId;
+use ruma_identifiers::{MxcUri, UserId};
 
 ruma_api! {
     metadata: {
@@ -30,7 +30,7 @@ ruma_api! {
             feature = "compat",
             serde(default, deserialize_with = "ruma_serde::empty_string_as_none")
         )]
-        pub avatar_url: Option<String>,
+        pub avatar_url: Option<MxcUri>,
 
         /// The user's display name, if set.
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -49,7 +49,7 @@ impl<'a> Request<'a> {
 
 impl Response {
     /// Creates a new `Response` with the given avatar URL and display name.
-    pub fn new(avatar_url: Option<String>, displayname: Option<String>) -> Self {
+    pub fn new(avatar_url: Option<MxcUri>, displayname: Option<String>) -> Self {
         Self { avatar_url, displayname }
     }
 }

--- a/ruma-common/CHANGELOG.md
+++ b/ruma-common/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [unreleased]
 
+Breaking changes:
+
+* Use `ruma_identifiers::MxcUri` instead of `String` for `avatar_url` field in
+  `directory::PublicRoomsChunk`
+
 # 0.3.1
 
 Bug fixes:

--- a/ruma-common/src/directory.rs
+++ b/ruma-common/src/directory.rs
@@ -3,7 +3,7 @@
 use std::fmt;
 
 use js_int::UInt;
-use ruma_identifiers::{RoomAliasId, RoomId};
+use ruma_identifiers::{MxcUri, RoomAliasId, RoomId};
 use ruma_serde::Outgoing;
 use serde::{
     de::{Error, MapAccess, Visitor},
@@ -55,7 +55,7 @@ pub struct PublicRoomsChunk {
         feature = "compat",
         serde(default, deserialize_with = "ruma_serde::empty_string_as_none")
     )]
-    pub avatar_url: Option<String>,
+    pub avatar_url: Option<MxcUri>,
 }
 
 /// Initial set of mandatory fields of `PublicRoomsChunk`.

--- a/ruma-events/CHANGELOG.md
+++ b/ruma-events/CHANGELOG.md
@@ -25,6 +25,21 @@ Breaking changes:
 * Remove the implementations of `From<EventType>` and `From<key::verification::cancel::CancelCode>`
   for `String`. Use the `Display` or `ToString` implementations for those types instead.
 * Remove `PduStub`, `RoomV1PduStub` and `RoomV3PduStub` types
+* Use `ruma_identifiers::MxcUri` instead of `String` for `avatar_url`, `thumbnail_url` or `url`
+  fields in the following types:
+  ```rust
+  presence::PresenceEventContent,
+  room::{
+      avatar::{AvatarEventContent, ImageInfo},
+      member::MemberEventContent,
+      message::{
+        AudioMessageEventContent, FileMessageEventContent, ImageMessageEventContent,
+        VideoMessageEventContent
+      }
+      EncryptedFile, ImageInfo,
+  },
+  sticker::StickerEventContent
+  ```
 
 Improvements:
 

--- a/ruma-events/src/presence.rs
+++ b/ruma-events/src/presence.rs
@@ -5,7 +5,7 @@
 use js_int::UInt;
 use ruma_common::presence::PresenceState;
 use ruma_events_macros::{Event, EventContent};
-use ruma_identifiers::UserId;
+use ruma_identifiers::{MxcUri, UserId};
 use serde::{Deserialize, Serialize};
 
 /// Presence event.
@@ -31,7 +31,7 @@ pub struct PresenceEventContent {
         feature = "compat",
         serde(default, deserialize_with = "ruma_serde::empty_string_as_none")
     )]
-    pub avatar_url: Option<String>,
+    pub avatar_url: Option<MxcUri>,
 
     /// Whether or not the user is currently active.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -58,7 +58,7 @@ mod tests {
     use js_int::uint;
     use matches::assert_matches;
     use ruma_common::presence::PresenceState;
-    use ruma_identifiers::user_id;
+    use ruma_identifiers::{mxc_uri, user_id};
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     use super::{PresenceEvent, PresenceEventContent};
@@ -67,7 +67,7 @@ mod tests {
     fn serialization() {
         let event = PresenceEvent {
             content: PresenceEventContent {
-                avatar_url: Some("mxc://localhost:wefuiwegh8742w".into()),
+                avatar_url: Some(mxc_uri!("mxc://localhost/wefuiwegh8742w")),
                 currently_active: Some(false),
                 displayname: None,
                 last_active_ago: Some(uint!(2_478_593)),
@@ -79,7 +79,7 @@ mod tests {
 
         let json = json!({
             "content": {
-                "avatar_url": "mxc://localhost:wefuiwegh8742w",
+                "avatar_url": "mxc://localhost/wefuiwegh8742w",
                 "currently_active": false,
                 "last_active_ago": 2_478_593,
                 "presence": "online",
@@ -96,7 +96,7 @@ mod tests {
     fn deserialization() {
         let json = json!({
             "content": {
-                "avatar_url": "mxc://localhost:wefuiwegh8742w",
+                "avatar_url": "mxc://localhost/wefuiwegh8742w",
                 "currently_active": false,
                 "last_active_ago": 2_478_593,
                 "presence": "online",
@@ -118,7 +118,7 @@ mod tests {
                     status_msg: Some(status_msg),
                 },
                 sender,
-            } if avatar_url == "mxc://localhost:wefuiwegh8742w"
+            } if avatar_url.to_string() == "mxc://localhost/wefuiwegh8742w"
                 && status_msg == "Making cupcakes"
                 && sender == "@example:localhost"
                 && last_active_ago == uint!(2_478_593)

--- a/ruma-events/src/room.rs
+++ b/ruma-events/src/room.rs
@@ -5,6 +5,7 @@
 use std::collections::BTreeMap;
 
 use js_int::UInt;
+use ruma_identifiers::MxcUri;
 use serde::{Deserialize, Serialize};
 
 pub mod aliases;
@@ -53,7 +54,7 @@ pub struct ImageInfo {
 
     /// The URL to the thumbnail of the image. Only present if the thumbnail is unencrypted.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub thumbnail_url: Option<String>,
+    pub thumbnail_url: Option<MxcUri>,
 
     /// Information on the encrypted thumbnail image. Only present if the thumbnail is encrypted.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -93,7 +94,7 @@ pub struct ThumbnailInfo {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct EncryptedFile {
     /// The URL to the file.
-    pub url: String,
+    pub url: MxcUri,
 
     /// A [JSON Web Key](https://tools.ietf.org/html/rfc7517#appendix-A.3) object.
     pub key: JsonWebKey,

--- a/ruma-events/src/room/avatar.rs
+++ b/ruma-events/src/room/avatar.rs
@@ -2,6 +2,7 @@
 
 use js_int::UInt;
 use ruma_events_macros::StateEventContent;
+use ruma_identifiers::MxcUri;
 use serde::{Deserialize, Serialize};
 
 use super::ThumbnailInfo;
@@ -24,17 +25,17 @@ pub struct AvatarEventContent {
 
     /// URL of the avatar image.
     #[cfg(not(feature = "unstable-pre-spec"))]
-    pub url: String,
+    pub url: MxcUri,
 
     /// URL of the avatar image.
     #[cfg(feature = "unstable-pre-spec")]
-    pub url: Option<String>,
+    pub url: Option<MxcUri>,
 }
 
 impl AvatarEventContent {
     /// Create an `AvatarEventContent` from the given image URL.
     #[cfg(not(feature = "unstable-pre-spec"))]
-    pub fn new(url: String) -> Self {
+    pub fn new(url: MxcUri) -> Self {
         Self { info: None, url }
     }
 
@@ -70,7 +71,7 @@ pub struct ImageInfo {
 
     /// The URL to the thumbnail of the image.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub thumbnail_url: Option<String>,
+    pub thumbnail_url: Option<MxcUri>,
 
     /// The [BlurHash](https://blurha.sh) for this image.
     ///

--- a/ruma-events/src/room/member.rs
+++ b/ruma-events/src/room/member.rs
@@ -3,7 +3,7 @@
 use std::collections::BTreeMap;
 
 use ruma_events_macros::StateEventContent;
-use ruma_identifiers::{ServerNameBox, ServerSigningKeyId, UserId};
+use ruma_identifiers::{MxcUri, ServerNameBox, ServerSigningKeyId, UserId};
 use ruma_serde::StringEnum;
 use serde::{Deserialize, Serialize};
 
@@ -46,7 +46,7 @@ pub struct MemberEventContent {
         feature = "compat",
         serde(default, deserialize_with = "ruma_serde::empty_string_as_none")
     )]
-    pub avatar_url: Option<String>,
+    pub avatar_url: Option<MxcUri>,
 
     /// The display name for this user, if any. This is added by the homeserver.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -409,7 +409,7 @@ mod tests {
                 state_key,
                 unsigned,
                 prev_content: None,
-            } if avatar_url == "mxc://example.org/SEsfnsuifSDFSSEF"
+            } if avatar_url.to_string() == "mxc://example.org/SEsfnsuifSDFSSEF"
                 && displayname == "Alice Margatroid"
                 && third_party_displayname == "alice"
                 && mxid == "@alice:example.org"
@@ -495,7 +495,7 @@ mod tests {
                 && sender == "@alice:example.org"
                 && state_key == "@alice:example.org"
                 && unsigned.is_empty()
-                && avatar_url == "mxc://example.org/SEsfnsuifSDFSSEF"
+                && avatar_url.to_string() == "mxc://example.org/SEsfnsuifSDFSSEF"
                 && displayname == "Alice Margatroid"
                 && third_party_displayname == "alice"
                 && mxid == "@alice:example.org"

--- a/ruma-events/src/room/message.rs
+++ b/ruma-events/src/room/message.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeMap;
 
 use js_int::UInt;
 use ruma_events_macros::MessageEventContent;
+use ruma_identifiers::MxcUri;
 #[cfg(feature = "unstable-pre-spec")]
 use ruma_identifiers::{DeviceIdBox, UserId};
 use ruma_serde::StringEnum;
@@ -206,7 +207,7 @@ pub struct AudioMessageEventContent {
     /// The URL to the audio clip. Required if the file is unencrypted. The URL (typically
     /// [MXC URI](https://matrix.org/docs/spec/client_server/r0.6.1#mxc-uri)) to the audio clip.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
+    pub url: Option<MxcUri>,
 
     /// Required if the audio clip is encrypted. Information on the encrypted audio clip.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -260,7 +261,7 @@ pub struct FileMessageEventContent {
     /// The URL to the file. Required if the file is unencrypted. The URL (typically
     /// [MXC URI](https://matrix.org/docs/spec/client_server/r0.6.1#mxc-uri)) to the file.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
+    pub url: Option<MxcUri>,
 
     /// Required if file is encrypted. Information on the encrypted file.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -284,7 +285,7 @@ pub struct FileInfo {
 
     /// The URL to the thumbnail of the file. Only present if the thumbnail is unencrypted.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub thumbnail_url: Option<String>,
+    pub thumbnail_url: Option<MxcUri>,
 
     /// Information on the encrypted thumbnail file. Only present if the thumbnail is encrypted.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -307,7 +308,7 @@ pub struct ImageMessageEventContent {
     /// The URL to the image. Required if the file is unencrypted. The URL (typically
     /// [MXC URI](https://matrix.org/docs/spec/client_server/r0.6.1#mxc-uri)) to the image.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
+    pub url: Option<MxcUri>,
 
     /// Required if image is encrypted. Information on the encrypted image.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -340,7 +341,7 @@ pub struct LocationInfo {
     /// The URL to a thumbnail of the location being represented. Only present if the thumbnail is
     /// unencrypted.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub thumbnail_url: Option<String>,
+    pub thumbnail_url: Option<MxcUri>,
 
     /// Information on an encrypted thumbnail of the location being represented. Only present if
     /// the thumbnail is encrypted.
@@ -517,7 +518,7 @@ pub struct VideoMessageEventContent {
     /// The URL to the video clip.  Required if the file is unencrypted. The URL (typically
     /// [MXC URI](https://matrix.org/docs/spec/client_server/r0.6.1#mxc-uri)) to the video clip.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
+    pub url: Option<MxcUri>,
 
     /// Required if video clip is encrypted. Information on the encrypted video clip.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -556,7 +557,7 @@ pub struct VideoInfo {
     /// The URL (typically [MXC URI](https://matrix.org/docs/spec/client_server/r0.6.1#mxc-uri)) to
     /// an image thumbnail of the video clip. Only present if the thumbnail is unencrypted.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub thumbnail_url: Option<String>,
+    pub thumbnail_url: Option<MxcUri>,
 
     /// Information on the encrypted thumbnail file.  Only present if the thumbnail is encrypted.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/ruma-events/src/sticker.rs
+++ b/ruma-events/src/sticker.rs
@@ -1,6 +1,7 @@
 //! Types for the *m.sticker* event.
 
 use ruma_events_macros::MessageEventContent;
+use ruma_identifiers::MxcUri;
 use serde::{Deserialize, Serialize};
 
 use crate::{room::ImageInfo, MessageEvent};
@@ -21,5 +22,5 @@ pub struct StickerEventContent {
     pub info: ImageInfo,
 
     /// The URL to the sticker image. This must be a valid `mxc://` URI.
-    pub url: String,
+    pub url: MxcUri,
 }

--- a/ruma-events/tests/event_enums.rs
+++ b/ruma-events/tests/event_enums.rs
@@ -2,7 +2,7 @@ use std::time::{Duration, UNIX_EPOCH};
 
 use js_int::UInt;
 use matches::assert_matches;
-use ruma_identifiers::{event_id, room_id, user_id};
+use ruma_identifiers::{event_id, mxc_uri, room_id, user_id};
 use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
 use ruma_events::{
@@ -82,12 +82,12 @@ fn serialize_message_event() {
                     mimetype: Some("image/png".into()),
                     size: UInt::new(82595),
                 })),
-                thumbnail_url: Some("mxc://matrix.org".into()),
+                thumbnail_url: Some(mxc_uri!("mxc://matrix.org/mnrsnsRRS787TSts")),
                 thumbnail_file: None,
                 #[cfg(feature = "unstable-pre-spec")]
                 blurhash: None,
             },
-            url: "http://www.matrix.org".into(),
+            url: mxc_uri!("mxc://matrix.org/arsrns98rsRSR"),
         },
         event_id: event_id!("$h29iv0s8:example.com"),
         origin_server_ts: UNIX_EPOCH + Duration::from_millis(1),
@@ -110,10 +110,10 @@ fn serialize_message_event() {
                 "size": 82595,
                 "w": 800
                 },
-                "thumbnail_url": "mxc://matrix.org",
+                "thumbnail_url": "mxc://matrix.org/mnrsnsRRS787TSts",
                 "w": 1011
             },
-            "url": "http://www.matrix.org"
+            "url": "mxc://matrix.org/arsrns98rsRSR"
         },
         "event_id": "$h29iv0s8:example.com",
         "origin_server_ts": 1,

--- a/ruma-events/tests/message_event.rs
+++ b/ruma-events/tests/message_event.rs
@@ -8,7 +8,7 @@ use ruma_events::{
     sticker::StickerEventContent,
     AnyMessageEventContent, AnySyncMessageEvent, MessageEvent, RawExt, Unsigned,
 };
-use ruma_identifiers::{event_id, room_id, user_id};
+use ruma_identifiers::{event_id, mxc_uri, room_id, user_id};
 use ruma_serde::Raw;
 use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
@@ -28,12 +28,12 @@ fn message_serialize_sticker() {
                     mimetype: Some("image/png".into()),
                     size: UInt::new(82595),
                 })),
-                thumbnail_url: Some("mxc://matrix.org".into()),
+                thumbnail_url: Some(mxc_uri!("mxc://matrix.org/irsns989Rrsn")),
                 thumbnail_file: None,
                 #[cfg(feature = "unstable-pre-spec")]
                 blurhash: None,
             },
-            url: "http://www.matrix.org".into(),
+            url: mxc_uri!("mxc://matrix.org/rnsldl8srs98IRrs"),
         }),
         event_id: event_id!("$h29iv0s8:example.com"),
         origin_server_ts: UNIX_EPOCH + Duration::from_millis(1),
@@ -56,10 +56,10 @@ fn message_serialize_sticker() {
                   "size": 82595,
                   "w": 800
                 },
-                "thumbnail_url": "mxc://matrix.org",
+                "thumbnail_url": "mxc://matrix.org/irsns989Rrsn",
                 "w": 1011
               },
-            "url": "http://www.matrix.org"
+            "url": "mxc://matrix.org/rnsldl8srs98IRrs"
         },
         "event_id": "$h29iv0s8:example.com",
         "origin_server_ts": 1,
@@ -163,10 +163,10 @@ fn deserialize_message_sticker() {
                   "size": 82595,
                   "w": 800
                 },
-                "thumbnail_url": "mxc://matrix.org",
+                "thumbnail_url": "mxc://matrix.org/irnsNRS2879",
                 "w": 1011
               },
-            "url": "http://www.matrix.org"
+            "url": "mxc://matrix.org/jxPXTKpyydzdHJkdFNZjTZrD"
         },
         "event_id": "$h29iv0s8:example.com",
         "origin_server_ts": 1,
@@ -210,7 +210,7 @@ fn deserialize_message_sticker() {
             && width == UInt::new(1011)
             && mimetype == "image/png"
             && size == UInt::new(84242)
-            && thumbnail_url == "mxc://matrix.org"
+            && thumbnail_url.to_string() == "mxc://matrix.org/irnsNRS2879"
             && matches!(
                 thumbnail_info.as_ref(),
                 ThumbnailInfo {
@@ -223,7 +223,7 @@ fn deserialize_message_sticker() {
                     && *thumb_mimetype == Some("image/png".into())
                     && *thumb_size == UInt::new(82595)
             )
-            && url == "http://www.matrix.org"
+            && url.to_string() == "mxc://matrix.org/jxPXTKpyydzdHJkdFNZjTZrD"
             && unsigned.is_empty()
     );
 }

--- a/ruma-events/tests/redacted.rs
+++ b/ruma-events/tests/redacted.rs
@@ -329,7 +329,7 @@ fn redact_method_properly_redacts() {
         "content": {
             "body": "test",
             "msgtype": "m.audio",
-            "url": "http://example.com/audio.mp3",
+            "url": "mxc://example.com/AuDi0",
         }
     });
 

--- a/ruma-events/tests/room_message.rs
+++ b/ruma-events/tests/room_message.rs
@@ -19,7 +19,7 @@ use ruma_events::{
 };
 #[cfg(feature = "unstable-pre-spec")]
 use ruma_identifiers::DeviceIdBox;
-use ruma_identifiers::{event_id, room_id, user_id};
+use ruma_identifiers::{event_id, mxc_uri, room_id, user_id};
 use ruma_serde::Raw;
 use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
@@ -29,7 +29,7 @@ fn serialization() {
         content: MessageEventContent::new(MessageType::Audio(AudioMessageEventContent {
             body: "test".into(),
             info: None,
-            url: Some("http://example.com/audio.mp3".into()),
+            url: Some(mxc_uri!("mxc://example.org/ffed755USFFxlgbQYZGtryd")),
             file: None,
         })),
         event_id: event_id!("$143273582443PhrSn:example.org"),
@@ -50,7 +50,7 @@ fn serialization() {
             "content": {
                 "body": "test",
                 "msgtype": "m.audio",
-                "url": "http://example.com/audio.mp3",
+                "url": "mxc://example.org/ffed755USFFxlgbQYZGtryd",
             }
         })
     );
@@ -62,7 +62,7 @@ fn content_serialization() {
         MessageEventContent::new(MessageType::Audio(AudioMessageEventContent {
             body: "test".into(),
             info: None,
-            url: Some("http://example.com/audio.mp3".into()),
+            url: Some(mxc_uri!("mxc://example.org/ffed755USFFxlgbQYZGtryd")),
             file: None,
         }));
 
@@ -71,7 +71,7 @@ fn content_serialization() {
         json!({
             "body": "test",
             "msgtype": "m.audio",
-            "url": "http://example.com/audio.mp3"
+            "url": "mxc://example.org/ffed755USFFxlgbQYZGtryd"
         })
     );
 }
@@ -321,7 +321,7 @@ fn content_deserialization() {
     let json_data = json!({
         "body": "test",
         "msgtype": "m.audio",
-        "url": "http://example.com/audio.mp3"
+        "url": "mxc://example.org/ffed755USFFxlgbQYZGtryd"
     });
 
     assert_matches!(
@@ -337,7 +337,7 @@ fn content_deserialization() {
                 file: None,
             }),
             ..
-        } if body == "test" && url == "http://example.com/audio.mp3"
+        } if body == "test" && url.to_string() == "mxc://example.org/ffed755USFFxlgbQYZGtryd"
     );
 }
 

--- a/ruma-events/tests/state_event.rs
+++ b/ruma-events/tests/state_event.rs
@@ -11,7 +11,7 @@ use ruma_events::{
     AnyRoomEvent, AnyStateEvent, AnyStateEventContent, AnySyncStateEvent, RawExt, StateEvent,
     SyncStateEvent, Unsigned,
 };
-use ruma_identifiers::{event_id, room_alias_id, room_id, user_id};
+use ruma_identifiers::{event_id, mxc_uri, room_alias_id, room_id, user_id};
 use ruma_serde::Raw;
 use serde_json::{
     from_value as from_json_value, json, to_value as to_json_value, Value as JsonValue,
@@ -173,10 +173,10 @@ fn deserialize_avatar_without_prev_content() {
                   "size": 82595,
                   "w": 800
                 },
-                "thumbnail_url": "mxc://matrix.org",
+                "thumbnail_url": "mxc://matrix.org/98irRSS23srs",
                 "w": 1011
               },
-            "url": "http://www.matrix.org"
+            "url": "mxc://matrix.org/rnsldl8srs98IRrs"
         },
         "event_id": "$h29iv0s8:example.com",
         "origin_server_ts": 1,
@@ -186,7 +186,7 @@ fn deserialize_avatar_without_prev_content() {
         "type": "m.room.avatar"
     });
 
-    let expected_url = "http://www.matrix.org";
+    let expected_url = "mxc://matrix.org/rnsldl8srs98IRrs";
 
     #[cfg(feature = "unstable-pre-spec")]
     let expected_url = Some(expected_url.to_owned());
@@ -240,10 +240,10 @@ fn deserialize_avatar_without_prev_content() {
                             && *thumb_height == UInt::new(334)
                             && *thumb_mimetype == Some("image/png".into())
                             && *thumb_size == UInt::new(82595)
-                            && *thumbnail_url == "mxc://matrix.org"
+                            && *thumbnail_url == mxc_uri!("mxc://matrix.org/98irRSS23srs")
                     )
             )
-            && url == expected_url
+            && url.to_string() == expected_url
             && unsigned.is_empty()
     );
 }

--- a/ruma-events/tests/stripped.rs
+++ b/ruma-events/tests/stripped.rs
@@ -3,7 +3,7 @@ use ruma_events::{
     room::{join_rules::JoinRule, topic::TopicEventContent},
     AnyStateEventContent, AnyStrippedStateEvent, StrippedStateEvent,
 };
-use ruma_identifiers::user_id;
+use ruma_identifiers::{mxc_uri, user_id};
 use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
 #[test]
@@ -80,7 +80,7 @@ fn deserialize_stripped_state_events() {
                     "mimetype": "image/jpeg",
                     "size": 32
                 },
-                "thumbnail_url": "https://example.com/image-thumbnail.jpg"
+                "thumbnail_url": "mxc://example.com/THumbNa1l"
             },
             "thumbnail_info": {
                 "h": 16,
@@ -88,8 +88,8 @@ fn deserialize_stripped_state_events() {
                 "mimetype": "image/jpeg",
                 "size": 32
             },
-            "thumbnail_url": "https://example.com/image-thumbnail.jpg",
-            "url": "https://example.com/image.jpg"
+            "thumbnail_url": "mxc://example.com/THumbNa1l",
+            "url": "mxc://example.com/iMag3"
         }
     });
 
@@ -117,10 +117,10 @@ fn deserialize_stripped_state_events() {
     match event {
         AnyStrippedStateEvent::RoomAvatar(event) => {
             let image_info = event.content.info.unwrap();
-            let expected_url = "https://example.com/image.jpg";
+            let expected_url = mxc_uri!("mxc://example.com/iMag3");
 
             #[cfg(feature = "unstable-pre-spec")]
-            let expected_url = Some(expected_url.to_owned());
+            let expected_url = Some(expected_url);
 
             assert_eq!(image_info.height.unwrap(), uint!(128));
             assert_eq!(image_info.width.unwrap(), uint!(128));

--- a/ruma-federation-api/CHANGELOG.md
+++ b/ruma-federation-api/CHANGELOG.md
@@ -9,6 +9,8 @@ Breaking Changes:
   * Rename `pdu_stub` fields to `pdu`
 * Upgrade dependencies
 * Wrap `Pdu`s in `backfill::get_backfill` in `Raw`
+* Use `ruma_identifiers::MxcUri` instead of `String` for `avatar_url` in
+  `query::get_profile_information::v1`
 
 Improvements:
 

--- a/ruma-federation-api/src/query/get_profile_information/v1.rs
+++ b/ruma-federation-api/src/query/get_profile_information/v1.rs
@@ -1,7 +1,7 @@
 //! [GET /_matrix/federation/v1/query/profile](https://matrix.org/docs/spec/server_server/r0.1.4#get-matrix-federation-v1-query-profile)
 
 use ruma_api::ruma_api;
-use ruma_identifiers::UserId;
+use ruma_identifiers::{MxcUri, UserId};
 use ruma_serde::StringEnum;
 
 ruma_api! {
@@ -37,7 +37,7 @@ ruma_api! {
             feature = "compat",
             serde(default, deserialize_with = "ruma_serde::empty_string_as_none")
         )]
-        pub avatar_url: Option<String>,
+        pub avatar_url: Option<MxcUri>,
     }
 }
 


### PR DESCRIPTION
As an extra bonus, this PR could be more complete if we also use `MxcUri` in `ruma_client_api::r0::media::get_content*::Request::new` instead of asking for `media_id` and `server_name` separately.

Fixes #456.