### PR TITLE
Convert resolve to use borrows

### DIFF
--- a/crates/ruma-state-res/src/lib.rs
+++ b/crates/ruma-state-res/src/lib.rs
@@ -530,7 +530,7 @@ fn mainline_sort<'r, E: Event + 'r>(
 
     // Sort the event_ids by their depth, timestamp and EventId
     // unwrap is OK order map and sort_event_ids are from to_sort (the same Vec)
-    let mut sort_event_ids = order_map.keys().map(|&k| k.clone()).collect::<Vec<_>>();
+    let mut sort_event_ids = order_map.keys().map(|&&k| k).collect::<Vec<_>>();
     sort_event_ids.sort_by_key(|sort_id| order_map.get(sort_id).unwrap());
 
     Ok(sort_event_ids)


### PR DESCRIPTION
This is an alternative to #767

This makes it so that the function signature of `resolve` (and all downstream functions) will use eventid references instead of objects, this could significantly reduce memory usage if the consumer/caller has gotten their act together, as these just become simple pointers.

Synergises but conflicts with #721, as this edits the same files