### PR TITLE
Fix response deserialization for get_backup and get_latest_backup

### DIFF
--- a/crates/ruma-api-macros/src/attribute.rs
+++ b/crates/ruma-api-macros/src/attribute.rs
@@ -43,15 +43,15 @@ impl<V: Parse> Parse for MetaNameValue<V> {
 }
 
 /// Like syn::Meta, but only parses ruma_api attributes
-pub enum Meta {
+pub enum Meta<T> {
     /// A single word, like `query` in `#[ruma_api(query)]`
     Word(Ident),
 
     /// A name-value pair, like `header = CONTENT_TYPE` in `#[ruma_api(header = CONTENT_TYPE)]`
-    NameValue(MetaNameValue<Ident>),
+    NameValue(MetaNameValue<T>),
 }
 
-impl Meta {
+impl<T: Parse> Meta<T> {
     /// Check if the given attribute is a ruma_api attribute.
     ///
     /// If it is, parse it.
@@ -64,7 +64,7 @@ impl Meta {
     }
 }
 
-impl Parse for Meta {
+impl<T: Parse> Parse for Meta<T> {
     fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
         let ident = input.parse()?;
 

--- a/crates/ruma-client-api/src/r0/backup/get_latest_backup.rs
+++ b/crates/ruma-client-api/src/r0/backup/get_latest_backup.rs
@@ -3,8 +3,13 @@
 use js_int::UInt;
 use ruma_api::ruma_api;
 use ruma_serde::Raw;
+use serde::{ser, Deserialize, Deserializer, Serialize};
+use serde_json::value::to_raw_value as to_raw_json_value;
 
-use super::BackupAlgorithm;
+use super::{
+    get_backup::{AlgorithmWithData, RefResponseBodyRepr, ResponseBodyRepr},
+    BackupAlgorithm,
+};
 
 ruma_api! {
     metadata: {
@@ -19,9 +24,9 @@ ruma_api! {
     #[derive(Default)]
     request: {}
 
+    #[ruma_api(manual_body_serde)]
     response: {
         /// The algorithm used for storing backups.
-        #[serde(flatten)]
         pub algorithm: Raw<BackupAlgorithm>,
 
         /// The number of keys stored in the backup.
@@ -56,5 +61,41 @@ impl Response {
         version: String,
     ) -> Self {
         Self { algorithm, count, etag, version }
+    }
+}
+
+impl<'de> Deserialize<'de> for ResponseBody {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let ResponseBodyRepr { algorithm, auth_data, count, etag, version } =
+            ResponseBodyRepr::deserialize(deserializer)?;
+
+        let algorithm =
+            Raw::from_json(to_raw_json_value(&AlgorithmWithData { algorithm, auth_data }).unwrap());
+
+        Ok(Self { algorithm, count, etag, version })
+    }
+}
+
+impl Serialize for ResponseBody {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let ResponseBody { algorithm, count, etag, version } = self;
+        let AlgorithmWithData { algorithm, auth_data } =
+            algorithm.deserialize_as().map_err(ser::Error::custom)?;
+
+        let repr = RefResponseBodyRepr {
+            algorithm: &algorithm,
+            auth_data: &auth_data,
+            count: *count,
+            etag,
+            version,
+        };
+
+        repr.serialize(serializer)
     }
 }


### PR DESCRIPTION
Fixes #826.

The fastest way to get this working would probably to add a `#[ruma_api(manual_serde)]` attribute (which doesn't require #827) and implement both `Deserialize` and `Serialize` manually (then we also don't need those trait impls and can instead inline them).