### PR TITLE
Add constructors for `ParentEventContent` and `ChildEventContent`.

### DIFF
--- a/crates/ruma-events/src/space/child.rs
+++ b/crates/ruma-events/src/space/child.rs
@@ -14,7 +14,7 @@ use crate::StateEvent;
 pub type ChildEvent = StateEvent<ChildEventContent>;
 
 /// The payload for `ChildEvent`.
-#[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[ruma_event(type = "m.space.child", kind = State)]
 pub struct ChildEventContent {
@@ -42,6 +42,13 @@ pub struct ChildEventContent {
     /// be a room or a subspace.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub suggested: Option<bool>,
+}
+
+impl ChildEventContent {
+    /// Creates a new `ChildEventContent`.
+    pub fn new() -> Self {
+        Self::default()
+    }
 }
 
 #[cfg(test)]

--- a/crates/ruma-events/src/space/parent.rs
+++ b/crates/ruma-events/src/space/parent.rs
@@ -32,6 +32,13 @@ pub struct ParentEventContent {
     pub canonical: bool,
 }
 
+impl ParentEventContent {
+    /// Creates a new `ParentEventContent` with the given canonical flag.
+    pub fn new(canonical: bool) -> Self {
+        Self { via: None, canonical }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::ParentEventContent;


### PR DESCRIPTION
Fixes the issue found in https://github.com/ruma/ruma/pull/677.

I've chosen to list all the parameters for the `ChildEventContent` constructor since they are all optional and I have added a derived `Default` implementation.