### PR TITLE
Rename `*ToDeviceEventContent` structs to `ToDevice*Content`

### DIFF
--- a/crates/ruma-events-macros/src/event_enum.rs
+++ b/crates/ruma-events-macros/src/event_enum.rs
@@ -866,7 +866,7 @@ fn to_event_path(name: &LitStr, struct_name: &Ident, ruma_events: &TokenStream) 
             quote! { #ruma_events::#struct_name<#ruma_events::#( #path )::*::#content> }
         }
         "ToDeviceEvent" => {
-            let content = format_ident!("{}ToDeviceEventContent", event);
+            let content = format_ident!("ToDevice{}EventContent", event);
             quote! { #ruma_events::#struct_name<#ruma_events::#( #path )::*::#content> }
         }
         struct_str if struct_str.contains("Redacted") => {
@@ -902,7 +902,7 @@ fn to_event_content_path(
 
     let content_str = match kind {
         EventKind::ToDevice => {
-            format_ident!("{}{}ToDeviceEventContent", prefix.unwrap_or(""), event)
+            format_ident!("ToDevice{}{}EventContent", prefix.unwrap_or(""), event)
         }
         _ => format_ident!("{}{}EventContent", prefix.unwrap_or(""), event),
     };

--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -7,6 +7,7 @@ Breaking changes:
 * Use `Box<RawJsonValue>` instead of `JsonValue` for PDU `content` field
 * Require `room::message::MessageType` to always contain a body
   * The `new` constructor now also has a body parameter
+* Rename `*ToDeviceEventContent` structs to `ToDevice*Content`
 
 Improvements:
 

--- a/crates/ruma-events/src/dummy.rs
+++ b/crates/ruma-events/src/dummy.rs
@@ -22,16 +22,16 @@ use serde::{
 #[derive(Clone, Debug, Default, EventContent)]
 #[allow(clippy::exhaustive_structs)]
 #[ruma_event(type = "m.dummy", kind = ToDevice)]
-pub struct DummyToDeviceEventContent;
+pub struct ToDeviceDummyEventContent;
 
-impl DummyToDeviceEventContent {
-    /// Create a new `DummyToDeviceEventContent`.
+impl ToDeviceDummyEventContent {
+    /// Create a new `ToDeviceDummyEventContent`.
     pub fn new() -> Self {
         Self
     }
 }
 
-impl<'de> Deserialize<'de> for DummyToDeviceEventContent {
+impl<'de> Deserialize<'de> for ToDeviceDummyEventContent {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -39,7 +39,7 @@ impl<'de> Deserialize<'de> for DummyToDeviceEventContent {
         struct Visitor;
 
         impl<'de> de::Visitor<'de> for Visitor {
-            type Value = DummyToDeviceEventContent;
+            type Value = ToDeviceDummyEventContent;
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("a struct")
@@ -50,19 +50,19 @@ impl<'de> Deserialize<'de> for DummyToDeviceEventContent {
                 A: de::MapAccess<'de>,
             {
                 while map.next_entry::<de::IgnoredAny, de::IgnoredAny>()?.is_some() {}
-                Ok(DummyToDeviceEventContent)
+                Ok(ToDeviceDummyEventContent)
             }
         }
 
-        deserializer.deserialize_struct("DummyToDeviceEventContent", &[], Visitor)
+        deserializer.deserialize_struct("ToDeviceDummyEventContent", &[], Visitor)
     }
 }
 
-impl Serialize for DummyToDeviceEventContent {
+impl Serialize for ToDeviceDummyEventContent {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        serializer.serialize_struct("DummyToDeviceEventContent", 0)?.end()
+        serializer.serialize_struct("ToDeviceDummyEventContent", 0)?.end()
     }
 }

--- a/crates/ruma-events/src/forwarded_room_key.rs
+++ b/crates/ruma-events/src/forwarded_room_key.rs
@@ -6,12 +6,12 @@ use serde::{Deserialize, Serialize};
 
 /// The content of an `m.forwarded_room_key` event.
 ///
-/// To create an instance of this type, first create a `ForwardedRoomKeyToDeviceEventContentInit`
-/// and convert it via `ForwardedRoomKeyToDeviceEventContent::from` / `.into()`.
+/// To create an instance of this type, first create a `ToDeviceForwardedRoomKeyEventContentInit`
+/// and convert it via `ToDeviceForwardedRoomKeyEventContent::from` / `.into()`.
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[ruma_event(type = "m.forwarded_room_key", kind = ToDevice)]
-pub struct ForwardedRoomKeyToDeviceEventContent {
+pub struct ToDeviceForwardedRoomKeyEventContent {
     /// The encryption algorithm the key in this event is to be used with.
     pub algorithm: EventEncryptionAlgorithm,
 
@@ -43,13 +43,13 @@ pub struct ForwardedRoomKeyToDeviceEventContent {
     pub forwarding_curve25519_key_chain: Vec<String>,
 }
 
-/// Initial set of fields of `ForwardedRoomKeyToDeviceEventContent`.
+/// Initial set of fields of `ToDeviceForwardedRoomKeyEventContent`.
 ///
 /// This struct will not be updated even if additional fields are added to `ConditionalPushRule` in
 /// a new (non-breaking) release of the Matrix specification.
 #[derive(Debug)]
 #[allow(clippy::exhaustive_structs)]
-pub struct ForwardedRoomKeyToDeviceEventContentInit {
+pub struct ToDeviceForwardedRoomKeyEventContentInit {
     /// The encryption algorithm the key in this event is to be used with.
     pub algorithm: EventEncryptionAlgorithm,
 
@@ -81,8 +81,8 @@ pub struct ForwardedRoomKeyToDeviceEventContentInit {
     pub forwarding_curve25519_key_chain: Vec<String>,
 }
 
-impl From<ForwardedRoomKeyToDeviceEventContentInit> for ForwardedRoomKeyToDeviceEventContent {
-    fn from(init: ForwardedRoomKeyToDeviceEventContentInit) -> Self {
+impl From<ToDeviceForwardedRoomKeyEventContentInit> for ToDeviceForwardedRoomKeyEventContent {
+    fn from(init: ToDeviceForwardedRoomKeyEventContentInit) -> Self {
         Self {
             algorithm: init.algorithm,
             room_id: init.room_id,

--- a/crates/ruma-events/src/key/verification/accept.rs
+++ b/crates/ruma-events/src/key/verification/accept.rs
@@ -18,7 +18,7 @@ use super::{
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[ruma_event(type = "m.key.verification.accept", kind = ToDevice)]
-pub struct AcceptToDeviceEventContent {
+pub struct ToDeviceAcceptEventContent {
     /// An opaque identifier for the verification process.
     ///
     /// Must be the same as the one used for the *m.key.verification.start* message.
@@ -29,8 +29,8 @@ pub struct AcceptToDeviceEventContent {
     pub method: AcceptMethod,
 }
 
-impl AcceptToDeviceEventContent {
-    /// Creates a new `AcceptToDeviceEventContent` with the given transaction ID and method-specific
+impl ToDeviceAcceptEventContent {
+    /// Creates a new `ToDeviceAcceptEventContent` with the given transaction ID and method-specific
     /// content.
     pub fn new(transaction_id: String, method: AcceptMethod) -> Self {
         Self { transaction_id, method }
@@ -57,7 +57,7 @@ pub struct AcceptEventContent {
 
 #[cfg(feature = "unstable-pre-spec")]
 impl AcceptEventContent {
-    /// Creates a new `AcceptToDeviceEventContent` with the given method-specific content and
+    /// Creates a new `ToDeviceAcceptEventContent` with the given method-specific content and
     /// relation.
     pub fn new(method: AcceptMethod, relates_to: Relation) -> Self {
         Self { method, relates_to }
@@ -176,8 +176,8 @@ mod tests {
     #[cfg(feature = "unstable-pre-spec")]
     use super::AcceptEventContent;
     use super::{
-        AcceptMethod, AcceptToDeviceEventContent, HashAlgorithm, KeyAgreementProtocol,
-        MessageAuthenticationCode, SasV1Content, ShortAuthenticationString, _CustomContent,
+        AcceptMethod, HashAlgorithm, KeyAgreementProtocol, MessageAuthenticationCode, SasV1Content,
+        ShortAuthenticationString, ToDeviceAcceptEventContent, _CustomContent,
     };
     #[cfg(feature = "unstable-pre-spec")]
     use crate::key::verification::Relation;
@@ -185,7 +185,7 @@ mod tests {
 
     #[test]
     fn serialization() {
-        let key_verification_accept_content = AcceptToDeviceEventContent {
+        let key_verification_accept_content = ToDeviceAcceptEventContent {
             transaction_id: "456".into(),
             method: AcceptMethod::SasV1(SasV1Content {
                 hash: HashAlgorithm::Sha256,
@@ -229,7 +229,7 @@ mod tests {
             "type": "m.key.verification.accept"
         });
 
-        let key_verification_accept_content = AcceptToDeviceEventContent {
+        let key_verification_accept_content = ToDeviceAcceptEventContent {
             transaction_id: "456".into(),
             method: AcceptMethod::_Custom(_CustomContent {
                 method: "m.sas.custom".to_owned(),
@@ -291,8 +291,8 @@ mod tests {
 
         // Deserialize the content struct separately to verify `TryFromRaw` is implemented for it.
         assert_matches!(
-            from_json_value::<AcceptToDeviceEventContent>(json).unwrap(),
-            AcceptToDeviceEventContent {
+            from_json_value::<ToDeviceAcceptEventContent>(json).unwrap(),
+            ToDeviceAcceptEventContent {
                 transaction_id,
                 method: AcceptMethod::SasV1(SasV1Content {
                     commitment,
@@ -326,10 +326,10 @@ mod tests {
         });
 
         assert_matches!(
-            from_json_value::<ToDeviceEvent<AcceptToDeviceEventContent>>(json).unwrap(),
+            from_json_value::<ToDeviceEvent<ToDeviceAcceptEventContent>>(json).unwrap(),
             ToDeviceEvent {
                 sender,
-                content: AcceptToDeviceEventContent {
+                content: ToDeviceAcceptEventContent {
                     transaction_id,
                     method: AcceptMethod::SasV1(SasV1Content {
                         commitment,
@@ -362,10 +362,10 @@ mod tests {
         });
 
         assert_matches!(
-            from_json_value::<ToDeviceEvent<AcceptToDeviceEventContent>>(json).unwrap(),
+            from_json_value::<ToDeviceEvent<ToDeviceAcceptEventContent>>(json).unwrap(),
             ToDeviceEvent {
                 sender,
-                content: AcceptToDeviceEventContent {
+                content: ToDeviceAcceptEventContent {
                     transaction_id,
                     method: AcceptMethod::_Custom(_CustomContent {
                         method,

--- a/crates/ruma-events/src/key/verification/cancel.rs
+++ b/crates/ruma-events/src/key/verification/cancel.rs
@@ -13,7 +13,7 @@ use super::Relation;
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[ruma_event(type = "m.key.verification.cancel", kind = ToDevice)]
-pub struct CancelToDeviceEventContent {
+pub struct ToDeviceCancelEventContent {
     /// The opaque identifier for the verification process/request.
     pub transaction_id: String,
 
@@ -26,8 +26,8 @@ pub struct CancelToDeviceEventContent {
     pub code: CancelCode,
 }
 
-impl CancelToDeviceEventContent {
-    /// Creates a new `CancelToDeviceEventContent` with the given transaction ID, reason and code.
+impl ToDeviceCancelEventContent {
+    /// Creates a new `ToDeviceCancelEventContent` with the given transaction ID, reason and code.
     pub fn new(transaction_id: String, reason: String, code: CancelCode) -> Self {
         Self { transaction_id, reason, code }
     }

--- a/crates/ruma-events/src/key/verification/done.rs
+++ b/crates/ruma-events/src/key/verification/done.rs
@@ -11,15 +11,15 @@ use super::Relation;
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[ruma_event(type = "m.key.verification.done", kind = ToDevice)]
-pub struct DoneToDeviceEventContent {
+pub struct ToDeviceDoneEventContent {
     /// An opaque identifier for the verification process.
     ///
     /// Must be the same as the one used for the *m.key.verification.start* message.
     pub transaction_id: String,
 }
 
-impl DoneToDeviceEventContent {
-    /// Creates a new `DoneToDeviceEventContent` with the given transaction ID.
+impl ToDeviceDoneEventContent {
+    /// Creates a new `ToDeviceDoneEventContent` with the given transaction ID.
     pub fn new(transaction_id: String) -> Self {
         Self { transaction_id }
     }

--- a/crates/ruma-events/src/key/verification/key.rs
+++ b/crates/ruma-events/src/key/verification/key.rs
@@ -12,7 +12,7 @@ use super::Relation;
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[ruma_event(type = "m.key.verification.key", kind = ToDevice)]
-pub struct KeyToDeviceEventContent {
+pub struct ToDeviceKeyEventContent {
     /// An opaque identifier for the verification process.
     ///
     /// Must be the same as the one used for the *m.key.verification.start* message.
@@ -22,8 +22,8 @@ pub struct KeyToDeviceEventContent {
     pub key: String,
 }
 
-impl KeyToDeviceEventContent {
-    /// Creates a new `KeyToDeviceEventContent` with the given transaction ID and key.
+impl ToDeviceKeyEventContent {
+    /// Creates a new `ToDeviceKeyEventContent` with the given transaction ID and key.
     pub fn new(transaction_id: String, key: String) -> Self {
         Self { transaction_id, key }
     }

--- a/crates/ruma-events/src/key/verification/mac.rs
+++ b/crates/ruma-events/src/key/verification/mac.rs
@@ -14,7 +14,7 @@ use super::Relation;
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[ruma_event(type = "m.key.verification.mac", kind = ToDevice)]
-pub struct MacToDeviceEventContent {
+pub struct ToDeviceMacEventContent {
     /// An opaque identifier for the verification process.
     ///
     /// Must be the same as the one used for the *m.key.verification.start* message.
@@ -30,9 +30,9 @@ pub struct MacToDeviceEventContent {
     pub keys: String,
 }
 
-impl MacToDeviceEventContent {
-    /// Creates a new `MacToDeviceEventContent` with the given transaction ID, key ID to MAC map and
-    /// key MAC.
+impl ToDeviceMacEventContent {
+    /// Creates a new `ToDeviceMacEventContent` with the given transaction ID, key ID to MAC
+    /// map and key MAC.
     pub fn new(transaction_id: String, mac: BTreeMap<String, String>, keys: String) -> Self {
         Self { transaction_id, mac, keys }
     }

--- a/crates/ruma-events/src/key/verification/ready.rs
+++ b/crates/ruma-events/src/key/verification/ready.rs
@@ -12,7 +12,7 @@ use super::{Relation, VerificationMethod};
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[ruma_event(type = "m.key.verification.ready", kind = ToDevice)]
-pub struct ReadyToDeviceEventContent {
+pub struct ToDeviceReadyEventContent {
     /// The device ID which is initiating the request.
     pub from_device: DeviceIdBox,
 
@@ -27,8 +27,8 @@ pub struct ReadyToDeviceEventContent {
     pub transaction_id: String,
 }
 
-impl ReadyToDeviceEventContent {
-    /// Creates a new `ReadyToDeviceEventContent` with the given device ID, verification methods and
+impl ToDeviceReadyEventContent {
+    /// Creates a new `ToDeviceReadyEventContent` with the given device ID, verification methods and
     /// transaction ID.
     pub fn new(
         from_device: DeviceIdBox,
@@ -75,7 +75,7 @@ mod tests {
     use ruma_identifiers::{event_id, DeviceIdBox};
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
-    use super::{ReadyEventContent, ReadyToDeviceEventContent};
+    use super::{ReadyEventContent, ToDeviceReadyEventContent};
     use crate::key::verification::{Relation, VerificationMethod};
 
     #[test]
@@ -106,7 +106,7 @@ mod tests {
             "transaction_id": "456",
         });
 
-        let content = ReadyToDeviceEventContent {
+        let content = ToDeviceReadyEventContent {
             from_device: device,
             transaction_id: "456".to_owned(),
             methods: vec![VerificationMethod::SasV1],
@@ -149,8 +149,8 @@ mod tests {
         });
 
         assert_matches!(
-            from_json_value::<ReadyToDeviceEventContent>(json_data).unwrap(),
-            ReadyToDeviceEventContent {
+            from_json_value::<ToDeviceReadyEventContent>(json_data).unwrap(),
+            ToDeviceReadyEventContent {
                 from_device,
                 transaction_id,
                 methods,

--- a/crates/ruma-events/src/key/verification/request.rs
+++ b/crates/ruma-events/src/key/verification/request.rs
@@ -11,7 +11,7 @@ use super::VerificationMethod;
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[ruma_event(type = "m.key.verification.request", kind = ToDevice)]
-pub struct RequestToDeviceEventContent {
+pub struct ToDeviceRequestEventContent {
     /// The device ID which is initiating the request.
     pub from_device: DeviceIdBox,
 
@@ -30,8 +30,8 @@ pub struct RequestToDeviceEventContent {
     pub timestamp: MilliSecondsSinceUnixEpoch,
 }
 
-impl RequestToDeviceEventContent {
-    /// Creates a new `RequestToDeviceEventContent` with the given device ID, transaction ID,
+impl ToDeviceRequestEventContent {
+    /// Creates a new `ToDeviceRequestEventContent` with the given device ID, transaction ID,
     /// methods and timestamp.
     pub fn new(
         from_device: DeviceIdBox,

--- a/crates/ruma-events/src/key/verification/start.rs
+++ b/crates/ruma-events/src/key/verification/start.rs
@@ -19,7 +19,7 @@ use super::{
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[ruma_event(type = "m.key.verification.start", kind = ToDevice)]
-pub struct StartToDeviceEventContent {
+pub struct ToDeviceStartEventContent {
     /// The device ID which is initiating the process.
     pub from_device: DeviceIdBox,
 
@@ -35,8 +35,8 @@ pub struct StartToDeviceEventContent {
     pub method: StartMethod,
 }
 
-impl StartToDeviceEventContent {
-    /// Creates a new `StartToDeviceEventContent` with the given device ID, transaction ID and
+impl ToDeviceStartEventContent {
+    /// Creates a new `ToDeviceStartEventContent` with the given device ID, transaction ID and
     /// method specific content.
     pub fn new(from_device: DeviceIdBox, transaction_id: String, method: StartMethod) -> Self {
         Self { from_device, transaction_id, method }
@@ -210,7 +210,7 @@ mod tests {
 
     use super::{
         HashAlgorithm, KeyAgreementProtocol, MessageAuthenticationCode, SasV1Content,
-        SasV1ContentInit, ShortAuthenticationString, StartMethod, StartToDeviceEventContent,
+        SasV1ContentInit, ShortAuthenticationString, StartMethod, ToDeviceStartEventContent,
         _CustomContent,
     };
     #[cfg(feature = "unstable-pre-spec")]
@@ -221,7 +221,7 @@ mod tests {
 
     #[test]
     fn serialization() {
-        let key_verification_start_content = StartToDeviceEventContent {
+        let key_verification_start_content = ToDeviceStartEventContent {
             from_device: "123".into(),
             transaction_id: "456".into(),
             method: StartMethod::SasV1(
@@ -269,7 +269,7 @@ mod tests {
             "sender": sender
         });
 
-        let key_verification_start_content = StartToDeviceEventContent {
+        let key_verification_start_content = ToDeviceStartEventContent {
             from_device: "123".into(),
             transaction_id: "456".into(),
             method: StartMethod::_Custom(_CustomContent {
@@ -289,7 +289,7 @@ mod tests {
         {
             let secret = "This is a secret to everybody".to_owned();
 
-            let key_verification_start_content = StartToDeviceEventContent {
+            let key_verification_start_content = ToDeviceStartEventContent {
                 from_device: "123".into(),
                 transaction_id: "456".into(),
                 method: StartMethod::ReciprocateV1(ReciprocateV1Content::new(secret.clone())),
@@ -375,8 +375,8 @@ mod tests {
 
         // Deserialize the content struct separately to verify `TryFromRaw` is implemented for it.
         assert_matches!(
-            from_json_value::<StartToDeviceEventContent>(json).unwrap(),
-            StartToDeviceEventContent {
+            from_json_value::<ToDeviceStartEventContent>(json).unwrap(),
+            ToDeviceStartEventContent {
                 from_device,
                 transaction_id,
                 method: StartMethod::SasV1(SasV1Content {
@@ -410,10 +410,10 @@ mod tests {
         });
 
         assert_matches!(
-            from_json_value::<ToDeviceEvent<StartToDeviceEventContent>>(json).unwrap(),
+            from_json_value::<ToDeviceEvent<ToDeviceStartEventContent>>(json).unwrap(),
             ToDeviceEvent {
                 sender,
-                content: StartToDeviceEventContent {
+                content: ToDeviceStartEventContent {
                     from_device,
                     transaction_id,
                     method: StartMethod::SasV1(SasV1Content {
@@ -446,10 +446,10 @@ mod tests {
         });
 
         assert_matches!(
-            from_json_value::<ToDeviceEvent<StartToDeviceEventContent>>(json).unwrap(),
+            from_json_value::<ToDeviceEvent<ToDeviceStartEventContent>>(json).unwrap(),
             ToDeviceEvent {
                 sender,
-                content: StartToDeviceEventContent {
+                content: ToDeviceStartEventContent {
                     from_device,
                     transaction_id,
                     method: StartMethod::_Custom(_CustomContent { method, data })
@@ -475,10 +475,10 @@ mod tests {
             });
 
             assert_matches!(
-                from_json_value::<ToDeviceEvent<StartToDeviceEventContent>>(json).unwrap(),
+                from_json_value::<ToDeviceEvent<ToDeviceStartEventContent>>(json).unwrap(),
                 ToDeviceEvent {
                     sender,
-                    content: StartToDeviceEventContent {
+                    content: ToDeviceStartEventContent {
                         from_device,
                         transaction_id,
                         method: StartMethod::ReciprocateV1(ReciprocateV1Content { secret }),

--- a/crates/ruma-events/src/room/encrypted.rs
+++ b/crates/ruma-events/src/room/encrypted.rs
@@ -48,20 +48,20 @@ impl From<EncryptedEventScheme> for EncryptedEventContent {
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[ruma_event(type = "m.room.encrypted", kind = ToDevice)]
-pub struct EncryptedToDeviceEventContent {
+pub struct ToDeviceEncryptedEventContent {
     /// Algorithm-specific fields.
     #[serde(flatten)]
     pub scheme: EncryptedEventScheme,
 }
 
-impl EncryptedToDeviceEventContent {
-    /// Creates a new `EncryptedToDeviceEventContent` with the given scheme.
+impl ToDeviceEncryptedEventContent {
+    /// Creates a new `ToDeviceEncryptedEventContent` with the given scheme.
     pub fn new(scheme: EncryptedEventScheme) -> Self {
         Self { scheme }
     }
 }
 
-impl From<EncryptedEventScheme> for EncryptedToDeviceEventContent {
+impl From<EncryptedEventScheme> for ToDeviceEncryptedEventContent {
     fn from(scheme: EncryptedEventScheme) -> Self {
         Self { scheme }
     }

--- a/crates/ruma-events/src/room_key.rs
+++ b/crates/ruma-events/src/room_key.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[ruma_event(type = "m.room_key", kind = ToDevice)]
-pub struct RoomKeyToDeviceEventContent {
+pub struct ToDeviceRoomKeyEventContent {
     /// The encryption algorithm the key in this event is to be used with.
     ///
     /// Must be `m.megolm.v1.aes-sha2`.
@@ -26,8 +26,8 @@ pub struct RoomKeyToDeviceEventContent {
     pub session_key: String,
 }
 
-impl RoomKeyToDeviceEventContent {
-    /// Creates a new `RoomKeyToDeviceEventContent` with the given algorithm, room ID, session ID
+impl ToDeviceRoomKeyEventContent {
+    /// Creates a new `ToDeviceRoomKeyEventContent` with the given algorithm, room ID, session ID
     /// and session key.
     pub fn new(
         algorithm: EventEncryptionAlgorithm,
@@ -44,13 +44,13 @@ mod tests {
     use ruma_identifiers::{room_id, user_id, EventEncryptionAlgorithm};
     use serde_json::{json, to_value as to_json_value};
 
-    use super::RoomKeyToDeviceEventContent;
+    use super::ToDeviceRoomKeyEventContent;
     use crate::ToDeviceEvent;
 
     #[test]
     fn serialization() {
         let ev = ToDeviceEvent {
-            content: RoomKeyToDeviceEventContent {
+            content: ToDeviceRoomKeyEventContent {
                 algorithm: EventEncryptionAlgorithm::MegolmV1AesSha2,
                 room_id: room_id!("!testroomid:example.org"),
                 session_id: "SessId".into(),

--- a/crates/ruma-events/src/room_key_request.rs
+++ b/crates/ruma-events/src/room_key_request.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[ruma_event(type = "m.room_key_request", kind = ToDevice)]
-pub struct RoomKeyRequestToDeviceEventContent {
+pub struct ToDeviceRoomKeyRequestEventContent {
     /// Whether this is a new key request or a cancellation of a previous request.
     pub action: Action,
 
@@ -28,8 +28,8 @@ pub struct RoomKeyRequestToDeviceEventContent {
     pub request_id: String,
 }
 
-impl RoomKeyRequestToDeviceEventContent {
-    /// Creates a new `RoomKeyRequestToDeviceEventContent` with the given action, boyd, device ID
+impl ToDeviceRoomKeyRequestEventContent {
+    /// Creates a new `ToDeviceRoomKeyRequestEventContent` with the given action, boyd, device ID
     /// and request ID.
     pub fn new(
         action: Action,

--- a/crates/ruma-events/src/secret/request.rs
+++ b/crates/ruma-events/src/secret/request.rs
@@ -15,7 +15,7 @@ use serde::{ser::SerializeStruct, Deserialize, Serialize};
 #[derive(Clone, Debug, Serialize, Deserialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[ruma_event(type = "m.secret.request", kind = ToDevice)]
-pub struct RequestToDeviceEventContent {
+pub struct ToDeviceRequestEventContent {
     /// The action for the request.
     #[serde(flatten)]
     pub action: RequestAction,
@@ -31,8 +31,8 @@ pub struct RequestToDeviceEventContent {
     pub request_id: String,
 }
 
-impl RequestToDeviceEventContent {
-    /// Creates a new `RequestToDeviceEventContent` with the given action, requesting device ID and
+impl ToDeviceRequestEventContent {
+    /// Creates a new `ToDeviceRequestEventContent` with the given action, requesting device ID and
     /// request ID.
     pub fn new(
         action: RequestAction,
@@ -133,13 +133,13 @@ pub enum SecretName {
 
 #[cfg(test)]
 mod test {
-    use super::{RequestAction, RequestToDeviceEventContent, SecretName};
+    use super::{RequestAction, SecretName, ToDeviceRequestEventContent};
     use matches::assert_matches;
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     #[test]
     fn secret_request_serialization() {
-        let content = RequestToDeviceEventContent::new(
+        let content = ToDeviceRequestEventContent::new(
             RequestAction::Request("org.example.some.secret".into()),
             "ABCDEFG".into(),
             "randomly_generated_id_9573".into(),
@@ -157,7 +157,7 @@ mod test {
 
     #[test]
     fn secret_request_recovery_key_serialization() {
-        let content = RequestToDeviceEventContent::new(
+        let content = ToDeviceRequestEventContent::new(
             RequestAction::Request(SecretName::RecoveryKey),
             "XYZxyz".into(),
             "this_is_a_request_id".into(),
@@ -175,7 +175,7 @@ mod test {
 
     #[test]
     fn secret_custom_action_serialization() {
-        let content = RequestToDeviceEventContent::new(
+        let content = ToDeviceRequestEventContent::new(
             RequestAction::_Custom("my_custom_action".into()),
             "XYZxyz".into(),
             "this_is_a_request_id".into(),
@@ -192,7 +192,7 @@ mod test {
 
     #[test]
     fn secret_request_cancellation_serialization() {
-        let content = RequestToDeviceEventContent::new(
+        let content = ToDeviceRequestEventContent::new(
             RequestAction::RequestCancellation,
             "ABCDEFG".into(),
             "randomly_generated_id_9573".into(),
@@ -218,7 +218,7 @@ mod test {
 
         assert_matches!(
             from_json_value(json).unwrap(),
-            RequestToDeviceEventContent {
+            ToDeviceRequestEventContent {
                 action: RequestAction::Request(
                     secret
                 ),
@@ -241,7 +241,7 @@ mod test {
 
         assert_matches!(
             from_json_value(json).unwrap(),
-            RequestToDeviceEventContent {
+            ToDeviceRequestEventContent {
                 action: RequestAction::RequestCancellation,
                 requesting_device_id,
                 request_id,
@@ -262,7 +262,7 @@ mod test {
 
         assert_matches!(
             from_json_value(json).unwrap(),
-            RequestToDeviceEventContent {
+            ToDeviceRequestEventContent {
                 action: RequestAction::Request(
                     SecretName::RecoveryKey
                 ),
@@ -283,8 +283,8 @@ mod test {
         });
 
         assert_matches!(
-            from_json_value::<RequestToDeviceEventContent>(json).unwrap(),
-            RequestToDeviceEventContent {
+            from_json_value::<ToDeviceRequestEventContent>(json).unwrap(),
+            ToDeviceRequestEventContent {
                 action,
                 requesting_device_id,
                 request_id,

--- a/crates/ruma-events/src/secret/send.rs
+++ b/crates/ruma-events/src/secret/send.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[ruma_event(type = "m.secret.send", kind = ToDevice)]
-pub struct SendToDeviceEventContent {
+pub struct ToDeviceSendEventContent {
     /// The ID of the request that this is a response to.
     pub request_id: String,
 
@@ -20,7 +20,7 @@ pub struct SendToDeviceEventContent {
     pub secret: String,
 }
 
-impl SendToDeviceEventContent {
+impl ToDeviceSendEventContent {
     /// Creates a new `SecretSendEventContent` with the given request ID and secret.
     pub fn new(request_id: String, secret: String) -> Self {
         Self { request_id, secret }

--- a/crates/ruma-events/tests/to_device.rs
+++ b/crates/ruma-events/tests/to_device.rs
@@ -1,4 +1,4 @@
-use ruma_events::{room_key::RoomKeyToDeviceEventContent, ToDeviceEvent};
+use ruma_events::{room_key::ToDeviceRoomKeyEventContent, ToDeviceEvent};
 use ruma_identifiers::{room_id, user_id, EventEncryptionAlgorithm};
 use serde_json::{json, to_value as to_json_value};
 
@@ -6,7 +6,7 @@ use serde_json::{json, to_value as to_json_value};
 fn serialization() {
     let ev = ToDeviceEvent {
         sender: user_id!("@example:example.org"),
-        content: RoomKeyToDeviceEventContent::new(
+        content: ToDeviceRoomKeyEventContent::new(
             EventEncryptionAlgorithm::MegolmV1AesSha2,
             room_id!("!testroomid:example.org"),
             "SessId".into(),


### PR DESCRIPTION
… to be consistent with the new type aliases.