### PR TITLE
docs: Improve ruma crate documentation

### DIFF
--- a/ruma-api-macros/src/lib.rs
+++ b/ruma-api-macros/src/lib.rs
@@ -1,7 +1,6 @@
 #![doc(html_favicon_url = "https://www.ruma.io/favicon.ico")]
 #![doc(html_logo_url = "https://www.ruma.io/images/logo.png")]
-//! Crate ruma-api-macros provides a procedural macro for easily generating
-//! [ruma-api]-compatible endpoints.
+//! A procedural macro for easily generating [ruma-api]-compatible endpoints.
 //!
 //! This crate should never be used directly; instead, use it through the
 //! re-exports in ruma-api. Also note that for technical reasons, the

--- a/ruma-api/src/lib.rs
+++ b/ruma-api/src/lib.rs
@@ -1,8 +1,7 @@
 #![doc(html_favicon_url = "https://www.ruma.io/favicon.ico")]
 #![doc(html_logo_url = "https://www.ruma.io/images/logo.png")]
-//! Crate `ruma_api` contains core types used to define the requests and responses for each endpoint
-//! in the various [Matrix](https://matrix.org) API specifications.
-//! These types can be shared by client and server code for all Matrix APIs.
+//! Core types used to define the requests and responses for each endpoint in the various
+//! [Matrix API specifications][apis].
 //!
 //! When implementing a new Matrix API, each endpoint has a request type which implements
 //! `Endpoint`, and a response type connected via an associated type.
@@ -11,6 +10,8 @@
 //! input parameters for requests, and the structure of a successful response.
 //! Such types can then be used by client code to make requests, and by server code to fulfill
 //! those requests.
+//!
+//! [apis]: https://matrix.org/docs/spec/#matrix-apis
 
 #![doc(html_favicon_url = "https://www.ruma.io/favicon.ico")]
 #![warn(rust_2018_idioms)]
@@ -232,7 +233,7 @@ pub trait EndpointError: StdError + Sized + 'static {
     ) -> Result<Self, error::ResponseDeserializationError>;
 }
 
-/// A request type for a Matrix API endpoint. (trait used for sending requests)
+/// A request type for a Matrix API endpoint, used for sending requests.
 pub trait OutgoingRequest {
     /// A type capturing the expected error conditions the server can return.
     type EndpointError: EndpointError;
@@ -261,7 +262,7 @@ pub trait OutgoingRequest {
     ) -> Result<http::Request<Vec<u8>>, IntoHttpError>;
 }
 
-/// A request type for a Matrix API endpoint. (trait used for receiving requests)
+/// A request type for a Matrix API endpoint, used for receiving requests.
 pub trait IncomingRequest: Sized {
     /// A type capturing the error conditions that can be returned in the response.
     type EndpointError: EndpointError;
@@ -276,10 +277,10 @@ pub trait IncomingRequest: Sized {
     fn try_from_http_request(req: http::Request<Vec<u8>>) -> Result<Self, FromHttpRequestError>;
 }
 
-/// Marker trait for requests that don't require authentication. (for the client side)
+/// Marker trait for requests that don't require authentication, for the client side.
 pub trait OutgoingNonAuthRequest: OutgoingRequest {}
 
-/// Marker trait for requests that don't require authentication. (for the server side)
+/// Marker trait for requests that don't require authentication, for the server side.
 pub trait IncomingNonAuthRequest: IncomingRequest {}
 
 /// Authentication scheme used by the endpoint.

--- a/ruma-appservice-api/src/lib.rs
+++ b/ruma-appservice-api/src/lib.rs
@@ -1,8 +1,9 @@
 #![doc(html_favicon_url = "https://www.ruma.io/favicon.ico")]
 #![doc(html_logo_url = "https://www.ruma.io/images/logo.png")]
-//! Crate ruma_appservice_api contains serializable types for the requests and responses for each
-//! endpoint in the [Matrix](https://matrix.org/) application service API specification. These
-//! types can be shared by application service and server code.
+//! (De)serializable types for the [Matrix Application Service API][appservice-api].
+//! These types can be shared by application service and server code.
+//!
+//! [appservice-api]: https://matrix.org/docs/spec/application_service/r0.1.2.html
 
 #![warn(missing_debug_implementations, missing_docs)]
 

--- a/ruma-client-api/src/lib.rs
+++ b/ruma-client-api/src/lib.rs
@@ -1,8 +1,9 @@
 #![doc(html_favicon_url = "https://www.ruma.io/favicon.ico")]
 #![doc(html_logo_url = "https://www.ruma.io/images/logo.png")]
-//! Crate ruma_client_api contains serializable types for the requests and responses for each
-//! endpoint in the [Matrix](https://matrix.org/) client API specification. These types can be
-//! shared by client and server code.
+//! (De)serializable types for the [Matrix Client-Server API][client-api].
+//! These types can be shared by client and server code.
+//!
+//! [client-api]: https://matrix.org/docs/spec/client_server/r0.6.1.html
 
 #![warn(missing_debug_implementations, missing_docs)]
 

--- a/ruma-client-api/src/r0/account/request_3pid_management_token_via_email.rs
+++ b/ruma-client-api/src/r0/account/request_3pid_management_token_via_email.rs
@@ -40,6 +40,9 @@ ruma_api! {
         pub sid: String,
 
         /// URL to submit validation token to. If omitted, verification happens without client.
+        ///
+        /// If you activate the `compat` feature, this field being an empty string in JSON will give
+        /// you `None` here.
         #[serde(skip_serializing_if = "Option::is_none")]
         #[cfg_attr(
             feature = "compat",

--- a/ruma-client-api/src/r0/account/request_3pid_management_token_via_msisdn.rs
+++ b/ruma-client-api/src/r0/account/request_3pid_management_token_via_msisdn.rs
@@ -43,6 +43,9 @@ ruma_api! {
         pub sid: String,
 
         /// URL to submit validation token to. If omitted, verification happens without client.
+        ///
+        /// If you activate the `compat` feature, this field being an empty string in JSON will give
+        /// you `None` here.
         #[serde(skip_serializing_if = "Option::is_none")]
         #[cfg_attr(
             feature = "compat",

--- a/ruma-client-api/src/r0/account/request_password_change_token_via_email.rs
+++ b/ruma-client-api/src/r0/account/request_password_change_token_via_email.rs
@@ -40,6 +40,9 @@ ruma_api! {
         pub sid: String,
 
         /// URL to submit validation token to. If omitted, verification happens without client.
+        ///
+        /// If you activate the `compat` feature, this field being an empty string in JSON will give
+        /// you `None` here.
         #[serde(skip_serializing_if = "Option::is_none")]
         #[cfg_attr(
             feature = "compat",

--- a/ruma-client-api/src/r0/account/request_password_change_token_via_msisdn.rs
+++ b/ruma-client-api/src/r0/account/request_password_change_token_via_msisdn.rs
@@ -36,6 +36,9 @@ ruma_api! {
         pub sid: String,
 
         /// URL to submit validation token to. If omitted, verification happens without client.
+        ///
+        /// If you activate the `compat` feature, this field being an empty string in JSON will give
+        /// you `None` here.
         #[serde(skip_serializing_if = "Option::is_none")]
         #[cfg_attr(
             feature = "compat",

--- a/ruma-client-api/src/r0/account/request_registration_token_via_email.rs
+++ b/ruma-client-api/src/r0/account/request_registration_token_via_email.rs
@@ -40,6 +40,9 @@ ruma_api! {
         pub sid: String,
 
         /// URL to submit validation token to. If omitted, verification happens without client.
+        ///
+        /// If you activate the `compat` feature, this field being an empty string in JSON will give
+        /// you `None` here.
         #[serde(skip_serializing_if = "Option::is_none")]
         #[cfg_attr(
             feature = "compat",

--- a/ruma-client-api/src/r0/account/request_registration_token_via_msisdn.rs
+++ b/ruma-client-api/src/r0/account/request_registration_token_via_msisdn.rs
@@ -43,6 +43,9 @@ ruma_api! {
         pub sid: String,
 
         /// URL to submit validation token to. If omitted, verification happens without client.
+        ///
+        /// If you activate the `compat` feature, this field being an empty string in JSON will give
+        /// you `None` here.
         #[serde(skip_serializing_if = "Option::is_none")]
         #[cfg_attr(
             feature = "compat",

--- a/ruma-client-api/src/r0/directory.rs
+++ b/ruma-client-api/src/r0/directory.rs
@@ -44,6 +44,9 @@ pub struct PublicRoomsChunk {
     pub guest_can_join: bool,
 
     /// The URL for the room's avatar, if one is set.
+    ///
+    /// If you activate the `compat` feature, this field being an empty string in JSON will give
+    /// you `None` here.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg_attr(
         feature = "compat",

--- a/ruma-client-api/src/r0/membership/joined_members.rs
+++ b/ruma-client-api/src/r0/membership/joined_members.rs
@@ -54,6 +54,9 @@ pub struct RoomMember {
     pub display_name: Option<String>,
 
     /// The mxc avatar url of the user.
+    ///
+    /// If you activate the `compat` feature, this field being an empty string in JSON will give
+    /// you `None` here.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg_attr(
         feature = "compat",

--- a/ruma-client-api/src/r0/profile/get_avatar_url.rs
+++ b/ruma-client-api/src/r0/profile/get_avatar_url.rs
@@ -25,6 +25,9 @@ ruma_api! {
     #[derive(Default)]
     response: {
         /// The user's avatar URL, if set.
+        ///
+        /// If you activate the `compat` feature, this field being an empty string in JSON will give
+        /// you `None` here.
         #[serde(skip_serializing_if = "Option::is_none")]
         #[cfg_attr(
             feature = "compat",

--- a/ruma-client-api/src/r0/profile/get_profile.rs
+++ b/ruma-client-api/src/r0/profile/get_profile.rs
@@ -25,6 +25,9 @@ ruma_api! {
     #[derive(Default)]
     response: {
         /// The user's avatar URL, if set.
+        ///
+        /// If you activate the `compat` feature, this field being an empty string in JSON will give
+        /// you `None` here.
         #[serde(skip_serializing_if = "Option::is_none")]
         #[cfg_attr(
             feature = "compat",

--- a/ruma-client-api/src/r0/profile/set_avatar_url.rs
+++ b/ruma-client-api/src/r0/profile/set_avatar_url.rs
@@ -21,6 +21,9 @@ ruma_api! {
         /// The new avatar URL for the user.
         ///
         /// `None` is used to unset the avatar.
+        ///
+        /// If you activate the `compat` feature, this field being an empty string in JSON will give
+        /// you `None` here.
         #[serde(skip_serializing_if = "Option::is_none")]
         #[cfg_attr(
             feature = "compat",

--- a/ruma-client-api/src/r0/search/search_events.rs
+++ b/ruma-client-api/src/r0/search/search_events.rs
@@ -436,6 +436,9 @@ impl SearchResult {
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct UserProfile {
     /// The user's avatar URL, if set.
+    ///
+    /// If you activate the `compat` feature, this field being an empty string in JSON will give
+    /// you `None` here.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg_attr(
         feature = "compat",

--- a/ruma-client-api/src/r0/user_directory/search_users.rs
+++ b/ruma-client-api/src/r0/user_directory/search_users.rs
@@ -78,6 +78,9 @@ pub struct User {
     pub display_name: Option<String>,
 
     /// The avatar url, as an MXC, if one exists.
+    ///
+    /// If you activate the `compat` feature, this field being an empty string in JSON will give
+    /// you `None` here.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg_attr(
         feature = "compat",

--- a/ruma-client/src/lib.rs
+++ b/ruma-client/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc(html_favicon_url = "https://www.ruma.io/favicon.ico")]
 #![doc(html_logo_url = "https://www.ruma.io/images/logo.png")]
-//! Crate `ruma_client` is a [Matrix](https://matrix.org/) client library.
+//! A [Matrix](https://matrix.org/) client library.
 //!
 //! # Usage
 //!

--- a/ruma-common/src/directory.rs
+++ b/ruma-common/src/directory.rs
@@ -50,6 +50,9 @@ pub struct PublicRoomsChunk {
     pub guest_can_join: bool,
 
     /// The URL for the room's avatar, if one is set.
+    ///
+    /// If you activate the `compat` feature, this field being an empty string in JSON will give
+    /// you `None` here.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg_attr(
         feature = "compat",

--- a/ruma-common/src/directory.rs
+++ b/ruma-common/src/directory.rs
@@ -1,4 +1,4 @@
-//! Common types for room directory endpoints
+//! Common types for room directory endpoints.
 
 use std::fmt;
 

--- a/ruma-common/src/power_levels.rs
+++ b/ruma-common/src/power_levels.rs
@@ -10,6 +10,9 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct NotificationPowerLevels {
     /// The level required to trigger an `@room` notification.
+    ///
+    /// If you activate the `compat` feature, this field being a string in JSON will give
+    /// you an `Int` here.
     #[cfg_attr(feature = "compat", serde(deserialize_with = "ruma_serde::int_or_string_to_int"))]
     #[serde(default = "default_power_level")]
     pub room: Int,

--- a/ruma-common/src/power_levels.rs
+++ b/ruma-common/src/power_levels.rs
@@ -1,4 +1,4 @@
-//! Common types for the [`m.room.power_levels` event][power_levels]
+//! Common types for the [`m.room.power_levels` event][power_levels].
 //!
 //! [power_levels]: https://matrix.org/docs/spec/client_server/r0.6.1#m-room-power-levels
 

--- a/ruma-common/src/power_levels.rs
+++ b/ruma-common/src/power_levels.rs
@@ -11,8 +11,8 @@ use serde::{Deserialize, Serialize};
 pub struct NotificationPowerLevels {
     /// The level required to trigger an `@room` notification.
     ///
-    /// If you activate the `compat` feature, this field being a string in JSON will give
-    /// you an `Int` here.
+    /// If you activate the `compat` feature, deserialization will work for stringified
+    /// integers too.
     #[cfg_attr(feature = "compat", serde(deserialize_with = "ruma_serde::int_or_string_to_int"))]
     #[serde(default = "default_power_level")]
     pub room: Int,

--- a/ruma-common/src/presence.rs
+++ b/ruma-common/src/presence.rs
@@ -1,4 +1,4 @@
-//! Common types for the [presence module][presence]
+//! Common types for the [presence module][presence].
 //!
 //! [presence]: https://matrix.org/docs/spec/client_server/r0.6.1#id62
 

--- a/ruma-common/src/push.rs
+++ b/ruma-common/src/push.rs
@@ -1,4 +1,4 @@
-//! Common types for the [push notifications module][push]
+//! Common types for the [push notifications module][push].
 //!
 //! [push]: https://matrix.org/docs/spec/client_server/r0.6.1#id89
 //!

--- a/ruma-common/src/thirdparty.rs
+++ b/ruma-common/src/thirdparty.rs
@@ -1,4 +1,4 @@
-//! Common types for the [third party networks module][thirdparty]
+//! Common types for the [third party networks module][thirdparty].
 //!
 //! [thirdparty]: https://matrix.org/docs/spec/client_server/r0.6.1#id153
 

--- a/ruma-events-macros/src/lib.rs
+++ b/ruma-events-macros/src/lib.rs
@@ -1,7 +1,6 @@
 #![doc(html_favicon_url = "https://www.ruma.io/favicon.ico")]
 #![doc(html_logo_url = "https://www.ruma.io/images/logo.png")]
-//! Crate `ruma_events_macros` provides a procedural macro for generating
-//! [ruma-events] events.
+//! A procedural macro for generating [ruma-events] events.
 //!
 //! See the documentation for the individual macros for usage details.
 //!

--- a/ruma-events/src/lib.rs
+++ b/ruma-events/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc(html_favicon_url = "https://www.ruma.io/favicon.ico")]
 #![doc(html_logo_url = "https://www.ruma.io/images/logo.png")]
-//! Crate `ruma_events` contains serializable types for the events in the
-//! [Matrix](https://matrix.org) specification that can be shared by client and server code.
+//! (De)serializable types for the events in the [Matrix](https://matrix.org) specification.
+//! These types are used by other ruma crates.
 //!
 //! All data exchanged over Matrix is expressed as an event.
 //! Different event types represent different actions, such as joining a room or sending a message.

--- a/ruma-events/src/lib.rs
+++ b/ruma-events/src/lib.rs
@@ -113,6 +113,7 @@
 
 #![recursion_limit = "1024"]
 #![warn(missing_debug_implementations, missing_docs, rust_2018_idioms)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 // This lint is no good
 #![allow(clippy::new_without_default)]
 // Remove this once our MSRV is >= 1.53

--- a/ruma-events/src/presence.rs
+++ b/ruma-events/src/presence.rs
@@ -26,6 +26,9 @@ pub struct PresenceEvent {
 #[ruma_event(type = "m.presence")]
 pub struct PresenceEventContent {
     /// The current avatar URL for this user.
+    ///
+    /// If you activate the `compat` feature, this field being an empty string in JSON will give
+    /// you `None` here.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg_attr(
         feature = "compat",

--- a/ruma-events/src/room/member.rs
+++ b/ruma-events/src/room/member.rs
@@ -41,6 +41,9 @@ pub type MemberEvent = StateEvent<MemberEventContent>;
 #[ruma_event(type = "m.room.member")]
 pub struct MemberEventContent {
     /// The avatar URL for this user, if any. This is added by the homeserver.
+    ///
+    /// If you activate the `compat` feature, this field being an empty string in JSON will give
+    /// you `None` here.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg_attr(
         feature = "compat",

--- a/ruma-events/src/room/message.rs
+++ b/ruma-events/src/room/message.rs
@@ -489,6 +489,7 @@ impl TextMessageEventContent {
 
     /// A convenience constructor to create a markdown message.
     #[cfg(feature = "markdown")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "markdown")))]
     pub fn markdown(body: impl Into<String>) -> Self {
         let body = body.into();
         let mut html_body = String::new();

--- a/ruma-events/src/room/power_levels.rs
+++ b/ruma-events/src/room/power_levels.rs
@@ -20,6 +20,9 @@ pub type PowerLevelsEvent = StateEvent<PowerLevelsEventContent>;
 #[ruma_event(type = "m.room.power_levels")]
 pub struct PowerLevelsEventContent {
     /// The level required to ban a user.
+    ///
+    /// If you activate the `compat` feature, this field being a string in JSON will give
+    /// you an `Int` here.
     #[cfg_attr(feature = "compat", serde(deserialize_with = "ruma_serde::int_or_string_to_int"))]
     #[serde(default = "default_power_level", skip_serializing_if = "is_default_power_level")]
     #[ruma_event(skip_redaction)]
@@ -28,6 +31,9 @@ pub struct PowerLevelsEventContent {
     /// The level required to send specific event types.
     ///
     /// This is a mapping from event type to power level required.
+    ///
+    /// If you activate the `compat` feature, the value being a string in JSON will give
+    /// you an `Int` here.
     #[cfg_attr(
         feature = "compat",
         serde(deserialize_with = "ruma_serde::btreemap_int_or_string_to_int_values")
@@ -37,29 +43,44 @@ pub struct PowerLevelsEventContent {
     pub events: BTreeMap<EventType, Int>,
 
     /// The default level required to send message events.
+    ///
+    /// If you activate the `compat` feature, this field being a string in JSON will give
+    /// you an `Int` here.
     #[cfg_attr(feature = "compat", serde(deserialize_with = "ruma_serde::int_or_string_to_int"))]
     #[serde(default, skip_serializing_if = "ruma_serde::is_default")]
     #[ruma_event(skip_redaction)]
     pub events_default: Int,
 
     /// The level required to invite a user.
+    ///
+    /// If you activate the `compat` feature, this field being a string in JSON will give
+    /// you an `Int` here.
     #[cfg_attr(feature = "compat", serde(deserialize_with = "ruma_serde::int_or_string_to_int"))]
     #[serde(default = "default_power_level", skip_serializing_if = "is_default_power_level")]
     pub invite: Int,
 
     /// The level required to kick a user.
+    ///
+    /// If you activate the `compat` feature, this field being a string in JSON will give
+    /// you an `Int` here.
     #[cfg_attr(feature = "compat", serde(deserialize_with = "ruma_serde::int_or_string_to_int"))]
     #[serde(default = "default_power_level", skip_serializing_if = "is_default_power_level")]
     #[ruma_event(skip_redaction)]
     pub kick: Int,
 
     /// The level required to redact an event.
+    ///
+    /// If you activate the `compat` feature, this field being a string in JSON will give
+    /// you an `Int` here.
     #[cfg_attr(feature = "compat", serde(deserialize_with = "ruma_serde::int_or_string_to_int"))]
     #[serde(default = "default_power_level", skip_serializing_if = "is_default_power_level")]
     #[ruma_event(skip_redaction)]
     pub redact: Int,
 
     /// The default level required to send state events.
+    ///
+    /// If you activate the `compat` feature, this field being a string in JSON will give
+    /// you an `Int` here.
     #[cfg_attr(feature = "compat", serde(deserialize_with = "ruma_serde::int_or_string_to_int"))]
     #[serde(default = "default_power_level", skip_serializing_if = "is_default_power_level")]
     #[ruma_event(skip_redaction)]
@@ -68,6 +89,9 @@ pub struct PowerLevelsEventContent {
     /// The power levels for specific users.
     ///
     /// This is a mapping from `user_id` to power level for that user.
+    ///
+    /// If you activate the `compat` feature, the value being a string in JSON will give
+    /// you an `Int` here.
     #[cfg_attr(
         feature = "compat",
         serde(deserialize_with = "ruma_serde::btreemap_int_or_string_to_int_values")
@@ -77,6 +101,9 @@ pub struct PowerLevelsEventContent {
     pub users: BTreeMap<UserId, Int>,
 
     /// The default power level for every user in the room.
+    ///
+    /// If you activate the `compat` feature, this field being a string in JSON will give
+    /// you an `Int` here.
     #[cfg_attr(feature = "compat", serde(deserialize_with = "ruma_serde::int_or_string_to_int"))]
     #[serde(default, skip_serializing_if = "ruma_serde::is_default")]
     #[ruma_event(skip_redaction)]

--- a/ruma-events/src/room/power_levels.rs
+++ b/ruma-events/src/room/power_levels.rs
@@ -21,8 +21,8 @@ pub type PowerLevelsEvent = StateEvent<PowerLevelsEventContent>;
 pub struct PowerLevelsEventContent {
     /// The level required to ban a user.
     ///
-    /// If you activate the `compat` feature, this field being a string in JSON will give
-    /// you an `Int` here.
+    /// If you activate the `compat` feature, deserialization will work for stringified
+    /// integers too.
     #[cfg_attr(feature = "compat", serde(deserialize_with = "ruma_serde::int_or_string_to_int"))]
     #[serde(default = "default_power_level", skip_serializing_if = "is_default_power_level")]
     #[ruma_event(skip_redaction)]
@@ -32,8 +32,8 @@ pub struct PowerLevelsEventContent {
     ///
     /// This is a mapping from event type to power level required.
     ///
-    /// If you activate the `compat` feature, the value being a string in JSON will give
-    /// you an `Int` here.
+    /// If you activate the `compat` feature, deserialization will work for stringified
+    /// integers too.
     #[cfg_attr(
         feature = "compat",
         serde(deserialize_with = "ruma_serde::btreemap_int_or_string_to_int_values")
@@ -44,8 +44,8 @@ pub struct PowerLevelsEventContent {
 
     /// The default level required to send message events.
     ///
-    /// If you activate the `compat` feature, this field being a string in JSON will give
-    /// you an `Int` here.
+    /// If you activate the `compat` feature, deserialization will work for stringified
+    /// integers too.
     #[cfg_attr(feature = "compat", serde(deserialize_with = "ruma_serde::int_or_string_to_int"))]
     #[serde(default, skip_serializing_if = "ruma_serde::is_default")]
     #[ruma_event(skip_redaction)]
@@ -53,16 +53,16 @@ pub struct PowerLevelsEventContent {
 
     /// The level required to invite a user.
     ///
-    /// If you activate the `compat` feature, this field being a string in JSON will give
-    /// you an `Int` here.
+    /// If you activate the `compat` feature, deserialization will work for stringified
+    /// integers too.
     #[cfg_attr(feature = "compat", serde(deserialize_with = "ruma_serde::int_or_string_to_int"))]
     #[serde(default = "default_power_level", skip_serializing_if = "is_default_power_level")]
     pub invite: Int,
 
     /// The level required to kick a user.
     ///
-    /// If you activate the `compat` feature, this field being a string in JSON will give
-    /// you an `Int` here.
+    /// If you activate the `compat` feature, deserialization will work for stringified
+    /// integers too.
     #[cfg_attr(feature = "compat", serde(deserialize_with = "ruma_serde::int_or_string_to_int"))]
     #[serde(default = "default_power_level", skip_serializing_if = "is_default_power_level")]
     #[ruma_event(skip_redaction)]
@@ -70,8 +70,8 @@ pub struct PowerLevelsEventContent {
 
     /// The level required to redact an event.
     ///
-    /// If you activate the `compat` feature, this field being a string in JSON will give
-    /// you an `Int` here.
+    /// If you activate the `compat` feature, deserialization will work for stringified
+    /// integers too.
     #[cfg_attr(feature = "compat", serde(deserialize_with = "ruma_serde::int_or_string_to_int"))]
     #[serde(default = "default_power_level", skip_serializing_if = "is_default_power_level")]
     #[ruma_event(skip_redaction)]
@@ -79,8 +79,8 @@ pub struct PowerLevelsEventContent {
 
     /// The default level required to send state events.
     ///
-    /// If you activate the `compat` feature, this field being a string in JSON will give
-    /// you an `Int` here.
+    /// If you activate the `compat` feature, deserialization will work for stringified
+    /// integers too.
     #[cfg_attr(feature = "compat", serde(deserialize_with = "ruma_serde::int_or_string_to_int"))]
     #[serde(default = "default_power_level", skip_serializing_if = "is_default_power_level")]
     #[ruma_event(skip_redaction)]
@@ -90,8 +90,8 @@ pub struct PowerLevelsEventContent {
     ///
     /// This is a mapping from `user_id` to power level for that user.
     ///
-    /// If you activate the `compat` feature, the value being a string in JSON will give
-    /// you an `Int` here.
+    /// If you activate the `compat` feature, deserialization will work for stringified
+    /// integers too.
     #[cfg_attr(
         feature = "compat",
         serde(deserialize_with = "ruma_serde::btreemap_int_or_string_to_int_values")
@@ -102,8 +102,8 @@ pub struct PowerLevelsEventContent {
 
     /// The default power level for every user in the room.
     ///
-    /// If you activate the `compat` feature, this field being a string in JSON will give
-    /// you an `Int` here.
+    /// If you activate the `compat` feature, deserialization will work for stringified
+    /// integers too.
     #[cfg_attr(feature = "compat", serde(deserialize_with = "ruma_serde::int_or_string_to_int"))]
     #[serde(default, skip_serializing_if = "ruma_serde::is_default")]
     #[ruma_event(skip_redaction)]

--- a/ruma-events/src/room/third_party_invite.rs
+++ b/ruma-events/src/room/third_party_invite.rs
@@ -17,14 +17,23 @@ pub type ThirdPartyInviteEvent = StateEvent<ThirdPartyInviteEventContent>;
 #[ruma_event(type = "m.room.third_party_invite")]
 pub struct ThirdPartyInviteEventContent {
     /// A user-readable string which represents the user who has been invited.
+    ///
+    /// If you activate the `compat` feature, this field being absent in JSON will give you an
+    /// empty string here.
     #[cfg_attr(feature = "compat", serde(default))]
     pub display_name: String,
 
     /// A URL which can be fetched to validate whether the key has been revoked.
+    ///
+    /// If you activate the `compat` feature, this field being absent in JSON will give you an
+    /// empty string here.
     #[cfg_attr(feature = "compat", serde(default))]
     pub key_validity_url: String,
 
     /// A Base64-encoded Ed25519 key with which the token must be signed.
+    ///
+    /// If you activate the `compat` feature, this field being absent in JSON will give you an
+    /// empty string here.
     #[cfg_attr(feature = "compat", serde(default))]
     pub public_key: String,
 

--- a/ruma-events/src/room/tombstone.rs
+++ b/ruma-events/src/room/tombstone.rs
@@ -15,6 +15,9 @@ pub type TombstoneEvent = StateEvent<TombstoneEventContent>;
 #[ruma_event(type = "m.room.tombstone")]
 pub struct TombstoneEventContent {
     /// A server-defined message.
+    ///
+    /// If you activate the `compat` feature, this field being absent in JSON will give you an
+    /// empty string here.
     #[cfg_attr(feature = "compat", serde(default))]
     pub body: String,
 

--- a/ruma-federation-api/src/lib.rs
+++ b/ruma-federation-api/src/lib.rs
@@ -1,6 +1,9 @@
 #![doc(html_favicon_url = "https://www.ruma.io/favicon.ico")]
 #![doc(html_logo_url = "https://www.ruma.io/images/logo.png")]
-//! (De)serializable types for the Matrix Federation API.
+//! (De)serializable types for the [Matrix Server-Server API][federation-api].
+//! These types are used by server code.
+//!
+//! [federation-api]: https://matrix.org/docs/spec/server_server/r0.1.4.html
 
 #![warn(missing_docs)]
 

--- a/ruma-federation-api/src/query/get_profile_information/v1.rs
+++ b/ruma-federation-api/src/query/get_profile_information/v1.rs
@@ -32,6 +32,9 @@ ruma_api! {
         pub displayname: Option<String>,
 
         /// Avatar URL for the user's avatar.
+        ///
+        /// If you activate the `compat` feature, this field being an empty string in JSON will give
+        /// you `None` here.
         #[serde(skip_serializing_if = "Option::is_none")]
         #[cfg_attr(
             feature = "compat",

--- a/ruma-identifiers/src/device_key_id.rs
+++ b/ruma-identifiers/src/device_key_id.rs
@@ -4,7 +4,7 @@ use std::{convert::TryInto, fmt, num::NonZeroU8};
 
 use crate::{crypto_algorithms::DeviceKeyAlgorithm, DeviceId, Error};
 
-/// A key algorithm and a device id, combined with a ':'
+/// A key algorithm and a device id, combined with a ':'.
 #[derive(Clone)]
 pub struct DeviceKeyId {
     full_id: Box<str>,

--- a/ruma-identifiers/src/lib.rs
+++ b/ruma-identifiers/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc(html_favicon_url = "https://www.ruma.io/favicon.ico")]
 #![doc(html_logo_url = "https://www.ruma.io/images/logo.png")]
-//! Crate **ruma_identifiers** contains types for [Matrix](https://matrix.org/) identifiers
-//! for events, rooms, room aliases, room versions, and users.
+//! Types for [Matrix](https://matrix.org/) identifiers for devices, events, keys, rooms, servers,
+//! users and URIs.
 
 #![warn(rust_2018_idioms, missing_debug_implementations, missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg))]

--- a/ruma-identity-service-api/src/lib.rs
+++ b/ruma-identity-service-api/src/lib.rs
@@ -1,6 +1,9 @@
 #![doc(html_favicon_url = "https://www.ruma.io/favicon.ico")]
 #![doc(html_logo_url = "https://www.ruma.io/images/logo.png")]
-//! (De)serializable types for the Matrix Identity Service API.
+//! (De)serializable types for the [Matrix Identity Service API][identity-api].
+//! These types can be shared by client and identity service code.
+//!
+//! [identity-api]: https://matrix.org/docs/spec/identity_service/r0.3.0.html
 
 #![warn(missing_docs)]
 

--- a/ruma-identity-service-api/src/tos/accept_terms_of_service/v2.rs
+++ b/ruma-identity-service-api/src/tos/accept_terms_of_service/v2.rs
@@ -15,7 +15,7 @@ ruma_api! {
     request: {
         /// The URLs the user is accepting in this request.
         ///
-        /// An example is "https://example.org/somewhere/terms-2.0-en.html".
+        /// An example is `https://example.org/somewhere/terms-2.0-en.html`.
         pub user_accepts: Vec<String>,
     }
 

--- a/ruma-identity-service-api/src/tos/get_terms_of_service/v2.rs
+++ b/ruma-identity-service-api/src/tos/get_terms_of_service/v2.rs
@@ -67,7 +67,7 @@ pub struct LocalizedPolicy {
 
     /// The URL at wich the policy is available.
     ///
-    /// Examples are "https://example.org/somewhere/terms-2.0-en.html"
-    /// and "https://example.org/somewhere/terms-2.0-fr.html".
+    /// Examples are `https://example.org/somewhere/terms-2.0-en.html`
+    /// and `https://example.org/somewhere/terms-2.0-fr.html`.
     pub url: String,
 }

--- a/ruma-push-gateway-api/src/lib.rs
+++ b/ruma-push-gateway-api/src/lib.rs
@@ -1,6 +1,9 @@
 #![doc(html_favicon_url = "https://www.ruma.io/favicon.ico")]
 #![doc(html_logo_url = "https://www.ruma.io/images/logo.png")]
-//! (De)serializable types for the Matrix Push Gateway API.
+//! (De)serializable types for the [Matrix Push Gateway API][push-api].
+//! These types can be shared by push gateway and server code.
+//!
+//! [push-api]: https://matrix.org/docs/spec/push_gateway/r0.1.1.html
 
 #![warn(missing_docs)]
 

--- a/ruma-serde/src/lib.rs
+++ b/ruma-serde/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc(html_favicon_url = "https://www.ruma.io/favicon.ico")]
 #![doc(html_logo_url = "https://www.ruma.io/images/logo.png")]
-//! De-/serialization helpers for other ruma crates
+//! (De)serialization helpers for other ruma crates.
 
 pub mod can_be_empty;
 mod canonical_json;
@@ -48,10 +48,12 @@ pub fn is_true(b: &bool) -> bool {
     *b
 }
 
-/// A type that can be sent to another party that understands the matrix protocol. If any of the
-/// fields of `Self` don't implement serde's `Deserialize`, you can derive this trait to generate a
-/// corresponding 'Incoming' type that supports deserialization. This is useful for things like
-/// ruma_events' `EventResult` type. For more details, see the [derive macro's documentation][doc].
+/// A type that can be sent to another party that understands the matrix protocol.
+///
+/// If any of the fields of `Self` don't implement serde's `Deserialize`, you can derive this trait
+/// to generate a corresponding 'Incoming' type that supports deserialization. This is useful for
+/// things like ruma_events' `EventResult` type. For more details, see the
+/// [derive macro's documentation][doc].
 ///
 /// [doc]: derive.Outgoing.html
 // TODO: Better explain how this trait relates to serde's traits

--- a/ruma-signatures/src/lib.rs
+++ b/ruma-signatures/src/lib.rs
@@ -1,7 +1,6 @@
 #![doc(html_favicon_url = "https://www.ruma.io/favicon.ico")]
 #![doc(html_logo_url = "https://www.ruma.io/images/logo.png")]
-//! Crate `ruma_signatures` implements digital signatures according to the
-//! [Matrix](https://matrix.org/) specification.
+//! Digital signatures according to the [Matrix](https://matrix.org/) specification.
 //!
 //! Digital signatures are used by Matrix homeservers to verify the authenticity of events in the
 //! Matrix system, as well as requests between homeservers for federation. Each homeserver has one

--- a/ruma/src/lib.rs
+++ b/ruma/src/lib.rs
@@ -1,23 +1,64 @@
 #![doc(html_favicon_url = "https://www.ruma.io/favicon.ico")]
 #![doc(html_logo_url = "https://www.ruma.io/images/logo.png")]
-//! Types and traits for working with the Matrix protocol.
+//! Types and traits for working with the [Matrix](https://matrix.org) protocol.
 //!
 //! This crate re-exports things from all of the other ruma crates so you don't
 //! have to manually keep all the versions in sync.
 //!
 //! Which crates are re-exported can be configured through cargo features.
-//! Depending on which parts of Matrix are relevant to you, activate the
-//! following features:
 //!
-//! * `client-api` for the client-server API
-//! * `federation-api` for the server-server (federation) API
-//! * `appservice-api` for the application service API
+//! > ⚠ Some details might be missing because of the re-exports so you may need to refer to the
+//!   other crates' documentations.
 //!
-//! There's also the features `api`, `events` and `signatures` for the
-//! submodules of the same names. Usually they are activated by one of the
-//! other features when needed. If you are viewing this on `docs.rs`, you can
-//! have a look at the feature dependencies by clicking 'Feature flags' in the
-//! toolbar at the top.
+//! # API features
+//!
+//! Depending on which parts of Matrix are relevant to you, activate the following features:
+//!
+//! * `appservice-api` -- Application Service API.
+//! * `client-api` -- Client-Server API.
+//! * `federation-api` -- Server-Server (Federation) API.
+//! * `identity-service-api` -- Identity Service API.
+//! * `push-gateway-api` -- Push Gateway API.
+//!
+//! These features have `client`- and `server`-optimized variants that are enabled respectively
+//! with the `-c` and `-s` suffixes. For example:
+//!   * `client-api-c` -- The Client-Server API optimized for the client side.
+//!   * `client-api-s` -- The Client-Server API optimized for the server side.
+//!
+//! # Compatibility feature
+//!
+//! * `compat` increases compatibility with other parts of the Matrix ecosystem, at the expense of
+//! deviating from the specification.
+//!
+//! # Convenience features
+//!
+//! These features are only useful if you want to use a method that requires it:
+//!
+//! * `either`
+//! * `rand`
+//! * `markdown`
+//!
+//! # Unstable features
+//!
+//! By using these features, you opt out of all semver guarantees Ruma otherwise provides:
+//!
+//! * `unstable-exhaustive-types` -- The events in Ruma are marked as non-exhaustive to avoid
+//!   breaking changes when new fields are added in the specification. This feature compiles all
+//!   types as exhaustive.
+//! * `unstable-pre-spec` -- Upcoming Matrix features that may be subject to change or removal.
+//! * `unstable-synapse-quirks` -- Improve compatibility with Synapse homeservers where it deviates
+//!   from the specification.
+//!
+//! # Common features
+//!
+//! These submodules are usually activated by the API features when needed:
+//!
+//! * `api`
+//! * `events`
+//! * `signatures`
+//!
+//! If you are viewing this on `docs.rs`, you can have a look at the feature dependencies by
+//! clicking **Feature flags** in the toolbar at the top.
 
 #![deny(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
@@ -52,7 +93,10 @@ pub use ruma_events as events;
 #[doc(inline)]
 pub use ruma_signatures as signatures;
 
-/// Rust types for various Matrix APIs requests and responses and abstractions for them.
+/// (De)serializable types for various [Matrix APIs][apis] requests and responses and abstractions
+/// for them.
+///
+/// [apis]: https://matrix.org/docs/spec/#matrix-apis
 #[cfg(feature = "api")]
 #[cfg_attr(docsrs, doc(cfg(feature = "api")))]
 pub mod api {

--- a/ruma/src/lib.rs
+++ b/ruma/src/lib.rs
@@ -7,8 +7,8 @@
 //!
 //! Which crates are re-exported can be configured through cargo features.
 //!
-//! > ⚠ Some details might be missing because of the re-exports so you may need to refer to the
-//!   other crates' documentations.
+//! > ⚠ Some details might be missing because rustdoc has trouble with re-exports so you may need
+//!   to refer to other crates' documentations.
 //!
 //! # API features
 //!
@@ -42,12 +42,12 @@
 //!
 //! By using these features, you opt out of all semver guarantees Ruma otherwise provides:
 //!
-//! * `unstable-exhaustive-types` -- The events in Ruma are marked as non-exhaustive to avoid
+//! * `unstable-exhaustive-types` -- Most types in Ruma are marked as non-exhaustive to avoid
 //!   breaking changes when new fields are added in the specification. This feature compiles all
 //!   types as exhaustive.
 //! * `unstable-pre-spec` -- Upcoming Matrix features that may be subject to change or removal.
-//! * `unstable-synapse-quirks` -- Improve compatibility with Synapse homeservers where it deviates
-//!   from the specification.
+//! * `unstable-synapse-quirks` -- Fix issues for clients expecting to connect to Synapse
+//!   homeservers, at the expense of being less compatible with other homeservers.
 //!
 //! # Common features
 //!


### PR DESCRIPTION
My focus was mainly on `ruma`'s index page and the `ruma::api` page. The commits are self-explanatory for the various steps.

Preview here: https://zecakeh.github.io/ruma/ruma/index.html

Also documented the `compat` feature to fix #404.