### PR TITLE
events: Move FullyReadEvent from EphemeralRoomEvent to BasicEvent

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -41,6 +41,7 @@ Breaking changes:
   sticker::StickerEventContent
   ```
 * Add `tag::TagName` type and use it for `tag::Tags`
+* Move `FullyRead` from `EphemeralRoom` enum to `Basic` enum
 
 Improvements:
 

--- a/crates/ruma-events/src/enums.rs
+++ b/crates/ruma-events/src/enums.rs
@@ -10,6 +10,7 @@ event_enum! {
     events: [
         "m.direct",
         "m.dummy",
+        "m.fully_read",
         "m.ignored_user_list",
         "m.presence",
         "m.push_rules",
@@ -22,7 +23,6 @@ event_enum! {
     /// Any ephemeral room event.
     kind: EphemeralRoom,
     events: [
-        "m.fully_read",
         "m.receipt",
         "m.typing",
     ]

--- a/crates/ruma-events/src/fully_read.rs
+++ b/crates/ruma-events/src/fully_read.rs
@@ -1,19 +1,19 @@
 //! Types for the *m.fully_read* event.
 
-use ruma_events_macros::EphemeralRoomEventContent;
+use ruma_events_macros::BasicEventContent;
 use ruma_identifiers::EventId;
 use serde::{Deserialize, Serialize};
 
-use crate::EphemeralRoomEvent;
+use crate::BasicEvent;
 
 /// The current location of the user's read marker in a room.
 ///
 /// This event appears in the user's room account data for the room the marker is applicable
 /// for.
-pub type FullyReadEvent = EphemeralRoomEvent<FullyReadEventContent>;
+pub type FullyReadEvent = BasicEvent<FullyReadEventContent>;
 
 /// The payload for `FullyReadEvent`.
-#[derive(Clone, Debug, Deserialize, Serialize, EphemeralRoomEventContent)]
+#[derive(Clone, Debug, Deserialize, Serialize, BasicEventContent)]
 #[ruma_event(type = "m.fully_read")]
 pub struct FullyReadEventContent {
     /// The event the user's read marker is located at in the room.


### PR DESCRIPTION
It seems like the [example](https://matrix.org/docs/spec/client_server/r0.6.1#m-fully-read) in the spec is [wrong](https://github.com/matrix-org/matrix-doc/issues/3183), plus the event is in room account data so it couldn't be retrieved otherwise.