### PR TITLE
state-res: fetch_event closure as owned F not &F in StateResolution::resolve

### DIFF
--- a/crates/ruma-state-res/tests/event_sorting.rs
+++ b/crates/ruma-state-res/tests/event_sorting.rs
@@ -30,7 +30,7 @@ fn test_event_sort() {
     // TODO these events are not guaranteed to be sorted but they are resolved, do
     // we need the auth_chain
     let sorted_power_events =
-        StateResolution::reverse_topological_power_sort(&power_events, &auth_chain, &|id| {
+        StateResolution::reverse_topological_power_sort(&power_events, &auth_chain, |id| {
             events.get(id).map(Arc::clone)
         });
 
@@ -40,7 +40,7 @@ fn test_event_sort() {
         &RoomVersion::version_6(),
         &sorted_power_events,
         &BTreeMap::new(), // unconflicted events
-        &|id| events.get(id).map(Arc::clone),
+        |id| events.get(id).map(Arc::clone),
     )
     .expect("iterative auth check failed on resolved events");
 
@@ -51,7 +51,7 @@ fn test_event_sort() {
 
     let power_level = resolved_power.get(&(EventType::RoomPowerLevels, "".to_owned()));
 
-    let sorted_event_ids = StateResolution::mainline_sort(&events_to_sort, power_level, &|id| {
+    let sorted_event_ids = StateResolution::mainline_sort(&events_to_sort, power_level, |id| {
         events.get(id).map(Arc::clone)
     });
 

--- a/crates/ruma-state-res/tests/res_with_auth_ids.rs
+++ b/crates/ruma-state-res/tests/res_with_auth_ids.rs
@@ -77,7 +77,7 @@ fn ban_with_auth_chains2() {
                     .unwrap()
             })
             .collect(),
-        &|id| ev_map.get(id).map(Arc::clone),
+        |id| ev_map.get(id).map(Arc::clone),
     ) {
         Ok(state) => state,
         Err(e) => panic!("{}", e),

--- a/crates/ruma-state-res/tests/state_res.rs
+++ b/crates/ruma-state-res/tests/state_res.rs
@@ -266,7 +266,7 @@ fn test_event_map_none() {
                     .unwrap()
             })
             .collect(),
-        &|id| ev_map.get(id).map(Arc::clone),
+        |id| ev_map.get(id).map(Arc::clone),
     ) {
         Ok(state) => state,
         Err(e) => panic!("{}", e),

--- a/crates/ruma-state-res/tests/utils.rs
+++ b/crates/ruma-state-res/tests/utils.rs
@@ -121,7 +121,7 @@ pub fn do_check(
                             .unwrap()
                     })
                     .collect(),
-                &|id| event_map.get(id).map(Arc::clone),
+                |id| event_map.get(id).map(Arc::clone),
             );
             match resolved {
                 Ok(state) => state,


### PR DESCRIPTION
This means that no `&F where F: Fn(&EventId) -> Option<Arc<E>>` is allowed because of https://github.com/rust-lang/rust/issues/87079. In practice, this limitation is fine with ways to work around it if one wanted to use the same closure multiple times.