### PR TITLE
Generate From impls for event (content) enums.

### DIFF
--- a/crates/ruma-events-macros/src/event_enum.rs
+++ b/crates/ruma-events-macros/src/event_enum.rs
@@ -489,11 +489,30 @@ fn expand_content_enum(
         }
     });
 
+    let from_impls = content
+        .iter()
+        .zip(variants)
+        .map(|(content, variant)| {
+            let variant_tokens = variant.ident.to_token_stream();
+            let variant_attrs = &variant.attrs;
+            quote! {
+                #[automatically_derived]
+                #(#variant_attrs)*
+                impl From<#content> for #ident {
+                    fn from(c: #content) -> Self {
+                        Self::#variant_tokens(c)
+                    }
+                }
+            }
+        })
+        .collect::<Vec<_>>();
+
     quote! {
         #content_enum
         #event_content_impl
         #marker_trait_impl
         #redacted_content_enum
+        #( #from_impls )*
     }
 }
 

--- a/crates/ruma-events-macros/src/lib.rs
+++ b/crates/ruma-events-macros/src/lib.rs
@@ -15,6 +15,8 @@ use proc_macro_crate::{crate_name, FoundCrate};
 use quote::{format_ident, quote};
 use syn::{parse_macro_input, DeriveInput};
 
+use crate::event_enum::expand_from_impls_derived;
+
 use self::{
     event::expand_event, event_content::expand_event_content, event_enum::expand_event_enum,
     event_type::expand_event_type_enum,
@@ -106,4 +108,11 @@ pub(crate) fn import_ruma_events() -> pm2::TokenStream {
     } else {
         quote! { ::ruma_events }
     }
+}
+
+/// Generates `From` implementations for event enums.
+#[proc_macro_derive(EventEnumFromEvent)]
+pub fn derive_from_event_to_enum(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    expand_from_impls_derived(input).into()
 }

--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [unreleased]
 
+Improvements:
+
+* Add `From` implementations for event and event content enums
+
 # 0.24.4
 
 Improvements:

--- a/crates/ruma-events/src/enums.rs
+++ b/crates/ruma-events/src/enums.rs
@@ -1,5 +1,5 @@
 use ruma_common::MilliSecondsSinceUnixEpoch;
-use ruma_events_macros::event_enum;
+use ruma_events_macros::{event_enum, EventEnumFromEvent};
 use ruma_identifiers::{EventId, RoomId, RoomVersionId, UserId};
 use serde::{de, Deserialize, Serialize};
 use serde_json::value::RawValue as RawJsonValue;
@@ -146,7 +146,7 @@ macro_rules! room_ev_accessor {
 
 /// Any room event.
 #[allow(clippy::large_enum_variant, clippy::exhaustive_enums)]
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, EventEnumFromEvent)]
 #[serde(untagged)]
 pub enum AnyRoomEvent {
     /// Any message event.
@@ -171,7 +171,7 @@ impl AnyRoomEvent {
 
 /// Any sync room event (room event without a `room_id`, as returned in `/sync` responses)
 #[allow(clippy::large_enum_variant, clippy::exhaustive_enums)]
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, EventEnumFromEvent)]
 #[serde(untagged)]
 pub enum AnySyncRoomEvent {
     /// Any sync message event
@@ -264,7 +264,7 @@ impl<'de> Deserialize<'de> for AnySyncRoomEvent {
 
 /// Any redacted room event.
 #[allow(clippy::large_enum_variant, clippy::exhaustive_enums)]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, EventEnumFromEvent)]
 pub enum AnyRedactedRoomEvent {
     /// Any message event that has been redacted.
     Message(AnyRedactedMessageEvent),
@@ -300,7 +300,7 @@ impl From<AnyRedactedRoomEvent> for AnyRoomEvent {
 
 /// Any redacted sync room event (room event without a `room_id`, as returned in `/sync` responses)
 #[allow(clippy::large_enum_variant, clippy::exhaustive_enums)]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, EventEnumFromEvent)]
 pub enum AnyRedactedSyncRoomEvent {
     /// Any sync message event that has been redacted.
     Message(AnyRedactedSyncMessageEvent),


### PR DESCRIPTION
Resolves: #245 

Tasks:

- [x] `From<SpecificEventContent> for Any[kind]EventContent`
- [x] `From<SpecificEvent> for Any[kind]Event`
- [x] `From` impls for the manually defined enums.

I'm not sure what other `For` implementations which could be useful, but I'd gladly add those too (if any).