### PR TITLE
signatures: Fix canonical json functions to now return Result

### DIFF
--- a/crates/ruma-signatures/CHANGELOG.md
+++ b/crates/ruma-signatures/CHANGELOG.md
@@ -5,6 +5,7 @@
 Breaking changes:
 
 * Replace `ring` dependency with `ed25519-dalek` and `pkcs8`
+* `canonical_json` and `content_hash` now return `Error` when JSON is not canonical
 
 # 0.7.2
 

--- a/crates/ruma-signatures/src/lib.rs
+++ b/crates/ruma-signatures/src/lib.rs
@@ -132,7 +132,7 @@ mod tests {
     /// Convenience for converting a string of JSON into its canonical form.
     fn test_canonical_json(input: &str) -> String {
         let object = from_json_str(input).unwrap();
-        canonical_json(&object)
+        canonical_json(&object).unwrap()
     }
 
     #[test]


### PR DESCRIPTION
Conduit ran into a PDU that failed the size check and panicked. Probably makes more sense to propagate the error back to the caller so all the functions that use canonical JSON now return a `Result<String, signatures::Error>`.