### PR TITLE
signatures: Move Room v9 allowed content keys out of unstable-pre-spec

### DIFF
--- a/crates/ruma-signatures/CHANGELOG.md
+++ b/crates/ruma-signatures/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [unreleased]
 
+Improvements:
+
+* Move Room Version 9 keys out of `unstable-pre-spec` in `allowed_content_keys_for`
+
 # 0.9.0
 
 Breaking changes:

--- a/crates/ruma-signatures/Cargo.toml
+++ b/crates/ruma-signatures/Cargo.toml
@@ -17,7 +17,6 @@ all-features = true
 [features]
 compat = ["tracing"]
 unstable-exhaustive-types = []
-unstable-pre-spec = []
 
 [dependencies]
 base64 = "0.13.0"

--- a/crates/ruma-signatures/src/functions.rs
+++ b/crates/ruma-signatures/src/functions.rs
@@ -44,7 +44,6 @@ static ALLOWED_KEYS: &[&str] = &[
 fn allowed_content_keys_for(event_type: &str, version: &RoomVersionId) -> &'static [&'static str] {
     match event_type {
         "m.room.member" => match version {
-            #[cfg(feature = "unstable-pre-spec")]
             RoomVersionId::V9 => &["membership", "join_authorised_via_users_server"],
             _ => &["membership"],
         },

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -113,7 +113,6 @@ unstable-pre-spec = [
     "ruma-client-api/unstable-pre-spec",
     "ruma-events/unstable-pre-spec",
     "ruma-federation-api/unstable-pre-spec",
-    "ruma-signatures/unstable-pre-spec",
     "ruma-state-res/__unstable-pre-spec", # for tests
 ]
 unstable-msc2448 = ["ruma-federation-api/unstable-msc2448"]


### PR DESCRIPTION
Removes `unstable-pre-spec` from the crate.

Part of #849