### PR TITLE
client-api: Add custom variant to LoginInfo

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -6,6 +6,8 @@ Breaking changes:
 * Make `r0::uiaa::ThirdpartyIdCredentials` an owned type and remove its `Incoming` equivalent
   * Previously, we had two fields of type `&'a [ThirdpartyIdCredentials<'a>]` and this kind of
     nested borrowing can be very annoying
+* `LoginInfo` no longer implements `PartialEq` and `Eq` due to the custom variant that was added.
+* `LoginInfo` converted to newtype variants.
 
 Improvements:
 
@@ -20,6 +22,10 @@ Improvements:
   }
   ```
 * Add a `.data()` accessor method to `r0::uiaa::{AuthData, IncomingAuthData}`
+* Allow to construct the custom `AuthData` variant with `IncomingAuthData::new` and then call
+  `IncomingAuthData::to_outgoing` on it.
+* Add custom variant to `LoginInfo` which can be constructed with `IncomingLoginInfo::new` and
+  then call `IncomingLoginInfo::to_outgoing` on it.
 
 # 0.12.3
 

--- a/crates/ruma-client-api/src/r0/uiaa.rs
+++ b/crates/ruma-client-api/src/r0/uiaa.rs
@@ -295,7 +295,7 @@ impl IncomingAuthData {
             Self::RegistrationToken(a) => AuthData::RegistrationToken(a.to_outgoing()),
             Self::FallbackAcknowledgement(a) => AuthData::FallbackAcknowledgement(a.to_outgoing()),
             Self::_Custom(a) => AuthData::_Custom(CustomAuthData {
-                auth_type: a.auth_type.as_ref(),
+                auth_type: &a.auth_type,
                 session: a.session.as_deref(),
                 extra: &a.extra,
             }),
@@ -712,7 +712,7 @@ pub enum UserIdentifier<'a> {
 }
 
 impl IncomingUserIdentifier {
-    fn to_outgoing(&self) -> UserIdentifier<'_> {
+    pub(crate) fn to_outgoing(&self) -> UserIdentifier<'_> {
         match self {
             Self::MatrixId(id) => UserIdentifier::MatrixId(id),
             Self::ThirdPartyId { address, medium } => {

--- a/crates/ruma-client/src/client_api.rs
+++ b/crates/ruma-client/src/client_api.rs
@@ -30,7 +30,7 @@ impl<C: HttpClient> Client<C> {
         let response = self
             .send_request(assign!(
                 login::Request::new(
-                    LoginInfo::Password { identifier: UserIdentifier::MatrixId(user), password }
+                    LoginInfo::Password(login::Password { identifier: UserIdentifier::MatrixId(user), password })
                 ), {
                     device_id,
                     initial_device_display_name,


### PR DESCRIPTION
This is a breaking change given `LoginInfo` no longer can implement `Eq` and it takes newtype variants.

Fixes #729 