### PR TITLE
add xtasks ci tests

### DIFF
--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -1,10 +1,15 @@
 use std::path::PathBuf;
 
-use xshell::pushd;
-
 use crate::{cmd, Result};
 
 const MSRV: &str = "1.45";
+
+macro_rules! cmd_in {
+    ($dir:expr, $($c:tt),+ $(,)?) => {{
+        let _p = xshell::pushd($dir)?;
+        $(super::cmd!($c).run()?;)+
+    }};
+}
 
 /// Task to run CI tests.
 pub struct CiTask {
@@ -35,38 +40,35 @@ impl CiTask {
     }
 
     fn build_msrv(&self) -> Result<()> {
-        {
-            let _p = pushd(self.project_root.join("ruma"))?;
-            cmd!("rustup run {MSRV} cargo build --features ruma-events,ruma-api,ruma-appservice-api,ruma-client-api,ruma-federation-api,ruma-identity-service-api,ruma-push-gateway-api --quiet").run()?;
-        }
-        {
-            let _p = pushd(self.project_root.join("ruma-client"))?;
-            cmd!("rustup run {MSRV} cargo build --quiet").run()?;
-        }
-        {
-            let _p = pushd(self.project_root.join("ruma-identifiers"))?;
-            cmd!("rustup run {MSRV} cargo build --no-default-features --quiet").run()?;
-        }
-        {
-            let _p = pushd(self.project_root.join("ruma-identifiers"))?;
-            cmd!("rustup run {MSRV} cargo build --all-features --quiet").run()?;
-        }
-        {
-            let _p = pushd(self.project_root.join("ruma-client-api"))?;
-            cmd!("rustup run {MSRV} cargo build --all-features --quiet").run()?;
-        }
+        cmd_in!(
+            self.project_root.join("ruma"),
+            "rustup run {MSRV} cargo build --features ruma-events,ruma-api,ruma-appservice-api,ruma-client-api,ruma-federation-api,ruma-identity-service-api,ruma-push-gateway-api --quiet",
+        );
+        cmd_in!(self.project_root.join("ruma-client"), "rustup run {MSRV} cargo build --quiet");
+        cmd_in!(
+            self.project_root.join("ruma-identifiers"),
+            "rustup run {MSRV} cargo build --no-default-features --quiet"
+        );
+        cmd_in!(
+            self.project_root.join("ruma-identifiers"),
+            "rustup run {MSRV} cargo build --all-features --quiet"
+        );
+        cmd_in!(
+            self.project_root.join("ruma-client-api"),
+            "rustup run {MSRV} cargo build --all-features --quiet"
+        );
         Ok(())
     }
 
     fn build_stable(&self) -> Result<()> {
         cmd!("cargo test --all --quiet").run()?;
         {
-            let _p = pushd(self.project_root.join("ruma-identifiers"))?;
+            let _p = xshell::pushd(self.project_root.join("ruma-identifiers"))?;
             cmd!("cargo test --no-default-features --quiet").run()?;
             cmd!("cargo test --all-features --quiet").run()?;
         }
         {
-            let _p = pushd(self.project_root.join("ruma-client-api"))?;
+            let _p = xshell::pushd(self.project_root.join("ruma-client-api"))?;
             cmd!("cargo check --no-default-features --features http1,http2 --quiet").run()?;
             cmd!("cargo check --no-default-features --features http1,http2,tls-rustls-native-roots --quiet").run()?;
             cmd!("cargo check --no-default-features --features http1,http2,tls-rustls-webpki-roots --quiet").run()?;
@@ -75,15 +77,9 @@ impl CiTask {
     }
 
     fn build_nightly(&self) -> Result<()> {
-        cmd!("cargo fmt --all --check").run()?;
-        {
-            let _p = pushd("ruma")?;
-            cmd!("cargo clippy --all-targets --all-features --quiet -- D warnings").run()?;
-        }
-        {
-            let _p = pushd("ruma-client")?;
-            cmd!("cargo clippy --all-targets --quiet -- D warnings").run()?;
-        }
+        cmd!("cargo fmt --all").run()?;
+        cmd_in!("ruma", "cargo clippy --all-targets --all-features --quiet -- -D warnings");
+        cmd_in!("ruma-client", "cargo clippy --all-targets --quiet -- -D warnings");
         Ok(())
     }
 }

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -1,0 +1,91 @@
+use std::{path::PathBuf, process::Command};
+
+use crate::{cmd, Result};
+
+const MSRV: &'static str = "1.45";
+
+/// Task to run CI tests.
+pub struct CiTask {
+    /// Which version of Rust to test against.
+    version: Option<String>,
+
+    /// The root of the workspace.
+    project_root: PathBuf,
+}
+
+impl CiTask {
+    pub(crate) fn new(version: Option<String>, project_root: PathBuf) -> Self {
+        Self { version, project_root }
+    }
+
+    pub(crate) fn run(self) -> Result<()> {
+        match self.version.as_ref().map(|s| s.as_str()) {
+            Some("msrv") => self.build_msrv(),
+            Some("stable") => self.build_stable(),
+            Some("nightly") => self.build_nightly(),
+            Some(_) => Err("Wrong Rust version specified.".into()),
+            None => {
+                self.build_msrv()?;
+                self.build_stable()?;
+                self.build_nightly()
+            }
+        }
+    }
+
+    fn build_msrv(&self) -> Result<()> {
+        self.run_in_dir(
+            "ruma",
+            format!("rustup run {} {}", MSRV,
+            r#"cargo build \
+--features ruma-events,ruma-api,ruma-appservice-api,ruma-client-api,ruma-federation-api,ruma-identity-service-api,ruma-push-gateway-api \
+--quiet"#).as_str(),
+        )?;
+        self.run_in_dir(
+            "ruma-client",
+            format!("rustup run {} {}", MSRV, "cargo build --quiet").as_str(),
+        )?;
+        self.run_in_dir(
+            "ruma-identifiers",
+            format!("rustup run {} {}", MSRV, "cargo build --no-default-features --quiet").as_str(),
+        )?;
+        self.run_in_dir(
+            "ruma-identifiers",
+            format!("rustup run {} {}", MSRV, "cargo build --all-features --quiet").as_str(),
+        )?;
+        self.run_in_dir(
+            "ruma-client-api",
+            format!("rustup run {} {}", MSRV, "cargo build --all-features --quiet").as_str(),
+        )
+    }
+
+    fn build_stable(&self) -> Result<()> {
+        self.run_in_dir("", "cargo test --all --quiet")?;
+        self.run_in_dir("ruma-identifiers", "cargo test --no-default-features --quiet")?;
+        self.run_in_dir("ruma-identifiers", "cargo test --all-features --quiet")?;
+        self.run_in_dir("ruma-client-api", "cargo check --all-targets --quiet")?;
+        self.run_in_dir(
+            "ruma-client",
+            "cargo check --no-default-features --features http1,http2 --quiet",
+        )?;
+        self.run_in_dir(
+            "ruma-client",
+            "cargo check --no-default-features --features http1,http2,tls-rustls-native-roots --quiet",
+        )?;
+        self.run_in_dir(
+            "ruma-client",
+            "cargo check --no-default-features --features http1,http2,tls-rustls-webpki-roots --quiet",
+        )
+    }
+
+    fn build_nightly(&self) -> Result<()> {
+        self.run_in_dir("", "cargo fmt --all --check")?;
+        self.run_in_dir("ruma", "cargo clippy --all-targets --all-features --quiet -- D warnings")?;
+        self.run_in_dir("ruma-client", "cargo clippy --all-targets --quiet -- D warnings")
+    }
+
+    fn run_in_dir(&self, crate_name: &str, command: &str) -> Result<()> {
+        let _p = xshell::pushd(self.project_root.join(crate_name))?;
+        cmd!("{command}").run()?;
+        Ok(())
+    }
+}

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -4,7 +4,7 @@ use xshell::pushd;
 
 use crate::{cmd, Result};
 
-const MSRV: &'static str = "1.45";
+const MSRV: &str = "1.45";
 
 /// Task to run CI tests.
 pub struct CiTask {
@@ -21,7 +21,7 @@ impl CiTask {
     }
 
     pub(crate) fn run(self) -> Result<()> {
-        match self.version.as_ref().map(|s| s.as_str()) {
+        match self.version.as_deref() {
             Some("msrv") => self.build_msrv(),
             Some("stable") => self.build_stable(),
             Some("nightly") => self.build_nightly(),

--- a/xtask/src/flags.rs
+++ b/xtask/src/flags.rs
@@ -13,6 +13,11 @@ xflags::xflags! {
             /// The crate to release
             required name: String
         {}
+
+        /// Run CI tests.
+        cmd ci
+            optional version: String
+        {}
     }
 }
 // generated start
@@ -27,6 +32,7 @@ pub struct Xtask {
 pub enum XtaskCmd {
     Help(Help),
     Release(Release),
+    Ci(Ci),
 }
 
 #[derive(Debug)]
@@ -39,11 +45,20 @@ pub struct Release {
     pub name: String,
 }
 
+#[derive(Debug)]
+pub struct Ci {
+    pub version: Option<String>,
+}
+
 impl Xtask {
     pub const HELP: &'static str = Self::HELP_;
 
     pub fn from_env() -> xflags::Result<Self> {
         Self::from_env_()
+    }
+
+    pub fn from_vec(args: Vec<std::ffi::OsString>) -> xflags::Result<Self> {
+        Self::from_vec_(args)
     }
 }
 // generated end

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -13,10 +13,11 @@ use serde_json::from_str as from_json_str;
 use toml::from_str as from_toml_str;
 use xshell::read_file;
 
+mod ci;
 mod flags;
 mod release;
 
-use self::release::ReleaseTask;
+use self::{ci::CiTask, release::ReleaseTask};
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
@@ -38,6 +39,10 @@ fn try_main() -> Result<()> {
         }
         flags::XtaskCmd::Release(cmd) => {
             let task = ReleaseTask::new(cmd.name, project_root)?;
+            task.run()
+        }
+        flags::XtaskCmd::Ci(ci) => {
+            let task = CiTask::new(ci.version , project_root);
             task.run()
         }
     }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -42,7 +42,7 @@ fn try_main() -> Result<()> {
             task.run()
         }
         flags::XtaskCmd::Ci(ci) => {
-            let task = CiTask::new(ci.version , project_root);
+            let task = CiTask::new(ci.version, project_root);
             task.run()
         }
     }


### PR DESCRIPTION
resolves #476.

adds the commands:

- `cargo xtask ci stable`
- `cargo xtask ci msrv`
- `cargo xtask ci nightly`
- `cargo xtask ci`
