### PR TITLE
Add support for MSC2785: Event notification attributes and actions.

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [unreleased]
 
+Improvements:
+
+* Add unstable support for event notification attributes and actions
+
 # 0.12.0
 
 Breaking changes:

--- a/crates/ruma-client-api/src/r0.rs
+++ b/crates/ruma-client-api/src/r0.rs
@@ -18,6 +18,9 @@ pub mod knock;
 pub mod media;
 pub mod membership;
 pub mod message;
+#[cfg(feature = "unstable-pre-spec")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable-pre-spec")))]
+pub mod notification_attribute_data;
 pub mod presence;
 pub mod profile;
 pub mod push;

--- a/crates/ruma-client-api/src/r0/notification_attribute_data.rs
+++ b/crates/ruma-client-api/src/r0/notification_attribute_data.rs
@@ -1,0 +1,3 @@
+//! Endpoints for notification attribute data.
+
+pub mod global;

--- a/crates/ruma-client-api/src/r0/notification_attribute_data/global.rs
+++ b/crates/ruma-client-api/src/r0/notification_attribute_data/global.rs
@@ -1,0 +1,6 @@
+//! Endpoints for setting and retrieving a user's global notification attribute settings.
+
+pub mod get_keywords;
+pub mod get_mentions;
+pub mod set_keywords;
+pub mod set_mentions;

--- a/crates/ruma-client-api/src/r0/notification_attribute_data/global/get_keywords.rs
+++ b/crates/ruma-client-api/src/r0/notification_attribute_data/global/get_keywords.rs
@@ -1,0 +1,38 @@
+//![GET /_matrix/client/r0/notification_attribute_data/global/keywords](https://github.com/matrix-org/matrix-doc/blob/rav/proposals/notification_attributes/proposals/2785-notification-attributes.md#get-_matrixclientr0notification_attribute_dataglobalkeywords)
+//!
+//! //! This uses the unstable prefix in [MSC2785](https://github.com/matrix-org/matrix-doc/pull/2785)
+use ruma_api::ruma_api;
+
+ruma_api! {
+    metadata: {
+        description: "Get the user's current global keyword list",
+        method: GET,
+        name: "get_keywords",
+        path: "/_matrix/client/unstable/org.matrix.msc2785/notification_attribute_data/global/keywords",
+        rate_limited: true,
+        authentication: AccessToken,
+    }
+
+    #[derive(Default)]
+    request: {}
+
+    #[derive(Default)]
+    response: {
+        /// The user's current global keyword list.
+        pub keywords: Vec<String>,
+    }
+}
+
+impl Request {
+    /// Creates a new empty `Request`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Response {
+    /// Creates a new `Response` with the given list of keywords.
+    pub fn new(keywords: Vec<String>) -> Self {
+        Self { keywords }
+    }
+}

--- a/crates/ruma-client-api/src/r0/notification_attribute_data/global/get_mentions.rs
+++ b/crates/ruma-client-api/src/r0/notification_attribute_data/global/get_mentions.rs
@@ -1,0 +1,57 @@
+//! [GET /_matrix/client/r0/notification_attribute_data/global/mentions](https://github.com/matrix-org/matrix-doc/blob/rav/proposals/notification_attributes/proposals/2785-notification-attributes.md#get-_matrixclientr0notification_attribute_dataglobalmentions)
+//!
+//! //! This uses the unstable prefix in [MSC2785](https://github.com/matrix-org/matrix-doc/pull/2785)
+use ruma_api::ruma_api;
+use serde::{Deserialize, Serialize};
+
+ruma_api! {
+    metadata: {
+        description: "Get the user's current global mention settings.",
+        method: GET,
+        name: "get_mentions",
+        path: "/_matrix/client/unstable/org.matrix.msc2785/notification_attribute_data/global/mentions",
+        rate_limited: true,
+        authentication: AccessToken,
+    }
+
+    #[derive(Default)]
+    request: {}
+
+    #[derive(Default)]
+    response: {
+        /// The user's global mentions settings.
+        pub mentions: Mentions,
+    }
+}
+
+/// An object containing booleans which define which events should qualify for `m.mention`
+/// attributes.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+pub struct Mentions {
+    /// Display name flag.
+    pub displayname: bool,
+
+    /// Matrix user ID flag.
+    pub mxid: bool,
+
+    /// Local part of user ID flag.
+    pub localpart: bool,
+
+    /// "@room" notification flag.
+    pub room_notif: bool,
+}
+
+impl Request {
+    /// Creates a new empty `Request`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Response {
+    /// Creates a new `Response` with the given global mentions settings.
+    pub fn new(mentions: Mentions) -> Self {
+        Self { mentions }
+    }
+}

--- a/crates/ruma-client-api/src/r0/notification_attribute_data/global/set_keywords.rs
+++ b/crates/ruma-client-api/src/r0/notification_attribute_data/global/set_keywords.rs
@@ -1,0 +1,38 @@
+//! [PUT /_matrix/client/r0/notification_attribute_data/global/keywords](https://github.com/matrix-org/matrix-doc/blob/rav/proposals/notification_attributes/proposals/2785-notification-attributes.md#put-_matrixclientr0notification_attribute_dataglobalkeywords)
+//!
+//! //! This uses the unstable prefix in [MSC2785](https://github.com/matrix-org/matrix-doc/pull/2785)  
+use ruma_api::ruma_api;
+
+ruma_api! {
+    metadata: {
+        description: "Replace the user's global keyword list",
+        method: POST,
+        name: "set_keywords",
+        path: "/_matrix/client/unstable/org.matrix.msc2785/notification_attribute_data/global/keywords",
+        rate_limited: true,
+        authentication: AccessToken,
+    }
+
+    #[derive(Default)]
+    request: {
+        /// The user's global keyword list.
+        pub keywords: &'a [String],
+    }
+
+    #[derive(Default)]
+    response: {}
+}
+
+impl<'a> Request<'a> {
+    /// Creates a new `Request` with the given keyword list.
+    pub fn new(keywords: &'a [String]) -> Self {
+        Self { keywords }
+    }
+}
+
+impl Response {
+    /// Creates a new empty `Response`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}

--- a/crates/ruma-client-api/src/r0/notification_attribute_data/global/set_mentions.rs
+++ b/crates/ruma-client-api/src/r0/notification_attribute_data/global/set_mentions.rs
@@ -1,0 +1,41 @@
+//! [PUT /_matrix/client/r0/notification_attribute_data/global/mentions](PUT
+//! /_matrix/client/r0/notification_attribute_data/global/mentions)
+//!
+//! This uses the unstable prefix in [MSC2785](https://github.com/matrix-org/matrix-doc/pull/2785)
+
+use ruma_api::ruma_api;
+use ruma_events::notification_attribute_data::Mentions;
+
+ruma_api! {
+    metadata: {
+        description: "Set the user's global mentions settings",
+        method: POST,
+        name: "set_mentions",
+        path: "/_matrix/client/unstable/org.matrix.msc2785/notification_attribute_data/global/mentions",
+        rate_limited: true,
+        authentication: AccessToken,
+    }
+
+    #[derive(Default)]
+    request: {
+        /// The user's global mentions settings.
+        pub mentions: Mentions,
+    }
+
+    #[derive(Default)]
+    response: {}
+}
+
+impl Request {
+    /// Creates a `Request` with the given global mentions settings.
+    pub fn new(mentions: Mentions) -> Self {
+        Self { mentions }
+    }
+}
+
+impl Response {
+    /// Creates an empty `Response`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}

--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [unreleased]
 
+Improvements:
+
+* Add unstable support for event notification attributes and actions
+
 # 0.24.3
 
 Improvements:

--- a/crates/ruma-events/src/lib.rs
+++ b/crates/ruma-events/src/lib.rs
@@ -161,6 +161,12 @@ pub mod forwarded_room_key;
 pub mod fully_read;
 pub mod ignored_user_list;
 pub mod key;
+#[cfg(feature = "unstable-pre-spec")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable-pre-spec")))]
+pub mod notification_attribute_data;
+#[cfg(feature = "unstable-pre-spec")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable-pre-spec")))]
+pub mod notifications_profile;
 pub mod pdu;
 pub mod policy;
 pub mod presence;

--- a/crates/ruma-events/src/notification_attribute_data.rs
+++ b/crates/ruma-events/src/notification_attribute_data.rs
@@ -12,7 +12,7 @@ pub type NotificationAttributeDataEvent =
 /// The payload for `NotificationAttributeDataEvent`.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-#[ruma_event(type = "m.notification_attribute_data", kind = GlobalAccountData)]
+#[ruma_event(type = "org.matrix.msc2785.notification_attribute_data", kind = GlobalAccountData)]
 pub struct NotificationAttributeDataEventContent {
     /// An array of string which form "notification keywords".
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/crates/ruma-events/src/notification_attribute_data.rs
+++ b/crates/ruma-events/src/notification_attribute_data.rs
@@ -1,0 +1,47 @@
+//! Types for the *m.notification_attribute_data* event.
+
+use ruma_events_macros::EventContent;
+use serde::{Deserialize, Serialize};
+
+use crate::GlobalAccountDataEvent;
+
+/// An event to store assignment of event notification attributes in a user's `account_data`.
+pub type NotificationAttributeDataEvent =
+    GlobalAccountDataEvent<NotificationAttributeDataEventContent>;
+
+/// The payload for `NotificationAttributeDataEvent`.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, EventContent)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+#[ruma_event(type = "m.notification_attribute_data", kind = GlobalAccountData)]
+pub struct NotificationAttributeDataEventContent {
+    /// An array of string which form "notification keywords".
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub keywords: Vec<String>,
+
+    /// An object containing booleans which define which events should qualify for `m.mention`
+    /// attributes.
+    #[serde(default, skip_serializing_if = "ruma_serde::is_default")]
+    pub mentions: Mentions,
+}
+
+/// An object containing booleans which define which events should qualify for `m.mention`
+/// attributes.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+pub struct Mentions {
+    /// Display name flag.
+    #[serde(default, skip_serializing_if = "ruma_serde::is_default")]
+    pub displayname: bool,
+
+    /// Matrix user ID flag.
+    #[serde(default, skip_serializing_if = "ruma_serde::is_default")]
+    pub mxid: bool,
+
+    /// Local part of user ID flag.
+    #[serde(default, skip_serializing_if = "ruma_serde::is_default")]
+    pub localpart: bool,
+
+    /// "@room" notification flag.
+    #[serde(default, skip_serializing_if = "ruma_serde::is_default")]
+    pub room_notif: bool,
+}

--- a/crates/ruma-events/src/notifications_profile.rs
+++ b/crates/ruma-events/src/notifications_profile.rs
@@ -1,0 +1,29 @@
+//! Types for *m.notifications_profile* events.
+//!
+//! See [MSC2785](https://github.com/matrix-org/matrix-doc/pull/2785) for more details.
+
+use ruma_events_macros::EventContent;
+use serde::{Deserialize, Serialize};
+
+use crate::GlobalAccountDataEvent;
+
+pub mod some_profile;
+
+/// An event to set a "notifications profile" in a user's `account_data`.
+pub type NotificationsProfileEvent = GlobalAccountDataEvent<NotificationsProfileEventContent>;
+
+/// The payload for `NotificationsProfileEvent`.
+#[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+#[ruma_event(type = "m.notifications_profile", kind = GlobalAccountData)]
+pub struct NotificationsProfileEventContent {
+    /// The user's "notifications profile".
+    pub profile: String,
+}
+
+impl NotificationsProfileEventContent {
+    /// Creates a new `NotificationsProfileEventContent` with the given profile name.
+    pub fn new(profile: String) -> Self {
+        Self { profile }
+    }
+}

--- a/crates/ruma-events/src/notifications_profile.rs
+++ b/crates/ruma-events/src/notifications_profile.rs
@@ -15,7 +15,7 @@ pub type NotificationsProfileEvent = GlobalAccountDataEvent<NotificationsProfile
 /// The payload for `NotificationsProfileEvent`.
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-#[ruma_event(type = "m.notifications_profile", kind = GlobalAccountData)]
+#[ruma_event(type = "org.matrix.msc2785.notifications_profile", kind = GlobalAccountData)]
 pub struct NotificationsProfileEventContent {
     /// The user's "notifications profile".
     pub profile: String,

--- a/crates/ruma-events/src/notifications_profile/some_profile.rs
+++ b/crates/ruma-events/src/notifications_profile/some_profile.rs
@@ -14,7 +14,7 @@ pub type SomeProfileEvent = GlobalAccountDataEvent<SomeProfileEventContent>;
 /// The payload for `SomeProfileEvent`.
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-#[ruma_event(type = "m.notifications_profile.<profile>", kind = GlobalAccountData)]
+#[ruma_event(type = "org.matrix.msc2785.notifications_profile.<profile>", kind = GlobalAccountData)]
 pub struct SomeProfileEventContent {
     /// A map from actions to the notification attributes which trigger the actions.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]

--- a/crates/ruma-events/src/notifications_profile/some_profile.rs
+++ b/crates/ruma-events/src/notifications_profile/some_profile.rs
@@ -1,0 +1,221 @@
+//! Types for the *m.notifications_profile.<profile>* event.
+
+use std::collections::BTreeMap;
+
+use ruma_events_macros::EventContent;
+use ruma_serde::StringEnum;
+use serde::{Deserialize, Serialize};
+
+use crate::GlobalAccountDataEvent;
+
+/// An event to store a "notifications profile" definition in a user's `account_data`.
+pub type SomeProfileEvent = GlobalAccountDataEvent<SomeProfileEventContent>;
+
+/// The payload for `SomeProfileEvent`.
+#[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+#[ruma_event(type = "m.notifications_profile.<profile>", kind = GlobalAccountData)]
+pub struct SomeProfileEventContent {
+    /// A map from actions to the notification attributes which trigger the actions.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub actions: BTreeMap<NotificationAction, Vec<RequiredNotificationAttribute>>,
+}
+
+impl SomeProfileEventContent {
+    /// Creates a new `SomeProfileEventContent` with the given actions.
+    pub fn new(actions: BTreeMap<NotificationAction, Vec<RequiredNotificationAttribute>>) -> Self {
+        Self { actions }
+    }
+}
+
+/// Event notification actions.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, StringEnum)]
+pub enum NotificationAction {
+    /// Show a "native notification".
+    #[ruma_enum(rename = "m.notify")]
+    Notify,
+
+    /// Play an audible alert.
+    #[ruma_enum(rename = "m.sound")]
+    Sound,
+
+    /// Highlight the room containing the event.
+    #[ruma_enum(rename = "m.highlight")]
+    Highlight,
+
+    #[doc(hidden)]
+    _Custom(String),
+}
+
+/// A notification attribute or series of notification attributes.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum RequiredNotificationAttribute {
+    /// A single notification attribute.
+    Single(NotificationAttribute),
+
+    /// A sequence of notification attributes which must all be satisfied.
+    Sequence(Vec<NotificationAttribute>),
+}
+
+/// Event notification attributes.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, StringEnum)]
+pub enum NotificationAttribute {
+    /// The event contains one of the user's registered "notification keywords".
+    #[ruma_enum(rename = "m.keyword")]
+    Keyword,
+
+    /// The event contains a "mention" of the user's userid, etc.
+    #[ruma_enum(rename = "m.mention")]
+    Mention,
+
+    /// The event is an invitation to a room.
+    #[ruma_enum(rename = "m.invite")]
+    Invite,
+
+    /// The event is a notification that a room has been upgraded.
+    #[ruma_enum(rename = "m.room_upgrade")]
+    RoomUpgrade,
+
+    /// The event is an invitation to a VoIP call.
+    #[ruma_enum(rename = "m.voip_call")]
+    VoipCall,
+
+    /// The event was in a Direct Message room.
+    #[ruma_enum(rename = "m.dm")]
+    DirectMessage,
+
+    /// The event contains a visible body.
+    #[ruma_enum(rename = "m.msg")]
+    VisibleBody,
+
+    #[doc(hidden)]
+    _Custom(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use matches::assert_matches;
+    use std::collections::BTreeMap;
+
+    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+
+    use crate::notifications_profile::some_profile::{
+        NotificationAction, NotificationAttribute, RequiredNotificationAttribute,
+        SomeProfileEventContent,
+    };
+
+    #[test]
+    fn deserialize_empty_profile_event() {
+        let json = json!({});
+
+        assert_matches!(
+            from_json_value(json).unwrap(),
+            SomeProfileEventContent { actions }
+            if actions.is_empty()
+        )
+    }
+
+    #[test]
+    fn deserialize_some_profile_event() {
+        let json = json!(
+            {
+                "actions": {
+                  "m.notify": [
+                      "m.mention", "m.keyword", "m.invite", "m.room_upgrade",
+                      "m.voip_call", ["m.dm", "m.msg"]
+                  ],
+                  "m.sound": [
+                      "m.mention", "m.keyword", "m.invite", "m.room_upgrade",
+                      "m.voip_call", ["m.dm", "m.msg"]
+                  ],
+                  "m.highlight": ["m.mention", "m.keyword"]
+                }
+              }
+        );
+
+        let notify_and_sound_attributes = vec![
+            RequiredNotificationAttribute::Single(NotificationAttribute::Mention),
+            RequiredNotificationAttribute::Single(NotificationAttribute::Keyword),
+            RequiredNotificationAttribute::Single(NotificationAttribute::Invite),
+            RequiredNotificationAttribute::Single(NotificationAttribute::RoomUpgrade),
+            RequiredNotificationAttribute::Single(NotificationAttribute::VoipCall),
+            RequiredNotificationAttribute::Sequence(vec![
+                NotificationAttribute::DirectMessage,
+                NotificationAttribute::VisibleBody,
+            ]),
+        ];
+
+        let highlight_attributes = vec![
+            RequiredNotificationAttribute::Single(NotificationAttribute::Mention),
+            RequiredNotificationAttribute::Single(NotificationAttribute::Keyword),
+        ];
+
+        let mut expected_actions = BTreeMap::new();
+        expected_actions.insert(NotificationAction::Notify, notify_and_sound_attributes.clone());
+        expected_actions.insert(NotificationAction::Sound, notify_and_sound_attributes);
+        expected_actions.insert(NotificationAction::Highlight, highlight_attributes);
+
+        assert_matches!(
+            from_json_value(json).unwrap(),
+            SomeProfileEventContent {
+                actions
+            }
+            if actions == expected_actions
+        );
+    }
+
+    #[test]
+    fn serialize_empty_profile_event() {
+        let json = json!({});
+
+        let content = SomeProfileEventContent::new(BTreeMap::new());
+
+        assert_eq!(to_json_value(&content).unwrap(), json);
+    }
+
+    #[test]
+    fn serialize_some_profile_event() {
+        let json = json!(
+            {
+                "actions": {
+                  "m.notify": [
+                      "m.mention", "m.keyword", "m.invite", "m.room_upgrade",
+                      "m.voip_call", ["m.dm", "m.msg"]
+                  ],
+                  "m.sound": [
+                      "m.mention", "m.keyword", "m.invite", "m.room_upgrade",
+                      "m.voip_call", ["m.dm", "m.msg"]
+                  ],
+                  "m.highlight": ["m.mention", "m.keyword"]
+                }
+              }
+        );
+
+        let notify_and_sound_attributes = vec![
+            RequiredNotificationAttribute::Single(NotificationAttribute::Mention),
+            RequiredNotificationAttribute::Single(NotificationAttribute::Keyword),
+            RequiredNotificationAttribute::Single(NotificationAttribute::Invite),
+            RequiredNotificationAttribute::Single(NotificationAttribute::RoomUpgrade),
+            RequiredNotificationAttribute::Single(NotificationAttribute::VoipCall),
+            RequiredNotificationAttribute::Sequence(vec![
+                NotificationAttribute::DirectMessage,
+                NotificationAttribute::VisibleBody,
+            ]),
+        ];
+
+        let highlight_attributes = vec![
+            RequiredNotificationAttribute::Single(NotificationAttribute::Mention),
+            RequiredNotificationAttribute::Single(NotificationAttribute::Keyword),
+        ];
+
+        let mut actions = BTreeMap::new();
+        actions.insert(NotificationAction::Notify, notify_and_sound_attributes.clone());
+        actions.insert(NotificationAction::Sound, notify_and_sound_attributes);
+        actions.insert(NotificationAction::Highlight, highlight_attributes);
+
+        let content = SomeProfileEventContent::new(actions);
+
+        assert_eq!(to_json_value(&content).unwrap(), json);
+    }
+}

--- a/crates/ruma-events/src/notifications_profile/some_profile.rs
+++ b/crates/ruma-events/src/notifications_profile/some_profile.rs
@@ -30,6 +30,7 @@ impl SomeProfileEventContent {
 
 /// Event notification actions.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, StringEnum)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub enum NotificationAction {
     /// Show a "native notification".
     #[ruma_enum(rename = "m.notify")]
@@ -49,6 +50,7 @@ pub enum NotificationAction {
 
 /// A notification attribute or series of notification attributes.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[serde(untagged)]
 pub enum RequiredNotificationAttribute {
     /// A single notification attribute.
@@ -60,6 +62,7 @@ pub enum RequiredNotificationAttribute {
 
 /// Event notification attributes.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, StringEnum)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub enum NotificationAttribute {
     /// The event contains one of the user's registered "notification keywords".
     #[ruma_enum(rename = "m.keyword")]


### PR DESCRIPTION
Resolves: #509.

Currently, the `*m.notifications_profile.<profile>*` event is defined using this fixed name, but will need #686 to be resolved.

What is left to be done:
- [x] set the unstable prefix for the event names
- [ ] [add API endpoints for manipulating notifications profiles, if they get added to the MSC](https://github.com/matrix-org/matrix-doc/blob/rav/proposals/notification_attributes/proposals/2785-notification-attributes.md#todo-apis-for-manipulating-notifications-profiles)
- [x] add more tests for the new events
- [x] add entries to changelogs