### PR TITLE
Fix docs CI warning

### DIFF
--- a/crates/ruma-events/src/room/encrypted.rs
+++ b/crates/ruma-events/src/room/encrypted.rs
@@ -109,8 +109,9 @@ pub enum Relation {
 
 /// The event this relation belongs to replaces another event.
 ///
-/// In contrast to [`message::Replacement`], this struct doesn't store the new content, since that
-/// is part of the encrypted content of an `m.room.encrypted` events.
+/// In contrast to [`message::Replacement`](crate::room::message::Replacement), this struct doesn't
+/// store the new content, since that is part of the encrypted content of an `m.room.encrypted`
+/// events.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg(feature = "unstable-pre-spec")]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]


### PR DESCRIPTION
This removes the warning highlighted at the bottom of PR diffs, like https://github.com/ruma/ruma/pull/881/files