### PR TITLE
Fix quoting of multiline fallback messages

### DIFF
--- a/crates/ruma-events/src/room/message.rs
+++ b/crates/ruma-events/src/room/message.rs
@@ -1221,6 +1221,7 @@ mod tests {
             } if event_id == ev_id
         );
     }
+
     #[test]
     fn plain_quote_fallback_multiline() {
         let sender = UserId::try_from("@alice:example.com").unwrap();


### PR DESCRIPTION
Previously, a '> ' was prepended only to the first line of the quoted message.