### PR TITLE
Fix inconsitent types on `RoomEventDefinition`

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [unreleased]
 
+Breaking changes:
+
+* Change inconsistent types in `rooms` and `not_rooms` fields in `RoomEventFilter` structure. Both types now use `RoomId`. 
+
 # 0.11.0
 
 Breaking changes:

--- a/crates/ruma-client-api/src/r0/filter.rs
+++ b/crates/ruma-client-api/src/r0/filter.rs
@@ -63,7 +63,7 @@ pub struct RoomEventFilter<'a> {
     /// If this list is absent then no rooms are excluded. A matching room will be excluded even if
     /// it is listed in the 'rooms' filter.
     #[serde(default, skip_serializing_if = "<[_]>::is_empty")]
-    pub not_rooms: &'a [String],
+    pub not_rooms: &'a [RoomId],
 
     /// The maximum number of events to return.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/ruma-client-api/src/r0/message/get_message_events.rs
+++ b/crates/ruma-client-api/src/r0/message/get_message_events.rs
@@ -148,7 +148,11 @@ mod tests {
         let filter = RoomEventFilter {
             lazy_load_options: LazyLoadOptions::Enabled { include_redundant_members: true },
             rooms: Some(rooms),
-            not_rooms: &["room".into(), "room2".into(), "room3".into()],
+            not_rooms: &[
+                room_id!("!room:example.org"),
+                room_id!("!room2:example.org"),
+                room_id!("!room3:example.org"),
+            ],
             not_types: &["type".into()],
             ..Default::default()
         };
@@ -172,9 +176,7 @@ mod tests {
              &to=token2\
              &dir=b\
              &limit=0\
-             &filter=%7B%22not_types%22%3A%5B%22type%22%5D%2C%22not_rooms%22%3A%5B%22room%22%2C%22\
-              room2%22%2C%22room3%22%5D%2C%22rooms%22%3A%5B%22%21roomid%3Aexample.org%22%5D%2C%22\
-              lazy_load_members%22%3Atrue%2C%22include_redundant_members%22%3Atrue%7D",
+             &filter=%7B%22not_types%22%3A%5B%22type%22%5D%2C%22not_rooms%22%3A%5B%22%21room%3Aexample.org%22%2C%22%21room2%3Aexample.org%22%2C%22%21room3%3Aexample.org%22%5D%2C%22rooms%22%3A%5B%22%21roomid%3Aexample.org%22%5D%2C%22lazy_load_members%22%3Atrue%2C%22include_redundant_members%22%3Atrue%7D",
             request.uri().query().unwrap()
         );
     }


### PR DESCRIPTION
`rooms` and `not_rooms` contained `String` and `RoomId` respectively and
the types have been change to use always `RoomId` as it's more concrete
and is more consistent with the other fields (like `senders` and
`not_senders`).