### PR TITLE
xtask: Add release commit creation to release

### DIFF
--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -9,10 +9,10 @@ publish = false
 
 [dependencies]
 isahc = { version = "1.2.0", features = ["json"] }
-itertools = "0.10.0"
 semver = { version = "0.11.0", features = ["serde"] }
 serde = { version = "1.0.118", features = ["derive"] }
 serde_json = "1.0.60"
 toml = "0.5.8"
+toml_edit = "0.2.0"
 xflags = "0.2.1"
 xshell = "0.1.9"

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -1,6 +1,6 @@
 # Ruma xtasks
 
-This crate is a helper bin for repetitive tasks during Ruma development, based on [cargo-xtask].
+This crate is a helper bin for repetitive tasks during Ruma development, based on [cargo xtask][xtask].
 
 To use it, run `cargo xtask [command]` anywhere in the workspace.
 
@@ -9,9 +9,10 @@ the appropriate fields.
 
 ## Commands
 
-- `release [crate] [version]`: Publish `crate` at given `version`, if applicable[^1], create a
+- `release [crate] [version]`: Publish `crate` at given `version`, if applicable<sup>[1](#ref-1)</sup>, create a
   signed tag based on its name and version and create a release on GitHub.
   **Requires all `github` fields in `config.toml`.**
 
-[cargo-xtask] : https://github.com/matklad/cargo-xtask
-[^1]: if `crate` is a user-facing crate and `version` is not a pre-release
+<sup><span id="ref-1">1</span></sup> if `crate` is a user-facing crate and `version` is not a pre-release.
+
+[xtask]: https://github.com/matklad/cargo-xtask

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -9,8 +9,9 @@ the appropriate fields.
 
 ## Commands
 
-- `release [crate] [version]`: Publish `crate` at given `version`, create a signed tag based on its
-  name and version and create a release on GitHub.
+- `release [crate] [version]`: Publish `crate` at given `version`, if applicable[^1], create a
+  signed tag based on its name and version and create a release on GitHub.
   **Requires all `github` fields in `config.toml`.**
 
 [cargo-xtask] : https://github.com/matklad/cargo-xtask
+[^1]: if `crate` is a user-facing crate and `version` is not a pre-release

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -9,7 +9,8 @@ the appropriate fields.
 
 ## Commands
 
-- `release [crate]`: Publish `crate`, create a signed tag based on its name and version and create
-  a release on GitHub. **Requires all `github` fields in `config.toml`.**
+- `release [crate] [version]`: Publish `crate` at given `version`, create a signed tag based on its
+  name and version and create a release on GitHub.
+  **Requires all `github` fields in `config.toml`.**
 
 [cargo-xtask] : https://github.com/matklad/cargo-xtask

--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -92,9 +92,9 @@ impl Package {
         Ok(())
     }
 
-    /// Update the changelog for the release of the given version. Returns the changes for the
-    /// version.
-    pub fn update_changelog(&self) -> Result<String> {
+    /// Get the changes for the version. If `update` is `true`, update the changelog for the release
+    /// of the given version.
+    pub fn changes(&self, update: bool) -> Result<String> {
         let mut changelog_path = self.manifest_path.clone();
         changelog_path.set_file_name("CHANGELOG.md");
 
@@ -124,14 +124,16 @@ impl Package {
             s => s,
         };
 
-        let changelog = format!(
-            "# [unreleased]\n\n# {}\n\n{}\n{}",
-            self.version,
-            changes,
-            &changelog[changes_end..]
-        );
+        if update {
+            let changelog = format!(
+                "# [unreleased]\n\n# {}\n\n{}\n{}",
+                self.version,
+                changes,
+                &changelog[changes_end..]
+            );
 
-        write_file(&changelog_path, changelog)?;
+            write_file(&changelog_path, changelog)?;
+        }
 
         Ok(changes.to_owned())
     }

--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -1,0 +1,211 @@
+use std::path::PathBuf;
+
+use isahc::{HttpClient, ReadResponseExt};
+use semver::{Version, VersionReq};
+use serde::{de::IgnoredAny, Deserialize};
+use serde_json::from_str as from_json_str;
+use toml_edit::{value, Document};
+use xshell::{cmd, pushd, read_file, write_file};
+
+use crate::{util::ask_yes_no, Result};
+
+const CRATESIO_API: &str = "https://crates.io/api/v1/crates";
+
+/// The metadata of a cargo workspace.
+#[derive(Clone, Debug, Deserialize)]
+pub struct Metadata {
+    pub workspace_root: PathBuf,
+    pub packages: Vec<Package>,
+}
+
+impl Metadata {
+    /// Load a new `Metadata` from the command line.
+    pub fn load() -> Result<Metadata> {
+        let metadata_json = cmd!("cargo metadata --no-deps --format-version 1").read()?;
+        Ok(from_json_str(&metadata_json)?)
+    }
+}
+
+/// A cargo package.
+#[derive(Clone, Debug, Deserialize)]
+pub struct Package {
+    /// The package name
+    pub name: String,
+
+    /// The package version.
+    pub version: Version,
+
+    /// The package's manifest path.
+    pub manifest_path: PathBuf,
+
+    /// A map of the package dependencies.
+    #[serde(default)]
+    pub dependencies: Vec<Dependency>,
+}
+
+impl Package {
+    /// Update the version of this crate.
+    pub fn update_version(&mut self, version: &Version) -> Result<()> {
+        println!("Updating {} to version {}…", self.name, version);
+
+        let mut document = read_file(&self.manifest_path)?.parse::<Document>()?;
+
+        document["package"]["version"] = value(version.to_string());
+
+        write_file(&self.manifest_path, document.to_string())?;
+
+        self.version = version.clone();
+
+        Ok(())
+    }
+
+    /// Update the version of this crate in dependant crates' manifest, with the given version
+    /// prefix.
+    pub fn update_dependants(&self, packages: &[Package]) -> Result<()> {
+        for package in
+            packages.iter().filter(|p| p.dependencies.iter().any(|d| d.name == self.name))
+        {
+            println!("Updating dependency in {} crate…", package.name);
+
+            let mut document = read_file(&package.manifest_path)?.parse::<Document>()?;
+
+            for dependency in package.dependencies.iter().filter(|d| d.name == self.name) {
+                let version = if dependency.req.is_exact() {
+                    format!("={}", self.version,)
+                } else {
+                    self.version.to_string()
+                };
+
+                match dependency.kind {
+                    Some(DependencyKind::Dev) => {
+                        document["dev-dependencies"][&self.name]["version"] =
+                            value(version.as_str());
+                    }
+                    None => {
+                        document["dependencies"][&self.name]["version"] = value(version.as_str());
+                    }
+                    _ => {}
+                }
+            }
+
+            if package
+                .dependencies
+                .iter()
+                .any(|p| p.name == self.name && p.kind == Some(DependencyKind::Dev))
+            {}
+
+            write_file(&package.manifest_path, document.to_string())?;
+        }
+
+        Ok(())
+    }
+
+    /// Update the changelog for the release of the given version. Returns the changes for the
+    /// version.
+    pub fn update_changelog(&self) -> Result<String> {
+        let mut changelog_path = self.manifest_path.clone();
+        changelog_path.set_file_name("CHANGELOG.md");
+
+        let changelog = read_file(&changelog_path)?;
+
+        let title_start = match changelog
+            .find(&format!("# {}\n", self.version))
+            .or_else(|| changelog.find(&format!("# {} (unreleased)\n", self.version)))
+            .or_else(|| changelog.find("# [unreleased]\n"))
+        {
+            Some(p) => p,
+            None => {
+                return Err("Could not find version title in changelog".into());
+            }
+        };
+
+        let changes_start = match changelog[title_start..].find('\n') {
+            Some(p) => title_start + p + 1,
+            None => {
+                return Err("Could not find end of version title in changelog".into());
+            }
+        };
+
+        let changes_end = match changelog[changes_start..].find("\n# ") {
+            Some(p) => changes_start + p,
+            None => changelog.len(),
+        };
+
+        let changes = match changelog[changes_start..changes_end].trim() {
+            s if s.is_empty() => "No changes for this version",
+            s => s,
+        };
+
+        let changelog = format!(
+            "{}# [unreleased]\n\n# {}\n\n{}\n{}",
+            &changelog[..title_start],
+            self.version,
+            changes,
+            &changelog[changes_end..]
+        );
+
+        write_file(&changelog_path, changelog)?;
+
+        println!(
+            "Changelog updated: title_start: {}, changes_start: {}, changes_end: {}\nchanges: {}",
+            title_start, changes_start, changes_end, changes
+        );
+
+        Ok(changes.to_owned())
+    }
+
+    /// Check if the current version of the crate is published on crates.io.
+    pub fn is_published(&self, client: &HttpClient) -> Result<bool> {
+        let response: CratesIoCrate =
+            client.get(format!("{}/{}/{}", CRATESIO_API, self.name, self.version))?.json()?;
+
+        Ok(response.version.is_some())
+    }
+
+    /// Publish this package on crates.io.
+    pub fn publish(&self, client: &HttpClient) -> Result<bool> {
+        println!("Publishing {} {} on crates.io…", self.name, self.version);
+        let _dir = pushd(&self.manifest_path.parent().unwrap())?;
+
+        if self.is_published(client)? {
+            if ask_yes_no("This version is already published. Skip this step and continue?")? {
+                Ok(false)
+            } else {
+                Err("Release interrupted by user.".into())
+            }
+        } else {
+            cmd!("cargo publish").run()?;
+            Ok(true)
+        }
+    }
+}
+
+/// A cargo package dependency.
+#[derive(Clone, Debug, Deserialize)]
+pub struct Dependency {
+    /// The package name.
+    pub name: String,
+
+    /// The version requirement for this dependency.
+    pub req: VersionReq,
+
+    /// The kind of the dependency.
+    pub kind: Option<DependencyKind>,
+}
+
+/// The kind of a cargo package dependency.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum DependencyKind {
+    /// A dev dependency.
+    Dev,
+
+    /// A build dependency.
+    Build,
+}
+
+/// A crate from the `GET /crates/{crate}` endpoint of crates.io.
+#[derive(Deserialize)]
+struct CratesIoCrate {
+    version: Option<IgnoredAny>,
+}

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use xshell::pushd;
 
-use crate::{cmd, Result};
+use crate::{cargo::Metadata, cmd, Result};
 
 const MSRV: &str = "1.45";
 
@@ -18,8 +18,9 @@ pub struct CiTask {
 }
 
 impl CiTask {
-    pub(crate) fn new(version: Option<String>, project_root: PathBuf) -> Self {
-        Self { version, project_root }
+    pub(crate) fn new(version: Option<String>) -> Result<Self> {
+        let project_root = Metadata::load()?.workspace_root;
+        Ok(Self { version, project_root })
     }
 
     pub(crate) fn run(self) -> Result<()> {

--- a/xtask/src/flags.rs
+++ b/xtask/src/flags.rs
@@ -21,6 +21,15 @@ xflags::xflags! {
             required version: Version
         {}
 
+        /// Alias for release.
+        cmd publish
+            /// The crate to release
+            required name: String
+
+            /// The new version of the crate
+            required version: Version
+        {}
+
         /// Run CI tests.
         cmd ci
             optional version: String
@@ -39,6 +48,7 @@ pub struct Xtask {
 pub enum XtaskCmd {
     Help(Help),
     Release(Release),
+    Publish(Publish),
     Ci(Ci),
 }
 
@@ -49,6 +59,12 @@ pub struct Help {
 
 #[derive(Debug)]
 pub struct Release {
+    pub name: String,
+    pub version: Version,
+}
+
+#[derive(Debug)]
+pub struct Publish {
     pub name: String,
     pub version: Version,
 }

--- a/xtask/src/flags.rs
+++ b/xtask/src/flags.rs
@@ -1,5 +1,7 @@
 #![allow(dead_code)] // silence never-used warning for from_vec in generated code
 
+use semver::Version;
+
 xflags::xflags! {
     src "./src/flags.rs"
 
@@ -14,6 +16,9 @@ xflags::xflags! {
         cmd release
             /// The crate to release
             required name: String
+
+            /// The new version of the crate
+            required version: Version
         {}
 
         /// Run CI tests.
@@ -45,6 +50,7 @@ pub struct Help {
 #[derive(Debug)]
 pub struct Release {
     pub name: String,
+    pub version: Version,
 }
 
 #[derive(Debug)]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -3,16 +3,13 @@
 //! This binary is integrated into the `cargo` command line by using an alias in
 //! `.cargo/config`. Run commands as `cargo xtask [command]`.
 
-use std::{
-    env,
-    path::{Path, PathBuf},
-};
+use std::{env, path::Path};
 
 use serde::Deserialize;
-use serde_json::from_str as from_json_str;
 use toml::from_str as from_toml_str;
 use xshell::read_file;
 
+mod cargo;
 mod ci;
 mod flags;
 mod release;
@@ -30,8 +27,6 @@ fn main() {
 }
 
 fn try_main() -> Result<()> {
-    let project_root = project_root()?;
-
     let flags = flags::Xtask::from_env()?;
     match flags.subcommand {
         flags::XtaskCmd::Help(_) => {
@@ -39,32 +34,29 @@ fn try_main() -> Result<()> {
             Ok(())
         }
         flags::XtaskCmd::Release(cmd) => {
-            let task = ReleaseTask::new(cmd.name, project_root)?;
+            let mut task = ReleaseTask::new(cmd.name, cmd.version)?;
             task.run()
         }
         flags::XtaskCmd::Ci(ci) => {
-            let task = CiTask::new(ci.version, project_root);
+            let task = CiTask::new(ci.version)?;
             task.run()
         }
     }
 }
 
 #[derive(Debug, Deserialize)]
-struct CargoMetadata {
-    workspace_root: PathBuf,
-}
-
-/// Get the project workspace root.
-fn project_root() -> Result<PathBuf> {
-    let metadata_json = cmd!("cargo metadata --format-version 1").read()?;
-    let metadata: CargoMetadata = from_json_str(&metadata_json)?;
-    Ok(metadata.workspace_root)
-}
-
-#[derive(Debug, Deserialize)]
 struct Config {
     /// Credentials to authenticate to GitHub.
     github: GithubConfig,
+}
+
+impl Config {
+    /// Load a new `Config` from `config.toml`.
+    fn load() -> Result<Self> {
+        let path = Path::new(&env!("CARGO_MANIFEST_DIR")).join("config.toml");
+        let config = read_file(path)?;
+        Ok(from_toml_str(&config)?)
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -74,13 +66,6 @@ struct GithubConfig {
 
     /// The personal access token to use for authentication.
     token: String,
-}
-
-/// Load the config from `config.toml`.
-fn config() -> Result<Config> {
-    let path = Path::new(&env!("CARGO_MANIFEST_DIR")).join("config.toml");
-    let config = read_file(path)?;
-    Ok(from_toml_str(&config)?)
 }
 
 #[macro_export]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -37,6 +37,10 @@ fn try_main() -> Result<()> {
             let mut task = ReleaseTask::new(cmd.name, cmd.version)?;
             task.run()
         }
+        flags::XtaskCmd::Publish(cmd) => {
+            let mut task = ReleaseTask::new(cmd.name, cmd.version)?;
+            task.run()
+        }
         flags::XtaskCmd::Ci(ci) => {
             let task = CiTask::new(ci.version)?;
             task.run()

--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -207,37 +207,37 @@ impl ReleaseTask {
         let mut input = String::new();
         let stdin = stdin();
 
-        print!("Ready to commit the changes. [continue/abort/DIFF]: ");
+        let instructions = "Ready to commit the changes. [continue/abort/diff]: ";
+        print!("{}", instructions);
         stdout().flush()?;
 
         let mut handle = stdin.lock();
-        handle.read_line(&mut input)?;
 
-        match input.trim().to_ascii_lowercase().as_str() {
-            "c" | "continue" => {}
-            "a" | "abort" => {
-                return Err("User aborted commit".into());
-            }
-            _ => {
-                cmd!("git diff").run()?;
-                print!("Commit the changes? [continue/ABORT]: ");
-                stdout().flush()?;
-
-                handle.read_line(&mut input)?;
-
-                match input.trim().to_ascii_lowercase().as_str() {
-                    "c" | "continue" => {}
-                    _ => {
-                        return Err("User aborted commit".into());
-                    }
+        while let _ = handle.read_line(&mut input)? {
+            match input.trim().to_ascii_lowercase().as_str() {
+                "c" | "continue" => {
+                    break;
+                }
+                "a" | "abort" => {
+                    return Err("User aborted commit".into());
+                }
+                "d" | "diff" => {
+                    cmd!("git diff").run()?;
+                }
+                _ => {
+                    println!("Unknown command.");
                 }
             }
+            print!("{}", instructions);
+            stdout().flush()?;
+
+            input = String::new();
         }
 
         let message = format!("Release {}", self.title());
 
         println!("Creating commit…");
-        cmd!("git commit -S -a -m {message}").read()?;
+        cmd!("git commit -a -m {message}").read()?;
 
         println!("Pushing commit…");
         cmd!("git push").read()?;

--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -113,7 +113,7 @@ impl ReleaseTask {
         self.package.update_version(&self.version)?;
         self.package.update_dependants(&self.metadata)?;
 
-        let changes = &self.package.update_changelog()?;
+        let changes = &self.package.changes(!prerelease)?;
 
         self.commit()?;
 
@@ -130,10 +130,6 @@ impl ReleaseTask {
 
         self.package.publish(&self.http_client)?;
 
-        if prerelease {
-            println!("Pre-release created successfully!");
-            return Ok(());
-        }
         if publish_only {
             println!("Crate published successfully!");
             return Ok(());
@@ -152,6 +148,11 @@ impl ReleaseTask {
         if cmd!("git ls-remote --tags {remote} {tag}").read()?.is_empty() {
             cmd!("git push {remote} {tag}").run()?;
         } else if !ask_yes_no("This tag has already been pushed. Skip this step and continue?")? {
+            return Ok(());
+        }
+
+        if prerelease {
+            println!("Pre-release created successfully!");
             return Ok(());
         }
 

--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -231,7 +231,7 @@ impl ReleaseTask {
             print!("{}", instructions);
             stdout().flush()?;
 
-            input = String::new();
+            input.clear();
         }
 
         let message = format!("Release {}", self.title());

--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -103,13 +103,13 @@ impl ReleaseTask {
             println!("Found macros crate {}.", m.name);
 
             m.update_version(&self.version)?;
-            m.update_dependants(&self.metadata.packages)?;
+            m.update_dependants(&self.metadata)?;
 
             println!("Resuming release of {}…", self.title());
         }
 
         self.package.update_version(&self.version)?;
-        self.package.update_dependants(&self.metadata.packages)?;
+        self.package.update_dependants(&self.metadata)?;
 
         let changes = &self.package.update_changelog()?;
 

--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -65,6 +65,8 @@ impl ReleaseTask {
     pub(crate) fn run(&mut self) -> Result<()> {
         let title = &self.title();
         let prerelease = self.version.is_prerelease();
+        let publish_only = self.package.name == "ruma-identifiers-validation";
+
         println!(
             "Starting {} for {}…",
             match prerelease {
@@ -130,6 +132,10 @@ impl ReleaseTask {
 
         if prerelease {
             println!("Pre-release created successfully!");
+            return Ok(());
+        }
+        if publish_only {
+            println!("Crate published successfully!");
             return Ok(());
         }
 


### PR DESCRIPTION
This adds several step:
1. Change the version in the `macros` crate manifest, if it exists.
2. Change the version in the manifest of crates that depend on the `macros` crate.
3. Change the version in the crate's manifest.
4. Change the version in the manifest of crates that depend on the crate.
5. Update the changelog of the crate.
6. Ask confirmation for commit with option to see the diff.
7. Commit and push.
8. Continues to publishing and releasing as before.

I changed quite a bit the organisation of the code. The main reason is that we now get all the data for the crates from the `cargo metadata` result, to avoid having to also parse all the manifests.

The only remaining quirk is the `ruma-identifiers-validation` crate that won't work with this.

edit(jplatte): resolves #452