### PR TITLE
doc: align comment with name

### DIFF
--- a/crates/ruma-client-api/src/r0/account/request_3pid_management_token_via_email.rs
+++ b/crates/ruma-client-api/src/r0/account/request_3pid_management_token_via_email.rs
@@ -10,7 +10,7 @@ ruma_api! {
     metadata: {
         description: "Request a 3PID management token with a 3rd party email.",
         method: POST,
-        name: "request_3pid_association_token_via_email",
+        name: "request_3pid_management_token_via_email",
         path: "/_matrix/client/r0/account/3pid/email/requestToken",
         rate_limited: false,
         authentication: None,

--- a/crates/ruma-client-api/src/r0/account/request_3pid_management_token_via_msisdn.rs
+++ b/crates/ruma-client-api/src/r0/account/request_3pid_management_token_via_msisdn.rs
@@ -10,7 +10,7 @@ ruma_api! {
     metadata: {
         description: "Request a 3PID management token with a phone number.",
         method: POST,
-        name: "request_3pid_association_token_via_msisdn",
+        name: "request_3pid_management_token_via_msisdn",
         path: "/_matrix/client/r0/account/3pid/msisdn/requestToken",
         rate_limited: false,
         authentication: None,


### PR DESCRIPTION
Hi,

Not sure if this was on purpose, but I copy pasted this string believing it was the same as the module name. However it wasn't. And then when it couldn't find the type I thought maybe I had failed to enable the right feature. Anyhow, you can close it if this was named "association" on purpose.

Cheers