### PR TITLE
Space related event changes

### DIFF
--- a/crates/ruma-client-api/src/r0/room/create_room.rs
+++ b/crates/ruma-client-api/src/r0/room/create_room.rs
@@ -159,7 +159,11 @@ impl CreationContent {
         room_version: RoomVersionId,
     ) -> CreateEventContent {
         #[allow(unused_mut)]
-        let mut content = assign!(CreateEventContent::new(creator), { federate: self.federate, room_version: room_version, predecessor:self.predecessor });
+        let mut content = assign!(CreateEventContent::new(creator), {
+            federate: self.federate,
+            room_version: room_version,
+            predecessor: self.predecessor
+        });
 
         #[cfg(feature = "unstable-pre-spec")]
         {

--- a/crates/ruma-client-api/src/r0/room/create_room.rs
+++ b/crates/ruma-client-api/src/r0/room/create_room.rs
@@ -129,27 +129,31 @@ pub struct CreationContent {
     /// A reference to the room this room replaces, if the previous room was upgraded.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub predecessor: Option<PreviousRoom>,
+
+    /// The room type that shall be set. This is currently used for spaces
+    #[serde(skip_serializing_if = "Option::is_none", rename = "type")]
+    pub room_type: Option<String>,
 }
 
 impl CreationContent {
     /// Creates a new `CreationContent` with all fields defaulted.
     pub fn new() -> Self {
-        Self { federate: true, predecessor: None }
+        Self { federate: true, predecessor: None, room_type: None }
     }
 
     /// Given a `CreationContent` and the other fields that a homeserver has to fill, construct
     /// a `CreateEventContent`.
     pub fn into_event_content(
-        Self { federate, predecessor }: Self,
+        Self { federate, predecessor, room_type }: Self,
         creator: UserId,
         room_version: RoomVersionId,
     ) -> CreateEventContent {
-        assign!(CreateEventContent::new(creator), { federate, room_version, predecessor })
+        assign!(CreateEventContent::new(creator), { federate, room_version, predecessor, room_type })
     }
 
     /// Returns whether all fields have their default value.
     pub fn is_empty(&self) -> bool {
-        self.federate && self.predecessor.is_none()
+        self.federate && self.predecessor.is_none() && self.room_type.is_none()
     }
 }
 

--- a/crates/ruma-client-api/src/r0/room/create_room.rs
+++ b/crates/ruma-client-api/src/r0/room/create_room.rs
@@ -134,7 +134,7 @@ pub struct CreationContent {
 
     /// The room type.
     ///
-    /// This is currently only used for spaces
+    /// This is currently only used for spaces.
     #[cfg(feature = "unstable-pre-spec")]
     #[serde(skip_serializing_if = "Option::is_none", rename = "type")]
     pub room_type: Option<RoomType>,

--- a/crates/ruma-client-api/src/r0/room/create_room.rs
+++ b/crates/ruma-client-api/src/r0/room/create_room.rs
@@ -162,7 +162,7 @@ impl CreationContent {
         let mut content = assign!(CreateEventContent::new(creator), {
             federate: self.federate,
             room_version: room_version,
-            predecessor: self.predecessor
+            predecessor: self.predecessor,
         });
 
         #[cfg(feature = "unstable-pre-spec")]

--- a/crates/ruma-events/src/enums.rs
+++ b/crates/ruma-events/src/enums.rs
@@ -85,6 +85,12 @@ event_enum! {
         "m.room.third_party_invite",
         "m.room.tombstone",
         "m.room.topic",
+        #[cfg(feature = "unstable-pre-spec")]
+        #[cfg_attr(docsrs, doc(cfg(feature = "unstable-pre-spec")))]
+        "m.space.child",
+        #[cfg(feature = "unstable-pre-spec")]
+        #[cfg_attr(docsrs, doc(cfg(feature = "unstable-pre-spec")))]
+        "m.space.parent",
     }
 
     /// Any to-device event.

--- a/crates/ruma-events/src/lib.rs
+++ b/crates/ruma-events/src/lib.rs
@@ -176,6 +176,9 @@ pub mod relation;
 pub mod room;
 pub mod room_key;
 pub mod room_key_request;
+#[cfg(feature = "unstable-pre-spec")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable-pre-spec")))]
+pub mod space;
 pub mod sticker;
 pub mod tag;
 pub mod typing;

--- a/crates/ruma-events/src/room/create.rs
+++ b/crates/ruma-events/src/room/create.rs
@@ -36,7 +36,9 @@ pub struct CreateEventContent {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub predecessor: Option<PreviousRoom>,
 
-    /// The room type that shall be set. This is currently used for spaces
+    /// The room type.
+    ///
+    /// This is currently only used for spaces.
     #[cfg(feature = "unstable-pre-spec")]
     #[serde(skip_serializing_if = "Option::is_none", rename = "type")]
     pub room_type: Option<RoomType>,
@@ -56,13 +58,13 @@ impl CreateEventContent {
     }
 }
 
-/// An enum of possible room types
+/// An enum of possible room types.
 #[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
 pub enum RoomType {
-    /// Defines the room as a space
+    /// Defines the room as a space.
     #[ruma_enum(rename = "m.space")]
     Space,
-    /// Defines the room as a custom type
+    /// Defines the room as a custom type.
     #[doc(hidden)]
     _Custom(String),
 }

--- a/crates/ruma-events/src/space.rs
+++ b/crates/ruma-events/src/space.rs
@@ -1,0 +1,8 @@
+//! Types for the *m.space* events.
+//!
+//! See [MSC2758] and [MSC1772].
+//! [MSC2758]: https://github.com/matrix-org/matrix-doc/blob/master/proposals/2758-textual-id-grammar.md
+//! [MSC1772]: https://github.com/matrix-org/matrix-doc/blob/master/proposals/1772-groups-as-rooms.md
+
+pub mod child;
+pub mod parent;

--- a/crates/ruma-events/src/space/child.rs
+++ b/crates/ruma-events/src/space/child.rs
@@ -1,0 +1,78 @@
+//! Types for the *m.space.child* event.
+
+use ruma_events_macros::EventContent;
+use ruma_identifiers::ServerNameBox;
+use serde::{Deserialize, Serialize};
+
+use crate::StateEvent;
+
+/// The admins of a space can advertise rooms and subspaces for their space by setting
+/// `m.space.child` state events.
+///
+/// The `state_key` is the ID of a child room or space, and the content must contain a `via` key
+/// which gives a list of candidate servers that can be used to join the room.
+pub type ChildEvent = StateEvent<ChildEventContent>;
+
+/// The payload for `ChildEvent`.
+#[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+#[ruma_event(type = "m.space.child", kind = State)]
+pub struct ChildEventContent {
+    /// List of candidate servers that can be used to join the room.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub via: Option<Vec<ServerNameBox>>,
+
+    /// Provide a default ordering of siblings in the room list.
+    ///
+    /// Rooms are sorted based on a lexicographic ordering of the Unicode codepoints of the
+    /// characters in `order` values. Rooms with no `order` come last, in ascending numeric order
+    /// of the origin_server_ts of their m.room.create events, or ascending lexicographic order of
+    /// their room_ids in case of equal `origin_server_ts`. `order`s which are not strings, or do
+    /// not consist solely of ascii characters in the range `\x20` (space) to `\x7E` (`~`), or
+    /// consist of more than 50 characters, are forbidden and the field should be ignored if
+    /// received.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub order: Option<String>,
+
+    /// Space admins can mark particular children of a space as "suggested".
+    ///
+    /// This mainly serves as a hint to clients that that they can be displayed differently, for
+    /// example by showing them eagerly in the room list. A child which is missing the `suggested`
+    /// property is treated identically to a child with `"suggested": false`. A suggested child may
+    /// be a room or a subspace.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub suggested: Option<bool>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ChildEventContent;
+    use ruma_identifiers::server_name;
+    use serde_json::{json, to_value as to_json_value};
+
+    #[test]
+    fn space_child_serialization() {
+        let content = ChildEventContent {
+            via: Some(vec![server_name!("example.com")]),
+            order: Some("uwu".to_owned()),
+            suggested: Some(false),
+        };
+
+        let json = json!({
+            "via": ["example.com"],
+            "order": "uwu",
+            "suggested": false,
+        });
+
+        assert_eq!(to_json_value(&content).unwrap(), json);
+    }
+
+    #[test]
+    fn space_child_empty_serialization() {
+        let content = ChildEventContent { via: None, order: None, suggested: None };
+
+        let json = json!({});
+
+        assert_eq!(to_json_value(&content).unwrap(), json);
+    }
+}

--- a/crates/ruma-events/src/space/parent.rs
+++ b/crates/ruma-events/src/space/parent.rs
@@ -1,0 +1,64 @@
+//! Types for the *m.space.child* event.
+
+use ruma_events_macros::EventContent;
+use ruma_identifiers::ServerNameBox;
+use serde::{Deserialize, Serialize};
+
+use crate::StateEvent;
+
+/// Rooms can claim parents via the `m.space.parent` state event.
+///
+/// Similar to `m.space.child`, the `state_key` is the ID of the parent space, and the content must
+/// contain a `via` key which gives a list of candidate servers that can be used to join the
+/// parent.
+pub type ParentEvent = StateEvent<ParentEventContent>;
+
+/// The payload for `ParentEvent`.
+#[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+#[ruma_event(type = "m.space.child", kind = State)]
+pub struct ParentEventContent {
+    /// List of candidate servers that can be used to join the room.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub via: Option<Vec<ServerNameBox>>,
+
+    /// Determines whether this is the main parent for the space.
+    ///
+    /// When a user joins a room with a canonical parent, clients may switch to view the room in
+    /// the context of that space, peeking into it in order to find other rooms and group them
+    /// together. In practice, well behaved rooms should only have one `canonical` parent, but
+    /// given this is not enforced: if multiple are present the client should select the one with
+    /// the lowest room ID, as determined via a lexicographic ordering of the Unicode code-points.
+    pub canonical: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ParentEventContent;
+    use ruma_identifiers::server_name;
+    use serde_json::{json, to_value as to_json_value};
+
+    #[test]
+    fn space_parent_serialization() {
+        let content =
+            ParentEventContent { via: Some(vec![server_name!("example.com")]), canonical: true };
+
+        let json = json!({
+            "via": ["example.com"],
+            "canonical": true,
+        });
+
+        assert_eq!(to_json_value(&content).unwrap(), json);
+    }
+
+    #[test]
+    fn space_parent_empty_serialization() {
+        let content = ParentEventContent { via: None, canonical: true };
+
+        let json = json!({
+            "canonical": true,
+        });
+
+        assert_eq!(to_json_value(&content).unwrap(), json);
+    }
+}


### PR DESCRIPTION
This PR adds the required parts needed for https://github.com/matrix-org/matrix-doc/pull/1772 

TODOs:

- [x] Add `m.space.child` See https://github.com/MTRNord/ruma/pull/1
- [x] Add `m.space.parent` See https://github.com/MTRNord/ruma/pull/1

The prop is called `room_type` in the `m.room.create` event because `type` is reserved in rust.

Also this PR will not cover the summary API synapse has for spaces. Therefor this only partially tackles #445