### PR TITLE
Implement reasons for leaving a room.

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [unreleased]
 
+Improvements:
+
+* Add unstable support for reasons for leaving rooms
+
 # 0.11.0
 
 Breaking changes:

--- a/crates/ruma-client-api/src/r0/membership/leave_room.rs
+++ b/crates/ruma-client-api/src/r0/membership/leave_room.rs
@@ -17,6 +17,12 @@ ruma_api! {
         /// The room to leave.
         #[ruma_api(path)]
         pub room_id: &'a RoomId,
+
+        /// Optional reason to be included as the `reason` on the subsequent membership event.
+        #[cfg(feature = "unstable-pre-spec")]
+        #[cfg_attr(docsrs, doc(cfg(feature = "unstable-pre-spec")))]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub reason: Option<&'a str>,
     }
 
     #[derive(Default)]
@@ -28,7 +34,11 @@ ruma_api! {
 impl<'a> Request<'a> {
     /// Creates a new `Request` with the given room id.
     pub fn new(room_id: &'a RoomId) -> Self {
-        Self { room_id }
+        Self {
+            room_id,
+            #[cfg(feature = "unstable-pre-spec")]
+            reason: None,
+        }
     }
 }
 

--- a/crates/ruma-events/src/room/member.rs
+++ b/crates/ruma-events/src/room/member.rs
@@ -79,6 +79,12 @@ pub struct MemberEventContent {
     #[serde(rename = "xyz.amorgan.blurhash")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub blurhash: Option<String>,
+
+    /// The reason for leaving a room.
+    #[cfg(feature = "unstable-pre-spec")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable-pre-spec")))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
 }
 
 impl MemberEventContent {
@@ -92,6 +98,8 @@ impl MemberEventContent {
             third_party_invite: None,
             #[cfg(feature = "unstable-pre-spec")]
             blurhash: None,
+            #[cfg(feature = "unstable-pre-spec")]
+            reason: None,
         }
     }
 }
@@ -241,6 +249,8 @@ fn membership_change(
             third_party_invite: None,
             #[cfg(feature = "unstable-pre-spec")]
             blurhash: None,
+            #[cfg(feature = "unstable-pre-spec")]
+            reason: None,
         }
     };
 


### PR DESCRIPTION
Resolves: https://github.com/ruma/ruma/issues/511

Also adds the `reason` field in the `leave_room` endpoint as defined in [the unstable spec](https://spec.matrix.org/unstable/client-server-api/#post_matrixclientr0roomsroomidleave).

However there is a compilation error that I can't figure out with this part:
```rust
        /// Optional reason to be included as the `reason` on the subsequent membership event.
        #[cfg(feature = "unstable-pre-spec")]
        #[cfg_attr(docsrs, doc(cfg(feature = "unstable-pre-spec")))]
        #[serde(skip_serializing_if = "Option::is_none")]
        pub reason: Option<&'a str>,
```
Compilation succeeds with `cargo check --all-features` but the regular `cargo check` fails with:

```
error[E0392]: parameter `'a` is never used
  --> crates/ruma-client-api/src/r0/membership/leave_room.rs:25:29
   |
25 |         pub reason: Option<&'a str>,
   |                             ^^ unused parameter
   |
   = help: consider removing `'a`, referring to it in a field, or using a marker such as `PhantomData`

error: aborting due to previous error
```

I feel like there something obvious that I'm missing, but the same code snippet worked fine when adding blurhash support. (That is the only other `Option<&str>` field that is feature-gated that I could find.)