### PR TITLE
Implement MSC3231: Token authenticated registration

### DIFF
--- a/crates/ruma-client-api/src/r0/uiaa.rs
+++ b/crates/ruma-client-api/src/r0/uiaa.rs
@@ -81,7 +81,6 @@ impl<'a> AuthData<'a> {
             Self::Msisdn(_) => Some("m.login.msisdn"),
             Self::Dummy(_) => Some("m.login.dummy"),
             #[cfg(feature = "unstable-pre-spec")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "unstable-pre-spec")))]
             Self::RegistrationToken(_) => Some("org.matrix.msc3231.login.registration_token"),
             Self::FallbackAcknowledgement(_) => None,
             Self::_Custom(c) => Some(c.auth_type),
@@ -99,7 +98,6 @@ impl<'a> AuthData<'a> {
             Self::Msisdn(x) => x.session,
             Self::Dummy(x) => x.session,
             #[cfg(feature = "unstable-pre-spec")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "unstable-pre-spec")))]
             Self::RegistrationToken(x) => x.session,
             Self::FallbackAcknowledgement(x) => Some(x.session),
             Self::_Custom(x) => x.session,
@@ -119,7 +117,6 @@ impl IncomingAuthData {
             Self::Msisdn(_) => Some("m.login.msisdn"),
             Self::Dummy(_) => Some("m.login.dummy"),
             #[cfg(feature = "unstable-pre-spec")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "unstable-pre-spec")))]
             Self::RegistrationToken(_) => Some("org.matrix.msc3231.login.registration_token"),
             Self::FallbackAcknowledgement(_) => None,
             Self::_Custom(c) => Some(&c.auth_type),
@@ -137,7 +134,6 @@ impl IncomingAuthData {
             Self::Msisdn(x) => x.session.as_deref(),
             Self::Dummy(x) => x.session.as_deref(),
             #[cfg(feature = "unstable-pre-spec")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "unstable-pre-spec")))]
             Self::RegistrationToken(x) => x.session.as_deref(),
             Self::FallbackAcknowledgement(x) => Some(&x.session),
             Self::_Custom(x) => x.session.as_deref(),
@@ -177,7 +173,6 @@ impl<'de> Deserialize<'de> for IncomingAuthData {
             Some("m.login.msisdn") => from_raw_json_value(&json).map(Self::Msisdn),
             Some("m.login.dummy") => from_raw_json_value(&json).map(Self::Dummy),
             #[cfg(feature = "unstable-pre-spec")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "unstable-pre-spec")))]
             Some("org.matrix.msc3231.login.registration_token") => {
                 from_raw_json_value(&json).map(Self::RegistrationToken)
             }

--- a/crates/ruma-client-api/src/r0/uiaa.rs
+++ b/crates/ruma-client-api/src/r0/uiaa.rs
@@ -52,6 +52,11 @@ pub enum AuthData<'a> {
     /// Dummy authentication (`m.login.dummy`).
     Dummy(Dummy<'a>),
 
+    /// Registration token-based authentication (`org.matrix.msc3231.login.registration_token`)
+    #[cfg(feature = "unstable-pre-spec")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable-pre-spec")))]
+    RegistrationToken(RegistrationToken<'a>),
+
     /// Fallback acknowledgement.
     FallbackAcknowledgement(FallbackAcknowledgement<'a>),
 
@@ -75,6 +80,9 @@ impl<'a> AuthData<'a> {
             Self::EmailIdentity(_) => Some("m.login.email.identity"),
             Self::Msisdn(_) => Some("m.login.msisdn"),
             Self::Dummy(_) => Some("m.login.dummy"),
+            #[cfg(feature = "unstable-pre-spec")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "unstable-pre-spec")))]
+            Self::RegistrationToken(_) => Some("org.matrix.msc3231.login.registration_token"),
             Self::FallbackAcknowledgement(_) => None,
             Self::_Custom(c) => Some(c.auth_type),
         }
@@ -90,6 +98,9 @@ impl<'a> AuthData<'a> {
             Self::EmailIdentity(x) => x.session,
             Self::Msisdn(x) => x.session,
             Self::Dummy(x) => x.session,
+            #[cfg(feature = "unstable-pre-spec")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "unstable-pre-spec")))]
+            Self::RegistrationToken(x) => x.session,
             Self::FallbackAcknowledgement(x) => Some(x.session),
             Self::_Custom(x) => x.session,
         }
@@ -107,6 +118,9 @@ impl IncomingAuthData {
             Self::EmailIdentity(_) => Some("m.login.email.identity"),
             Self::Msisdn(_) => Some("m.login.msisdn"),
             Self::Dummy(_) => Some("m.login.dummy"),
+            #[cfg(feature = "unstable-pre-spec")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "unstable-pre-spec")))]
+            Self::RegistrationToken(_) => Some("org.matrix.msc3231.login.registration_token"),
             Self::FallbackAcknowledgement(_) => None,
             Self::_Custom(c) => Some(&c.auth_type),
         }
@@ -122,6 +136,9 @@ impl IncomingAuthData {
             Self::EmailIdentity(x) => x.session.as_deref(),
             Self::Msisdn(x) => x.session.as_deref(),
             Self::Dummy(x) => x.session.as_deref(),
+            #[cfg(feature = "unstable-pre-spec")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "unstable-pre-spec")))]
+            Self::RegistrationToken(x) => x.session.as_deref(),
             Self::FallbackAcknowledgement(x) => Some(&x.session),
             Self::_Custom(x) => x.session.as_deref(),
         }
@@ -159,6 +176,11 @@ impl<'de> Deserialize<'de> for IncomingAuthData {
             Some("m.login.email.identity") => from_raw_json_value(&json).map(Self::EmailIdentity),
             Some("m.login.msisdn") => from_raw_json_value(&json).map(Self::Msisdn),
             Some("m.login.dummy") => from_raw_json_value(&json).map(Self::Dummy),
+            #[cfg(feature = "unstable-pre-spec")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "unstable-pre-spec")))]
+            Some("org.matrix.msc3231.login.registration_token") => {
+                from_raw_json_value(&json).map(Self::RegistrationToken)
+            }
             None => from_raw_json_value(&json).map(Self::FallbackAcknowledgement),
             Some(_) => from_raw_json_value(&json).map(Self::_Custom),
         }
@@ -314,6 +336,33 @@ impl Dummy<'_> {
     /// Creates an empty `Dummy`.
     pub fn new() -> Self {
         Self::default()
+    }
+}
+
+/// Data for registration token-based UIAA flow.
+///
+/// See [MSC3231] for how to use this.
+///
+/// [MSC3231]: https://github.com/matrix-org/matrix-doc/pull/3231
+#[derive(Clone, Debug, Outgoing, Serialize)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+#[cfg(feature = "unstable-pre-spec")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable-pre-spec")))]
+#[serde(tag = "type", rename = "org.matrix.msc3231.login.registration_token")]
+pub struct RegistrationToken<'a> {
+    /// The registration token.
+    pub token: &'a str,
+
+    /// The value of the session key given by the homeserver, if any.
+    pub session: Option<&'a str>,
+}
+
+#[cfg(feature = "unstable-pre-spec")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable-pre-spec")))]
+impl<'a> RegistrationToken<'a> {
+    /// Creates a new `RegistrationToken` with the given token.
+    pub fn new(token: &'a str) -> Self {
+        Self { token, session: None }
     }
 }
 

--- a/crates/ruma-client-api/tests/uiaa.rs
+++ b/crates/ruma-client-api/tests/uiaa.rs
@@ -64,6 +64,45 @@ fn deserialize_auth_data_direct_request() {
 }
 
 #[test]
+#[cfg(feature = "unstable-pre-spec")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable-pre-spec")))]
+fn serialize_auth_data_registration_token() {
+    let auth_data = AuthData::RegistrationToken(
+        assign!(uiaa::RegistrationToken::new("mytoken"), { session: Some("session") }),
+    );
+
+    assert_matches!(
+        to_json_value(auth_data),
+        Ok(val) if val == json!({
+            "type": "org.matrix.msc3231.login.registration_token",
+            "token": "mytoken",
+            "session": "session",
+        })
+    );
+
+}
+
+#[test]
+#[cfg(feature = "unstable-pre-spec")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable-pre-spec")))]
+fn deserialize_auth_data_registration_token() {
+    let json = json!({
+        "type": "org.matrix.msc3231.login.registration_token",
+        "token": "mytoken",
+        "session": "session",
+    });
+
+    assert_matches!(
+        from_json_value(json),
+        Ok(IncomingAuthData::RegistrationToken(
+            uiaa::IncomingRegistrationToken { token, session: Some(session), .. },
+        ))
+        if token == "mytoken" && session == "session"
+    );
+
+}
+
+#[test]
 fn serialize_auth_data_fallback() {
     let auth_data = AuthData::FallbackAcknowledgement(uiaa::FallbackAcknowledgement::new("ZXY000"));
 

--- a/crates/ruma-client-api/tests/uiaa.rs
+++ b/crates/ruma-client-api/tests/uiaa.rs
@@ -65,7 +65,6 @@ fn deserialize_auth_data_direct_request() {
 
 #[test]
 #[cfg(feature = "unstable-pre-spec")]
-#[cfg_attr(docsrs, doc(cfg(feature = "unstable-pre-spec")))]
 fn serialize_auth_data_registration_token() {
     let auth_data = AuthData::RegistrationToken(
         assign!(uiaa::RegistrationToken::new("mytoken"), { session: Some("session") }),
@@ -79,12 +78,10 @@ fn serialize_auth_data_registration_token() {
             "session": "session",
         })
     );
-
 }
 
 #[test]
 #[cfg(feature = "unstable-pre-spec")]
-#[cfg_attr(docsrs, doc(cfg(feature = "unstable-pre-spec")))]
 fn deserialize_auth_data_registration_token() {
     let json = json!({
         "type": "org.matrix.msc3231.login.registration_token",
@@ -99,7 +96,6 @@ fn deserialize_auth_data_registration_token() {
         ))
         if token == "mytoken" && session == "session"
     );
-
 }
 
 #[test]


### PR DESCRIPTION
Add support for registration tokens as described in [MSCS3231](https://github.com/matrix-org/matrix-doc/pull/3231)
asd
#708 

- [X] Add registration token UIAA type
~~- Add endpoint for checking the validity of tokens~~