### PR TITLE
ruma-events: Add secret sharing.

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -38,6 +38,7 @@ Improvements:
 
 * Add unstable blurhash field to member event content struct
 * Add constructors for the unstable spaces parent and child event content types
+* Add unstable support for `m.secret.request` and `m.secret.send` events.
 
 Bug fixes:
 

--- a/crates/ruma-events/src/enums.rs
+++ b/crates/ruma-events/src/enums.rs
@@ -112,6 +112,12 @@ event_enum! {
         #[cfg_attr(docsrs, doc(cfg(feature = "unstable-pre-spec")))]
         "m.key.verification.done",
         "m.room.encrypted",
+        #[cfg(feature = "unstable-pre-spec")]
+        #[cfg_attr(docsrs, doc(cfg(feature = "unstable-pre-spec")))]
+        "m.secret.request",
+        #[cfg(feature = "unstable-pre-spec")]
+        #[cfg_attr(docsrs, doc(cfg(feature = "unstable-pre-spec")))]
+        "m.secret.send",
     }
 }
 

--- a/crates/ruma-events/src/lib.rs
+++ b/crates/ruma-events/src/lib.rs
@@ -177,6 +177,9 @@ pub mod room_key;
 pub mod room_key_request;
 #[cfg(feature = "unstable-pre-spec")]
 #[cfg_attr(docsrs, doc(cfg(feature = "unstable-pre-spec")))]
+pub mod secret;
+#[cfg(feature = "unstable-pre-spec")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable-pre-spec")))]
 pub mod space;
 pub mod sticker;
 pub mod tag;

--- a/crates/ruma-events/src/secret.rs
+++ b/crates/ruma-events/src/secret.rs
@@ -1,0 +1,4 @@
+//! Module for events in the *m.secret* namespace.
+
+pub mod request;
+pub mod send;

--- a/crates/ruma-events/src/secret/request.rs
+++ b/crates/ruma-events/src/secret/request.rs
@@ -195,7 +195,7 @@ impl<'de> Deserialize<'de> for RequestToDeviceEventContent {
 }
 
 /// Action for a *m.secret.request* event.
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Deserialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub enum RequestAction {
     /// Request a secret by its name.
@@ -231,7 +231,7 @@ impl Serialize for RequestAction {
 }
 
 /// The name of a secret.
-#[derive(Clone, Debug, StringEnum)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, StringEnum)]
 pub enum SecretName {
     /// Cross-signing master key (m.cross_signing.master).
     #[ruma_enum(rename = "m.cross_signing.master")]
@@ -249,8 +249,8 @@ pub enum SecretName {
     #[ruma_enum(rename = "m.megolm_backup.v1")]
     RecoveryKey,
 
-    /// Custom secret name.
-    Custom(String),
+    #[doc(hidden)]
+    _Custom(String),
 }
 
 #[cfg(test)]
@@ -262,7 +262,7 @@ mod test {
     #[test]
     fn secret_request_serialization() {
         let content = RequestToDeviceEventContent::new(
-            RequestAction::Request(SecretName::Custom("org.example.some.secret".into())),
+            RequestAction::Request(SecretName::_Custom("org.example.some.secret".into())),
             "ABCDEFG".into(),
             "randomly_generated_id_9573".into(),
         );
@@ -325,7 +325,7 @@ mod test {
             from_json_value(json).unwrap(),
             RequestToDeviceEventContent {
                 action: RequestAction::Request(
-                    SecretName::Custom(secret)
+                    SecretName::_Custom(secret)
                 ),
                 requesting_device_id,
                 request_id,

--- a/crates/ruma-events/src/secret/request.rs
+++ b/crates/ruma-events/src/secret/request.rs
@@ -1,0 +1,52 @@
+//! Types for the *m.secret.request* event.
+
+use ruma_events_macros::EventContent;
+use ruma_identifiers::DeviceIdBox;
+use ruma_serde::StringEnum;
+use serde::{Deserialize, Serialize};
+
+use crate::ToDeviceEvent;
+
+/// Event sent by a client to request a secret from another device or to cancel a previous request.
+///
+/// It is sent as an unencrypted to-device event.
+pub type SecretRequestEvent = ToDeviceEvent<SecretRequestEventContent>;
+
+/// The payload for SecretRequestEvent
+#[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+#[ruma_event(type = "m.secret.request", kind = ToDevice)]
+pub struct SecretRequestEventContent {
+    /// The name of the secret that is being requested.
+    ///
+    /// Required if `action` is `request`.
+    pub name: Option<String>,
+
+    /// One of ["request", "request_cancellation"].
+    pub action: RequestAction,
+
+    /// The ID of the device requesting the event.
+    pub requesting_device_id: DeviceIdBox,
+
+    /// A random string uniquely identifying (with respect to the requester and the target) the
+    /// target for a secret.
+    ///
+    /// If the secret is requested from multiple devices at the same time, the same ID may be used
+    /// for every target. The same ID is also used in order to cancel a previous request.
+    pub request_id: String,
+}
+
+/// Action for a *m.secret.request* event.
+#[derive(Clone, Debug, StringEnum)]
+#[ruma_enum(rename_all = "snake_case")]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+pub enum RequestAction {
+    /// Request a secret.
+    Request,
+
+    /// Cancel a request for a secret.
+    RequestCancellation,
+
+    #[doc(hidden)]
+    _Custom(String),
+}

--- a/crates/ruma-events/src/secret/request.rs
+++ b/crates/ruma-events/src/secret/request.rs
@@ -36,6 +36,19 @@ pub struct SecretRequestEventContent {
     pub request_id: String,
 }
 
+impl SecretRequestEventContent {
+    /// Creates a new `SecretRequestEventContent` with the given name, action, requesting device ID
+    /// and request ID.
+    pub fn new(
+        name: Option<String>,
+        action: RequestAction,
+        requesting_device_id: DeviceIdBox,
+        request_id: String,
+    ) -> Self {
+        Self { name, action, requesting_device_id, request_id }
+    }
+}
+
 /// Action for a *m.secret.request* event.
 #[derive(Clone, Debug, StringEnum)]
 #[ruma_enum(rename_all = "snake_case")]

--- a/crates/ruma-events/src/secret/request.rs
+++ b/crates/ruma-events/src/secret/request.rs
@@ -19,9 +19,7 @@ pub type RequestToDeviceEvent = ToDeviceEvent<RequestToDeviceEventContent>;
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[ruma_event(type = "m.secret.request", kind = ToDevice)]
 pub struct RequestToDeviceEventContent {
-    /// The action for the request, one of `["request", "request_cancellation"]`.
-    ///
-    /// If the action is "request", the name of the secret must also be provided.
+    /// The action for the request.
     #[serde(flatten)]
     pub action: RequestAction,
 
@@ -48,10 +46,10 @@ impl RequestToDeviceEventContent {
     }
 }
 
-/// Action for a *m.secret.request* event.
+/// Action for an *m.secret.request* event.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Deserialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-#[serde(try_from = "RequestActionInit")]
+#[serde(try_from = "RequestActionJsonRepr")]
 pub enum RequestAction {
     /// Request a secret by its name.
     Request(SecretName),
@@ -89,15 +87,15 @@ impl Serialize for RequestAction {
 }
 
 #[derive(Deserialize)]
-struct RequestActionInit {
+struct RequestActionJsonRepr {
     action: String,
     name: Option<SecretName>,
 }
 
-impl TryFrom<RequestActionInit> for RequestAction {
+impl TryFrom<RequestActionJsonRepr> for RequestAction {
     type Error = &'static str;
 
-    fn try_from(value: RequestActionInit) -> Result<Self, Self::Error> {
+    fn try_from(value: RequestActionJsonRepr) -> Result<Self, Self::Error> {
         match value.action.as_str() {
             "request" => {
                 if let Some(name) = value.name {

--- a/crates/ruma-events/src/secret/send.rs
+++ b/crates/ruma-events/src/secret/send.rs
@@ -1,0 +1,24 @@
+//! Types for the *m.secret.send* event.
+
+use ruma_events_macros::EventContent;
+use serde::{Deserialize, Serialize};
+
+use crate::ToDeviceEvent;
+
+/// An event sent by a client to share a secret with another device, in response to an
+/// `m.secret.request` event.
+///
+/// It must be encrypted as an `m.room.encrypted` event, then sent as a to-device
+pub type SecretSendEvent = ToDeviceEvent<SecretSendEventContent>;
+
+/// The payload for `SecretSendEvent`.
+#[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+#[ruma_event(type = "m.secret.send", kind = ToDevice)]
+pub struct SecretSendEventContent {
+    /// The ID of the request that this is a response to.
+    pub request_id: String,
+
+    /// The contents of the secret.
+    pub secret: String,
+}

--- a/crates/ruma-events/src/secret/send.rs
+++ b/crates/ruma-events/src/secret/send.rs
@@ -8,14 +8,14 @@ use crate::ToDeviceEvent;
 /// An event sent by a client to share a secret with another device, in response to an
 /// `m.secret.request` event.
 ///
-/// It must be encrypted as an `m.room.encrypted` event, then sent as a to-device
-pub type SecretSendEvent = ToDeviceEvent<SecretSendEventContent>;
+/// It must be encrypted as an `m.room.encrypted` event, then sent as a to-device event.
+pub type SendToDeviceEvent = ToDeviceEvent<SendToDeviceEventContent>;
 
-/// The payload for `SecretSendEvent`.
+/// The payload for `SendToDeviceEvent`.
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[ruma_event(type = "m.secret.send", kind = ToDevice)]
-pub struct SecretSendEventContent {
+pub struct SendToDeviceEventContent {
     /// The ID of the request that this is a response to.
     pub request_id: String,
 
@@ -23,7 +23,7 @@ pub struct SecretSendEventContent {
     pub secret: String,
 }
 
-impl SecretSendEventContent {
+impl SendToDeviceEventContent {
     /// Creates a new `SecretSendEventContent` with the given request ID and secret.
     pub fn new(request_id: String, secret: String) -> Self {
         Self { request_id, secret }

--- a/crates/ruma-events/src/secret/send.rs
+++ b/crates/ruma-events/src/secret/send.rs
@@ -22,3 +22,10 @@ pub struct SecretSendEventContent {
     /// The contents of the secret.
     pub secret: String,
 }
+
+impl SecretSendEventContent {
+    /// Creates a new `SecretSendEventContent` with the given request ID and secret.
+    pub fn new(request_id: String, secret: String) -> Self {
+        Self { request_id, secret }
+    }
+}


### PR DESCRIPTION
This is a first PR working towards https://github.com/ruma/ruma/issues/478. It adds the [Secret Sharing](https://github.com/matrix-org/matrix-doc/blob/master/proposals/1946-secure_server-side_storage.md#sharing) part of MSC 1946.

Two questions I have:
- what's the policy on adding constructors for events? I see some have them and some don't.
- would it be useful to write tests for these two events, or are they small enough that it doesnt matter?

I also used the `String` type for secrets, instead of `ruma_identifiers::ClientSecret` as neither the unstable spec nor the MSC text specify a grammar for the secrets.