### PR TITLE
Update expected stderr on tests for Rust 1.54.

### DIFF
--- a/crates/ruma-events/tests/ui/02-no-event-type.stderr
+++ b/crates/ruma-events/tests/ui/02-no-event-type.stderr
@@ -4,4 +4,4 @@ error: no event type attribute found, add `#[ruma_event(type = "any.room.event",
 4 | #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
   |                                                ^^^^^^^^^^^^
   |
-  = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the derive macro `EventContent` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/ruma-events/tests/ui/03-invalid-event-type.stderr
+++ b/crates/ruma-events/tests/ui/03-invalid-event-type.stderr
@@ -4,7 +4,7 @@ error: no event type attribute found, add `#[ruma_event(type = "any.room.event",
 4 | #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
   |                                                ^^^^^^^^^^^^
   |
-  = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the derive macro `EventContent` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected one of: `type`, `kind`, `skip_redaction`, `custom_redacted`
   --> $DIR/03-invalid-event-type.rs:11:14

--- a/crates/ruma-events/tests/ui/06-no-content-field.stderr
+++ b/crates/ruma-events/tests/ui/06-no-content-field.stderr
@@ -4,4 +4,4 @@ error: struct must contain a `content` field
 5 | #[derive(Clone, Debug, Event)]
   |                        ^^^^^
   |
-  = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the derive macro `Event` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/ruma-identifiers/tests/ui/02-invalid-id-macros.stderr
+++ b/crates/ruma-identifiers/tests/ui/02-invalid-id-macros.stderr
@@ -5,7 +5,7 @@ error: proc macro panicked
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: message: Invalid event id
-  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `ruma_identifiers::event_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: proc macro panicked
  --> $DIR/02-invalid-id-macros.rs:3:13
@@ -14,7 +14,7 @@ error: proc macro panicked
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: message: Invalid event id
-  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `ruma_identifiers::event_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: proc macro panicked
  --> $DIR/02-invalid-id-macros.rs:4:13
@@ -23,7 +23,7 @@ error: proc macro panicked
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: message: Invalid mxc://
-  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `ruma_identifiers::mxc_uri` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: proc macro panicked
  --> $DIR/02-invalid-id-macros.rs:5:13
@@ -32,7 +32,7 @@ error: proc macro panicked
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: message: Invalid room_alias_id
-  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `ruma_identifiers::room_alias_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: proc macro panicked
  --> $DIR/02-invalid-id-macros.rs:6:13
@@ -41,7 +41,7 @@ error: proc macro panicked
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: message: Invalid room_id
-  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `ruma_identifiers::room_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: proc macro panicked
  --> $DIR/02-invalid-id-macros.rs:7:13
@@ -50,7 +50,7 @@ error: proc macro panicked
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: message: Invalid room_version_id
-  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `ruma_identifiers::room_version_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: proc macro panicked
  --> $DIR/02-invalid-id-macros.rs:8:13
@@ -59,7 +59,7 @@ error: proc macro panicked
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: message: Invalid server_name
-  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `ruma_identifiers::server_name` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: proc macro panicked
  --> $DIR/02-invalid-id-macros.rs:9:13
@@ -68,4 +68,4 @@ error: proc macro panicked
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: message: Invalid user_id
-  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `ruma_identifiers::user_id` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
I could not find it in the release notes, but it seems that Rust 1.54 slightly changed the wording on an error. The stable CI checks fail now with:
```
EXPECTED:
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
error: struct must contain a `content` field
 --> $DIR/06-no-content-field.rs:5:24
  |
5 | #[derive(Clone, Debug, Event)]
  |                        ^^^^^
  |
  = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈

ACTUAL OUTPUT:
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
error: struct must contain a `content` field
 --> $DIR/06-no-content-field.rs:5:24
  |
5 | #[derive(Clone, Debug, Event)]
  |                        ^^^^^
  |
  = note: this error originates in the derive macro `Event` (in Nightly builds, run with -Z macro-backtrace for more info)
  ```
  
  This PR changes the wording accordingly in the affected tests, but of course makes the tests fail when using a previous version of stable Rust.