### PR TITLE
Create issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,14 @@
+---
+name: Bug report
+about: Oh no its a bug. Where is the squasher?
+title: ''
+labels: type/bug, untriaged
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Code To Reproduce**
+If applicable, a minimal code example in order to replicate the bug.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,14 +1,13 @@
 ---
-name: Bug report
-about: Oh no its a bug. Where is the squasher?
+name: Bug Report
+about: Oh no, it's a bug. Where is the squasher?
 title: ''
 labels: type/bug, untriaged
 assignees: ''
-
 ---
 
 **Describe the bug**
 A clear and concise description of what the bug is.
 
-**Code To Reproduce**
+**How to Reproduce**
 If applicable, a minimal code example in order to replicate the bug.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug Report
-about: Oh no, it's a bug. Where is the squasher?
+about: Oh no, it's a bug. Let's squash it!
 title: ''
 labels: type/bug, untriaged
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/doc-improvement.md
+++ b/.github/ISSUE_TEMPLATE/doc-improvement.md
@@ -1,0 +1,11 @@
+---
+name: Doc improvement
+about: You have a suggestion for the docs?
+title: ''
+labels: type/docs, untriaged
+assignees: ''
+
+---
+
+**What do you want to see changed**
+Write here what you think is missing.

--- a/.github/ISSUE_TEMPLATE/doc-improvement.md
+++ b/.github/ISSUE_TEMPLATE/doc-improvement.md
@@ -1,11 +1,11 @@
 ---
-name: Doc improvement
-about: You have a suggestion for the docs?
+name: Documentation improvement
+about: You have a suggestion for the documentation?
 title: ''
 labels: type/docs, untriaged
 assignees: ''
 
 ---
 
-**What do you want to see changed**
+**What you want to see changed**
 Write here what you think is missing.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,14 @@
+---
+name: Feature request
+about: Have a suggestion?
+title: ''
+labels: untriaged
+assignees: ''
+
+---
+
+**The shortcoming in this library you see**
+A short description of what the underlying issue is.
+
+**The improvement**
+How you think this shortcoming can be fixed.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,13 +1,12 @@
 ---
-name: Feature request
+name: Feature Request
 about: Have a suggestion?
 title: ''
 labels: untriaged
 assignees: ''
-
 ---
 
-**The shortcoming in this library you see**
+**The shortcoming you see**
 A short description of what the underlying issue is.
 
 **The improvement**


### PR DESCRIPTION
This PR closes #552. I realized that there is no designated label for the docs, maybe you want that?

A "live" example can be found when opening [an issue in my fork](https://github.com/Poolitzer/ruma/issues/new/choose).