### PR TITLE
client-api: Add registration token validity checking endpoint

### DIFF
--- a/crates/ruma-client-api/src/r0/account.rs
+++ b/crates/ruma-client-api/src/r0/account.rs
@@ -3,12 +3,12 @@
 pub mod add_3pid;
 pub mod bind_3pid;
 pub mod change_password;
+#[cfg(feature = "unstable-pre-spec")]
+pub mod check_registration_token_validity;
 pub mod deactivate;
 pub mod delete_3pid;
 pub mod get_username_availability;
 pub mod register;
-#[cfg(feature = "unstable-pre-spec")]
-pub mod check_registration_token_validity;
 pub mod request_3pid_management_token_via_email;
 pub mod request_3pid_management_token_via_msisdn;
 pub mod request_openid_token;

--- a/crates/ruma-client-api/src/r0/account.rs
+++ b/crates/ruma-client-api/src/r0/account.rs
@@ -7,6 +7,9 @@ pub mod deactivate;
 pub mod delete_3pid;
 pub mod get_username_availability;
 pub mod register;
+#[cfg(feature = "unstable-pre-spec")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable-pre-spec")))]
+pub mod registration_token_validity;
 pub mod request_3pid_management_token_via_email;
 pub mod request_3pid_management_token_via_msisdn;
 pub mod request_openid_token;

--- a/crates/ruma-client-api/src/r0/account.rs
+++ b/crates/ruma-client-api/src/r0/account.rs
@@ -8,7 +8,7 @@ pub mod delete_3pid;
 pub mod get_username_availability;
 pub mod register;
 #[cfg(feature = "unstable-pre-spec")]
-pub mod registration_token_validity;
+pub mod check_registration_token_validity;
 pub mod request_3pid_management_token_via_email;
 pub mod request_3pid_management_token_via_msisdn;
 pub mod request_openid_token;

--- a/crates/ruma-client-api/src/r0/account.rs
+++ b/crates/ruma-client-api/src/r0/account.rs
@@ -8,7 +8,6 @@ pub mod delete_3pid;
 pub mod get_username_availability;
 pub mod register;
 #[cfg(feature = "unstable-pre-spec")]
-#[cfg_attr(docsrs, doc(cfg(feature = "unstable-pre-spec")))]
 pub mod registration_token_validity;
 pub mod request_3pid_management_token_via_email;
 pub mod request_3pid_management_token_via_msisdn;

--- a/crates/ruma-client-api/src/r0/account/check_registration_token_validity.rs
+++ b/crates/ruma-client-api/src/r0/account/check_registration_token_validity.rs
@@ -6,7 +6,7 @@ ruma_api! {
     metadata: {
         description: "Checks to see if the given registration token is valid.",
         method: GET,
-        name: "registration_token_validity",
+        name: "check_registration_token_validity",
         path: "/_matrix/client/unstable/org.matrix.msc3231/register/org.matrix.msc3231.login.registration_token/validity",
         rate_limited: true,
         authentication: None,

--- a/crates/ruma-client-api/src/r0/account/registration_token_validity.rs
+++ b/crates/ruma-client-api/src/r0/account/registration_token_validity.rs
@@ -1,0 +1,41 @@
+//! [GET /_matrix/client/unstable/org.matrix.msc3231/register/org.matrix.msc3231.login.registration_token/validity](https://github.com/matrix-org/matrix-doc/blob/main/proposals/3231-token-authenticated-registration.md#checking-the-validity-of-a-token)
+
+use ruma_api::ruma_api;
+
+ruma_api! {
+    metadata: {
+        description: "Checks to see if the given registration token is valid.",
+        method: GET,
+        name: "registration_token_validity",
+        path: "/_matrix/client/unstable/org.matrix.msc3231/register/org.matrix.msc3231.login.registration_token/validity",
+        rate_limited: true,
+        authentication: None,
+    }
+
+    request: {
+        /// The registration token to check the validity of.
+        #[ruma_api(query)]
+        pub registration_token: &'a str,
+    }
+
+    response: {
+        /// A flag to indicate that the registration token is valid.
+        pub valid: bool,
+    }
+
+    error: crate::Error
+}
+
+impl<'a> Request<'a> {
+    /// Creates a new `Request` with the given registration token.
+    pub fn new(registration_token: &'a str) -> Self {
+        Self { registration_token }
+    }
+}
+
+impl Response {
+    /// Creates a new `Response` with the given validity flag.
+    pub fn new(valid: bool) -> Self {
+        Self { valid }
+    }
+}


### PR DESCRIPTION
Proposed in [MSC3231](https://github.com/matrix-org/matrix-doc/pull/3231)

https://github.com/matrix-org/matrix-doc/blob/main/proposals/3231-token-authenticated-registration.md#checking-the-validity-of-a-token

Closes #708 

I only put the `unstable-pre-spec` attributes in `account.rs`, which I'm not sure is correct.
Also I couldn't find anywhere endpoints are tested (but didn't look very hard).