### PR TITLE
ruma-api-macros: Avoid empty POST/PUT request bodys

### DIFF
--- a/crates/ruma-api-macros/src/request/outgoing.rs
+++ b/crates/ruma-api-macros/src/request/outgoing.rs
@@ -176,8 +176,10 @@ impl Request {
             quote! {
                 #ruma_serde::json_to_buf(&RequestBody { #initializers })?
             }
-        } else {
+        } else if method == "GET" {
             quote! { <T as ::std::default::Default>::default() }
+        } else {
+            quote! { #ruma_serde::slice_to_buf(b"{}") }
         };
 
         let (impl_generics, ty_generics, where_clause) = self.generics.split_for_impl();

--- a/crates/ruma-api/tests/no_fields.rs
+++ b/crates/ruma-api/tests/no_fields.rs
@@ -1,33 +1,72 @@
-use ruma_api::{ruma_api, OutgoingRequest as _, OutgoingResponse as _, SendAccessToken};
+use ruma_api::{OutgoingRequest as _, OutgoingResponse as _, SendAccessToken};
 
-ruma_api! {
-    metadata: {
-        description: "Does something.",
-        method: GET,
-        name: "no_fields",
-        path: "/_matrix/my/endpoint",
-        rate_limited: false,
-        authentication: None,
+mod get {
+    ruma_api::ruma_api! {
+        metadata: {
+            description: "Does something.",
+            method: GET,
+            name: "no_fields",
+            path: "/_matrix/my/endpoint",
+            rate_limited: false,
+            authentication: None,
+        }
+
+        request: {}
+        response: {}
     }
+}
 
-    request: {}
-    response: {}
+mod post {
+    ruma_api::ruma_api! {
+        metadata: {
+            description: "Does something.",
+            method: POST,
+            name: "no_fields",
+            path: "/_matrix/my/endpoint",
+            rate_limited: false,
+            authentication: None,
+        }
+
+        request: {}
+        response: {}
+    }
 }
 
 #[test]
-fn empty_request_http_repr() {
-    let req = Request {};
+fn empty_post_request_http_repr() {
+    let req = post::Request {};
     let http_req = req
         .try_into_http_request::<Vec<u8>>("https://homeserver.tld", SendAccessToken::None)
         .unwrap();
 
+    // Empty POST requests should contain an empty dictionary as a body...
+    assert_eq!(http_req.body(), b"{}");
+}
+#[test]
+fn empty_get_request_http_repr() {
+    let req = get::Request {};
+    let http_req = req
+        .try_into_http_request::<Vec<u8>>("https://homeserver.tld", SendAccessToken::None)
+        .unwrap();
+
+    // ... but GET requests' bodies should be empty.
     assert!(http_req.body().is_empty());
 }
 
 #[test]
-fn empty_response_http_repr() {
-    let res = Response {};
+fn empty_post_response_http_repr() {
+    let res = post::Response {};
     let http_res = res.try_into_http_response::<Vec<u8>>().unwrap();
 
+    // For the reponse, the body should be an empty dict again...
+    assert_eq!(http_res.body(), b"{}");
+}
+
+#[test]
+fn empty_get_response_http_repr() {
+    let res = get::Response {};
+    let http_res = res.try_into_http_response::<Vec<u8>>().unwrap();
+
+    // ... even for GET requests.
     assert_eq!(http_res.body(), b"{}");
 }


### PR DESCRIPTION
This is a continuation of #785 (from the correct source branch).

@jplatte I think I have addressed your concerns raised there by changing `outgoing.rs` as you suggested and split the test case in `no_fields` into two for GET and POST requests, respectively.