### PR TITLE
Derive Serialize and Deserialize impls for Relation.

### DIFF
--- a/crates/ruma-events/src/room/encrypted.rs
+++ b/crates/ruma-events/src/room/encrypted.rs
@@ -90,7 +90,7 @@ pub enum EncryptedEventScheme {
 /// Relationship information about an encrypted event.
 ///
 /// Outside of the encrypted payload to support server aggregation.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub enum Relation {
     /// An `m.in_reply_to` relation indicating that the event is a reply to another event.


### PR DESCRIPTION
I'm adding an API to matrix-rust-sdk that will allow me to send raw JSON as room messages, that is to bypass the usual validation so that I can send malformed stuff. The purpose of this is to allow me to use matrix-rust-sdk to find breakage/vulnerabilities.

It turns out I need `Serialize` and `Deserialize` impls on `Relation` for this. Can I get them please?