### PR TITLE
Allow our proc-macros to be used when re-exported from matrix-sdk

### DIFF
--- a/crates/ruma-api-macros/src/util.rs
+++ b/crates/ruma-api-macros/src/util.rs
@@ -31,6 +31,12 @@ pub(crate) fn import_ruma_api() -> TokenStream {
     } else if let Ok(FoundCrate::Name(name)) = crate_name("ruma") {
         let import = format_ident!("{}", name);
         quote! { ::#import::api }
+    } else if let Ok(FoundCrate::Name(name)) = crate_name("matrix-sdk") {
+        let import = format_ident!("{}", name);
+        quote! { ::#import::ruma::api }
+    } else if let Ok(FoundCrate::Name(name)) = crate_name("matrix-sdk-appservice") {
+        let import = format_ident!("{}", name);
+        quote! { ::#import::ruma::api }
     } else {
         quote! { ::ruma_api }
     }

--- a/crates/ruma-events-macros/src/lib.rs
+++ b/crates/ruma-events-macros/src/lib.rs
@@ -97,6 +97,12 @@ pub(crate) fn import_ruma_events() -> pm2::TokenStream {
     } else if let Ok(FoundCrate::Name(name)) = crate_name("ruma") {
         let import = format_ident!("{}", name);
         quote! { ::#import::events }
+    } else if let Ok(FoundCrate::Name(name)) = crate_name("matrix-sdk") {
+        let import = format_ident!("{}", name);
+        quote! { ::#import::ruma::events }
+    } else if let Ok(FoundCrate::Name(name)) = crate_name("matrix-sdk-appservice") {
+        let import = format_ident!("{}", name);
+        quote! { ::#import::ruma::events }
     } else {
         quote! { ::ruma_events }
     }

--- a/crates/ruma-serde-macros/src/util.rs
+++ b/crates/ruma-serde-macros/src/util.rs
@@ -15,6 +15,12 @@ pub fn import_ruma_serde() -> TokenStream {
     } else if let Ok(FoundCrate::Name(name)) = crate_name("ruma") {
         let import = format_ident!("{}", name);
         quote! { ::#import::serde }
+    } else if let Ok(FoundCrate::Name(name)) = crate_name("matrix-sdk") {
+        let import = format_ident!("{}", name);
+        quote! { ::#import::ruma::serde }
+    } else if let Ok(FoundCrate::Name(name)) = crate_name("matrix-sdk-appservice") {
+        let import = format_ident!("{}", name);
+        quote! { ::#import::ruma::serde }
     } else {
         quote! { ::ruma_serde }
     }


### PR DESCRIPTION
Kinda depends on https://github.com/matrix-org/matrix-rust-sdk/pull/284.