### PR TITLE
Remove various `Box<>` wrappers

### DIFF
--- a/crates/ruma-client-api/src/r0/config/set_room_account_data.rs
+++ b/crates/ruma-client-api/src/r0/config/set_room_account_data.rs
@@ -19,7 +19,7 @@ ruma_api! {
         ///
         /// To create a `RawJsonValue`, use `serde_json::value::to_raw_value`.
         #[ruma_api(body)]
-        pub data: Box<RawJsonValue>,
+        pub data: &'a RawJsonValue,
 
         /// The event type of the account_data to set.
         ///
@@ -47,7 +47,7 @@ ruma_api! {
 impl<'a> Request<'a> {
     /// Creates a new `Request` with the given data, event type, room ID and user ID.
     pub fn new(
-        data: Box<RawJsonValue>,
+        data: &'a RawJsonValue,
         event_type: &'a str,
         room_id: &'a RoomId,
         user_id: &'a UserId,

--- a/crates/ruma-client-api/src/r0/to_device/send_event_to_device.rs
+++ b/crates/ruma-client-api/src/r0/to_device/send_event_to_device.rs
@@ -34,7 +34,7 @@ ruma_api! {
         /// The content's type for this field will be updated in a future
         /// release, until then you can create a value using
         /// `serde_json::value::to_raw_value`.
-        pub messages: BTreeMap<UserId, BTreeMap<DeviceIdOrAllDevices, &'a RawJsonValue>>
+        pub messages: BTreeMap<UserId, BTreeMap<DeviceIdOrAllDevices, Box<RawJsonValue>>>,
     }
 
     #[derive(Default)]
@@ -48,7 +48,7 @@ impl<'a> Request<'a> {
     pub fn new(
         event_type: EventType,
         txn_id: &'a str,
-        messages: BTreeMap<UserId, BTreeMap<DeviceIdOrAllDevices, &'a RawJsonValue>>,
+        messages: BTreeMap<UserId, BTreeMap<DeviceIdOrAllDevices, Box<RawJsonValue>>>,
     ) -> Self {
         Self { event_type, txn_id, messages }
     }

--- a/crates/ruma-client-api/src/r0/to_device/send_event_to_device.rs
+++ b/crates/ruma-client-api/src/r0/to_device/send_event_to_device.rs
@@ -34,7 +34,7 @@ ruma_api! {
         /// The content's type for this field will be updated in a future
         /// release, until then you can create a value using
         /// `serde_json::value::to_raw_value`.
-        pub messages: BTreeMap<UserId, BTreeMap<DeviceIdOrAllDevices, Box<RawJsonValue>>>
+        pub messages: BTreeMap<UserId, BTreeMap<DeviceIdOrAllDevices, &'a RawJsonValue>>
     }
 
     #[derive(Default)]
@@ -48,7 +48,7 @@ impl<'a> Request<'a> {
     pub fn new(
         event_type: EventType,
         txn_id: &'a str,
-        messages: BTreeMap<UserId, BTreeMap<DeviceIdOrAllDevices, Box<RawJsonValue>>>,
+        messages: BTreeMap<UserId, BTreeMap<DeviceIdOrAllDevices, &'a RawJsonValue>>,
     ) -> Self {
         Self { event_type, txn_id, messages }
     }

--- a/crates/ruma-push-gateway-api/src/send_event_notification/v1.rs
+++ b/crates/ruma-push-gateway-api/src/send_event_notification/v1.rs
@@ -112,7 +112,7 @@ pub struct Notification<'a> {
     /// The `content` field from the event, if present. The pusher may omit this
     /// if the event had no content or for any other reason.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub content: Option<Box<RawJsonValue>>,
+    pub content: Option<&'a RawJsonValue>,
 
     /// This is a dictionary of the current number of unacknowledged
     /// communications for the recipient user. Counts whose value is zero should


### PR DESCRIPTION
Resolves #309

This removes all uses of `Box<>` inside `request` macro blocks.