### PR TITLE
Convert resolve to use dynamic wrapper types

### DIFF
--- a/crates/ruma-state-res/benches/state_res_bench.rs
+++ b/crates/ruma-state-res/benches/state_res_bench.rs
@@ -80,6 +80,7 @@ fn resolution_shallow_auth_chain(c: &mut Criterion) {
                     .collect(),
                 |id| ev_map.get(id).map(Arc::clone),
                 |id| id.clone(),
+                |t, s| (t.clone(), s.to_owned()),
             ) {
                 Ok(state) => state,
                 Err(e) => panic!("{}", e),
@@ -149,6 +150,7 @@ fn resolve_deeper_event_set(c: &mut Criterion) {
                     .collect(),
                 |id| inner.get(id).map(Arc::clone),
                 |id| id.clone(),
+                |t, s| (t.clone(), s.to_owned()),
             ) {
                 Ok(state) => state,
                 Err(_) => panic!("resolution failed during benchmarking"),

--- a/crates/ruma-state-res/benches/state_res_bench.rs
+++ b/crates/ruma-state-res/benches/state_res_bench.rs
@@ -48,8 +48,8 @@ fn lexico_topo_sort(c: &mut Criterion) {
             event_id("p") => hashset![event_id("o")],
         };
         b.iter(|| {
-            let _ = state_res::lexicographical_topological_sort(&graph, |id| {
-                Ok((int!(0), MilliSecondsSinceUnixEpoch(uint!(0)), id.clone()))
+            let _ = state_res::lexicographical_topological_sort(&graph, |_| {
+                Ok((int!(0), MilliSecondsSinceUnixEpoch(uint!(0))))
             });
         })
     });
@@ -71,10 +71,15 @@ fn resolution_shallow_auth_chain(c: &mut Criterion) {
                 state_sets
                     .iter()
                     .map(|map| {
-                        store.auth_event_ids(&room_id(), map.values().cloned().collect()).unwrap()
+                        store
+                            .auth_event_ids(&room_id(), map.values().cloned().collect())
+                            .unwrap()
+                            .into_iter()
+                            .collect()
                     })
                     .collect(),
                 |id| ev_map.get(id).map(Arc::clone),
+                |id| id.clone(),
             ) {
                 Ok(state) => state,
                 Err(e) => panic!("{}", e),
@@ -135,10 +140,15 @@ fn resolve_deeper_event_set(c: &mut Criterion) {
                 state_sets
                     .iter()
                     .map(|map| {
-                        store.auth_event_ids(&room_id(), map.values().cloned().collect()).unwrap()
+                        store
+                            .auth_event_ids(&room_id(), map.values().cloned().collect())
+                            .unwrap()
+                            .into_iter()
+                            .collect()
                     })
                     .collect(),
                 |id| inner.get(id).map(Arc::clone),
+                |id| id.clone(),
             ) {
                 Ok(state) => state,
                 Err(_) => panic!("resolution failed during benchmarking"),

--- a/crates/ruma-state-res/src/lib.rs
+++ b/crates/ruma-state-res/src/lib.rs
@@ -266,7 +266,7 @@ where
         // This return value is the key used for sorting events,
         // events are then sorted by power level, time,
         // and lexically by event_id.
-        Ok((-*pl, ev.origin_server_ts(), event_id))
+        Ok((-*pl, ev.origin_server_ts()))
     })
 }
 
@@ -279,7 +279,7 @@ pub fn lexicographical_topological_sort<F, EID>(
     key_fn: F,
 ) -> Result<Vec<EID>>
 where
-    F: for<'a> Fn(&'a EID) -> Result<(Int, MilliSecondsSinceUnixEpoch, &'a EID)>,
+    F: Fn(&EID) -> Result<(Int, MilliSecondsSinceUnixEpoch)>,
     EID: Deref<Target = EventId>
         + Clone
         + Eq
@@ -1146,8 +1146,8 @@ mod tests {
         .map(|(e, s)| (Box::new(e), s.into_iter().map(Box::new).collect()))
         .collect();
 
-        let res = crate::lexicographical_topological_sort(&graph, |id| {
-            Ok((int!(0), MilliSecondsSinceUnixEpoch(uint!(0)), id))
+        let res = crate::lexicographical_topological_sort(&graph, |_| {
+            Ok((int!(0), MilliSecondsSinceUnixEpoch(uint!(0))))
         })
         .unwrap();
 

--- a/crates/ruma-state-res/src/test_utils.rs
+++ b/crates/ruma-state-res/src/test_utils.rs
@@ -30,14 +30,6 @@ pub use event::StateEvent;
 
 static SERVER_TIMESTAMP: AtomicU64 = AtomicU64::new(0);
 
-pub fn map_unbox_value<K: Eq + std::hash::Hash, V>(map: HashMap<K, Box<V>>) -> HashMap<K, V> {
-    map.into_iter().map(|(k, v)| (k, *v)).collect()
-}
-
-pub fn map_box_value<K: Eq + std::hash::Hash, V>(map: HashMap<K, V>) -> HashMap<K, Box<V>> {
-    map.into_iter().map(|(k, v)| (k, Box::new(v))).collect()
-}
-
 pub fn do_check(
     events: &[Arc<StateEvent>],
     edges: Vec<Vec<EventId>>,
@@ -136,6 +128,7 @@ pub fn do_check(
                 auth_chain_sets,
                 |id| event_map.get(id).map(Arc::clone),
                 |e| Box::new(e.clone()),
+                |t, s| (t.clone(), s.to_owned()),
             );
             match resolved {
                 Ok(state) => state,

--- a/crates/ruma-state-res/src/test_utils.rs
+++ b/crates/ruma-state-res/src/test_utils.rs
@@ -89,8 +89,8 @@ pub fn do_check(
 
     // Resolve the current state and add it to the state_at_event map then continue
     // on in "time"
-    for node in crate::lexicographical_topological_sort(&graph, |id| {
-        Ok((int!(0), MilliSecondsSinceUnixEpoch(uint!(0)), id))
+    for node in crate::lexicographical_topological_sort(&graph, |_| {
+        Ok((int!(0), MilliSecondsSinceUnixEpoch(uint!(0))))
     })
     .unwrap()
     {


### PR DESCRIPTION
This enables `resolve` to handle multiple wrappings of `EventId`s that're being processed, the main advantage of this is that the consumer can specify specific wrappings like `Box`, `Arc`, `Rc`, or others (like an exotic `ArcInterner`, wink wink), which would only have to implement;
```rust
Borrow<EventId>
        + Clone
        + Eq
        + Ord
        + std::hash::Hash
        + std::fmt::Debug
        + std::fmt::Display
        + 'a,
```

The `Borrow` also means that this can be just `EventId` itself, if need be.

Additionally, a `clean_id` of `impl Fn(&EventId) -> EID` will have to be passed (in the most simple cases this can just be `|e| Box::new(e.clone())`), which would allow the consumer to deduplicate new Event ID references.

Note: the type is reduced to `&EventId` as this is what the interface of `Event` uses for retrieving some vital event ID types.

Note: the trait bounds on some of the functions are definitely too much, but this isn't easily prunable, it's intended for this to be done when this PR goes out of draft mode.

This PR synergizes but conflicts with #721; #721 wants to implement Dynamically Sized Types, this PR helps it by making `resolve` mostly ready to receive a sized wrapper type for `EventId`, but conflicts as it specifies some specific lines for which #721 just specifies `Box<_>` wrappings.