### PR TITLE
Support for fallback keys

### DIFF
--- a/crates/ruma-api-macros/src/response.rs
+++ b/crates/ruma-api-macros/src/response.rs
@@ -198,7 +198,7 @@ impl ResponseField {
         }
     }
 
-    /// Return the contained field and HTTP header ident if this repsonse field is a header kind.
+    /// Return the contained field and HTTP header ident if this response field is a header kind.
     fn as_header_field(&self) -> Option<(&Field, &Ident)> {
         match self {
             ResponseField::Header(field, ident) => Some((field, ident)),

--- a/crates/ruma-api/CHANGELOG.md
+++ b/crates/ruma-api/CHANGELOG.md
@@ -84,7 +84,7 @@ Breaking changes:
 
 Improvements:
 
-* The `EndpointError`s that come with ruma crates now implement `std::errror::Error`
+* The `EndpointError`s that come with ruma crates now implement `std::error::Error`
 * Add a new `MatrixError` type to the `error` module that consists of a HTTP status code and JSON
   `body` and is the new default error type for `ruma_api!`
 

--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -200,7 +200,7 @@ Improvements:
 * Add method `into_event_content` for `r0::room::create_room::CreationContent`
 * Add room visibility endpoints: `r0::directory::{get_room_visibility, set_room_visibility}`.
 * Add is_empty helpers for structs in `r0::sync::sync_events`
-* Add a constructor for request structs of the followign endpoints
+* Add a constructor for request structs of the following endpoints
   * `r0::room::create_room`
   * `r0::message::get_message_events`
 * Add `logout_devices` field to `r0::account::change_password`
@@ -276,7 +276,7 @@ Improvements:
 * Add missing serde attributes to `get_content_thumbnail` query parameters
 * Add missing `state` response field to `r0::message::get_message_events`
 * Normalize `serde_json` imports
-* Remove dependeny on the `url` crate
+* Remove dependency on the `url` crate
 
 # 0.7.2
 
@@ -368,7 +368,7 @@ Improvements:
   * `r0::account::request_3pid_management_token_via_msisdn`
   * `r0::account::request_password_change_token_via_msisdn`
   * `r0::account::request_registration_token_via_msisdn`
-  * `r0::acount::request_3pid_management_token_via_email`
+  * `r0::account::request_3pid_management_token_via_email`
 * Update `r0::presence_get_presence` from r0.4.0 to r0.6.0
 * Add `r0::account::bind_3pid`
 * Add `r0::account::delete_3pid`

--- a/crates/ruma-client-api/src/r0/backup.rs
+++ b/crates/ruma-client-api/src/r0/backup.rs
@@ -19,6 +19,7 @@ use std::collections::BTreeMap;
 
 use js_int::UInt;
 use ruma_identifiers::{DeviceKeyId, UserId};
+use ruma_serde::Raw;
 use serde::{Deserialize, Serialize};
 
 /// A wrapper around a mapping of session IDs to key data.
@@ -26,12 +27,12 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct RoomKeyBackup {
     /// A map of session IDs to key data.
-    pub sessions: BTreeMap<String, KeyBackupData>,
+    pub sessions: BTreeMap<String, Raw<KeyBackupData>>,
 }
 
 impl RoomKeyBackup {
     /// Creates a new `RoomKeyBackup` with the given sessions.
-    pub fn new(sessions: BTreeMap<String, KeyBackupData>) -> Self {
+    pub fn new(sessions: BTreeMap<String, Raw<KeyBackupData>>) -> Self {
         Self { sessions }
     }
 }

--- a/crates/ruma-client-api/src/r0/backup/add_backup_key_session.rs
+++ b/crates/ruma-client-api/src/r0/backup/add_backup_key_session.rs
@@ -3,6 +3,7 @@
 use js_int::UInt;
 use ruma_api::ruma_api;
 use ruma_identifiers::RoomId;
+use ruma_serde::Raw;
 
 use super::KeyBackupData;
 
@@ -33,7 +34,7 @@ ruma_api! {
 
         /// The key information to backup.
         #[ruma_api(body)]
-        pub session_data: KeyBackupData,
+        pub session_data: Raw<KeyBackupData>,
     }
 
     response: {
@@ -56,7 +57,7 @@ impl<'a> Request<'a> {
         version: &'a str,
         room_id: &'a RoomId,
         session_id: &'a str,
-        session_data: KeyBackupData,
+        session_data: Raw<KeyBackupData>,
     ) -> Self {
         Self { version, room_id, session_id, session_data }
     }

--- a/crates/ruma-client-api/src/r0/backup/add_backup_key_sessions.rs
+++ b/crates/ruma-client-api/src/r0/backup/add_backup_key_sessions.rs
@@ -5,6 +5,7 @@ use std::collections::BTreeMap;
 use js_int::UInt;
 use ruma_api::ruma_api;
 use ruma_identifiers::RoomId;
+use ruma_serde::Raw;
 
 use super::KeyBackupData;
 
@@ -30,7 +31,7 @@ ruma_api! {
         pub room_id: &'a RoomId,
 
         /// A map from session IDs to key data.
-        pub sessions: BTreeMap<String, KeyBackupData>,
+        pub sessions: BTreeMap<String, Raw<KeyBackupData>>,
     }
 
     response: {
@@ -52,7 +53,7 @@ impl<'a> Request<'a> {
     pub fn new(
         version: &'a str,
         room_id: &'a RoomId,
-        sessions: BTreeMap<String, KeyBackupData>,
+        sessions: BTreeMap<String, Raw<KeyBackupData>>,
     ) -> Self {
         Self { version, room_id, sessions }
     }

--- a/crates/ruma-client-api/src/r0/backup/create_backup.rs
+++ b/crates/ruma-client-api/src/r0/backup/create_backup.rs
@@ -1,6 +1,7 @@
 //! [POST /_matrix/client/r0/room_keys/version](https://matrix.org/docs/spec/client_server/unstable#post-matrix-client-r0-room-keys-version)
 
 use ruma_api::ruma_api;
+use ruma_serde::Raw;
 
 use super::BackupAlgorithm;
 
@@ -17,7 +18,7 @@ ruma_api! {
     request: {
         /// The algorithm used for storing backups.
         #[serde(flatten)]
-        pub algorithm: BackupAlgorithm,
+        pub algorithm: Raw<BackupAlgorithm>,
     }
 
     response: {
@@ -30,7 +31,7 @@ ruma_api! {
 
 impl Request {
     /// Creates a new `Request` with the given backup algorithm.
-    pub fn new(algorithm: BackupAlgorithm) -> Self {
+    pub fn new(algorithm: Raw<BackupAlgorithm>) -> Self {
         Self { algorithm }
     }
 }

--- a/crates/ruma-client-api/src/r0/backup/get_backup.rs
+++ b/crates/ruma-client-api/src/r0/backup/get_backup.rs
@@ -2,6 +2,7 @@
 
 use js_int::UInt;
 use ruma_api::ruma_api;
+use ruma_serde::Raw;
 
 use super::BackupAlgorithm;
 
@@ -24,7 +25,7 @@ ruma_api! {
     response: {
         /// The algorithm used for storing backups.
         #[serde(flatten)]
-        pub algorithm: BackupAlgorithm,
+        pub algorithm: Raw<BackupAlgorithm>,
 
         /// The number of keys stored in the backup.
         pub count: UInt,
@@ -51,7 +52,12 @@ impl<'a> Request<'a> {
 
 impl Response {
     /// Creates a new `Response` with the gien algorithm, key count, etag and version.
-    pub fn new(algorithm: BackupAlgorithm, count: UInt, etag: String, version: String) -> Self {
+    pub fn new(
+        algorithm: Raw<BackupAlgorithm>,
+        count: UInt,
+        etag: String,
+        version: String,
+    ) -> Self {
         Self { algorithm, count, etag, version }
     }
 }

--- a/crates/ruma-client-api/src/r0/backup/get_backup_key_session.rs
+++ b/crates/ruma-client-api/src/r0/backup/get_backup_key_session.rs
@@ -2,6 +2,7 @@
 
 use ruma_api::ruma_api;
 use ruma_identifiers::RoomId;
+use ruma_serde::Raw;
 
 use super::KeyBackupData;
 
@@ -34,7 +35,7 @@ ruma_api! {
     response: {
         /// Information about the requested backup key.
         #[ruma_api(body)]
-        pub key_data: KeyBackupData,
+        pub key_data: Raw<KeyBackupData>,
     }
 
     error: crate::Error
@@ -49,7 +50,7 @@ impl<'a> Request<'a> {
 
 impl Response {
     /// Creates a new `Response` with the given key_data.
-    pub fn new(key_data: KeyBackupData) -> Self {
+    pub fn new(key_data: Raw<KeyBackupData>) -> Self {
         Self { key_data }
     }
 }

--- a/crates/ruma-client-api/src/r0/backup/get_backup_key_sessions.rs
+++ b/crates/ruma-client-api/src/r0/backup/get_backup_key_sessions.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeMap;
 
 use ruma_api::ruma_api;
 use ruma_identifiers::RoomId;
+use ruma_serde::Raw;
 
 use super::KeyBackupData;
 
@@ -31,7 +32,7 @@ ruma_api! {
 
     response: {
         /// A map of session IDs to key data.
-        pub sessions: BTreeMap<String, KeyBackupData>,
+        pub sessions: BTreeMap<String, Raw<KeyBackupData>>,
     }
 
     error: crate::Error
@@ -46,7 +47,7 @@ impl<'a> Request<'a> {
 
 impl Response {
     /// Creates a new `Response` with the given sessions.
-    pub fn new(sessions: BTreeMap<String, KeyBackupData>) -> Self {
+    pub fn new(sessions: BTreeMap<String, Raw<KeyBackupData>>) -> Self {
         Self { sessions }
     }
 }

--- a/crates/ruma-client-api/src/r0/backup/get_backup_keys.rs
+++ b/crates/ruma-client-api/src/r0/backup/get_backup_keys.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeMap;
 
 use ruma_api::ruma_api;
 use ruma_identifiers::RoomId;
+use ruma_serde::Raw;
 
 use super::RoomKeyBackup;
 
@@ -27,7 +28,7 @@ ruma_api! {
 
     response: {
         /// A map from room IDs to session IDs to key data.
-        pub rooms: BTreeMap<Box<RoomId>, RoomKeyBackup>,
+        pub rooms: BTreeMap<Box<RoomId>, Raw<RoomKeyBackup>>,
     }
 
     error: crate::Error
@@ -42,7 +43,7 @@ impl<'a> Request<'a> {
 
 impl Response {
     /// Creates a new `Response` with the given room key backups.
-    pub fn new(rooms: BTreeMap<Box<RoomId>, RoomKeyBackup>) -> Self {
+    pub fn new(rooms: BTreeMap<Box<RoomId>, Raw<RoomKeyBackup>>) -> Self {
         Self { rooms }
     }
 }

--- a/crates/ruma-client-api/src/r0/backup/get_latest_backup.rs
+++ b/crates/ruma-client-api/src/r0/backup/get_latest_backup.rs
@@ -2,6 +2,7 @@
 
 use js_int::UInt;
 use ruma_api::ruma_api;
+use ruma_serde::Raw;
 
 use super::BackupAlgorithm;
 
@@ -21,7 +22,7 @@ ruma_api! {
     response: {
         /// The algorithm used for storing backups.
         #[serde(flatten)]
-        pub algorithm: BackupAlgorithm,
+        pub algorithm: Raw<BackupAlgorithm>,
 
         /// The number of keys stored in the backup.
         pub count: UInt,
@@ -48,7 +49,12 @@ impl Request {
 
 impl Response {
     /// Creates a new `Response` with the given algorithm, key count, etag and version.
-    pub fn new(algorithm: BackupAlgorithm, count: UInt, etag: String, version: String) -> Self {
+    pub fn new(
+        algorithm: Raw<BackupAlgorithm>,
+        count: UInt,
+        etag: String,
+        version: String,
+    ) -> Self {
         Self { algorithm, count, etag, version }
     }
 }

--- a/crates/ruma-client-api/src/r0/backup/update_backup.rs
+++ b/crates/ruma-client-api/src/r0/backup/update_backup.rs
@@ -1,6 +1,7 @@
 //! [POST /_matrix/client/r0/room_keys/version](https://matrix.org/docs/spec/client_server/unstable#post-matrix-client-r0-room-keys-version)
 
 use ruma_api::ruma_api;
+use ruma_serde::Raw;
 
 use super::BackupAlgorithm;
 
@@ -21,7 +22,7 @@ ruma_api! {
 
         /// The algorithm used for storing backups.
         #[serde(flatten)]
-        pub algorithm: BackupAlgorithm,
+        pub algorithm: Raw<BackupAlgorithm>,
     }
 
     #[derive(Default)]
@@ -32,7 +33,7 @@ ruma_api! {
 
 impl<'a> Request<'a> {
     /// Creates a new `Request` with the given backup version and algorithm.
-    pub fn new(version: &'a str, algorithm: BackupAlgorithm) -> Self {
+    pub fn new(version: &'a str, algorithm: Raw<BackupAlgorithm>) -> Self {
         Self { version, algorithm }
     }
 }

--- a/crates/ruma-client-api/src/r0/keys/claim_keys.rs
+++ b/crates/ruma-client-api/src/r0/keys/claim_keys.rs
@@ -5,6 +5,7 @@ use std::{collections::BTreeMap, time::Duration};
 use ruma_api::ruma_api;
 use ruma_common::encryption::OneTimeKey;
 use ruma_identifiers::{DeviceId, DeviceKeyAlgorithm, DeviceKeyId, UserId};
+use ruma_serde::Raw;
 use serde_json::Value as JsonValue;
 
 ruma_api! {
@@ -60,4 +61,4 @@ impl Response {
 }
 
 /// The one-time keys for a given device.
-pub type OneTimeKeys = BTreeMap<Box<DeviceId>, BTreeMap<Box<DeviceKeyId>, OneTimeKey>>;
+pub type OneTimeKeys = BTreeMap<Box<DeviceId>, BTreeMap<Box<DeviceKeyId>, Raw<OneTimeKey>>>;

--- a/crates/ruma-client-api/src/r0/keys/get_keys.rs
+++ b/crates/ruma-client-api/src/r0/keys/get_keys.rs
@@ -5,6 +5,7 @@ use std::{collections::BTreeMap, time::Duration};
 use ruma_api::ruma_api;
 use ruma_common::encryption::DeviceKeys;
 use ruma_identifiers::{DeviceId, UserId};
+use ruma_serde::Raw;
 use serde_json::Value as JsonValue;
 
 #[cfg(feature = "unstable-pre-spec")]
@@ -56,22 +57,22 @@ ruma_api! {
 
         /// Information on the queried devices.
         #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-        pub device_keys: BTreeMap<Box<UserId>, BTreeMap<Box<DeviceId>, DeviceKeys>>,
+        pub device_keys: BTreeMap<Box<UserId>, BTreeMap<Box<DeviceId>, Raw<DeviceKeys>>>,
 
         /// Information on the master cross-signing keys of the queried users.
         #[cfg(feature = "unstable-pre-spec")]
         #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-        pub master_keys: BTreeMap<Box<UserId>, CrossSigningKey>,
+        pub master_keys: BTreeMap<Box<UserId>, Raw<CrossSigningKey>>,
 
         /// Information on the self-signing keys of the queried users.
         #[cfg(feature = "unstable-pre-spec")]
         #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-        pub self_signing_keys: BTreeMap<Box<UserId>, CrossSigningKey>,
+        pub self_signing_keys: BTreeMap<Box<UserId>, Raw<CrossSigningKey>>,
 
         /// Information on the user-signing keys of the queried users.
         #[cfg(feature = "unstable-pre-spec")]
         #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-        pub user_signing_keys: BTreeMap<Box<UserId>, CrossSigningKey>,
+        pub user_signing_keys: BTreeMap<Box<UserId>, Raw<CrossSigningKey>>,
     }
 
     error: crate::Error

--- a/crates/ruma-client-api/src/r0/keys/upload_keys.rs
+++ b/crates/ruma-client-api/src/r0/keys/upload_keys.rs
@@ -6,6 +6,7 @@ use js_int::UInt;
 use ruma_api::ruma_api;
 use ruma_common::encryption::{DeviceKeys, OneTimeKey};
 use ruma_identifiers::{DeviceKeyAlgorithm, DeviceKeyId};
+use ruma_serde::Raw;
 
 ruma_api! {
     metadata: {
@@ -23,11 +24,11 @@ ruma_api! {
         ///
         /// May be absent if no new identity keys are required.
         #[serde(skip_serializing_if = "Option::is_none")]
-        pub device_keys: Option<DeviceKeys>,
+        pub device_keys: Option<Raw<DeviceKeys>>,
 
         /// One-time public keys for "pre-key" messages.
         #[serde(skip_serializing_if = "Option::is_none")]
-        pub one_time_keys: Option<BTreeMap<Box<DeviceKeyId>, OneTimeKey>>,
+        pub one_time_keys: Option<BTreeMap<Box<DeviceKeyId>, Raw<OneTimeKey>>>,
     }
 
     response: {

--- a/crates/ruma-client-api/src/r0/keys/upload_keys.rs
+++ b/crates/ruma-client-api/src/r0/keys/upload_keys.rs
@@ -29,6 +29,11 @@ ruma_api! {
         /// One-time public keys for "pre-key" messages.
         #[serde(skip_serializing_if = "Option::is_none")]
         pub one_time_keys: Option<BTreeMap<Box<DeviceKeyId>, Raw<OneTimeKey>>>,
+
+        /// Fallback public keys for "pre-key" messages.
+        #[cfg(feature = "unstable-pre-spec")]
+        #[serde(skip_serializing_if = "Option::is_none", rename = "org.matrix.msc2732.fallback_keys")]
+        pub fallback_keys: Option<BTreeMap<Box<DeviceKeyId>, Raw<OneTimeKey>>>,
     }
 
     response: {

--- a/crates/ruma-client-api/src/r0/keys/upload_keys.rs
+++ b/crates/ruma-client-api/src/r0/keys/upload_keys.rs
@@ -27,13 +27,13 @@ ruma_api! {
         pub device_keys: Option<Raw<DeviceKeys>>,
 
         /// One-time public keys for "pre-key" messages.
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub one_time_keys: Option<BTreeMap<Box<DeviceKeyId>, Raw<OneTimeKey>>>,
+        #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+        pub one_time_keys: BTreeMap<Box<DeviceKeyId>, Raw<OneTimeKey>>,
 
         /// Fallback public keys for "pre-key" messages.
         #[cfg(feature = "unstable-pre-spec")]
-        #[serde(skip_serializing_if = "Option::is_none", rename = "org.matrix.msc2732.fallback_keys")]
-        pub fallback_keys: Option<BTreeMap<Box<DeviceKeyId>, Raw<OneTimeKey>>>,
+        #[serde(default, skip_serializing_if = "BTreeMap::is_empty", rename = "org.matrix.msc2732.fallback_keys")]
+        pub fallback_keys: BTreeMap<Box<DeviceKeyId>, Raw<OneTimeKey>>,
     }
 
     response: {

--- a/crates/ruma-client-api/src/r0/keys/upload_signing_keys.rs
+++ b/crates/ruma-client-api/src/r0/keys/upload_signing_keys.rs
@@ -4,6 +4,7 @@
 
 use ruma_api::ruma_api;
 use ruma_common::encryption::CrossSigningKey;
+use ruma_serde::Raw;
 
 use crate::r0::uiaa::{AuthData, IncomingAuthData, UiaaResponse};
 
@@ -25,21 +26,21 @@ ruma_api! {
 
         /// The user's master key.
         #[serde(skip_serializing_if = "Option::is_none")]
-        pub master_key: Option<CrossSigningKey>,
+        pub master_key: Option<Raw<CrossSigningKey>>,
 
         /// The user's self-signing key.
         ///
         /// Must be signed with the accompanied master, or by the user's most recently uploaded
         /// master key if no master key is included in the request.
         #[serde(skip_serializing_if = "Option::is_none")]
-        pub self_signing_key: Option<CrossSigningKey>,
+        pub self_signing_key: Option<Raw<CrossSigningKey>>,
 
         /// The user's user-signing key.
         ///
         /// Must be signed with the accompanied master, or by the user's most recently uploaded
         /// master key if no master key is included in the request.
         #[serde(skip_serializing_if = "Option::is_none")]
-        pub user_signing_key: Option<CrossSigningKey>,
+        pub user_signing_key: Option<Raw<CrossSigningKey>>,
     }
 
     #[derive(Default)]

--- a/crates/ruma-client-api/src/r0/membership/invite_user.rs
+++ b/crates/ruma-client-api/src/r0/membership/invite_user.rs
@@ -70,13 +70,13 @@ impl Response {
 #[incoming_derive(PartialEq)]
 #[serde(untagged)]
 pub enum InvitationRecipient<'a> {
-    /// Used to invite user by their Matrix identifer.
+    /// Used to invite user by their Matrix identifier.
     UserId {
         /// Matrix identifier of user.
         user_id: &'a UserId,
     },
 
-    /// Used to invite user by a third party identifer.
+    /// Used to invite user by a third party identifier.
     ThirdPartyId(Invite3pid<'a>),
 }
 

--- a/crates/ruma-client-api/src/r0/message.rs
+++ b/crates/ruma-client-api/src/r0/message.rs
@@ -1,4 +1,4 @@
-//! Enpoints for sending and receiving messages
+//! Endpoints for sending and receiving messages
 
 pub mod get_message_events;
 pub mod send_message_event;

--- a/crates/ruma-client-api/src/r0/push/get_pushers.rs
+++ b/crates/ruma-client-api/src/r0/push/get_pushers.rs
@@ -57,7 +57,7 @@ pub struct Pusher {
 
     /// A reverse-DNS style identifier for the application.
     ///
-    /// The maximum allowed lenght is 64 bytes.
+    /// The maximum allowed length is 64 bytes.
     pub app_id: String,
 
     /// A string that will allow the user to identify what application owns this pusher.

--- a/crates/ruma-client-api/src/r0/search/search_events.rs
+++ b/crates/ruma-client-api/src/r0/search/search_events.rs
@@ -217,7 +217,7 @@ impl EventContextResult {
     }
 }
 
-/// A grouping for partioning the result set.
+/// A grouping for partitioning the result set.
 #[derive(Clone, Default, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct Grouping {

--- a/crates/ruma-client-api/src/r0/sync/sync_events.rs
+++ b/crates/ruma-client-api/src/r0/sync/sync_events.rs
@@ -93,6 +93,15 @@ ruma_api! {
         /// currently held on the server for a device.
         #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
         pub device_one_time_keys_count: BTreeMap<DeviceKeyAlgorithm, UInt>,
+
+        /// For each key algorithm, the number of unclaimed one-time keys
+        /// currently held on the server for a device.
+        ///
+        /// The presence of this field indicates that the server supports
+        /// fallback keys.
+        #[cfg(feature = "unstable-pre-spec")]
+        #[serde(rename = "org.matrix.msc2732.device_unused_fallback_key_types")]
+        pub device_unused_fallback_key_types: Option<Vec<DeviceKeyAlgorithm>>,
     }
 
     error: crate::Error
@@ -116,6 +125,8 @@ impl Response {
             to_device: Default::default(),
             device_lists: Default::default(),
             device_one_time_keys_count: BTreeMap::new(),
+            #[cfg(feature = "unstable-pre-spec")]
+            device_unused_fallback_key_types: None,
         }
     }
 }

--- a/crates/ruma-client-api/src/r0/sync/sync_events.rs
+++ b/crates/ruma-client-api/src/r0/sync/sync_events.rs
@@ -79,7 +79,7 @@ ruma_api! {
         #[serde(default, skip_serializing_if = "GlobalAccountData::is_empty")]
         pub account_data: GlobalAccountData,
 
-        /// Messages sent dirrectly between devices.
+        /// Messages sent directly between devices.
         #[serde(default, skip_serializing_if = "ToDevice::is_empty")]
         pub to_device: ToDevice,
 
@@ -539,7 +539,7 @@ impl Presence {
     }
 }
 
-/// Messages sent dirrectly between devices.
+/// Messages sent directly between devices.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct ToDevice {
@@ -560,7 +560,7 @@ impl ToDevice {
     }
 }
 
-/// Information on E2E device udpates.
+/// Information on E2E device updates.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct DeviceLists {

--- a/crates/ruma-client-api/src/r0/uiaa.rs
+++ b/crates/ruma-client-api/src/r0/uiaa.rs
@@ -729,7 +729,7 @@ impl IncomingUserIdentifier {
     }
 }
 
-/// Credentials for thirdparty authentification (e.g. email / phone number).
+/// Credentials for third-party authentication (e.g. email / phone number).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct ThirdpartyIdCredentials {

--- a/crates/ruma-common/src/encryption.rs
+++ b/crates/ruma-common/src/encryption.rs
@@ -83,12 +83,28 @@ pub struct SignedKey {
 
     /// Signatures for the key object.
     pub signatures: SignedKeySignatures,
+
+    /// Is this key considered to be a fallback key, defaults to false.
+    #[cfg(feature = "unstable-pre-spec")]
+    #[serde(default, skip_serializing_if = "ruma_serde::is_default")]
+    pub fallback: bool,
 }
 
 impl SignedKey {
     /// Creates a new `SignedKey` with the given key and signatures.
     pub fn new(key: String, signatures: SignedKeySignatures) -> Self {
-        Self { key, signatures }
+        Self {
+            key,
+            signatures,
+            #[cfg(feature = "unstable-pre-spec")]
+            fallback: false,
+        }
+    }
+
+    /// Creates a new fallback `SignedKey` with the given key and signatures.
+    #[cfg(feature = "unstable-pre-spec")]
+    pub fn new_fallback(key: String, signatures: SignedKeySignatures) -> Self {
+        Self { key, signatures, fallback: true }
     }
 }
 

--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -156,7 +156,7 @@ Breaking changes:
   ids without the need to understand the concrete method.
 * Change `get_message_events` limit field type from `Option<UInt>` to `UInt`
 * Add `alt_aliases` to `CanonicalAliasEventContent`
-* Replace `format` and `formatted_body` fields in `TextMessagEventContent`,
+* Replace `format` and `formatted_body` fields in `TextMessageEventContent`,
   `NoticeMessageEventContent` and `EmoteMessageEventContent` with `formatted: FormattedBody`
 * Rename `override_rules` in `push_rules::Ruleset` to `override_`
 * Change `push_rules::PushCondition` variants from newtype variants with separate inner types to
@@ -297,7 +297,7 @@ Improvements:
 
 Breaking changes:
 
-* `collections::only` no longer exports a `raw` submodule. It was never meant ot be exported in the first place.
+* `collections::only` no longer exports a `raw` submodule. It was never meant to be exported in the first place.
 * Renamed `stripped::{StrippedState => AnyStrippedStateEvent, StrippedStateContent => StrippedStateEvent}`
 
 Improvements:

--- a/crates/ruma-identifiers-validation/CHANGELOG.md
+++ b/crates/ruma-identifiers-validation/CHANGELOG.md
@@ -48,4 +48,4 @@ Improvements:
 
 Breaking changes:
 
-* Remove `key_algorithms` module (moved to ruma-identifers as `crypto_algorithms`)
+* Remove `key_algorithms` module (moved to ruma-identifiers as `crypto_algorithms`)

--- a/crates/ruma-serde/src/strings.rs
+++ b/crates/ruma-serde/src/strings.rs
@@ -32,7 +32,7 @@ where
 }
 
 /// Serde serializiation decorator to map None to an empty String,
-/// and forward Somes to the Serialize implemention for T.
+/// and forward Somes to the Serialize implementation for T.
 ///
 /// To be used like this:
 /// `#[serde(serialize_with = "empty_string_as_none")]`


### PR DESCRIPTION
This PR adds support for [MSC2732], fallback keys. 

To do so, we first swapped to Raw variants of the types that are used to upload and download various keys in Matrix land. At the same time we swapped to Raw variants for the backup API as well.

The last commit fixes a bunch of typos discovered looking through the code and using [typos].

This closes #760.

[MSC2732]: https://github.com/matrix-org/matrix-doc/pull/2732
[typos]: https://github.com/crate-ci/typos
