### PR TITLE
events: Improve room::message::TextMessageEventContent::markdown

### DIFF
--- a/crates/ruma-events/src/room/message.rs
+++ b/crates/ruma-events/src/room/message.rs
@@ -430,13 +430,8 @@ impl EmoteMessageEventContent {
     /// plain-text emote.
     #[cfg(feature = "markdown")]
     #[cfg_attr(docsrs, doc(cfg(feature = "markdown")))]
-    pub fn markdown(body: impl Into<String>) -> Self {
-        let body = body.into();
-
-        match FormattedBody::markdown(&body) {
-            Some(formatted_body) => Self { formatted: Some(formatted_body), ..Self::plain(body) },
-            _ => Self::plain(body),
-        }
+    pub fn markdown(body: impl AsRef<str> + Into<String>) -> Self {
+        Self { formatted: FormattedBody::markdown(&body), ..Self::plain(body) }
     }
 }
 
@@ -592,13 +587,8 @@ impl NoticeMessageEventContent {
     /// text notice.
     #[cfg(feature = "markdown")]
     #[cfg_attr(docsrs, doc(cfg(feature = "markdown")))]
-    pub fn markdown(body: impl Into<String>) -> Self {
-        let body = body.into();
-
-        match FormattedBody::markdown(&body) {
-            Some(formatted_body) => Self { formatted: Some(formatted_body), ..Self::plain(body) },
-            _ => Self::plain(body),
-        }
+    pub fn markdown(body: impl AsRef<str> + Into<String>) -> Self {
+        Self { formatted: FormattedBody::markdown(&body), ..Self::plain(body) }
     }
 }
 
@@ -692,14 +682,14 @@ impl FormattedBody {
 
     /// Creates a new HTML-formatted message body by parsing the markdown in `body`.
     ///
-    /// Returns None if no markdown formatting was found.
+    /// Returns `None` if no markdown formatting was found.
     #[cfg(feature = "markdown")]
     #[cfg_attr(docsrs, doc(cfg(feature = "markdown")))]
-    pub fn markdown(body: impl Into<String>) -> Option<Self> {
-        let body = body.into();
+    pub fn markdown(body: impl AsRef<str>) -> Option<Self> {
+        let body = body.as_ref();
         let mut html_body = String::new();
 
-        pulldown_cmark::html::push_html(&mut html_body, pulldown_cmark::Parser::new(&body));
+        pulldown_cmark::html::push_html(&mut html_body, pulldown_cmark::Parser::new(body));
 
         if html_body == format!("<p>{}</p>\n", body) {
             None
@@ -739,13 +729,8 @@ impl TextMessageEventContent {
     /// text message.
     #[cfg(feature = "markdown")]
     #[cfg_attr(docsrs, doc(cfg(feature = "markdown")))]
-    pub fn markdown(body: impl Into<String>) -> Self {
-        let body = body.into();
-
-        match FormattedBody::markdown(&body) {
-            Some(formatted_body) => Self { formatted: Some(formatted_body), ..Self::plain(body) },
-            _ => Self::plain(body),
-        }
+    pub fn markdown(body: impl AsRef<str> + Into<String>) -> Self {
+        Self { formatted: FormattedBody::markdown(&body), ..Self::plain(body) }
     }
 
     /// A convenience constructor to create a plain text message.

--- a/crates/ruma-events/src/room/message.rs
+++ b/crates/ruma-events/src/room/message.rs
@@ -425,13 +425,18 @@ impl EmoteMessageEventContent {
     }
 
     /// A convenience constructor to create a markdown emote.
+    ///
+    /// Returns an html emote message if some markdown formatting was detected, otherwise returns a
+    /// plain-text emote.
     #[cfg(feature = "markdown")]
     #[cfg_attr(docsrs, doc(cfg(feature = "markdown")))]
     pub fn markdown(body: impl Into<String>) -> Self {
         let body = body.into();
-        let mut html_body = String::new();
-        pulldown_cmark::html::push_html(&mut html_body, pulldown_cmark::Parser::new(&body));
-        Self::html(body, html_body)
+
+        match FormattedBody::markdown(&body) {
+            Some(formatted_body) => Self { formatted: Some(formatted_body), ..Self::plain(body) },
+            _ => Self::plain(body),
+        }
     }
 }
 
@@ -580,6 +585,21 @@ impl NoticeMessageEventContent {
     pub fn html(body: impl Into<String>, html_body: impl Into<String>) -> Self {
         Self { formatted: Some(FormattedBody::html(html_body)), ..Self::plain(body) }
     }
+
+    /// A convenience constructor to create a markdown notice.
+    ///
+    /// Returns an html notice if some markdown formatting was detected, otherwise returns a plain
+    /// text notice.
+    #[cfg(feature = "markdown")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "markdown")))]
+    pub fn markdown(body: impl Into<String>) -> Self {
+        let body = body.into();
+
+        match FormattedBody::markdown(&body) {
+            Some(formatted_body) => Self { formatted: Some(formatted_body), ..Self::plain(body) },
+            _ => Self::plain(body),
+        }
+    }
 }
 
 /// The payload for a server notice message.
@@ -669,6 +689,24 @@ impl FormattedBody {
     pub fn html(body: impl Into<String>) -> Self {
         Self { format: MessageFormat::Html, body: body.into() }
     }
+
+    /// Creates a new HTML-formatted message body by parsing the markdown in `body`.
+    ///
+    /// Returns None if no markdown formatting was found.
+    #[cfg(feature = "markdown")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "markdown")))]
+    pub fn markdown(body: impl Into<String>) -> Option<Self> {
+        let body = body.into();
+        let mut html_body = String::new();
+
+        pulldown_cmark::html::push_html(&mut html_body, pulldown_cmark::Parser::new(&body));
+
+        if html_body == format!("<p>{}</p>\n", body) {
+            None
+        } else {
+            Some(Self::html(html_body))
+        }
+    }
 }
 
 /// The payload for a text message.
@@ -696,13 +734,18 @@ impl TextMessageEventContent {
     }
 
     /// A convenience constructor to create a markdown message.
+    ///
+    /// Returns an html message if some markdown formatting was detected, otherwise returns a plain
+    /// text message.
     #[cfg(feature = "markdown")]
     #[cfg_attr(docsrs, doc(cfg(feature = "markdown")))]
     pub fn markdown(body: impl Into<String>) -> Self {
         let body = body.into();
-        let mut html_body = String::new();
-        pulldown_cmark::html::push_html(&mut html_body, pulldown_cmark::Parser::new(&body));
-        Self::html(body, html_body)
+
+        match FormattedBody::markdown(&body) {
+            Some(formatted_body) => Self { formatted: Some(formatted_body), ..Self::plain(body) },
+            _ => Self::plain(body),
+        }
     }
 
     /// A convenience constructor to create a plain text message.

--- a/crates/ruma-events/tests/room_message.rs
+++ b/crates/ruma-events/tests/room_message.rs
@@ -163,6 +163,50 @@ fn plain_text_content_serialization() {
 }
 
 #[test]
+#[cfg(feature = "markdown")]
+fn markdown_content_serialization() {
+    let formatted_message = MessageEventContent::new(MessageType::Text(
+        TextMessageEventContent::markdown("Testing **bold** and _italic_!"),
+    ));
+
+    assert_eq!(
+        to_json_value(&formatted_message).unwrap(),
+        json!({
+            "body": "Testing **bold** and _italic_!",
+            "formatted_body": "<p>Testing <strong>bold</strong> and <em>italic</em>!</p>\n",
+            "format": "org.matrix.custom.html",
+            "msgtype": "m.text"
+        })
+    );
+
+    let plain_message_simple = MessageEventContent::new(MessageType::Text(
+        TextMessageEventContent::markdown("Testing a simple phrase…"),
+    ));
+
+    assert_eq!(
+        to_json_value(&plain_message_simple).unwrap(),
+        json!({
+            "body": "Testing a simple phrase…",
+            "msgtype": "m.text"
+        })
+    );
+
+    let plain_message_paragraphs = MessageEventContent::new(MessageType::Text(
+        TextMessageEventContent::markdown("Testing\n\nSeveral\n\nParagraphs."),
+    ));
+
+    assert_eq!(
+        to_json_value(&plain_message_paragraphs).unwrap(),
+        json!({
+            "body": "Testing\n\nSeveral\n\nParagraphs.",
+            "formatted_body": "<p>Testing</p>\n<p>Several</p>\n<p>Paragraphs.</p>\n",
+            "format": "org.matrix.custom.html",
+            "msgtype": "m.text"
+        })
+    );
+}
+
+#[test]
 fn relates_to_content_serialization() {
     let message_event_content =
         assign!(MessageEventContent::text_plain("> <@test:example.com> test\n\ntest reply"), {


### PR DESCRIPTION
It only returns an HTML message if some markdown formatting was detected.

Since `Parser` doesn't implement the clone trait I used its constructor twice. I don't know if you prefer another way.