### PR TITLE
xtask: Make release check before each step and ask to continue

### DIFF
--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -8,7 +8,9 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+isahc = { version = "1.2.0", features = ["json"] }
 itertools = "0.10.0"
+semver = { version = "0.11.0", features = ["serde"] }
 serde = { version = "1.0.118", features = ["derive"] }
 serde_json = "1.0.60"
 toml = "0.5.8"

--- a/xtask/src/flags.rs
+++ b/xtask/src/flags.rs
@@ -10,6 +10,7 @@ xflags::xflags! {
 
         /// Create a new release of the given crate.
         cmd release
+            /// The crate to release
             required name: String
         {}
     }


### PR DESCRIPTION
Also reorganize the code to have a nicer struct to work with.

Now even if the task fails at some point, you can just launch it again and skip the steps that worked the first time.

I disabled the echo of the `cmd` and instead it prints a line describing the step. Some useful output is kept: `cargo publish`, `git push`.

As asked, it starts by checking if the version is already released on GitHub.

Closes #462