### PR TITLE
Bump thiserror across ruma, use thiserror in id-validation, improve mxc-uri errors

### DIFF
--- a/crates/ruma-api/Cargo.toml
+++ b/crates/ruma-api/Cargo.toml
@@ -34,7 +34,7 @@ ruma-identifiers = { version = "0.20.0", path = "../ruma-identifiers" }
 ruma-serde = { version = "0.5.0", path = "../ruma-serde" }
 serde = { version = "1.0.118", features = ["derive"] }
 serde_json = "1.0.61"
-thiserror = "1.0.23"
+thiserror = "1.0.26"
 
 [dev-dependencies]
 ruma-events = { version = "0.24.4", path = "../ruma-events" }

--- a/crates/ruma-client-api/src/r0/media/get_content.rs
+++ b/crates/ruma-client-api/src/r0/media/get_content.rs
@@ -60,11 +60,9 @@ impl<'a> Request<'a> {
 
     /// Creates a new `Request` with the given url.
     pub fn from_url(url: &'a MxcUri) -> Result<Self, Error> {
-        if let Some((server_name, media_id)) = url.parts() {
-            Ok(Self { media_id, server_name, allow_remote: true })
-        } else {
-            Err(Error::InvalidMxcUri)
-        }
+        url.parts_err()
+            .map(|(server_name, media_id)| Self { media_id, server_name, allow_remote: true })
+            .map_err(Into::into)
     }
 }
 

--- a/crates/ruma-client-api/src/r0/media/get_content.rs
+++ b/crates/ruma-client-api/src/r0/media/get_content.rs
@@ -60,9 +60,9 @@ impl<'a> Request<'a> {
 
     /// Creates a new `Request` with the given url.
     pub fn from_url(url: &'a MxcUri) -> Result<Self, Error> {
-        url.parts_err()
-            .map(|(server_name, media_id)| Self { media_id, server_name, allow_remote: true })
-            .map_err(Into::into)
+        let (server_name, media_id) = url.parts()?;
+
+        Ok(Self { media_id, server_name, allow_remote: true })
     }
 }
 

--- a/crates/ruma-client-api/src/r0/media/get_content_as_filename.rs
+++ b/crates/ruma-client-api/src/r0/media/get_content_as_filename.rs
@@ -65,14 +65,9 @@ impl<'a> Request<'a> {
 
     /// Creates a new `Request` with the given url and filename.
     pub fn from_url(url: &'a MxcUri, filename: &'a str) -> Result<Self, Error> {
-        url.parts_err()
-            .map(|(server_name, media_id)| Self {
-                media_id,
-                server_name,
-                filename,
-                allow_remote: true,
-            })
-            .map_err(Into::into)
+        let (server_name, media_id) = url.parts()?;
+
+        Ok(Self { media_id, server_name, filename, allow_remote: true })
     }
 }
 

--- a/crates/ruma-client-api/src/r0/media/get_content_as_filename.rs
+++ b/crates/ruma-client-api/src/r0/media/get_content_as_filename.rs
@@ -65,11 +65,14 @@ impl<'a> Request<'a> {
 
     /// Creates a new `Request` with the given url and filename.
     pub fn from_url(url: &'a MxcUri, filename: &'a str) -> Result<Self, Error> {
-        if let Some((server_name, media_id)) = url.parts() {
-            Ok(Self { media_id, server_name, filename, allow_remote: true })
-        } else {
-            Err(Error::InvalidMxcUri)
-        }
+        url.parts_err()
+            .map(|(server_name, media_id)| Self {
+                media_id,
+                server_name,
+                filename,
+                allow_remote: true,
+            })
+            .map_err(Into::into)
     }
 }
 

--- a/crates/ruma-client-api/src/r0/media/get_content_thumbnail.rs
+++ b/crates/ruma-client-api/src/r0/media/get_content_thumbnail.rs
@@ -70,11 +70,16 @@ impl<'a> Request<'a> {
     /// Creates a new `Request` with the given url, desired thumbnail width and
     /// desired thumbnail height.
     pub fn from_url(url: &'a MxcUri, width: UInt, height: UInt) -> Result<Self, Error> {
-        if let Some((server_name, media_id)) = url.parts() {
-            Ok(Self { media_id, server_name, method: None, width, height, allow_remote: true })
-        } else {
-            Err(Error::InvalidMxcUri)
-        }
+        url.parts_err()
+            .map(|(server_name, media_id)| Self {
+                media_id,
+                server_name,
+                method: None,
+                width,
+                height,
+                allow_remote: true,
+            })
+            .map_err(Into::into)
     }
 }
 

--- a/crates/ruma-client-api/src/r0/media/get_content_thumbnail.rs
+++ b/crates/ruma-client-api/src/r0/media/get_content_thumbnail.rs
@@ -70,16 +70,9 @@ impl<'a> Request<'a> {
     /// Creates a new `Request` with the given url, desired thumbnail width and
     /// desired thumbnail height.
     pub fn from_url(url: &'a MxcUri, width: UInt, height: UInt) -> Result<Self, Error> {
-        url.parts_err()
-            .map(|(server_name, media_id)| Self {
-                media_id,
-                server_name,
-                method: None,
-                width,
-                height,
-                allow_remote: true,
-            })
-            .map_err(Into::into)
+        let (server_name, media_id) = url.parts()?;
+
+        Ok(Self { media_id, server_name, method: None, width, height, allow_remote: true })
     }
 }
 

--- a/crates/ruma-events/Cargo.toml
+++ b/crates/ruma-events/Cargo.toml
@@ -33,7 +33,7 @@ ruma-identifiers = { version = "0.20.0", path = "../ruma-identifiers", features 
 ruma-serde = { version = "0.5.0", path = "../ruma-serde" }
 serde = { version = "1.0.118", features = ["derive"] }
 serde_json = { version = "1.0.60", features = ["raw_value"] }
-thiserror = "1.0.25"
+thiserror = "1.0.26"
 
 [dev-dependencies]
 assign = "1.1.1"

--- a/crates/ruma-identifiers-validation/Cargo.toml
+++ b/crates/ruma-identifiers-validation/Cargo.toml
@@ -16,3 +16,6 @@ all-features = true
 
 [features]
 compat = []
+
+[dependencies]
+thiserror = "1.0.26"

--- a/crates/ruma-identifiers-validation/src/error.rs
+++ b/crates/ruma-identifiers-validation/src/error.rs
@@ -1,66 +1,65 @@
 //! Error conditions.
 
-use std::fmt;
-
 /// An error encountered when trying to parse an invalid ID string.
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, thiserror::Error)]
 #[non_exhaustive]
 pub enum Error {
     /// The client secret is empty.
+    #[error("client secret is empty")]
     EmptyClientSecret,
 
     /// The room name is empty.
+    #[error("room name is empty")]
     EmptyRoomName,
 
     /// The room version ID is empty.
+    #[error("room version ID is empty")]
     EmptyRoomVersionId,
 
     /// The ID's localpart contains invalid characters.
     ///
     /// Only relevant for user IDs.
+    #[error("localpart contains invalid characters")]
     InvalidCharacters,
 
     /// The key algorithm is invalid (e.g. empty).
+    #[error("invalid key algorithm specified")]
     InvalidKeyAlgorithm,
 
     /// The key version contains outside of [a-zA-Z0-9_].
+    #[error("key ID version contains invalid characters")]
     InvalidKeyVersion,
 
     /// The mxc:// isn't a valid Matrix Content URI.
-    InvalidMxcUri,
+    #[error("invalid Matrix Content URI: {0}")]
+    InvalidMxcUri(#[from] MxcUriError),
 
     /// The server name part of the the ID string is not a valid server name.
+    #[error("server name is not a valid IP address or domain name")]
     InvalidServerName,
 
     /// The ID exceeds 255 bytes (or 32 codepoints for a room version ID).
+    #[error("ID exceeds 255 bytes")]
     MaximumLengthExceeded,
 
     /// The ID is missing the colon delimiter between localpart and server name, or between key
     /// algorithm and key name / version.
+    #[error("required colon is missing")]
     MissingDelimiter,
 
     /// The ID is missing the correct leading sigil.
+    #[error("leading sigil is incorrect or missing")]
     MissingLeadingSigil,
 }
 
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let message = match self {
-            Error::EmptyClientSecret => "client secret is empty",
-            Error::EmptyRoomName => "room name is empty",
-            Error::EmptyRoomVersionId => "room version ID is empty",
-            Error::InvalidCharacters => "localpart contains invalid characters",
-            Error::InvalidKeyAlgorithm => "invalid key algorithm specified",
-            Error::InvalidKeyVersion => "key ID version contains invalid characters",
-            Error::InvalidMxcUri => "the mxc:// isn't a valid Matrix Content URI",
-            Error::InvalidServerName => "server name is not a valid IP address or domain name",
-            Error::MaximumLengthExceeded => "ID exceeds 255 bytes",
-            Error::MissingDelimiter => "required colon is missing",
-            Error::MissingLeadingSigil => "leading sigil is incorrect or missing",
-        };
-
-        write!(f, "{}", message)
-    }
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, thiserror::Error)]
+pub enum MxcUriError {
+    #[error("MXC URI schema was not mxc://")]
+    WrongSchema,
+    #[error("MXC URI does not have first slash")]
+    MissingSlash,
+    #[error("Media Identifier malformed, invalid characters")]
+    MediaIdMalformed,
+    #[error("invalid Server Name")]
+    ServerNameMalformed,
 }
-
-impl std::error::Error for Error {}

--- a/crates/ruma-identifiers-validation/src/error.rs
+++ b/crates/ruma-identifiers-validation/src/error.rs
@@ -52,15 +52,26 @@ pub enum Error {
     MissingLeadingSigil,
 }
 
+/// An error occurred while validating a MXC URI.
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, thiserror::Error)]
 #[non_exhaustive]
 pub enum MxcUriError {
+    /// MXC URI did not start with `mxc://`.
     #[error("MXC URI schema was not mxc://")]
     WrongSchema,
+
+    /// MXC URI did not have first slash, required for `server.name/media_id`.
     #[error("MXC URI does not have first slash")]
     MissingSlash,
+
+    /// Media identifier malformed due to invalid characters detected.
+    ///
+    /// Valid characters are (in regex notation) `[A-Za-z0-9_-]+`.
+    /// See [here](https://matrix.org/docs/spec/client_server/r0.6.1#id408) for more details.
     #[error("Media Identifier malformed, invalid characters")]
     MediaIdMalformed,
+
+    /// Server identifier malformed; invalid IP, or invalid domain name.
     #[error("invalid Server Name")]
     ServerNameMalformed,
 }

--- a/crates/ruma-identifiers-validation/src/error.rs
+++ b/crates/ruma-identifiers-validation/src/error.rs
@@ -63,3 +63,18 @@ pub enum MxcUriError {
     #[error("invalid Server Name")]
     ServerNameMalformed,
 }
+
+// Required for MxcUri
+impl PartialOrd for MxcUriError {
+    fn partial_cmp(&self, _: &Self) -> Option<std::cmp::Ordering> {
+        None
+    }
+}
+
+// Required for MxcUri
+impl Ord for MxcUriError {
+    fn cmp(&self, _: &Self) -> std::cmp::Ordering {
+        // Makes this effectively a noop in ordering
+        std::cmp::Ordering::Equal
+    }
+}

--- a/crates/ruma-identifiers-validation/src/error.rs
+++ b/crates/ruma-identifiers-validation/src/error.rs
@@ -52,7 +52,7 @@ pub enum Error {
     MissingLeadingSigil,
 }
 
-/// An error occurred while validating a MXC URI.
+/// An error occurred while validating an MXC URI.
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, thiserror::Error)]
 #[non_exhaustive]
 pub enum MxcUriError {
@@ -71,7 +71,7 @@ pub enum MxcUriError {
     #[error("Media Identifier malformed, invalid characters")]
     MediaIdMalformed,
 
-    /// Server identifier malformed; invalid IP, or invalid domain name.
+    /// Server identifier malformed: invalid IP or domain name.
     #[error("invalid Server Name")]
     ServerNameMalformed,
 }

--- a/crates/ruma-identifiers-validation/src/error.rs
+++ b/crates/ruma-identifiers-validation/src/error.rs
@@ -64,18 +64,3 @@ pub enum MxcUriError {
     #[error("invalid Server Name")]
     ServerNameMalformed,
 }
-
-// Required for MxcUri
-impl PartialOrd for MxcUriError {
-    fn partial_cmp(&self, _: &Self) -> Option<std::cmp::Ordering> {
-        None
-    }
-}
-
-// Required for MxcUri
-impl Ord for MxcUriError {
-    fn cmp(&self, _: &Self) -> std::cmp::Ordering {
-        // Makes this effectively a noop in ordering
-        std::cmp::Ordering::Equal
-    }
-}

--- a/crates/ruma-identifiers-validation/src/error.rs
+++ b/crates/ruma-identifiers-validation/src/error.rs
@@ -53,6 +53,7 @@ pub enum Error {
 }
 
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, thiserror::Error)]
+#[non_exhaustive]
 pub enum MxcUriError {
     #[error("MXC URI schema was not mxc://")]
     WrongSchema,

--- a/crates/ruma-identifiers-validation/src/mxc_uri.rs
+++ b/crates/ruma-identifiers-validation/src/mxc_uri.rs
@@ -1,18 +1,18 @@
 use std::num::NonZeroU8;
 
-use crate::{error::MxcUriError, server_name, Error};
+use crate::{error::MxcUriError, server_name};
 
 const PROTOCOL: &str = "mxc://";
 
-pub fn validate(uri: &str) -> Result<NonZeroU8, Error> {
+pub fn validate(uri: &str) -> Result<NonZeroU8, MxcUriError> {
     let uri = match uri.strip_prefix(PROTOCOL) {
         Some(uri) => uri,
-        None => return Err(MxcUriError::WrongSchema.into()),
+        None => return Err(MxcUriError::WrongSchema),
     };
 
     let index = match uri.find('/') {
         Some(index) => index,
-        None => return Err(MxcUriError::MissingSlash.into()),
+        None => return Err(MxcUriError::MissingSlash),
     };
 
     let server_name = &uri[..index];
@@ -22,9 +22,9 @@ pub fn validate(uri: &str) -> Result<NonZeroU8, Error> {
         media_id.bytes().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'z' | b'A'..=b'Z' | b'-' ));
 
     if !media_id_is_valid {
-        Err(MxcUriError::MediaIdMalformed.into())
+        Err(MxcUriError::MediaIdMalformed)
     } else if !server_name::validate(server_name).is_ok() {
-        Err(MxcUriError::ServerNameMalformed.into())
+        Err(MxcUriError::ServerNameMalformed)
     } else {
         Ok(NonZeroU8::new((index + 6) as u8).unwrap())
     }

--- a/crates/ruma-identifiers-validation/src/mxc_uri.rs
+++ b/crates/ruma-identifiers-validation/src/mxc_uri.rs
@@ -23,7 +23,7 @@ pub fn validate(uri: &str) -> Result<NonZeroU8, MxcUriError> {
 
     if !media_id_is_valid {
         Err(MxcUriError::MediaIdMalformed)
-    } else if !server_name::validate(server_name).is_ok() {
+    } else if server_name::validate(server_name).is_err() {
         Err(MxcUriError::ServerNameMalformed)
     } else {
         Ok(NonZeroU8::new((index + 6) as u8).unwrap())

--- a/crates/ruma-identifiers/src/mxc_uri.rs
+++ b/crates/ruma-identifiers/src/mxc_uri.rs
@@ -14,28 +14,23 @@ use crate::ServerName;
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MxcUri {
     full_uri: Box<str>,
-    slash_idx: Result<NonZeroU8, MxcUriError>,
 }
 
 impl MxcUri {
     /// If this is a valid MXC URI, returns the media ID.
     pub fn media_id(&self) -> Option<&str> {
-        self.parts().map(|(_, s)| s)
+        self.parts().ok().map(|(_, s)| s)
     }
 
     /// If this is a valid MXC URI, returns the server name.
     pub fn server_name(&self) -> Option<&ServerName> {
-        self.parts().map(|(s, _)| s)
+        self.parts().ok().map(|(s, _)| s)
     }
 
-    /// If this is a valid MXC URI, returns a `(server_name, media_id)` tuple.
-    pub fn parts(&self) -> Option<(&ServerName, &str)> {
-        self.parts_err().ok()
-    }
-
-    /// Similar to [MxcUri::parts], except returns the error if this is not a valid MXC URI.
-    pub fn parts_err(&self) -> Result<(&ServerName, &str), MxcUriError> {
-        self.slash_idx.map(|idx| {
+    /// If this is a valid MXC URI, returns a `(server_name, media_id)` tuple, else it returns the
+    /// error.
+    pub fn parts(&self) -> Result<(&ServerName, &str), MxcUriError> {
+        self.extract().map(|idx| {
             (
                 <&ServerName>::try_from(&self.full_uri[6..idx.get() as usize]).unwrap(),
                 &self.full_uri[idx.get() as usize + 1..],
@@ -43,19 +38,27 @@ impl MxcUri {
         })
     }
 
-    /// If an error occurred during parsing, retrieve it via here.
-    pub fn inner_err(&self) -> Option<MxcUriError> {
-        self.slash_idx.err()
+    /// Validates the URI and returns an error if it failed.
+    pub fn validate(&self) -> Result<(), MxcUriError> {
+        self.extract().map(|_| ())
     }
 
-    /// Returns if this is a spec-compliant MXC URI.
+    /// Convenience method for `.validate().is_ok()`
+    #[inline(always)]
     pub fn is_valid(&self) -> bool {
-        self.slash_idx.is_ok()
+        self.validate().is_ok()
     }
 
     /// Create a string slice from this MXC URI.
+    #[inline(always)]
     pub fn as_str(&self) -> &str {
         &self.full_uri
+    }
+
+    // convenience method for calling validate(self)
+    #[inline(always)]
+    fn extract(&self) -> Result<NonZeroU8, MxcUriError> {
+        validate(self.as_str())
     }
 }
 
@@ -75,7 +78,7 @@ fn from<S>(uri: S) -> MxcUri
 where
     S: AsRef<str> + Into<Box<str>>,
 {
-    MxcUri { slash_idx: validate(uri.as_ref()), full_uri: uri.into() }
+    MxcUri { full_uri: uri.into() }
 }
 
 impl From<&str> for MxcUri {
@@ -114,6 +117,8 @@ impl serde::Serialize for MxcUri {
 mod tests {
     use std::convert::TryFrom;
 
+    use ruma_identifiers_validation::error::MxcUriError;
+
     use crate::ServerName;
 
     use super::MxcUri;
@@ -125,7 +130,7 @@ mod tests {
         assert!(mxc.is_valid());
         assert_eq!(
             mxc.parts(),
-            Some((
+            Ok((
                 <&ServerName>::try_from("127.0.0.1").expect("Failed to create ServerName"),
                 "asd32asdfasdsd"
             ))
@@ -137,7 +142,7 @@ mod tests {
         let mxc = MxcUri::from("mxc://127.0.0.1");
 
         assert!(!mxc.is_valid());
-        assert_eq!(mxc.parts(), None);
+        assert_eq!(mxc.parts(), Err(MxcUriError::WrongSchema));
     }
 
     #[test]
@@ -165,10 +170,7 @@ mod tests {
         assert!(mxc.is_valid());
         assert_eq!(
             mxc.parts(),
-            Some((
-                <&ServerName>::try_from("server").expect("Failed to create ServerName"),
-                "1234id"
-            ))
+            Ok((<&ServerName>::try_from("server").expect("Failed to create ServerName"), "1234id"))
         );
     }
 }

--- a/crates/ruma-identifiers/src/mxc_uri.rs
+++ b/crates/ruma-identifiers/src/mxc_uri.rs
@@ -43,7 +43,7 @@ impl MxcUri {
         self.extract().map(|_| ())
     }
 
-    /// Convenience method for `.validate().is_ok()`
+    /// Convenience method for `.validate().is_ok()`.
     #[inline(always)]
     pub fn is_valid(&self) -> bool {
         self.validate().is_ok()

--- a/crates/ruma-signatures/Cargo.toml
+++ b/crates/ruma-signatures/Cargo.toml
@@ -28,5 +28,5 @@ ruma-identifiers = { version = "0.20.0", path = "../ruma-identifiers" }
 ruma-serde = { version = "0.5.0", path = "../ruma-serde" }
 serde_json = "1.0.60"
 sha2 = "0.9.5"
-thiserror = "1.0.23"
+thiserror = "1.0.26"
 tracing = { version = "0.1.25", optional = true }

--- a/crates/ruma-state-res/Cargo.toml
+++ b/crates/ruma-state-res/Cargo.toml
@@ -28,7 +28,7 @@ ruma-identifiers = { version = "0.20.0", path = "../ruma-identifiers" }
 ruma-serde = { version = "0.5.0", path = "../ruma-serde" }
 serde = { version = "1.0.118", features = ["derive"] }
 serde_json = "1.0.60"
-thiserror = "1.0.22"
+thiserror = "1.0.26"
 tracing = "0.1.26"
 
 [dev-dependencies]


### PR DESCRIPTION
This;

- Bumps all `thiserror` dependencies to 1.0.26
- Converts `ruma_identifiers_validation::Error` to use `thiserror`
- Adds `MxcUriError` to `error.rs`, which is referred to by `Error::InvalidMxcUri`, for extra error clarification.

fixes #695