### PR TITLE
events: Make all pub enums non_exhaustive

### DIFF
--- a/crates/ruma-events-macros/src/event_enum.rs
+++ b/crates/ruma-events-macros/src/event_enum.rs
@@ -137,6 +137,7 @@ fn expand_any_with_deser(
         #[derive(Clone, Debug, #serde::Serialize)]
         #[serde(untagged)]
         #[allow(clippy::large_enum_variant)]
+        #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
         pub enum #ident {
             #(
                 #[doc = #events]
@@ -380,6 +381,7 @@ fn expand_content_enum(
         #[derive(Clone, Debug, #serde::Serialize)]
         #[serde(untagged)]
         #[allow(clippy::large_enum_variant)]
+        #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
         pub enum #ident {
             #(
                 #[doc = #event_type_str]
@@ -444,6 +446,7 @@ fn expand_content_enum(
             #[derive(Clone, Debug, #serde::Serialize)]
             #[serde(untagged)]
             #[allow(clippy::large_enum_variant)]
+            #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
             pub enum #redacted_ident {
                 #(
                     #[doc = #event_type_str]
@@ -591,6 +594,7 @@ fn expand_redacted_enum(
             /// An enum that holds either regular un-redacted events or redacted events.
             #[derive(Clone, Debug, #serde::Serialize)]
             #[serde(untagged)]
+            #[allow(clippy::exhaustive_enums)]
             pub enum #ident {
                 /// An un-redacted event.
                 Regular(#regular_enum_ident),

--- a/crates/ruma-events-macros/src/event_type.rs
+++ b/crates/ruma-events-macros/src/event_type.rs
@@ -128,6 +128,7 @@ fn generate_enum(
         /// This type can hold an arbitrary string. To check for events that are not available as a
         /// documented variant here, use its string representation, obtained through `.as_str()`.
         #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, #ruma_serde::StringEnum)]
+        #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
         pub enum #ident {
             #(
                 #[doc = #ev_type_strings]

--- a/crates/ruma-events/src/call.rs
+++ b/crates/ruma-events/src/call.rs
@@ -30,8 +30,12 @@ impl SessionDescription {
 }
 
 /// The type of VoIP session description.
+///
+/// This type can hold an arbitrary string. To check for formats that are not available as a
+/// documented variant here, use its string representation, obtained through `.as_str()`.
 #[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
 #[ruma_enum(rename_all = "snake_case")]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub enum SessionDescriptionType {
     /// An answer.
     Answer,
@@ -41,4 +45,11 @@ pub enum SessionDescriptionType {
 
     #[doc(hidden)]
     _Custom(String),
+}
+
+impl SessionDescriptionType {
+    /// Creates a string slice from this `SessionDescriptionType`.
+    pub fn as_str(&self) -> &str {
+        self.as_ref()
+    }
 }

--- a/crates/ruma-events/src/call.rs
+++ b/crates/ruma-events/src/call.rs
@@ -35,7 +35,7 @@ impl SessionDescription {
 /// documented variant here, use its string representation, obtained through `.as_str()`.
 #[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
 #[ruma_enum(rename_all = "snake_case")]
-#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+#[non_exhaustive]
 pub enum SessionDescriptionType {
     /// An answer.
     Answer,

--- a/crates/ruma-events/src/call/hangup.rs
+++ b/crates/ruma-events/src/call/hangup.rs
@@ -44,7 +44,7 @@ impl HangupEventContent {
 /// documented variant here, use its string representation, obtained through `.as_str()`.
 #[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
 #[ruma_enum(rename_all = "snake_case")]
-#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+#[non_exhaustive]
 pub enum Reason {
     /// ICE negotiation failure.
     IceFailed,

--- a/crates/ruma-events/src/call/hangup.rs
+++ b/crates/ruma-events/src/call/hangup.rs
@@ -39,8 +39,12 @@ impl HangupEventContent {
 /// This should not be provided when the user naturally ends or rejects the call. When there was an
 /// error in the call negotiation, this should be `ice_failed` for when ICE negotiation fails or
 /// `invite_timeout` for when the other party did not answer in time.
+///
+/// This type can hold an arbitrary string. To check for formats that are not available as a
+/// documented variant here, use its string representation, obtained through `.as_str()`.
 #[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
 #[ruma_enum(rename_all = "snake_case")]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub enum Reason {
     /// ICE negotiation failure.
     IceFailed,
@@ -50,4 +54,11 @@ pub enum Reason {
 
     #[doc(hidden)]
     _Custom(String),
+}
+
+impl Reason {
+    /// Creates a string slice from this `Reason`.
+    pub fn as_str(&self) -> &str {
+        self.as_ref()
+    }
 }

--- a/crates/ruma-events/src/enums.rs
+++ b/crates/ruma-events/src/enums.rs
@@ -139,7 +139,7 @@ macro_rules! room_ev_accessor {
 }
 
 /// Any room event.
-#[allow(clippy::large_enum_variant)]
+#[allow(clippy::large_enum_variant, clippy::exhaustive_enums)]
 #[derive(Clone, Debug, Serialize)]
 #[serde(untagged)]
 pub enum AnyRoomEvent {
@@ -164,7 +164,7 @@ impl AnyRoomEvent {
 }
 
 /// Any sync room event (room event without a `room_id`, as returned in `/sync` responses)
-#[allow(clippy::large_enum_variant)]
+#[allow(clippy::large_enum_variant, clippy::exhaustive_enums)]
 #[derive(Clone, Debug, Serialize)]
 #[serde(untagged)]
 pub enum AnySyncRoomEvent {
@@ -250,7 +250,7 @@ impl<'de> de::Deserialize<'de> for AnySyncRoomEvent {
 }
 
 /// Any redacted room event.
-#[allow(clippy::large_enum_variant)]
+#[allow(clippy::large_enum_variant, clippy::exhaustive_enums)]
 #[derive(Clone, Debug)]
 pub enum AnyRedactedRoomEvent {
     /// Any message event that has been redacted.
@@ -286,7 +286,7 @@ impl From<AnyRedactedRoomEvent> for AnyRoomEvent {
 }
 
 /// Any redacted sync room event (room event without a `room_id`, as returned in `/sync` responses)
-#[allow(clippy::large_enum_variant)]
+#[allow(clippy::large_enum_variant, clippy::exhaustive_enums)]
 #[derive(Clone, Debug)]
 pub enum AnyRedactedSyncRoomEvent {
     /// Any sync message event that has been redacted.

--- a/crates/ruma-events/src/key/verification.rs
+++ b/crates/ruma-events/src/key/verification.rs
@@ -29,7 +29,7 @@ pub mod start;
 /// documented variant here, use its string representation, obtained through `.as_str()`.
 #[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
 #[ruma_enum(rename_all = "snake_case")]
-#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+#[non_exhaustive]
 pub enum HashAlgorithm {
     /// The SHA256 hash algorithm.
     Sha256,
@@ -51,7 +51,7 @@ impl HashAlgorithm {
 /// documented variant here, use its string representation, obtained through `.as_str()`.
 #[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
 #[ruma_enum(rename_all = "kebab-case")]
-#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+#[non_exhaustive]
 pub enum KeyAgreementProtocol {
     /// The [Curve25519](https://cr.yp.to/ecdh.html) key agreement protocol.
     Curve25519,
@@ -76,7 +76,7 @@ impl KeyAgreementProtocol {
 /// documented variant here, use its string representation, obtained through `.as_str()`.
 #[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
 #[ruma_enum(rename_all = "kebab-case")]
-#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+#[non_exhaustive]
 pub enum MessageAuthenticationCode {
     /// The HKDF-HMAC-SHA256 MAC.
     HkdfHmacSha256,
@@ -101,7 +101,7 @@ impl MessageAuthenticationCode {
 /// documented variant here, use its string representation, obtained through `.as_str()`.
 #[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
 #[ruma_enum(rename_all = "snake_case")]
-#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+#[non_exhaustive]
 pub enum ShortAuthenticationString {
     /// The decimal method.
     Decimal,
@@ -144,7 +144,7 @@ impl Relation {
 /// This type can hold an arbitrary string. To check for formats that are not available as a
 /// documented variant here, use its string representation, obtained through `.as_str()`.
 #[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
-#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+#[non_exhaustive]
 pub enum VerificationMethod {
     /// The *m.sas.v1* verification method.
     #[ruma_enum(rename = "m.sas.v1")]

--- a/crates/ruma-events/src/key/verification.rs
+++ b/crates/ruma-events/src/key/verification.rs
@@ -24,8 +24,12 @@ pub mod request;
 pub mod start;
 
 /// A hash algorithm.
+///
+/// This type can hold an arbitrary string. To check for formats that are not available as a
+/// documented variant here, use its string representation, obtained through `.as_str()`.
 #[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
 #[ruma_enum(rename_all = "snake_case")]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub enum HashAlgorithm {
     /// The SHA256 hash algorithm.
     Sha256,
@@ -34,9 +38,20 @@ pub enum HashAlgorithm {
     _Custom(String),
 }
 
+impl HashAlgorithm {
+    /// Creates a string slice from this `HashAlgorithm`.
+    pub fn as_str(&self) -> &str {
+        self.as_ref()
+    }
+}
+
 /// A key agreement protocol.
+///
+/// This type can hold an arbitrary string. To check for formats that are not available as a
+/// documented variant here, use its string representation, obtained through `.as_str()`.
 #[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
 #[ruma_enum(rename_all = "kebab-case")]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub enum KeyAgreementProtocol {
     /// The [Curve25519](https://cr.yp.to/ecdh.html) key agreement protocol.
     Curve25519,
@@ -48,9 +63,20 @@ pub enum KeyAgreementProtocol {
     _Custom(String),
 }
 
+impl KeyAgreementProtocol {
+    /// Creates a string slice from this `KeyAgreementProtocol`.
+    pub fn as_str(&self) -> &str {
+        self.as_ref()
+    }
+}
+
 /// A message authentication code algorithm.
+///
+/// This type can hold an arbitrary string. To check for formats that are not available as a
+/// documented variant here, use its string representation, obtained through `.as_str()`.
 #[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
 #[ruma_enum(rename_all = "kebab-case")]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub enum MessageAuthenticationCode {
     /// The HKDF-HMAC-SHA256 MAC.
     HkdfHmacSha256,
@@ -62,9 +88,20 @@ pub enum MessageAuthenticationCode {
     _Custom(String),
 }
 
+impl MessageAuthenticationCode {
+    /// Creates a string slice from this `MessageAuthenticationCode`.
+    pub fn as_str(&self) -> &str {
+        self.as_ref()
+    }
+}
+
 /// A Short Authentication String method.
+///
+/// This type can hold an arbitrary string. To check for formats that are not available as a
+/// documented variant here, use its string representation, obtained through `.as_str()`.
 #[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
 #[ruma_enum(rename_all = "snake_case")]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub enum ShortAuthenticationString {
     /// The decimal method.
     Decimal,
@@ -74,6 +111,13 @@ pub enum ShortAuthenticationString {
 
     #[doc(hidden)]
     _Custom(String),
+}
+
+impl ShortAuthenticationString {
+    /// Creates a string slice from this `ShortAuthenticationString`.
+    pub fn as_str(&self) -> &str {
+        self.as_ref()
+    }
 }
 
 /// A relation which associates an `m.key.verification.request` with another key verification event.
@@ -96,7 +140,11 @@ impl Relation {
 }
 
 /// A Short Authentication String (SAS) verification method.
+///
+/// This type can hold an arbitrary string. To check for formats that are not available as a
+/// documented variant here, use its string representation, obtained through `.as_str()`.
 #[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub enum VerificationMethod {
     /// The *m.sas.v1* verification method.
     #[ruma_enum(rename = "m.sas.v1")]
@@ -119,6 +167,13 @@ pub enum VerificationMethod {
 
     #[doc(hidden)]
     _Custom(String),
+}
+
+impl VerificationMethod {
+    /// Creates a string slice from this `VerificationMethod`.
+    pub fn as_str(&self) -> &str {
+        self.as_ref()
+    }
 }
 
 #[cfg(test)]

--- a/crates/ruma-events/src/key/verification/cancel.rs
+++ b/crates/ruma-events/src/key/verification/cancel.rs
@@ -75,6 +75,7 @@ impl CancelEventContent {
 /// obtained through `.as_str()`.
 // FIXME: Add `m.foo_bar` as a naming scheme in StringEnum and remove rename attributes.
 #[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub enum CancelCode {
     /// The user cancelled the verification.
     #[ruma_enum(rename = "m.user")]

--- a/crates/ruma-events/src/key/verification/cancel.rs
+++ b/crates/ruma-events/src/key/verification/cancel.rs
@@ -75,7 +75,7 @@ impl CancelEventContent {
 /// obtained through `.as_str()`.
 // FIXME: Add `m.foo_bar` as a naming scheme in StringEnum and remove rename attributes.
 #[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
-#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+#[non_exhaustive]
 pub enum CancelCode {
     /// The user cancelled the verification.
     #[ruma_enum(rename = "m.user")]

--- a/crates/ruma-events/src/lib.rs
+++ b/crates/ruma-events/src/lib.rs
@@ -367,6 +367,7 @@ pub trait RedactedStateEventContent: RedactedEventContent {}
 /// to aid in deserializing redacted events.
 #[doc(hidden)]
 #[derive(Debug)]
+#[allow(clippy::exhaustive_enums)]
 pub enum HasDeserializeFields {
     /// Deserialize the event's content, failing if invalid.
     True,

--- a/crates/ruma-events/src/policy/rule.rs
+++ b/crates/ruma-events/src/policy/rule.rs
@@ -34,7 +34,7 @@ impl PolicyRuleEventContent {
 /// This type can hold an arbitrary string. To check for formats that are not available as a
 /// documented variant here, use its string representation, obtained through `.as_str()`.
 #[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
-#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+#[non_exhaustive]
 pub enum Recommendation {
     /// Entities affected by the rule should be banned from participation where possible.
     #[ruma_enum(rename = "m.ban")]

--- a/crates/ruma-events/src/policy/rule.rs
+++ b/crates/ruma-events/src/policy/rule.rs
@@ -29,8 +29,12 @@ impl PolicyRuleEventContent {
     }
 }
 
-/// Rules recommendations
+/// The possible actions that can be taken.
+///
+/// This type can hold an arbitrary string. To check for formats that are not available as a
+/// documented variant here, use its string representation, obtained through `.as_str()`.
 #[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub enum Recommendation {
     /// Entities affected by the rule should be banned from participation where possible.
     #[ruma_enum(rename = "m.ban")]

--- a/crates/ruma-events/src/room/create.rs
+++ b/crates/ruma-events/src/room/create.rs
@@ -63,7 +63,7 @@ impl CreateEventContent {
 /// This type can hold an arbitrary string. To check for formats that are not available as a
 /// documented variant here, use its string representation, obtained through `.as_str()`.
 #[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
-#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+#[non_exhaustive]
 pub enum RoomType {
     /// Defines the room as a space.
     #[ruma_enum(rename = "m.space")]

--- a/crates/ruma-events/src/room/create.rs
+++ b/crates/ruma-events/src/room/create.rs
@@ -59,7 +59,11 @@ impl CreateEventContent {
 }
 
 /// An enum of possible room types.
+///
+/// This type can hold an arbitrary string. To check for formats that are not available as a
+/// documented variant here, use its string representation, obtained through `.as_str()`.
 #[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub enum RoomType {
     /// Defines the room as a space.
     #[ruma_enum(rename = "m.space")]
@@ -67,6 +71,13 @@ pub enum RoomType {
     /// Defines the room as a custom type.
     #[doc(hidden)]
     _Custom(String),
+}
+
+impl RoomType {
+    /// Creates a string slice from this `RoomType`.
+    pub fn as_str(&self) -> &str {
+        self.as_ref()
+    }
 }
 
 /// A reference to an old room replaced during a room version upgrade.

--- a/crates/ruma-events/src/room/guest_access.rs
+++ b/crates/ruma-events/src/room/guest_access.rs
@@ -29,8 +29,12 @@ impl GuestAccessEventContent {
 }
 
 /// A policy for guest user access to a room.
+///
+/// This type can hold an arbitrary string. To check for formats that are not available as a
+/// documented variant here, use its string representation, obtained through `.as_str()`.
 #[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
 #[ruma_enum(rename_all = "snake_case")]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub enum GuestAccess {
     /// Guests are allowed to join the room.
     CanJoin,
@@ -40,4 +44,11 @@ pub enum GuestAccess {
 
     #[doc(hidden)]
     _Custom(String),
+}
+
+impl GuestAccess {
+    /// Creates a string slice from this `GuestAccess`.
+    pub fn as_str(&self) -> &str {
+        self.as_ref()
+    }
 }

--- a/crates/ruma-events/src/room/guest_access.rs
+++ b/crates/ruma-events/src/room/guest_access.rs
@@ -34,7 +34,7 @@ impl GuestAccessEventContent {
 /// documented variant here, use its string representation, obtained through `.as_str()`.
 #[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
 #[ruma_enum(rename_all = "snake_case")]
-#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+#[non_exhaustive]
 pub enum GuestAccess {
     /// Guests are allowed to join the room.
     CanJoin,

--- a/crates/ruma-events/src/room/history_visibility.rs
+++ b/crates/ruma-events/src/room/history_visibility.rs
@@ -33,7 +33,7 @@ impl HistoryVisibilityEventContent {
 /// documented variant here, use its string representation, obtained through `.as_str()`.
 #[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
 #[ruma_enum(rename_all = "snake_case")]
-#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+#[non_exhaustive]
 pub enum HistoryVisibility {
     /// Previous events are accessible to newly joined members from the point they were invited
     /// onwards. Events stop being accessible when the member's state changes to something other

--- a/crates/ruma-events/src/room/history_visibility.rs
+++ b/crates/ruma-events/src/room/history_visibility.rs
@@ -28,8 +28,12 @@ impl HistoryVisibilityEventContent {
 }
 
 /// Who can see a room's history.
+///
+/// This type can hold an arbitrary string. To check for formats that are not available as a
+/// documented variant here, use its string representation, obtained through `.as_str()`.
 #[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
 #[ruma_enum(rename_all = "snake_case")]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub enum HistoryVisibility {
     /// Previous events are accessible to newly joined members from the point they were invited
     /// onwards. Events stop being accessible when the member's state changes to something other
@@ -51,4 +55,11 @@ pub enum HistoryVisibility {
 
     #[doc(hidden)]
     _Custom(String),
+}
+
+impl HistoryVisibility {
+    /// Creates a string slice from this `HistoryVisibility`.
+    pub fn as_str(&self) -> &str {
+        self.as_ref()
+    }
 }

--- a/crates/ruma-events/src/room/join_rules.rs
+++ b/crates/ruma-events/src/room/join_rules.rs
@@ -32,7 +32,7 @@ impl JoinRulesEventContent {
 /// documented variant here, use its string representation, obtained through `.as_str()`.
 #[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
 #[ruma_enum(rename_all = "lowercase")]
-#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+#[non_exhaustive]
 pub enum JoinRule {
     /// A user who wishes to join the room must first receive an invite to the room from someone
     /// already inside of the room.

--- a/crates/ruma-events/src/room/join_rules.rs
+++ b/crates/ruma-events/src/room/join_rules.rs
@@ -27,8 +27,12 @@ impl JoinRulesEventContent {
 }
 
 /// The rule used for users wishing to join this room.
+///
+/// This type can hold an arbitrary string. To check for formats that are not available as a
+/// documented variant here, use its string representation, obtained through `.as_str()`.
 #[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
 #[ruma_enum(rename_all = "lowercase")]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub enum JoinRule {
     /// A user who wishes to join the room must first receive an invite to the room from someone
     /// already inside of the room.
@@ -45,4 +49,11 @@ pub enum JoinRule {
 
     #[doc(hidden)]
     _Custom(String),
+}
+
+impl JoinRule {
+    /// Creates a string slice from this `JoinRule`.
+    pub fn as_str(&self) -> &str {
+        self.as_ref()
+    }
 }

--- a/crates/ruma-events/src/room/member.rs
+++ b/crates/ruma-events/src/room/member.rs
@@ -90,7 +90,7 @@ impl MemberEventContent {
 /// documented variant here, use its string representation, obtained through `.as_str()`.
 #[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
 #[ruma_enum(rename_all = "lowercase")]
-#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+#[non_exhaustive]
 pub enum MembershipState {
     /// The user is banned.
     Ban,

--- a/crates/ruma-events/src/room/member.rs
+++ b/crates/ruma-events/src/room/member.rs
@@ -85,8 +85,12 @@ impl MemberEventContent {
 }
 
 /// The membership state of a user.
+///
+/// This type can hold an arbitrary string. To check for formats that are not available as a
+/// documented variant here, use its string representation, obtained through `.as_str()`.
 #[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
 #[ruma_enum(rename_all = "lowercase")]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub enum MembershipState {
     /// The user is banned.
     Ban,
@@ -105,6 +109,13 @@ pub enum MembershipState {
 
     #[doc(hidden)]
     _Custom(String),
+}
+
+impl MembershipState {
+    /// Creates a string slice from this `MembershipState`.
+    pub fn as_str(&self) -> &str {
+        self.as_ref()
+    }
 }
 
 /// Information about a third party invitation.

--- a/crates/ruma-events/src/room/message.rs
+++ b/crates/ruma-events/src/room/message.rs
@@ -652,7 +652,7 @@ impl ServerNoticeMessageEventContent {
 /// This type can hold an arbitrary string. To check for formats that are not available as a
 /// documented variant here, use its string representation, obtained through `.as_str()`.
 #[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
-#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+#[non_exhaustive]
 pub enum ServerNoticeType {
     /// The server has exceeded some limit which requires the server administrator to intervene.
     #[ruma_enum(rename = "m.server_notice.usage_limit_reached")]
@@ -675,7 +675,7 @@ impl ServerNoticeType {
 /// documented variant here, use its string representation, obtained through `.as_str()`.
 #[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
 #[ruma_enum(rename_all = "snake_case")]
-#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+#[non_exhaustive]
 pub enum LimitType {
     /// The server's number of active users in the last 30 days has exceeded the maximum.
     ///
@@ -699,7 +699,7 @@ impl LimitType {
 /// This type can hold an arbitrary string. To check for formats that are not available as a
 /// documented variant here, use its string representation, obtained through `.as_str()`.
 #[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
-#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+#[non_exhaustive]
 pub enum MessageFormat {
     /// HTML.
     #[ruma_enum(rename = "org.matrix.custom.html")]

--- a/crates/ruma-events/src/room/message.rs
+++ b/crates/ruma-events/src/room/message.rs
@@ -142,6 +142,7 @@ impl MessageEventContent {
 /// The content that is specific to each message type variant.
 #[derive(Clone, Debug, Serialize)]
 #[serde(untagged)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub enum MessageType {
     /// An audio message.
     Audio(AudioMessageEventContent),
@@ -647,7 +648,11 @@ impl ServerNoticeMessageEventContent {
 }
 
 /// Types of server notices.
+///
+/// This type can hold an arbitrary string. To check for formats that are not available as a
+/// documented variant here, use its string representation, obtained through `.as_str()`.
 #[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub enum ServerNoticeType {
     /// The server has exceeded some limit which requires the server administrator to intervene.
     #[ruma_enum(rename = "m.server_notice.usage_limit_reached")]
@@ -657,9 +662,20 @@ pub enum ServerNoticeType {
     _Custom(String),
 }
 
+impl ServerNoticeType {
+    /// Creates a string slice from this `ServerNoticeType`.
+    pub fn as_str(&self) -> &str {
+        self.as_ref()
+    }
+}
+
 /// Types of usage limits.
+///
+/// This type can hold an arbitrary string. To check for formats that are not available as a
+/// documented variant here, use its string representation, obtained through `.as_str()`.
 #[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
 #[ruma_enum(rename_all = "snake_case")]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub enum LimitType {
     /// The server's number of active users in the last 30 days has exceeded the maximum.
     ///
@@ -671,11 +687,19 @@ pub enum LimitType {
     _Custom(String),
 }
 
+impl LimitType {
+    /// Creates a string slice from this `LimitType`.
+    pub fn as_str(&self) -> &str {
+        self.as_ref()
+    }
+}
+
 /// The format for the formatted representation of a message body.
 ///
 /// This type can hold an arbitrary string. To check for formats that are not available as a
 /// documented variant here, use its string representation, obtained through `.as_str()`.
 #[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub enum MessageFormat {
     /// HTML.
     #[ruma_enum(rename = "org.matrix.custom.html")]

--- a/crates/ruma-events/src/room/message/feedback.rs
+++ b/crates/ruma-events/src/room/message/feedback.rs
@@ -34,8 +34,12 @@ impl FeedbackEventContent {
 }
 
 /// A type of feedback.
+///
+/// This type can hold an arbitrary string. To check for formats that are not available as a
+/// documented variant here, use its string representation, obtained through `.as_str()`.
 #[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
 #[ruma_enum(rename_all = "snake_case")]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub enum FeedbackType {
     /// Sent when a message is received.
     Delivered,
@@ -45,4 +49,11 @@ pub enum FeedbackType {
 
     #[doc(hidden)]
     _Custom(String),
+}
+
+impl FeedbackType {
+    /// Creates a string slice from this `FeedbackType`.
+    pub fn as_str(&self) -> &str {
+        self.as_ref()
+    }
 }

--- a/crates/ruma-events/src/room/message/feedback.rs
+++ b/crates/ruma-events/src/room/message/feedback.rs
@@ -39,7 +39,7 @@ impl FeedbackEventContent {
 /// documented variant here, use its string representation, obtained through `.as_str()`.
 #[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
 #[ruma_enum(rename_all = "snake_case")]
-#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+#[non_exhaustive]
 pub enum FeedbackType {
     /// Sent when a message is received.
     Delivered,

--- a/crates/ruma-events/src/room_key_request.rs
+++ b/crates/ruma-events/src/room_key_request.rs
@@ -47,7 +47,7 @@ impl RoomKeyRequestToDeviceEventContent {
 /// documented variant here, use its string representation, obtained through `.as_str()`.
 #[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
 #[ruma_enum(rename_all = "snake_case")]
-#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+#[non_exhaustive]
 pub enum Action {
     /// Request a key.
     Request,

--- a/crates/ruma-events/src/room_key_request.rs
+++ b/crates/ruma-events/src/room_key_request.rs
@@ -42,8 +42,12 @@ impl RoomKeyRequestToDeviceEventContent {
 }
 
 /// A new key request or a cancellation of a previous request.
+///
+/// This type can hold an arbitrary string. To check for formats that are not available as a
+/// documented variant here, use its string representation, obtained through `.as_str()`.
 #[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
 #[ruma_enum(rename_all = "snake_case")]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub enum Action {
     /// Request a key.
     Request,
@@ -54,6 +58,13 @@ pub enum Action {
 
     #[doc(hidden)]
     _Custom(String),
+}
+
+impl Action {
+    /// Creates a string slice from this `Action`.
+    pub fn as_str(&self) -> &str {
+        self.as_ref()
+    }
 }
 
 /// Information about a requested key.


### PR DESCRIPTION
So anything that had a `_Custom(String)` variant I added the `as_str` method to... let me know what you think?