### PR TITLE
Properly deserialize well-known response

### DIFF
--- a/ruma-federation-api/CHANGELOG.md
+++ b/ruma-federation-api/CHANGELOG.md
@@ -41,7 +41,7 @@ Improvements:
 
 Bug fixes:
 
-* Properly decode well-known response
+* Fixes `discover_homeserver::Response` serialization and deserialization
 
 # 0.0.3
 

--- a/ruma-federation-api/CHANGELOG.md
+++ b/ruma-federation-api/CHANGELOG.md
@@ -38,6 +38,10 @@ Improvements:
   },
   ```
 
+Bug fixes:
+
+* Properly decode well-known response
+
 # 0.0.3
 
 Breaking Changes:

--- a/ruma-federation-api/CHANGELOG.md
+++ b/ruma-federation-api/CHANGELOG.md
@@ -11,6 +11,7 @@ Breaking Changes:
 * Wrap `Pdu`s in `backfill::get_backfill` in `Raw`
 * Use `ruma_identifiers::MxcUri` instead of `String` for `avatar_url` in
   `query::get_profile_information::v1`
+* Rename `homeserver` property to `server` on `discover_homeserver::Response`
 
 Improvements:
 

--- a/ruma-federation-api/src/discovery/discover_homeserver.rs
+++ b/ruma-federation-api/src/discovery/discover_homeserver.rs
@@ -17,8 +17,8 @@ ruma_api! {
     request: {}
 
     response: {
-        /// The server name to delegate server-server communciations to, with optional port.
-        #[serde(rename = "m.homeserver")]
+        /// The server name to delegate server-server communications to, with optional port.
+        #[serde(rename = "m.server")]
         pub homeserver: ServerNameBox,
     }
 }

--- a/ruma-federation-api/src/discovery/discover_homeserver.rs
+++ b/ruma-federation-api/src/discovery/discover_homeserver.rs
@@ -19,7 +19,7 @@ ruma_api! {
     response: {
         /// The server name to delegate server-server communications to, with optional port.
         #[serde(rename = "m.server")]
-        pub homeserver: ServerNameBox,
+        pub server: ServerNameBox,
     }
 }
 
@@ -32,7 +32,7 @@ impl Request {
 
 impl Response {
     /// Creates a new `Response` with the given homeserver.
-    pub fn new(homeserver: ServerNameBox) -> Self {
-        Self { homeserver }
+    pub fn new(server: ServerNameBox) -> Self {
+        Self { server }
     }
 }


### PR DESCRIPTION
According to the spec
(https://matrix.org/docs/spec/server_server/r0.1.4#get-well-known-matrix-server),
the expected field to receive the delegated name is `m.server` instead
of `m.homeserver`.