### PR TITLE
Remove unneeded parameter on `get_remote_server_keys_batch`

### DIFF
--- a/crates/ruma-federation-api/CHANGELOG.md
+++ b/crates/ruma-federation-api/CHANGELOG.md
@@ -5,6 +5,7 @@ Breaking changes:
 * Replace `Raw<Pdu>` with `Box<RawJsonValue>` or `&RawJsonValue`
 * Borrow more request fields
 * Make `device_display_name` field optional in `DeviceListUpdateContent` and update constructor accordingly
+* Remove unneeded `minimum_valid_until_ts` query parameter from `get_remote_server_keys_batch` endpoint
 
 # 0.3.1
 

--- a/crates/ruma-federation-api/src/discovery/get_remote_server_keys_batch/v2.rs
+++ b/crates/ruma-federation-api/src/discovery/get_remote_server_keys_batch/v2.rs
@@ -39,7 +39,7 @@ ruma_api! {
 }
 
 impl Request {
-    /// Creates a new `Request` with the given query criteria and `minimum_valid_until` timestamp.
+    /// Creates a new `Request` with the given query criteria.
     pub fn new(
         server_keys: BTreeMap<ServerNameBox, BTreeMap<ServerSigningKeyId, QueryCriteria>>,
     ) -> Self {

--- a/crates/ruma-federation-api/src/discovery/get_remote_server_keys_batch/v2.rs
+++ b/crates/ruma-federation-api/src/discovery/get_remote_server_keys_batch/v2.rs
@@ -20,14 +20,6 @@ ruma_api! {
     }
 
     request: {
-        /// The time until which the returned certificates will need to be valid to be useful to
-        /// the requesting server.
-        ///
-        /// If not supplied, the current time as determined by the notary server is used.
-        #[ruma_api(query)]
-        #[serde(default = "MilliSecondsSinceUnixEpoch::now")]
-        pub minimum_valid_until_ts: MilliSecondsSinceUnixEpoch,
-
         /// The query criteria.
         ///
         /// The outer string key on the object is the server name (eg: matrix.org). The inner
@@ -50,9 +42,8 @@ impl Request {
     /// Creates a new `Request` with the given query criteria and `minimum_valid_until` timestamp.
     pub fn new(
         server_keys: BTreeMap<ServerNameBox, BTreeMap<ServerSigningKeyId, QueryCriteria>>,
-        minimum_valid_until_ts: MilliSecondsSinceUnixEpoch,
     ) -> Self {
-        Self { server_keys, minimum_valid_until_ts }
+        Self { server_keys }
     }
 }
 


### PR DESCRIPTION
The `minimum_valid_until_ts` parameter is not needed on this endpoint
(https://matrix.org/docs/spec/server_server/r0.1.4#post-matrix-key-v2-query).