### PR TITLE
client-api: Fix deserialization of get_login_types::CustomLoginType

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [unreleased]
 
+Bug fixes:
+
+* Fix deserialization of `r0::session::get_login_types::CustomLoginType`.
+
 Breaking changes:
 
 * Use an enum for user-interactive auth stage type (used to be `&str` / `String`)


### PR DESCRIPTION
And add a test for it.

I wanted to add support for [MSC2778: Providing authentication method for appservice users](https://github.com/matrix-org/matrix-doc/pull/2778) at the same time because that's what triggered a deserialization error in the first place, but I'm wasn't sure how to deal with the fact that the `POST /login` endpoint requires to authenticate `access_token` only for the new `m.login.appservice` type.