### PR TITLE
Make `deserialize_v1_powerlevel` more accurate to python's `int`

### DIFF
--- a/crates/ruma-common/src/power_levels.rs
+++ b/crates/ruma-common/src/power_levels.rs
@@ -13,7 +13,10 @@ pub struct NotificationPowerLevels {
     ///
     /// If you activate the `compat` feature, deserialization will work for stringified
     /// integers too.
-    #[cfg_attr(feature = "compat", serde(deserialize_with = "ruma_serde::int_or_string_to_int"))]
+    #[cfg_attr(
+        feature = "compat",
+        serde(deserialize_with = "ruma_serde::deserialize_v1_powerlevel")
+    )]
     #[serde(default = "default_power_level")]
     pub room: Int,
 }

--- a/crates/ruma-events/src/room/power_levels.rs
+++ b/crates/ruma-events/src/room/power_levels.rs
@@ -25,7 +25,10 @@ pub struct RoomPowerLevelsEventContent {
     ///
     /// If you activate the `compat` feature, deserialization will work for stringified
     /// integers too.
-    #[cfg_attr(feature = "compat", serde(deserialize_with = "ruma_serde::int_or_string_to_int"))]
+    #[cfg_attr(
+        feature = "compat",
+        serde(deserialize_with = "ruma_serde::deserialize_v1_powerlevel")
+    )]
     #[serde(default = "default_power_level", skip_serializing_if = "is_default_power_level")]
     #[ruma_event(skip_redaction)]
     pub ban: Int,
@@ -38,7 +41,7 @@ pub struct RoomPowerLevelsEventContent {
     /// integers too.
     #[cfg_attr(
         feature = "compat",
-        serde(deserialize_with = "ruma_serde::btreemap_int_or_string_to_int_values")
+        serde(deserialize_with = "ruma_serde::btreemap_deserialize_v1_powerlevel_values")
     )]
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     #[ruma_event(skip_redaction)]
@@ -48,7 +51,10 @@ pub struct RoomPowerLevelsEventContent {
     ///
     /// If you activate the `compat` feature, deserialization will work for stringified
     /// integers too.
-    #[cfg_attr(feature = "compat", serde(deserialize_with = "ruma_serde::int_or_string_to_int"))]
+    #[cfg_attr(
+        feature = "compat",
+        serde(deserialize_with = "ruma_serde::deserialize_v1_powerlevel")
+    )]
     #[serde(default, skip_serializing_if = "ruma_serde::is_default")]
     #[ruma_event(skip_redaction)]
     pub events_default: Int,
@@ -57,7 +63,10 @@ pub struct RoomPowerLevelsEventContent {
     ///
     /// If you activate the `compat` feature, deserialization will work for stringified
     /// integers too.
-    #[cfg_attr(feature = "compat", serde(deserialize_with = "ruma_serde::int_or_string_to_int"))]
+    #[cfg_attr(
+        feature = "compat",
+        serde(deserialize_with = "ruma_serde::deserialize_v1_powerlevel")
+    )]
     #[serde(default = "default_power_level", skip_serializing_if = "is_default_power_level")]
     pub invite: Int,
 
@@ -65,7 +74,10 @@ pub struct RoomPowerLevelsEventContent {
     ///
     /// If you activate the `compat` feature, deserialization will work for stringified
     /// integers too.
-    #[cfg_attr(feature = "compat", serde(deserialize_with = "ruma_serde::int_or_string_to_int"))]
+    #[cfg_attr(
+        feature = "compat",
+        serde(deserialize_with = "ruma_serde::deserialize_v1_powerlevel")
+    )]
     #[serde(default = "default_power_level", skip_serializing_if = "is_default_power_level")]
     #[ruma_event(skip_redaction)]
     pub kick: Int,
@@ -74,7 +86,10 @@ pub struct RoomPowerLevelsEventContent {
     ///
     /// If you activate the `compat` feature, deserialization will work for stringified
     /// integers too.
-    #[cfg_attr(feature = "compat", serde(deserialize_with = "ruma_serde::int_or_string_to_int"))]
+    #[cfg_attr(
+        feature = "compat",
+        serde(deserialize_with = "ruma_serde::deserialize_v1_powerlevel")
+    )]
     #[serde(default = "default_power_level", skip_serializing_if = "is_default_power_level")]
     #[ruma_event(skip_redaction)]
     pub redact: Int,
@@ -83,7 +98,10 @@ pub struct RoomPowerLevelsEventContent {
     ///
     /// If you activate the `compat` feature, deserialization will work for stringified
     /// integers too.
-    #[cfg_attr(feature = "compat", serde(deserialize_with = "ruma_serde::int_or_string_to_int"))]
+    #[cfg_attr(
+        feature = "compat",
+        serde(deserialize_with = "ruma_serde::deserialize_v1_powerlevel")
+    )]
     #[serde(default = "default_power_level", skip_serializing_if = "is_default_power_level")]
     #[ruma_event(skip_redaction)]
     pub state_default: Int,
@@ -96,7 +114,7 @@ pub struct RoomPowerLevelsEventContent {
     /// integers too.
     #[cfg_attr(
         feature = "compat",
-        serde(deserialize_with = "ruma_serde::btreemap_int_or_string_to_int_values")
+        serde(deserialize_with = "ruma_serde::btreemap_deserialize_v1_powerlevel_values")
     )]
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     #[ruma_event(skip_redaction)]
@@ -106,7 +124,10 @@ pub struct RoomPowerLevelsEventContent {
     ///
     /// If you activate the `compat` feature, deserialization will work for stringified
     /// integers too.
-    #[cfg_attr(feature = "compat", serde(deserialize_with = "ruma_serde::int_or_string_to_int"))]
+    #[cfg_attr(
+        feature = "compat",
+        serde(deserialize_with = "ruma_serde::deserialize_v1_powerlevel")
+    )]
     #[serde(default, skip_serializing_if = "ruma_serde::is_default")]
     #[ruma_event(skip_redaction)]
     pub users_default: Int,

--- a/crates/ruma-serde/src/lib.rs
+++ b/crates/ruma-serde/src/lib.rs
@@ -33,7 +33,7 @@ pub use self::{
     empty::vec_as_map_of_empty,
     raw::Raw,
     strings::{
-        btreemap_int_or_string_to_int_values, empty_string_as_none, int_or_string_to_int,
+        btreemap_deserialize_v1_powerlevel_values, deserialize_v1_powerlevel, empty_string_as_none,
         none_as_empty_string,
     },
 };

--- a/crates/ruma-serde/src/strings.rs
+++ b/crates/ruma-serde/src/strings.rs
@@ -123,6 +123,10 @@ where
                 next = &trimmed[1..]
             }
 
+            if trimmed.len() == 0 {
+                return Err(E::custom("string only contained plus/minus, no number"))
+            }
+
             let mut reduced = next.trim_start_matches('0');
 
             if reduced.len() == 0 {

--- a/crates/ruma-state-res/src/lib.rs
+++ b/crates/ruma-state-res/src/lib.rs
@@ -339,12 +339,15 @@ where
 struct PowerLevelsContentFields {
     #[cfg_attr(
         feature = "compat",
-        serde(deserialize_with = "ruma_serde::btreemap_int_or_string_to_int_values")
+        serde(deserialize_with = "ruma_serde::btreemap_deserialize_v1_powerlevel_values")
     )]
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     users: BTreeMap<Box<UserId>, Int>,
 
-    #[cfg_attr(feature = "compat", serde(deserialize_with = "ruma_serde::int_or_string_to_int"))]
+    #[cfg_attr(
+        feature = "compat",
+        serde(deserialize_with = "ruma_serde::deserialize_v1_powerlevel")
+    )]
     #[serde(default, skip_serializing_if = "ruma_serde::is_default")]
     users_default: Int,
 }


### PR DESCRIPTION
Fixes #835

Related to https://github.com/matrix-org/matrix-spec/issues/853