### PR TITLE
Make ruma-client as thin as possible

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
           RUSTDOCFLAGS: "--enable-index-page -Zunstable-options --cfg docsrs"
         with:
           command: doc
-          args: --no-deps --workspace --exclude xtask --features full,compat,unstable-pre-spec -Zrustdoc-map
+          args: --no-deps --workspace --exclude xtask --all-features -Zrustdoc-map
       - name: Deploy to docs branch
         uses: JamesIves/github-pages-deploy-action@4.1.0
         with:

--- a/contrib/ide/vscode/settings.json
+++ b/contrib/ide/vscode/settings.json
@@ -1,6 +1,3 @@
 {
-    "rust-analyzer.cargo.features": [
-        "full",
-        "unstable-pre-spec"
-    ]
+    "rust-analyzer.cargo.allFeatures": true
 }

--- a/ruma-api/src/lib.rs
+++ b/ruma-api/src/lib.rs
@@ -354,7 +354,7 @@ pub trait OutgoingResponse {
 }
 
 /// Gives users the ability to define their own serializable / deserializable errors.
-pub trait EndpointError: OutgoingResponse + StdError + Sized + 'static {
+pub trait EndpointError: OutgoingResponse + StdError + Sized + Send + 'static {
     /// Tries to construct `Self` from an `http::Response`.
     ///
     /// This will always return `Err` variant when no `error` field is defined in

--- a/ruma-client/Cargo.toml
+++ b/ruma-client/Cargo.toml
@@ -15,36 +15,22 @@ repository = "https://github.com/ruma/ruma"
 version = "0.5.0-alpha.2"
 
 [features]
-default = ["http1", "http2", "tls-native"]
-
 client-api = ["ruma-client-api"]
 
-http1 = ["hyper/http1"]
-http2 = ["hyper/http2"]
-tls-native = ["hyper-tls", "_tls"]
-tls-rustls-native-roots = [
-    "hyper-rustls",
-    "hyper-rustls/native-tokio",
-    "_tls-rustls",
-]
-tls-rustls-webpki-roots = [
-    "hyper-rustls",
-    "hyper-rustls/webpki-tokio",
-    "_tls-rustls",
-]
-
-# Internal, not meant to be used directly
-_tls = []
-_tls-rustls = ["_tls"]
+# HTTP clients
+hyper-native-tls = ["hyper", "hyper-tls"]
+hyper-rustls = ["hyper", "hyper-rustls-crate"]
 
 [dependencies]
 assign = "1.1.1"
 async-stream = "0.3.0"
+async-trait = "0.1.50"
+bytes = "1.0.1"
 futures-core = "0.3.8"
 http = "0.2.2"
-hyper = { version = "0.14.2", features = ["client", "tcp"] }
+hyper = { version = "0.14.2", optional = true, features = ["client", "http1", "http2", "tcp"] }
 hyper-tls = { version = "0.5.0", optional = true }
-hyper-rustls = { version = "0.22.1", optional = true, default-features = false }
+hyper-rustls-crate = { package = "hyper-rustls", version = "0.22.1", optional = true, default-features = false }
 ruma-api = { version = "=0.17.0-alpha.4", path = "../ruma-api" }
 ruma-client-api = { version = "=0.10.0-alpha.3", path = "../ruma-client-api", optional = true, features = ["client"] }
 ruma-common = { version = "0.5.0", path = "../ruma-common" }
@@ -62,8 +48,8 @@ tokio-stream = { version = "0.1.1", default-features = false }
 
 [[example]]
 name = "hello_world"
-required-features = ["client-api"]
+required-features = ["client-api", "hyper-native-tls"]
 
 [[example]]
 name = "message_log"
-required-features = ["client-api"]
+required-features = ["client-api", "hyper-native-tls"]

--- a/ruma-client/Cargo.toml
+++ b/ruma-client/Cargo.toml
@@ -14,31 +14,10 @@ readme = "README.md"
 repository = "https://github.com/ruma/ruma"
 version = "0.5.0-alpha.2"
 
-[dependencies]
-assign = "1.1.1"
-async-stream = "0.3.0"
-futures-core = "0.3.8"
-http = "0.2.2"
-hyper = { version = "0.14.2", features = ["client", "tcp"] }
-hyper-tls = { version = "0.5.0", optional = true }
-hyper-rustls = { version = "0.22.1", optional = true, default-features = false }
-ruma-api = { version = "=0.17.0-alpha.4", path = "../ruma-api" }
-ruma-client-api = { version = "=0.10.0-alpha.3", path = "../ruma-client-api", features = ["client"] }
-ruma-common = { version = "0.5.0", path = "../ruma-common" }
-ruma-events = { version = "=0.22.0-alpha.3", path = "../ruma-events" }
-ruma-identifiers = { version = "0.19.0", path = "../ruma-identifiers" }
-ruma-serde = { version = "0.3.1", path = "../ruma-serde" }
-serde = { version = "1.0.118", features = ["derive"] }
-serde_json = "1.0.61"
-
-[dev-dependencies]
-anyhow = "1.0.37"
-ruma = { version = "0.0.3", path = "../ruma", features = ["client-api-c"] }
-tokio = { version = "1.0.1", features = ["macros", "rt"] }
-tokio-stream = { version = "0.1.1", default-features = false }
-
 [features]
 default = ["http1", "http2", "tls-native"]
+
+client-api = ["ruma-client-api"]
 
 http1 = ["hyper/http1"]
 http2 = ["hyper/http2"]
@@ -57,3 +36,34 @@ tls-rustls-webpki-roots = [
 # Internal, not meant to be used directly
 _tls = []
 _tls-rustls = ["_tls"]
+
+[dependencies]
+assign = "1.1.1"
+async-stream = "0.3.0"
+futures-core = "0.3.8"
+http = "0.2.2"
+hyper = { version = "0.14.2", features = ["client", "tcp"] }
+hyper-tls = { version = "0.5.0", optional = true }
+hyper-rustls = { version = "0.22.1", optional = true, default-features = false }
+ruma-api = { version = "=0.17.0-alpha.4", path = "../ruma-api" }
+ruma-client-api = { version = "=0.10.0-alpha.3", path = "../ruma-client-api", optional = true, features = ["client"] }
+ruma-common = { version = "0.5.0", path = "../ruma-common" }
+ruma-events = { version = "=0.22.0-alpha.3", path = "../ruma-events" }
+ruma-identifiers = { version = "0.19.0", path = "../ruma-identifiers" }
+ruma-serde = { version = "0.3.1", path = "../ruma-serde" }
+serde = { version = "1.0.118", features = ["derive"] }
+serde_json = "1.0.61"
+
+[dev-dependencies]
+anyhow = "1.0.37"
+ruma = { version = "0.0.3", path = "../ruma", features = ["client-api-c"] }
+tokio = { version = "1.0.1", features = ["macros", "rt"] }
+tokio-stream = { version = "0.1.1", default-features = false }
+
+[[example]]
+name = "hello_world"
+required-features = ["client-api"]
+
+[[example]]
+name = "message_log"
+required-features = ["client-api"]

--- a/ruma-client/Cargo.toml
+++ b/ruma-client/Cargo.toml
@@ -20,6 +20,7 @@ client-api = ["ruma-client-api"]
 # HTTP clients
 hyper-native-tls = ["hyper", "hyper-tls"]
 hyper-rustls = ["hyper", "hyper-rustls-crate"]
+isahc = ["isahc-crate", "futures-lite"]
 reqwest-native-tls = ["reqwest", "reqwest/native-tls"]
 reqwest-native-tls-vendored = ["reqwest", "reqwest/native-tls-vendored"]
 reqwest-rustls-manual-roots = ["reqwest", "reqwest/rustls-tls-manual-roots"]
@@ -32,10 +33,12 @@ async-stream = "0.3.0"
 async-trait = "0.1.50"
 bytes = "1.0.1"
 futures-core = "0.3.8"
+futures-lite = { version = "1.11.3", optional = true }
 http = "0.2.2"
 hyper = { version = "0.14.2", optional = true, features = ["client", "http1", "http2", "tcp"] }
 hyper-tls = { version = "0.5.0", optional = true }
 hyper-rustls-crate = { package = "hyper-rustls", version = "0.22.1", optional = true, default-features = false }
+isahc-crate = { package = "isahc", version = "1.3.1", optional = true }
 reqwest = { version = "0.11.3", optional = true, default-features = false }
 ruma-api = { version = "=0.17.0-alpha.4", path = "../ruma-api" }
 ruma-client-api = { version = "=0.10.0-alpha.3", path = "../ruma-client-api", optional = true, features = ["client"] }
@@ -55,6 +58,10 @@ tokio-stream = { version = "0.1.1", default-features = false }
 [[example]]
 name = "hello_world"
 required-features = ["client-api", "hyper-native-tls"]
+
+[[example]]
+name = "hello_isahc"
+required-features = ["client-api", "isahc"]
 
 [[example]]
 name = "message_log"

--- a/ruma-client/Cargo.toml
+++ b/ruma-client/Cargo.toml
@@ -20,6 +20,11 @@ client-api = ["ruma-client-api"]
 # HTTP clients
 hyper-native-tls = ["hyper", "hyper-tls"]
 hyper-rustls = ["hyper", "hyper-rustls-crate"]
+reqwest-native-tls = ["reqwest", "reqwest/native-tls"]
+reqwest-native-tls-vendored = ["reqwest", "reqwest/native-tls-vendored"]
+reqwest-rustls-manual-roots = ["reqwest", "reqwest/rustls-tls-manual-roots"]
+reqwest-rustls-webpki-roots = ["reqwest", "reqwest/rustls-tls-webpki-roots"]
+reqwest-rustls-native-roots = ["reqwest", "reqwest/rustls-tls-native-roots"]
 
 [dependencies]
 assign = "1.1.1"
@@ -31,6 +36,7 @@ http = "0.2.2"
 hyper = { version = "0.14.2", optional = true, features = ["client", "http1", "http2", "tcp"] }
 hyper-tls = { version = "0.5.0", optional = true }
 hyper-rustls-crate = { package = "hyper-rustls", version = "0.22.1", optional = true, default-features = false }
+reqwest = { version = "0.11.3", optional = true, default-features = false }
 ruma-api = { version = "=0.17.0-alpha.4", path = "../ruma-api" }
 ruma-client-api = { version = "=0.10.0-alpha.3", path = "../ruma-client-api", optional = true, features = ["client"] }
 ruma-common = { version = "0.5.0", path = "../ruma-common" }

--- a/ruma-client/examples/hello_world.rs
+++ b/ruma-client/examples/hello_world.rs
@@ -1,6 +1,5 @@
 use std::{convert::TryFrom, env, process::exit};
 
-use http::Uri;
 use ruma::{
     api::client::r0::{alias::get_alias, membership::join_room_by_id, message::send_message_event},
     events::{room::message::MessageEventContent, AnyMessageEventContent},
@@ -10,7 +9,7 @@ use ruma::{
 type MatrixClient = ruma_client::Client<ruma_client::http_client::HyperNativeTls>;
 
 async fn hello_world(
-    homeserver_url: Uri,
+    homeserver_url: String,
     username: &str,
     password: &str,
     room_alias: &RoomAliasId,
@@ -18,10 +17,10 @@ async fn hello_world(
     let client = MatrixClient::new(homeserver_url, None);
     client.log_in(username, password, None, Some("ruma-example-client")).await?;
 
-    let room_id = client.request(get_alias::Request::new(room_alias)).await?.room_id;
-    client.request(join_room_by_id::Request::new(&room_id)).await?;
+    let room_id = client.send_request(get_alias::Request::new(room_alias)).await?.room_id;
+    client.send_request(join_room_by_id::Request::new(&room_id)).await?;
     client
-        .request(send_message_event::Request::new(
+        .send_request(send_message_event::Request::new(
             &room_id,
             "1",
             &AnyMessageEventContent::RoomMessage(MessageEventContent::text_plain("Hello World!")),
@@ -45,11 +44,5 @@ async fn main() -> anyhow::Result<()> {
             }
         };
 
-    hello_world(
-        homeserver_url.parse()?,
-        &username,
-        &password,
-        &RoomAliasId::try_from(room.as_str())?,
-    )
-    .await
+    hello_world(homeserver_url, &username, &password, &RoomAliasId::try_from(room.as_str())?).await
 }

--- a/ruma-client/examples/hello_world.rs
+++ b/ruma-client/examples/hello_world.rs
@@ -6,7 +6,8 @@ use ruma::{
     events::{room::message::MessageEventContent, AnyMessageEventContent},
     RoomAliasId,
 };
-use ruma_client::Client;
+
+type MatrixClient = ruma_client::Client<ruma_client::http_client::HyperNativeTls>;
 
 async fn hello_world(
     homeserver_url: Uri,
@@ -14,7 +15,7 @@ async fn hello_world(
     password: &str,
     room_alias: &RoomAliasId,
 ) -> anyhow::Result<()> {
-    let client = Client::new(homeserver_url, None);
+    let client = MatrixClient::new(homeserver_url, None);
     client.log_in(username, password, None, Some("ruma-example-client")).await?;
 
     let room_id = client.request(get_alias::Request::new(room_alias)).await?.room_id;

--- a/ruma-client/examples/message_log.rs
+++ b/ruma-client/examples/message_log.rs
@@ -10,11 +10,12 @@ use ruma::{
     },
     presence::PresenceState,
 };
-use ruma_client::Client;
 use tokio_stream::StreamExt as _;
 
+type MatrixClient = ruma_client::Client<ruma_client::http_client::HyperNativeTls>;
+
 async fn log_messages(homeserver_url: Uri, username: &str, password: &str) -> anyhow::Result<()> {
-    let client = Client::new(homeserver_url, None);
+    let client = MatrixClient::new(homeserver_url, None);
 
     client.log_in(username, password, None, None).await?;
 

--- a/ruma-client/examples/message_log.rs
+++ b/ruma-client/examples/message_log.rs
@@ -1,7 +1,6 @@
 use std::{env, process::exit, time::Duration};
 
 use assign::assign;
-use http::Uri;
 use ruma::{
     api::client::r0::{filter::FilterDefinition, sync::sync_events},
     events::{
@@ -14,14 +13,18 @@ use tokio_stream::StreamExt as _;
 
 type MatrixClient = ruma_client::Client<ruma_client::http_client::HyperNativeTls>;
 
-async fn log_messages(homeserver_url: Uri, username: &str, password: &str) -> anyhow::Result<()> {
+async fn log_messages(
+    homeserver_url: String,
+    username: &str,
+    password: &str,
+) -> anyhow::Result<()> {
     let client = MatrixClient::new(homeserver_url, None);
 
     client.log_in(username, password, None, None).await?;
 
     let filter = FilterDefinition::ignore_all().into();
     let initial_sync_response = client
-        .request(assign!(sync_events::Request::new(), {
+        .send_request(assign!(sync_events::Request::new(), {
             filter: Some(&filter),
         }))
         .await?;
@@ -76,6 +79,5 @@ async fn main() -> anyhow::Result<()> {
             }
         };
 
-    let server = homeserver_url.parse()?;
-    log_messages(server, &username, &password).await
+    log_messages(homeserver_url, &username, &password).await
 }

--- a/ruma-client/src/client_api.rs
+++ b/ruma-client/src/client_api.rs
@@ -83,14 +83,14 @@ impl<C: HttpClient> Client<C> {
     ///
     /// # Example:
     ///
-    /// ```ignore
+    /// ```no_run
     /// use std::time::Duration;
     ///
-    /// # use ruma_client::Client;
+    /// # type MatrixClient = ruma_client::Client<ruma_client::http_client::Dummy>;
     /// # use ruma::presence::PresenceState;
     /// # use tokio_stream::{StreamExt as _};
     /// # let homeserver_url = "https://example.com".parse().unwrap();
-    /// # let client = Client::new(homeserver_url, None);
+    /// # let client = MatrixClient::new(homeserver_url, None);
     /// # let next_batch_token = String::new();
     /// # async {
     /// let mut sync_stream = Box::pin(client.sync(

--- a/ruma-client/src/client_api.rs
+++ b/ruma-client/src/client_api.rs
@@ -80,6 +80,31 @@ impl<C: HttpClient> Client<C> {
     }
 
     /// Convenience method that represents repeated calls to the sync_events endpoint as a stream.
+    ///
+    /// # Example:
+    ///
+    /// ```ignore
+    /// use std::time::Duration;
+    ///
+    /// # use ruma_client::Client;
+    /// # use ruma::presence::PresenceState;
+    /// # use tokio_stream::{StreamExt as _};
+    /// # let homeserver_url = "https://example.com".parse().unwrap();
+    /// # let client = Client::new(homeserver_url, None);
+    /// # let next_batch_token = String::new();
+    /// # async {
+    /// let mut sync_stream = Box::pin(client.sync(
+    ///     None,
+    ///     next_batch_token,
+    ///     &PresenceState::Online,
+    ///     Some(Duration::from_secs(30)),
+    /// ));
+    /// while let Some(response) = sync_stream.try_next().await? {
+    ///     // Do something with the data in the response...
+    /// }
+    /// # Result::<(), ruma_client::Error<_, _>>::Ok(())
+    /// # };
+    /// ```
     pub fn sync<'a>(
         &'a self,
         filter: Option<&'a sync_events::Filter<'a>>,

--- a/ruma-client/src/client_api.rs
+++ b/ruma-client/src/client_api.rs
@@ -3,34 +3,32 @@ use std::time::Duration;
 use assign::assign;
 use async_stream::try_stream;
 use futures_core::stream::Stream;
-use ruma_client_api::r0::sync::sync_events::{
-    Filter as SyncFilter, Request as SyncRequest, Response as SyncResponse,
+use ruma_client_api::r0::{
+    account::register::{self, RegistrationKind},
+    session::login::{self, LoginInfo, UserIdentifier},
+    sync::sync_events,
 };
 use ruma_common::presence::PresenceState;
 use ruma_identifiers::DeviceId;
 
-use super::{Client, Error, Identification, Session};
+use super::{Client, Error};
 
+/// Client-API specific functionality of `Client`.
 impl Client {
     /// Log in with a username and password.
     ///
-    /// In contrast to `api::r0::session::login::call()`, this method stores the
-    /// session data returned by the endpoint in this client, instead of
-    /// returning it.
+    /// In contrast to [`request`], this method stores the access token returned by the endpoint in
+    /// this client, in addition to returning it.
     pub async fn log_in(
         &self,
         user: &str,
         password: &str,
         device_id: Option<&DeviceId>,
         initial_device_display_name: Option<&str>,
-    ) -> Result<Session, Error<ruma_client_api::Error>> {
-        use ruma_client_api::r0::session::login::{
-            LoginInfo, Request as LoginRequest, UserIdentifier,
-        };
-
+    ) -> Result<login::Response, Error<ruma_client_api::Error>> {
         let response = self
             .request(assign!(
-                LoginRequest::new(
+                login::Request::new(
                     LoginInfo::Password { identifier: UserIdentifier::MatrixId(user), password }
                 ), {
                     device_id,
@@ -39,92 +37,61 @@ impl Client {
             ))
             .await?;
 
-        let session = Session {
-            access_token: response.access_token,
-            identification: Some(Identification {
-                device_id: response.device_id,
-                user_id: response.user_id,
-            }),
-        };
-        *self.0.session.lock().unwrap() = Some(session.clone());
+        *self.0.access_token.lock().unwrap() = Some(response.access_token.clone());
 
-        Ok(session)
+        Ok(response)
     }
 
-    /// Register as a guest. In contrast to `api::r0::account::register::call()`,
-    /// this method stores the session data returned by the endpoint in this
-    /// client, instead of returning it.
+    /// Register as a guest.
+    ///
+    /// In contrast to [`request`], this method stores the access token returned by the endpoint in
+    /// this client, in addition to returning it.
     pub async fn register_guest(
         &self,
-    ) -> Result<Session, Error<ruma_client_api::r0::uiaa::UiaaResponse>> {
-        use ruma_client_api::r0::account::register::{self, RegistrationKind};
-
+    ) -> Result<register::Response, Error<ruma_client_api::r0::uiaa::UiaaResponse>> {
         let response = self
             .request(assign!(register::Request::new(), { kind: RegistrationKind::Guest }))
             .await?;
 
-        let session = Session {
-            // since we supply inhibit_login: false above, the access token needs to be there
-            // TODO: maybe unwrap is not the best solution though
-            access_token: response.access_token.unwrap(),
-            identification: Some(Identification {
-                // same as access_token
-                device_id: response.device_id.unwrap(),
-                user_id: response.user_id,
-            }),
-        };
-        *self.0.session.lock().unwrap() = Some(session.clone());
+        *self.0.access_token.lock().unwrap() = response.access_token.clone();
 
-        Ok(session)
+        Ok(response)
     }
 
     /// Register as a new user on this server.
     ///
-    /// In contrast to `api::r0::account::register::call()`, this method stores
-    /// the session data returned by the endpoint in this client, instead of
-    /// returning it.
+    /// In contrast to [`request`], this method stores the access token returned by the endpoint in
+    /// this client, in addition to returning it.
     ///
-    /// The username is the local part of the returned user_id. If it is
-    /// omitted from this request, the server will generate one.
+    /// The username is the local part of the returned user_id. If it is omitted from this request,
+    /// the server will generate one.
     pub async fn register_user(
         &self,
         username: Option<&str>,
         password: &str,
-    ) -> Result<Session, Error<ruma_client_api::r0::uiaa::UiaaResponse>> {
-        use ruma_client_api::r0::account::register;
-
+    ) -> Result<register::Response, Error<ruma_client_api::r0::uiaa::UiaaResponse>> {
         let response = self
             .request(assign!(register::Request::new(), { username, password: Some(password) }))
             .await?;
 
-        let session = Session {
-            // since we supply inhibit_login: false above, the access token needs to be there
-            // TODO: maybe unwrap is not the best solution though
-            access_token: response.access_token.unwrap(),
-            identification: Some(Identification {
-                // same as access_token
-                device_id: response.device_id.unwrap(),
-                user_id: response.user_id,
-            }),
-        };
-        *self.0.session.lock().unwrap() = Some(session.clone());
+        *self.0.access_token.lock().unwrap() = response.access_token.clone();
 
-        Ok(session)
+        Ok(response)
     }
 
     /// Convenience method that represents repeated calls to the sync_events endpoint as a stream.
     pub fn sync<'a>(
         &self,
-        filter: Option<&'a SyncFilter<'a>>,
+        filter: Option<&'a sync_events::Filter<'a>>,
         mut since: String,
         set_presence: &'a PresenceState,
         timeout: Option<Duration>,
-    ) -> impl Stream<Item = Result<SyncResponse, Error<ruma_client_api::Error>>> + 'a {
+    ) -> impl Stream<Item = Result<sync_events::Response, Error<ruma_client_api::Error>>> + 'a {
         let client = self.clone();
         try_stream! {
             loop {
                 let response = client
-                    .request(assign!(SyncRequest::new(), {
+                    .request(assign!(sync_events::Request::new(), {
                         filter,
                         since: Some(&since),
                         set_presence,

--- a/ruma-client/src/client_api.rs
+++ b/ruma-client/src/client_api.rs
@@ -14,7 +14,7 @@ use ruma_identifiers::DeviceId;
 use super::{Client, Error};
 
 /// Client-API specific functionality of `Client`.
-impl Client {
+impl Client<super::HyperClient<super::Connector>> {
     /// Log in with a username and password.
     ///
     /// In contrast to [`request`], this method stores the access token returned by the endpoint in

--- a/ruma-client/src/client_api.rs
+++ b/ruma-client/src/client_api.rs
@@ -1,0 +1,140 @@
+use std::time::Duration;
+
+use assign::assign;
+use async_stream::try_stream;
+use futures_core::stream::Stream;
+use ruma_client_api::r0::sync::sync_events::{
+    Filter as SyncFilter, Request as SyncRequest, Response as SyncResponse,
+};
+use ruma_common::presence::PresenceState;
+use ruma_identifiers::DeviceId;
+
+use super::{Client, Error, Identification, Session};
+
+impl Client {
+    /// Log in with a username and password.
+    ///
+    /// In contrast to `api::r0::session::login::call()`, this method stores the
+    /// session data returned by the endpoint in this client, instead of
+    /// returning it.
+    pub async fn log_in(
+        &self,
+        user: &str,
+        password: &str,
+        device_id: Option<&DeviceId>,
+        initial_device_display_name: Option<&str>,
+    ) -> Result<Session, Error<ruma_client_api::Error>> {
+        use ruma_client_api::r0::session::login::{
+            LoginInfo, Request as LoginRequest, UserIdentifier,
+        };
+
+        let response = self
+            .request(assign!(
+                LoginRequest::new(
+                    LoginInfo::Password { identifier: UserIdentifier::MatrixId(user), password }
+                ), {
+                    device_id,
+                    initial_device_display_name,
+                }
+            ))
+            .await?;
+
+        let session = Session {
+            access_token: response.access_token,
+            identification: Some(Identification {
+                device_id: response.device_id,
+                user_id: response.user_id,
+            }),
+        };
+        *self.0.session.lock().unwrap() = Some(session.clone());
+
+        Ok(session)
+    }
+
+    /// Register as a guest. In contrast to `api::r0::account::register::call()`,
+    /// this method stores the session data returned by the endpoint in this
+    /// client, instead of returning it.
+    pub async fn register_guest(
+        &self,
+    ) -> Result<Session, Error<ruma_client_api::r0::uiaa::UiaaResponse>> {
+        use ruma_client_api::r0::account::register::{self, RegistrationKind};
+
+        let response = self
+            .request(assign!(register::Request::new(), { kind: RegistrationKind::Guest }))
+            .await?;
+
+        let session = Session {
+            // since we supply inhibit_login: false above, the access token needs to be there
+            // TODO: maybe unwrap is not the best solution though
+            access_token: response.access_token.unwrap(),
+            identification: Some(Identification {
+                // same as access_token
+                device_id: response.device_id.unwrap(),
+                user_id: response.user_id,
+            }),
+        };
+        *self.0.session.lock().unwrap() = Some(session.clone());
+
+        Ok(session)
+    }
+
+    /// Register as a new user on this server.
+    ///
+    /// In contrast to `api::r0::account::register::call()`, this method stores
+    /// the session data returned by the endpoint in this client, instead of
+    /// returning it.
+    ///
+    /// The username is the local part of the returned user_id. If it is
+    /// omitted from this request, the server will generate one.
+    pub async fn register_user(
+        &self,
+        username: Option<&str>,
+        password: &str,
+    ) -> Result<Session, Error<ruma_client_api::r0::uiaa::UiaaResponse>> {
+        use ruma_client_api::r0::account::register;
+
+        let response = self
+            .request(assign!(register::Request::new(), { username, password: Some(password) }))
+            .await?;
+
+        let session = Session {
+            // since we supply inhibit_login: false above, the access token needs to be there
+            // TODO: maybe unwrap is not the best solution though
+            access_token: response.access_token.unwrap(),
+            identification: Some(Identification {
+                // same as access_token
+                device_id: response.device_id.unwrap(),
+                user_id: response.user_id,
+            }),
+        };
+        *self.0.session.lock().unwrap() = Some(session.clone());
+
+        Ok(session)
+    }
+
+    /// Convenience method that represents repeated calls to the sync_events endpoint as a stream.
+    pub fn sync<'a>(
+        &self,
+        filter: Option<&'a SyncFilter<'a>>,
+        mut since: String,
+        set_presence: &'a PresenceState,
+        timeout: Option<Duration>,
+    ) -> impl Stream<Item = Result<SyncResponse, Error<ruma_client_api::Error>>> + 'a {
+        let client = self.clone();
+        try_stream! {
+            loop {
+                let response = client
+                    .request(assign!(SyncRequest::new(), {
+                        filter,
+                        since: Some(&since),
+                        set_presence,
+                        timeout,
+                    }))
+                    .await?;
+
+                since = response.next_batch.clone();
+                yield response;
+            }
+        }
+    }
+}

--- a/ruma-client/src/client_api.rs
+++ b/ruma-client/src/client_api.rs
@@ -27,7 +27,7 @@ impl<C: HttpClient> Client<C> {
         initial_device_display_name: Option<&str>,
     ) -> Result<login::Response, Error<C::Error, ruma_client_api::Error>> {
         let response = self
-            .request(assign!(
+            .send_request(assign!(
                 login::Request::new(
                     LoginInfo::Password { identifier: UserIdentifier::MatrixId(user), password }
                 ), {
@@ -50,7 +50,7 @@ impl<C: HttpClient> Client<C> {
         &self,
     ) -> Result<register::Response, Error<C::Error, ruma_client_api::r0::uiaa::UiaaResponse>> {
         let response = self
-            .request(assign!(register::Request::new(), { kind: RegistrationKind::Guest }))
+            .send_request(assign!(register::Request::new(), { kind: RegistrationKind::Guest }))
             .await?;
 
         *self.0.access_token.lock().unwrap() = response.access_token.clone();
@@ -71,7 +71,7 @@ impl<C: HttpClient> Client<C> {
         password: &str,
     ) -> Result<register::Response, Error<C::Error, ruma_client_api::r0::uiaa::UiaaResponse>> {
         let response = self
-            .request(assign!(register::Request::new(), { username, password: Some(password) }))
+            .send_request(assign!(register::Request::new(), { username, password: Some(password) }))
             .await?;
 
         *self.0.access_token.lock().unwrap() = response.access_token.clone();
@@ -116,7 +116,7 @@ impl<C: HttpClient> Client<C> {
         try_stream! {
             loop {
                 let response = self
-                    .request(assign!(sync_events::Request::new(), {
+                    .send_request(assign!(sync_events::Request::new(), {
                         filter,
                         since: Some(&since),
                         set_presence,

--- a/ruma-client/src/http_client.rs
+++ b/ruma-client/src/http_client.rs
@@ -1,0 +1,40 @@
+//! This module contains an abstraction for HTTP clients as well as friendly-named re-exports of
+//! client types that implement this trait.
+
+use async_trait::async_trait;
+use bytes::BufMut;
+
+#[cfg(feature = "hyper")]
+mod hyper;
+
+#[cfg(feature = "hyper")]
+pub use self::hyper::Hyper;
+#[cfg(feature = "hyper-native-tls")]
+pub use self::hyper::HyperNativeTls;
+#[cfg(feature = "hyper-rustls")]
+pub use self::hyper::HyperRustls;
+
+/// An HTTP client that can be used to send requests to a Matrix homeserver.
+#[async_trait]
+pub trait HttpClient {
+    /// The type to use for `try_into_http_request`.
+    type RequestBody: Default + BufMut;
+
+    /// The type to use for `try_from_http_response`.
+    type ResponseBody: AsRef<[u8]>;
+
+    /// The error type for the `send_request` function.
+    type Error: Unpin;
+
+    /// Send an `http::Request` to get back an `http::Response`.
+    async fn send_http_request(
+        &self,
+        req: http::Request<Self::RequestBody>,
+    ) -> Result<http::Response<Self::ResponseBody>, Self::Error>;
+}
+
+/// An HTTP client that has a default configuration.
+pub trait DefaultConstructibleHttpClient: HttpClient {
+    /// Creates a new HTTP client with default configuration.
+    fn default() -> Self;
+}

--- a/ruma-client/src/http_client.rs
+++ b/ruma-client/src/http_client.rs
@@ -56,19 +56,19 @@ pub trait DefaultConstructibleHttpClient: HttpClient {
 pub trait HttpClientExt: HttpClient {
     /// Send a strongly-typed matrix request to get back a strongly-typed response.
     // TODO: `R: 'a` bound should not be needed
-    fn send_request<'a, R: OutgoingRequest + 'a>(
+    fn send_matrix_request<'a, R: OutgoingRequest + 'a>(
         &'a self,
         homeserver_url: &str,
         access_token: SendAccessToken<'_>,
         request: R,
     ) -> Pin<Box<dyn Future<Output = ResponseResult<Self, R>> + 'a>> {
-        self.send_customized_request(homeserver_url, access_token, request, |_| Ok(()))
+        self.send_customized_matrix_request(homeserver_url, access_token, request, |_| Ok(()))
     }
 
     /// Turn a strongly-typed matrix request into an `http::Request`, customize it and send it to
     /// get back a strongly-typed response.
     // TODO: `R: 'a` and `F: 'a` should not be needed
-    fn send_customized_request<'a, R, F>(
+    fn send_customized_matrix_request<'a, R, F>(
         &'a self,
         homeserver_url: &str,
         access_token: SendAccessToken<'_>,
@@ -93,14 +93,14 @@ pub trait HttpClientExt: HttpClient {
     ///
     /// This method is meant to be used by application services when interacting with the
     /// client-server API.
-    fn send_request_as<'a, R: OutgoingRequest + 'a>(
+    fn send_matrix_request_as<'a, R: OutgoingRequest + 'a>(
         &'a self,
         homeserver_url: &str,
         access_token: SendAccessToken<'_>,
         user_id: &'a UserId,
         request: R,
     ) -> Pin<Box<dyn Future<Output = ResponseResult<Self, R>> + 'a>> {
-        self.send_customized_request(
+        self.send_customized_matrix_request(
             homeserver_url,
             access_token,
             request,

--- a/ruma-client/src/http_client.rs
+++ b/ruma-client/src/http_client.rs
@@ -11,6 +11,8 @@ use crate::ResponseResult;
 
 #[cfg(feature = "hyper")]
 mod hyper;
+#[cfg(feature = "reqwest")]
+mod reqwest;
 
 #[cfg(feature = "hyper")]
 pub use self::hyper::Hyper;
@@ -18,6 +20,8 @@ pub use self::hyper::Hyper;
 pub use self::hyper::HyperNativeTls;
 #[cfg(feature = "hyper-rustls")]
 pub use self::hyper::HyperRustls;
+#[cfg(feature = "reqwest")]
+pub use self::reqwest::Reqwest;
 
 /// An HTTP client that can be used to send requests to a Matrix homeserver.
 #[async_trait]

--- a/ruma-client/src/http_client.rs
+++ b/ruma-client/src/http_client.rs
@@ -61,13 +61,7 @@ pub trait HttpClientExt: HttpClient {
         access_token: SendAccessToken<'_>,
         request: R,
     ) -> Pin<Box<dyn Future<Output = ResponseResult<Self, R>> + 'a>> {
-        Box::pin(crate::send_customized_request(
-            self,
-            homeserver_url,
-            access_token,
-            request,
-            |_| {},
-        ))
+        self.send_customized_request(homeserver_url, access_token, request, |_| {})
     }
 
     /// Turn a strongly-typed matrix request into an `http::Request`, customize it and send it to

--- a/ruma-client/src/http_client.rs
+++ b/ruma-client/src/http_client.rs
@@ -90,3 +90,27 @@ pub trait HttpClientExt: HttpClient {
 
 #[async_trait]
 impl<T: HttpClient> HttpClientExt for T {}
+
+#[doc(hidden)]
+#[derive(Debug)]
+pub struct Dummy;
+
+#[async_trait]
+impl HttpClient for Dummy {
+    type RequestBody = Vec<u8>;
+    type ResponseBody = Vec<u8>;
+    type Error = ();
+
+    async fn send_http_request(
+        &self,
+        _req: http::Request<Self::RequestBody>,
+    ) -> Result<http::Response<Self::ResponseBody>, Self::Error> {
+        unimplemented!("this client only exists to allow doctests to compile")
+    }
+}
+
+impl DefaultConstructibleHttpClient for Dummy {
+    fn default() -> Self {
+        Dummy
+    }
+}

--- a/ruma-client/src/http_client.rs
+++ b/ruma-client/src/http_client.rs
@@ -1,8 +1,13 @@
 //! This module contains an abstraction for HTTP clients as well as friendly-named re-exports of
 //! client types that implement this trait.
 
+use std::{collections::BTreeMap, future::Future, pin::Pin};
+
 use async_trait::async_trait;
 use bytes::BufMut;
+use ruma_api::{OutgoingRequest, SendAccessToken};
+
+use crate::ResponseResult;
 
 #[cfg(feature = "hyper")]
 mod hyper;
@@ -16,9 +21,9 @@ pub use self::hyper::HyperRustls;
 
 /// An HTTP client that can be used to send requests to a Matrix homeserver.
 #[async_trait]
-pub trait HttpClient {
+pub trait HttpClient: Sync {
     /// The type to use for `try_into_http_request`.
-    type RequestBody: Default + BufMut;
+    type RequestBody: Default + BufMut + Send;
 
     /// The type to use for `try_from_http_response`.
     type ResponseBody: AsRef<[u8]>;
@@ -38,3 +43,46 @@ pub trait DefaultConstructibleHttpClient: HttpClient {
     /// Creates a new HTTP client with default configuration.
     fn default() -> Self;
 }
+
+/// Convenience functionality on top of `HttpClient`.
+///
+/// If you want to build your own matrix client type instead of using `ruma_client::Client`, this
+/// trait should make that relatively easy.
+pub trait HttpClientExt: HttpClient {
+    /// Send a strongly-typed matrix request to get back a strongly-typed response.
+    // TODO: `R: 'a` bound should not be needed
+    fn send_request<'a, R: OutgoingRequest + 'a>(
+        &'a self,
+        homeserver_url: &str,
+        access_token: SendAccessToken<'_>,
+        request: R,
+    ) -> Pin<Box<dyn Future<Output = ResponseResult<Self, R>> + 'a>> {
+        Box::pin(crate::send_request_with_url_params(
+            self,
+            homeserver_url,
+            access_token,
+            None,
+            request,
+        ))
+    }
+
+    /// Send a strongly-typed matrix request to get back a strongly-typed response.
+    fn send_request_with_url_params<'a, R: OutgoingRequest + 'a>(
+        &'a self,
+        homeserver_url: &str,
+        access_token: SendAccessToken<'_>,
+        extra_params: BTreeMap<String, String>,
+        request: R,
+    ) -> Pin<Box<dyn Future<Output = ResponseResult<Self, R>> + 'a>> {
+        Box::pin(crate::send_request_with_url_params(
+            self,
+            homeserver_url,
+            access_token,
+            Some(extra_params),
+            request,
+        ))
+    }
+}
+
+#[async_trait]
+impl<T: HttpClient> HttpClientExt for T {}

--- a/ruma-client/src/http_client.rs
+++ b/ruma-client/src/http_client.rs
@@ -12,6 +12,8 @@ use crate::{add_user_id_to_query, ResponseError, ResponseResult};
 
 #[cfg(feature = "hyper")]
 mod hyper;
+#[cfg(feature = "isahc")]
+mod isahc;
 #[cfg(feature = "reqwest")]
 mod reqwest;
 
@@ -21,6 +23,8 @@ pub use self::hyper::Hyper;
 pub use self::hyper::HyperNativeTls;
 #[cfg(feature = "hyper-rustls")]
 pub use self::hyper::HyperRustls;
+#[cfg(feature = "isahc")]
+pub use self::isahc::Isahc;
 #[cfg(feature = "reqwest")]
 pub use self::reqwest::Reqwest;
 

--- a/ruma-client/src/http_client.rs
+++ b/ruma-client/src/http_client.rs
@@ -61,10 +61,7 @@ pub trait HttpClientExt: HttpClient {
         homeserver_url: &str,
         access_token: SendAccessToken<'_>,
         request: R,
-    ) -> Pin<Box<dyn Future<Output = ResponseResult<Self, R>> + 'a>>
-    where
-        <R as OutgoingRequest>::EndpointError: Send,
-    {
+    ) -> Pin<Box<dyn Future<Output = ResponseResult<Self, R>> + 'a>> {
         self.send_customized_request(homeserver_url, access_token, request, |_| Ok(()))
     }
 
@@ -80,7 +77,6 @@ pub trait HttpClientExt: HttpClient {
     ) -> Pin<Box<dyn Future<Output = ResponseResult<Self, R>> + 'a>>
     where
         R: OutgoingRequest + 'a,
-        <R as OutgoingRequest>::EndpointError: Send,
         F: FnOnce(&mut http::Request<Self::RequestBody>) -> Result<(), ResponseError<Self, R>> + 'a,
     {
         Box::pin(crate::send_customized_request(
@@ -103,10 +99,7 @@ pub trait HttpClientExt: HttpClient {
         access_token: SendAccessToken<'_>,
         user_id: &'a UserId,
         request: R,
-    ) -> Pin<Box<dyn Future<Output = ResponseResult<Self, R>> + 'a>>
-    where
-        <R as OutgoingRequest>::EndpointError: Send,
-    {
+    ) -> Pin<Box<dyn Future<Output = ResponseResult<Self, R>> + 'a>> {
         self.send_customized_request(
             homeserver_url,
             access_token,

--- a/ruma-client/src/http_client/hyper.rs
+++ b/ruma-client/src/http_client/hyper.rs
@@ -1,0 +1,60 @@
+use async_trait::async_trait;
+use bytes::{Bytes, BytesMut};
+use hyper::client::{connect::Connect, HttpConnector};
+
+use super::{DefaultConstructibleHttpClient, HttpClient};
+
+/// A basic hyper HTTP client.
+///
+/// You basically never want this, since it doesn't support `https`.
+pub type Hyper = hyper::Client<HttpConnector>;
+
+/// A hyper HTTP client using native-tls for TLS support.
+#[cfg(feature = "hyper-native-tls")]
+pub type HyperNativeTls = hyper::Client<hyper_tls::HttpsConnector<HttpConnector>>;
+
+/// A hyper HTTP client using rustls for TLS support.
+///
+/// This client does not implement `DefaultConstructibleHttpClient`. To use it, you need to manually
+/// construct
+#[cfg(feature = "hyper-rustls")]
+pub type HyperRustls = hyper::Client<hyper_rustls::HttpsConnector<HttpConnector>>;
+
+#[async_trait]
+impl<C> HttpClient for hyper::Client<C>
+where
+    C: Connect + Clone + Send + Sync + 'static,
+{
+    type RequestBody = BytesMut;
+    type ResponseBody = Bytes;
+    type Error = hyper::Error;
+
+    async fn send_http_request(
+        &self,
+        req: http::Request<BytesMut>,
+    ) -> Result<http::Response<Bytes>, hyper::Error> {
+        let (head, body) = self
+            .request(req.map(|body| hyper::body::Body::from(body.freeze())))
+            .await?
+            .into_parts();
+
+        // FIXME: Use aggregate instead of to_bytes once serde_json can parse from a reader at a
+        // comparable speed as reading from a slice: https://github.com/serde-rs/json/issues/160
+        let body = hyper::body::to_bytes(body).await?;
+        Ok(http::Response::from_parts(head, body))
+    }
+}
+
+#[cfg(feature = "hyper")]
+impl DefaultConstructibleHttpClient for Hyper {
+    fn default() -> Self {
+        hyper::Client::new()
+    }
+}
+
+#[cfg(feature = "hyper-native-tls")]
+impl DefaultConstructibleHttpClient for HyperNativeTls {
+    fn default() -> Self {
+        hyper::Client::builder().build(hyper_tls::HttpsConnector::new())
+    }
+}

--- a/ruma-client/src/http_client/isahc.rs
+++ b/ruma-client/src/http_client/isahc.rs
@@ -1,0 +1,24 @@
+use super::HttpClient;
+
+use async_trait::async_trait;
+use futures_lite::AsyncReadExt;
+
+/// The `isahc` crate's `HttpClient`.
+pub type Isahc = isahc::HttpClient;
+
+#[async_trait]
+impl HttpClient for Isahc {
+    type RequestBody = Vec<u8>;
+    type ResponseBody = Vec<u8>;
+    type Error = isahc::Error;
+
+    async fn send_http_request(
+        &self,
+        req: http::Request<Vec<u8>>,
+    ) -> Result<http::Response<Vec<u8>>, isahc::Error> {
+        let (head, mut body) = self.send_async(req).await?.into_parts();
+        let mut full_body = Vec::new();
+        body.read_to_end(&mut full_body).await?;
+        Ok(http::Response::from_parts(head, full_body))
+    }
+}

--- a/ruma-client/src/http_client/reqwest.rs
+++ b/ruma-client/src/http_client/reqwest.rs
@@ -1,0 +1,39 @@
+use std::{convert::TryInto, mem};
+
+use async_trait::async_trait;
+use bytes::{Bytes, BytesMut};
+
+use super::{DefaultConstructibleHttpClient, HttpClient};
+
+/// The `reqwest` crate's `Client`.
+pub type Reqwest = reqwest::Client;
+
+#[async_trait]
+impl HttpClient for Reqwest {
+    type RequestBody = BytesMut;
+    type ResponseBody = Bytes;
+    type Error = reqwest::Error;
+
+    async fn send_http_request(
+        &self,
+        req: http::Request<BytesMut>,
+    ) -> Result<http::Response<Bytes>, reqwest::Error> {
+        let req = req.map(|body| body.freeze()).try_into()?;
+        let mut res = self.execute(req).await?;
+
+        let mut http_builder =
+            http::Response::builder().status(res.status()).version(res.version());
+        mem::swap(
+            http_builder.headers_mut().expect("http::response::Builder to be usable"),
+            res.headers_mut(),
+        );
+
+        Ok(http_builder.body(res.bytes().await?).expect("http::Response construction to work"))
+    }
+}
+
+impl DefaultConstructibleHttpClient for Reqwest {
+    fn default() -> Self {
+        reqwest::Client::new()
+    }
+}

--- a/ruma-client/src/lib.rs
+++ b/ruma-client/src/lib.rs
@@ -7,7 +7,7 @@
 //! Begin by creating a `Client` type, usually using the `https` method for a client that supports
 //! secure connections, and then logging in:
 //!
-//! ```no_run
+//! ```ignore
 //! use ruma_client::Client;
 //!
 //! let work = async {
@@ -43,7 +43,7 @@
 //! For the standard use case of synchronizing with the homeserver (i.e. getting all the latest
 //! events), use the `Client::sync`:
 //!
-//! ```no_run
+//! ```ignore
 //! use std::time::Duration;
 //!
 //! # use ruma_client::Client;
@@ -105,22 +105,16 @@
 use std::{
     collections::BTreeMap,
     sync::{Arc, Mutex},
-    time::Duration,
 };
 
 use assign::assign;
-use async_stream::try_stream;
-use futures_core::stream::Stream;
 use http::{uri::Uri, Response as HttpResponse};
 use hyper::client::{Client as HyperClient, HttpConnector};
 use ruma_api::{AuthScheme, OutgoingRequest, SendAccessToken};
-use ruma_client_api::r0::sync::sync_events::{
-    Filter as SyncFilter, Request as SyncRequest, Response as SyncResponse,
-};
-use ruma_common::presence::PresenceState;
-use ruma_identifiers::DeviceId;
 use ruma_serde::urlencoded;
 
+#[cfg(feature = "client-api")]
+mod client_api;
 mod error;
 mod session;
 
@@ -201,132 +195,6 @@ impl Client {
     /// Useful for serializing and persisting the session to be restored later.
     pub fn session(&self) -> Option<Session> {
         self.0.session.lock().expect("session mutex was poisoned").clone()
-    }
-
-    /// Log in with a username and password.
-    ///
-    /// In contrast to `api::r0::session::login::call()`, this method stores the
-    /// session data returned by the endpoint in this client, instead of
-    /// returning it.
-    pub async fn log_in(
-        &self,
-        user: &str,
-        password: &str,
-        device_id: Option<&DeviceId>,
-        initial_device_display_name: Option<&str>,
-    ) -> Result<Session, Error<ruma_client_api::Error>> {
-        use ruma_client_api::r0::session::login::{
-            LoginInfo, Request as LoginRequest, UserIdentifier,
-        };
-
-        let response = self
-            .request(assign!(
-                LoginRequest::new(
-                    LoginInfo::Password { identifier: UserIdentifier::MatrixId(user), password }
-                ), {
-                    device_id,
-                    initial_device_display_name,
-                }
-            ))
-            .await?;
-
-        let session = Session {
-            access_token: response.access_token,
-            identification: Some(Identification {
-                device_id: response.device_id,
-                user_id: response.user_id,
-            }),
-        };
-        *self.0.session.lock().unwrap() = Some(session.clone());
-
-        Ok(session)
-    }
-
-    /// Register as a guest. In contrast to `api::r0::account::register::call()`,
-    /// this method stores the session data returned by the endpoint in this
-    /// client, instead of returning it.
-    pub async fn register_guest(
-        &self,
-    ) -> Result<Session, Error<ruma_client_api::r0::uiaa::UiaaResponse>> {
-        use ruma_client_api::r0::account::register::{self, RegistrationKind};
-
-        let response = self
-            .request(assign!(register::Request::new(), { kind: RegistrationKind::Guest }))
-            .await?;
-
-        let session = Session {
-            // since we supply inhibit_login: false above, the access token needs to be there
-            // TODO: maybe unwrap is not the best solution though
-            access_token: response.access_token.unwrap(),
-            identification: Some(Identification {
-                // same as access_token
-                device_id: response.device_id.unwrap(),
-                user_id: response.user_id,
-            }),
-        };
-        *self.0.session.lock().unwrap() = Some(session.clone());
-
-        Ok(session)
-    }
-
-    /// Register as a new user on this server.
-    ///
-    /// In contrast to `api::r0::account::register::call()`, this method stores
-    /// the session data returned by the endpoint in this client, instead of
-    /// returning it.
-    ///
-    /// The username is the local part of the returned user_id. If it is
-    /// omitted from this request, the server will generate one.
-    pub async fn register_user(
-        &self,
-        username: Option<&str>,
-        password: &str,
-    ) -> Result<Session, Error<ruma_client_api::r0::uiaa::UiaaResponse>> {
-        use ruma_client_api::r0::account::register;
-
-        let response = self
-            .request(assign!(register::Request::new(), { username, password: Some(password) }))
-            .await?;
-
-        let session = Session {
-            // since we supply inhibit_login: false above, the access token needs to be there
-            // TODO: maybe unwrap is not the best solution though
-            access_token: response.access_token.unwrap(),
-            identification: Some(Identification {
-                // same as access_token
-                device_id: response.device_id.unwrap(),
-                user_id: response.user_id,
-            }),
-        };
-        *self.0.session.lock().unwrap() = Some(session.clone());
-
-        Ok(session)
-    }
-
-    /// Convenience method that represents repeated calls to the sync_events endpoint as a stream.
-    pub fn sync<'a>(
-        &self,
-        filter: Option<&'a SyncFilter<'a>>,
-        mut since: String,
-        set_presence: &'a PresenceState,
-        timeout: Option<Duration>,
-    ) -> impl Stream<Item = Result<SyncResponse, Error<ruma_client_api::Error>>> + 'a {
-        let client = self.clone();
-        try_stream! {
-            loop {
-                let response = client
-                    .request(assign!(SyncRequest::new(), {
-                        filter,
-                        since: Some(&since),
-                        set_presence,
-                        timeout,
-                    }))
-                    .await?;
-
-                since = response.next_batch.clone();
-                yield response;
-            }
-        }
     }
 
     /// Makes a request to a Matrix API endpoint.

--- a/ruma-client/src/lib.rs
+++ b/ruma-client/src/lib.rs
@@ -40,7 +40,7 @@
 //! ```
 //!
 //! For the standard use case of synchronizing with the homeserver (i.e. getting all the latest
-//! events), use the `Client::sync`:
+//! events), use the `Client::sync` method:
 //!
 //! ```ignore
 //! use std::time::Duration;
@@ -69,10 +69,8 @@
 //! one with the given homeserver.
 //!
 //! Beyond these basic convenience methods, `ruma-client` gives you access to the entire Matrix
-//! client-server API via the `api` module. Each leaf module under this tree of modules contains
-//! the necessary types for one API endpoint. Simply call the module's `call` method, passing it
-//! the logged in `Client` and the relevant `Request` type. `call` will return a future that will
-//! resolve to the relevant `Response` type.
+//! client-server API via the `request` method. You can pass it any of the `Request` types found in
+//! `ruma::api::*` and get back a corresponding response from the homeserver.
 //!
 //! For example:
 //!

--- a/ruma-client/src/lib.rs
+++ b/ruma-client/src/lib.rs
@@ -28,7 +28,7 @@
 //! session rather than calling `log_in`. This can also be used to create a session for an
 //! application service that does not need to log in, but uses the access_token directly:
 //!
-//! ```no_run
+//! ```ignore
 //! use ruma_client::Client;
 //!
 //! let work = async {
@@ -37,32 +37,6 @@
 //!
 //!     // make calls to the API
 //! };
-//! ```
-//!
-//! For the standard use case of synchronizing with the homeserver (i.e. getting all the latest
-//! events), use the `Client::sync` method:
-//!
-//! ```ignore
-//! use std::time::Duration;
-//!
-//! # use ruma_client::Client;
-//! # use ruma::presence::PresenceState;
-//! # use tokio_stream::{StreamExt as _};
-//! # let homeserver_url = "https://example.com".parse().unwrap();
-//! # let client = Client::new(homeserver_url, None);
-//! # let next_batch_token = String::new();
-//! # async {
-//! let mut sync_stream = Box::pin(client.sync(
-//!     None,
-//!     next_batch_token,
-//!     &PresenceState::Online,
-//!     Some(Duration::from_secs(30)),
-//! ));
-//! while let Some(response) = sync_stream.try_next().await? {
-//!     // Do something with the data in the response...
-//! }
-//! # Result::<(), ruma_client::Error<_>>::Ok(())
-//! # };
 //! ```
 //!
 //! The `Client` type also provides methods for registering a new account if you don't already have
@@ -74,7 +48,7 @@
 //!
 //! For example:
 //!
-//! ```no_run
+//! ```ignore
 //! # use ruma_client::Client;
 //! # let homeserver_url = "https://example.com".parse().unwrap();
 //! # let client = Client::new(homeserver_url, None);
@@ -87,11 +61,11 @@
 //!
 //! async {
 //!     let response = client
-//!         .request(get_alias::Request::new(&room_alias_id!("#example_room:example.com")))
+//!         .send_request(get_alias::Request::new(&room_alias_id!("#example_room:example.com")))
 //!         .await?;
 //!
 //!     assert_eq!(response.room_id, room_id!("!n8f893n9:example.com"));
-//! #   Result::<(), ruma_client::Error<_>>::Ok(())
+//! #   Result::<(), ruma_client::Error<_, _>>::Ok(())
 //! }
 //! # ;
 //! ```

--- a/ruma-client/src/lib.rs
+++ b/ruma-client/src/lib.rs
@@ -75,12 +75,13 @@
 
 use std::{
     collections::BTreeMap,
+    future::Future,
     sync::{Arc, Mutex},
 };
 
 use assign::assign;
 use http::uri::Uri;
-use ruma_api::{AuthScheme, OutgoingRequest, SendAccessToken};
+use ruma_api::{OutgoingRequest, SendAccessToken};
 use ruma_serde::urlencoded;
 
 // "Undo" rename from `Cargo.toml` that only serves to make `hyper-rustls` available as a Cargo
@@ -95,8 +96,14 @@ pub mod http_client;
 
 pub use self::{
     error::Error,
-    http_client::{DefaultConstructibleHttpClient, HttpClient},
+    http_client::{DefaultConstructibleHttpClient, HttpClient, HttpClientExt},
 };
+
+/// The result of sending the request `R` with the http client `C`.
+pub type ResponseResult<C, R> = Result<
+    <R as OutgoingRequest>::IncomingResponse,
+    Error<<C as HttpClient>::Error, <R as OutgoingRequest>::EndpointError>,
+>;
 
 /// A client for the Matrix client-server API.
 #[derive(Clone, Debug)]
@@ -106,7 +113,7 @@ pub struct Client<C>(Arc<ClientData<C>>);
 #[derive(Debug)]
 struct ClientData<C> {
     /// The URL of the homeserver to connect to.
-    homeserver_url: Uri,
+    homeserver_url: String,
 
     /// The underlying HTTP client.
     http_client: C,
@@ -121,7 +128,7 @@ impl<C> Client<C> {
     /// This allows the user to configure the details of HTTP as desired.
     pub fn with_http_client(
         http_client: C,
-        homeserver_url: Uri,
+        homeserver_url: String,
         access_token: Option<String>,
     ) -> Self {
         Self(Arc::new(ClientData {
@@ -141,7 +148,7 @@ impl<C> Client<C> {
 
 impl<C: DefaultConstructibleHttpClient> Client<C> {
     /// Creates a new client based on a default-constructed hyper HTTP client.
-    pub fn new(homeserver_url: Uri, access_token: Option<String>) -> Self {
+    pub fn new(homeserver_url: String, access_token: Option<String>) -> Self {
         Self(Arc::new(ClientData {
             homeserver_url,
             http_client: DefaultConstructibleHttpClient::default(),
@@ -152,48 +159,81 @@ impl<C: DefaultConstructibleHttpClient> Client<C> {
 
 impl<C: HttpClient> Client<C> {
     /// Makes a request to a Matrix API endpoint.
-    pub async fn request<Request: OutgoingRequest>(
+    pub async fn send_request<R: OutgoingRequest>(
         &self,
-        request: Request,
-    ) -> Result<Request::IncomingResponse, Error<C::Error, Request::EndpointError>> {
-        self.request_with_url_params(request, None).await
+        request: R,
+    ) -> Result<R::IncomingResponse, Error<C::Error, R::EndpointError>> {
+        let access_token = self.access_token();
+        let send_access_token = match access_token.as_deref() {
+            Some(at) => SendAccessToken::IfRequired(at),
+            None => SendAccessToken::None,
+        };
+
+        send_request_with_url_params(
+            &self.0.http_client,
+            &self.0.homeserver_url,
+            send_access_token,
+            None,
+            request,
+        )
+        .await
     }
 
     /// Makes a request to a Matrix API endpoint including additional URL parameters.
-    pub async fn request_with_url_params<Request: OutgoingRequest>(
+    pub async fn send_request_with_url_params<R: OutgoingRequest>(
         &self,
-        request: Request,
-        extra_params: Option<BTreeMap<String, String>>,
-    ) -> Result<Request::IncomingResponse, Error<C::Error, Request::EndpointError>> {
-        let client = self.0.clone();
-        let mut http_request = {
-            let lock;
-            let access_token = if Request::METADATA.authentication == AuthScheme::AccessToken {
-                lock = client.access_token.lock().unwrap();
-                if let Some(access_token) = &*lock {
-                    SendAccessToken::IfRequired(access_token.as_str())
-                } else {
-                    return Err(Error::AuthenticationRequired);
-                }
-            } else {
-                SendAccessToken::None
+        extra_params: BTreeMap<String, String>,
+        request: R,
+    ) -> Result<R::IncomingResponse, Error<C::Error, R::EndpointError>> {
+        let access_token = self.access_token();
+        let send_access_token = match access_token.as_deref() {
+            Some(at) => SendAccessToken::IfRequired(at),
+            None => SendAccessToken::None,
+        };
+
+        send_request_with_url_params(
+            &self.0.http_client,
+            &self.0.homeserver_url,
+            send_access_token,
+            Some(extra_params),
+            request,
+        )
+        .await
+    }
+}
+
+fn send_request_with_url_params<'a, C, Request>(
+    http_client: &'a C,
+    homeserver_url: &str,
+    send_access_token: SendAccessToken<'_>,
+    extra_params: Option<BTreeMap<String, String>>,
+    request: Request,
+) -> impl Future<Output = Result<Request::IncomingResponse, Error<C::Error, Request::EndpointError>>>
+       + Send
+       + 'a
+where
+    C: HttpClient + ?Sized,
+    Request: OutgoingRequest,
+{
+    let res = request.try_into_http_request(homeserver_url, send_access_token);
+
+    async move {
+        let mut http_request = res?;
+
+        if let Some(extra_params) = extra_params {
+            let extra_params = urlencoded::to_string(extra_params).unwrap();
+            let uri = http_request.uri_mut();
+            let new_path_and_query = match uri.query() {
+                Some(params) => format!("{}?{}&{}", uri.path(), params, extra_params),
+                None => format!("{}?{}", uri.path(), extra_params),
             };
-
-            request.try_into_http_request(&client.homeserver_url.to_string(), access_token)?
-        };
-
-        let extra_params = urlencoded::to_string(extra_params).unwrap();
-        let uri = http_request.uri_mut();
-        let new_path_and_query = match uri.query() {
-            Some(params) => format!("{}?{}&{}", uri.path(), params, extra_params),
-            None => format!("{}?{}", uri.path(), extra_params),
-        };
-        *uri = Uri::from_parts(assign!(uri.clone().into_parts(), {
-            path_and_query: Some(new_path_and_query.parse()?),
-        }))?;
+            *uri = Uri::from_parts(assign!(uri.clone().into_parts(), {
+                path_and_query: Some(new_path_and_query.parse()?),
+            }))?;
+        }
 
         let http_response =
-            client.http_client.send_http_request(http_request).await.map_err(Error::Response)?;
+            http_client.send_http_request(http_request).await.map_err(Error::Response)?;
         Ok(ruma_api::IncomingResponse::try_from_http_response(http_response)?)
     }
 }

--- a/ruma-client/src/lib.rs
+++ b/ruma-client/src/lib.rs
@@ -159,20 +159,7 @@ impl<C: HttpClient> Client<C> {
         &self,
         request: R,
     ) -> Result<R::IncomingResponse, Error<C::Error, R::EndpointError>> {
-        let access_token = self.access_token();
-        let send_access_token = match access_token.as_deref() {
-            Some(at) => SendAccessToken::IfRequired(at),
-            None => SendAccessToken::None,
-        };
-
-        send_customized_request(
-            &self.0.http_client,
-            &self.0.homeserver_url,
-            send_access_token,
-            request,
-            |_| {},
-        )
-        .await
+        self.send_customized_request(request, |_| {}).await
     }
 
     /// Makes a request to a Matrix API endpoint including additional URL parameters.

--- a/ruma-client/src/lib.rs
+++ b/ruma-client/src/lib.rs
@@ -158,10 +158,7 @@ impl<C: DefaultConstructibleHttpClient> Client<C> {
 
 impl<C: HttpClient> Client<C> {
     /// Makes a request to a Matrix API endpoint.
-    pub async fn send_request<R: OutgoingRequest>(&self, request: R) -> ResponseResult<C, R>
-    where
-        <R as OutgoingRequest>::EndpointError: Send,
-    {
+    pub async fn send_request<R: OutgoingRequest>(&self, request: R) -> ResponseResult<C, R> {
         self.send_customized_request(request, |_| Ok(())).await
     }
 
@@ -173,7 +170,6 @@ impl<C: HttpClient> Client<C> {
     ) -> ResponseResult<C, R>
     where
         R: OutgoingRequest,
-        <R as OutgoingRequest>::EndpointError: Send,
         F: FnOnce(&mut http::Request<C::RequestBody>) -> Result<(), ResponseError<C, R>>,
     {
         let access_token = self.access_token();
@@ -200,10 +196,7 @@ impl<C: HttpClient> Client<C> {
         &self,
         user_id: &UserId,
         request: R,
-    ) -> ResponseResult<C, R>
-    where
-        <R as OutgoingRequest>::EndpointError: Send,
-    {
+    ) -> ResponseResult<C, R> {
         self.send_customized_request(request, add_user_id_to_query::<C, R>(user_id)).await
     }
 }
@@ -218,7 +211,6 @@ fn send_customized_request<'a, C, R, F>(
 where
     C: HttpClient + ?Sized,
     R: OutgoingRequest,
-    <R as OutgoingRequest>::EndpointError: Send,
     F: FnOnce(&mut http::Request<C::RequestBody>) -> Result<(), ResponseError<C, R>>,
 {
     let http_req = request

--- a/ruma-client/src/lib.rs
+++ b/ruma-client/src/lib.rs
@@ -155,10 +155,7 @@ impl<C: DefaultConstructibleHttpClient> Client<C> {
 
 impl<C: HttpClient> Client<C> {
     /// Makes a request to a Matrix API endpoint.
-    pub async fn send_request<R: OutgoingRequest>(
-        &self,
-        request: R,
-    ) -> Result<R::IncomingResponse, Error<C::Error, R::EndpointError>> {
+    pub async fn send_request<R: OutgoingRequest>(&self, request: R) -> ResponseResult<C, R> {
         self.send_customized_request(request, |_| {}).await
     }
 
@@ -167,7 +164,7 @@ impl<C: HttpClient> Client<C> {
         &self,
         request: R,
         customize: F,
-    ) -> Result<R::IncomingResponse, Error<C::Error, R::EndpointError>>
+    ) -> ResponseResult<C, R>
     where
         R: OutgoingRequest,
         F: FnOnce(&mut http::Request<C::RequestBody>),
@@ -195,7 +192,7 @@ fn send_customized_request<'a, C, R, F>(
     send_access_token: SendAccessToken<'_>,
     request: R,
     customize: F,
-) -> impl Future<Output = Result<R::IncomingResponse, Error<C::Error, R::EndpointError>>> + Send + 'a
+) -> impl Future<Output = ResponseResult<C, R>> + Send + 'a
 where
     C: HttpClient + ?Sized,
     R: OutgoingRequest,

--- a/ruma-client/src/lib.rs
+++ b/ruma-client/src/lib.rs
@@ -4,36 +4,37 @@
 //!
 //! # Usage
 //!
-//! Begin by creating a `Client` type, usually using the `https` method for a client that supports
-//! secure connections, and then logging in:
+//! Begin by creating a `Client`, selecting one of the type aliases from `ruma_client::http_client`
+//! for the generic parameter. For the client API, there are login and registration methods
+//! provided for the client (feature `client-api`):
 //!
 //! ```ignore
-//! use ruma_client::Client;
+//! // type MatrixClient = ruma_client::Client<ruma_client::http_client::_>;
+//! # type MatrixClient = ruma_client::Client<ruma_client::http_client::Dummy>;
+//! # let work = async {
+//! let homeserver_url = "https://example.com".parse().unwrap();
+//! let client = MatrixClient::new(homeserver_url, None);
 //!
-//! let work = async {
-//!     let homeserver_url = "https://example.com".parse().unwrap();
-//!     let client = Client::new(homeserver_url, None);
+//! let session = client
+//!     .log_in("@alice:example.com", "secret", None, None)
+//!     .await?;
 //!
-//!     let session = client
-//!         .log_in("@alice:example.com", "secret", None, None)
-//!         .await?;
-//!
-//!     // You're now logged in! Write the session to a file if you want to restore it later.
-//!     // Then start using the API!
-//! # Result::<(), ruma_client::Error<_>>::Ok(())
-//! };
+//! // You're now logged in! Write the session to a file if you want to restore it later.
+//! // Then start using the API!
+//! # Result::<(), ruma_client::Error<_, _>>::Ok(())
+//! # };
 //! ```
 //!
 //! You can also pass an existing access token to the `Client` constructor to restore a previous
 //! session rather than calling `log_in`. This can also be used to create a session for an
 //! application service that does not need to log in, but uses the access_token directly:
 //!
-//! ```ignore
-//! use ruma_client::Client;
+//! ```no_run
+//! # type MatrixClient = ruma_client::Client<ruma_client::http_client::Dummy>;
 //!
 //! let work = async {
 //!     let homeserver_url = "https://example.com".parse().unwrap();
-//!     let client = Client::new(homeserver_url, Some("as_access_token".into()));
+//!     let client = MatrixClient::new(homeserver_url, Some("as_access_token".into()));
 //!
 //!     // make calls to the API
 //! };
@@ -48,10 +49,10 @@
 //!
 //! For example:
 //!
-//! ```ignore
-//! # use ruma_client::Client;
+//! ```no_run
+//! # type MatrixClient = ruma_client::Client<ruma_client::http_client::Dummy>;
 //! # let homeserver_url = "https://example.com".parse().unwrap();
-//! # let client = Client::new(homeserver_url, None);
+//! # let client = MatrixClient::new(homeserver_url, None);
 //! use std::convert::TryFrom;
 //!
 //! use ruma::{

--- a/ruma-client/src/lib.rs
+++ b/ruma-client/src/lib.rs
@@ -82,10 +82,12 @@ use std::{
 use ruma_api::{OutgoingRequest, SendAccessToken};
 use ruma_identifiers::UserId;
 
-// "Undo" rename from `Cargo.toml` that only serves to make `hyper-rustls` available as a Cargo
-// feature name.
+// "Undo" rename from `Cargo.toml` that only serves to make crate names available as a Cargo
+// feature names.
 #[cfg(feature = "hyper-rustls")]
 extern crate hyper_rustls_crate as hyper_rustls;
+#[cfg(feature = "isahc")]
+extern crate isahc_crate as isahc;
 
 #[cfg(feature = "client-api")]
 mod client_api;

--- a/ruma/Cargo.toml
+++ b/ruma/Cargo.toml
@@ -23,6 +23,7 @@ ruma-common = { version = "0.5.0", path = "../ruma-common" }
 ruma-identifiers = { version = "0.19.0", path = "../ruma-identifiers", features = ["serde"] }
 ruma-serde = { version = "0.3.1", path = "../ruma-serde" }
 
+ruma-client = { version = "=0.5.0-alpha.2", path = "../ruma-client", optional = true }
 ruma-events = { version = "=0.22.0-alpha.3", path = "../ruma-events", optional = true }
 ruma-signatures = { version = "0.7.0", path = "../ruma-signatures", optional = true }
 
@@ -38,8 +39,11 @@ serde = { version = "1.0.118", features = ["derive"] }
 
 [features]
 api = ["ruma-api"]
+client = ["ruma-client"]
 events = ["ruma-events"]
 signatures = ["ruma-signatures"]
+
+client-ext-client-api = ["client", "ruma-client/client-api"]
 
 appservice-api-c = ["api", "events", "ruma-appservice-api/client"]
 appservice-api-s = ["api", "events", "ruma-appservice-api/server"]

--- a/ruma/Cargo.toml
+++ b/ruma/Cargo.toml
@@ -43,7 +43,16 @@ client = ["ruma-client"]
 events = ["ruma-events"]
 signatures = ["ruma-signatures"]
 
+# ruma-client feature flags
 client-ext-client-api = ["client", "ruma-client/client-api"]
+client-hyper = ["client", "ruma-client/hyper"]
+client-hyper-native-tls = ["client", "ruma-client/hyper-native-tls"]
+client-reqwest = ["client", "ruma-client/reqwest"]
+client-reqwest-native-tls = ["client", "ruma-client/reqwest-native-tls"]
+client-reqwest-native-tls-vendored = ["client", "ruma-client/reqwest-native-tls-vendored"]
+client-reqwest-rustls-manual-roots = ["client", "ruma-client/reqwest-rustls-manual-roots"]
+client-reqwest-rustls-webpki-roots = ["client", "ruma-client/reqwest-rustls-webpki-roots"]
+client-reqwest-rustls-native-roots = ["client", "ruma-client/reqwest-rustls-native-roots"]
 
 appservice-api-c = ["api", "events", "ruma-appservice-api/client"]
 appservice-api-s = ["api", "events", "ruma-appservice-api/server"]

--- a/ruma/src/lib.rs
+++ b/ruma/src/lib.rs
@@ -84,6 +84,10 @@ pub use ruma_identifiers::{
     ServerSigningKeyId, Signatures, SigningKeyAlgorithm, UserId,
 };
 
+#[cfg(feature = "client")]
+#[cfg_attr(docsrs, doc(cfg(feature = "client")))]
+#[doc(inline)]
+pub use ruma_client as client;
 #[cfg(feature = "events")]
 #[cfg_attr(docsrs, doc(cfg(feature = "events")))]
 #[doc(inline)]

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -61,29 +61,8 @@ impl CiTask {
 
         {
             let _p = pushd("ruma-client")?;
-            r.push(
-                cmd!(
-                    "rustup run stable cargo check
-                        --no-default-features --features http1,http2 --quiet"
-                )
-                .run(),
-            );
-            r.push(
-                cmd!(
-                    "rustup run stable cargo check
-                        --no-default-features --features http1,http2,tls-rustls-native-roots
-                        --quiet"
-                )
-                .run(),
-            );
-            r.push(
-                cmd!(
-                    "rustup run stable cargo check
-                        --no-default-features --features http1,http2,tls-rustls-webpki-roots
-                        --quiet"
-                )
-                .run(),
-            );
+            r.push(cmd!("rustup run stable cargo check --no-default-features --quiet").run());
+            r.push(cmd!("rustup run stable cargo check --all-features --quiet").run());
         }
 
         r.into_iter().collect()


### PR DESCRIPTION
Resolves #401.

Left to do:

* [x] Implement `HttpClient` for `reqwest::Client`
* [x] Add a `Dummy` http client for doctests
* [x] Update doctests to use `http_client::Dummy`.
* [ ] ~~Make sure this actually works by integrating it (for example into matrix-rust-sdk)~~
* [x] Re-export ruma-client from ruma
* [x] Have a brief look at what is required for appservice-api integration 