### PR TITLE
Add reasons for each doctest ignore

### DIFF
--- a/crates/ruma-client/src/lib.rs
+++ b/crates/ruma-client/src/lib.rs
@@ -9,6 +9,7 @@
 //! provided for the client (feature `client-api`):
 //!
 //! ```ignore
+//! # // HACK: "ignore" the doctest here because client.log_in needs client-api feature.
 //! // type MatrixClient = ruma_client::Client<ruma_client::http_client::_>;
 //! # type MatrixClient = ruma_client::Client<ruma_client::http_client::Dummy>;
 //! # let work = async {
@@ -89,6 +90,7 @@ extern crate hyper_rustls_crate as hyper_rustls;
 extern crate isahc_crate as isahc;
 
 #[cfg(feature = "client-api")]
+#[cfg_attr(docsrs, doc(cfg(feature = "client")))]
 mod client_api;
 mod error;
 pub mod http_client;

--- a/crates/ruma-events-macros/Cargo.toml
+++ b/crates/ruma-events-macros/Cargo.toml
@@ -23,7 +23,3 @@ proc-macro-crate = "1.0.0"
 
 [lib]
 proc-macro = true
-
-[dev-dependencies]
-ruma-events = { path = "../ruma-events" }
-serde = "1.0.125"

--- a/crates/ruma-events-macros/Cargo.toml
+++ b/crates/ruma-events-macros/Cargo.toml
@@ -26,3 +26,4 @@ proc-macro = true
 
 [dev-dependencies]
 ruma-events = { path = "../ruma-events" }
+serde = "1.0.125"

--- a/crates/ruma-events-macros/Cargo.toml
+++ b/crates/ruma-events-macros/Cargo.toml
@@ -23,3 +23,6 @@ proc-macro-crate = "1.0.0"
 
 [lib]
 proc-macro = true
+
+[dev-dependencies]
+ruma-events = { path = "../ruma-events" }

--- a/crates/ruma-events-macros/src/lib.rs
+++ b/crates/ruma-events-macros/src/lib.rs
@@ -48,8 +48,8 @@ mod event_parse;
 /// }
 /// ```
 /// (The argument to `kind` has to be a valid identifier for `<EventKind as Parse>::parse`)
-//// TODO: Change above (`<EventKind as Parse>::parse`) to [] after fully qualified syntax is supported:
-////  https://github.com/rust-lang/rust/issues/74563
+//// TODO: Change above (`<EventKind as Parse>::parse`) to [] after fully qualified syntax is
+//// supported:  https://github.com/rust-lang/rust/issues/74563
 #[proc_macro]
 pub fn event_enum(input: TokenStream) -> TokenStream {
     let event_enum_input = syn::parse_macro_input!(input as EventEnumInput);

--- a/crates/ruma-events-macros/src/lib.rs
+++ b/crates/ruma-events-macros/src/lib.rs
@@ -35,19 +35,20 @@ mod event_parse;
 ///
 /// # Examples
 ///
-/// ```ignore
-/// # // HACK: "ignore" the doctest here because it needs ruma_events, which cannot be imported
-/// # // without becoming a cyclical dependency.
+/// ```no_run
 /// use ruma_events_macros::event_enum;
 ///
 /// event_enum! {
-///     kind: BarEvent, // `BarEvent` has to be a valid type at `::ruma_events::BarEvent`
+///     kind: ToDevice,
 ///     events: [
 ///         "m.any.event",
 ///         "m.other.event",
 ///     ]
 /// }
 /// ```
+/// (The argument to `kind` has to be a valid identifier for `<EventKind as Parse>::parse`)
+//// TODO: Change above (`<EventKind as Parse>::parse`) to [] after fully qualified syntax is supported:
+////  https://github.com/rust-lang/rust/issues/74563
 #[proc_macro]
 pub fn event_enum(input: TokenStream) -> TokenStream {
     let event_enum_input = syn::parse_macro_input!(input as EventEnumInput);

--- a/crates/ruma-events-macros/src/lib.rs
+++ b/crates/ruma-events-macros/src/lib.rs
@@ -41,7 +41,7 @@ mod event_parse;
 /// use ruma_events_macros::event_enum;
 ///
 /// event_enum! {
-///     kind: ToDevice, // `BarEvent` has to be a valid type at `::ruma_events::BarEvent`
+///     kind: BarEvent, // `BarEvent` has to be a valid type at `::ruma_events::BarEvent`
 ///     events: [
 ///         "m.any.event",
 ///         "m.other.event",

--- a/crates/ruma-events-macros/src/lib.rs
+++ b/crates/ruma-events-macros/src/lib.rs
@@ -36,10 +36,12 @@ mod event_parse;
 /// # Examples
 ///
 /// ```ignore
+/// # // HACK: "ignore" the doctest here because it needs ruma_events, which cannot be imported
+/// # // without becoming a cyclical dependency.
 /// use ruma_events_macros::event_enum;
 ///
 /// event_enum! {
-///     name: AnyBarEvent, // `BarEvent` has to be a valid type at `::ruma_events::BarEvent`
+///     kind: ToDevice, // `BarEvent` has to be a valid type at `::ruma_events::BarEvent`
 ///     events: [
 ///         "m.any.event",
 ///         "m.other.event",

--- a/crates/ruma-events-macros/src/lib.rs
+++ b/crates/ruma-events-macros/src/lib.rs
@@ -35,7 +35,8 @@ mod event_parse;
 ///
 /// # Examples
 ///
-/// ```no_run
+/// ```ignore
+/// # // HACK: This is "ignore" because of cyclical dependency drama.
 /// use ruma_events_macros::event_enum;
 ///
 /// event_enum! {

--- a/crates/ruma-serde-macros/src/lib.rs
+++ b/crates/ruma-serde-macros/src/lib.rs
@@ -27,6 +27,7 @@ mod util;
 /// of the struct, this simple implementation will be generated:
 ///
 /// ```ignore
+/// # // TODO: "ignore" this doctest until it is more extensively documented.
 /// impl Outgoing for MyType {
 ///     type Incoming = Self;
 /// }

--- a/crates/ruma-serde-macros/src/lib.rs
+++ b/crates/ruma-serde-macros/src/lib.rs
@@ -27,7 +27,7 @@ mod util;
 /// of the struct, this simple implementation will be generated:
 ///
 /// ```ignore
-/// # // TODO: "ignore" this doctest until it is more extensively documented.
+/// # // TODO: "ignore" this doctest until it is more extensively documented. (See #541)
 /// impl Outgoing for MyType {
 ///     type Incoming = Self;
 /// }

--- a/crates/ruma-serde/src/raw.rs
+++ b/crates/ruma-serde/src/raw.rs
@@ -22,9 +22,12 @@ use crate::cow::MyCowStr;
 /// All event structs and enums implement `Serialize` / `Deserialize`, `Raw` should be used
 /// to pass around events in a lossless way.
 ///
-/// ```ignore
-/// # // HACK: "ignore" the doctest here because `AnyRoomEvent` comes from ruma_events, which cannot
-/// # // be depended on without creating a cyclical dependency.
+/// ```no_run
+/// # use serde::Deserialize;
+/// # use ruma_serde::Raw;
+/// # #[derive(Deserialize)]
+/// # struct AnyRoomEvent;
+///
 /// let json = r#"{ "type": "imagine a full event", "content": {...} }"#;
 ///
 /// let deser = serde_json::from_str::<Raw<AnyRoomEvent>>(json)

--- a/crates/ruma-serde/src/raw.rs
+++ b/crates/ruma-serde/src/raw.rs
@@ -23,6 +23,8 @@ use crate::cow::MyCowStr;
 /// to pass around events in a lossless way.
 ///
 /// ```ignore
+/// # // HACK: "ignore" the doctest here because `AnyRoomEvent` comes from ruma_events, which cannot
+/// # // be depended on without creating a cyclical dependency.
 /// let json = r#"{ "type": "imagine a full event", "content": {...} }"#;
 ///
 /// let deser = serde_json::from_str::<Raw<AnyRoomEvent>>(json)


### PR DESCRIPTION
Fixes #541.

This adds the actual reason why some tests cannot be `no_run`, and one actual TODO label for `ruma-events-macros`.