### PR TITLE
client-api: Support appservice login type on /register

### DIFF
--- a/ruma-api/src/lib.rs
+++ b/ruma-api/src/lib.rs
@@ -212,6 +212,20 @@ pub mod exports {
 
 use error::{FromHttpRequestError, FromHttpResponseError, IntoHttpError};
 
+/// An enum to control whether an access token should be added to outgoing requests
+#[derive(Debug, Clone)]
+pub enum SendAccessToken<'a> {
+    /// Add the given access token to the request only if the `METADATA` on the request requires it
+    IfRequired(&'a str),
+
+    /// Always add the access token
+    Always(&'a str),
+
+    /// Don't add an access token. This will lead to an error if the request endpoint requires
+    /// authentication
+    None,
+}
+
 /// A request type for a Matrix API endpoint, used for sending requests.
 pub trait OutgoingRequest: Sized {
     /// A type capturing the expected error conditions the server can return.
@@ -234,7 +248,7 @@ pub trait OutgoingRequest: Sized {
     fn try_into_http_request(
         self,
         base_url: &str,
-        access_token: Option<&str>,
+        access_token: SendAccessToken<'_>,
     ) -> Result<http::Request<Vec<u8>>, IntoHttpError>;
 }
 
@@ -258,7 +272,7 @@ pub trait OutgoingRequestAppserviceExt: OutgoingRequest {
     fn try_into_http_request_with_user_id(
         self,
         base_url: &str,
-        access_token: Option<&str>,
+        access_token: SendAccessToken<'_>,
         user_id: UserId,
     ) -> Result<http::Request<Vec<u8>>, IntoHttpError> {
         let mut http_request = self.try_into_http_request(base_url, access_token)?;

--- a/ruma-api/tests/conversions.rs
+++ b/ruma-api/tests/conversions.rs
@@ -1,5 +1,6 @@
 use ruma_api::{
     ruma_api, IncomingRequest as _, OutgoingRequest as _, OutgoingRequestAppserviceExt as _,
+    SendAccessToken,
 };
 use ruma_identifiers::{user_id, UserId};
 
@@ -47,7 +48,8 @@ fn request_serde() {
         user: user_id!("@bazme:ruma.io"),
     };
 
-    let http_req = req.clone().try_into_http_request("https://homeserver.tld", None).unwrap();
+    let http_req =
+        req.clone().try_into_http_request("https://homeserver.tld", SendAccessToken::None).unwrap();
     let req2 = Request::try_from_http_request(http_req).unwrap();
 
     assert_eq!(req.hello, req2.hello);
@@ -70,8 +72,13 @@ fn request_with_user_id_serde() {
     };
 
     let user_id = user_id!("@_virtual_:ruma.io");
-    let http_req =
-        req.try_into_http_request_with_user_id("https://homeserver.tld", None, user_id).unwrap();
+    let http_req = req
+        .try_into_http_request_with_user_id(
+            "https://homeserver.tld",
+            SendAccessToken::None,
+            user_id,
+        )
+        .unwrap();
 
     let query = http_req.uri().query().unwrap();
 
@@ -124,7 +131,11 @@ mod without_query {
 
         let user_id = user_id!("@_virtual_:ruma.io");
         let http_req = req
-            .try_into_http_request_with_user_id("https://homeserver.tld", None, user_id)
+            .try_into_http_request_with_user_id(
+                "https://homeserver.tld",
+                SendAccessToken::None,
+                user_id,
+            )
             .unwrap();
 
         let query = http_req.uri().query().unwrap();

--- a/ruma-api/tests/header_override.rs
+++ b/ruma-api/tests/header_override.rs
@@ -1,5 +1,5 @@
 use http::header::{Entry, CONTENT_TYPE};
-use ruma_api::{ruma_api, OutgoingRequest as _, OutgoingResponse as _};
+use ruma_api::{ruma_api, OutgoingRequest as _, OutgoingResponse as _, SendAccessToken};
 
 ruma_api! {
     metadata: {
@@ -45,7 +45,8 @@ fn response_content_type_override() {
 #[test]
 fn request_content_type_override() {
     let req = Request { location: None, stuff: "magic".into() };
-    let mut http_req = req.try_into_http_request("https://homeserver.tld", None).unwrap();
+    let mut http_req =
+        req.try_into_http_request("https://homeserver.tld", SendAccessToken::None).unwrap();
 
     assert_eq!(
         match http_req.headers_mut().entry(CONTENT_TYPE) {

--- a/ruma-api/tests/manual_endpoint_impl.rs
+++ b/ruma-api/tests/manual_endpoint_impl.rs
@@ -6,7 +6,7 @@ use http::{header::CONTENT_TYPE, method::Method};
 use ruma_api::{
     error::{FromHttpRequestError, FromHttpResponseError, IntoHttpError, ServerError, Void},
     AuthScheme, EndpointError, IncomingRequest, IncomingResponse, Metadata, OutgoingRequest,
-    OutgoingResponse,
+    OutgoingResponse, SendAccessToken,
 };
 use ruma_identifiers::{RoomAliasId, RoomId};
 use ruma_serde::Outgoing;
@@ -41,7 +41,7 @@ impl OutgoingRequest for Request {
     fn try_into_http_request(
         self,
         base_url: &str,
-        _access_token: Option<&str>,
+        _access_token: SendAccessToken<'_>,
     ) -> Result<http::Request<Vec<u8>>, IntoHttpError> {
         let url = (base_url.to_owned() + METADATA.path)
             .replace(":room_alias", &self.room_alias.to_string());

--- a/ruma-api/tests/no_fields.rs
+++ b/ruma-api/tests/no_fields.rs
@@ -1,4 +1,4 @@
-use ruma_api::{ruma_api, OutgoingRequest as _, OutgoingResponse as _};
+use ruma_api::{ruma_api, OutgoingRequest as _, OutgoingResponse as _, SendAccessToken};
 
 ruma_api! {
     metadata: {
@@ -17,7 +17,8 @@ ruma_api! {
 #[test]
 fn empty_request_http_repr() {
     let req = Request {};
-    let http_req = req.try_into_http_request("https://homeserver.tld", None).unwrap();
+    let http_req =
+        req.try_into_http_request("https://homeserver.tld", SendAccessToken::None).unwrap();
 
     assert!(http_req.body().is_empty());
 }

--- a/ruma-appservice-api/src/event/push_events/v1.rs
+++ b/ruma-appservice-api/src/event/push_events/v1.rs
@@ -147,7 +147,7 @@ mod helper_tests {
 #[cfg(feature = "server")]
 #[cfg(test)]
 mod tests {
-    use ruma_api::{exports::http, OutgoingRequest};
+    use ruma_api::{exports::http, OutgoingRequest, SendAccessToken};
     use ruma_events::AnyEvent;
     use ruma_serde::Raw;
     use serde_json::json;
@@ -165,7 +165,10 @@ mod tests {
         let events = vec![dummy_event];
 
         let req: http::Request<Vec<u8>> = Request { events: &events, txn_id: "any_txn_id" }
-            .try_into_http_request("https://homeserver.tld", Some("auth_tok"))
+            .try_into_http_request(
+                "https://homeserver.tld",
+                SendAccessToken::IfRequired("auth_tok"),
+            )
             .unwrap();
         let json_body: serde_json::Value = serde_json::from_slice(&req.body()).unwrap();
 

--- a/ruma-client-api/Cargo.toml
+++ b/ruma-client-api/Cargo.toml
@@ -37,6 +37,5 @@ matches = "0.1.8"
 compat = []
 unstable-exhaustive-types = []
 unstable-pre-spec = []
-unstable-synapse-quirks = []
 client = []
 server = []

--- a/ruma-client-api/src/r0/account/register.rs
+++ b/ruma-client-api/src/r0/account/register.rs
@@ -64,6 +64,15 @@ ruma_api! {
         /// from this call, therefore preventing an automatic login.
         #[serde(default, skip_serializing_if = "ruma_serde::is_default")]
         pub inhibit_login: bool,
+
+        /// Login `type` used by Appservices.
+        ///
+        /// Appservices can [bypass the registration flows][admin] entirely by providing their
+        /// token in the header and setting this login `type` to `m.login.application_service`.
+        ///
+        /// [admin]: https://matrix.org/docs/spec/application_service/r0.1.2#server-admin-style-permissions
+        #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+        pub login_type: Option<&'a LoginType>,
     }
 
     response: {
@@ -116,4 +125,12 @@ impl Default for RegistrationKind {
     fn default() -> Self {
         Self::User
     }
+}
+
+/// The login type.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub enum LoginType {
+    /// An appservice-specific login type
+    #[serde(rename = "m.login.application_service")]
+    ApplicationService,
 }

--- a/ruma-client-api/src/r0/directory/get_public_rooms.rs
+++ b/ruma-client-api/src/r0/directory/get_public_rooms.rs
@@ -76,7 +76,7 @@ mod tests {
     #[cfg(feature = "client")]
     #[test]
     fn construct_request_from_refs() {
-        use ruma_api::OutgoingRequest as _;
+        use ruma_api::{OutgoingRequest as _, SendAccessToken};
         use ruma_identifiers::server_name;
 
         let req = super::Request {
@@ -84,7 +84,7 @@ mod tests {
             since: Some("hello"),
             server: Some(&server_name!("test.tld")),
         }
-        .try_into_http_request("https://homeserver.tld", Some("auth_tok"))
+        .try_into_http_request("https://homeserver.tld", SendAccessToken::IfRequired("auth_tok"))
         .unwrap();
 
         let uri = req.uri();

--- a/ruma-client-api/src/r0/message/get_message_events.rs
+++ b/ruma-client-api/src/r0/message/get_message_events.rs
@@ -134,7 +134,7 @@ pub enum Direction {
 #[cfg(all(test, feature = "client"))]
 mod tests {
     use js_int::uint;
-    use ruma_api::OutgoingRequest;
+    use ruma_api::{OutgoingRequest, SendAccessToken};
     use ruma_identifiers::room_id;
 
     use super::{Direction, Request};
@@ -160,8 +160,12 @@ mod tests {
             filter: Some(filter),
         };
 
-        let request: http::Request<Vec<u8>> =
-            req.try_into_http_request("https://homeserver.tld", Some("auth_tok")).unwrap();
+        let request: http::Request<Vec<u8>> = req
+            .try_into_http_request(
+                "https://homeserver.tld",
+                SendAccessToken::IfRequired("auth_tok"),
+            )
+            .unwrap();
         assert_eq!(
             "from=token\
              &to=token2\
@@ -186,8 +190,12 @@ mod tests {
             filter: None,
         };
 
-        let request =
-            req.try_into_http_request("https://homeserver.tld", Some("auth_tok")).unwrap();
+        let request = req
+            .try_into_http_request(
+                "https://homeserver.tld",
+                SendAccessToken::IfRequired("auth_tok"),
+            )
+            .unwrap();
         assert_eq!("from=token&to=token2&dir=b&limit=0", request.uri().query().unwrap(),);
     }
 
@@ -203,8 +211,12 @@ mod tests {
             filter: Some(RoomEventFilter::default()),
         };
 
-        let request: http::Request<Vec<u8>> =
-            req.try_into_http_request("https://homeserver.tld", Some("auth_tok")).unwrap();
+        let request: http::Request<Vec<u8>> = req
+            .try_into_http_request(
+                "https://homeserver.tld",
+                SendAccessToken::IfRequired("auth_tok"),
+            )
+            .unwrap();
         assert_eq!(
             "from=token&to=token2&dir=b&limit=0&filter=%7B%7D",
             request.uri().query().unwrap(),

--- a/ruma-client-api/src/r0/profile/get_avatar_url.rs
+++ b/ruma-client-api/src/r0/profile/get_avatar_url.rs
@@ -10,10 +10,7 @@ ruma_api! {
         name: "get_avatar_url",
         path: "/_matrix/client/r0/profile/:user_id/avatar_url",
         rate_limited: false,
-        #[cfg(not(feature = "unstable-synapse-quirks"))]
         authentication: None,
-        #[cfg(feature = "unstable-synapse-quirks")]
-        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/profile/get_display_name.rs
+++ b/ruma-client-api/src/r0/profile/get_display_name.rs
@@ -10,10 +10,7 @@ ruma_api! {
         name: "get_display_name",
         path: "/_matrix/client/r0/profile/:user_id/displayname",
         rate_limited: false,
-        #[cfg(not(feature = "unstable-synapse-quirks"))]
         authentication: None,
-        #[cfg(feature = "unstable-synapse-quirks")]
-        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/profile/get_profile.rs
+++ b/ruma-client-api/src/r0/profile/get_profile.rs
@@ -10,10 +10,7 @@ ruma_api! {
         name: "get_profile",
         path: "/_matrix/client/r0/profile/:user_id",
         rate_limited: false,
-        #[cfg(not(feature = "unstable-synapse-quirks"))]
         authentication: None,
-        #[cfg(feature = "unstable-synapse-quirks")]
-        authentication: AccessToken,
     }
 
     request: {

--- a/ruma-client-api/src/r0/session/login.rs
+++ b/ruma-client-api/src/r0/session/login.rs
@@ -201,7 +201,7 @@ mod tests {
     #[test]
     #[cfg(feature = "client")]
     fn serialize_login_request_body() {
-        use ruma_api::OutgoingRequest;
+        use ruma_api::{OutgoingRequest, SendAccessToken};
         use serde_json::Value as JsonValue;
 
         use super::{LoginInfo, Medium, Request, UserIdentifier};
@@ -211,7 +211,7 @@ mod tests {
             device_id: None,
             initial_device_display_name: Some("test"),
         }
-        .try_into_http_request("https://homeserver.tld", None)
+        .try_into_http_request("https://homeserver.tld", SendAccessToken::None)
         .unwrap();
 
         let req_body_value: JsonValue = serde_json::from_slice(req.body()).unwrap();
@@ -235,7 +235,7 @@ mod tests {
             device_id: None,
             initial_device_display_name: Some("test"),
         }
-        .try_into_http_request("https://homeserver.tld", None)
+        .try_into_http_request("https://homeserver.tld", SendAccessToken::None)
         .unwrap();
 
         let req_body_value: JsonValue = serde_json::from_slice(req.body()).unwrap();

--- a/ruma-client-api/src/r0/session/sso_login.rs
+++ b/ruma-client-api/src/r0/session/sso_login.rs
@@ -46,14 +46,14 @@ impl Response {
 
 #[cfg(all(test, feature = "client"))]
 mod tests {
-    use ruma_api::OutgoingRequest;
+    use ruma_api::{OutgoingRequest, SendAccessToken};
 
     use super::Request;
 
     #[test]
     fn serialize_sso_login_request_uri() {
         let req: http::Request<Vec<u8>> = Request { redirect_url: "https://example.com/sso" }
-            .try_into_http_request("https://homeserver.tld", None)
+            .try_into_http_request("https://homeserver.tld", SendAccessToken::None)
             .unwrap();
 
         assert_eq!(

--- a/ruma-client-api/src/r0/session/sso_login_with_provider.rs
+++ b/ruma-client-api/src/r0/session/sso_login_with_provider.rs
@@ -53,14 +53,14 @@ impl Response {
 
 #[cfg(all(test, feature = "client"))]
 mod tests {
-    use ruma_api::OutgoingRequest as _;
+    use ruma_api::{OutgoingRequest as _, SendAccessToken};
 
     use super::Request;
 
     #[test]
     fn serialize_sso_login_with_provider_request_uri() {
         let req = Request { idp_id: "provider", redirect_url: "https://example.com/sso" }
-            .try_into_http_request("https://homeserver.tld", None)
+            .try_into_http_request("https://homeserver.tld", SendAccessToken::None)
             .unwrap();
 
         assert_eq!(

--- a/ruma-client-api/src/r0/sync/sync_events.rs
+++ b/ruma-client-api/src/r0/sync/sync_events.rs
@@ -777,7 +777,7 @@ mod tests {
 mod client_tests {
     use std::time::Duration;
 
-    use ruma_api::OutgoingRequest as _;
+    use ruma_api::{OutgoingRequest as _, SendAccessToken};
 
     use super::{Filter, PresenceState, Request};
 
@@ -790,7 +790,7 @@ mod client_tests {
             set_presence: &PresenceState::Offline,
             timeout: Some(Duration::from_millis(30000)),
         }
-        .try_into_http_request("https://homeserver.tld", Some("auth_tok"))
+        .try_into_http_request("https://homeserver.tld", SendAccessToken::IfRequired("auth_tok"))
         .unwrap();
 
         let uri = req.uri();

--- a/ruma-client/src/lib.rs
+++ b/ruma-client/src/lib.rs
@@ -113,7 +113,7 @@ use async_stream::try_stream;
 use futures_core::stream::Stream;
 use http::{uri::Uri, Response as HttpResponse};
 use hyper::client::{Client as HyperClient, HttpConnector};
-use ruma_api::{AuthScheme, OutgoingRequest};
+use ruma_api::{AuthScheme, OutgoingRequest, SendAccessToken};
 use ruma_client_api::r0::sync::sync_events::{
     Filter as SyncFilter, Request as SyncRequest, Response as SyncResponse,
 };
@@ -349,12 +349,12 @@ impl Client {
             let access_token = if Request::METADATA.authentication == AuthScheme::AccessToken {
                 session = client.session.lock().unwrap();
                 if let Some(s) = &*session {
-                    Some(s.access_token.as_str())
+                    SendAccessToken::IfRequired(s.access_token.as_str())
                 } else {
                     return Err(Error::AuthenticationRequired);
                 }
             } else {
-                None
+                SendAccessToken::None
             };
 
             request.try_into_http_request(&client.homeserver_url.to_string(), access_token)?

--- a/ruma/Cargo.toml
+++ b/ruma/Cargo.toml
@@ -116,6 +116,3 @@ unstable-pre-spec = [
     #"ruma-identity-service-api/unstable-pre-spec",
     #"ruma-push-gateway-api/unstable-pre-spec",
 ]
-unstable-synapse-quirks = [
-    "ruma-client-api/unstable-synapse-quirks",
-]

--- a/ruma/src/lib.rs
+++ b/ruma/src/lib.rs
@@ -46,8 +46,6 @@
 //!   breaking changes when new fields are added in the specification. This feature compiles all
 //!   types as exhaustive.
 //! * `unstable-pre-spec` -- Upcoming Matrix features that may be subject to change or removal.
-//! * `unstable-synapse-quirks` -- Fix issues for clients expecting to connect to Synapse
-//!   homeservers, at the expense of being less compatible with other homeservers.
 //!
 //! # Common features
 //!


### PR DESCRIPTION
Relevant part of the spec: https://matrix.org/docs/spec/application_service/r0.1.2#server-admin-style-permissions

Blocks https://github.com/matrix-org/matrix-rust-sdk/pull/204