### PR TITLE
ruma-api-macros: Avoid empty request bodys

### DIFF
--- a/crates/ruma-api-macros/src/request/outgoing.rs
+++ b/crates/ruma-api-macros/src/request/outgoing.rs
@@ -177,7 +177,7 @@ impl Request {
                 #ruma_serde::json_to_buf(&RequestBody { #initializers })?
             }
         } else {
-            quote! { <T as ::std::default::Default>::default() }
+            quote! { #ruma_serde::slice_to_buf(b"{}") }
         };
 
         let (impl_generics, ty_generics, where_clause) = self.generics.split_for_impl();

--- a/crates/ruma-api/tests/no_fields.rs
+++ b/crates/ruma-api/tests/no_fields.rs
@@ -21,7 +21,7 @@ fn empty_request_http_repr() {
         .try_into_http_request::<Vec<u8>>("https://homeserver.tld", SendAccessToken::None)
         .unwrap();
 
-    assert!(http_req.body().is_empty());
+    assert_eq!(http_req.body(), b"{}");
 }
 
 #[test]


### PR DESCRIPTION
I've recently upgraded my synapse installation (to version 1.48.0) and realized that requests with empty messages are rejected starting from at least that version. The relevant portion of code is [here](https://github.com/matrix-org/synapse/blob/33abbc327813e65aaa91e10f98a31622c045004c/synapse/http/servlet.py#L637). It looks like in principle empty requests are allowed by the function, but all calls actually use the default value (`False`) for parameter `allow_empty_bode`.

In order to be compatible with the above mentioned and (for now) future versions of Synapse, I think we need to emit empty json dictionaries instead.

Apart from the compatibility issue, this is actually in line with current the behavior of responses (see for example `crates/ruma-api/tests/no_fields.rs`).