### PR TITLE
Add deserialize_redacted_content

### DIFF
--- a/crates/ruma-events/src/lib.rs
+++ b/crates/ruma-events/src/lib.rs
@@ -288,6 +288,16 @@ pub trait RawExt<T> {
     fn deserialize_content(&self, event_type: &str) -> serde_json::Result<T>
     where
         T: EventContent;
+
+    /// Try to deserialize the JSON as an event's redacted content.
+    ///
+    /// This method works even if the JSON is a non-redacted event content, effectively redacting it
+    /// through deserialization (which is more efficient than first deserializing the full content
+    /// to then redact it).
+    fn deserialize_redacted_content(&self, event_type: &str) -> serde_json::Result<T::Redacted>
+    where
+        T: RedactContent,
+        T::Redacted: EventContent;
 }
 
 impl<T> RawExt<T> for Raw<T> {
@@ -296,6 +306,14 @@ impl<T> RawExt<T> for Raw<T> {
         T: EventContent,
     {
         T::from_parts(event_type, self.json())
+    }
+
+    fn deserialize_redacted_content(&self, event_type: &str) -> serde_json::Result<T::Redacted>
+    where
+        T: RedactContent,
+        T::Redacted: EventContent,
+    {
+        T::Redacted::from_parts(event_type, self.json())
     }
 }
 

--- a/crates/ruma-events/src/lib.rs
+++ b/crates/ruma-events/src/lib.rs
@@ -283,13 +283,18 @@ pub trait RedactContent {
 }
 
 /// Extension trait for [`Raw<_>`][ruma_serde::Raw].
-pub trait RawExt<T: EventContent> {
+pub trait RawExt<T> {
     /// Try to deserialize the JSON as an event's content.
-    fn deserialize_content(&self, event_type: &str) -> serde_json::Result<T>;
+    fn deserialize_content(&self, event_type: &str) -> serde_json::Result<T>
+    where
+        T: EventContent;
 }
 
-impl<T: EventContent> RawExt<T> for Raw<T> {
-    fn deserialize_content(&self, event_type: &str) -> serde_json::Result<T> {
+impl<T> RawExt<T> for Raw<T> {
+    fn deserialize_content(&self, event_type: &str) -> serde_json::Result<T>
+    where
+        T: EventContent,
+    {
         T::from_parts(event_type, self.json())
     }
 }


### PR DESCRIPTION
This almost works, but version-specific stuff means that we need a little more. I see two solutions:

* Version-specific deserialization. Likely more code.
* My preference: re-redacting redacted events. So basically first deserialize all of the fields that *might* be kept in redaction, then supply the room version to get rid of any fields that still need to be removed.