### PR TITLE
docs: Use docsrs config attributes

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,29 +1,29 @@
 on:
-  push:
-    branches: [main]
+    push:
+        branches: [main]
 
 jobs:
-  build-deploy:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout repo
-      uses: actions/checkout@v2
-    - name: Install nightly rust toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        # Needed for use of unstable options
-        toolchain: nightly
-        override: true
-    - name: Build docs
-      uses: actions-rs/cargo@v1
-      env:
-       RUSTDOCFLAGS: "--enable-index-page -Zunstable-options"
-      with:
-        command: doc
-        args: --no-deps --workspace --exclude xtask --features api,events,signatures,appservice-api,client-api,federation-api,identity-service-api,push-gateway-api,either,rand,markdown,compat,unstable-pre-spec -Zrustdoc-map
-    - name: Deploy to docs branch
-      uses: JamesIves/github-pages-deploy-action@4.1.0
-      with:
-        branch: docs
-        folder: target/doc
+    build-deploy:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repo
+              uses: actions/checkout@v2
+            - name: Install nightly rust toolchain
+              uses: actions-rs/toolchain@v1
+              with:
+                  profile: minimal
+                  # Needed for use of unstable options
+                  toolchain: nightly
+                  override: true
+            - name: Build docs
+              uses: actions-rs/cargo@v1
+              env:
+                  RUSTDOCFLAGS: "--enable-index-page -Zunstable-options --cfg docsrs"
+              with:
+                  command: doc
+                  args: --no-deps --workspace --exclude xtask --features api,events,signatures,appservice-api,client-api,federation-api,identity-service-api,push-gateway-api,either,rand,markdown,compat,unstable-pre-spec -Zrustdoc-map
+            - name: Deploy to docs branch
+              uses: JamesIves/github-pages-deploy-action@4.1.0
+              with:
+                  branch: docs
+                  folder: target/doc


### PR DESCRIPTION
This enables the doc attributes that are already present, and are displayed on docs.rs.

Example: https://zecakeh.github.io/ruma/ruma/api/index.html