### PR TITLE
A test for `empty_string_as_none` with absent field

### DIFF
--- a/crates/ruma-serde/Cargo.toml
+++ b/crates/ruma-serde/Cargo.toml
@@ -23,3 +23,4 @@ serde_json = { version = "1.0.61", features = ["raw_value"] }
 
 [dev-dependencies]
 matches = "0.1.8"
+ruma-identifiers = { path = "../ruma-identifiers" }

--- a/crates/ruma-serde/tests/empty_strings.rs
+++ b/crates/ruma-serde/tests/empty_strings.rs
@@ -31,3 +31,19 @@ fn empty_de() {
     assert_eq!(from_json_value::<StringStruct>(json!({"x": ""})).unwrap(), string);
     assert_eq!(from_json_value::<NoneStruct>(json!({})).unwrap(), none);
 }
+
+#[test]
+fn empty_de_no_field() {
+    #[derive(Deserialize, PartialEq, Debug)]
+    struct UndecoratedStringStruct {
+        x: Option<String>,
+    }
+
+    // A test with an absent underorated field passes
+    let string = UndecoratedStringStruct { x: None };
+    assert_eq!(from_json_value::<UndecoratedStringStruct>(json!({})).unwrap(), string);
+
+    // While with a decorated one it fails
+    let string = StringStruct { x: None };
+    assert_eq!(from_json_value::<StringStruct>(json!({})).unwrap(), string);
+}

--- a/crates/ruma-serde/tests/empty_strings.rs
+++ b/crates/ruma-serde/tests/empty_strings.rs
@@ -12,6 +12,16 @@ struct StringStruct {
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
+struct IntStruct {
+    #[serde(
+        default,
+        deserialize_with = "ruma_serde::empty_string_as_none",
+        serialize_with = "ruma_serde::none_as_empty_string"
+    )]
+    x: Option<i32>,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
 struct NoneStruct {
     #[serde(skip_serializing_if = "Option::is_none")]
     x: Option<String>,
@@ -26,10 +36,29 @@ fn empty_se() {
 }
 
 #[test]
-fn empty_de() {
+fn empty_de_string_none() {
     let string = StringStruct { x: None };
     let none = NoneStruct { x: None };
     assert_eq!(from_json_value::<StringStruct>(json!({"x": ""})).unwrap(), string);
     assert_eq!(from_json_value::<StringStruct>(json!({})).unwrap(), string);
     assert_eq!(from_json_value::<NoneStruct>(json!({})).unwrap(), none);
+}
+
+#[test]
+fn empty_de_string_some() {
+    let string = StringStruct { x: Some("foo".into()) };
+    assert_eq!(from_json_value::<StringStruct>(json!({"x": "foo"})).unwrap(), string);
+}
+
+#[test]
+fn empty_de_int_none() {
+    let expected = IntStruct { x: None };
+    assert_eq!(from_json_value::<IntStruct>(json!({"x": ""})).unwrap(), expected);
+    assert_eq!(from_json_value::<IntStruct>(json!({})).unwrap(), expected);
+}
+
+#[test]
+fn empty_de_int_some() {
+    let expected = IntStruct { x: Some(1) };
+    assert_eq!(from_json_value::<IntStruct>(json!({"x": 1})).unwrap(), expected);
 }

--- a/crates/ruma-serde/tests/empty_strings.rs
+++ b/crates/ruma-serde/tests/empty_strings.rs
@@ -49,10 +49,11 @@ mod string {
 }
 
 mod user {
-    use ruma_identifiers::UserId;
+    use ruma_identifiers::{user_id, UserId};
     use serde::{Deserialize, Serialize};
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
-    use std::convert::TryFrom;
+
+    const CARL: &str = "@carl:example.com";
 
     fn carl() -> UserId {
         user_id!("@carl:example.com")

--- a/crates/ruma-serde/tests/empty_strings.rs
+++ b/crates/ruma-serde/tests/empty_strings.rs
@@ -4,6 +4,7 @@ use serde_json::{from_value as from_json_value, json, to_value as to_json_value}
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 struct StringStruct {
     #[serde(
+        default,
         deserialize_with = "ruma_serde::empty_string_as_none",
         serialize_with = "ruma_serde::none_as_empty_string"
     )]
@@ -29,21 +30,6 @@ fn empty_de() {
     let string = StringStruct { x: None };
     let none = NoneStruct { x: None };
     assert_eq!(from_json_value::<StringStruct>(json!({"x": ""})).unwrap(), string);
-    assert_eq!(from_json_value::<NoneStruct>(json!({})).unwrap(), none);
-}
-
-#[test]
-fn empty_de_no_field() {
-    #[derive(Deserialize, PartialEq, Debug)]
-    struct UndecoratedStringStruct {
-        x: Option<String>,
-    }
-
-    // A test with an absent underorated field passes
-    let string = UndecoratedStringStruct { x: None };
-    assert_eq!(from_json_value::<UndecoratedStringStruct>(json!({})).unwrap(), string);
-
-    // While with a decorated one it fails
-    let string = StringStruct { x: None };
     assert_eq!(from_json_value::<StringStruct>(json!({})).unwrap(), string);
+    assert_eq!(from_json_value::<NoneStruct>(json!({})).unwrap(), none);
 }

--- a/crates/ruma-serde/tests/empty_strings.rs
+++ b/crates/ruma-serde/tests/empty_strings.rs
@@ -54,10 +54,8 @@ mod user {
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
     use std::convert::TryFrom;
 
-    const CARL: &str = "@carl:example.com";
-
     fn carl() -> UserId {
-        UserId::try_from(CARL).expect("Failed to create UserId.")
+        user_id!("@carl:example.com")
     }
 
     #[derive(Serialize, Deserialize, PartialEq, Debug)]

--- a/crates/ruma-serde/tests/empty_strings.rs
+++ b/crates/ruma-serde/tests/empty_strings.rs
@@ -1,64 +1,107 @@
-use serde::{Deserialize, Serialize};
-use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+mod string {
+    use serde::{Deserialize, Serialize};
+    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
-struct StringStruct {
-    #[serde(
-        default,
-        deserialize_with = "ruma_serde::empty_string_as_none",
-        serialize_with = "ruma_serde::none_as_empty_string"
-    )]
-    x: Option<String>,
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    struct StringStruct {
+        #[serde(
+            default,
+            deserialize_with = "ruma_serde::empty_string_as_none",
+            serialize_with = "ruma_serde::none_as_empty_string"
+        )]
+        x: Option<String>,
+    }
+
+    #[test]
+    fn none_se() {
+        let decoded = StringStruct { x: None };
+        let encoded = json!({ "x": "" });
+        assert_eq!(to_json_value(decoded).unwrap(), encoded);
+    }
+
+    #[test]
+    fn some_se() {
+        let decoded = StringStruct { x: Some("foo".into()) };
+        let encoded = json!({ "x": "foo" });
+        assert_eq!(to_json_value(decoded).unwrap(), encoded);
+    }
+
+    #[test]
+    fn absent_de() {
+        let encoded = json!({});
+        let decoded = StringStruct { x: None };
+        assert_eq!(from_json_value::<StringStruct>(encoded).unwrap(), decoded);
+    }
+
+    #[test]
+    fn empty_de() {
+        let encoded = json!({ "x": "" });
+        let decoded = StringStruct { x: None };
+        assert_eq!(from_json_value::<StringStruct>(encoded).unwrap(), decoded);
+    }
+
+    #[test]
+    fn some_de() {
+        let encoded = json!({ "x": "foo" });
+        let decoded = StringStruct { x: Some("foo".into()) };
+        assert_eq!(from_json_value::<StringStruct>(encoded).unwrap(), decoded);
+    }
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
-struct IntStruct {
-    #[serde(
-        default,
-        deserialize_with = "ruma_serde::empty_string_as_none",
-        serialize_with = "ruma_serde::none_as_empty_string"
-    )]
-    x: Option<i32>,
-}
+mod user {
+    use ruma_identifiers::UserId;
+    use serde::{Deserialize, Serialize};
+    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+    use std::convert::TryFrom;
 
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
-struct NoneStruct {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    x: Option<String>,
-}
+    const CARL: &str = "@carl:example.com";
 
-#[test]
-fn empty_se() {
-    let string = StringStruct { x: None };
-    let none = NoneStruct { x: None };
-    assert_eq!(to_json_value(string).unwrap(), json!({"x": ""}));
-    assert_eq!(to_json_value(none).unwrap(), json!({}));
-}
+    fn carl() -> UserId {
+        UserId::try_from(CARL).expect("Failed to create UserId.")
+    }
 
-#[test]
-fn empty_de_string_none() {
-    let string = StringStruct { x: None };
-    let none = NoneStruct { x: None };
-    assert_eq!(from_json_value::<StringStruct>(json!({"x": ""})).unwrap(), string);
-    assert_eq!(from_json_value::<StringStruct>(json!({})).unwrap(), string);
-    assert_eq!(from_json_value::<NoneStruct>(json!({})).unwrap(), none);
-}
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    struct User {
+        #[serde(
+            default,
+            deserialize_with = "ruma_serde::empty_string_as_none",
+            serialize_with = "ruma_serde::none_as_empty_string"
+        )]
+        x: Option<UserId>,
+    }
 
-#[test]
-fn empty_de_string_some() {
-    let string = StringStruct { x: Some("foo".into()) };
-    assert_eq!(from_json_value::<StringStruct>(json!({"x": "foo"})).unwrap(), string);
-}
+    #[test]
+    fn none_se() {
+        let decoded = User { x: None };
+        let encoded = json!({ "x": "" });
+        assert_eq!(to_json_value(decoded).unwrap(), encoded);
+    }
 
-#[test]
-fn empty_de_int_none() {
-    let expected = IntStruct { x: None };
-    assert_eq!(from_json_value::<IntStruct>(json!({"x": ""})).unwrap(), expected);
-    assert_eq!(from_json_value::<IntStruct>(json!({})).unwrap(), expected);
-}
+    #[test]
+    fn some_se() {
+        let decoded = User { x: Some(carl()) };
+        let encoded = json!({ "x": CARL });
+        assert_eq!(to_json_value(decoded).unwrap(), encoded);
+    }
 
-#[test]
-fn empty_de_int_some() {
-    let expected = IntStruct { x: Some(1) };
-    assert_eq!(from_json_value::<IntStruct>(json!({"x": 1})).unwrap(), expected);
+    #[test]
+    fn absent_de() {
+        let encoded = json!({});
+        let decoded = User { x: None };
+        assert_eq!(from_json_value::<User>(encoded).unwrap(), decoded);
+    }
+
+    #[test]
+    fn empty_de() {
+        let encoded = json!({ "x": "" });
+        let decoded = User { x: None };
+        assert_eq!(from_json_value::<User>(encoded).unwrap(), decoded);
+    }
+
+    #[test]
+    fn some_de() {
+        let encoded = json!({ "x": CARL });
+        let decoded = User { x: Some(carl()) };
+        assert_eq!(from_json_value::<User>(encoded).unwrap(), decoded);
+    }
 }


### PR DESCRIPTION
`empty_string_as_none` seems to change default serde behaviour with an absent field. I don't know how to fix it, but here's a test :) @jplatte 