### PR TITLE
Typo corrections

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ Specification type | Rust type
 `[…]`              | `Vec<…>`
 `{string: …}`      | `BTreeMap<String, …>` (or `BTreeMap<SomeId, …>`)
 
-### (Type) Privacy and Forwards Compatiblity
+### (Type) Privacy and Forwards Compatibility
 
 Generally, all `struct`s that are mirroring types defined in the Matrix specification should have
 all their fields `pub`lic. Where there are restrictions to the fields value beyond their type, these

--- a/crates/ruma-api/src/error.rs
+++ b/crates/ruma-api/src/error.rs
@@ -15,7 +15,7 @@ use crate::{EndpointError, OutgoingResponse};
 /// Note that individual `ruma-*-api` crates may provide more specific error types.
 #[derive(Clone, Debug)]
 pub struct MatrixError {
-    /// The http reponse's status code.
+    /// The http response's status code.
     pub status_code: http::StatusCode,
 
     /// The http response's body.

--- a/crates/ruma-client-api/src/r0/directory.rs
+++ b/crates/ruma-client-api/src/r0/directory.rs
@@ -59,7 +59,7 @@ impl PublicRoomsChunk {
     /// Creates a new `PublicRoomsChunk` with the given room ID.
     ///
     /// All other fields will be propagated with default values (an empty list of aliases, `None`
-    /// for all `Option`al fields and `false` for all boolean fields), which should be overriden;
+    /// for all `Option`al fields and `false` for all boolean fields), which should be overridden;
     /// the `assign!` macro from the `assign` crate can simplify this.
     pub fn new(room_id: RoomId) -> Self {
         Self {

--- a/crates/ruma-client-api/src/r0/push/get_pushrule_actions.rs
+++ b/crates/ruma-client-api/src/r0/push/get_pushrule_actions.rs
@@ -45,7 +45,7 @@ impl<'a> Request<'a> {
 }
 
 impl Response {
-    /// Creates a new `Repsonse` with the given actions.
+    /// Creates a new `Response` with the given actions.
     pub fn new(actions: Vec<Action>) -> Self {
         Self { actions }
     }

--- a/crates/ruma-client-api/src/r0/redact/redact_event.rs
+++ b/crates/ruma-client-api/src/r0/redact/redact_event.rs
@@ -43,7 +43,7 @@ ruma_api! {
 }
 
 impl<'a> Request<'a> {
-    /// Creates a new `Request` with the given room ID, event ID and transation ID.
+    /// Creates a new `Request` with the given room ID, event ID and transaction ID.
     pub fn new(room_id: &'a RoomId, event_id: &'a EventId, txn_id: &'a str) -> Self {
         Self { room_id, event_id, txn_id, reason: None }
     }

--- a/crates/ruma-client-api/src/r0/room/create_room.rs
+++ b/crates/ruma-client-api/src/r0/room/create_room.rs
@@ -36,7 +36,7 @@ ruma_api! {
 
         /// List of state events to send to the new room.
         ///
-        /// Takes precedence over events set by preset, but gets overriden by
+        /// Takes precedence over events set by preset, but gets overridden by
         /// name and topic keys.
         #[serde(default, skip_serializing_if = "<[_]>::is_empty")]
         pub initial_state: &'a [AnyInitialStateEvent],

--- a/crates/ruma-client-api/src/r0/thirdparty/get_location_for_room_alias.rs
+++ b/crates/ruma-client-api/src/r0/thirdparty/get_location_for_room_alias.rs
@@ -37,7 +37,7 @@ impl<'a> Request<'a> {
 }
 
 impl Response {
-    /// Creates a new `Reponse` with the given locations.
+    /// Creates a new `Response` with the given locations.
     pub fn new(locations: Vec<Location>) -> Self {
         Self { locations }
     }

--- a/crates/ruma-client-api/src/r0/thirdparty/get_protocol.rs
+++ b/crates/ruma-client-api/src/r0/thirdparty/get_protocol.rs
@@ -36,7 +36,7 @@ impl<'a> Request<'a> {
 }
 
 impl Response {
-    /// Creates a new `Response` with the given procotol.
+    /// Creates a new `Response` with the given protocol.
     pub fn new(protocol: Protocol) -> Self {
         Self { protocol }
     }

--- a/crates/ruma-client-api/src/r0/thirdparty/get_protocols.rs
+++ b/crates/ruma-client-api/src/r0/thirdparty/get_protocols.rs
@@ -35,7 +35,7 @@ impl Request {
 }
 
 impl Response {
-    /// Creates a new `Response` with the given procotols.
+    /// Creates a new `Response` with the given protocols.
     pub fn new(protocols: BTreeMap<String, Protocol>) -> Self {
         Self { protocols }
     }

--- a/crates/ruma-events/src/lib.rs
+++ b/crates/ruma-events/src/lib.rs
@@ -281,7 +281,7 @@ pub trait RedactContent {
     /// A small number of events have room-version specific redaction behavior, so a version has to
     /// be specified.
     ///
-    /// Where applicable, it is prefered to use [`Redact::redact`] on the outer event.
+    /// Where applicable, it is preferred to use [`Redact::redact`] on the outer event.
     fn redact(self, version: &RoomVersionId) -> Self::Redacted;
 }
 

--- a/crates/ruma-identifiers/CHANGELOG.md
+++ b/crates/ruma-identifiers/CHANGELOG.md
@@ -210,7 +210,7 @@ Improvements:
 Breaking changes:
 
 * Our Minimum Supported Rust Version is now 1.36.0
-  * This is done in a patch version because it is only a documentation change. Practially, a new
+  * This is done in a patch version because it is only a documentation change. Practically, a new
     project using even ruma-identifiers 0.14 won't build out of the box on older versions of Rust
     because of an MSRV bump in a minor release of an indirect dependency. Using ruma-identifiers
     with older versions of Rust will potentially continue to work with some crates pinned to older

--- a/crates/ruma-identity-service-api/src/association/email.rs
+++ b/crates/ruma-identity-service-api/src/association/email.rs
@@ -1,4 +1,4 @@
-//! Endpoints to create an association betwen a Matrix ID and an email ID on the identity server.
+//! Endpoints to create an association between a Matrix ID and an email ID on the identity server.
 
 pub mod create_email_validation_session;
 pub mod validate_email;

--- a/crates/ruma-identity-service-api/src/tos.rs
+++ b/crates/ruma-identity-service-api/src/tos.rs
@@ -1,4 +1,4 @@
-//! Endpoints to retreive and accept terms of service of an identity server.
+//! Endpoints to retrieve and accept terms of service of an identity server.
 
 pub mod accept_terms_of_service;
 pub mod get_terms_of_service;

--- a/crates/ruma-identity-service-api/src/tos/get_terms_of_service/v2.rs
+++ b/crates/ruma-identity-service-api/src/tos/get_terms_of_service/v2.rs
@@ -65,7 +65,7 @@ pub struct LocalizedPolicy {
     /// Examples are "Terms of Service", "Conditions d'utilisation".
     pub name: String,
 
-    /// The URL at wich the policy is available.
+    /// The URL at which the policy is available.
     ///
     /// Examples are `https://example.org/somewhere/terms-2.0-en.html`
     /// and `https://example.org/somewhere/terms-2.0-fr.html`.

--- a/crates/ruma-state-res/src/lib.rs
+++ b/crates/ruma-state-res/src/lib.rs
@@ -175,7 +175,7 @@ impl StateResolution {
     ) -> (StateMap<EventId>, StateMap<Vec<EventId>>) {
         use itertools::Itertools;
 
-        info!("seperating {} sets of events into conflicted/unconflicted", state_sets.len());
+        info!("separating {} sets of events into conflicted/unconflicted", state_sets.len());
 
         let mut unconflicted_state = StateMap::new();
         let mut conflicted_state = StateMap::new();


### PR DESCRIPTION
The "comforming" typo in the function name at `crates/ruma-identifiers-validation/src/user_id.rs:22:26` was not corrected as that would be a breaking change, and I thought it best to make that a separate PR.