### PR TITLE
Rework the traits in ruma-api

### DIFF
--- a/ruma-api-macros/src/api/request.rs
+++ b/ruma-api-macros/src/api/request.rs
@@ -2,13 +2,16 @@
 
 use std::collections::BTreeSet;
 
-use proc_macro2::{Span, TokenStream};
-use quote::{quote, quote_spanned};
-use syn::{spanned::Spanned, Attribute, Field, Ident, Lifetime};
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{Attribute, Field, Ident, Lifetime};
 
 use crate::util;
 
 use super::metadata::Metadata;
+
+mod incoming;
+mod outgoing;
 
 #[derive(Debug, Default)]
 pub(super) struct RequestLifetimes {
@@ -54,11 +57,6 @@ impl Request {
     /// Produces an iterator over all the body fields.
     pub(super) fn body_fields(&self) -> impl Iterator<Item = &Field> {
         self.fields.iter().filter_map(|field| field.as_body_field())
-    }
-
-    /// The number of unique lifetime annotations for `body` fields.
-    fn body_lifetime_count(&self) -> usize {
-        self.lifetimes.body.len()
     }
 
     /// Whether any `body` field has a lifetime annotation.
@@ -128,74 +126,14 @@ impl Request {
         self.fields.iter().find_map(RequestField::as_query_map_field)
     }
 
-    /// Produces code for a struct initializer for the given field kind to be accessed through the
-    /// given variable name.
-    fn struct_init_fields(
-        &self,
-        request_field_kind: RequestFieldKind,
-        src: TokenStream,
-    ) -> TokenStream {
-        let fields =
-            self.fields.iter().filter_map(|f| f.field_of_kind(request_field_kind)).map(|field| {
-                let field_name =
-                    field.ident.as_ref().expect("expected field to have an identifier");
-                let span = field.span();
-                let cfg_attrs =
-                    field.attrs.iter().filter(|a| a.path.is_ident("cfg")).collect::<Vec<_>>();
-
-                quote_spanned! {span=>
-                    #( #cfg_attrs )*
-                    #field_name: #src.#field_name
-                }
-            });
-
-        quote! { #(#fields,)* }
-    }
-
-    fn vars(
-        &self,
-        request_field_kind: RequestFieldKind,
-        src: TokenStream,
-    ) -> (TokenStream, TokenStream) {
-        let (decls, names): (TokenStream, Vec<_>) = self
-            .fields
-            .iter()
-            .filter_map(|f| f.field_of_kind(request_field_kind))
-            .map(|field| {
-                let field_name =
-                    field.ident.as_ref().expect("expected field to have an identifier");
-                let span = field.span();
-                let cfg_attrs =
-                    field.attrs.iter().filter(|a| a.path.is_ident("cfg")).collect::<Vec<_>>();
-
-                let decl = quote_spanned! {span=>
-                    #( #cfg_attrs )*
-                    let #field_name = #src.#field_name;
-                };
-
-                (decl, field_name)
-            })
-            .unzip();
-
-        let names = quote! { #(#names,)* };
-
-        (decls, names)
-    }
-
     pub(super) fn expand(
         &self,
         metadata: &Metadata,
         error_ty: &TokenStream,
         ruma_api: &TokenStream,
     ) -> TokenStream {
-        let bytes = quote! { #ruma_api::exports::bytes };
-        let http = quote! { #ruma_api::exports::http };
-        let percent_encoding = quote! { #ruma_api::exports::percent_encoding };
         let ruma_serde = quote! { #ruma_api::exports::ruma_serde };
         let serde = quote! { #ruma_api::exports::serde };
-        let serde_json = quote! { #ruma_api::exports::serde_json };
-
-        let method = &metadata.method;
 
         let docs = format!(
             "Data for a request to the `{}` API endpoint.\n\n{}",
@@ -210,342 +148,6 @@ impl Request {
             let fields = self.fields.iter().map(|request_field| request_field.field());
             quote! { { #(#fields),* } }
         };
-
-        let incoming_request_type =
-            if self.contains_lifetimes() { quote!(IncomingRequest) } else { quote!(Request) };
-
-        let (request_path_string, parse_request_path, path_vars) = if self.has_path_fields() {
-            let path_string = metadata.path.value();
-
-            assert!(path_string.starts_with('/'), "path needs to start with '/'");
-            assert!(
-                path_string.chars().filter(|c| *c == ':').count() == self.path_field_count(),
-                "number of declared path parameters needs to match amount of placeholders in path"
-            );
-
-            let format_call = {
-                let mut format_string = path_string.clone();
-                let mut format_args = Vec::new();
-
-                while let Some(start_of_segment) = format_string.find(':') {
-                    // ':' should only ever appear at the start of a segment
-                    assert_eq!(&format_string[start_of_segment - 1..start_of_segment], "/");
-
-                    let end_of_segment = match format_string[start_of_segment..].find('/') {
-                        Some(rel_pos) => start_of_segment + rel_pos,
-                        None => format_string.len(),
-                    };
-
-                    let path_var = Ident::new(
-                        &format_string[start_of_segment + 1..end_of_segment],
-                        Span::call_site(),
-                    );
-                    format_args.push(quote! {
-                        #percent_encoding::utf8_percent_encode(
-                            &self.#path_var.to_string(),
-                            #percent_encoding::NON_ALPHANUMERIC,
-                        )
-                    });
-                    format_string.replace_range(start_of_segment..end_of_segment, "{}");
-                }
-
-                quote! {
-                    format_args!(#format_string, #(#format_args),*)
-                }
-            };
-
-            let path_var_decls = path_string[1..]
-                .split('/')
-                .enumerate()
-                .filter(|(_, seg)| seg.starts_with(':'))
-                .map(|(i, seg)| {
-                    let path_var = Ident::new(&seg[1..], Span::call_site());
-                    quote! {
-                        let #path_var = {
-                            let segment = path_segments[#i].as_bytes();
-                            let decoded =
-                                #percent_encoding::percent_decode(segment).decode_utf8()?;
-
-                            ::std::convert::TryFrom::try_from(&*decoded)?
-                        };
-                    }
-                });
-
-            let parse_request_path = quote! {
-                let path_segments: ::std::vec::Vec<&::std::primitive::str> =
-                    request.uri().path()[1..].split('/').collect();
-
-                #(#path_var_decls)*
-            };
-
-            let path_vars = path_string[1..]
-                .split('/')
-                .filter(|seg| seg.starts_with(':'))
-                .map(|seg| Ident::new(&seg[1..], Span::call_site()));
-
-            (format_call, parse_request_path, quote! { #(#path_vars,)* })
-        } else {
-            (quote! { metadata.path.to_owned() }, TokenStream::new(), TokenStream::new())
-        };
-
-        let request_query_string = if let Some(field) = self.query_map_field() {
-            let field_name = field.ident.as_ref().expect("expected field to have identifier");
-
-            quote!({
-                // This function exists so that the compiler will throw an error when the type of
-                // the field with the query_map attribute doesn't implement
-                // `IntoIterator<Item = (String, String)>`.
-                //
-                // This is necessary because the `ruma_serde::urlencoded::to_string` call will
-                // result in a runtime error when the type cannot be encoded as a list key-value
-                // pairs (?key1=value1&key2=value2).
-                //
-                // By asserting that it implements the iterator trait, we can ensure that it won't
-                // fail.
-                fn assert_trait_impl<T>(_: &T)
-                where
-                    T: ::std::iter::IntoIterator<
-                        Item = (::std::string::String, ::std::string::String),
-                    >,
-                {}
-
-                let request_query = RequestQuery(self.#field_name);
-                assert_trait_impl(&request_query.0);
-
-                format_args!(
-                    "?{}",
-                    #ruma_serde::urlencoded::to_string(request_query)?
-                )
-            })
-        } else if self.has_query_fields() {
-            let request_query_init_fields =
-                self.struct_init_fields(RequestFieldKind::Query, quote!(self));
-
-            quote!({
-                let request_query = RequestQuery {
-                    #request_query_init_fields
-                };
-
-                format_args!(
-                    "?{}",
-                    #ruma_serde::urlencoded::to_string(request_query)?
-                )
-            })
-        } else {
-            quote! { "" }
-        };
-
-        let (parse_query, query_vars) = if let Some(field) = self.query_map_field() {
-            let field_name = field.ident.as_ref().expect("expected field to have an identifier");
-            let parse = quote! {
-                let #field_name = #ruma_serde::urlencoded::from_str(
-                    &request.uri().query().unwrap_or(""),
-                )?;
-            };
-
-            (parse, quote! { #field_name, })
-        } else if self.has_query_fields() {
-            let (decls, names) = self.vars(RequestFieldKind::Query, quote!(request_query));
-
-            let parse = quote! {
-                let request_query: <RequestQuery as #ruma_serde::Outgoing>::Incoming =
-                    #ruma_serde::urlencoded::from_str(
-                        &request.uri().query().unwrap_or("")
-                    )?;
-
-                #decls
-            };
-
-            (parse, names)
-        } else {
-            (TokenStream::new(), TokenStream::new())
-        };
-
-        let mut header_kvs: TokenStream = self
-            .header_fields()
-            .map(|request_field| {
-                let (field, header_name) = match request_field {
-                    RequestField::Header(field, header_name) => (field, header_name),
-                    _ => unreachable!("expected request field to be header variant"),
-                };
-
-                let field_name = &field.ident;
-
-                match &field.ty {
-                    syn::Type::Path(syn::TypePath { path: syn::Path { segments, .. }, .. })
-                        if segments.last().unwrap().ident == "Option" =>
-                    {
-                        quote! {
-                            if let Some(header_val) = self.#field_name.as_ref() {
-                                req_headers.insert(
-                                    #http::header::#header_name,
-                                    #http::header::HeaderValue::from_str(header_val)?,
-                                );
-                            }
-                        }
-                    }
-                    _ => quote! {
-                        req_headers.insert(
-                            #http::header::#header_name,
-                            #http::header::HeaderValue::from_str(self.#field_name.as_ref())?,
-                        );
-                    },
-                }
-            })
-            .collect();
-
-        for auth in &metadata.authentication {
-            if auth.value == "AccessToken" {
-                let attrs = &auth.attrs;
-                header_kvs.extend(quote! {
-                    #( #attrs )*
-                    req_headers.insert(
-                        #http::header::AUTHORIZATION,
-                        #http::header::HeaderValue::from_str(
-                            &::std::format!(
-                                "Bearer {}",
-                                access_token.ok_or(
-                                    #ruma_api::error::IntoHttpError::NeedsAuthentication
-                                )?
-                            )
-                        )?
-                    );
-                });
-            }
-        }
-
-        let (parse_headers, header_vars) = if self.has_header_fields() {
-            let (decls, names): (TokenStream, Vec<_>) = self
-                .header_fields()
-                .map(|request_field| {
-                    let (field, header_name) = match request_field {
-                        RequestField::Header(field, header_name) => (field, header_name),
-                        _ => panic!("expected request field to be header variant"),
-                    };
-
-                    let field_name = &field.ident;
-                    let header_name_string = header_name.to_string();
-
-                    let (some_case, none_case) = match &field.ty {
-                        syn::Type::Path(syn::TypePath {
-                            path: syn::Path { segments, .. }, ..
-                        }) if segments.last().unwrap().ident == "Option" => {
-                            (quote! { Some(str_value.to_owned()) }, quote! { None })
-                        }
-                        _ => (
-                            quote! { str_value.to_owned() },
-                            quote! {
-                                return Err(
-                                    #ruma_api::error::HeaderDeserializationError::MissingHeader(
-                                        #header_name_string.into()
-                                    ).into(),
-                                )
-                            },
-                        ),
-                    };
-
-                    let decl = quote! {
-                        let #field_name = match headers.get(#http::header::#header_name) {
-                            Some(header_value) => {
-                                let str_value = header_value.to_str()?;
-                                #some_case
-                            }
-                            None => #none_case,
-                        };
-                    };
-
-                    (decl, field_name)
-                })
-                .unzip();
-
-            let parse = quote! {
-                let headers = request.headers();
-
-                #decls
-            };
-
-            (parse, quote! { #(#names,)* })
-        } else {
-            (TokenStream::new(), TokenStream::new())
-        };
-
-        let extract_body = if self.has_body_fields() || self.newtype_body_field().is_some() {
-            let body_lifetimes = if self.has_body_lifetimes() {
-                // duplicate the anonymous lifetime as many times as needed
-                let lifetimes = std::iter::repeat(quote! { '_ }).take(self.body_lifetime_count());
-                quote! { < #( #lifetimes, )* >}
-            } else {
-                TokenStream::new()
-            };
-
-            quote! {
-                let request_body: <
-                    RequestBody #body_lifetimes
-                    as #ruma_serde::Outgoing
-                >::Incoming = {
-                    let body = request.into_body();
-                    if #bytes::Buf::has_remaining(&body) {
-                        #serde_json::from_reader(#bytes::Buf::reader(body))?
-                    } else {
-                        // If the request body is completely empty, pretend it is an empty JSON
-                        // object instead. This allows requests with only optional body parameters
-                        // to be deserialized in that case.
-                        #serde_json::from_str("{}")?
-                    }
-                };
-            }
-        } else {
-            TokenStream::new()
-        };
-
-        let request_body = if let Some(field) = self.newtype_raw_body_field() {
-            let field_name = field.ident.as_ref().expect("expected field to have an identifier");
-            quote! { self.#field_name }
-        } else if self.has_body_fields() || self.newtype_body_field().is_some() {
-            let request_body_initializers = if let Some(field) = self.newtype_body_field() {
-                let field_name =
-                    field.ident.as_ref().expect("expected field to have an identifier");
-                quote! { (self.#field_name) }
-            } else {
-                let initializers = self.struct_init_fields(RequestFieldKind::Body, quote!(self));
-                quote! { { #initializers } }
-            };
-
-            quote! {
-                {
-                    let request_body = RequestBody #request_body_initializers;
-                    #serde_json::to_vec(&request_body)?
-                }
-            }
-        } else {
-            quote! { Vec::new() }
-        };
-
-        let (parse_body, body_vars) = if let Some(field) = self.newtype_body_field() {
-            let field_name = field.ident.as_ref().expect("expected field to have an identifier");
-            let parse = quote! {
-                let #field_name = request_body.0;
-            };
-
-            (parse, quote! { #field_name, })
-        } else if let Some(field) = self.newtype_raw_body_field() {
-            let field_name = field.ident.as_ref().expect("expected field to have an identifier");
-            let parse = quote! {
-                let #field_name = {
-                    let mut reader = #bytes::Buf::reader(request.into_body());
-                    let mut vec = ::std::vec::Vec::new();
-                    ::std::io::Read::read_to_end(&mut reader, &mut vec)
-                        .expect("reading from a bytes::Buf never fails");
-                    vec
-                };
-            };
-
-            (parse, quote! { #field_name, })
-        } else {
-            self.vars(RequestFieldKind::Body, quote!(request_body))
-        };
-
-        let request_generics = self.combine_lifetimes();
 
         let request_body_struct =
             if let Some(body_field) = self.fields.iter().find(|f| f.is_newtype_body()) {
@@ -629,31 +231,9 @@ impl Request {
             TokenStream::new()
         };
 
-        let request_lifetimes = self.combine_lifetimes();
-        let non_auth_endpoint_impls: TokenStream = metadata
-            .authentication
-            .iter()
-            .map(|auth| {
-                if auth.value != "None" {
-                    TokenStream::new()
-                } else {
-                    let attrs = &auth.attrs;
-                    quote! {
-                        #( #attrs )*
-                        #[automatically_derived]
-                        #[cfg(feature = "client")]
-                        impl #request_lifetimes #ruma_api::OutgoingNonAuthRequest
-                            for Request #request_lifetimes
-                            {}
-
-                        #( #attrs )*
-                        #[automatically_derived]
-                        #[cfg(feature = "server")]
-                        impl #ruma_api::IncomingNonAuthRequest for #incoming_request_type {}
-                    }
-                }
-            })
-            .collect();
+        let lifetimes = self.combine_lifetimes();
+        let outgoing_request_impl = self.expand_outgoing(metadata, error_ty, &lifetimes, ruma_api);
+        let incoming_request_impl = self.expand_incoming(metadata, error_ty, ruma_api);
 
         quote! {
             #[doc = #docs]
@@ -661,89 +241,13 @@ impl Request {
             #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
             #[incoming_derive(!Deserialize)]
             #( #struct_attributes )*
-            pub struct Request #request_generics #request_def
-
-            #non_auth_endpoint_impls
+            pub struct Request #lifetimes #request_def
 
             #request_body_struct
             #request_query_struct
 
-            #[automatically_derived]
-            #[cfg(feature = "client")]
-            impl #request_lifetimes #ruma_api::OutgoingRequest for Request #request_lifetimes {
-                type EndpointError = #error_ty;
-                type IncomingResponse = <Response as #ruma_serde::Outgoing>::Incoming;
-
-                const METADATA: #ruma_api::Metadata = self::METADATA;
-
-                fn try_into_http_request(
-                    self,
-                    base_url: &::std::primitive::str,
-                    access_token: ::std::option::Option<&str>,
-                ) -> ::std::result::Result<
-                    #http::Request<Vec<u8>>,
-                    #ruma_api::error::IntoHttpError,
-                > {
-                    let metadata = self::METADATA;
-
-                    let mut req_builder = #http::Request::builder()
-                        .method(#http::Method::#method)
-                        .uri(::std::format!(
-                            "{}{}{}",
-                            base_url.strip_suffix('/').unwrap_or(base_url),
-                            #request_path_string,
-                            #request_query_string,
-                        ))
-                        .header(
-                            #ruma_api::exports::http::header::CONTENT_TYPE,
-                            "application/json",
-                        );
-
-                    let mut req_headers = req_builder
-                        .headers_mut()
-                        .expect("`http::RequestBuilder` is in unusable state");
-
-                    #header_kvs
-
-                    let http_request = req_builder.body(#request_body)?;
-
-                    Ok(http_request)
-                }
-            }
-
-            #[automatically_derived]
-            #[cfg(feature = "server")]
-            impl #ruma_api::IncomingRequest for #incoming_request_type {
-                type EndpointError = #error_ty;
-                type OutgoingResponse = Response;
-
-                const METADATA: #ruma_api::Metadata = self::METADATA;
-
-                fn try_from_http_request<T: #bytes::Buf>(
-                    request: #http::Request<T>
-                ) -> ::std::result::Result<Self, #ruma_api::error::FromHttpRequestError> {
-                    if request.method() != #http::Method::#method {
-                        return Err(#ruma_api::error::FromHttpRequestError::MethodMismatch {
-                            expected: #http::Method::#method,
-                            received: request.method().clone(),
-                        });
-                    }
-
-                    #parse_request_path
-                    #parse_query
-                    #parse_headers
-
-                    #extract_body
-                    #parse_body
-
-                    Ok(Self {
-                        #path_vars
-                        #query_vars
-                        #header_vars
-                        #body_vars
-                    })
-                }
-            }
+            #outgoing_request_impl
+            #incoming_request_impl
         }
     }
 }
@@ -774,7 +278,7 @@ pub(crate) enum RequestField {
 
 impl RequestField {
     /// Creates a new `RequestField`.
-    pub fn new(kind: RequestFieldKind, field: Field, header: Option<Ident>) -> Self {
+    pub(super) fn new(kind: RequestFieldKind, field: Field, header: Option<Ident>) -> Self {
         match kind {
             RequestFieldKind::Body => RequestField::Body(field),
             RequestFieldKind::Header => {
@@ -788,71 +292,58 @@ impl RequestField {
         }
     }
 
-    /// Gets the kind of the request field.
-    pub fn kind(&self) -> RequestFieldKind {
-        match self {
-            RequestField::Body(..) => RequestFieldKind::Body,
-            RequestField::Header(..) => RequestFieldKind::Header,
-            RequestField::NewtypeBody(..) => RequestFieldKind::NewtypeBody,
-            RequestField::NewtypeRawBody(..) => RequestFieldKind::NewtypeRawBody,
-            RequestField::Path(..) => RequestFieldKind::Path,
-            RequestField::Query(..) => RequestFieldKind::Query,
-            RequestField::QueryMap(..) => RequestFieldKind::QueryMap,
-        }
-    }
-
     /// Whether or not this request field is a body kind.
-    pub fn is_body(&self) -> bool {
-        self.kind() == RequestFieldKind::Body
+    pub(super) fn is_body(&self) -> bool {
+        matches!(self, RequestField::Body(..))
     }
 
     /// Whether or not this request field is a header kind.
-    pub fn is_header(&self) -> bool {
-        self.kind() == RequestFieldKind::Header
+    fn is_header(&self) -> bool {
+        matches!(self, RequestField::Header(..))
     }
 
     /// Whether or not this request field is a newtype body kind.
-    pub fn is_newtype_body(&self) -> bool {
-        self.kind() == RequestFieldKind::NewtypeBody
+    fn is_newtype_body(&self) -> bool {
+        matches!(self, RequestField::NewtypeBody(..))
     }
 
     /// Whether or not this request field is a path kind.
-    pub fn is_path(&self) -> bool {
-        self.kind() == RequestFieldKind::Path
+    fn is_path(&self) -> bool {
+        matches!(self, RequestField::Path(..))
     }
 
     /// Whether or not this request field is a query string kind.
-    pub fn is_query(&self) -> bool {
-        self.kind() == RequestFieldKind::Query
+    pub(super) fn is_query(&self) -> bool {
+        matches!(self, RequestField::Query(..))
     }
 
     /// Return the contained field if this request field is a body kind.
-    pub fn as_body_field(&self) -> Option<&Field> {
+    fn as_body_field(&self) -> Option<&Field> {
         self.field_of_kind(RequestFieldKind::Body)
     }
 
     /// Return the contained field if this request field is a body kind.
-    pub fn as_newtype_body_field(&self) -> Option<&Field> {
+    fn as_newtype_body_field(&self) -> Option<&Field> {
         self.field_of_kind(RequestFieldKind::NewtypeBody)
     }
 
     /// Return the contained field if this request field is a raw body kind.
-    pub fn as_newtype_raw_body_field(&self) -> Option<&Field> {
+    fn as_newtype_raw_body_field(&self) -> Option<&Field> {
         self.field_of_kind(RequestFieldKind::NewtypeRawBody)
     }
 
     /// Return the contained field if this request field is a query kind.
-    pub fn as_query_field(&self) -> Option<&Field> {
+    fn as_query_field(&self) -> Option<&Field> {
         self.field_of_kind(RequestFieldKind::Query)
     }
 
     /// Return the contained field if this request field is a query map kind.
-    pub fn as_query_map_field(&self) -> Option<&Field> {
+    fn as_query_map_field(&self) -> Option<&Field> {
         self.field_of_kind(RequestFieldKind::QueryMap)
     }
 
     /// Gets the inner `Field` value.
-    pub fn field(&self) -> &Field {
+    fn field(&self) -> &Field {
         match self {
             RequestField::Body(field)
             | RequestField::Header(field, _)
@@ -865,11 +356,16 @@ impl RequestField {
     }
 
     /// Gets the inner `Field` value if it's of the provided kind.
-    pub fn field_of_kind(&self, kind: RequestFieldKind) -> Option<&Field> {
-        if self.kind() == kind {
-            Some(self.field())
-        } else {
-            None
+    fn field_of_kind(&self, kind: RequestFieldKind) -> Option<&Field> {
+        match (self, kind) {
+            (RequestField::Body(field), RequestFieldKind::Body)
+            | (RequestField::Header(field, _), RequestFieldKind::Header)
+            | (RequestField::NewtypeBody(field), RequestFieldKind::NewtypeBody)
+            | (RequestField::NewtypeRawBody(field), RequestFieldKind::NewtypeRawBody)
+            | (RequestField::Path(field), RequestFieldKind::Path)
+            | (RequestField::Query(field), RequestFieldKind::Query)
+            | (RequestField::QueryMap(field), RequestFieldKind::QueryMap) => Some(field),
+            _ => None,
         }
     }
 }
@@ -877,24 +373,11 @@ impl RequestField {
 /// The types of fields that a request can have, without their values.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub(crate) enum RequestFieldKind {
-    /// See the similarly named variant of `RequestField`.
     Body,
-
-    /// See the similarly named variant of `RequestField`.
     Header,
-
-    /// See the similarly named variant of `RequestField`.
     NewtypeBody,
-
-    /// See the similarly named variant of `RequestField`.
     NewtypeRawBody,
-
-    /// See the similarly named variant of `RequestField`.
     Path,
-
-    /// See the similarly named variant of `RequestField`.
     Query,
-
-    /// See the similarly named variant of `RequestField`.
     QueryMap,
 }

--- a/ruma-api-macros/src/api/request/incoming.rs
+++ b/ruma-api-macros/src/api/request/incoming.rs
@@ -1,0 +1,277 @@
+use proc_macro2::{Ident, Span, TokenStream};
+use quote::quote;
+
+use super::{Metadata, Request, RequestField, RequestFieldKind};
+
+impl Request {
+    pub fn expand_incoming(
+        &self,
+        metadata: &Metadata,
+        error_ty: &TokenStream,
+        ruma_api: &TokenStream,
+    ) -> TokenStream {
+        let bytes = quote! { #ruma_api::exports::bytes };
+        let http = quote! { #ruma_api::exports::http };
+        let percent_encoding = quote! { #ruma_api::exports::percent_encoding };
+        let ruma_serde = quote! { #ruma_api::exports::ruma_serde };
+        let serde_json = quote! { #ruma_api::exports::serde_json };
+
+        let method = &metadata.method;
+
+        let incoming_request_type =
+            if self.contains_lifetimes() { quote!(IncomingRequest) } else { quote!(Request) };
+
+        let (parse_request_path, path_vars) = if self.has_path_fields() {
+            let path_string = metadata.path.value();
+
+            assert!(path_string.starts_with('/'), "path needs to start with '/'");
+            assert!(
+                path_string.chars().filter(|c| *c == ':').count() == self.path_field_count(),
+                "number of declared path parameters needs to match amount of placeholders in path"
+            );
+
+            let path_var_decls = path_string[1..]
+                .split('/')
+                .enumerate()
+                .filter(|(_, seg)| seg.starts_with(':'))
+                .map(|(i, seg)| {
+                    let path_var = Ident::new(&seg[1..], Span::call_site());
+                    quote! {
+                        let #path_var = {
+                            let segment = path_segments[#i].as_bytes();
+                            let decoded =
+                                #percent_encoding::percent_decode(segment).decode_utf8()?;
+
+                            ::std::convert::TryFrom::try_from(&*decoded)?
+                        };
+                    }
+                });
+
+            let parse_request_path = quote! {
+                let path_segments: ::std::vec::Vec<&::std::primitive::str> =
+                    request.uri().path()[1..].split('/').collect();
+
+                #(#path_var_decls)*
+            };
+
+            let path_vars = path_string[1..]
+                .split('/')
+                .filter(|seg| seg.starts_with(':'))
+                .map(|seg| Ident::new(&seg[1..], Span::call_site()));
+
+            (parse_request_path, quote! { #(#path_vars,)* })
+        } else {
+            (TokenStream::new(), TokenStream::new())
+        };
+
+        let (parse_query, query_vars) = if let Some(field) = self.query_map_field() {
+            let field_name = field.ident.as_ref().expect("expected field to have an identifier");
+            let parse = quote! {
+                let #field_name = #ruma_serde::urlencoded::from_str(
+                    &request.uri().query().unwrap_or(""),
+                )?;
+            };
+
+            (parse, quote! { #field_name, })
+        } else if self.has_query_fields() {
+            let (decls, names) = self.vars(RequestFieldKind::Query, quote!(request_query));
+
+            let parse = quote! {
+                let request_query: <RequestQuery as #ruma_serde::Outgoing>::Incoming =
+                    #ruma_serde::urlencoded::from_str(
+                        &request.uri().query().unwrap_or("")
+                    )?;
+
+                #decls
+            };
+
+            (parse, names)
+        } else {
+            (TokenStream::new(), TokenStream::new())
+        };
+
+        let (parse_headers, header_vars) = if self.has_header_fields() {
+            let (decls, names): (TokenStream, Vec<_>) = self
+                .header_fields()
+                .map(|request_field| {
+                    let (field, header_name) = match request_field {
+                        RequestField::Header(field, header_name) => (field, header_name),
+                        _ => panic!("expected request field to be header variant"),
+                    };
+
+                    let field_name = &field.ident;
+                    let header_name_string = header_name.to_string();
+
+                    let (some_case, none_case) = match &field.ty {
+                        syn::Type::Path(syn::TypePath {
+                            path: syn::Path { segments, .. }, ..
+                        }) if segments.last().unwrap().ident == "Option" => {
+                            (quote! { Some(str_value.to_owned()) }, quote! { None })
+                        }
+                        _ => (
+                            quote! { str_value.to_owned() },
+                            quote! {
+                                return Err(
+                                    #ruma_api::error::HeaderDeserializationError::MissingHeader(
+                                        #header_name_string.into()
+                                    ).into(),
+                                )
+                            },
+                        ),
+                    };
+
+                    let decl = quote! {
+                        let #field_name = match headers.get(#http::header::#header_name) {
+                            Some(header_value) => {
+                                let str_value = header_value.to_str()?;
+                                #some_case
+                            }
+                            None => #none_case,
+                        };
+                    };
+
+                    (decl, field_name)
+                })
+                .unzip();
+
+            let parse = quote! {
+                let headers = request.headers();
+
+                #decls
+            };
+
+            (parse, quote! { #(#names,)* })
+        } else {
+            (TokenStream::new(), TokenStream::new())
+        };
+
+        let extract_body = if self.has_body_fields() || self.newtype_body_field().is_some() {
+            let body_lifetimes = if self.has_body_lifetimes() {
+                // duplicate the anonymous lifetime as many times as needed
+                let lifetimes = std::iter::repeat(quote! { '_ }).take(self.lifetimes.body.len());
+                quote! { < #( #lifetimes, )* >}
+            } else {
+                TokenStream::new()
+            };
+
+            quote! {
+                let request_body: <
+                    RequestBody #body_lifetimes
+                    as #ruma_serde::Outgoing
+                >::Incoming = {
+                    let body = request.into_body();
+                    if #bytes::Buf::has_remaining(&body) {
+                        #serde_json::from_reader(#bytes::Buf::reader(body))?
+                    } else {
+                        // If the request body is completely empty, pretend it is an empty JSON
+                        // object instead. This allows requests with only optional body parameters
+                        // to be deserialized in that case.
+                        #serde_json::from_str("{}")?
+                    }
+                };
+            }
+        } else {
+            TokenStream::new()
+        };
+
+        let (parse_body, body_vars) = if let Some(field) = self.newtype_body_field() {
+            let field_name = field.ident.as_ref().expect("expected field to have an identifier");
+            let parse = quote! {
+                let #field_name = request_body.0;
+            };
+
+            (parse, quote! { #field_name, })
+        } else if let Some(field) = self.newtype_raw_body_field() {
+            let field_name = field.ident.as_ref().expect("expected field to have an identifier");
+            let parse = quote! {
+                let #field_name = {
+                    let mut reader = #bytes::Buf::reader(request.into_body());
+                    let mut vec = ::std::vec::Vec::new();
+                    ::std::io::Read::read_to_end(&mut reader, &mut vec)
+                        .expect("reading from a bytes::Buf never fails");
+                    vec
+                };
+            };
+
+            (parse, quote! { #field_name, })
+        } else {
+            self.vars(RequestFieldKind::Body, quote!(request_body))
+        };
+
+        let non_auth_impls = metadata.authentication.iter().map(|auth| {
+            if auth.value == "None" {
+                let attrs = &auth.attrs;
+                quote! {
+                    #( #attrs )*
+                    #[automatically_derived]
+                    #[cfg(feature = "server")]
+                    impl #ruma_api::IncomingNonAuthRequest for #incoming_request_type {}
+                }
+            } else {
+                TokenStream::new()
+            }
+        });
+
+        quote! {
+            #[automatically_derived]
+            #[cfg(feature = "server")]
+            impl #ruma_api::IncomingRequest for #incoming_request_type {
+                type EndpointError = #error_ty;
+                type OutgoingResponse = Response;
+
+                const METADATA: #ruma_api::Metadata = self::METADATA;
+
+                fn try_from_http_request<T: #bytes::Buf>(
+                    request: #http::Request<T>
+                ) -> ::std::result::Result<Self, #ruma_api::error::FromHttpRequestError> {
+                    if request.method() != #http::Method::#method {
+                        return Err(#ruma_api::error::FromHttpRequestError::MethodMismatch {
+                            expected: #http::Method::#method,
+                            received: request.method().clone(),
+                        });
+                    }
+
+                    #parse_request_path
+                    #parse_query
+                    #parse_headers
+
+                    #extract_body
+                    #parse_body
+
+                    Ok(Self {
+                        #path_vars
+                        #query_vars
+                        #header_vars
+                        #body_vars
+                    })
+                }
+            }
+
+            #(#non_auth_impls)*
+        }
+    }
+
+    fn vars(
+        &self,
+        request_field_kind: RequestFieldKind,
+        src: TokenStream,
+    ) -> (TokenStream, TokenStream) {
+        self.fields
+            .iter()
+            .filter_map(|f| f.field_of_kind(request_field_kind))
+            .map(|field| {
+                let field_name =
+                    field.ident.as_ref().expect("expected field to have an identifier");
+                let cfg_attrs =
+                    field.attrs.iter().filter(|a| a.path.is_ident("cfg")).collect::<Vec<_>>();
+
+                let decl = quote! {
+                    #( #cfg_attrs )*
+                    let #field_name = #src.#field_name;
+                };
+
+                (decl, quote! { #field_name, })
+            })
+            .unzip()
+    }
+}

--- a/ruma-api-macros/src/api/request/incoming.rs
+++ b/ruma-api-macros/src/api/request/incoming.rs
@@ -215,6 +215,7 @@ impl Request {
         quote! {
             #[automatically_derived]
             #[cfg(feature = "server")]
+            #[allow(clippy::inconsistent_struct_constructor)]
             impl #ruma_api::IncomingRequest for #incoming_request_type {
                 type EndpointError = #error_ty;
                 type OutgoingResponse = Response;

--- a/ruma-api-macros/src/api/request/outgoing.rs
+++ b/ruma-api-macros/src/api/request/outgoing.rs
@@ -1,0 +1,261 @@
+use proc_macro2::{Ident, Span, TokenStream};
+use quote::quote;
+
+use super::{Metadata, Request, RequestField, RequestFieldKind};
+
+impl Request {
+    pub fn expand_outgoing(
+        &self,
+        metadata: &Metadata,
+        error_ty: &TokenStream,
+        lifetimes: &TokenStream,
+        ruma_api: &TokenStream,
+    ) -> TokenStream {
+        let http = quote! { #ruma_api::exports::http };
+        let percent_encoding = quote! { #ruma_api::exports::percent_encoding };
+        let ruma_serde = quote! { #ruma_api::exports::ruma_serde };
+        let serde_json = quote! { #ruma_api::exports::serde_json };
+
+        let method = &metadata.method;
+        let request_path_string = if self.has_path_fields() {
+            let mut format_string = metadata.path.value();
+            let mut format_args = Vec::new();
+
+            while let Some(start_of_segment) = format_string.find(':') {
+                // ':' should only ever appear at the start of a segment
+                assert_eq!(&format_string[start_of_segment - 1..start_of_segment], "/");
+
+                let end_of_segment = match format_string[start_of_segment..].find('/') {
+                    Some(rel_pos) => start_of_segment + rel_pos,
+                    None => format_string.len(),
+                };
+
+                let path_var = Ident::new(
+                    &format_string[start_of_segment + 1..end_of_segment],
+                    Span::call_site(),
+                );
+                format_args.push(quote! {
+                    #percent_encoding::utf8_percent_encode(
+                        &self.#path_var.to_string(),
+                        #percent_encoding::NON_ALPHANUMERIC,
+                    )
+                });
+                format_string.replace_range(start_of_segment..end_of_segment, "{}");
+            }
+
+            quote! {
+                format_args!(#format_string, #(#format_args),*)
+            }
+        } else {
+            quote! { metadata.path.to_owned() }
+        };
+
+        let request_query_string = if let Some(field) = self.query_map_field() {
+            let field_name = field.ident.as_ref().expect("expected field to have identifier");
+
+            quote!({
+                // This function exists so that the compiler will throw an error when the type of
+                // the field with the query_map attribute doesn't implement
+                // `IntoIterator<Item = (String, String)>`.
+                //
+                // This is necessary because the `ruma_serde::urlencoded::to_string` call will
+                // result in a runtime error when the type cannot be encoded as a list key-value
+                // pairs (?key1=value1&key2=value2).
+                //
+                // By asserting that it implements the iterator trait, we can ensure that it won't
+                // fail.
+                fn assert_trait_impl<T>(_: &T)
+                where
+                    T: ::std::iter::IntoIterator<
+                        Item = (::std::string::String, ::std::string::String),
+                    >,
+                {}
+
+                let request_query = RequestQuery(self.#field_name);
+                assert_trait_impl(&request_query.0);
+
+                format_args!(
+                    "?{}",
+                    #ruma_serde::urlencoded::to_string(request_query)?
+                )
+            })
+        } else if self.has_query_fields() {
+            let request_query_init_fields =
+                self.struct_init_fields(RequestFieldKind::Query, quote!(self));
+
+            quote!({
+                let request_query = RequestQuery {
+                    #request_query_init_fields
+                };
+
+                format_args!(
+                    "?{}",
+                    #ruma_serde::urlencoded::to_string(request_query)?
+                )
+            })
+        } else {
+            quote! { "" }
+        };
+
+        let mut header_kvs: TokenStream = self
+            .header_fields()
+            .map(|request_field| {
+                let (field, header_name) = match request_field {
+                    RequestField::Header(field, header_name) => (field, header_name),
+                    _ => unreachable!("expected request field to be header variant"),
+                };
+
+                let field_name = &field.ident;
+
+                match &field.ty {
+                    syn::Type::Path(syn::TypePath { path: syn::Path { segments, .. }, .. })
+                        if segments.last().unwrap().ident == "Option" =>
+                    {
+                        quote! {
+                            if let Some(header_val) = self.#field_name.as_ref() {
+                                req_headers.insert(
+                                    #http::header::#header_name,
+                                    #http::header::HeaderValue::from_str(header_val)?,
+                                );
+                            }
+                        }
+                    }
+                    _ => quote! {
+                        req_headers.insert(
+                            #http::header::#header_name,
+                            #http::header::HeaderValue::from_str(self.#field_name.as_ref())?,
+                        );
+                    },
+                }
+            })
+            .collect();
+
+        for auth in &metadata.authentication {
+            if auth.value == "AccessToken" {
+                let attrs = &auth.attrs;
+                header_kvs.extend(quote! {
+                    #( #attrs )*
+                    req_headers.insert(
+                        #http::header::AUTHORIZATION,
+                        #http::header::HeaderValue::from_str(
+                            &::std::format!(
+                                "Bearer {}",
+                                access_token.ok_or(
+                                    #ruma_api::error::IntoHttpError::NeedsAuthentication
+                                )?
+                            )
+                        )?
+                    );
+                });
+            }
+        }
+
+        let request_body = if let Some(field) = self.newtype_raw_body_field() {
+            let field_name = field.ident.as_ref().expect("expected field to have an identifier");
+            quote! { self.#field_name }
+        } else if self.has_body_fields() || self.newtype_body_field().is_some() {
+            let request_body_initializers = if let Some(field) = self.newtype_body_field() {
+                let field_name =
+                    field.ident.as_ref().expect("expected field to have an identifier");
+                quote! { (self.#field_name) }
+            } else {
+                let initializers = self.struct_init_fields(RequestFieldKind::Body, quote!(self));
+                quote! { { #initializers } }
+            };
+
+            quote! {
+                {
+                    let request_body = RequestBody #request_body_initializers;
+                    #serde_json::to_vec(&request_body)?
+                }
+            }
+        } else {
+            quote! { Vec::new() }
+        };
+
+        let non_auth_impls = metadata.authentication.iter().map(|auth| {
+            if auth.value == "None" {
+                let attrs = &auth.attrs;
+                quote! {
+                    #( #attrs )*
+                    #[automatically_derived]
+                    #[cfg(feature = "client")]
+                    impl #lifetimes #ruma_api::OutgoingNonAuthRequest for Request #lifetimes {}
+                }
+            } else {
+                TokenStream::new()
+            }
+        });
+
+        quote! {
+            #[automatically_derived]
+            #[cfg(feature = "client")]
+            impl #lifetimes #ruma_api::OutgoingRequest for Request #lifetimes {
+                type EndpointError = #error_ty;
+                type IncomingResponse = <Response as #ruma_serde::Outgoing>::Incoming;
+
+                const METADATA: #ruma_api::Metadata = self::METADATA;
+
+                fn try_into_http_request(
+                    self,
+                    base_url: &::std::primitive::str,
+                    access_token: ::std::option::Option<&str>,
+                ) -> ::std::result::Result<
+                    #http::Request<Vec<u8>>,
+                    #ruma_api::error::IntoHttpError,
+                > {
+                    let metadata = self::METADATA;
+
+                    let mut req_builder = #http::Request::builder()
+                        .method(#http::Method::#method)
+                        .uri(::std::format!(
+                            "{}{}{}",
+                            base_url.strip_suffix('/').unwrap_or(base_url),
+                            #request_path_string,
+                            #request_query_string,
+                        ))
+                        .header(
+                            #ruma_api::exports::http::header::CONTENT_TYPE,
+                            "application/json",
+                        );
+
+                    let mut req_headers = req_builder
+                        .headers_mut()
+                        .expect("`http::RequestBuilder` is in unusable state");
+
+                    #header_kvs
+
+                    let http_request = req_builder.body(#request_body)?;
+
+                    Ok(http_request)
+                }
+            }
+
+            #(#non_auth_impls)*
+        }
+    }
+
+    /// Produces code for a struct initializer for the given field kind to be accessed through the
+    /// given variable name.
+    fn struct_init_fields(
+        &self,
+        request_field_kind: RequestFieldKind,
+        src: TokenStream,
+    ) -> TokenStream {
+        self.fields
+            .iter()
+            .filter_map(|f| f.field_of_kind(request_field_kind))
+            .map(|field| {
+                let field_name =
+                    field.ident.as_ref().expect("expected field to have an identifier");
+                let cfg_attrs =
+                    field.attrs.iter().filter(|a| a.path.is_ident("cfg")).collect::<Vec<_>>();
+
+                quote! {
+                    #( #cfg_attrs )*
+                    #field_name: #src.#field_name,
+                }
+            })
+            .collect()
+    }
+}

--- a/ruma-api-macros/src/api/request/outgoing.rs
+++ b/ruma-api-macros/src/api/request/outgoing.rs
@@ -190,6 +190,7 @@ impl Request {
         quote! {
             #[automatically_derived]
             #[cfg(feature = "client")]
+            #[allow(clippy::inconsistent_struct_constructor)]
             impl #lifetimes #ruma_api::OutgoingRequest for Request #lifetimes {
                 type EndpointError = #error_ty;
                 type IncomingResponse = <Response as #ruma_serde::Outgoing>::Incoming;

--- a/ruma-api-macros/src/api/response.rs
+++ b/ruma-api-macros/src/api/response.rs
@@ -231,7 +231,7 @@ impl Response {
                             #serde_json::from_reader(#bytes::Buf::reader(body))?
                         } else {
                             // If the reponse body is completely empty, pretend it is an empty JSON
-                            // object instead. This allows reponses with only optional body
+                            // object instead. This allows responses with only optional body
                             // parameters to be deserialized in that case.
                             #serde_json::from_str("{}")?
                         }

--- a/ruma-api-macros/src/api/response.rs
+++ b/ruma-api-macros/src/api/response.rs
@@ -52,22 +52,20 @@ impl Response {
                             path: syn::Path { segments, .. }, ..
                         }) if segments.last().unwrap().ident == "Option" => {
                             quote! {
-                                #field_name: #ruma_api::try_deserialize!(
-                                    response,
+                                #field_name: {
                                     headers.remove(#http::header::#header_name)
                                         .map(|h| h.to_str().map(|s| s.to_owned()))
-                                        .transpose()
-                                )
+                                        .transpose()?
+                                }
                             }
                         }
                         _ => quote! {
-                            #field_name: #ruma_api::try_deserialize!(
-                                response,
+                            #field_name: {
                                 headers.remove(#http::header::#header_name)
                                     .expect("response missing expected header")
-                                    .to_str()
-                            )
-                            .to_owned()
+                                    .to_str()?
+                                    .to_owned()
+                            }
                         },
                     };
                     quote_spanned! {span=> #optional_header }
@@ -228,10 +226,7 @@ impl Response {
                             body => body,
                         };
 
-                        #ruma_api::try_deserialize!(
-                            response,
-                            #serde_json::from_slice(json),
-                        )
+                        #serde_json::from_slice(json)?
                     };
                 }
             } else {

--- a/ruma-api-macros/src/api/response/incoming.rs
+++ b/ruma-api-macros/src/api/response/incoming.rs
@@ -1,0 +1,147 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+
+use super::{Response, ResponseField};
+
+impl Response {
+    pub fn expand_incoming(&self, error_ty: &TokenStream, ruma_api: &TokenStream) -> TokenStream {
+        let bytes = quote! { #ruma_api::exports::bytes };
+        let http = quote! { #ruma_api::exports::http };
+        let ruma_serde = quote! { #ruma_api::exports::ruma_serde };
+        let serde_json = quote! { #ruma_api::exports::serde_json };
+
+        let extract_response_headers = if self.has_header_fields() {
+            quote! {
+                let mut headers = response.headers().clone();
+            }
+        } else {
+            TokenStream::new()
+        };
+
+        let typed_response_body_decl =
+            if self.has_body_fields() || self.newtype_body_field().is_some() {
+                quote! {
+                    let response_body: <
+                        ResponseBody
+                        as #ruma_serde::Outgoing
+                    >::Incoming = {
+                        let body = response.into_body();
+                        if #bytes::Buf::has_remaining(&body) {
+                            #serde_json::from_reader(#bytes::Buf::reader(body))?
+                        } else {
+                            // If the reponse body is completely empty, pretend it is an empty JSON
+                            // object instead. This allows responses with only optional body
+                            // parameters to be deserialized in that case.
+                            #serde_json::from_str("{}")?
+                        }
+                    };
+                }
+            } else {
+                TokenStream::new()
+            };
+
+        let response_init_fields = {
+            let mut fields = vec![];
+            let mut new_type_raw_body = None;
+
+            for response_field in &self.fields {
+                let field = response_field.field();
+                let field_name =
+                    field.ident.as_ref().expect("expected field to have an identifier");
+                let cfg_attrs =
+                    field.attrs.iter().filter(|a| a.path.is_ident("cfg")).collect::<Vec<_>>();
+
+                fields.push(match response_field {
+                    ResponseField::Body(_) => {
+                        quote! {
+                            #( #cfg_attrs )*
+                            #field_name: response_body.#field_name
+                        }
+                    }
+                    ResponseField::Header(_, header_name) => {
+                        let optional_header = match &field.ty {
+                            syn::Type::Path(syn::TypePath {
+                                path: syn::Path { segments, .. },
+                                ..
+                            }) if segments.last().unwrap().ident == "Option" => {
+                                quote! {
+                                    #field_name: {
+                                        headers.remove(#http::header::#header_name)
+                                            .map(|h| h.to_str().map(|s| s.to_owned()))
+                                            .transpose()?
+                                    }
+                                }
+                            }
+                            _ => quote! {
+                                #field_name: {
+                                    headers.remove(#http::header::#header_name)
+                                        .expect("response missing expected header")
+                                        .to_str()?
+                                        .to_owned()
+                                }
+                            },
+                        };
+                        quote! { #optional_header }
+                    }
+                    ResponseField::NewtypeBody(_) => {
+                        quote! {
+                            #field_name: response_body.0
+                        }
+                    }
+                    // This field must be instantiated last to avoid `use of move value` error.
+                    // We are guaranteed only one new body field because of a check in `try_from`.
+                    ResponseField::NewtypeRawBody(_) => {
+                        new_type_raw_body = Some(quote! {
+                            #field_name: {
+                                let mut reader = #bytes::Buf::reader(response.into_body());
+                                let mut vec = ::std::vec::Vec::new();
+                                ::std::io::Read::read_to_end(&mut reader, &mut vec)
+                                    .expect("reading from a bytes::Buf never fails");
+                                vec
+                            }
+                        });
+                        // skip adding to the vec
+                        continue;
+                    }
+                });
+            }
+
+            fields.extend(new_type_raw_body);
+
+            quote! {
+                #(#fields,)*
+            }
+        };
+
+        quote! {
+            #[automatically_derived]
+            #[cfg(feature = "client")]
+            impl #ruma_api::IncomingResponse for Response {
+                type EndpointError = #error_ty;
+
+                fn try_from_http_response<T: #bytes::Buf>(
+                    response: #http::Response<T>,
+                ) -> ::std::result::Result<
+                    Self,
+                    #ruma_api::error::FromHttpResponseError<#error_ty>,
+                > {
+                    if response.status().as_u16() < 400 {
+                        #extract_response_headers
+                        #typed_response_body_decl
+
+                        Ok(Self {
+                            #response_init_fields
+                        })
+                    } else {
+                        match <#error_ty as #ruma_api::EndpointError>::try_from_response(response) {
+                            Ok(err) => Err(#ruma_api::error::ServerError::Known(err).into()),
+                            Err(response_err) => {
+                                Err(#ruma_api::error::ServerError::Unknown(response_err).into())
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ruma-api-macros/src/api/response/incoming.rs
+++ b/ruma-api-macros/src/api/response/incoming.rs
@@ -29,8 +29,8 @@ impl Response {
                         if #bytes::Buf::has_remaining(&body) {
                             #serde_json::from_reader(#bytes::Buf::reader(body))?
                         } else {
-                            // If the reponse body is completely empty, pretend it is an empty JSON
-                            // object instead. This allows responses with only optional body
+                            // If the response body is completely empty, pretend it is an empty
+                            // JSON object instead. This allows responses with only optional body
                             // parameters to be deserialized in that case.
                             #serde_json::from_str("{}")?
                         }

--- a/ruma-api-macros/src/api/response/incoming.rs
+++ b/ruma-api-macros/src/api/response/incoming.rs
@@ -116,6 +116,7 @@ impl Response {
         quote! {
             #[automatically_derived]
             #[cfg(feature = "client")]
+            #[allow(clippy::inconsistent_struct_constructor)]
             impl #ruma_api::IncomingResponse for Response {
                 type EndpointError = #error_ty;
 

--- a/ruma-api-macros/src/api/response/outgoing.rs
+++ b/ruma-api-macros/src/api/response/outgoing.rs
@@ -1,0 +1,95 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+
+use super::{Response, ResponseField};
+
+impl Response {
+    pub fn expand_outgoing(&self, ruma_api: &TokenStream) -> TokenStream {
+        let http = quote! { #ruma_api::exports::http };
+        let serde_json = quote! { #ruma_api::exports::serde_json };
+
+        let serialize_response_headers = self.fields.iter().map(|response_field| {
+            if let ResponseField::Header(field, header_name) = response_field {
+                let field_name =
+                    field.ident.as_ref().expect("expected field to have an identifier");
+
+                match &field.ty {
+                    syn::Type::Path(syn::TypePath { path: syn::Path { segments, .. }, .. })
+                        if segments.last().unwrap().ident == "Option" =>
+                    {
+                        quote! {
+                            if let Some(header) = self.#field_name {
+                                headers.insert(
+                                    #http::header::#header_name,
+                                    header.parse()?,
+                                );
+                            }
+                        }
+                    }
+                    _ => quote! {
+                        headers.insert(
+                            #http::header::#header_name,
+                            self.#field_name.parse()?,
+                        );
+                    },
+                }
+            } else {
+                TokenStream::new()
+            }
+        });
+
+        let body = if let Some(field) = self.newtype_raw_body_field() {
+            let field_name = field.ident.as_ref().expect("expected field to have an identifier");
+            quote! { self.#field_name }
+        } else if let Some(field) = self.newtype_body_field() {
+            let field_name = field.ident.as_ref().expect("expected field to have an identifier");
+            quote! {
+                #serde_json::to_vec(&self.#field_name)?
+            }
+        } else {
+            let fields = self.fields.iter().map(|response_field| {
+                if let ResponseField::Body(field) = response_field {
+                    let field_name =
+                        field.ident.as_ref().expect("expected field to have an identifier");
+                    let cfg_attrs = field.attrs.iter().filter(|a| a.path.is_ident("cfg"));
+
+                    quote! {
+                        #( #cfg_attrs )*
+                        #field_name: self.#field_name,
+                    }
+                } else {
+                    TokenStream::new()
+                }
+            });
+
+            quote! {
+                #serde_json::to_vec(&ResponseBody { #(#fields)* })?
+            }
+        };
+
+        quote! {
+            #[automatically_derived]
+            #[cfg(feature = "server")]
+            impl #ruma_api::OutgoingResponse for Response {
+                fn try_into_http_response(
+                    self,
+                ) -> ::std::result::Result<
+                    #http::Response<::std::vec::Vec<u8>>,
+                    #ruma_api::error::IntoHttpError,
+                > {
+                    let mut resp_builder = #http::Response::builder()
+                        .header(#http::header::CONTENT_TYPE, "application/json");
+
+                    let mut headers = resp_builder
+                        .headers_mut()
+                        .expect("`http::ResponseBuilder` is in unusable state");
+                    #(#serialize_response_headers)*
+
+                    // This cannot fail because we parse each header value checking for errors as
+                    // each value is inserted and we only allow keys from the `http::header` module.
+                    Ok(resp_builder.body(#body).unwrap())
+                }
+            }
+        }
+    }
+}

--- a/ruma-api-macros/src/api/response/outgoing.rs
+++ b/ruma-api-macros/src/api/response/outgoing.rs
@@ -70,6 +70,7 @@ impl Response {
         quote! {
             #[automatically_derived]
             #[cfg(feature = "server")]
+            #[allow(clippy::inconsistent_struct_constructor)]
             impl #ruma_api::OutgoingResponse for Response {
                 fn try_into_http_response(
                     self,

--- a/ruma-api/Cargo.toml
+++ b/ruma-api/Cargo.toml
@@ -19,6 +19,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
+bytes = "1.0.1"
 http = "0.2.2"
 percent-encoding = "2.1.0"
 ruma-api-macros = { version = "=0.17.0-alpha.2", path = "../ruma-api-macros" }

--- a/ruma-api/src/error.rs
+++ b/ruma-api/src/error.rs
@@ -65,7 +65,7 @@ pub enum IntoHttpError {
 pub enum FromHttpRequestError {
     /// Deserialization failed
     #[error("deserialization failed: {0}")]
-    Deserialization(#[from] RequestDeserializationError),
+    Deserialization(RequestDeserializationError),
 
     /// HTTP method mismatch
     #[error("http method mismatch: expected {expected}, received: {received}")]
@@ -77,22 +77,28 @@ pub enum FromHttpRequestError {
     },
 }
 
+impl<T> From<T> for FromHttpRequestError
+where
+    T: Into<RequestDeserializationError>,
+{
+    fn from(err: T) -> Self {
+        Self::Deserialization(err.into())
+    }
+}
+
 /// An error that occurred when trying to deserialize a request.
 #[derive(Debug, Error)]
 #[error("{inner}")]
 pub struct RequestDeserializationError {
     inner: DeserializationError,
-    http_request: http::Request<Vec<u8>>,
 }
 
-impl RequestDeserializationError {
-    /// Creates a new `RequestDeserializationError` from the given deserialization error and http
-    /// request.
-    pub fn new(
-        inner: impl Into<DeserializationError>,
-        http_request: http::Request<Vec<u8>>,
-    ) -> Self {
-        Self { inner: inner.into(), http_request }
+impl<T> From<T> for RequestDeserializationError
+where
+    T: Into<DeserializationError>,
+{
+    fn from(err: T) -> Self {
+        Self { inner: err.into() }
     }
 }
 

--- a/ruma-api/src/lib.rs
+++ b/ruma-api/src/lib.rs
@@ -363,17 +363,3 @@ pub struct Metadata {
     /// What authentication scheme the server uses for this endpoint.
     pub authentication: AuthScheme,
 }
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! try_deserialize {
-    ($kind:ident, $call:expr $(,)?) => {
-        $crate::try_deserialize!(@$kind, $kind, $call)
-    };
-    (@request, $kind:ident, $call:expr) => {
-        match $call {
-            Ok(val) => val,
-            Err(err) => return Err($crate::error::RequestDeserializationError::new(err, $kind).into()),
-        }
-    };
-}

--- a/ruma-api/src/lib.rs
+++ b/ruma-api/src/lib.rs
@@ -312,7 +312,7 @@ pub trait IncomingRequest: Sized {
     const METADATA: Metadata;
 
     /// Tries to turn the given `http::Request` into this request type.
-    fn try_from_http_request(req: http::Request<Vec<u8>>) -> Result<Self, FromHttpRequestError>;
+    fn try_from_http_request<T: Buf>(req: http::Request<T>) -> Result<Self, FromHttpRequestError>;
 }
 
 /// A request type for a Matrix API endpoint, used for sending responses.

--- a/ruma-api/src/lib.rs
+++ b/ruma-api/src/lib.rs
@@ -369,10 +369,4 @@ macro_rules! try_deserialize {
             Err(err) => return Err($crate::error::RequestDeserializationError::new(err, $kind).into()),
         }
     };
-    (@response, $kind:ident, $call:expr) => {
-        match $call {
-            Ok(val) => val,
-            Err(err) => return Err($crate::error::ResponseDeserializationError::new(err, $kind).into()),
-        }
-    };
 }

--- a/ruma-api/tests/conversions.rs
+++ b/ruma-api/tests/conversions.rs
@@ -48,7 +48,7 @@ fn request_serde() -> Result<(), Box<dyn std::error::Error + 'static>> {
     };
 
     let http_req = req.clone().try_into_http_request("https://homeserver.tld", None)?;
-    let req2 = Request::try_from_http_request(http_req)?;
+    let req2 = Request::try_from_http_request(http_req.map(std::io::Cursor::new))?;
 
     assert_eq!(req.hello, req2.hello);
     assert_eq!(req.world, req2.world);

--- a/ruma-api/tests/conversions.rs
+++ b/ruma-api/tests/conversions.rs
@@ -8,7 +8,7 @@ ruma_api! {
         description: "Does something.",
         method: POST,
         name: "my_endpoint",
-        path: "/_matrix/foo/:bar/:baz",
+        path: "/_matrix/foo/:bar/:user",
         rate_limited: false,
         authentication: None,
     }
@@ -24,7 +24,7 @@ ruma_api! {
         #[ruma_api(path)]
         pub bar: String,
         #[ruma_api(path)]
-        pub baz: UserId,
+        pub user: UserId,
     }
 
     response: {
@@ -44,7 +44,7 @@ fn request_serde() -> Result<(), Box<dyn std::error::Error + 'static>> {
         q1: "query_param_special_chars %/&@!".to_owned(),
         q2: 55,
         bar: "barVal".to_owned(),
-        baz: user_id!("@bazme:ruma.io"),
+        user: user_id!("@bazme:ruma.io"),
     };
 
     let http_req = req.clone().try_into_http_request("https://homeserver.tld", None)?;
@@ -55,7 +55,7 @@ fn request_serde() -> Result<(), Box<dyn std::error::Error + 'static>> {
     assert_eq!(req.q1, req2.q1);
     assert_eq!(req.q2, req2.q2);
     assert_eq!(req.bar, req2.bar);
-    assert_eq!(req.baz, req2.baz);
+    assert_eq!(req.user, req2.user);
 
     Ok(())
 }
@@ -68,12 +68,12 @@ fn request_with_user_id_serde() -> Result<(), Box<dyn std::error::Error + 'stati
         q1: "query_param_special_chars %/&@!".to_owned(),
         q2: 55,
         bar: "barVal".to_owned(),
-        baz: user_id!("@bazme:ruma.io"),
+        user: user_id!("@bazme:ruma.io"),
     };
 
     let user_id = user_id!("@_virtual_:ruma.io");
     let http_req =
-        req.clone().try_into_http_request_with_user_id("https://homeserver.tld", None, user_id)?;
+        req.try_into_http_request_with_user_id("https://homeserver.tld", None, user_id)?;
 
     let query = http_req.uri().query().unwrap();
 
@@ -93,7 +93,7 @@ mod without_query {
             description: "Does something without query.",
             method: POST,
             name: "my_endpoint",
-            path: "/_matrix/foo/:bar/:baz",
+            path: "/_matrix/foo/:bar/:user",
             rate_limited: false,
             authentication: None,
         }
@@ -105,7 +105,7 @@ mod without_query {
             #[ruma_api(path)]
             pub bar: String,
             #[ruma_api(path)]
-            pub baz: UserId,
+            pub user: UserId,
         }
 
         response: {
@@ -124,15 +124,12 @@ mod without_query {
             hello: "hi".to_owned(),
             world: "test".to_owned(),
             bar: "barVal".to_owned(),
-            baz: user_id!("@bazme:ruma.io"),
+            user: user_id!("@bazme:ruma.io"),
         };
 
         let user_id = user_id!("@_virtual_:ruma.io");
-        let http_req = req.clone().try_into_http_request_with_user_id(
-            "https://homeserver.tld",
-            None,
-            user_id,
-        )?;
+        let http_req =
+            req.try_into_http_request_with_user_id("https://homeserver.tld", None, user_id)?;
 
         let query = http_req.uri().query().unwrap();
 

--- a/ruma-api/tests/header_override.rs
+++ b/ruma-api/tests/header_override.rs
@@ -1,7 +1,5 @@
-use std::convert::TryFrom;
-
 use http::header::{Entry, CONTENT_TYPE};
-use ruma_api::{ruma_api, OutgoingRequest as _};
+use ruma_api::{ruma_api, OutgoingRequest as _, OutgoingResponse as _};
 
 ruma_api! {
     metadata: {
@@ -30,7 +28,7 @@ ruma_api! {
 #[test]
 fn response_content_type_override() {
     let res = Response { stuff: "magic".into() };
-    let mut http_res = http::Response::<Vec<u8>>::try_from(res).unwrap();
+    let mut http_res = res.try_into_http_response().unwrap();
 
     // Test that we correctly replaced the default content type,
     // not adding another content-type header.

--- a/ruma-api/tests/manual_endpoint_impl.rs
+++ b/ruma-api/tests/manual_endpoint_impl.rs
@@ -7,6 +7,7 @@ use http::{header::CONTENT_TYPE, method::Method};
 use ruma_api::{
     error::{FromHttpRequestError, FromHttpResponseError, IntoHttpError, ServerError, Void},
     AuthScheme, EndpointError, IncomingRequest, IncomingResponse, Metadata, OutgoingRequest,
+    OutgoingResponse,
 };
 use ruma_identifiers::{RoomAliasId, RoomId};
 use ruma_serde::Outgoing;
@@ -113,10 +114,8 @@ impl IncomingResponse for Response {
     }
 }
 
-impl TryFrom<Response> for http::Response<Vec<u8>> {
-    type Error = IntoHttpError;
-
-    fn try_from(_: Response) -> Result<http::Response<Vec<u8>>, Self::Error> {
+impl OutgoingResponse for Response {
+    fn try_into_http_response(self) -> Result<http::Response<Vec<u8>>, IntoHttpError> {
         let response = http::Response::builder()
             .header(CONTENT_TYPE, "application/json")
             .body(b"{}".to_vec())

--- a/ruma-api/tests/manual_endpoint_impl.rs
+++ b/ruma-api/tests/manual_endpoint_impl.rs
@@ -2,10 +2,12 @@
 
 use std::convert::TryFrom;
 
+use bytes::Buf;
 use http::{header::CONTENT_TYPE, method::Method};
 use ruma_api::{
     error::{FromHttpRequestError, FromHttpResponseError, IntoHttpError, ServerError, Void},
-    try_deserialize, AuthScheme, EndpointError, IncomingRequest, Metadata, OutgoingRequest,
+    try_deserialize, AuthScheme, EndpointError, IncomingRequest, IncomingResponse, Metadata,
+    OutgoingRequest,
 };
 use ruma_identifiers::{RoomAliasId, RoomId};
 use ruma_serde::Outgoing;
@@ -99,10 +101,12 @@ impl Outgoing for Response {
     type Incoming = Self;
 }
 
-impl TryFrom<http::Response<Vec<u8>>> for Response {
-    type Error = FromHttpResponseError<Void>;
+impl IncomingResponse for Response {
+    type EndpointError = Void;
 
-    fn try_from(http_response: http::Response<Vec<u8>>) -> Result<Response, Self::Error> {
+    fn try_from_http_response<T: Buf>(
+        http_response: http::Response<T>,
+    ) -> Result<Self, FromHttpResponseError<Void>> {
         if http_response.status().as_u16() < 400 {
             Ok(Response)
         } else {

--- a/ruma-api/tests/manual_endpoint_impl.rs
+++ b/ruma-api/tests/manual_endpoint_impl.rs
@@ -6,8 +6,7 @@ use bytes::Buf;
 use http::{header::CONTENT_TYPE, method::Method};
 use ruma_api::{
     error::{FromHttpRequestError, FromHttpResponseError, IntoHttpError, ServerError, Void},
-    try_deserialize, AuthScheme, EndpointError, IncomingRequest, IncomingResponse, Metadata,
-    OutgoingRequest,
+    AuthScheme, EndpointError, IncomingRequest, IncomingResponse, Metadata, OutgoingRequest,
 };
 use ruma_identifiers::{RoomAliasId, RoomId};
 use ruma_serde::Outgoing;
@@ -70,19 +69,16 @@ impl IncomingRequest for Request {
     fn try_from_http_request(
         request: http::Request<Vec<u8>>,
     ) -> Result<Self, FromHttpRequestError> {
-        let request_body: RequestBody =
-            try_deserialize!(request, serde_json::from_slice(request.body().as_slice()));
+        let request_body: RequestBody = serde_json::from_slice(request.body().as_slice())?;
         let path_segments: Vec<&str> = request.uri().path()[1..].split('/').collect();
 
         Ok(Request {
             room_id: request_body.room_id,
             room_alias: {
-                let decoded = try_deserialize!(
-                    request,
-                    percent_encoding::percent_decode(path_segments[5].as_bytes()).decode_utf8(),
-                );
+                let decoded =
+                    percent_encoding::percent_decode(path_segments[5].as_bytes()).decode_utf8()?;
 
-                try_deserialize!(request, TryFrom::try_from(&*decoded))
+                TryFrom::try_from(&*decoded)?
             },
         })
     }

--- a/ruma-api/tests/manual_endpoint_impl.rs
+++ b/ruma-api/tests/manual_endpoint_impl.rs
@@ -4,11 +4,8 @@ use std::convert::TryFrom;
 
 use http::{header::CONTENT_TYPE, method::Method};
 use ruma_api::{
-    error::{
-        FromHttpRequestError, FromHttpResponseError, IntoHttpError, ResponseDeserializationError,
-        ServerError, Void,
-    },
-    try_deserialize, AuthScheme, IncomingRequest, Metadata, OutgoingRequest,
+    error::{FromHttpRequestError, FromHttpResponseError, IntoHttpError, ServerError, Void},
+    try_deserialize, AuthScheme, EndpointError, IncomingRequest, Metadata, OutgoingRequest,
 };
 use ruma_identifiers::{RoomAliasId, RoomId};
 use ruma_serde::Outgoing;
@@ -109,8 +106,8 @@ impl TryFrom<http::Response<Vec<u8>>> for Response {
         if http_response.status().as_u16() < 400 {
             Ok(Response)
         } else {
-            Err(FromHttpResponseError::Http(ServerError::Unknown(
-                ResponseDeserializationError::from_response(http_response),
+            Err(FromHttpResponseError::Http(ServerError::Known(
+                <Void as EndpointError>::try_from_response(http_response)?,
             )))
         }
     }

--- a/ruma-api/tests/no_fields.rs
+++ b/ruma-api/tests/no_fields.rs
@@ -1,6 +1,4 @@
-use std::convert::TryFrom;
-
-use ruma_api::{ruma_api, OutgoingRequest as _};
+use ruma_api::{ruma_api, OutgoingRequest as _, OutgoingResponse as _};
 
 ruma_api! {
     metadata: {
@@ -27,7 +25,7 @@ fn empty_request_http_repr() {
 #[test]
 fn empty_response_http_repr() {
     let res = Response {};
-    let http_res = http::Response::<Vec<u8>>::try_from(res).unwrap();
+    let http_res = res.try_into_http_response().unwrap();
 
     assert_eq!(http_res.body(), b"{}");
 }

--- a/ruma-api/tests/ruma_api_macros.rs
+++ b/ruma-api/tests/ruma_api_macros.rs
@@ -1,6 +1,7 @@
 pub mod some_endpoint {
     use ruma_api::ruma_api;
     use ruma_events::{tag::TagEvent, AnyRoomEvent};
+    use ruma_identifiers::UserId;
     use ruma_serde::Raw;
 
     ruma_api! {
@@ -8,7 +9,7 @@ pub mod some_endpoint {
             description: "Does something.",
             method: POST, // An `http::Method` constant. No imports required.
             name: "some_endpoint",
-            path: "/_matrix/some/endpoint/:baz",
+            path: "/_matrix/some/endpoint/:user",
 
             #[cfg(all())]
             rate_limited: true,
@@ -23,7 +24,7 @@ pub mod some_endpoint {
 
         request: {
             // With no attribute on the field, it will be put into the body of the request.
-            pub foo: String,
+            pub a_field: String,
 
             // This value will be put into the "Content-Type" HTTP header.
             #[ruma_api(header = CONTENT_TYPE)]
@@ -34,9 +35,9 @@ pub mod some_endpoint {
             pub bar: String,
 
             // This value will be inserted into the request's URL in place of the
-            // ":baz" path component.
+            // ":user" path component.
             #[ruma_api(path)]
-            pub baz: String,
+            pub user: UserId,
         }
 
         response: {
@@ -65,7 +66,7 @@ pub mod newtype_body_endpoint {
 
     #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
     pub struct MyCustomType {
-        pub foo: String,
+        pub a_field: String,
     }
 
     ruma_api! {
@@ -95,7 +96,7 @@ pub mod newtype_raw_body_endpoint {
 
     #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
     pub struct MyCustomType {
-        pub foo: String,
+        pub a_field: String,
     }
 
     ruma_api! {

--- a/ruma-api/tests/ui/05-request-only.rs
+++ b/ruma-api/tests/ui/05-request-only.rs
@@ -1,9 +1,7 @@
-use std::convert::TryFrom;
-
 use bytes::Buf;
 use ruma_api::{
     error::{FromHttpResponseError, IntoHttpError, Void},
-    ruma_api, IncomingResponse,
+    ruma_api, IncomingResponse, OutgoingResponse,
 };
 use ruma_serde::Outgoing;
 
@@ -37,10 +35,8 @@ impl IncomingResponse for Response {
     }
 }
 
-impl TryFrom<Response> for http::Response<Vec<u8>> {
-    type Error = IntoHttpError;
-
-    fn try_from(_: Response) -> Result<Self, Self::Error> {
+impl OutgoingResponse for Response {
+    fn try_into_http_response(self) -> Result<http::Response<Vec<u8>>, IntoHttpError> {
         todo!()
     }
 }

--- a/ruma-api/tests/ui/05-request-only.rs
+++ b/ruma-api/tests/ui/05-request-only.rs
@@ -1,8 +1,9 @@
 use std::convert::TryFrom;
 
+use bytes::Buf;
 use ruma_api::{
     error::{FromHttpResponseError, IntoHttpError, Void},
-    ruma_api,
+    ruma_api, IncomingResponse,
 };
 use ruma_serde::Outgoing;
 
@@ -26,10 +27,12 @@ ruma_api! {
 #[derive(Outgoing)]
 pub struct Response;
 
-impl TryFrom<http::Response<Vec<u8>>> for Response {
-    type Error = FromHttpResponseError<Void>;
+impl IncomingResponse for Response {
+    type EndpointError = Void;
 
-    fn try_from(_: http::Response<Vec<u8>>) -> Result<Self, Self::Error> {
+    fn try_from_http_response<T: Buf>(
+        _: http::Response<T>,
+    ) -> Result<Self, FromHttpResponseError<Void>> {
         todo!()
     }
 }

--- a/ruma-client-api/Cargo.toml
+++ b/ruma-client-api/Cargo.toml
@@ -17,6 +17,7 @@ edition = "2018"
 
 [dependencies]
 assign = "1.1.1"
+bytes = "1.0.1"
 http = "0.2.2"
 js_int = { version = "0.2.0", features = ["serde"] }
 maplit = "1.0.2"

--- a/ruma-client-api/src/error.rs
+++ b/ruma-client-api/src/error.rs
@@ -207,7 +207,7 @@ impl EndpointError for Error {
     ) -> Result<Self, ResponseDeserializationError> {
         match from_json_slice::<ErrorBody>(response.body()) {
             Ok(error_body) => Ok(error_body.into_error(response.status())),
-            Err(de_error) => Err(ResponseDeserializationError::new(de_error, response)),
+            Err(de_error) => Err(ResponseDeserializationError::new(de_error)),
         }
     }
 }

--- a/ruma-client-api/src/r0/directory/get_public_rooms.rs
+++ b/ruma-client-api/src/r0/directory/get_public_rooms.rs
@@ -71,19 +71,18 @@ impl Response {
 
 #[cfg(all(test, any(feature = "client", feature = "server")))]
 mod tests {
-    use std::convert::TryInto;
-
     use js_int::uint;
 
     #[cfg(feature = "client")]
     #[test]
     fn construct_request_from_refs() {
-        use ruma_api::OutgoingRequest;
+        use ruma_api::OutgoingRequest as _;
+        use ruma_identifiers::server_name;
 
-        let req: http::Request<Vec<u8>> = super::Request {
+        let req = super::Request {
             limit: Some(uint!(10)),
             since: Some("hello"),
-            server: Some("address".try_into().unwrap()),
+            server: Some(&server_name!("test.tld")),
         }
         .try_into_http_request("https://homeserver.tld", Some("auth_tok"))
         .unwrap();
@@ -94,19 +93,21 @@ mod tests {
         assert_eq!(uri.path(), "/_matrix/client/r0/publicRooms");
         assert!(query.contains("since=hello"));
         assert!(query.contains("limit=10"));
-        assert!(query.contains("server=address"));
+        assert!(query.contains("server=test.tld"));
     }
 
     #[cfg(feature = "server")]
     #[test]
     fn construct_response_from_refs() {
-        let res: http::Response<Vec<u8>> = super::Response {
+        use ruma_api::OutgoingResponse as _;
+
+        let res = super::Response {
             chunk: vec![],
             next_batch: Some("next_batch_token".into()),
             prev_batch: Some("prev_batch_token".into()),
             total_room_count_estimate: Some(uint!(10)),
         }
-        .try_into()
+        .try_into_http_response()
         .unwrap();
 
         assert_eq!(

--- a/ruma-client-api/src/r0/membership/get_member_events.rs
+++ b/ruma-client-api/src/r0/membership/get_member_events.rs
@@ -103,7 +103,7 @@ mod tests {
             .unwrap();
 
         let req = IncomingRequest::try_from_http_request(
-            http::Request::builder().uri(uri).body(Vec::<u8>::new()).unwrap(),
+            http::Request::builder().uri(uri).body(&[] as &[u8]).unwrap(),
         );
 
         assert_matches!(

--- a/ruma-client-api/src/r0/message/send_message_event.rs
+++ b/ruma-client-api/src/r0/message/send_message_event.rs
@@ -104,15 +104,16 @@ impl ruma_api::IncomingRequest for IncomingRequest {
 
     const METADATA: ruma_api::Metadata = METADATA;
 
-    fn try_from_http_request(
-        request: http::Request<Vec<u8>>,
+    fn try_from_http_request<T: bytes::Buf>(
+        request: http::Request<T>,
     ) -> Result<Self, ruma_api::error::FromHttpRequestError> {
         use std::convert::TryFrom;
 
         use ruma_events::EventContent as _;
         use serde_json::value::RawValue as RawJsonValue;
 
-        let path_segments: Vec<&str> = request.uri().path()[1..].split('/').collect();
+        let (parts, body) = request.into_parts();
+        let path_segments: Vec<&str> = parts.uri.path()[1..].split('/').collect();
 
         let room_id = {
             let decoded =
@@ -126,13 +127,11 @@ impl ruma_api::IncomingRequest for IncomingRequest {
             .into_owned();
 
         let content = {
-            let request_body: Box<RawJsonValue> =
-                serde_json::from_slice(request.body().as_slice())?;
-
             let event_type =
                 percent_encoding::percent_decode(path_segments[6].as_bytes()).decode_utf8()?;
+            let body: Box<RawJsonValue> = serde_json::from_reader(body.reader())?;
 
-            AnyMessageEventContent::from_parts(&event_type, request_body)?
+            AnyMessageEventContent::from_parts(&event_type, body)?
         };
 
         Ok(Self { room_id, txn_id, content })

--- a/ruma-client-api/src/r0/profile/set_avatar_url.rs
+++ b/ruma-client-api/src/r0/profile/set_avatar_url.rs
@@ -66,7 +66,7 @@ mod tests {
                 http::Request::builder()
                     .method("PUT")
                     .uri("https://bar.org/_matrix/client/r0/profile/@foo:bar.org/avatar_url")
-                    .body(Vec::<u8>::new())?,
+                    .body(&[] as &[u8])?,
             )?,
             IncomingRequest { user_id, avatar_url: None } if user_id == "@foo:bar.org"
         );
@@ -77,7 +77,9 @@ mod tests {
                 http::Request::builder()
                     .method("PUT")
                     .uri("https://bar.org/_matrix/client/r0/profile/@foo:bar.org/avatar_url")
-                    .body(serde_json::to_vec(&serde_json::json!({ "avatar_url": "" }))?)?,
+                    .body(std::io::Cursor::new(
+                        serde_json::to_vec(&serde_json::json!({ "avatar_url": "" }))?,
+                    ))?,
             )?,
             IncomingRequest { user_id, avatar_url: None } if user_id == "@foo:bar.org"
         );

--- a/ruma-client-api/src/r0/state/get_state_events_for_key.rs
+++ b/ruma-client-api/src/r0/state/get_state_events_for_key.rs
@@ -113,36 +113,27 @@ impl ruma_api::IncomingRequest for IncomingRequest {
     ) -> Result<Self, ruma_api::error::FromHttpRequestError> {
         use std::convert::TryFrom;
 
-        use ruma_api::try_deserialize;
-
         let path_segments: Vec<&str> = request.uri().path()[1..].split('/').collect();
 
         let room_id = {
-            let decoded = try_deserialize!(
-                request,
-                percent_encoding::percent_decode(path_segments[4].as_bytes()).decode_utf8()
-            );
+            let decoded =
+                percent_encoding::percent_decode(path_segments[4].as_bytes()).decode_utf8()?;
 
-            try_deserialize!(request, RoomId::try_from(&*decoded))
+            RoomId::try_from(&*decoded)?
         };
 
         let event_type = {
-            let decoded = try_deserialize!(
-                request,
-                percent_encoding::percent_decode(path_segments[6].as_bytes()).decode_utf8()
-            );
+            let decoded =
+                percent_encoding::percent_decode(path_segments[6].as_bytes()).decode_utf8()?;
 
-            try_deserialize!(request, EventType::try_from(&*decoded))
+            EventType::try_from(&*decoded)?
         };
 
         let state_key = match path_segments.get(7) {
             Some(segment) => {
-                let decoded = try_deserialize!(
-                    request,
-                    percent_encoding::percent_decode(segment.as_bytes()).decode_utf8()
-                );
+                let decoded = percent_encoding::percent_decode(segment.as_bytes()).decode_utf8()?;
 
-                try_deserialize!(request, String::try_from(&*decoded))
+                String::try_from(&*decoded)?
             }
             None => "".into(),
         };

--- a/ruma-client-api/src/r0/state/get_state_events_for_key.rs
+++ b/ruma-client-api/src/r0/state/get_state_events_for_key.rs
@@ -108,8 +108,8 @@ impl ruma_api::IncomingRequest for IncomingRequest {
 
     const METADATA: ruma_api::Metadata = METADATA;
 
-    fn try_from_http_request(
-        request: http::Request<Vec<u8>>,
+    fn try_from_http_request<T: bytes::Buf>(
+        request: http::Request<T>,
     ) -> Result<Self, ruma_api::error::FromHttpRequestError> {
         use std::convert::TryFrom;
 

--- a/ruma-client-api/src/r0/state/send_state_event.rs
+++ b/ruma-client-api/src/r0/state/send_state_event.rs
@@ -111,42 +111,35 @@ impl ruma_api::IncomingRequest for IncomingRequest {
     fn try_from_http_request(
         request: http::Request<Vec<u8>>,
     ) -> Result<Self, ruma_api::error::FromHttpRequestError> {
-        use std::convert::TryFrom;
+        use std::{borrow::Cow, convert::TryFrom};
 
-        use ruma_api::try_deserialize;
         use ruma_events::EventContent;
         use serde_json::value::RawValue as RawJsonValue;
 
         let path_segments: Vec<&str> = request.uri().path()[1..].split('/').collect();
 
         let room_id = {
-            let decoded = try_deserialize!(
-                request,
-                percent_encoding::percent_decode(path_segments[4].as_bytes()).decode_utf8()
-            );
+            let decoded =
+                percent_encoding::percent_decode(path_segments[4].as_bytes()).decode_utf8()?;
 
-            try_deserialize!(request, RoomId::try_from(&*decoded))
+            RoomId::try_from(&*decoded)?
         };
 
-        let state_key = match path_segments.get(7) {
-            Some(segment) => try_deserialize!(
-                request,
-                percent_encoding::percent_decode(segment.as_bytes()).decode_utf8()
-            )
-            .into_owned(),
-            None => "".into(),
-        };
+        let state_key = path_segments
+            .get(7)
+            .map(|segment| percent_encoding::percent_decode(segment.as_bytes()).decode_utf8())
+            .transpose()?
+            .unwrap_or(Cow::Borrowed(""))
+            .into_owned();
 
         let content = {
             let request_body: Box<RawJsonValue> =
-                try_deserialize!(request, serde_json::from_slice(request.body().as_slice()));
+                serde_json::from_slice(request.body().as_slice())?;
 
-            let event_type = try_deserialize!(
-                request,
-                percent_encoding::percent_decode(path_segments[6].as_bytes()).decode_utf8()
-            );
+            let event_type =
+                percent_encoding::percent_decode(path_segments[6].as_bytes()).decode_utf8()?;
 
-            try_deserialize!(request, AnyStateEventContent::from_parts(&event_type, request_body))
+            AnyStateEventContent::from_parts(&event_type, request_body)?
         };
 
         Ok(Self { room_id, state_key, content })

--- a/ruma-client-api/src/r0/sync/sync_events.rs
+++ b/ruma-client-api/src/r0/sync/sync_events.rs
@@ -618,7 +618,7 @@ mod server_tests {
             .unwrap();
 
         let req = IncomingRequest::try_from_http_request(
-            http::Request::builder().uri(uri).body(Vec::<u8>::new()).unwrap(),
+            http::Request::builder().uri(uri).body(&[] as &[u8]).unwrap(),
         )
         .unwrap();
 
@@ -639,7 +639,7 @@ mod server_tests {
             .unwrap();
 
         let req = IncomingRequest::try_from_http_request(
-            http::Request::builder().uri(uri).body(Vec::<u8>::new()).unwrap(),
+            http::Request::builder().uri(uri).body(&[] as &[u8]).unwrap(),
         )
         .unwrap();
 
@@ -664,7 +664,7 @@ mod server_tests {
             .unwrap();
 
         let req = IncomingRequest::try_from_http_request(
-            http::Request::builder().uri(uri).body(Vec::<u8>::new()).unwrap(),
+            http::Request::builder().uri(uri).body(&[] as &[u8]).unwrap(),
         )
         .unwrap();
 

--- a/ruma-client-api/src/r0/tag/get_tags.rs
+++ b/ruma-client-api/src/r0/tag/get_tags.rs
@@ -48,9 +48,8 @@ impl Response {
 
 #[cfg(all(test, feature = "server"))]
 mod server_tests {
-    use std::convert::TryFrom;
-
     use assign::assign;
+    use ruma_api::OutgoingResponse;
     use ruma_events::tag::{TagInfo, Tags};
     use serde_json::json;
 
@@ -63,7 +62,7 @@ mod server_tests {
         tags.insert("u.user_tag".into(), assign!(TagInfo::new(), { order: Some(0.11) }));
         let response = Response { tags };
 
-        let http_response = http::Response::<Vec<u8>>::try_from(response).unwrap();
+        let http_response = response.try_into_http_response().unwrap();
 
         let json_response: serde_json::Value =
             serde_json::from_slice(http_response.body()).unwrap();


### PR DESCRIPTION
Trying to tackle #389, I've gone back and forth a lot but I think I have a found a decent design now. The first thing that has to be done to enable that is removing `http::Response<Vec<u8>>` and `http::Request<Vec<u8>>` in the error types so the traits can be changed to accept generic `http::Request` and `http::Response` types. I think the only reason this might be problematic now is that our default endpoint error type is `Void`. I've opened a separate issue about changing that: #480

Closes #389.