### PR TITLE
Add helpers to construct the fallback for rich replies

### DIFF
--- a/crates/ruma-events/Cargo.toml
+++ b/crates/ruma-events/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 
 [dependencies]
 criterion = { version = "0.3.3", optional = true }
+indoc = "1.0"
 js_int = { version = "0.2.0", features = ["serde"] }
 ruma-common = { version = "0.5.0", path = "../ruma-common" }
 ruma-events-macros = { version = "=0.22.0-alpha.3", path = "../ruma-events-macros" }
@@ -21,7 +22,6 @@ ruma-serde = { version = "0.3.1", path = "../ruma-serde" }
 serde = { version = "1.0.118", features = ["derive"] }
 serde_json = { version = "1.0.60", features = ["raw_value"] }
 pulldown-cmark = { version = "0.8", default-features = false, optional = true }
-indoc = "1.0"
 
 [dev-dependencies]
 assign = "1.1.1"

--- a/crates/ruma-events/Cargo.toml
+++ b/crates/ruma-events/Cargo.toml
@@ -21,6 +21,7 @@ ruma-serde = { version = "0.3.1", path = "../ruma-serde" }
 serde = { version = "1.0.118", features = ["derive"] }
 serde_json = { version = "1.0.60", features = ["raw_value"] }
 pulldown-cmark = { version = "0.8", default-features = false, optional = true }
+indoc = "1.0"
 
 [dev-dependencies]
 assign = "1.1.1"

--- a/crates/ruma-events/src/room/message.rs
+++ b/crates/ruma-events/src/room/message.rs
@@ -690,3 +690,216 @@ pub struct CustomEventContent {
     #[serde(flatten)]
     pub data: JsonObject,
 }
+
+/// Construct the unformatted fallback to a rich reply.
+pub fn rich_reply_fallback_body(
+    reply: impl Into<String>,
+    original_message: MessageEvent,
+) -> String {
+    let quoted = match &original_message.content.msgtype {
+        MessageType::Audio(_) => {
+            format!("> <{:?}> sent an audio file.", original_message.sender)
+        }
+        MessageType::Emote(content) => {
+            format!("> * <{:?}> {}", original_message.sender, content.body)
+        }
+        MessageType::File(_) => {
+            format!("> <{:?}> sent a file.", original_message.sender)
+        }
+        MessageType::Image(_) => {
+            format!("> <{:?}> sent an image.", original_message.sender)
+        }
+        MessageType::Location(content) => {
+            format!("> <{:?}> {}", original_message.sender, content.body)
+        }
+        MessageType::Notice(content) => {
+            format!("> <{:?}> {}", original_message.sender, content.body)
+        }
+        MessageType::ServerNotice(content) => {
+            format!("> <{:?}> {}", original_message.sender, content.body)
+        }
+        MessageType::Text(content) => {
+            format!("> <{:?}> {}", original_message.sender, content.body)
+        }
+        MessageType::Video(_) => {
+            format!("> <{:?}> sent a video.", original_message.sender)
+        }
+        MessageType::_Custom(content) => {
+            // TODO: figure out what to do with custom events
+            format!("> <{:?}> sent a custom event.", original_message.sender)
+        }
+    };
+
+    format!("{}\n\n{}", quoted, reply.into())
+}
+
+/// Construct the formatted fallback to a rich reply.
+pub fn rich_reply_fallback_formatted(
+    formatted_reply: impl Into<String>,
+    original_message: MessageEvent,
+) -> String {
+    let quote_formatted = match &original_message.content.msgtype {
+        MessageType::Audio(_) => {
+            format!(
+                "<mx-reply>
+    <blockquote>
+        <a href=\"https://matrix.to/#/!{}/${}\">In reply to</a>
+        <a href=\"https://matrix.to/#/{}\">{}</a>
+        <br />
+        sent an audio file.
+    </blockquote>
+</mx-reply>",
+                original_message.room_id.server_name(),
+                original_message.event_id.as_str(),
+                original_message.sender.as_str(),
+                original_message.sender.as_str(),
+            )
+        }
+        MessageType::Emote(content) => {
+            format!(
+                "<mx-reply>
+    <blockquote>
+        <a href=\"https://matrix.to/#/!{}/${}\">In reply to</a>
+        * <a href=\"https://matrix.to/#/{}\">{}</a>
+        <br />
+        {:?}
+    </blockquote>
+</mx-reply>",
+                original_message.room_id.server_name(),
+                original_message.event_id.as_str(),
+                original_message.sender.as_str(),
+                original_message.sender.as_str(),
+                content.formatted.as_ref().unwrap().body
+            )
+        }
+        MessageType::File(_) => {
+            format!(
+                "<mx-reply>
+    <blockquote>
+        <a href=\"https://matrix.to/#/!{}/${}\">In reply to</a>
+        <a href=\"https://matrix.to/#/{}\">{}</a>
+        <br />
+        sent a file.
+    </blockquote>
+</mx-reply>",
+                original_message.room_id.server_name(),
+                original_message.event_id.as_str(),
+                original_message.sender.as_str(),
+                original_message.sender.as_str(),
+            )
+        }
+        MessageType::Image(_) => {
+            format!(
+                "<mx-reply>
+    <blockquote>
+        <a href=\"https://matrix.to/#/!{}/${}\">In reply to</a>
+        <a href=\"https://matrix.to/#/{}\">{}</a>
+        <br />
+        sent an image.
+    </blockquote>
+</mx-reply>",
+                original_message.room_id.server_name(),
+                original_message.event_id.as_str(),
+                original_message.sender.as_str(),
+                original_message.sender.as_str(),
+            )
+        }
+        MessageType::Location(_) => {
+            format!(
+                "<mx-reply>
+    <blockquote>
+        <a href=\"https://matrix.to/#/!{}/${}\">In reply to</a>
+        <a href=\"https://matrix.to/#/{}\">{}</a>
+        <br />
+        sent a location.
+    </blockquote>
+</mx-reply>",
+                original_message.room_id.server_name(),
+                original_message.event_id.as_str(),
+                original_message.sender.as_str(),
+                original_message.sender.as_str(),
+            )
+        }
+        MessageType::Notice(content) => {
+            format!(
+                "<mx-reply>
+    <blockquote>
+        <a href=\"https://matrix.to/#/!{}/${}\">In reply to</a>
+        <a href=\"https://matrix.to/#/{}\">{}</a>
+        <br />
+        {:?}
+    </blockquote>
+</mx-reply>",
+                original_message.room_id.server_name(),
+                original_message.event_id.as_str(),
+                original_message.sender.as_str(),
+                original_message.sender.as_str(),
+                if let Some(formatted) = &content.formatted {
+                    formatted.body.as_str()
+                } else {
+                    content.body.as_str()
+                }
+            )
+        }
+        MessageType::ServerNotice(content) => {
+            format!(
+                "<mx-reply>
+    <blockquote>
+        <a href=\"https://matrix.to/#/!{}/${}\">In reply to</a>
+        <a href=\"https://matrix.to/#/{}\">{}</a>
+        <br />
+        {:?}
+    </blockquote>
+</mx-reply>",
+                original_message.room_id.server_name(),
+                original_message.event_id.as_str(),
+                original_message.sender.as_str(),
+                original_message.sender.as_str(),
+                content.body
+            )
+        }
+        MessageType::Text(content) => {
+            format!(
+                "<mx-reply>
+    <blockquote>
+        <a href=\"https://matrix.to/#/!{}/${}\">In reply to</a>
+        <a href=\"https://matrix.to/#/{}\">{}</a>
+        <br />
+        {:?}
+    </blockquote>
+</mx-reply>",
+                original_message.room_id.server_name(),
+                original_message.event_id.as_str(),
+                original_message.sender.as_str(),
+                original_message.sender.as_str(),
+                if let Some(formatted) = &content.formatted {
+                    formatted.body.as_str()
+                } else {
+                    content.body.as_str()
+                }
+            )
+        }
+        MessageType::Video(_) => {
+            format!(
+                "<mx-reply>
+    <blockquote>
+        <a href=\"https://matrix.to/#/!{}/${}\">In reply to</a>
+        <a href=\"https://matrix.to/#/{}\">{}</a>
+        <br />
+        sent a video.
+    </blockquote>
+</mx-reply>",
+                original_message.room_id.server_name(),
+                original_message.event_id.as_str(),
+                original_message.sender.as_str(),
+                original_message.sender.as_str(),
+            )
+        }
+        MessageType::_Custom(_) => {
+            // TODO: figure out what to do with custom events
+            format!("")
+        }
+    };
+
+    format!("{}\n{}", quote_formatted, formatted_reply.into())
+}

--- a/crates/ruma-events/src/room/message.rs
+++ b/crates/ruma-events/src/room/message.rs
@@ -99,10 +99,12 @@ impl MessageEventContent {
             relates_to: Some(Relation::Reply {
                 in_reply_to: InReplyTo { event_id: original_message.event_id.clone() },
             }),
+            #[cfg(feature = "unstable-pre-spec")]
+            new_content: None,
         }
     }
 
-    /// A construly to create a html text reply to a message.
+    /// A contructor to create a html text reply to a message.
     pub fn text_reply_html(
         reply: impl Into<String>,
         html_reply: impl Into<String>,
@@ -121,6 +123,8 @@ impl MessageEventContent {
             relates_to: Some(Relation::Reply {
                 in_reply_to: InReplyTo { event_id: original_message.event_id.clone() },
             }),
+            #[cfg(feature = "unstable-pre-spec")]
+            new_content: None,
         }
     }
 
@@ -137,6 +141,8 @@ impl MessageEventContent {
             relates_to: Some(Relation::Reply {
                 in_reply_to: InReplyTo { event_id: original_message.event_id.clone() },
             }),
+            #[cfg(feature = "unstable-pre-spec")]
+            new_content: None,
         }
     }
 
@@ -152,16 +158,16 @@ impl MessageEventContent {
         let body = format!("{}\n\n{}", quoted, reply.into());
         let formatted = format!("{}\n\n{}", quoted_html, html_reply.into());
 
-        let notice_message_content = NoticeMessageEventContent {
-            body,
-            formatted: Some(FormattedBody::html(formatted)),
-        };
+        let notice_message_content =
+            NoticeMessageEventContent { body, formatted: Some(FormattedBody::html(formatted)) };
 
         Self {
             msgtype: MessageType::Notice(notice_message_content),
             relates_to: Some(Relation::Reply {
                 in_reply_to: InReplyTo { event_id: original_message.event_id.clone() },
             }),
+            #[cfg(feature = "unstable-pre-spec")]
+            new_content: None,
         }
     }
 
@@ -202,6 +208,11 @@ impl MessageEventContent {
                     content.data["body"].as_str().unwrap_or("")
                 )
             }
+            #[cfg(feature = "unstable-pre-spec")]
+            MessageType::VerificationRequest(content) => {
+                // Eagerly deserialize `body` since we assume every message should have it
+                format!("> <{:?}> {}", original_message.sender, content.body)
+            }
         }
     }
 
@@ -210,13 +221,13 @@ impl MessageEventContent {
             MessageType::Audio(_) => {
                 format!(
                     "<mx-reply>
-        <blockquote>
-            <a href=\"https://matrix.to/#/!{}/${}\">In reply to</a>
-            <a href=\"https://matrix.to/#/{}\">{}</a>
-            <br />
-            sent an audio file.
-        </blockquote>
-    </mx-reply>",
+    <blockquote>
+        <a href=\"https://matrix.to/#/!{}/${}\">In reply to</a>
+        <a href=\"https://matrix.to/#/{}\">{}</a>
+        <br />
+        sent an audio file.
+    </blockquote>
+</mx-reply>",
                     original_message.room_id.server_name(),
                     original_message.event_id.as_str(),
                     original_message.sender.as_str(),
@@ -226,13 +237,13 @@ impl MessageEventContent {
             MessageType::Emote(content) => {
                 format!(
                     "<mx-reply>
-        <blockquote>
-            <a href=\"https://matrix.to/#/!{}/${}\">In reply to</a>
-            * <a href=\"https://matrix.to/#/{}\">{}</a>
-            <br />
-            {:?}
-        </blockquote>
-    </mx-reply>",
+    <blockquote>
+        <a href=\"https://matrix.to/#/!{}/${}\">In reply to</a>
+        * <a href=\"https://matrix.to/#/{}\">{}</a>
+        <br />
+        {:?}
+    </blockquote>
+</mx-reply>",
                     original_message.room_id.server_name(),
                     original_message.event_id.as_str(),
                     original_message.sender.as_str(),
@@ -247,13 +258,13 @@ impl MessageEventContent {
             MessageType::File(_) => {
                 format!(
                     "<mx-reply>
-        <blockquote>
-            <a href=\"https://matrix.to/#/!{}/${}\">In reply to</a>
-            <a href=\"https://matrix.to/#/{}\">{}</a>
-            <br />
-            sent a file.
-        </blockquote>
-    </mx-reply>",
+    <blockquote>
+        <a href=\"https://matrix.to/#/!{}/${}\">In reply to</a>
+        <a href=\"https://matrix.to/#/{}\">{}</a>
+        <br />
+        sent a file.
+    </blockquote>
+</mx-reply>",
                     original_message.room_id.server_name(),
                     original_message.event_id.as_str(),
                     original_message.sender.as_str(),
@@ -263,13 +274,13 @@ impl MessageEventContent {
             MessageType::Image(_) => {
                 format!(
                     "<mx-reply>
-        <blockquote>
-            <a href=\"https://matrix.to/#/!{}/${}\">In reply to</a>
-            <a href=\"https://matrix.to/#/{}\">{}</a>
-            <br />
-            sent an image.
-        </blockquote>
-    </mx-reply>",
+    <blockquote>
+        <a href=\"https://matrix.to/#/!{}/${}\">In reply to</a>
+        <a href=\"https://matrix.to/#/{}\">{}</a>
+        <br />
+        sent an image.
+    </blockquote>
+</mx-reply>",
                     original_message.room_id.server_name(),
                     original_message.event_id.as_str(),
                     original_message.sender.as_str(),
@@ -279,13 +290,13 @@ impl MessageEventContent {
             MessageType::Location(_) => {
                 format!(
                     "<mx-reply>
-        <blockquote>
-            <a href=\"https://matrix.to/#/!{}/${}\">In reply to</a>
-            <a href=\"https://matrix.to/#/{}\">{}</a>
-            <br />
-            sent a location.
-        </blockquote>
-    </mx-reply>",
+    <blockquote>
+        <a href=\"https://matrix.to/#/!{}/${}\">In reply to</a>
+        <a href=\"https://matrix.to/#/{}\">{}</a>
+        <br />
+        sent a location.
+    </blockquote>
+</mx-reply>",
                     original_message.room_id.server_name(),
                     original_message.event_id.as_str(),
                     original_message.sender.as_str(),
@@ -295,13 +306,13 @@ impl MessageEventContent {
             MessageType::Notice(content) => {
                 format!(
                     "<mx-reply>
-        <blockquote>
-            <a href=\"https://matrix.to/#/!{}/${}\">In reply to</a>
-            <a href=\"https://matrix.to/#/{}\">{}</a>
-            <br />
-            {:?}
-        </blockquote>
-    </mx-reply>",
+    <blockquote>
+        <a href=\"https://matrix.to/#/!{}/${}\">In reply to</a>
+        <a href=\"https://matrix.to/#/{}\">{}</a>
+        <br />
+        {:?}
+    </blockquote>
+</mx-reply>",
                     original_message.room_id.server_name(),
                     original_message.event_id.as_str(),
                     original_message.sender.as_str(),
@@ -316,13 +327,13 @@ impl MessageEventContent {
             MessageType::ServerNotice(content) => {
                 format!(
                     "<mx-reply>
-        <blockquote>
-            <a href=\"https://matrix.to/#/!{}/${}\">In reply to</a>
-            <a href=\"https://matrix.to/#/{}\">{}</a>
-            <br />
-            {:?}
-        </blockquote>
-    </mx-reply>",
+    <blockquote>
+        <a href=\"https://matrix.to/#/!{}/${}\">In reply to</a>
+        <a href=\"https://matrix.to/#/{}\">{}</a>
+        <br />
+        {:?}
+    </blockquote>
+</mx-reply>",
                     original_message.room_id.server_name(),
                     original_message.event_id.as_str(),
                     original_message.sender.as_str(),
@@ -333,13 +344,13 @@ impl MessageEventContent {
             MessageType::Text(content) => {
                 format!(
                     "<mx-reply>
-        <blockquote>
-            <a href=\"https://matrix.to/#/!{}/${}\">In reply to</a>
-            <a href=\"https://matrix.to/#/{}\">{}</a>
-            <br />
-            {:?}
-        </blockquote>
-    </mx-reply>",
+    <blockquote>
+        <a href=\"https://matrix.to/#/!{}/${}\">In reply to</a>
+        <a href=\"https://matrix.to/#/{}\">{}</a>
+        <br />
+        {:?}
+    </blockquote>
+</mx-reply>",
                     original_message.room_id.server_name(),
                     original_message.event_id.as_str(),
                     original_message.sender.as_str(),
@@ -354,22 +365,54 @@ impl MessageEventContent {
             MessageType::Video(_) => {
                 format!(
                     "<mx-reply>
-        <blockquote>
-            <a href=\"https://matrix.to/#/!{}/${}\">In reply to</a>
-            <a href=\"https://matrix.to/#/{}\">{}</a>
-            <br />
-            sent a video.
-        </blockquote>
-    </mx-reply>",
+    <blockquote>
+        <a href=\"https://matrix.to/#/!{}/${}\">In reply to</a>
+        <a href=\"https://matrix.to/#/{}\">{}</a>
+        <br />
+        sent a video.
+    </blockquote>
+</mx-reply>",
                     original_message.room_id.server_name(),
                     original_message.event_id.as_str(),
                     original_message.sender.as_str(),
                     original_message.sender.as_str(),
                 )
             }
-            MessageType::_Custom(_) => {
-                // TODO: figure out what to do with custom events
-                format!("")
+            MessageType::_Custom(content) => {
+                format!(
+                    "<mx-reply>
+    <blockquote>
+        <a href=\"https://matrix.to/#/!{}/${}\">In reply to</a>
+        <a href=\"https://matrix.to/#/{}\">{}</a>
+        <br />
+        {:?}
+    </blockquote>
+</mx-reply>",
+                    original_message.room_id.server_name(),
+                    original_message.event_id.as_str(),
+                    original_message.sender.as_str(),
+                    original_message.sender.as_str(),
+                    // Eagerly deserialize `body` since we assume every message should have it
+                    content.data["body"].as_str().unwrap_or("")
+                )
+            }
+            #[cfg(feature = "unstable-pre-spec")]
+            MessageType::VerificationRequest(content) => {
+                format!(
+                    "<mx-reply>
+    <blockquote>
+        <a href=\"https://matrix.to/#/!{}/${}\">In reply to</a>
+        <a href=\"https://matrix.to/#/{}\">{}</a>
+        <br />
+        {:?}
+    </blockquote>
+</mx-reply>",
+                    original_message.room_id.server_name(),
+                    original_message.event_id.as_str(),
+                    original_message.sender.as_str(),
+                    original_message.sender.as_str(),
+                    content.body
+                )
             }
         }
     }

--- a/crates/ruma-events/src/room/message.rs
+++ b/crates/ruma-events/src/room/message.rs
@@ -94,15 +94,11 @@ impl MessageEventContent {
 
         let body = format!("{}\n\n{}", quoted, reply.into());
 
-        let text_message_content = TextMessageEventContent { body, formatted: None };
-
         Self {
-            msgtype: MessageType::Text(text_message_content),
             relates_to: Some(Relation::Reply {
                 in_reply_to: InReplyTo { event_id: original_message.event_id.clone() },
             }),
-            #[cfg(feature = "unstable-pre-spec")]
-            new_content: None,
+            ..Self::text_plain(body)
         }
     }
 
@@ -116,17 +112,13 @@ impl MessageEventContent {
         let quoted_html = MessageEventContent::get_html_quote_fallback(original_message);
 
         let body = format!("{}\n\n{}", quoted, reply.into());
-        let formatted = format!("{}\n\n{}", quoted_html, html_reply.into());
-        let text_message_content =
-            TextMessageEventContent { body, formatted: Some(FormattedBody::html(formatted)) };
+        let html_body = format!("{}\n\n{}", quoted_html, html_reply.into());
 
         Self {
-            msgtype: MessageType::Text(text_message_content),
             relates_to: Some(Relation::Reply {
                 in_reply_to: InReplyTo { event_id: original_message.event_id.clone() },
             }),
-            #[cfg(feature = "unstable-pre-spec")]
-            new_content: None,
+            ..Self::text_html(body, html_body)
         }
     }
 
@@ -135,16 +127,11 @@ impl MessageEventContent {
         let quoted = MessageEventContent::get_plain_quote_fallback(original_message);
 
         let body = format!("{}\n\n{}", quoted, reply.into());
-
-        let notice_message_content = NoticeMessageEventContent { body, formatted: None };
-
         Self {
-            msgtype: MessageType::Notice(notice_message_content),
             relates_to: Some(Relation::Reply {
                 in_reply_to: InReplyTo { event_id: original_message.event_id.clone() },
             }),
-            #[cfg(feature = "unstable-pre-spec")]
-            new_content: None,
+            ..Self::notice_plain(body)
         }
     }
 
@@ -158,18 +145,13 @@ impl MessageEventContent {
         let quoted_html = MessageEventContent::get_html_quote_fallback(original_message);
 
         let body = format!("{}\n\n{}", quoted, reply.into());
-        let formatted = format!("{}\n\n{}", quoted_html, html_reply.into());
-
-        let notice_message_content =
-            NoticeMessageEventContent { body, formatted: Some(FormattedBody::html(formatted)) };
+        let html_body = format!("{}\n\n{}", quoted_html, html_reply.into());
 
         Self {
-            msgtype: MessageType::Notice(notice_message_content),
             relates_to: Some(Relation::Reply {
                 in_reply_to: InReplyTo { event_id: original_message.event_id.clone() },
             }),
-            #[cfg(feature = "unstable-pre-spec")]
-            new_content: None,
+            ..Self::notice_html(body, html_body)
         }
     }
 

--- a/crates/ruma-events/src/room/message.rs
+++ b/crates/ruma-events/src/room/message.rs
@@ -11,6 +11,8 @@ use ruma_serde::StringEnum;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
+use indoc::formatdoc;
+
 #[cfg(feature = "unstable-pre-spec")]
 use super::relationships::{Annotation, Reference, RelationJsonRepr, Replacement};
 use super::{relationships::RelatesToJsonRepr, EncryptedFile, ImageInfo, ThumbnailInfo};
@@ -201,7 +203,6 @@ impl MessageEventContent {
                 format!("> <{:?}> sent a video.", original_message.sender)
             }
             MessageType::_Custom(content) => {
-                // Eagerly deserialize `body` since we assume every message should have it
                 format!(
                     "> <{:?}> {}",
                     original_message.sender,
@@ -210,7 +211,6 @@ impl MessageEventContent {
             }
             #[cfg(feature = "unstable-pre-spec")]
             MessageType::VerificationRequest(content) => {
-                // Eagerly deserialize `body` since we assume every message should have it
                 format!("> <{:?}> {}", original_message.sender, content.body)
             }
         }
@@ -219,200 +219,188 @@ impl MessageEventContent {
     fn get_html_quote_fallback(original_message: &MessageEvent) -> String {
         match &original_message.content.msgtype {
             MessageType::Audio(_) => {
-                format!(
-                    "<mx-reply>
-    <blockquote>
-        <a href=\"https://matrix.to/#/!{}/${}\">In reply to</a>
-        <a href=\"https://matrix.to/#/{}\">{}</a>
-        <br />
-        sent an audio file.
-    </blockquote>
-</mx-reply>",
-                    original_message.room_id.server_name(),
-                    original_message.event_id.as_str(),
-                    original_message.sender.as_str(),
-                    original_message.sender.as_str(),
-                )
+                formatdoc! {"
+                    <mx-reply>
+                        <blockquote>
+                            <a href=\"https://matrix.to/#/{room_id}/{event_id}\">In reply to</a>
+                            <a href=\"https://matrix.to/#/{sender}\">{sender}</a>
+                            <br />
+                            sent an audio file.
+                        </blockquote>
+                    </mx-reply>",
+                    room_id = original_message.room_id,
+                    event_id = original_message.event_id,
+                    sender = original_message.sender,
+                }
             }
             MessageType::Emote(content) => {
-                format!(
-                    "<mx-reply>
-    <blockquote>
-        <a href=\"https://matrix.to/#/!{}/${}\">In reply to</a>
-        * <a href=\"https://matrix.to/#/{}\">{}</a>
-        <br />
-        {:?}
-    </blockquote>
-</mx-reply>",
-                    original_message.room_id.server_name(),
-                    original_message.event_id.as_str(),
-                    original_message.sender.as_str(),
-                    original_message.sender.as_str(),
-                    if let Some(formatted) = &content.formatted {
+                formatdoc! {"
+                    <mx-reply>
+                        <blockquote>
+                            <a href=\"https://matrix.to/#/{room_id}/{event_id}\">In reply to</a>
+                            * <a href=\"https://matrix.to/#/{sender}\">{sender}</a>
+                            <br />
+                            {body}
+                        </blockquote>
+                    </mx-reply>",
+                    room_id = original_message.room_id,
+                    event_id = original_message.event_id,
+                    sender = original_message.sender,
+                    body = if let Some(formatted) = &content.formatted {
                         formatted.body.as_str()
                     } else {
                         content.body.as_str()
                     }
-                )
+                }
             }
             MessageType::File(_) => {
-                format!(
-                    "<mx-reply>
-    <blockquote>
-        <a href=\"https://matrix.to/#/!{}/${}\">In reply to</a>
-        <a href=\"https://matrix.to/#/{}\">{}</a>
-        <br />
-        sent a file.
-    </blockquote>
-</mx-reply>",
-                    original_message.room_id.server_name(),
-                    original_message.event_id.as_str(),
-                    original_message.sender.as_str(),
-                    original_message.sender.as_str(),
-                )
+                formatdoc! {"
+                    <mx-reply>
+                        <blockquote>
+                            <a href=\"https://matrix.to/#/{room_id}/{event_id}\">In reply to</a>
+                            <a href=\"https://matrix.to/#/{sender}\">{sender}</a>
+                            <br />
+                            sent a file.
+                        </blockquote>
+                    </mx-reply>",
+                    room_id = original_message.room_id,
+                    event_id = original_message.event_id,
+                    sender = original_message.sender,
+                }
             }
             MessageType::Image(_) => {
-                format!(
-                    "<mx-reply>
-    <blockquote>
-        <a href=\"https://matrix.to/#/!{}/${}\">In reply to</a>
-        <a href=\"https://matrix.to/#/{}\">{}</a>
-        <br />
-        sent an image.
-    </blockquote>
-</mx-reply>",
-                    original_message.room_id.server_name(),
-                    original_message.event_id.as_str(),
-                    original_message.sender.as_str(),
-                    original_message.sender.as_str(),
-                )
+                formatdoc! {"
+                    <mx-reply>
+                        <blockquote>
+                            <a href=\"https://matrix.to/#/{room_id}/{event_id}\">In reply to</a>
+                            <a href=\"https://matrix.to/#/{sender}\">{sender}</a>
+                            <br />
+                            sent an image.
+                        </blockquote>
+                    </mx-reply>",
+                    room_id = original_message.room_id,
+                    event_id = original_message.event_id,
+                    sender = original_message.sender,
+                }
             }
             MessageType::Location(_) => {
-                format!(
-                    "<mx-reply>
-    <blockquote>
-        <a href=\"https://matrix.to/#/!{}/${}\">In reply to</a>
-        <a href=\"https://matrix.to/#/{}\">{}</a>
-        <br />
-        sent a location.
-    </blockquote>
-</mx-reply>",
-                    original_message.room_id.server_name(),
-                    original_message.event_id.as_str(),
-                    original_message.sender.as_str(),
-                    original_message.sender.as_str(),
-                )
+                formatdoc! {"
+                    <mx-reply>
+                        <blockquote>
+                            <a href=\"https://matrix.to/#/{room_id}/{event_id}\">In reply to</a>
+                            <a href=\"https://matrix.to/#/{sender}\">{sender}</a>
+                            <br />
+                            sent a location.
+                        </blockquote>
+                    </mx-reply>",
+                    room_id = original_message.room_id,
+                    event_id = original_message.event_id,
+                    sender = original_message.sender,
+                }
             }
             MessageType::Notice(content) => {
-                format!(
-                    "<mx-reply>
-    <blockquote>
-        <a href=\"https://matrix.to/#/!{}/${}\">In reply to</a>
-        <a href=\"https://matrix.to/#/{}\">{}</a>
-        <br />
-        {:?}
-    </blockquote>
-</mx-reply>",
-                    original_message.room_id.server_name(),
-                    original_message.event_id.as_str(),
-                    original_message.sender.as_str(),
-                    original_message.sender.as_str(),
-                    if let Some(formatted) = &content.formatted {
+                formatdoc! {"
+                    <mx-reply>
+                        <blockquote>
+                            <a href=\"https://matrix.to/#/{room_id}/{event_id}\">In reply to</a>
+                            <a href=\"https://matrix.to/#/{sender}\">{sender}</a>
+                            <br />
+                            {body}
+                        </blockquote>
+                    </mx-reply>",
+                    room_id = original_message.room_id,
+                    event_id = original_message.event_id,
+                    sender = original_message.sender,
+                    body = if let Some(formatted) = &content.formatted {
                         formatted.body.as_str()
                     } else {
                         content.body.as_str()
-                    }
-                )
+                    },
+                }
             }
             MessageType::ServerNotice(content) => {
-                format!(
-                    "<mx-reply>
-    <blockquote>
-        <a href=\"https://matrix.to/#/!{}/${}\">In reply to</a>
-        <a href=\"https://matrix.to/#/{}\">{}</a>
-        <br />
-        {:?}
-    </blockquote>
-</mx-reply>",
-                    original_message.room_id.server_name(),
-                    original_message.event_id.as_str(),
-                    original_message.sender.as_str(),
-                    original_message.sender.as_str(),
-                    content.body
-                )
+                formatdoc! {"
+                    <mx-reply>
+                        <blockquote>
+                            <a href=\"https://matrix.to/#/{room_id}/{event_id}\">In reply to</a>
+                            <a href=\"https://matrix.to/#/{sender}\">{sender}</a>
+                            <br />
+                            {body}
+                        </blockquote>
+                    </mx-reply>",
+                    room_id = original_message.room_id,
+                    event_id = original_message.event_id,
+                    sender = original_message.sender,
+                    body = content.body
+                }
             }
             MessageType::Text(content) => {
-                format!(
-                    "<mx-reply>
-    <blockquote>
-        <a href=\"https://matrix.to/#/!{}/${}\">In reply to</a>
-        <a href=\"https://matrix.to/#/{}\">{}</a>
-        <br />
-        {:?}
-    </blockquote>
-</mx-reply>",
-                    original_message.room_id.server_name(),
-                    original_message.event_id.as_str(),
-                    original_message.sender.as_str(),
-                    original_message.sender.as_str(),
-                    if let Some(formatted) = &content.formatted {
+                formatdoc! {"
+                    <mx-reply>
+                        <blockquote>
+                            <a href=\"https://matrix.to/#/{room_id}/{event_id}\">In reply to</a>
+                            <a href=\"https://matrix.to/#/{sender}\">{sender}</a>
+                            <br />
+                            {body}
+                        </blockquote>
+                    </mx-reply>",
+                    room_id = original_message.room_id,
+                    event_id = original_message.event_id,
+                    sender = original_message.sender,
+                    body = if let Some(formatted) = &content.formatted {
                         formatted.body.as_str()
                     } else {
                         content.body.as_str()
                     }
-                )
+                }
             }
             MessageType::Video(_) => {
-                format!(
-                    "<mx-reply>
-    <blockquote>
-        <a href=\"https://matrix.to/#/!{}/${}\">In reply to</a>
-        <a href=\"https://matrix.to/#/{}\">{}</a>
-        <br />
-        sent a video.
-    </blockquote>
-</mx-reply>",
-                    original_message.room_id.server_name(),
-                    original_message.event_id.as_str(),
-                    original_message.sender.as_str(),
-                    original_message.sender.as_str(),
-                )
+                formatdoc! {"
+                    <mx-reply>
+                        <blockquote>
+                            <a href=\"https://matrix.to/#/{room_id}/{event_id}\">In reply to</a>
+                            <a href=\"https://matrix.to/#/{sender}\">{sender}</a>
+                            <br />
+                            sent a video.
+                        </blockquote>
+                    </mx-reply>",
+                    room_id = original_message.room_id,
+                    event_id = original_message.event_id,
+                    sender = original_message.sender,
+                }
             }
             MessageType::_Custom(content) => {
-                format!(
-                    "<mx-reply>
-    <blockquote>
-        <a href=\"https://matrix.to/#/!{}/${}\">In reply to</a>
-        <a href=\"https://matrix.to/#/{}\">{}</a>
-        <br />
-        {:?}
-    </blockquote>
-</mx-reply>",
-                    original_message.room_id.server_name(),
-                    original_message.event_id.as_str(),
-                    original_message.sender.as_str(),
-                    original_message.sender.as_str(),
-                    // Eagerly deserialize `body` since we assume every message should have it
-                    content.data["body"].as_str().unwrap_or("")
-                )
+                formatdoc! {"
+                    <mx-reply>
+                        <blockquote>
+                            <a href=\"https://matrix.to/#/{room_id}/{event_id}\">In reply to</a>
+                            <a href=\"https://matrix.to/#/{sender}\">{sender}</a>
+                            <br />
+                            {body}
+                        </blockquote>
+                    </mx-reply>",
+                    room_id = original_message.room_id,
+                    event_id = original_message.event_id,
+                    sender = original_message.sender,
+                    body = content.data["body"].as_str().unwrap_or("")
+                }
             }
             #[cfg(feature = "unstable-pre-spec")]
             MessageType::VerificationRequest(content) => {
-                format!(
-                    "<mx-reply>
-    <blockquote>
-        <a href=\"https://matrix.to/#/!{}/${}\">In reply to</a>
-        <a href=\"https://matrix.to/#/{}\">{}</a>
-        <br />
-        {:?}
-    </blockquote>
-</mx-reply>",
-                    original_message.room_id.server_name(),
-                    original_message.event_id.as_str(),
-                    original_message.sender.as_str(),
-                    original_message.sender.as_str(),
-                    content.body
-                )
+                formatdoc! {"
+                    <mx-reply>
+                        <blockquote>
+                            <a href=\"https://matrix.to/#/{server_name}/{event_id}\">In reply to</a>
+                            <a href=\"https://matrix.to/#/{sender}\">{sender}</a>
+                            <br />
+                            {body}
+                        </blockquote>
+                    </mx-reply>",
+                    server_name = original_message.room_id,
+                    event_id = original_message.event_id,
+                    sender = original_message.sender,
+                    body = content.body
+                }
             }
         }
     }

--- a/crates/ruma-events/src/room/message.rs
+++ b/crates/ruma-events/src/room/message.rs
@@ -90,7 +90,7 @@ impl MessageEventContent {
 
     /// A constructor to create a plain text reply to a message.
     pub fn text_reply_plain(reply: impl Into<String>, original_message: &MessageEvent) -> Self {
-        let quoted = MessageEventContent::get_plain_quote_fallback(original_message);
+        let quoted = get_plain_quote_fallback(original_message);
 
         let body = format!("{}\n\n{}", quoted, reply.into());
 
@@ -108,8 +108,8 @@ impl MessageEventContent {
         html_reply: impl Into<String>,
         original_message: &MessageEvent,
     ) -> Self {
-        let quoted = MessageEventContent::get_plain_quote_fallback(original_message);
-        let quoted_html = MessageEventContent::get_html_quote_fallback(original_message);
+        let quoted = get_plain_quote_fallback(original_message);
+        let quoted_html = get_html_quote_fallback(original_message);
 
         let body = format!("{}\n\n{}", quoted, reply.into());
         let html_body = format!("{}\n\n{}", quoted_html, html_reply.into());
@@ -124,7 +124,7 @@ impl MessageEventContent {
 
     /// A constructor to create a plain text notice reply to a message.
     pub fn notice_reply_plain(reply: impl Into<String>, original_message: &MessageEvent) -> Self {
-        let quoted = MessageEventContent::get_plain_quote_fallback(original_message);
+        let quoted = get_plain_quote_fallback(original_message);
 
         let body = format!("{}\n\n{}", quoted, reply.into());
         Self {
@@ -141,8 +141,8 @@ impl MessageEventContent {
         html_reply: impl Into<String>,
         original_message: &MessageEvent,
     ) -> Self {
-        let quoted = MessageEventContent::get_plain_quote_fallback(original_message);
-        let quoted_html = MessageEventContent::get_html_quote_fallback(original_message);
+        let quoted = get_plain_quote_fallback(original_message);
+        let quoted_html = get_html_quote_fallback(original_message);
 
         let body = format!("{}\n\n{}", quoted, reply.into());
         let html_body = format!("{}\n\n{}", quoted_html, html_reply.into());
@@ -152,238 +152,6 @@ impl MessageEventContent {
                 in_reply_to: InReplyTo { event_id: original_message.event_id.clone() },
             }),
             ..Self::notice_html(body, html_body)
-        }
-    }
-
-    fn get_plain_quote_fallback(original_message: &MessageEvent) -> String {
-        match &original_message.content.msgtype {
-            MessageType::Audio(_) => {
-                format!("> <{:?}> sent an audio file.", original_message.sender)
-            }
-            MessageType::Emote(content) => {
-                format!("> * <{:?}> {}", original_message.sender, content.body)
-            }
-            MessageType::File(_) => {
-                format!("> <{:?}> sent a file.", original_message.sender)
-            }
-            MessageType::Image(_) => {
-                format!("> <{:?}> sent an image.", original_message.sender)
-            }
-            MessageType::Location(content) => {
-                format!("> <{:?}> {}", original_message.sender, content.body)
-            }
-            MessageType::Notice(content) => {
-                format!("> <{:?}> {}", original_message.sender, content.body)
-            }
-            MessageType::ServerNotice(content) => {
-                format!("> <{:?}> {}", original_message.sender, content.body)
-            }
-            MessageType::Text(content) => {
-                format!("> <{:?}> {}", original_message.sender, content.body)
-            }
-            MessageType::Video(_) => {
-                format!("> <{:?}> sent a video.", original_message.sender)
-            }
-            MessageType::_Custom(content) => {
-                format!(
-                    "> <{:?}> {}",
-                    original_message.sender,
-                    content.data["body"].as_str().unwrap_or("")
-                )
-            }
-            #[cfg(feature = "unstable-pre-spec")]
-            MessageType::VerificationRequest(content) => {
-                format!("> <{:?}> {}", original_message.sender, content.body)
-            }
-        }
-    }
-
-    fn get_html_quote_fallback(original_message: &MessageEvent) -> String {
-        match &original_message.content.msgtype {
-            MessageType::Audio(_) => {
-                formatdoc! {"
-                    <mx-reply>
-                        <blockquote>
-                            <a href=\"https://matrix.to/#/{room_id}/{event_id}\">In reply to</a>
-                            <a href=\"https://matrix.to/#/{sender}\">{sender}</a>
-                            <br />
-                            sent an audio file.
-                        </blockquote>
-                    </mx-reply>",
-                    room_id = original_message.room_id,
-                    event_id = original_message.event_id,
-                    sender = original_message.sender,
-                }
-            }
-            MessageType::Emote(content) => {
-                formatdoc! {"
-                    <mx-reply>
-                        <blockquote>
-                            <a href=\"https://matrix.to/#/{room_id}/{event_id}\">In reply to</a>
-                            * <a href=\"https://matrix.to/#/{sender}\">{sender}</a>
-                            <br />
-                            {body}
-                        </blockquote>
-                    </mx-reply>",
-                    room_id = original_message.room_id,
-                    event_id = original_message.event_id,
-                    sender = original_message.sender,
-                    body = if let Some(formatted) = &content.formatted {
-                        formatted.body.as_str()
-                    } else {
-                        content.body.as_str()
-                    }
-                }
-            }
-            MessageType::File(_) => {
-                formatdoc! {"
-                    <mx-reply>
-                        <blockquote>
-                            <a href=\"https://matrix.to/#/{room_id}/{event_id}\">In reply to</a>
-                            <a href=\"https://matrix.to/#/{sender}\">{sender}</a>
-                            <br />
-                            sent a file.
-                        </blockquote>
-                    </mx-reply>",
-                    room_id = original_message.room_id,
-                    event_id = original_message.event_id,
-                    sender = original_message.sender,
-                }
-            }
-            MessageType::Image(_) => {
-                formatdoc! {"
-                    <mx-reply>
-                        <blockquote>
-                            <a href=\"https://matrix.to/#/{room_id}/{event_id}\">In reply to</a>
-                            <a href=\"https://matrix.to/#/{sender}\">{sender}</a>
-                            <br />
-                            sent an image.
-                        </blockquote>
-                    </mx-reply>",
-                    room_id = original_message.room_id,
-                    event_id = original_message.event_id,
-                    sender = original_message.sender,
-                }
-            }
-            MessageType::Location(_) => {
-                formatdoc! {"
-                    <mx-reply>
-                        <blockquote>
-                            <a href=\"https://matrix.to/#/{room_id}/{event_id}\">In reply to</a>
-                            <a href=\"https://matrix.to/#/{sender}\">{sender}</a>
-                            <br />
-                            sent a location.
-                        </blockquote>
-                    </mx-reply>",
-                    room_id = original_message.room_id,
-                    event_id = original_message.event_id,
-                    sender = original_message.sender,
-                }
-            }
-            MessageType::Notice(content) => {
-                formatdoc! {"
-                    <mx-reply>
-                        <blockquote>
-                            <a href=\"https://matrix.to/#/{room_id}/{event_id}\">In reply to</a>
-                            <a href=\"https://matrix.to/#/{sender}\">{sender}</a>
-                            <br />
-                            {body}
-                        </blockquote>
-                    </mx-reply>",
-                    room_id = original_message.room_id,
-                    event_id = original_message.event_id,
-                    sender = original_message.sender,
-                    body = if let Some(formatted) = &content.formatted {
-                        formatted.body.as_str()
-                    } else {
-                        content.body.as_str()
-                    },
-                }
-            }
-            MessageType::ServerNotice(content) => {
-                formatdoc! {"
-                    <mx-reply>
-                        <blockquote>
-                            <a href=\"https://matrix.to/#/{room_id}/{event_id}\">In reply to</a>
-                            <a href=\"https://matrix.to/#/{sender}\">{sender}</a>
-                            <br />
-                            {body}
-                        </blockquote>
-                    </mx-reply>",
-                    room_id = original_message.room_id,
-                    event_id = original_message.event_id,
-                    sender = original_message.sender,
-                    body = content.body
-                }
-            }
-            MessageType::Text(content) => {
-                formatdoc! {"
-                    <mx-reply>
-                        <blockquote>
-                            <a href=\"https://matrix.to/#/{room_id}/{event_id}\">In reply to</a>
-                            <a href=\"https://matrix.to/#/{sender}\">{sender}</a>
-                            <br />
-                            {body}
-                        </blockquote>
-                    </mx-reply>",
-                    room_id = original_message.room_id,
-                    event_id = original_message.event_id,
-                    sender = original_message.sender,
-                    body = if let Some(formatted) = &content.formatted {
-                        formatted.body.as_str()
-                    } else {
-                        content.body.as_str()
-                    }
-                }
-            }
-            MessageType::Video(_) => {
-                formatdoc! {"
-                    <mx-reply>
-                        <blockquote>
-                            <a href=\"https://matrix.to/#/{room_id}/{event_id}\">In reply to</a>
-                            <a href=\"https://matrix.to/#/{sender}\">{sender}</a>
-                            <br />
-                            sent a video.
-                        </blockquote>
-                    </mx-reply>",
-                    room_id = original_message.room_id,
-                    event_id = original_message.event_id,
-                    sender = original_message.sender,
-                }
-            }
-            MessageType::_Custom(content) => {
-                formatdoc! {"
-                    <mx-reply>
-                        <blockquote>
-                            <a href=\"https://matrix.to/#/{room_id}/{event_id}\">In reply to</a>
-                            <a href=\"https://matrix.to/#/{sender}\">{sender}</a>
-                            <br />
-                            {body}
-                        </blockquote>
-                    </mx-reply>",
-                    room_id = original_message.room_id,
-                    event_id = original_message.event_id,
-                    sender = original_message.sender,
-                    body = content.data["body"].as_str().unwrap_or("")
-                }
-            }
-            #[cfg(feature = "unstable-pre-spec")]
-            MessageType::VerificationRequest(content) => {
-                formatdoc! {"
-                    <mx-reply>
-                        <blockquote>
-                            <a href=\"https://matrix.to/#/{server_name}/{event_id}\">In reply to</a>
-                            <a href=\"https://matrix.to/#/{sender}\">{sender}</a>
-                            <br />
-                            {body}
-                        </blockquote>
-                    </mx-reply>",
-                    server_name = original_message.room_id,
-                    event_id = original_message.event_id,
-                    sender = original_message.sender,
-                    body = content.body
-                }
-            }
         }
     }
 }
@@ -990,4 +758,236 @@ pub struct CustomEventContent {
     /// Remaining event content
     #[serde(flatten)]
     pub data: JsonObject,
+}
+
+fn get_plain_quote_fallback(original_message: &MessageEvent) -> String {
+    match &original_message.content.msgtype {
+        MessageType::Audio(_) => {
+            format!("> <{:?}> sent an audio file.", original_message.sender)
+        }
+        MessageType::Emote(content) => {
+            format!("> * <{:?}> {}", original_message.sender, content.body)
+        }
+        MessageType::File(_) => {
+            format!("> <{:?}> sent a file.", original_message.sender)
+        }
+        MessageType::Image(_) => {
+            format!("> <{:?}> sent an image.", original_message.sender)
+        }
+        MessageType::Location(content) => {
+            format!("> <{:?}> {}", original_message.sender, content.body)
+        }
+        MessageType::Notice(content) => {
+            format!("> <{:?}> {}", original_message.sender, content.body)
+        }
+        MessageType::ServerNotice(content) => {
+            format!("> <{:?}> {}", original_message.sender, content.body)
+        }
+        MessageType::Text(content) => {
+            format!("> <{:?}> {}", original_message.sender, content.body)
+        }
+        MessageType::Video(_) => {
+            format!("> <{:?}> sent a video.", original_message.sender)
+        }
+        MessageType::_Custom(content) => {
+            format!(
+                "> <{:?}> {}",
+                original_message.sender,
+                content.data["body"].as_str().unwrap_or("")
+            )
+        }
+        #[cfg(feature = "unstable-pre-spec")]
+        MessageType::VerificationRequest(content) => {
+            format!("> <{:?}> {}", original_message.sender, content.body)
+        }
+    }
+}
+
+fn get_html_quote_fallback(original_message: &MessageEvent) -> String {
+    match &original_message.content.msgtype {
+        MessageType::Audio(_) => {
+            formatdoc! {"
+                <mx-reply>
+                    <blockquote>
+                        <a href=\"https://matrix.to/#/{room_id}/{event_id}\">In reply to</a>
+                        <a href=\"https://matrix.to/#/{sender}\">{sender}</a>
+                        <br />
+                        sent an audio file.
+                    </blockquote>
+                </mx-reply>",
+                room_id = original_message.room_id,
+                event_id = original_message.event_id,
+                sender = original_message.sender,
+            }
+        }
+        MessageType::Emote(content) => {
+            formatdoc! {"
+                <mx-reply>
+                    <blockquote>
+                        <a href=\"https://matrix.to/#/{room_id}/{event_id}\">In reply to</a>
+                        * <a href=\"https://matrix.to/#/{sender}\">{sender}</a>
+                        <br />
+                        {body}
+                    </blockquote>
+                </mx-reply>",
+                room_id = original_message.room_id,
+                event_id = original_message.event_id,
+                sender = original_message.sender,
+                body = if let Some(formatted) = &content.formatted {
+                    formatted.body.as_str()
+                } else {
+                    content.body.as_str()
+                }
+            }
+        }
+        MessageType::File(_) => {
+            formatdoc! {"
+                <mx-reply>
+                    <blockquote>
+                        <a href=\"https://matrix.to/#/{room_id}/{event_id}\">In reply to</a>
+                        <a href=\"https://matrix.to/#/{sender}\">{sender}</a>
+                        <br />
+                        sent a file.
+                    </blockquote>
+                </mx-reply>",
+                room_id = original_message.room_id,
+                event_id = original_message.event_id,
+                sender = original_message.sender,
+            }
+        }
+        MessageType::Image(_) => {
+            formatdoc! {"
+                <mx-reply>
+                    <blockquote>
+                        <a href=\"https://matrix.to/#/{room_id}/{event_id}\">In reply to</a>
+                        <a href=\"https://matrix.to/#/{sender}\">{sender}</a>
+                        <br />
+                        sent an image.
+                    </blockquote>
+                </mx-reply>",
+                room_id = original_message.room_id,
+                event_id = original_message.event_id,
+                sender = original_message.sender,
+            }
+        }
+        MessageType::Location(_) => {
+            formatdoc! {"
+                <mx-reply>
+                    <blockquote>
+                        <a href=\"https://matrix.to/#/{room_id}/{event_id}\">In reply to</a>
+                        <a href=\"https://matrix.to/#/{sender}\">{sender}</a>
+                        <br />
+                        sent a location.
+                    </blockquote>
+                </mx-reply>",
+                room_id = original_message.room_id,
+                event_id = original_message.event_id,
+                sender = original_message.sender,
+            }
+        }
+        MessageType::Notice(content) => {
+            formatdoc! {"
+                <mx-reply>
+                    <blockquote>
+                        <a href=\"https://matrix.to/#/{room_id}/{event_id}\">In reply to</a>
+                        <a href=\"https://matrix.to/#/{sender}\">{sender}</a>
+                        <br />
+                        {body}
+                    </blockquote>
+                </mx-reply>",
+                room_id = original_message.room_id,
+                event_id = original_message.event_id,
+                sender = original_message.sender,
+                body = if let Some(formatted) = &content.formatted {
+                    formatted.body.as_str()
+                } else {
+                    content.body.as_str()
+                },
+            }
+        }
+        MessageType::ServerNotice(content) => {
+            formatdoc! {"
+                <mx-reply>
+                    <blockquote>
+                        <a href=\"https://matrix.to/#/{room_id}/{event_id}\">In reply to</a>
+                        <a href=\"https://matrix.to/#/{sender}\">{sender}</a>
+                        <br />
+                        {body}
+                    </blockquote>
+                </mx-reply>",
+                room_id = original_message.room_id,
+                event_id = original_message.event_id,
+                sender = original_message.sender,
+                body = content.body
+            }
+        }
+        MessageType::Text(content) => {
+            formatdoc! {"
+                <mx-reply>
+                    <blockquote>
+                        <a href=\"https://matrix.to/#/{room_id}/{event_id}\">In reply to</a>
+                        <a href=\"https://matrix.to/#/{sender}\">{sender}</a>
+                        <br />
+                        {body}
+                    </blockquote>
+                </mx-reply>",
+                room_id = original_message.room_id,
+                event_id = original_message.event_id,
+                sender = original_message.sender,
+                body = if let Some(formatted) = &content.formatted {
+                    formatted.body.as_str()
+                } else {
+                    content.body.as_str()
+                }
+            }
+        }
+        MessageType::Video(_) => {
+            formatdoc! {"
+                <mx-reply>
+                    <blockquote>
+                        <a href=\"https://matrix.to/#/{room_id}/{event_id}\">In reply to</a>
+                        <a href=\"https://matrix.to/#/{sender}\">{sender}</a>
+                        <br />
+                        sent a video.
+                    </blockquote>
+                </mx-reply>",
+                room_id = original_message.room_id,
+                event_id = original_message.event_id,
+                sender = original_message.sender,
+            }
+        }
+        MessageType::_Custom(content) => {
+            formatdoc! {"
+                <mx-reply>
+                    <blockquote>
+                        <a href=\"https://matrix.to/#/{room_id}/{event_id}\">In reply to</a>
+                        <a href=\"https://matrix.to/#/{sender}\">{sender}</a>
+                        <br />
+                        {body}
+                    </blockquote>
+                </mx-reply>",
+                room_id = original_message.room_id,
+                event_id = original_message.event_id,
+                sender = original_message.sender,
+                body = content.data["body"].as_str().unwrap_or("")
+            }
+        }
+        #[cfg(feature = "unstable-pre-spec")]
+        MessageType::VerificationRequest(content) => {
+            formatdoc! {"
+                <mx-reply>
+                    <blockquote>
+                        <a href=\"https://matrix.to/#/{server_name}/{event_id}\">In reply to</a>
+                        <a href=\"https://matrix.to/#/{sender}\">{sender}</a>
+                        <br />
+                        {body}
+                    </blockquote>
+                </mx-reply>",
+                server_name = original_message.room_id,
+                event_id = original_message.event_id,
+                sender = original_message.sender,
+                body = content.body
+            }
+        }
+    }
 }


### PR DESCRIPTION
Add helpers to construct the fallback for rich replies,
both unformatted and formatted versions.

Resolves: #37

Apologies for the delay as I've been busy recently. This is what I've come up with until now, and I have two queries to move forwards:
Firstly, I'd like to know if this is actually going in the right direction to solve the issue.
Secondly, I'm not sure how to deal with `_Custom` events, the spec says to treat them the same as `m.text`, but I'm unsure about how I'd get the event's body.