### PR TITLE
Add the --order flag to cargo sort

### DIFF
--- a/crates/ruma-api-macros/Cargo.toml
+++ b/crates/ruma-api-macros/Cargo.toml
@@ -14,11 +14,11 @@ repository = "https://github.com/ruma/ruma"
 version = "0.17.0"
 edition = "2018"
 
+[lib]
+proc-macro = true
+
 [dependencies]
 proc-macro-crate = "1.0.0"
 proc-macro2 = "1.0.24"
 quote = "1.0.8"
 syn = { version = "1.0.57", features = ["full", "visit"] }
-
-[lib]
-proc-macro = true

--- a/crates/ruma-api/Cargo.toml
+++ b/crates/ruma-api/Cargo.toml
@@ -18,6 +18,13 @@ edition = "2018"
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
+# These feature gates exist only for the tests. Disabling them results in a
+# compile error.
+[features]
+default = ["client", "server"]
+client = []
+server = []
+
 [dependencies]
 bytes = "1.0.1"
 http = "0.2.2"
@@ -32,10 +39,3 @@ thiserror = "1.0.23"
 [dev-dependencies]
 ruma-events = { version = "0.22.2", path = "../ruma-events" }
 trybuild = "1.0.38"
-
-# These feature gates exist only for the tests. Disabling them results in a
-# compile error.
-[features]
-default = ["client", "server"]
-client = []
-server = []

--- a/crates/ruma-appservice-api/Cargo.toml
+++ b/crates/ruma-appservice-api/Cargo.toml
@@ -14,6 +14,12 @@ edition = "2018"
 [package.metadata.docs.rs]
 all-features = true
 
+[features]
+unstable-exhaustive-types = []
+helper = ["ruma-client-api", "tracing"]
+client = []
+server = []
+
 [dependencies]
 ruma-api = { version = "0.17.0", path = "../ruma-api" }
 ruma-client-api = { version = "0.10.2", path = "../ruma-client-api", features = ["client"], optional = true }
@@ -28,9 +34,3 @@ tracing = { version = "0.1.25", optional = true }
 [dev-dependencies]
 matches = "0.1.8"
 serde_yaml = "0.8.17"
-
-[features]
-unstable-exhaustive-types = []
-helper = ["ruma-client-api", "tracing"]
-client = []
-server = []

--- a/crates/ruma-client-api/Cargo.toml
+++ b/crates/ruma-client-api/Cargo.toml
@@ -19,6 +19,14 @@ edition = "2018"
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
+[features]
+compat = []
+unstable-exhaustive-types = []
+# feature dependency required for r0::room::create_room::CreationContent::into_event_content
+unstable-pre-spec = ["ruma-events/unstable-pre-spec"]
+client = []
+server = []
+
 [dependencies]
 assign = "1.1.1"
 bytes = "1.0.1"
@@ -37,11 +45,3 @@ serde_json = "1.0.61"
 [dev-dependencies]
 maplit = "1.0.2"
 matches = "0.1.8"
-
-[features]
-compat = []
-unstable-exhaustive-types = []
-# feature dependency required for r0::room::create_room::CreationContent::into_event_content
-unstable-pre-spec = ["ruma-events/unstable-pre-spec"]
-client = []
-server = []

--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -14,6 +14,11 @@ edition = "2018"
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
+[features]
+compat = []
+unstable-exhaustive-types = []
+unstable-pre-spec = []
+
 [dependencies]
 indexmap = { version = "1.6.2", features = ["serde-1"] }
 js_int = { version = "0.2.0", features = ["serde"] }
@@ -27,8 +32,3 @@ wildmatch = "2.0.0"
 [dev-dependencies]
 maplit = "1.0.2"
 matches = "0.1.8"
-
-[features]
-compat = []
-unstable-exhaustive-types = []
-unstable-pre-spec = []

--- a/crates/ruma-events-macros/Cargo.toml
+++ b/crates/ruma-events-macros/Cargo.toml
@@ -15,11 +15,11 @@ readme = "README.md"
 repository = "https://github.com/ruma/ruma"
 version = "0.22.2"
 
+[lib]
+proc-macro = true
+
 [dependencies]
 proc-macro-crate = "1.0.0"
 proc-macro2 = "1.0.24"
 quote = "1.0.8"
 syn = { version = "1.0.57", features = ["extra-traits", "full"] }
-
-[lib]
-proc-macro = true

--- a/crates/ruma-events/Cargo.toml
+++ b/crates/ruma-events/Cargo.toml
@@ -15,6 +15,13 @@ edition = "2018"
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
+[features]
+compat = []
+markdown = ["pulldown-cmark"]
+
+unstable-exhaustive-types = []
+unstable-pre-spec = []
+
 [dependencies]
 criterion = { version = "0.3.3", optional = true }
 indoc = "1.0"
@@ -33,13 +40,6 @@ maplit = "1.0.2"
 matches = "0.1.8"
 ruma-identifiers = { version = "0.19.1", path = "../ruma-identifiers", features = ["rand"] }
 trybuild = "1.0.38"
-
-[features]
-compat = []
-markdown = ["pulldown-cmark"]
-
-unstable-exhaustive-types = []
-unstable-pre-spec = []
 
 [[bench]]
 name = "event_deserialize"

--- a/crates/ruma-federation-api/Cargo.toml
+++ b/crates/ruma-federation-api/Cargo.toml
@@ -18,6 +18,12 @@ version = "0.1.0"
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
+[features]
+unstable-exhaustive-types = []
+unstable-pre-spec = []
+client = []
+server = []
+
 [dependencies]
 js_int = { version = "0.2.0", features = ["serde"] }
 ruma-api = { version = "0.17.0", path = "../ruma-api" }
@@ -31,9 +37,3 @@ serde_json = "1.0.61"
 [dev-dependencies]
 http = "0.2.2"
 matches = "0.1.8"
-
-[features]
-unstable-exhaustive-types = []
-unstable-pre-spec = []
-client = []
-server = []

--- a/crates/ruma-identifiers-macros/Cargo.toml
+++ b/crates/ruma-identifiers-macros/Cargo.toml
@@ -9,10 +9,10 @@ repository = "https://github.com/ruma/ruma"
 version = "0.19.1"
 edition = "2018"
 
+[lib]
+proc-macro = true
+
 [dependencies]
 quote = "1.0.8"
 ruma-identifiers-validation = { version = "0.4.0", path = "../ruma-identifiers-validation", default-features = false }
 syn = "1.0.55"
-
-[lib]
-proc-macro = true

--- a/crates/ruma-identity-service-api/Cargo.toml
+++ b/crates/ruma-identity-service-api/Cargo.toml
@@ -13,6 +13,11 @@ edition = "2018"
 [package.metadata.docs.rs]
 all-features = true
 
+[features]
+unstable-exhaustive-types = []
+client = []
+server = []
+
 [dependencies]
 js_int = { version = "0.2.0", features = ["serde"] }
 ruma-api = { version = "0.17.0", path = "../ruma-api" }
@@ -23,8 +28,3 @@ serde = { version = "1.0.118", features = ["derive"] }
 
 [dev-dependencies]
 serde_json = "1.0.61"
-
-[features]
-unstable-exhaustive-types = []
-client = []
-server = []

--- a/crates/ruma-push-gateway-api/Cargo.toml
+++ b/crates/ruma-push-gateway-api/Cargo.toml
@@ -13,6 +13,11 @@ edition = "2018"
 [package.metadata.docs.rs]
 all-features = true
 
+[features]
+unstable-exhaustive-types = []
+client = []
+server = []
+
 [dependencies]
 js_int = { version = "0.2.0", features = ["serde"] }
 ruma-api = { version = "0.17.0", path = "../ruma-api" }
@@ -22,8 +27,3 @@ ruma-identifiers = { version = "0.19.1", path = "../ruma-identifiers" }
 ruma-serde = { version = "0.4.0", path = "../ruma-serde" }
 serde = { version = "1.0.118", features = ["derive"] }
 serde_json = "1.0.61"
-
-[features]
-unstable-exhaustive-types = []
-client = []
-server = []

--- a/crates/ruma-signatures/Cargo.toml
+++ b/crates/ruma-signatures/Cargo.toml
@@ -14,6 +14,9 @@ version = "0.7.2"
 [package.metadata.docs.rs]
 all-features = true
 
+[features]
+compat = ["tracing"]
+
 [dependencies]
 base64 = "0.13.0"
 ring = "0.16.19"
@@ -22,6 +25,3 @@ ruma-serde = { version = "0.4.0", path = "../ruma-serde" }
 serde_json = "1.0.60"
 tracing = { version = "0.1.25", optional = true }
 untrusted = "0.7.1"
-
-[features]
-compat = ["tracing"]

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -15,33 +15,6 @@ edition = "2018"
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
-[dependencies]
-assign = "1.1.1"
-js_int = "0.2.0"
-
-ruma-common = { version = "0.5.2", path = "../ruma-common" }
-ruma-identifiers = { version = "0.19.1", path = "../ruma-identifiers", features = ["serde"] }
-ruma-serde = { version = "0.4.0", path = "../ruma-serde" }
-
-ruma-client = { version = "0.5.0", path = "../ruma-client", optional = true }
-ruma-events = { version = "0.22.2", path = "../ruma-events", optional = true }
-ruma-signatures = { version = "0.7.2", path = "../ruma-signatures", optional = true }
-ruma-state-res = { version = "0.1.0", path = "../ruma-state-res", optional = true }
-
-ruma-api = { version = "0.17.0", path = "../ruma-api", optional = true }
-ruma-appservice-api = { version = "0.2.0", path = "../ruma-appservice-api", optional = true }
-ruma-client-api = { version = "0.10.2", path = "../ruma-client-api", optional = true }
-ruma-federation-api = { version = "0.1.0", path = "../ruma-federation-api", optional = true }
-ruma-identity-service-api = { version = "0.1.0", path = "../ruma-identity-service-api", optional = true }
-ruma-push-gateway-api = { version = "0.1.0", path = "../ruma-push-gateway-api", optional = true }
-
-[dev-dependencies]
-anyhow = "1.0.37"
-isahc = "1.3.1"
-serde = { version = "1.0.118", features = ["derive"] }
-tokio = { version = "1.0.1", features = ["macros", "rt"] }
-tokio-stream = { version = "0.1.1", default-features = false }
-
 [features]
 api = ["ruma-api"]
 client = ["ruma-client"]
@@ -139,6 +112,33 @@ unstable-pre-spec = [
     #"ruma-identity-service-api/unstable-pre-spec",
     #"ruma-push-gateway-api/unstable-pre-spec",
 ]
+
+[dependencies]
+assign = "1.1.1"
+js_int = "0.2.0"
+
+ruma-common = { version = "0.5.2", path = "../ruma-common" }
+ruma-identifiers = { version = "0.19.1", path = "../ruma-identifiers", features = ["serde"] }
+ruma-serde = { version = "0.4.0", path = "../ruma-serde" }
+
+ruma-client = { version = "0.5.0", path = "../ruma-client", optional = true }
+ruma-events = { version = "0.22.2", path = "../ruma-events", optional = true }
+ruma-signatures = { version = "0.7.2", path = "../ruma-signatures", optional = true }
+ruma-state-res = { version = "0.1.0", path = "../ruma-state-res", optional = true }
+
+ruma-api = { version = "0.17.0", path = "../ruma-api", optional = true }
+ruma-appservice-api = { version = "0.2.0", path = "../ruma-appservice-api", optional = true }
+ruma-client-api = { version = "0.10.2", path = "../ruma-client-api", optional = true }
+ruma-federation-api = { version = "0.1.0", path = "../ruma-federation-api", optional = true }
+ruma-identity-service-api = { version = "0.1.0", path = "../ruma-identity-service-api", optional = true }
+ruma-push-gateway-api = { version = "0.1.0", path = "../ruma-push-gateway-api", optional = true }
+
+[dev-dependencies]
+anyhow = "1.0.37"
+isahc = "1.3.1"
+serde = { version = "1.0.118", features = ["derive"] }
+tokio = { version = "1.0.1", features = ["macros", "rt"] }
+tokio-stream = { version = "0.1.1", default-features = false }
 
 [[example]]
 name = "hello_world"

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -71,7 +71,14 @@ impl CiTask {
     fn build_nightly(&self) -> xshell::Result<()> {
         let fmt_res = cmd!("rustup run nightly cargo fmt -- --check").run();
         let clippy_res = cmd!("rustup run nightly cargo ruma-clippy -D warnings").run();
-        let sort_res = cmd!("rustup run nightly cargo sort --workspace --grouped --check").run();
+        let sort_res = cmd!(
+            "
+            rustup run nightly cargo sort
+                --workspace --grouped --check
+                --order package,lib,features,dependencies,dev-dependencies,build-dependencies
+            "
+        )
+        .run();
 
         fmt_res.and(clippy_res).and(sort_res)
     }


### PR DESCRIPTION
I had to fix trailing commas so there will be a new release of cargo-sort but this is the result of running the new version on it. Just FYI the --check flag doesn't actually run the formatter so it wouldn't make a difference to our CI but still want the thing to work well. Side note: It is amazing how complicated something that seemed fairly simple is, I hate formatting toml now :laughing: 

I wasn't sure of exactly the items/order of the `--order` list so just let me know.