### PR TITLE
client-api: Move MSC2858 out of unstable-pre-spec

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -38,6 +38,10 @@ Improvements:
   `IncomingAuthData::to_outgoing` on it.
 * Add custom variant to `LoginInfo` which can be constructed with `IncomingLoginInfo::new` and
   then call `IncomingLoginInfo::to_outgoing` on it.
+* Move MSC2858 - Multiple SSO Identity Providers out of the `unstable-pre-spec` feature flag, this
+  includes:
+  * The `r0::session::get_login_types::{IdentityProvider, IdentityProviderBrand}` types
+  * The `r0::session::sso_login_with_provider` endpoint
 
 # 0.12.3
 

--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -3,6 +3,7 @@
 Bug fixes:
 
 * Fix deserialization of `r0::session::get_login_types::CustomLoginType`.
+* Make fields of `r0::session::get_login_types::IdentityProvider` public.
 
 Breaking changes:
 

--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -42,7 +42,7 @@ Improvements:
 * Move MSC2858 - Multiple SSO Identity Providers out of the `unstable-pre-spec` feature flag, this
   includes:
   * The `r0::session::get_login_types::{IdentityProvider, IdentityProviderBrand}` types
-  * The `r0::session::sso_login_with_provider` endpoint
+  * The `session::sso_login_with_provider::v3` endpoint
 
 # 0.12.3
 

--- a/crates/ruma-client-api/src/lib.rs
+++ b/crates/ruma-client-api/src/lib.rs
@@ -10,6 +10,7 @@
 
 pub mod error;
 pub mod r0;
+pub mod session;
 pub mod unversioned;
 
 pub use error::Error;

--- a/crates/ruma-client-api/src/r0/session.rs
+++ b/crates/ruma-client-api/src/r0/session.rs
@@ -6,4 +6,3 @@ pub mod login_fallback;
 pub mod logout;
 pub mod logout_all;
 pub mod sso_login;
-pub mod sso_login_with_provider;

--- a/crates/ruma-client-api/src/r0/session.rs
+++ b/crates/ruma-client-api/src/r0/session.rs
@@ -6,5 +6,4 @@ pub mod login_fallback;
 pub mod logout;
 pub mod logout_all;
 pub mod sso_login;
-#[cfg(feature = "unstable-pre-spec")]
 pub mod sso_login_with_provider;

--- a/crates/ruma-client-api/src/r0/session/get_login_types.rs
+++ b/crates/ruma-client-api/src/r0/session/get_login_types.rs
@@ -3,11 +3,8 @@
 use std::borrow::Cow;
 
 use ruma_api::ruma_api;
-#[cfg(feature = "unstable-pre-spec")]
 use ruma_identifiers::MxcUri;
-use ruma_serde::JsonObject;
-#[cfg(feature = "unstable-pre-spec")]
-use ruma_serde::StringEnum;
+use ruma_serde::{JsonObject, StringEnum};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
@@ -150,15 +147,7 @@ impl TokenLoginType {
 #[serde(tag = "type", rename = "m.login.sso")]
 pub struct SsoLoginType {
     /// The identity provider choices.
-    ///
-    /// This uses the unstable prefix in
-    /// [MSC2858](https://github.com/matrix-org/matrix-doc/pull/2858).
-    #[cfg(feature = "unstable-pre-spec")]
-    #[serde(
-        default,
-        rename = "org.matrix.msc2858.identity_providers",
-        skip_serializing_if = "Vec::is_empty"
-    )]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub identity_providers: Vec<IdentityProvider>,
 }
 
@@ -170,7 +159,6 @@ impl SsoLoginType {
 }
 
 /// An SSO login identity provider.
-#[cfg(feature = "unstable-pre-spec")]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct IdentityProvider {
@@ -187,7 +175,6 @@ pub struct IdentityProvider {
     brand: Option<IdentityProviderBrand>,
 }
 
-#[cfg(feature = "unstable-pre-spec")]
 impl IdentityProvider {
     /// Creates an `IdentityProvider` with the given `id` and `name`.
     pub fn new(id: String, name: String) -> Self {
@@ -196,10 +183,6 @@ impl IdentityProvider {
 }
 
 /// An SSO login identity provider brand identifier.
-///
-/// This uses the unstable prefix in
-/// [MSC2858](https://github.com/matrix-org/matrix-doc/pull/2858).
-#[cfg(feature = "unstable-pre-spec")]
 #[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub enum IdentityProviderBrand {
@@ -259,13 +242,12 @@ mod login_type_serde;
 mod tests {
     use matches::assert_matches;
     use serde::{Deserialize, Serialize};
-    #[cfg(feature = "unstable-pre-spec")]
-    use serde_json::to_value as to_json_value;
-    use serde_json::{from_value as from_json_value, json};
+    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
-    use super::{CustomLoginType, LoginType, PasswordLoginType};
-    #[cfg(feature = "unstable-pre-spec")]
-    use super::{IdentityProvider, IdentityProviderBrand, SsoLoginType, TokenLoginType};
+    use super::{
+        CustomLoginType, IdentityProvider, IdentityProviderBrand, LoginType, PasswordLoginType,
+        SsoLoginType, TokenLoginType,
+    };
 
     #[derive(Debug, Deserialize, Serialize)]
     struct Wrapper {
@@ -309,13 +291,12 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "unstable-pre-spec")]
     fn deserialize_sso_login_type() {
         let mut wrapper = from_json_value::<Wrapper>(json!({
             "flows": [
                 {
                     "type": "m.login.sso",
-                    "org.matrix.msc2858.identity_providers": [
+                    "identity_providers": [
                         {
                             "id": "oidc-gitlab",
                             "name": "GitLab",
@@ -367,7 +348,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "unstable-pre-spec")]
     fn serialize_sso_login_type() {
         let wrapper = to_json_value(Wrapper {
             flows: vec![
@@ -393,7 +373,7 @@ mod tests {
                     },
                     {
                         "type": "m.login.sso",
-                        "org.matrix.msc2858.identity_providers": [
+                        "identity_providers": [
                             {
                                 "id": "oidc-github",
                                 "name": "GitHub",

--- a/crates/ruma-client-api/src/r0/session/get_login_types.rs
+++ b/crates/ruma-client-api/src/r0/session/get_login_types.rs
@@ -8,7 +8,6 @@ use ruma_serde::{JsonObject, StringEnum};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
-#[cfg(feature = "unstable-pre-spec")]
 use crate::PrivOwnedStr;
 
 ruma_api! {

--- a/crates/ruma-client-api/src/r0/session/get_login_types.rs
+++ b/crates/ruma-client-api/src/r0/session/get_login_types.rs
@@ -163,16 +163,16 @@ impl SsoLoginType {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct IdentityProvider {
     /// The ID of the provider.
-    id: String,
+    pub id: String,
 
     /// The display name of the provider.
-    name: String,
+    pub name: String,
 
     /// The icon for the provider.
-    icon: Option<Box<MxcUri>>,
+    pub icon: Option<Box<MxcUri>>,
 
     /// The brand identifier for the provider.
-    brand: Option<IdentityProviderBrand>,
+    pub brand: Option<IdentityProviderBrand>,
 }
 
 impl IdentityProvider {

--- a/crates/ruma-client-api/src/r0/session/sso_login_with_provider.rs
+++ b/crates/ruma-client-api/src/r0/session/sso_login_with_provider.rs
@@ -1,6 +1,4 @@
-//! [GET /_matrix/client/r0/login/sso/redirect/{idp_id}](https://github.com/matrix-org/matrix-doc/blob/master/proposals/2858-Multiple-SSO-Identity-Providers.md)
-//!
-//! This uses the unstable prefix in [MSC2858](https://github.com/matrix-org/matrix-doc/pull/2858).
+//! [GET /_matrix/client/r0/login/sso/redirect/{idp_id}](https://spec.matrix.org/v1.1/client-server-api/#get_matrixclientv3loginssoredirectidpid)
 
 use ruma_api::ruma_api;
 
@@ -9,7 +7,7 @@ ruma_api! {
         description: "Get the SSO login identity provider url.",
         method: GET,
         name: "sso_login_with_provider",
-        path: "/_matrix/client/unstable/org.matrix.msc2858/login/sso/redirect/:idp_id",
+        path: "/_matrix/client/v3/login/sso/redirect/:idp_id",
         rate_limited: false,
         authentication: None,
     }
@@ -63,7 +61,7 @@ mod tests {
 
         assert_eq!(
             req.uri().to_string(),
-            "https://homeserver.tld/_matrix/client/unstable/org.matrix.msc2858/login/sso/redirect/provider?redirectUrl=https%3A%2F%2Fexample.com%2Fsso"
+            "https://homeserver.tld/_matrix/client/v3/login/sso/redirect/provider?redirectUrl=https%3A%2F%2Fexample.com%2Fsso"
         );
     }
 }

--- a/crates/ruma-client-api/src/session.rs
+++ b/crates/ruma-client-api/src/session.rs
@@ -1,0 +1,3 @@
+//! Endpoints for user session management.
+
+pub mod sso_login_with_provider;

--- a/crates/ruma-client-api/src/session/sso_login_with_provider.rs
+++ b/crates/ruma-client-api/src/session/sso_login_with_provider.rs
@@ -1,0 +1,3 @@
+//! Get the SSO login identity provider url.
+
+pub mod v3;

--- a/crates/ruma-client-api/src/session/sso_login_with_provider/v3.rs
+++ b/crates/ruma-client-api/src/session/sso_login_with_provider/v3.rs
@@ -1,4 +1,4 @@
-//! [GET /_matrix/client/r0/login/sso/redirect/{idp_id}](https://spec.matrix.org/v1.1/client-server-api/#get_matrixclientv3loginssoredirectidpid)
+//! [GET /_matrix/client/v3/login/sso/redirect/{idp_id}](https://spec.matrix.org/v1.1/client-server-api/#get_matrixclientv3loginssoredirectidpid)
 
 use ruma_api::ruma_api;
 


### PR DESCRIPTION
Synapse works with both the `r0` and `v3` versions in the path so I went with the one from the spec.