### PR TITLE
Calculate auth_events in state res and fix bug when calculating common events

### DIFF
--- a/crates/ruma-state-res/CHANGELOG.md
+++ b/crates/ruma-state-res/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [unreleased]
 
+Breaking changes:
+
+* state_res::resolve now doesn't take auth_events anymore and calculates it on its own instead
+
 # 0.2.0
 
 Breaking changes:

--- a/crates/ruma-state-res/benches/state_res_bench.rs
+++ b/crates/ruma-state-res/benches/state_res_bench.rs
@@ -66,15 +66,7 @@ fn resolution_shallow_auth_chain(c: &mut Criterion) {
                 &room_id(),
                 &RoomVersionId::Version6,
                 &state_sets,
-                state_sets
-                    .iter()
-                    .map(|map| {
-                        store
-                            .auth_event_ids(&room_id(), &map.values().cloned().collect::<Vec<_>>())
-                            .unwrap()
-                    })
-                    .collect(),
-                &|id| ev_map.get(id).map(Arc::clone),
+                |id| ev_map.get(id).map(Arc::clone),
             ) {
                 Ok(state) => state,
                 Err(e) => panic!("{}", e),
@@ -89,7 +81,7 @@ fn resolve_deeper_event_set(c: &mut Criterion) {
         let ban = BAN_STATE_SET();
 
         inner.extend(ban);
-        let store = TestStore(inner.clone());
+        let _store = TestStore(inner.clone());
 
         let state_set_a = [
             inner.get(&event_id("CREATE")).unwrap(),
@@ -123,15 +115,7 @@ fn resolve_deeper_event_set(c: &mut Criterion) {
                 &room_id(),
                 &RoomVersionId::Version6,
                 &state_sets,
-                state_sets
-                    .iter()
-                    .map(|map| {
-                        store
-                            .auth_event_ids(&room_id(), &map.values().cloned().collect::<Vec<_>>())
-                            .unwrap()
-                    })
-                    .collect(),
-                &|id| inner.get(id).map(Arc::clone),
+                |id| inner.get(id).map(Arc::clone),
             ) {
                 Ok(state) => state,
                 Err(_) => panic!("resolution failed during benchmarking"),

--- a/crates/ruma-state-res/src/lib.rs
+++ b/crates/ruma-state-res/src/lib.rs
@@ -96,9 +96,11 @@ impl StateResolution {
         }
 
         // The set of auth events that are not common across server forks
-        // This includes the conflicted events
-        let auth_diff =
+        let mut auth_diff =
             StateResolution::get_auth_chain_diff(room_id, &conflicting_state_sets, &fetch_event)?;
+
+        // Add the auth_diff to conflicting now we have a full set of conflicting events
+        auth_diff.extend(conflicting.values().cloned().flatten().filter_map(|o| o));
 
         debug!("auth diff size {:?}", auth_diff);
 

--- a/crates/ruma-state-res/tests/res_with_auth_ids.rs
+++ b/crates/ruma-state-res/tests/res_with_auth_ids.rs
@@ -69,14 +69,6 @@ fn ban_with_auth_chains2() {
         &room_id(),
         &RoomVersionId::Version6,
         &state_sets,
-        state_sets
-            .iter()
-            .map(|map| {
-                store
-                    .auth_event_ids(&room_id(), &map.values().cloned().collect::<Vec<_>>())
-                    .unwrap()
-            })
-            .collect(),
         |id| ev_map.get(id).map(Arc::clone),
     ) {
         Ok(state) => state,

--- a/crates/ruma-state-res/tests/state_res.rs
+++ b/crates/ruma-state-res/tests/state_res.rs
@@ -258,14 +258,6 @@ fn test_event_map_none() {
         &room_id(),
         &RoomVersionId::Version2,
         &state_sets,
-        state_sets
-            .iter()
-            .map(|map| {
-                store
-                    .auth_event_ids(&room_id(), &map.values().cloned().collect::<Vec<_>>())
-                    .unwrap()
-            })
-            .collect(),
         |id| ev_map.get(id).map(Arc::clone),
     ) {
         Ok(state) => state,

--- a/crates/ruma-state-res/tests/utils.rs
+++ b/crates/ruma-state-res/tests/utils.rs
@@ -113,14 +113,6 @@ pub fn do_check(
                 &room_id(),
                 &RoomVersionId::Version6,
                 &state_sets,
-                state_sets
-                    .iter()
-                    .map(|map| {
-                        store
-                            .auth_event_ids(&room_id(), &map.values().cloned().collect::<Vec<_>>())
-                            .unwrap()
-                    })
-                    .collect(),
                 |id| event_map.get(id).map(Arc::clone),
             );
             match resolved {

--- a/crates/ruma-state-res/tests/utils.rs
+++ b/crates/ruma-state-res/tests/utils.rs
@@ -109,12 +109,10 @@ pub fn do_check(
                     .collect::<Vec<_>>()
             );
 
-            let resolved = StateResolution::resolve(
-                &room_id(),
-                &RoomVersionId::Version6,
-                &state_sets,
-                |id| event_map.get(id).map(Arc::clone),
-            );
+            let resolved =
+                StateResolution::resolve(&room_id(), &RoomVersionId::Version6, &state_sets, |id| {
+                    event_map.get(id).map(Arc::clone)
+                });
             match resolved {
                 Ok(state) => state,
                 Err(e) => panic!("resolution for {} failed: {}", node, e),


### PR DESCRIPTION
state_res::resolve now doesn't take auth_events anymore and calculates it on its own instead