### PR TITLE
Add the remaining to-device key verification events

### DIFF
--- a/crates/ruma-client-api/src/r0/to_device.rs
+++ b/crates/ruma-client-api/src/r0/to_device.rs
@@ -32,6 +32,12 @@ impl Display for DeviceIdOrAllDevices {
     }
 }
 
+impl From<DeviceIdBox> for DeviceIdOrAllDevices {
+    fn from(d: DeviceIdBox) -> Self {
+        DeviceIdOrAllDevices::DeviceId(d)
+    }
+}
+
 impl TryFrom<&str> for DeviceIdOrAllDevices {
     type Error = &'static str;
     fn try_from(device_id_or_all_devices: &str) -> Result<Self, Self::Error> {

--- a/crates/ruma-events/src/enums.rs
+++ b/crates/ruma-events/src/enums.rs
@@ -107,6 +107,9 @@ event_enum! {
         "m.room_key_request",
         "m.forwarded_room_key",
         "m.key.verification.request",
+        #[cfg(feature = "unstable-pre-spec")]
+        #[cfg_attr(docsrs, doc(cfg(feature = "unstable-pre-spec")))]
+        "m.key.verification.ready",
         "m.key.verification.start",
         "m.key.verification.cancel",
         "m.key.verification.accept",

--- a/crates/ruma-events/src/enums.rs
+++ b/crates/ruma-events/src/enums.rs
@@ -115,6 +115,9 @@ event_enum! {
         "m.key.verification.accept",
         "m.key.verification.key",
         "m.key.verification.mac",
+        #[cfg(feature = "unstable-pre-spec")]
+        #[cfg_attr(docsrs, doc(cfg(feature = "unstable-pre-spec")))]
+        "m.key.verification.done",
         "m.room.encrypted",
     ]
 }

--- a/crates/ruma-events/src/event_type.rs
+++ b/crates/ruma-events/src/event_type.rs
@@ -56,6 +56,10 @@ pub enum EventType {
     #[ruma_enum(rename = "m.key.verification.mac")]
     KeyVerificationMac,
 
+    /// m.key.verification.ready
+    #[ruma_enum(rename = "m.key.verification.ready")]
+    KeyVerificationReady,
+
     /// m.key.verification.request
     #[ruma_enum(rename = "m.key.verification.request")]
     KeyVerificationRequest,
@@ -229,6 +233,7 @@ mod tests {
         serde_json_eq(EventType::KeyVerificationCancel, json!("m.key.verification.cancel"));
         serde_json_eq(EventType::KeyVerificationKey, json!("m.key.verification.key"));
         serde_json_eq(EventType::KeyVerificationMac, json!("m.key.verification.mac"));
+        serde_json_eq(EventType::KeyVerificationReady, json!("m.key.verification.ready"));
         serde_json_eq(EventType::KeyVerificationRequest, json!("m.key.verification.request"));
         serde_json_eq(EventType::KeyVerificationStart, json!("m.key.verification.start"));
         serde_json_eq(EventType::IgnoredUserList, json!("m.ignored_user_list"));

--- a/crates/ruma-events/src/event_type.rs
+++ b/crates/ruma-events/src/event_type.rs
@@ -48,6 +48,10 @@ pub enum EventType {
     #[ruma_enum(rename = "m.key.verification.cancel")]
     KeyVerificationCancel,
 
+    /// m.key.verification.done
+    #[ruma_enum(rename = "m.key.verification.done")]
+    KeyVerificationDone,
+
     /// m.key.verification.key
     #[ruma_enum(rename = "m.key.verification.key")]
     KeyVerificationKey,
@@ -231,6 +235,7 @@ mod tests {
         serde_json_eq(EventType::FullyRead, json!("m.fully_read"));
         serde_json_eq(EventType::KeyVerificationAccept, json!("m.key.verification.accept"));
         serde_json_eq(EventType::KeyVerificationCancel, json!("m.key.verification.cancel"));
+        serde_json_eq(EventType::KeyVerificationDone, json!("m.key.verification.done"));
         serde_json_eq(EventType::KeyVerificationKey, json!("m.key.verification.key"));
         serde_json_eq(EventType::KeyVerificationMac, json!("m.key.verification.mac"));
         serde_json_eq(EventType::KeyVerificationReady, json!("m.key.verification.ready"));

--- a/crates/ruma-events/src/key/verification/done.rs
+++ b/crates/ruma-events/src/key/verification/done.rs
@@ -1,6 +1,6 @@
 //! Types for the *m.key.verification.done* event.
 
-use ruma_events_macros::MessageEventContent;
+use ruma_events_macros::{EventContent, MessageEventContent};
 use serde::{Deserialize, Serialize};
 
 use super::Relation;
@@ -10,7 +10,17 @@ use crate::MessageEvent;
 /// concluded.
 pub type DoneEvent = MessageEvent<DoneEventContent>;
 
-/// The payload for `DoneEvent`.
+/// The payload for a to-device `m.key.verification.done` event.
+#[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
+#[ruma_event(type = "m.key.verification.done")]
+pub struct DoneToDeviceEventContent {
+    /// An opaque identifier for the verification process.
+    ///
+    /// Must be the same as the one used for the *m.key.verification.start* message.
+    pub transaction_id: String,
+}
+
+/// The payload for a in-room `m.key.verification.done` event.
 #[derive(Clone, Debug, Deserialize, Serialize, MessageEventContent)]
 #[ruma_event(type = "m.key.verification.done")]
 pub struct DoneEventContent {


### PR DESCRIPTION
This adds the `*.done` and `*.ready` key verification events as to-device variants.