### PR TITLE
Remove as much occurrences of unstable-pre-spec feature in ruma-events as possible

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -20,6 +20,7 @@ Improvements:
 * Add `room::message::MessageType::body` accessor method
 * Implement `Redact` for event structs (in addition to `Any` event enums)
 * Add `room::message::RoomMessageEventContent::{body, msgtype}` accessor methods
+* Move `room::message::MessageType::VerificationRequest` out of `unstable-pre-spec`
 
 # 0.24.6
 

--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -21,6 +21,13 @@ Improvements:
 * Implement `Redact` for event structs (in addition to `Any` event enums)
 * Add `room::message::RoomMessageEventContent::{body, msgtype}` accessor methods
 * Move `room::message::MessageType::VerificationRequest` out of `unstable-pre-spec`
+* Move MSC implementations from `unstable-pre-spec` to per-msc features:
+  ```
+  unstable-msc2448
+  unstable-msc2675
+  unstable-msc2676
+  unstable-msc2677
+  ```
 
 # 0.24.6
 

--- a/crates/ruma-events/Cargo.toml
+++ b/crates/ruma-events/Cargo.toml
@@ -22,6 +22,10 @@ markdown = ["pulldown-cmark"]
 unstable-exhaustive-types = []
 unstable-pdu = []
 unstable-pre-spec = []
+unstable-msc2448 = []
+unstable-msc2675 = []
+unstable-msc2676 = []
+unstable-msc2677 = []
 
 [dependencies]
 criterion = { version = "0.3.3", optional = true }

--- a/crates/ruma-events/src/enums.rs
+++ b/crates/ruma-events/src/enums.rs
@@ -44,7 +44,7 @@ event_enum! {
         "m.key.verification.key",
         "m.key.verification.mac",
         "m.key.verification.done",
-        #[cfg(feature = "unstable-pre-spec")]
+        #[cfg(feature = "unstable-msc2677")]
         "m.reaction",
         "m.room.encrypted",
         "m.room.message",
@@ -340,7 +340,7 @@ impl AnyMessageEventContent {
                     event_id: event_id.clone(),
                 }))
             }
-            #[cfg(feature = "unstable-pre-spec")]
+            #[cfg(feature = "unstable-msc2677")]
             Self::Reaction(ev) => {
                 use crate::reaction;
 
@@ -355,7 +355,7 @@ impl AnyMessageEventContent {
                 message::Relation::Reply { in_reply_to } => {
                     encrypted::Relation::Reply { in_reply_to }
                 }
-                #[cfg(feature = "unstable-pre-spec")]
+                #[cfg(feature = "unstable-msc2676")]
                 message::Relation::Replacement(re) => {
                     encrypted::Relation::Replacement(encrypted::Replacement {
                         event_id: re.event_id,

--- a/crates/ruma-events/src/lib.rs
+++ b/crates/ruma-events/src/lib.rs
@@ -165,10 +165,10 @@ pub mod pdu;
 pub mod policy;
 pub mod presence;
 pub mod push_rules;
-#[cfg(feature = "unstable-pre-spec")]
+#[cfg(feature = "unstable-msc2677")]
 pub mod reaction;
 pub mod receipt;
-#[cfg(feature = "unstable-pre-spec")]
+#[cfg(feature = "unstable-msc2675")]
 pub mod relation;
 pub mod room;
 pub mod room_key;
@@ -179,7 +179,7 @@ pub mod sticker;
 pub mod tag;
 pub mod typing;
 
-#[cfg(feature = "unstable-pre-spec")]
+#[cfg(feature = "unstable-msc2675")]
 pub use self::relation::Relations;
 pub use self::{
     enums::*,

--- a/crates/ruma-events/src/policy/rule/room.rs
+++ b/crates/ruma-events/src/policy/rule/room.rs
@@ -43,7 +43,7 @@ mod tests {
             unsigned: Unsigned {
                 age: Some(int!(1234)),
                 transaction_id: None,
-                #[cfg(feature = "unstable-pre-spec")]
+                #[cfg(feature = "unstable-msc2675")]
                 relations: None,
             },
             content: PolicyRuleRoomEventContent(PolicyRuleEventContent {

--- a/crates/ruma-events/src/relation.rs
+++ b/crates/ruma-events/src/relation.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 
 /// Summary of all reactions with the given key to an event.
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
+#[cfg(feature = "unstable-msc2677")]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct BundledReaction {
     /// The key (emoji) used for reaction.
@@ -21,6 +22,7 @@ pub struct BundledReaction {
     pub count: UInt,
 }
 
+#[cfg(feature = "unstable-msc2677")]
 impl BundledReaction {
     /// Creates a new `BundledReaction`.
     pub fn new(
@@ -34,6 +36,7 @@ impl BundledReaction {
 
 /// Type of bundled annotation.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg(feature = "unstable-msc2677")]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[serde(tag = "type")]
 pub enum BundledAnnotation {
@@ -44,6 +47,7 @@ pub enum BundledAnnotation {
 
 /// The first chunk of annotations with a token for loading more.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[cfg(feature = "unstable-msc2677")]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct AnnotationChunk {
     /// The first batch of bundled annotations.
@@ -54,6 +58,7 @@ pub struct AnnotationChunk {
     pub next_batch: Option<String>,
 }
 
+#[cfg(feature = "unstable-msc2677")]
 impl AnnotationChunk {
     /// Creates a new `AnnotationChunk` with the given chunk and next batch token.
     pub fn new(chunk: Vec<BundledAnnotation>, next_batch: Option<String>) -> Self {
@@ -66,13 +71,26 @@ impl AnnotationChunk {
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct Relations {
     /// Annotation relations.
+    #[cfg(feature = "unstable-msc2677")]
     #[serde(rename = "m.annotation")]
     pub annotation: Option<AnnotationChunk>,
 }
 
 impl Relations {
+    #[cfg(feature = "unstable-msc2677")]
     /// Creates a new `Relations` with the given annotation.
+    ///
+    /// Without the `unstable-msc-2677` feature, this method doesn't have any
+    /// parameters.
     pub fn new(annotation: Option<AnnotationChunk>) -> Self {
         Self { annotation }
+    }
+
+    #[cfg(not(feature = "unstable-msc2677"))]
+    /// Creates a new empty `Relations`.
+    ///
+    /// With the `unstable-msc-2677` feature, this method takes an annotation.
+    pub fn new() -> Self {
+        Self {}
     }
 }

--- a/crates/ruma-events/src/room.rs
+++ b/crates/ruma-events/src/room.rs
@@ -69,7 +69,7 @@ pub struct ImageInfo {
     ///
     /// This uses the unstable prefix in
     /// [MSC2448](https://github.com/matrix-org/matrix-doc/pull/2448).
-    #[cfg(feature = "unstable-pre-spec")]
+    #[cfg(feature = "unstable-msc2448")]
     #[serde(rename = "xyz.amorgan.blurhash", skip_serializing_if = "Option::is_none")]
     pub blurhash: Option<String>,
 }

--- a/crates/ruma-events/src/room/avatar.rs
+++ b/crates/ruma-events/src/room/avatar.rs
@@ -26,12 +26,14 @@ pub struct RoomAvatarEventContent {
     /// URL of the avatar image.
     ///
     /// With the `unstable-pre-spec` feature, this field is optional.
+    /// See [matrix-doc#2006](https://github.com/matrix-org/matrix-doc/issues/2006).
     #[cfg(not(feature = "unstable-pre-spec"))]
     pub url: Box<MxcUri>,
 
     /// URL of the avatar image.
     ///
     /// Without the `unstable-pre-spec` feature, this field is not optional.
+    /// See [matrix-doc#2006](https://github.com/matrix-org/matrix-doc/issues/2006).
     #[cfg(feature = "unstable-pre-spec")]
     pub url: Option<Box<MxcUri>>,
 }
@@ -40,6 +42,7 @@ impl RoomAvatarEventContent {
     /// Create an `RoomAvatarEventContent` from the given image URL.
     ///
     /// With the `unstable-pre-spec` feature, this method takes no parameters.
+    /// See [matrix-doc#2006](https://github.com/matrix-org/matrix-doc/issues/2006).
     #[cfg(not(feature = "unstable-pre-spec"))]
     pub fn new(url: Box<MxcUri>) -> Self {
         Self { info: None, url }
@@ -48,6 +51,7 @@ impl RoomAvatarEventContent {
     /// Create an empty `RoomAvatarEventContent`.
     ///
     /// With the `unstable-pre-spec` feature, this method takes an `MxcUri`.
+    /// See [matrix-doc#2006](https://github.com/matrix-org/matrix-doc/issues/2006).
     #[cfg(feature = "unstable-pre-spec")]
     pub fn new() -> Self {
         Self::default()
@@ -86,7 +90,7 @@ pub struct ImageInfo {
     ///
     /// This uses the unstable prefix in
     /// [MSC2448](https://github.com/matrix-org/matrix-doc/pull/2448).
-    #[cfg(feature = "unstable-pre-spec")]
+    #[cfg(feature = "unstable-msc2448")]
     #[serde(rename = "xyz.amorgan.blurhash", skip_serializing_if = "Option::is_none")]
     pub blurhash: Option<String>,
 }

--- a/crates/ruma-events/src/room/create.rs
+++ b/crates/ruma-events/src/room/create.rs
@@ -175,7 +175,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "unstable-pre-spec")]
     #[test]
     fn space_deserialization() {
         let json = json!({

--- a/crates/ruma-events/src/room/encrypted.rs
+++ b/crates/ruma-events/src/room/encrypted.rs
@@ -93,14 +93,14 @@ pub enum Relation {
     },
 
     /// An event that replaces another event.
-    #[cfg(feature = "unstable-pre-spec")]
+    #[cfg(feature = "unstable-msc2676")]
     Replacement(Replacement),
 
     /// A reference to another event.
     Reference(Reference),
 
     /// An annotation to an event.
-    #[cfg(feature = "unstable-pre-spec")]
+    #[cfg(feature = "unstable-msc2677")]
     Annotation(Annotation),
 
     #[doc(hidden)]
@@ -112,7 +112,7 @@ pub enum Relation {
 /// In contrast to [`message::Replacement`], this struct doesn't store the new content, since that
 /// is part of the encrypted content of an `m.room.encrypted` events.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[cfg(feature = "unstable-pre-spec")]
+#[cfg(feature = "unstable-msc2676")]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct Replacement {
     /// The ID of the event being replacing.
@@ -136,7 +136,7 @@ impl Reference {
 
 /// An annotation for an event.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[cfg(feature = "unstable-pre-spec")]
+#[cfg(feature = "unstable-msc2677")]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct Annotation {
     /// The event that is being annotated.
@@ -146,7 +146,7 @@ pub struct Annotation {
     pub key: String,
 }
 
-#[cfg(feature = "unstable-pre-spec")]
+#[cfg(feature = "unstable-msc2677")]
 impl Annotation {
     /// Creates a new `Annotation` with the given event ID and key.
     pub fn new(event_id: Box<EventId>, key: String) -> Self {

--- a/crates/ruma-events/src/room/encrypted/relation_serde.rs
+++ b/crates/ruma-events/src/room/encrypted/relation_serde.rs
@@ -1,7 +1,9 @@
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-#[cfg(feature = "unstable-pre-spec")]
-use super::{Annotation, Replacement};
+#[cfg(feature = "unstable-msc2677")]
+use super::Annotation;
+#[cfg(feature = "unstable-msc2676")]
+use super::Replacement;
 use super::{InReplyTo, Reference, Relation};
 
 impl<'de> Deserialize<'de> for Relation {
@@ -16,10 +18,10 @@ impl<'de> Deserialize<'de> for Relation {
 
             if let Some(relation) = ev.relates_to.relation {
                 return match relation {
-                    #[cfg(feature = "unstable-pre-spec")]
+                    #[cfg(feature = "unstable-msc2677")]
                     RelationJsonRepr::Annotation(a) => Relation::Annotation(a),
                     RelationJsonRepr::Reference(r) => Relation::Reference(r),
-                    #[cfg(feature = "unstable-pre-spec")]
+                    #[cfg(feature = "unstable-msc2676")]
                     RelationJsonRepr::Replacement(Replacement { event_id }) => {
                         Relation::Replacement(Replacement { event_id })
                     }
@@ -43,7 +45,7 @@ impl Serialize for Relation {
     {
         #[allow(clippy::needless_update)]
         let relates_to = match self {
-            #[cfg(feature = "unstable-pre-spec")]
+            #[cfg(feature = "unstable-msc2677")]
             Relation::Annotation(r) => RelatesToJsonRepr {
                 relation: Some(RelationJsonRepr::Annotation(r.clone())),
                 ..Default::default()
@@ -52,7 +54,7 @@ impl Serialize for Relation {
                 relation: Some(RelationJsonRepr::Reference(r.clone())),
                 ..Default::default()
             },
-            #[cfg(feature = "unstable-pre-spec")]
+            #[cfg(feature = "unstable-msc2676")]
             Relation::Replacement(r) => RelatesToJsonRepr {
                 relation: Some(RelationJsonRepr::Replacement(r.clone())),
                 ..Default::default()
@@ -95,7 +97,7 @@ impl RelatesToJsonRepr {
 #[serde(tag = "rel_type")]
 enum RelationJsonRepr {
     /// An annotation to an event.
-    #[cfg(feature = "unstable-pre-spec")]
+    #[cfg(feature = "unstable-msc2677")]
     #[serde(rename = "m.annotation")]
     Annotation(Annotation),
 
@@ -104,7 +106,7 @@ enum RelationJsonRepr {
     Reference(Reference),
 
     /// An event that replaces another event.
-    #[cfg(feature = "unstable-pre-spec")]
+    #[cfg(feature = "unstable-msc2676")]
     #[serde(rename = "m.replace")]
     Replacement(Replacement),
 

--- a/crates/ruma-events/src/room/member.rs
+++ b/crates/ruma-events/src/room/member.rs
@@ -80,7 +80,7 @@ pub struct RoomMemberEventContent {
     ///
     /// This uses the unstable prefix in
     /// [MSC2448](https://github.com/matrix-org/matrix-doc/pull/2448).
-    #[cfg(feature = "unstable-pre-spec")]
+    #[cfg(feature = "unstable-msc2448")]
     #[serde(rename = "xyz.amorgan.blurhash", skip_serializing_if = "Option::is_none")]
     pub blurhash: Option<String>,
 
@@ -112,7 +112,7 @@ impl RoomMemberEventContent {
             displayname: None,
             is_direct: None,
             third_party_invite: None,
-            #[cfg(feature = "unstable-pre-spec")]
+            #[cfg(feature = "unstable-msc2448")]
             blurhash: None,
             reason: None,
             join_authorized_via_users_server: None,
@@ -341,7 +341,7 @@ fn membership_change(
             is_direct: None,
             membership: St::Leave,
             third_party_invite: None,
-            #[cfg(feature = "unstable-pre-spec")]
+            #[cfg(feature = "unstable-msc2448")]
             blurhash: None,
             reason: None,
             join_authorized_via_users_server: None,

--- a/crates/ruma-events/src/room/message.rs
+++ b/crates/ruma-events/src/room/message.rs
@@ -343,7 +343,7 @@ pub enum Relation {
     },
 
     /// An event that replaces another event.
-    #[cfg(feature = "unstable-pre-spec")]
+    #[cfg(feature = "unstable-msc2676")]
     Replacement(Replacement),
 
     #[doc(hidden)]
@@ -367,7 +367,7 @@ impl InReplyTo {
 
 /// The event this relation belongs to replaces another event.
 #[derive(Clone, Debug)]
-#[cfg(feature = "unstable-pre-spec")]
+#[cfg(feature = "unstable-msc2676")]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct Replacement {
     /// The ID of the event being replacing.
@@ -377,7 +377,7 @@ pub struct Replacement {
     pub new_content: Box<RoomMessageEventContent>,
 }
 
-#[cfg(feature = "unstable-pre-spec")]
+#[cfg(feature = "unstable-msc2676")]
 impl Replacement {
     /// Creates a new `Replacement` with the given event ID and new content.
     pub fn new(event_id: Box<EventId>, new_content: Box<RoomMessageEventContent>) -> Self {
@@ -936,7 +936,7 @@ pub struct VideoInfo {
     ///
     /// This uses the unstable prefix in
     /// [MSC2448](https://github.com/matrix-org/matrix-doc/pull/2448).
-    #[cfg(feature = "unstable-pre-spec")]
+    #[cfg(feature = "unstable-msc2448")]
     #[serde(rename = "xyz.amorgan.blurhash", skip_serializing_if = "Option::is_none")]
     pub blurhash: Option<String>,
 }

--- a/crates/ruma-events/src/room/message/content_serde.rs
+++ b/crates/ruma-events/src/room/message/content_serde.rs
@@ -45,7 +45,6 @@ impl<'de> Deserialize<'de> for MessageType {
             "m.server_notice" => Self::ServerNotice(from_raw_json_value(&json)?),
             "m.text" => Self::Text(from_raw_json_value(&json)?),
             "m.video" => Self::Video(from_raw_json_value(&json)?),
-            #[cfg(feature = "unstable-pre-spec")]
             "m.key.verification.request" => Self::VerificationRequest(from_raw_json_value(&json)?),
             _ => Self::_Custom(from_raw_json_value(&json)?),
         })

--- a/crates/ruma-events/src/room/message/relation_serde.rs
+++ b/crates/ruma-events/src/room/message/relation_serde.rs
@@ -1,11 +1,11 @@
-#[cfg(feature = "unstable-pre-spec")]
+#[cfg(feature = "unstable-msc2676")]
 use ruma_identifiers::EventId;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-#[cfg(feature = "unstable-pre-spec")]
+#[cfg(feature = "unstable-msc2676")]
 use super::Replacement;
 use super::{InReplyTo, Relation};
-#[cfg(feature = "unstable-pre-spec")]
+#[cfg(feature = "unstable-msc2676")]
 use crate::room::message::RoomMessageEventContent;
 
 impl<'de> Deserialize<'de> for Relation {
@@ -19,7 +19,7 @@ impl<'de> Deserialize<'de> for Relation {
             return Ok(Relation::Reply { in_reply_to });
         }
 
-        #[cfg(feature = "unstable-pre-spec")]
+        #[cfg(feature = "unstable-msc2676")]
         if let Some(relation) = ev.relates_to.relation {
             return Ok(match relation {
                 RelationJsonRepr::Replacement(ReplacementJsonRepr { event_id }) => {
@@ -49,7 +49,7 @@ impl Serialize for Relation {
                 in_reply_to: Some(in_reply_to.clone()),
                 ..Default::default()
             }),
-            #[cfg(feature = "unstable-pre-spec")]
+            #[cfg(feature = "unstable-msc2676")]
             Relation::Replacement(Replacement { event_id, new_content }) => {
                 EventWithRelatesToJsonRepr {
                     relates_to: RelatesToJsonRepr {
@@ -73,7 +73,7 @@ struct EventWithRelatesToJsonRepr {
     #[serde(rename = "m.relates_to", default, skip_serializing_if = "RelatesToJsonRepr::is_empty")]
     relates_to: RelatesToJsonRepr,
 
-    #[cfg(feature = "unstable-pre-spec")]
+    #[cfg(feature = "unstable-msc2676")]
     #[serde(rename = "m.new_content", skip_serializing_if = "Option::is_none")]
     new_content: Option<Box<RoomMessageEventContent>>,
 }
@@ -82,7 +82,7 @@ impl EventWithRelatesToJsonRepr {
     fn new(relates_to: RelatesToJsonRepr) -> Self {
         Self {
             relates_to,
-            #[cfg(feature = "unstable-pre-spec")]
+            #[cfg(feature = "unstable-msc2676")]
             new_content: None,
         }
     }
@@ -95,19 +95,19 @@ struct RelatesToJsonRepr {
     #[serde(rename = "m.in_reply_to", skip_serializing_if = "Option::is_none")]
     in_reply_to: Option<InReplyTo>,
 
-    #[cfg(feature = "unstable-pre-spec")]
+    #[cfg(feature = "unstable-msc2676")]
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
     relation: Option<RelationJsonRepr>,
 }
 
 impl RelatesToJsonRepr {
     fn is_empty(&self) -> bool {
-        #[cfg(not(feature = "unstable-pre-spec"))]
+        #[cfg(not(feature = "unstable-msc2676"))]
         {
             self.in_reply_to.is_none()
         }
 
-        #[cfg(feature = "unstable-pre-spec")]
+        #[cfg(feature = "unstable-msc2676")]
         {
             self.in_reply_to.is_none() && self.relation.is_none()
         }
@@ -116,7 +116,7 @@ impl RelatesToJsonRepr {
 
 /// A relation, which associates new information to an existing event.
 #[derive(Clone, Deserialize, Serialize)]
-#[cfg(feature = "unstable-pre-spec")]
+#[cfg(feature = "unstable-msc2676")]
 #[serde(tag = "rel_type")]
 enum RelationJsonRepr {
     /// An event that replaces another event.
@@ -132,7 +132,7 @@ enum RelationJsonRepr {
 }
 
 #[derive(Clone, Deserialize, Serialize)]
-#[cfg(feature = "unstable-pre-spec")]
+#[cfg(feature = "unstable-msc2676")]
 struct ReplacementJsonRepr {
     event_id: Box<EventId>,
 }

--- a/crates/ruma-events/src/unsigned.rs
+++ b/crates/ruma-events/src/unsigned.rs
@@ -2,7 +2,7 @@ use js_int::Int;
 use ruma_identifiers::TransactionId;
 use serde::{Deserialize, Serialize};
 
-#[cfg(feature = "unstable-pre-spec")]
+#[cfg(feature = "unstable-msc2675")]
 use crate::relation::Relations;
 use crate::room::redaction::SyncRoomRedactionEvent;
 
@@ -24,7 +24,7 @@ pub struct Unsigned {
     pub transaction_id: Option<Box<TransactionId>>,
 
     /// Server-compiled information from other events relating to this event.
-    #[cfg(feature = "unstable-pre-spec")]
+    #[cfg(feature = "unstable-msc2675")]
     #[serde(rename = "m.relations", skip_serializing_if = "Option::is_none")]
     pub relations: Option<Relations>,
 }
@@ -41,12 +41,12 @@ impl Unsigned {
     /// events. Do not use it to determine whether an incoming `unsigned` field was present - it
     /// could still have been present but contained none of the known fields.
     pub fn is_empty(&self) -> bool {
-        #[cfg(not(feature = "unstable-pre-spec"))]
+        #[cfg(not(feature = "unstable-msc2675"))]
         {
             self.age.is_none() && self.transaction_id.is_none()
         }
 
-        #[cfg(feature = "unstable-pre-spec")]
+        #[cfg(feature = "unstable-msc2675")]
         {
             self.age.is_none() && self.transaction_id.is_none() && self.relations.is_none()
         }
@@ -93,7 +93,7 @@ pub struct UnsignedWithPrevContent {
     #[serde(skip_serializing_if = "Option::is_none")]
     transaction_id: Option<Box<TransactionId>>,
 
-    #[cfg(feature = "unstable-pre-spec")]
+    #[cfg(feature = "unstable-msc2675")]
     #[serde(rename = "m.relations", skip_serializing_if = "Option::is_none")]
     relations: Option<Relations>,
 
@@ -106,7 +106,7 @@ impl From<UnsignedWithPrevContent> for Unsigned {
         Self {
             age: u.age,
             transaction_id: u.transaction_id,
-            #[cfg(feature = "unstable-pre-spec")]
+            #[cfg(feature = "unstable-msc2675")]
             relations: u.relations,
         }
     }

--- a/crates/ruma-events/tests/message_event.rs
+++ b/crates/ruma-events/tests/message_event.rs
@@ -182,7 +182,7 @@ fn deserialize_message_sticker() {
                     thumbnail_info: Some(thumbnail_info),
                     thumbnail_url: Some(thumbnail_url),
                     thumbnail_file: None,
-                    #[cfg(feature = "unstable-pre-spec")]
+                    #[cfg(feature = "unstable-msc2448")]
                     blurhash: None,
                     ..
                 },

--- a/crates/ruma-events/tests/room_message.rs
+++ b/crates/ruma-events/tests/room_message.rs
@@ -218,7 +218,7 @@ fn relates_to_content_serialization() {
 }
 
 #[test]
-#[cfg(not(feature = "unstable-pre-spec"))]
+#[cfg(not(feature = "unstable-msc2676"))]
 fn edit_deserialization_061() {
     let json_data = json!({
         "body": "s/foo/bar",
@@ -247,7 +247,7 @@ fn edit_deserialization_061() {
 }
 
 #[test]
-#[cfg(feature = "unstable-pre-spec")]
+#[cfg(feature = "unstable-msc2676")]
 fn edit_deserialization_future() {
     use ruma_events::room::message::Replacement;
 

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -115,7 +115,13 @@ unstable-pre-spec = [
     "ruma-federation-api/unstable-pre-spec",
     "ruma-state-res/__unstable-pre-spec", # for tests
 ]
-unstable-msc2448 = ["ruma-federation-api/unstable-msc2448"]
+unstable-msc2448 = [
+    "ruma-events/unstable-msc2448",
+    "ruma-federation-api/unstable-msc2448"
+]
+unstable-msc2675 = ["ruma-events/unstable-msc2675"]
+unstable-msc2676 = ["ruma-events/unstable-msc2676"]
+unstable-msc2677 = ["ruma-events/unstable-msc2677"]
 unstable-msc3618 = ["ruma-federation-api/unstable-msc3618"]
 
 [dependencies]


### PR DESCRIPTION
- Move VerificationRequest's deserialization out of unstable-pre-spec: part of #808.
- Move space deserialization test out of unstable-pre-spec: part of #849.
- Move MSCs to per-msc features: part of #820.

I did only one PR as the two first commits are single-line changes.