### PR TITLE
ruma-events: Add links to specs in modules docs

### DIFF
--- a/crates/ruma-events/src/call/answer.rs
+++ b/crates/ruma-events/src/call/answer.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.call.answer` event.
+//! Types for the [`m.call.answer`] event.
+//!
+//! [`m.call.answer`]: https://spec.matrix.org/v1.1/client-server-api/#mcallanswer
 
 use js_int::UInt;
 use ruma_events_macros::EventContent;

--- a/crates/ruma-events/src/call/candidates.rs
+++ b/crates/ruma-events/src/call/candidates.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.call.candidates` event.
+//! Types for the [`m.call.candidates`] event.
+//!
+//! [`m.call.candidates`]: https://spec.matrix.org/v1.1/client-server-api/#mcallcandidates
 
 use js_int::UInt;
 use ruma_events_macros::EventContent;

--- a/crates/ruma-events/src/call/hangup.rs
+++ b/crates/ruma-events/src/call/hangup.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.call.hangup` event.
+//! Types for the [`m.call.hangup`] event.
+//!
+//! [`m.call.hangup`]: https://spec.matrix.org/v1.1/client-server-api/#mcallhangup
 
 use js_int::UInt;
 use ruma_events_macros::EventContent;

--- a/crates/ruma-events/src/call/invite.rs
+++ b/crates/ruma-events/src/call/invite.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.call.invite`] event.
 //!
-//! `m.call.invite`: https://spec.matrix.org/v1.1/client-server-api/#mcallinvite
+//! [`m.call.invite`]: https://spec.matrix.org/v1.1/client-server-api/#mcallinvite
 
 use js_int::UInt;
 use ruma_events_macros::EventContent;

--- a/crates/ruma-events/src/call/invite.rs
+++ b/crates/ruma-events/src/call/invite.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.call.invite` event.
+//! Types for the [`m.call.invite`] event.
+//!
+//! `m.call.invite`: https://spec.matrix.org/v1.1/client-server-api/#mcallinvite
 
 use js_int::UInt;
 use ruma_events_macros::EventContent;

--- a/crates/ruma-events/src/direct.rs
+++ b/crates/ruma-events/src/direct.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.direct` event.
+//! Types for the [`m.direct`] event.
+//!
+//! [`m.direct`]: https://spec.matrix.org/v1.1/client-server-api/#mdirect
 
 use std::{
     collections::BTreeMap,

--- a/crates/ruma-events/src/dummy.rs
+++ b/crates/ruma-events/src/dummy.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.dummy` event.
+//! Types for the [`m.dummy`] event.
+//!
+//! [`m.dummy`]: https://spec.matrix.org/v1.1/client-server-api/#mdummy
 
 use std::fmt;
 

--- a/crates/ruma-events/src/forwarded_room_key.rs
+++ b/crates/ruma-events/src/forwarded_room_key.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.forwarded_room_key` event.
+//! Types for the [`m.forwarded_room_key`] event.
+//!
+//! [`m.forwarded_room_key`]: https://spec.matrix.org/v1.1/client-server-api/#mforwarded_room_key
 
 use ruma_events_macros::EventContent;
 use ruma_identifiers::{EventEncryptionAlgorithm, RoomId};

--- a/crates/ruma-events/src/fully_read.rs
+++ b/crates/ruma-events/src/fully_read.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.fully_read` event.
+//! Types for the [`m.fully_read`] event.
+//!
+//! [`m.fully_read`]: https://spec.matrix.org/v1.1/client-server-api/#mfully_read
 
 use ruma_events_macros::EventContent;
 use ruma_identifiers::EventId;

--- a/crates/ruma-events/src/ignored_user_list.rs
+++ b/crates/ruma-events/src/ignored_user_list.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.ignored_user_list` event.
+//! Types for the [`m.ignored_user_list`] event.
+//!
+//! [`m.ignored_user_list`]: https://spec.matrix.org/v1.1/client-server-api/#mignored_user_list
 
 use ruma_events_macros::EventContent;
 use ruma_identifiers::UserId;

--- a/crates/ruma-events/src/key/verification.rs
+++ b/crates/ruma-events/src/key/verification.rs
@@ -3,7 +3,9 @@
 //! This module also contains types shared by events in its child namespaces.
 //!
 //! The MSC for the in-room variants of the `m.key.verification.*` events can be found
-//! [here](https://github.com/matrix-org/matrix-doc/pull/2241).
+//! [on GitHub][github-matrix-doc-2214].
+//!
+//! [github-matrix-doc-2214]: https://github.com/matrix-org/matrix-doc/pull/2241
 #[cfg(feature = "unstable-pre-spec")]
 use ruma_identifiers::EventId;
 use ruma_serde::StringEnum;

--- a/crates/ruma-events/src/key/verification/accept.rs
+++ b/crates/ruma-events/src/key/verification/accept.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.key.verification.accept` event.
+//! Types for the [`m.key.verification.accept`] event.
+//!
+//! [`m.key.verification.accept`]: https://spec.matrix.org/v1.1/client-server-api/#mkeyverificationaccept
 
 use std::collections::BTreeMap;
 

--- a/crates/ruma-events/src/key/verification/cancel.rs
+++ b/crates/ruma-events/src/key/verification/cancel.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.key.verification.cancel` event.
+//! Types for the [`m.key.verification.cancel`] event.
+//!
+//! [`m.key.verification.cancel`]: https://spec.matrix.org/v1.1/client-server-api/#mkeyverificationcancel
 
 use ruma_events_macros::EventContent;
 use ruma_serde::StringEnum;

--- a/crates/ruma-events/src/key/verification/done.rs
+++ b/crates/ruma-events/src/key/verification/done.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.key.verification.done` event.
+//! Types for the [`m.key.verification.done`] event.
+//!
+//! [`m.key.verification.done`]: https://spec.matrix.org/v1.1/client-server-api/#mkeyverificationdone
 
 use ruma_events_macros::EventContent;
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-events/src/key/verification/key.rs
+++ b/crates/ruma-events/src/key/verification/key.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.key.verification.key` event.
+//! Types for the [`m.key.verification.key`] event.
+//!
+//! [`m.key.verification.key`]: https://spec.matrix.org/v1.1/client-server-api/#mkeyverificationkey
 
 use ruma_events_macros::EventContent;
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-events/src/key/verification/mac.rs
+++ b/crates/ruma-events/src/key/verification/mac.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.key.verification.mac` event.
+//! Types for the [`m.key.verification.mac`] event.
+//!
+//! [`m.key.verification.mac`]: https://spec.matrix.org/v1.1/client-server-api/#mkeyverificationmac
 
 use std::collections::BTreeMap;
 

--- a/crates/ruma-events/src/key/verification/ready.rs
+++ b/crates/ruma-events/src/key/verification/ready.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.key.verification.ready` event.
+//! Types for the [`m.key.verification.ready`] event.
+//!
+//! [`m.key.verification.ready`]: https://spec.matrix.org/v1.1/client-server-api/#mkeyverificationready
 
 use ruma_events_macros::EventContent;
 use ruma_identifiers::DeviceId;

--- a/crates/ruma-events/src/key/verification/request.rs
+++ b/crates/ruma-events/src/key/verification/request.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.key.verification.request` event.
+//! Types for the [`m.key.verification.request`] event.
+//!
+//! [`m.key.verification.request`]: https://spec.matrix.org/v1.1/client-server-api/#mkeyverificationrequest
 
 use ruma_common::MilliSecondsSinceUnixEpoch;
 use ruma_events_macros::EventContent;

--- a/crates/ruma-events/src/key/verification/start.rs
+++ b/crates/ruma-events/src/key/verification/start.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.key.verification.start` event.
+//! Types for the [`m.key.verification.start`] event.
+//!
+//! [`m.key.verification.start`]: https://spec.matrix.org/v1.1/client-server-api/#mkeyverificationstart
 
 use std::collections::BTreeMap;
 

--- a/crates/ruma-events/src/policy/rule/room.rs
+++ b/crates/ruma-events/src/policy/rule/room.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.policy.rule.room` event.
+//! Types for the [`m.policy.rule.room`] event.
+//!
+//! [`m.policy.rule.room`]: https://spec.matrix.org/v1.1/client-server-api/#mpolicyruleroom
 
 use ruma_events_macros::EventContent;
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-events/src/policy/rule/server.rs
+++ b/crates/ruma-events/src/policy/rule/server.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.policy.rule.server` event.
+//! Types for the [`m.policy.rule.server`] event.
+//!
+//! [`m.policy.rule.server`]: https://spec.matrix.org/v1.1/client-server-api/#mpolicyruleserver
 
 use ruma_events_macros::EventContent;
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-events/src/policy/rule/user.rs
+++ b/crates/ruma-events/src/policy/rule/user.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.policy.rule.user` event.
+//! Types for the [`m.policy.rule.user`] event.
+//!
+//! [`m.policy.rule.user`]: https://spec.matrix.org/v1.1/client-server-api/#mpolicyruleuser
 
 use ruma_events_macros::EventContent;
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-events/src/push_rules.rs
+++ b/crates/ruma-events/src/push_rules.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.push_rules` event.
+//! Types for the [`m.push_rules`] event.
+//!
+//! [`m.push_rules`]: https://spec.matrix.org/v1.1/client-server-api/#mpush_rules
 
 use ruma_common::push::Ruleset;
 use ruma_events_macros::EventContent;

--- a/crates/ruma-events/src/receipt.rs
+++ b/crates/ruma-events/src/receipt.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.receipt` event.
+//! Types for the [`m.receipt`] event.
+//!
+//! [`m.receipt`]: https://spec.matrix.org/v1.1/client-server-api/#mreceipt
 
 use std::{
     collections::BTreeMap,

--- a/crates/ruma-events/src/room/avatar.rs
+++ b/crates/ruma-events/src/room/avatar.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.room.avatar` event.
+//! Types for the [`m.room.avatar`] event.
+//!
+//! [`m.room.avatar`]: https://spec.matrix.org/v1.1/client-server-api/#mroomavatar
 
 use js_int::UInt;
 use ruma_events_macros::EventContent;

--- a/crates/ruma-events/src/room/canonical_alias.rs
+++ b/crates/ruma-events/src/room/canonical_alias.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.room.canonical_alias` event.
+//! Types for the [`m.room.canonical_alias`] event.
+//!
+//! [`m.room.canonical_alias`]: https://spec.matrix.org/v1.1/client-server-api/#mroomcanonical_alias
 
 use ruma_events_macros::EventContent;
 use ruma_identifiers::RoomAliasId;

--- a/crates/ruma-events/src/room/create.rs
+++ b/crates/ruma-events/src/room/create.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.room.create` event.
+//! Types for the [`m.room.create`] event.
+//!
+//! [`m.room.create`]: https://spec.matrix.org/v1.1/client-server-api/#mroomcreate
 
 use ruma_events_macros::EventContent;
 use ruma_identifiers::{EventId, RoomId, RoomVersionId, UserId};

--- a/crates/ruma-events/src/room/encrypted.rs
+++ b/crates/ruma-events/src/room/encrypted.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.room.encrypted` event.
+//! Types for the [`m.room.encrypted`] event.
+//!
+//! [`m.room.encrypted`]: https://spec.matrix.org/v1.1/client-server-api/#mroomencrypted
 
 use std::collections::BTreeMap;
 

--- a/crates/ruma-events/src/room/encryption.rs
+++ b/crates/ruma-events/src/room/encryption.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.room.encryption` event.
+//! Types for the [`m.room.encryption`] event.
+//!
+//! [`m.room.encryption`]: https://spec.matrix.org/v1.1/client-server-api/#mroomencryption
 
 use js_int::UInt;
 use ruma_events_macros::EventContent;

--- a/crates/ruma-events/src/room/guest_access.rs
+++ b/crates/ruma-events/src/room/guest_access.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.room.guest_access` event.
+//! Types for the [`m.room.guest_access`] event.
+//!
+//! [`m.room.guest_access`]: https://spec.matrix.org/v1.1/client-server-api/#mroomguest_access
 
 use ruma_events_macros::EventContent;
 use ruma_serde::StringEnum;

--- a/crates/ruma-events/src/room/history_visibility.rs
+++ b/crates/ruma-events/src/room/history_visibility.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.room.history_visibility` event.
+//! Types for the [`m.room.history_visibility`] event.
+//!
+//! [`m.room.history_visibility`]: https://spec.matrix.org/v1.1/client-server-api/#mroomhistory_visibility
 
 use ruma_events_macros::EventContent;
 use ruma_serde::StringEnum;

--- a/crates/ruma-events/src/room/join_rules.rs
+++ b/crates/ruma-events/src/room/join_rules.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.room.join_rules` event.
+//! Types for the [`m.room.join_rules`] event.
+//!
+//! [`m.room.join_rules`]: https://spec.matrix.org/v1.1/client-server-api/#mroomjoin_rules
 
 use ruma_events_macros::EventContent;
 #[cfg(feature = "unstable-pre-spec")]

--- a/crates/ruma-events/src/room/member.rs
+++ b/crates/ruma-events/src/room/member.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.room.member` event.
+//! Types for the [`m.room.member`] event.
+//!
+//! [`m.room.member`]: https://spec.matrix.org/v1.1/client-server-api/#mroommember
 
 use std::collections::BTreeMap;
 

--- a/crates/ruma-events/src/room/message.rs
+++ b/crates/ruma-events/src/room/message.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.room.message` event.
+//! Types for the [`m.room.message`] event.
+//!
+//! [`m.room.message`]: https://spec.matrix.org/v1.1/client-server-api/#mroommessage
 
 use std::{borrow::Cow, fmt};
 

--- a/crates/ruma-events/src/room/message/feedback.rs
+++ b/crates/ruma-events/src/room/message/feedback.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.room.message.feedback` event.
+//! Types for the [`m.room.message.feedback`] event.
+//!
+//! [`m.room.message.feedback`]: https://spec.matrix.org/v1.1/client-server-api/#events-19
 
 use ruma_events_macros::EventContent;
 use ruma_identifiers::EventId;

--- a/crates/ruma-events/src/room/message/feedback.rs
+++ b/crates/ruma-events/src/room/message/feedback.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.room.message.feedback`] event.
 //!
-//! [`m.room.message.feedback`]: https://spec.matrix.org/v1.1/client-server-api/#events-19
+//! [`m.room.message.feedback`]: https://spec.matrix.org/v1.1/client-server-api/#mroommessagefeedback
 
 use ruma_events_macros::EventContent;
 use ruma_identifiers::EventId;

--- a/crates/ruma-events/src/room/name.rs
+++ b/crates/ruma-events/src/room/name.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.room.name` event.
+//! Types for the [`m.room.name`] event.
+//!
+//! [`m.room.name`]: https://spec.matrix.org/v1.1/client-server-api/#mroomname
 
 use ruma_events_macros::EventContent;
 use ruma_identifiers::RoomName;

--- a/crates/ruma-events/src/room/pinned_events.rs
+++ b/crates/ruma-events/src/room/pinned_events.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.room.pinned_events` event.
+//! Types for the [`m.room.pinned_events`] event.
+//!
+//! [`m.room.pinned_events`]: https://spec.matrix.org/v1.1/client-server-api/#mroompinned_events
 
 use ruma_events_macros::EventContent;
 use ruma_identifiers::EventId;

--- a/crates/ruma-events/src/room/power_levels.rs
+++ b/crates/ruma-events/src/room/power_levels.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.room.power_levels` event.
+//! Types for the [`m.room.power_levels`] event.
+//!
+//! [`m.room.power_levels`]: https://spec.matrix.org/v1.1/client-server-api/#mroompower_levels
 
 use std::collections::BTreeMap;
 

--- a/crates/ruma-events/src/room/redaction.rs
+++ b/crates/ruma-events/src/room/redaction.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.room.redaction` event.
+//! Types for the [`m.room.redaction`] event.
+//!
+//! [`m.room.redaction`]: https://spec.matrix.org/v1.1/client-server-api/#mroomredaction
 
 use ruma_common::MilliSecondsSinceUnixEpoch;
 use ruma_events_macros::{Event, EventContent};

--- a/crates/ruma-events/src/room/server_acl.rs
+++ b/crates/ruma-events/src/room/server_acl.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.room.server_acl` event.
+//! Types for the [`m.room.server_acl`] event.
+//!
+//! [`m.room.server_acl`]: https://spec.matrix.org/v1.1/client-server-api/#mroomserver_acl
 
 use ruma_events_macros::EventContent;
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-events/src/room/third_party_invite.rs
+++ b/crates/ruma-events/src/room/third_party_invite.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.room.third_party_invite` event.
+//! Types for the [`m.room.third_party_invite`] event.
+//!
+//! [`m.room.third_party_invite`]: https://spec.matrix.org/v1.1/client-server-api/#mroomthird_party_invite
 
 use ruma_events_macros::EventContent;
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-events/src/room/tombstone.rs
+++ b/crates/ruma-events/src/room/tombstone.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.room.tombstone` event.
+//! Types for the [`m.room.tombstone`] event.
+//!
+//! [`m.room.tombstone`]: https://spec.matrix.org/v1.1/client-server-api/#mroomtombstone
 
 use ruma_events_macros::EventContent;
 use ruma_identifiers::RoomId;

--- a/crates/ruma-events/src/room/topic.rs
+++ b/crates/ruma-events/src/room/topic.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.room.topic` event.
+//! Types for the [`m.room.topic`] event.
+//!
+//! [`m.room.topic`]: https://spec.matrix.org/v1.1/client-server-api/#mroomtopic
 
 use ruma_events_macros::EventContent;
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-events/src/room_key.rs
+++ b/crates/ruma-events/src/room_key.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.room_key` event.
+//! Types for the [`m.room_key`] event.
+//!
+//! [`m.room_key`]: https://spec.matrix.org/v1.1/client-server-api/#mroom_key
 
 use ruma_events_macros::EventContent;
 use ruma_identifiers::{EventEncryptionAlgorithm, RoomId};

--- a/crates/ruma-events/src/room_key_request.rs
+++ b/crates/ruma-events/src/room_key_request.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.room_key_request` event.
+//! Types for the [`m.room_key_request`] event.
+//!
+//! [`m.room_key_request`]: https://spec.matrix.org/v1.1/client-server-api/#mroom_key_request
 
 use ruma_events_macros::EventContent;
 use ruma_identifiers::{DeviceId, EventEncryptionAlgorithm, RoomId};

--- a/crates/ruma-events/src/secret/request.rs
+++ b/crates/ruma-events/src/secret/request.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.secret.request` event.
+//! Types for the [`m.secret.request`] event.
+//!
+//! [`m.secret.request`]: https://spec.matrix.org/v1.1/client-server-api/#msecretrequest
 
 use std::convert::TryFrom;
 

--- a/crates/ruma-events/src/secret/send.rs
+++ b/crates/ruma-events/src/secret/send.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.secret.send` event.
+//! Types for the [`m.secret.send`] event.
+//!
+//! [`m.secret.send`]: https://spec.matrix.org/v1.1/client-server-api/#msecretsend
 
 use ruma_events_macros::EventContent;
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-events/src/sticker.rs
+++ b/crates/ruma-events/src/sticker.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.sticker` event.
+//! Types for the [`m.sticker`] event.
+//!
+//! [`m.sticker`]: https://spec.matrix.org/v1.1/client-server-api/#msticker
 
 use ruma_events_macros::EventContent;
 use ruma_identifiers::MxcUri;

--- a/crates/ruma-events/src/tag.rs
+++ b/crates/ruma-events/src/tag.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.tag` event.
+//! Types for the [`m.tag`] event.
+//!
+//! [`m.tag`]: https://spec.matrix.org/v1.1/client-server-api/#mtag
 
 use std::{collections::BTreeMap, error::Error, fmt, str::FromStr};
 

--- a/crates/ruma-events/src/typing.rs
+++ b/crates/ruma-events/src/typing.rs
@@ -1,4 +1,6 @@
-//! Types for the `m.typing` event.
+//! Types for the [`m.typing`] event.
+//!
+//! [`m.typing`]: https://spec.matrix.org/v1.1/client-server-api/#mtyping
 
 use ruma_events_macros::EventContent;
 use ruma_identifiers::UserId;


### PR DESCRIPTION
Fixes #550 

Links points to the v1.1 (I just noticed they should point to the latest r0.x version ...), is it still ok ?

During the addition of the documentation I did not add links to the following elements:
- `m.room.aliases` => no longer in use (https://spec.matrix.org/v1.1/client-server-api/#historical-events)
- `m.key.verification`, `m.policy.rule`, `m.call` => namespaces
- `m.space.child`, `m.space.parent` => no more `m.space`
- `m.reaction` => does not exist