### PR TITLE
Create and integrate `redact_content`

### DIFF
--- a/crates/ruma-signatures/src/functions.rs
+++ b/crates/ruma-signatures/src/functions.rs
@@ -748,7 +748,7 @@ pub fn redact_in_place(
             _ => return Err(JsonError::not_of_type("content", JsonType::Object)),
         };
 
-        redact_content(content, version, &event_type);
+        redact_content_in_place(content, version, &event_type);
     }
 
     let mut old_event = mem::take(event);
@@ -765,7 +765,7 @@ pub fn redact_in_place(
 /// Redacts event content using the rules specified in the Matrix client-server specification.
 ///
 /// Edits the `object` in-place.
-pub fn redact_content(
+pub fn redact_content_in_place(
     object: &mut CanonicalJsonObject,
     version: &RoomVersionId,
     event_type: impl AsRef<str>,

--- a/crates/ruma-signatures/src/functions.rs
+++ b/crates/ruma-signatures/src/functions.rs
@@ -769,7 +769,7 @@ pub fn redact_content_in_place(
     object: &mut CanonicalJsonObject,
     version: &RoomVersionId,
     event_type: impl AsRef<str>,
-)  {
+) {
     let allowed_content_keys = allowed_content_keys_for(event_type.as_ref(), version);
 
     let mut old_content = mem::take(object);

--- a/crates/ruma-signatures/src/functions.rs
+++ b/crates/ruma-signatures/src/functions.rs
@@ -768,9 +768,9 @@ pub fn redact_in_place(
 pub fn redact_content(
     object: &mut CanonicalJsonObject,
     version: &RoomVersionId,
-    event_type: &str,
+    event_type: impl AsRef<str>,
 )  {
-    let allowed_content_keys = allowed_content_keys_for(event_type, version);
+    let allowed_content_keys = allowed_content_keys_for(event_type.as_ref(), version);
 
     let mut old_content = mem::take(object);
 

--- a/crates/ruma-signatures/src/functions.rs
+++ b/crates/ruma-signatures/src/functions.rs
@@ -740,7 +740,7 @@ pub fn redact_in_place(
     // a disjoint borrow.
     let allowed_content_keys: &[&str] = match event.get("type") {
         Some(CanonicalJsonValue::String(event_type)) => {
-            allowed_content_keys_for(event_type.as_ref(), version)
+            allowed_content_keys_for(event_type, version)
         }
         Some(_) => return Err(JsonError::not_of_type("type", JsonType::String)),
         None => return Err(JsonError::field_missing_from_object("type")),

--- a/crates/ruma-signatures/src/lib.rs
+++ b/crates/ruma-signatures/src/lib.rs
@@ -48,8 +48,8 @@ use ruma_serde::{AsRefStr, DisplayAsRefStr};
 
 pub use error::{Error, JsonError, JsonType, ParseError, SplitError, VerificationError};
 pub use functions::{
-    canonical_json, content_hash, hash_and_sign_event, redact, reference_hash, sign_json,
-    verify_event, verify_json,
+    canonical_json, content_hash, hash_and_sign_event, redact, redact_content_in_place,
+    redact_in_place, reference_hash, sign_json, verify_event, verify_json,
 };
 pub use keys::{Ed25519KeyPair, KeyPair, PublicKeyMap, PublicKeySet};
 pub use ruma_serde::{CanonicalJsonError, CanonicalJsonObject, CanonicalJsonValue};


### PR DESCRIPTION
Closes https://github.com/ruma/ruma/issues/830

This uses `AsRef<str>` to make it possible to pass `EventType`s as well.