### PR TITLE
Stablise token registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,14 @@ them. Check out the documentation [on docs.rs][docs] (or on
 ## Status
 
 As of 2021-02-10, we support all events and REST endpoints the latest released
-versions of the various Matrix APIs. Various changes from the unstable version
-of the specifications and some MSCs are also implemented, gated behind the
-`unstable-pre-spec` Cargo feature.
+versions of the various Matrix APIs.
+
+Various changes from in-progress MSCs, finished MSCs,
+and (often) unreleased versions of the specification are also implemented,
+gated behind the `unstable-pre-spec` Cargo feature.
+
+Various changes from the unreleased version of the specification are also
+implemented, gated behind the `unstable-spec` Cargo feature.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -38,15 +38,15 @@ them. Check out the documentation [on docs.rs][docs] (or on
 
 ## Status
 
-As of 2021-02-10, we support all events and REST endpoints the latest released
-versions of the various Matrix APIs.
+As of 2021-02-10, we support all events and REST endpoints of the v1 version of
+the Matrix specification, with v1.1 coverage in progress.
+
+Various changes from the unreleased version of the specification are also
+implemented, gated behind the `unstable-spec` Cargo feature.
 
 Various changes from in-progress MSCs, finished MSCs,
 and (often) unreleased versions of the specification are also implemented,
 gated behind the `unstable-pre-spec` Cargo feature.
-
-Various changes from the unreleased version of the specification are also
-implemented, gated behind the `unstable-spec` Cargo feature.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ them. Check out the documentation [on docs.rs][docs] (or on
 
 ## Status
 
-As of 2021-02-10, we support all events and REST endpoints of the v1 version of
+As of 2022-01-31, we support all events and REST endpoints of the v1 version of
 the Matrix specification, with v1.1 coverage in progress.
 
 Various changes from the unreleased version of the specification are also

--- a/crates/ruma-client-api/Cargo.toml
+++ b/crates/ruma-client-api/Cargo.toml
@@ -24,6 +24,7 @@ compat = []
 unstable-exhaustive-types = []
 # feature dependency required for r0::room::create_room::CreationContent::into_event_content
 unstable-pre-spec = ["ruma-events/unstable-pre-spec"]
+unstable-spec = []
 client = []
 server = []
 

--- a/crates/ruma-client-api/src/r0/account.rs
+++ b/crates/ruma-client-api/src/r0/account.rs
@@ -3,7 +3,6 @@
 pub mod add_3pid;
 pub mod bind_3pid;
 pub mod change_password;
-#[cfg(feature = "unstable-pre-spec")]
 pub mod check_registration_token_validity;
 pub mod deactivate;
 pub mod delete_3pid;

--- a/crates/ruma-client-api/src/r0/account.rs
+++ b/crates/ruma-client-api/src/r0/account.rs
@@ -3,6 +3,7 @@
 pub mod add_3pid;
 pub mod bind_3pid;
 pub mod change_password;
+#[cfg(feature = "unstable-spec")]  // todo: v1.2
 pub mod check_registration_token_validity;
 pub mod deactivate;
 pub mod delete_3pid;

--- a/crates/ruma-client-api/src/r0/account/check_registration_token_validity.rs
+++ b/crates/ruma-client-api/src/r0/account/check_registration_token_validity.rs
@@ -1,4 +1,4 @@
-//! [GET /_matrix/client/unstable/org.matrix.msc3231/register/org.matrix.msc3231.login.registration_token/validity](https://github.com/matrix-org/matrix-doc/blob/main/proposals/3231-token-authenticated-registration.md#checking-the-validity-of-a-token)
+//! [GET /_matrix/client/v1/register/m.login.registration_token/validity](https://spec.matrix.org/unstable/client-server-api/#get_matrixclientv1registermloginregistration_tokenvalidity)
 
 use ruma_api::ruma_api;
 
@@ -7,7 +7,7 @@ ruma_api! {
         description: "Checks to see if the given registration token is valid.",
         method: GET,
         name: "check_registration_token_validity",
-        path: "/_matrix/client/unstable/org.matrix.msc3231/register/org.matrix.msc3231.login.registration_token/validity",
+        path: "/_matrix/client/v1/register/m.login.registration_token/validity",
         rate_limited: true,
         authentication: None,
     }

--- a/crates/ruma-client-api/src/r0/uiaa.rs
+++ b/crates/ruma-client-api/src/r0/uiaa.rs
@@ -60,6 +60,7 @@ pub enum AuthData<'a> {
     Dummy(Dummy<'a>),
 
     /// Registration token-based authentication (`m.login.registration_token`).
+    #[cfg(feature = "unstable-spec")] // todo: v1.2
     RegistrationToken(RegistrationToken<'a>),
 
     /// Fallback acknowledgement.
@@ -85,6 +86,7 @@ impl<'a> AuthData<'a> {
             Self::EmailIdentity(_) => Some(AuthType::EmailIdentity),
             Self::Msisdn(_) => Some(AuthType::Msisdn),
             Self::Dummy(_) => Some(AuthType::Dummy),
+            #[cfg(feature = "unstable-spec")] // todo: v1.2
             Self::RegistrationToken(_) => Some(AuthType::RegistrationToken),
             Self::FallbackAcknowledgement(_) => None,
             Self::_Custom(c) => Some(AuthType::_Custom(PrivOwnedStr(c.auth_type.into()))),
@@ -101,6 +103,7 @@ impl<'a> AuthData<'a> {
             Self::EmailIdentity(x) => x.session,
             Self::Msisdn(x) => x.session,
             Self::Dummy(x) => x.session,
+            #[cfg(feature = "unstable-spec")] // todo: v1.2
             Self::RegistrationToken(x) => x.session,
             Self::FallbackAcknowledgement(x) => Some(x.session),
             Self::_Custom(x) => x.session,
@@ -143,6 +146,7 @@ impl<'a> AuthData<'a> {
                 thirdparty_id_creds: x.thirdparty_id_creds,
                 session: None,
             })),
+            #[cfg(feature = "unstable-spec")] // todo: v1.2
             Self::RegistrationToken(x) => {
                 Cow::Owned(serialize(RegistrationToken { token: x.token, session: None }))
             }
@@ -187,6 +191,7 @@ impl IncomingAuthData {
             "m.login.email.identity" => Self::EmailIdentity(deserialize_variant(session, data)?),
             "m.login.msisdn" => Self::Msisdn(deserialize_variant(session, data)?),
             "m.login.dummy" => Self::Dummy(deserialize_variant(session, data)?),
+            #[cfg(feature = "unstable-spec")] // todo: v1.2
             "m.registration_token" => Self::RegistrationToken(deserialize_variant(session, data)?),
             _ => Self::_Custom(IncomingCustomAuthData {
                 auth_type: auth_type.into(),
@@ -206,6 +211,7 @@ impl IncomingAuthData {
             Self::EmailIdentity(_) => Some(AuthType::EmailIdentity),
             Self::Msisdn(_) => Some(AuthType::Msisdn),
             Self::Dummy(_) => Some(AuthType::Dummy),
+            #[cfg(feature = "unstable-spec")]  // todo: v1.2
             Self::RegistrationToken(_) => Some(AuthType::RegistrationToken),
             Self::FallbackAcknowledgement(_) => None,
             Self::_Custom(c) => Some(AuthType::_Custom(PrivOwnedStr(c.auth_type.as_str().into()))),
@@ -222,6 +228,7 @@ impl IncomingAuthData {
             Self::EmailIdentity(x) => x.session.as_deref(),
             Self::Msisdn(x) => x.session.as_deref(),
             Self::Dummy(x) => x.session.as_deref(),
+            #[cfg(feature = "unstable-spec")]  // todo: v1.2
             Self::RegistrationToken(x) => x.session.as_deref(),
             Self::FallbackAcknowledgement(x) => Some(&x.session),
             Self::_Custom(x) => x.session.as_deref(),
@@ -264,6 +271,7 @@ impl IncomingAuthData {
                 thirdparty_id_creds: &x.thirdparty_id_creds,
                 session: None,
             })),
+            #[cfg(feature = "unstable-spec")]  // todo: v1.2
             Self::RegistrationToken(x) => {
                 Cow::Owned(serialize(RegistrationToken { token: &x.token, session: None }))
             }
@@ -283,6 +291,7 @@ impl IncomingAuthData {
             Self::EmailIdentity(a) => AuthData::EmailIdentity(a.to_outgoing()),
             Self::Msisdn(a) => AuthData::Msisdn(a.to_outgoing()),
             Self::Dummy(a) => AuthData::Dummy(a.to_outgoing()),
+            #[cfg(feature = "unstable-spec")] // todo: v1.2
             Self::RegistrationToken(a) => AuthData::RegistrationToken(a.to_outgoing()),
             Self::FallbackAcknowledgement(a) => AuthData::FallbackAcknowledgement(a.to_outgoing()),
             Self::_Custom(a) => AuthData::_Custom(CustomAuthData {
@@ -325,6 +334,7 @@ impl<'de> Deserialize<'de> for IncomingAuthData {
             Some("m.login.email.identity") => from_raw_json_value(&json).map(Self::EmailIdentity),
             Some("m.login.msisdn") => from_raw_json_value(&json).map(Self::Msisdn),
             Some("m.login.dummy") => from_raw_json_value(&json).map(Self::Dummy),
+            #[cfg(feature = "unstable-spec")] // todo: v1.2
             Some("m.login.registration_token") => {
                 from_raw_json_value(&json).map(Self::RegistrationToken)
             }
@@ -372,6 +382,7 @@ pub enum AuthType {
 
     /// Registration token-based authentication (`m.login.registration_token`).
     #[ruma_enum(rename = "m.login.registration_token")]
+    #[cfg(feature = "unstable-spec")] // todo: v1.2
     RegistrationToken,
 
     #[doc(hidden)]
@@ -602,6 +613,7 @@ impl IncomingDummy {
 #[derive(Clone, Debug, Outgoing, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[serde(tag = "type", rename = "m.login.registration_token")]
+#[cfg(feature = "unstable-spec")] // todo: v1.2
 pub struct RegistrationToken<'a> {
     /// The registration token.
     pub token: &'a str,
@@ -610,6 +622,7 @@ pub struct RegistrationToken<'a> {
     pub session: Option<&'a str>,
 }
 
+#[cfg(feature = "unstable-spec")] // todo: v1.2
 impl<'a> RegistrationToken<'a> {
     /// Creates a new `RegistrationToken` with the given token.
     pub fn new(token: &'a str) -> Self {
@@ -617,6 +630,7 @@ impl<'a> RegistrationToken<'a> {
     }
 }
 
+#[cfg(feature = "unstable-spec")] // todo: v1.2
 impl IncomingRegistrationToken {
     /// Convert from `IncomingRegistrationToken` to `RegistrationToken`.
     fn to_outgoing(&self) -> RegistrationToken<'_> {

--- a/crates/ruma-client-api/src/r0/uiaa.rs
+++ b/crates/ruma-client-api/src/r0/uiaa.rs
@@ -59,8 +59,7 @@ pub enum AuthData<'a> {
     /// Dummy authentication (`m.login.dummy`).
     Dummy(Dummy<'a>),
 
-    /// Registration token-based authentication (`org.matrix.msc3231.login.registration_token`).
-    #[cfg(feature = "unstable-pre-spec")]
+    /// Registration token-based authentication (`m.login.registration_token`).
     RegistrationToken(RegistrationToken<'a>),
 
     /// Fallback acknowledgement.
@@ -86,7 +85,6 @@ impl<'a> AuthData<'a> {
             Self::EmailIdentity(_) => Some(AuthType::EmailIdentity),
             Self::Msisdn(_) => Some(AuthType::Msisdn),
             Self::Dummy(_) => Some(AuthType::Dummy),
-            #[cfg(feature = "unstable-pre-spec")]
             Self::RegistrationToken(_) => Some(AuthType::RegistrationToken),
             Self::FallbackAcknowledgement(_) => None,
             Self::_Custom(c) => Some(AuthType::_Custom(PrivOwnedStr(c.auth_type.into()))),
@@ -103,7 +101,6 @@ impl<'a> AuthData<'a> {
             Self::EmailIdentity(x) => x.session,
             Self::Msisdn(x) => x.session,
             Self::Dummy(x) => x.session,
-            #[cfg(feature = "unstable-pre-spec")]
             Self::RegistrationToken(x) => x.session,
             Self::FallbackAcknowledgement(x) => Some(x.session),
             Self::_Custom(x) => x.session,
@@ -146,7 +143,6 @@ impl<'a> AuthData<'a> {
                 thirdparty_id_creds: x.thirdparty_id_creds,
                 session: None,
             })),
-            #[cfg(feature = "unstable-pre-spec")]
             Self::RegistrationToken(x) => {
                 Cow::Owned(serialize(RegistrationToken { token: x.token, session: None }))
             }
@@ -191,10 +187,7 @@ impl IncomingAuthData {
             "m.login.email.identity" => Self::EmailIdentity(deserialize_variant(session, data)?),
             "m.login.msisdn" => Self::Msisdn(deserialize_variant(session, data)?),
             "m.login.dummy" => Self::Dummy(deserialize_variant(session, data)?),
-            #[cfg(feature = "unstable-pre-spec")]
-            "org.matrix.msc3231.login.registration_token" => {
-                Self::RegistrationToken(deserialize_variant(session, data)?)
-            }
+            "m.registration_token" => Self::RegistrationToken(deserialize_variant(session, data)?),
             _ => Self::_Custom(IncomingCustomAuthData {
                 auth_type: auth_type.into(),
                 session,
@@ -213,7 +206,6 @@ impl IncomingAuthData {
             Self::EmailIdentity(_) => Some(AuthType::EmailIdentity),
             Self::Msisdn(_) => Some(AuthType::Msisdn),
             Self::Dummy(_) => Some(AuthType::Dummy),
-            #[cfg(feature = "unstable-pre-spec")]
             Self::RegistrationToken(_) => Some(AuthType::RegistrationToken),
             Self::FallbackAcknowledgement(_) => None,
             Self::_Custom(c) => Some(AuthType::_Custom(PrivOwnedStr(c.auth_type.as_str().into()))),
@@ -230,7 +222,6 @@ impl IncomingAuthData {
             Self::EmailIdentity(x) => x.session.as_deref(),
             Self::Msisdn(x) => x.session.as_deref(),
             Self::Dummy(x) => x.session.as_deref(),
-            #[cfg(feature = "unstable-pre-spec")]
             Self::RegistrationToken(x) => x.session.as_deref(),
             Self::FallbackAcknowledgement(x) => Some(&x.session),
             Self::_Custom(x) => x.session.as_deref(),
@@ -273,7 +264,6 @@ impl IncomingAuthData {
                 thirdparty_id_creds: &x.thirdparty_id_creds,
                 session: None,
             })),
-            #[cfg(feature = "unstable-pre-spec")]
             Self::RegistrationToken(x) => {
                 Cow::Owned(serialize(RegistrationToken { token: &x.token, session: None }))
             }
@@ -293,7 +283,6 @@ impl IncomingAuthData {
             Self::EmailIdentity(a) => AuthData::EmailIdentity(a.to_outgoing()),
             Self::Msisdn(a) => AuthData::Msisdn(a.to_outgoing()),
             Self::Dummy(a) => AuthData::Dummy(a.to_outgoing()),
-            #[cfg(feature = "unstable-pre-spec")]
             Self::RegistrationToken(a) => AuthData::RegistrationToken(a.to_outgoing()),
             Self::FallbackAcknowledgement(a) => AuthData::FallbackAcknowledgement(a.to_outgoing()),
             Self::_Custom(a) => AuthData::_Custom(CustomAuthData {
@@ -336,8 +325,7 @@ impl<'de> Deserialize<'de> for IncomingAuthData {
             Some("m.login.email.identity") => from_raw_json_value(&json).map(Self::EmailIdentity),
             Some("m.login.msisdn") => from_raw_json_value(&json).map(Self::Msisdn),
             Some("m.login.dummy") => from_raw_json_value(&json).map(Self::Dummy),
-            #[cfg(feature = "unstable-pre-spec")]
-            Some("org.matrix.msc3231.login.registration_token") => {
+            Some("m.login.registration_token") => {
                 from_raw_json_value(&json).map(Self::RegistrationToken)
             }
             None => from_raw_json_value(&json).map(Self::FallbackAcknowledgement),
@@ -382,9 +370,8 @@ pub enum AuthType {
     #[ruma_enum(rename = "m.login.dummy")]
     Dummy,
 
-    /// Registration token-based authentication (`org.matrix.msc3231.login.registration_token`).
-    #[cfg(feature = "unstable-pre-spec")]
-    #[ruma_enum(rename = "org.matrix.msc3231.login.registration_token")]
+    /// Registration token-based authentication (`m.login.registration_token`).
+    #[ruma_enum(rename = "m.login.registration_token")]
     RegistrationToken,
 
     #[doc(hidden)]
@@ -609,13 +596,12 @@ impl IncomingDummy {
 
 /// Data for registration token-based UIAA flow.
 ///
-/// See [MSC3231] for how to use this.
+/// See [the spec] for how to use this.
 ///
-/// [MSC3231]: https://github.com/matrix-org/matrix-doc/pull/3231
+/// [the spec]: https://spec.matrix.org/unstable/client-server-api/#token-authenticated-registration
 #[derive(Clone, Debug, Outgoing, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-#[cfg(feature = "unstable-pre-spec")]
-#[serde(tag = "type", rename = "org.matrix.msc3231.login.registration_token")]
+#[serde(tag = "type", rename = "m.login.registration_token")]
 pub struct RegistrationToken<'a> {
     /// The registration token.
     pub token: &'a str,
@@ -624,7 +610,6 @@ pub struct RegistrationToken<'a> {
     pub session: Option<&'a str>,
 }
 
-#[cfg(feature = "unstable-pre-spec")]
 impl<'a> RegistrationToken<'a> {
     /// Creates a new `RegistrationToken` with the given token.
     pub fn new(token: &'a str) -> Self {
@@ -632,7 +617,6 @@ impl<'a> RegistrationToken<'a> {
     }
 }
 
-#[cfg(feature = "unstable-pre-spec")]
 impl IncomingRegistrationToken {
     /// Convert from `IncomingRegistrationToken` to `RegistrationToken`.
     fn to_outgoing(&self) -> RegistrationToken<'_> {

--- a/crates/ruma-client-api/tests/uiaa.rs
+++ b/crates/ruma-client-api/tests/uiaa.rs
@@ -65,7 +65,7 @@ fn deserialize_auth_data_direct_request() {
 }
 
 #[test]
-#[cfg(feature = "unstable-pre-spec")]
+#[cfg(feature = "unstable-spec")]  // todo: v1.2
 fn serialize_auth_data_registration_token() {
     let auth_data = AuthData::RegistrationToken(
         assign!(uiaa::RegistrationToken::new("mytoken"), { session: Some("session") }),
@@ -82,7 +82,7 @@ fn serialize_auth_data_registration_token() {
 }
 
 #[test]
-#[cfg(feature = "unstable-pre-spec")]
+#[cfg(feature = "unstable-spec")]  // todo: v1.2
 fn deserialize_auth_data_registration_token() {
     let json = json!({
         "type": "m.login.registration_token",

--- a/crates/ruma-client-api/tests/uiaa.rs
+++ b/crates/ruma-client-api/tests/uiaa.rs
@@ -74,7 +74,7 @@ fn serialize_auth_data_registration_token() {
     assert_matches!(
         to_json_value(auth_data),
         Ok(val) if val == json!({
-            "type": "org.matrix.msc3231.login.registration_token",
+            "type": "m.login.registration_token",
             "token": "mytoken",
             "session": "session",
         })
@@ -85,7 +85,7 @@ fn serialize_auth_data_registration_token() {
 #[cfg(feature = "unstable-pre-spec")]
 fn deserialize_auth_data_registration_token() {
     let json = json!({
-        "type": "org.matrix.msc3231.login.registration_token",
+        "type": "m.login.registration_token",
         "token": "mytoken",
         "session": "session",
     });

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -119,6 +119,9 @@ unstable-pre-spec = [
     #"ruma-identity-service-api/unstable-pre-spec",
     #"ruma-push-gateway-api/unstable-pre-spec",
 ]
+unstable-spec = [
+    "ruma-client-api/unstable-spec"
+]
 
 [dependencies]
 assign = "1.1.1"

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -72,7 +72,7 @@ impl CiTask {
 
         // 2. Run tests
         let workspace_res =
-            cmd!("rustup run stable cargo test --workspace --features full,unstable-pre-spec")
+            cmd!("rustup run stable cargo test --workspace --features full,unstable-pre-spec,unstable-spec")
                 .run();
         let events_compat_res =
             cmd!("rustup run stable cargo test -p ruma-events --features compat compat").run();
@@ -98,7 +98,7 @@ impl CiTask {
         let clippy_all_res = cmd!(
             "
             rustup run nightly cargo clippy
-                --workspace --all-targets --features=full,compat,unstable-pre-spec -- -D warnings
+                --workspace --all-targets --features=full,compat,unstable-pre-spec,unstable-spec -- -D warnings
             "
         )
         .run();


### PR DESCRIPTION
Stablises token registration according to https://github.com/matrix-org/matrix-doc/pull/3616

Builds on the work of https://github.com/ruma/ruma/pull/722 and https://github.com/ruma/ruma/pull/757

This also adds the `unstable-spec` crate feature.