### PR TITLE
federation-api: Move MSCs to per-msc features

### DIFF
--- a/crates/ruma-federation-api/CHANGELOG.md
+++ b/crates/ruma-federation-api/CHANGELOG.md
@@ -12,6 +12,11 @@ Improvements:
 * Move `knock` module out of `unstable-pre-spec`
   * `knock:::send_knock::v1::Request` requires a PDU instead of the `knock_event`
 * Move cross-signing properties of `keys::get_keys::v1::Response` out of `unstable-pre-spec`
+* Move MSC implementations from `unstable-pre-spec` to per-msc features:
+  ```
+  unstable-msc2448
+  unstable-msc3618
+  ```
 
 # 0.3.1
 

--- a/crates/ruma-federation-api/Cargo.toml
+++ b/crates/ruma-federation-api/Cargo.toml
@@ -21,6 +21,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 [features]
 unstable-exhaustive-types = []
 unstable-pre-spec = []
+unstable-msc2448 = []
+unstable-msc3618 = []
 client = []
 server = []
 

--- a/crates/ruma-federation-api/src/membership/create_join_event.rs
+++ b/crates/ruma-federation-api/src/membership/create_join_event.rs
@@ -34,6 +34,7 @@ impl RoomState {
     /// Creates an empty `RoomState` with the given `origin`.
     ///
     /// With the `unstable-pre-spec` feature, this method doesn't take any parameters.
+    /// See [matrix-doc#1664](https://github.com/matrix-org/matrix-doc/issues/1664).
     pub fn new(origin: String) -> Self {
         Self { origin, auth_chain: Vec::new(), state: Vec::new() }
     }
@@ -42,7 +43,7 @@ impl RoomState {
     /// Creates an empty `RoomState` with the given `origin`.
     ///
     /// Without the `unstable-pre-spec` feature, this method takes a parameter for the origin
-    /// server.
+    /// server. See [matrix-doc#1664](https://github.com/matrix-org/matrix-doc/issues/1664).
     pub fn new() -> Self {
         Self { auth_chain: Vec::new(), state: Vec::new() }
     }

--- a/crates/ruma-federation-api/src/query/get_profile_information/v1.rs
+++ b/crates/ruma-federation-api/src/query/get_profile_information/v1.rs
@@ -48,7 +48,7 @@ ruma_api! {
         ///
         /// This uses the unstable prefix in
         /// [MSC2448](https://github.com/matrix-org/matrix-doc/pull/2448).
-        #[cfg(feature = "unstable-pre-spec")]
+        #[cfg(feature = "unstable-msc2448")]
         #[serde(rename = "xyz.amorgan.blurhash", skip_serializing_if = "Option::is_none")]
         pub blurhash: Option<String>,
     }

--- a/crates/ruma-federation-api/src/transactions/send_transaction_message/v1.rs
+++ b/crates/ruma-federation-api/src/transactions/send_transaction_message/v1.rs
@@ -35,6 +35,9 @@ ruma_api! {
         /// List of persistent updates to rooms.
         ///
         /// Must not be more than 50 items.
+        ///
+        /// With the `unstable-pre-spec` feature, sending `pdus` is optional.
+        /// See [matrix-doc#2824](https://github.com/matrix-org/matrix-doc/issues/2824).
         #[cfg_attr(feature = "unstable-pre-spec", serde(default, skip_serializing_if = "<[_]>::is_empty"))]
         pub pdus: &'a [Box<RawJsonValue>],
 
@@ -48,8 +51,10 @@ ruma_api! {
     #[derive(Default)]
     response: {
         /// Map of event IDs and response for each PDU given in the request.
-        // https://github.com/matrix-org/matrix-doc/pull/3618 makes returning `pdus` optional.
-        #[cfg_attr(feature = "unstable-pre-spec", serde(default))]
+        ///
+        /// With the `unstable-msc3618` feature, returning `pdus` is optional.
+        /// See [MSC3618](https://github.com/matrix-org/matrix-doc/pull/3618).
+        #[cfg_attr(feature = "unstable-msc3618", serde(default))]
         #[serde(with = "crate::serde::pdu_process_response")]
         pub pdus: BTreeMap<Box<EventId>, Result<(), String>>,
     }

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -116,6 +116,8 @@ unstable-pre-spec = [
     "ruma-signatures/unstable-pre-spec",
     "ruma-state-res/__unstable-pre-spec", # for tests
 ]
+unstable-msc2448 = ["ruma-federation-api/unstable-msc2448"]
+unstable-msc3618 = ["ruma-federation-api/unstable-msc3618"]
 
 [dependencies]
 assign = "1.1.1"


### PR DESCRIPTION
As discussed, the pre-spec features without MSCs are left untouched. I just added links to the matrix-doc issues in the docs.

Part of #820