### PR TITLE
Remove serde attribute from chunk field

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -18,6 +18,8 @@ Breaking changes:
     `r0::account::request_3pid_management_token_via_email`
   * `get_contacts` has been can now be found at `r0::account::get_3pids`
 * Move `r0::uiaa::authorize_fallback` to `r0::uiaa::get_uiaa_fallback_page`
+* Change type of field `start` of `r0::message::get_message_events::Response` to
+  `String` in accordance with the updated specification.
 
 Improvements:
 

--- a/crates/ruma-client-api/src/r0/message/get_message_events.rs
+++ b/crates/ruma-client-api/src/r0/message/get_message_events.rs
@@ -73,7 +73,7 @@ ruma_api! {
         pub end: Option<String>,
 
         /// A list of room events.
-        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        #[serde(default)]
         pub chunk: Vec<Raw<AnyRoomEvent>>,
 
         /// A list of state events relevant to showing the `chunk`.

--- a/crates/ruma-client-api/src/r0/message/get_message_events.rs
+++ b/crates/ruma-client-api/src/r0/message/get_message_events.rs
@@ -1,4 +1,4 @@
-//! [GET /_matrix/client/r0/rooms/{roomId}/messages](https://matrix.org/docs/spec/client_server/r0.6.1#get-matrix-client-r0-rooms-roomid-messages)
+//! [GET /_matrix/client/r0/rooms/{roomId}/messages](https://spec.matrix.org/v1.1/client-server-api/#get_matrixclientv3roomsroomidmessages)
 
 use js_int::{uint, UInt};
 use ruma_api::ruma_api;
@@ -65,8 +65,7 @@ ruma_api! {
     #[derive(Default)]
     response: {
         /// The token the pagination starts from.
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub start: Option<String>,
+        pub start: String,
 
         /// The token the pagination ends at.
         #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
Remove `serde(skip_serializing_if = ...)` attribute from chunk field of `ruma::api::client::r0::message::get_message_events::Response`. This change is necessary because [v1.1 of the Matrix specification](https://spec.matrix.org/v1.1/client-server-api/#get_matrixclientv3roomsroomidmessages) requires the chunk field in the response to **GET /_matrix/client/v3/rooms/{roomId}/messages**. Previously the chunk field was omitted, if it was empty.