### PR TITLE
xtask: Improve release

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -16,6 +16,7 @@ use xshell::read_file;
 mod ci;
 mod flags;
 mod release;
+mod util;
 
 use self::{ci::CiTask, release::ReleaseTask};
 

--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -42,7 +42,15 @@ impl ReleaseTask {
     /// Run the task to effectively create a release.
     pub(crate) fn run(self) -> Result<()> {
         let title = &self.title();
-        println!("Starting release for {}…", title);
+        let prerelease = self.local_crate.version.is_prerelease();
+        println!(
+            "Starting {} for {}…",
+            match prerelease {
+                true => "pre-release",
+                false => "release",
+            },
+            title
+        );
 
         if self.is_released()? {
             return Err("This crate version is already released".into());
@@ -67,6 +75,11 @@ impl ReleaseTask {
         let _dir = pushd(&self.local_crate.path)?;
 
         self.local_crate.publish(&self.client)?;
+
+        if prerelease {
+            println!("Pre-release created successfully!");
+            return Ok(());
+        }
 
         let changes = &self.local_crate.changes()?;
 

--- a/xtask/src/util.rs
+++ b/xtask/src/util.rs
@@ -1,0 +1,19 @@
+use std::io::{stdin, stdout, BufRead, Write};
+
+use crate::Result;
+
+/// Ask the user the given yes or no question and wait for their input. Returns `true` for yes.
+pub fn ask_yes_no(question: &str) -> Result<bool> {
+    let mut input = String::new();
+    let stdin = stdin();
+
+    print!("{} [y/N]: ", question);
+    stdout().flush()?;
+
+    let mut handle = stdin.lock();
+    handle.read_line(&mut input)?;
+
+    input = input.trim().to_ascii_lowercase();
+
+    Ok(input == "y" || input == "yes")
+}


### PR DESCRIPTION
- Publish `-macros` crate before the "main" crate, if any.
- Handle pre-releases (only publish, don't tag and release).