### PR TITLE
Use MxcUri in media::get_content*::Request::new

### DIFF
--- a/ruma-client-api/CHANGELOG.md
+++ b/ruma-client-api/CHANGELOG.md
@@ -78,15 +78,6 @@ Breaking changes:
       search::{search_events, search_users}
   }
   ```
-* Use `ruma_identifiers::MxcUri` instead of `media_id` and `server_name` params in `Request::new` 
-  for the following endpoints:
-  ```rust
-  r0::media::{
-      get_content,
-      get_content_as_filename,
-      get_content_thumbnail
-  }
-  ```
 
 Improvements:
 
@@ -98,6 +89,14 @@ Improvements:
   * `r0::message::get_message_events`
 * Add `logout_devices` field to `r0::account::change_password`
 * Add `r0::room::aliases` (introduced in r0.6.1)
+* Add constructors that use `ruma_identifiers::MxcUri` for `Request` in the following endpoints:
+  ```rust
+  r0::media::{
+      get_content,
+      get_content_as_filename,
+      get_content_thumbnail
+  }
+  ```
 
 # 0.9.0
 

--- a/ruma-client-api/CHANGELOG.md
+++ b/ruma-client-api/CHANGELOG.md
@@ -78,6 +78,15 @@ Breaking changes:
       search::{search_events, search_users}
   }
   ```
+* Use `ruma_identifiers::MxcUri` instead of `media_id` and `server_name` params in `Request::new` 
+  for the following endpoints:
+  ```rust
+  r0::media::{
+      get_content,
+      get_content_as_filename,
+      get_content_thumbnail
+  }
+  ```
 
 Improvements:
 

--- a/ruma-client-api/src/r0/media/get_content.rs
+++ b/ruma-client-api/src/r0/media/get_content.rs
@@ -53,8 +53,13 @@ ruma_api! {
 }
 
 impl<'a> Request<'a> {
+    /// Creates a new `Request` with the given media ID and server name.
+    pub fn new(media_id: &'a str, server_name: &'a ServerName) -> Self {
+        Self { media_id, server_name, allow_remote: true }
+    }
+
     /// Creates a new `Request` with the given url.
-    pub fn new(url: &'a MxcUri) -> Self {
+    pub fn from_url(url: &'a MxcUri) -> Self {
         Self { media_id: url.media_id(), server_name: url.server_name(), allow_remote: true }
     }
 }

--- a/ruma-client-api/src/r0/media/get_content.rs
+++ b/ruma-client-api/src/r0/media/get_content.rs
@@ -1,7 +1,7 @@
 //! [GET /_matrix/media/r0/download/{serverName}/{mediaId}](https://matrix.org/docs/spec/client_server/r0.6.0#get-matrix-media-r0-download-servername-mediaid)
 
 use ruma_api::ruma_api;
-use ruma_identifiers::ServerName;
+use ruma_identifiers::{MxcUri, ServerName};
 
 ruma_api! {
     metadata: {
@@ -53,9 +53,9 @@ ruma_api! {
 }
 
 impl<'a> Request<'a> {
-    /// Creates a new `Request` with the given media ID and server name.
-    pub fn new(media_id: &'a str, server_name: &'a ServerName) -> Self {
-        Self { media_id, server_name, allow_remote: true }
+    /// Creates a new `Request` with the given url.
+    pub fn new(url: &'a MxcUri) -> Self {
+        Self { media_id: url.media_id(), server_name: url.server_name(), allow_remote: true }
     }
 }
 

--- a/ruma-client-api/src/r0/media/get_content_as_filename.rs
+++ b/ruma-client-api/src/r0/media/get_content_as_filename.rs
@@ -1,7 +1,7 @@
 //! [GET /_matrix/media/r0/download/{serverName}/{mediaId}/{fileName}](https://matrix.org/docs/spec/client_server/r0.6.0#get-matrix-media-r0-download-servername-mediaid-filename)
 
 use ruma_api::ruma_api;
-use ruma_identifiers::ServerName;
+use ruma_identifiers::{MxcUri, ServerName};
 
 ruma_api! {
     metadata: {
@@ -58,9 +58,14 @@ ruma_api! {
 }
 
 impl<'a> Request<'a> {
-    /// Creates a new `Request` with the given media ID, server name and filename.
-    pub fn new(media_id: &'a str, server_name: &'a ServerName, filename: &'a str) -> Self {
-        Self { media_id, server_name, filename, allow_remote: true }
+    /// Creates a new `Request` with the given url and filename.
+    pub fn new(url: &'a MxcUri, filename: &'a str) -> Self {
+        Self {
+            media_id: url.media_id(),
+            server_name: url.server_name(),
+            filename,
+            allow_remote: true,
+        }
     }
 }
 

--- a/ruma-client-api/src/r0/media/get_content_as_filename.rs
+++ b/ruma-client-api/src/r0/media/get_content_as_filename.rs
@@ -58,8 +58,13 @@ ruma_api! {
 }
 
 impl<'a> Request<'a> {
+    /// Creates a new `Request` with the given media ID, server name and filename.
+    pub fn new(media_id: &'a str, server_name: &'a ServerName, filename: &'a str) -> Self {
+        Self { media_id, server_name, filename, allow_remote: true }
+    }
+
     /// Creates a new `Request` with the given url and filename.
-    pub fn new(url: &'a MxcUri, filename: &'a str) -> Self {
+    pub fn from_url(url: &'a MxcUri, filename: &'a str) -> Self {
         Self {
             media_id: url.media_id(),
             server_name: url.server_name(),

--- a/ruma-client-api/src/r0/media/get_content_thumbnail.rs
+++ b/ruma-client-api/src/r0/media/get_content_thumbnail.rs
@@ -2,7 +2,7 @@
 
 use js_int::UInt;
 use ruma_api::ruma_api;
-use ruma_identifiers::ServerName;
+use ruma_identifiers::{MxcUri, ServerName};
 use ruma_serde::StringEnum;
 
 /// The desired resizing method.
@@ -75,10 +75,17 @@ ruma_api! {
 }
 
 impl<'a> Request<'a> {
-    /// Creates a new `Request` with the given media ID, server name, desired thumbnail width and
+    /// Creates a new `Request` with the given url, desired thumbnail width and
     /// desired thumbnail height.
-    pub fn new(media_id: &'a str, server_name: &'a ServerName, width: UInt, height: UInt) -> Self {
-        Self { media_id, server_name, method: None, width, height, allow_remote: true }
+    pub fn new(url: &'a MxcUri, width: UInt, height: UInt) -> Self {
+        Self {
+            media_id: url.media_id(),
+            server_name: url.server_name(),
+            method: None,
+            width,
+            height,
+            allow_remote: true,
+        }
     }
 }
 

--- a/ruma-client-api/src/r0/media/get_content_thumbnail.rs
+++ b/ruma-client-api/src/r0/media/get_content_thumbnail.rs
@@ -75,9 +75,15 @@ ruma_api! {
 }
 
 impl<'a> Request<'a> {
+    /// Creates a new `Request` with the given media ID, server name, desired thumbnail width and
+    /// desired thumbnail height.
+    pub fn new(media_id: &'a str, server_name: &'a ServerName, width: UInt, height: UInt) -> Self {
+        Self { media_id, server_name, method: None, width, height, allow_remote: true }
+    }
+
     /// Creates a new `Request` with the given url, desired thumbnail width and
     /// desired thumbnail height.
-    pub fn new(url: &'a MxcUri, width: UInt, height: UInt) -> Self {
+    pub fn from_url(url: &'a MxcUri, width: UInt, height: UInt) -> Self {
         Self {
             media_id: url.media_id(),
             server_name: url.server_name(),


### PR DESCRIPTION
This simplifies the API since we get an `MxcUri` in responses.