### PR TITLE
Implement is_allowed for RoomServerAclEventContent

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -14,6 +14,7 @@ Breaking changes:
 
 Improvements:
 
+* Add `is_allowed` to `RoomServerAclEventContent`
 * Add `room::message::MessageType::body` accessor method
 * Implement `Redact` for event structs (in addition to `Any` event enums)
 * Add `room::message::RoomMessageEventContent::{body, msgtype}` accessor methods

--- a/crates/ruma-events/Cargo.toml
+++ b/crates/ruma-events/Cargo.toml
@@ -25,6 +25,7 @@ unstable-pre-spec = ["ruma-identifiers/unstable-pre-spec"]
 
 [dependencies]
 criterion = { version = "0.3.3", optional = true }
+glob = "0.3.0"
 indoc = "1.0"
 js_int = { version = "0.2.0", features = ["serde"] }
 pulldown-cmark = { version = "0.8", default-features = false, optional = true }

--- a/crates/ruma-events/Cargo.toml
+++ b/crates/ruma-events/Cargo.toml
@@ -25,7 +25,6 @@ unstable-pre-spec = ["ruma-identifiers/unstable-pre-spec"]
 
 [dependencies]
 criterion = { version = "0.3.3", optional = true }
-glob = "0.3.0"
 indoc = "1.0"
 js_int = { version = "0.2.0", features = ["serde"] }
 pulldown-cmark = { version = "0.8", default-features = false, optional = true }
@@ -36,6 +35,7 @@ ruma-serde = { version = "0.5.0", path = "../ruma-serde" }
 serde = { version = "1.0.118", features = ["derive"] }
 serde_json = { version = "1.0.60", features = ["raw_value"] }
 thiserror = "1.0.26"
+wildmatch = "2.0.0"
 
 [dev-dependencies]
 assign = "1.1.1"

--- a/crates/ruma-events/src/room/server_acl.rs
+++ b/crates/ruma-events/src/room/server_acl.rs
@@ -56,19 +56,8 @@ impl RoomServerAclEventContent {
 
         let host = server_name.host();
 
-        for deny in &self.deny {
-            if WildMatch::new(deny).matches(host) {
-                return false;
-            }
-        }
-
-        for allow in &self.allow {
-            if WildMatch::new(allow).matches(host) {
-                return true;
-            }
-        }
-
-        false
+        self.deny.iter().all(|d| !WildMatch::new(d).matches(host))
+            && self.allow.iter().any(|a| WildMatch::new(a).matches(host))
     }
 }
 


### PR DESCRIPTION
(This build on top of #810 and adds a new commit on top of it)

https://spec.matrix.org/v1.1/client-server-api/#mroomserver_acl

This mostly follows the spec, but for the glob matching I used the `glob` crate which has more functionality than the matrix spec specifies. I hope this is okay.

