### PR TITLE
state-res: Refactor lexicographical_topological_sort

### DIFF
--- a/crates/ruma-state-res/CHANGELOG.md
+++ b/crates/ruma-state-res/CHANGELOG.md
@@ -4,6 +4,8 @@ Breaking changes:
 
 * Remove some trait methods from `Event`
 * Update `Event::content` signature to return `&RawJsonValue` instead of `&JsonValue`
+* The `key_fn` in `lexicographical_topological_sort` has removed the event ID from its return type
+  and changed to expect just the power level, not the negated power level
 
 # 0.4.1
 

--- a/crates/ruma-state-res/benches/state_res_bench.rs
+++ b/crates/ruma-state-res/benches/state_res_bench.rs
@@ -48,8 +48,8 @@ fn lexico_topo_sort(c: &mut Criterion) {
             event_id("p") => hashset![event_id("o")],
         };
         b.iter(|| {
-            let _ = state_res::lexicographical_topological_sort(&graph, |id| {
-                Ok((int!(0), MilliSecondsSinceUnixEpoch(uint!(0)), id.to_owned()))
+            let _ = state_res::lexicographical_topological_sort(&graph, |_id| {
+                Ok((int!(0), MilliSecondsSinceUnixEpoch(uint!(0))))
             });
         })
     });

--- a/crates/ruma-state-res/src/test_utils.rs
+++ b/crates/ruma-state-res/src/test_utils.rs
@@ -80,8 +80,8 @@ pub fn do_check(
 
     // Resolve the current state and add it to the state_at_event map then continue
     // on in "time"
-    for node in crate::lexicographical_topological_sort(&graph, |id| {
-        Ok((int!(0), MilliSecondsSinceUnixEpoch(uint!(0)), id.to_owned()))
+    for node in crate::lexicographical_topological_sort(&graph, |_id| {
+        Ok((int!(0), MilliSecondsSinceUnixEpoch(uint!(0))))
     })
     .unwrap()
     {


### PR DESCRIPTION
Gets rid of unnecessary copying and makes things more explicit by using a struct with named fields instead of a tuple for tie breaking.