### PR TITLE
add ephemeral key validity endpoint

### DIFF
--- a/ruma-identity-service-api/src/keys.rs
+++ b/ruma-identity-service-api/src/keys.rs
@@ -2,3 +2,4 @@
 
 pub mod check_public_key_validity;
 pub mod get_public_key;
+pub mod validate_ephemeral_key;

--- a/ruma-identity-service-api/src/keys/validate_ephemeral_key.rs
+++ b/ruma-identity-service-api/src/keys/validate_ephemeral_key.rs
@@ -1,0 +1,3 @@
+//! Endpoint to check for validity of short-term public key.
+
+pub mod v2;

--- a/ruma-identity-service-api/src/keys/validate_ephemeral_key/v2.rs
+++ b/ruma-identity-service-api/src/keys/validate_ephemeral_key/v2.rs
@@ -1,0 +1,40 @@
+//! [GET /_matrix/identity/v2/pubkey/ephemeral/isvalid](https://matrix.org/docs/spec/identity_service/r0.3.0#get-matrix-identity-v2-pubkey-ephemeral-isvalid)
+
+use ruma_api::ruma_api;
+
+ruma_api! {
+    metadata: {
+        description: "Check whether a short-term public key is valid.",
+        method: GET,
+        name: "validate_ephemeral_key",
+        path: "/_matrix/identity/v2/pubkey/ephemeral/isvalid",
+        authentication: None,
+        rate_limited: false,
+    }
+
+    request: {
+        /// The unpadded base64-encoded short-term public key to check.
+        #[ruma_api(query)]
+        pub public_key: &'a str,
+    }
+
+    response: {
+        /// Whether the short-term public key is recognised and is currently valid.
+        pub valid: bool,
+    }
+}
+
+impl<'a> Request<'a> {
+    /// Create a `Request` with the given base64-encoded (unpadded) short-term public key.
+    pub fn new(public_key: &'a str) -> Self {
+        Self { public_key }
+    }
+}
+
+impl Response {
+    /// Create a `Response` with the given bool indicating the validity of the short-term public
+    /// key.
+    pub fn new(valid: bool) -> Self {
+        Self { valid }
+    }
+}


### PR DESCRIPTION
Add ephemeral key validity endpoint endpoint to `ruma-identity-service-api`.

Resolves: #320