### PR TITLE
Remove as many occurrences of unstable-pre-spec feature in ruma-common as possible

### DIFF
--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -18,6 +18,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 compat = []
 unstable-exhaustive-types = []
 unstable-pre-spec = []
+unstable-msc2677 = []
 
 [dependencies]
 indexmap = { version = "1.6.2", features = ["serde-1"] }

--- a/crates/ruma-common/src/encryption.rs
+++ b/crates/ruma-common/src/encryption.rs
@@ -97,7 +97,6 @@ impl SignedKey {
     }
 
     /// Creates a new fallback `SignedKey` with the given key and signatures.
-    #[cfg(feature = "unstable-pre-spec")]
     pub fn new_fallback(key: Base64, signatures: SignedKeySignatures) -> Self {
         Self { key, signatures, fallback: true }
     }

--- a/crates/ruma-common/src/push/predefined.rs
+++ b/crates/ruma-common/src/push/predefined.rs
@@ -21,7 +21,7 @@ impl Ruleset {
     pub fn server_default(user_id: &UserId) -> Self {
         Self {
             content: indexset![PatternedPushRule::contains_user_name(user_id)],
-            #[cfg(feature = "unstable-pre-spec")]
+            #[cfg(feature = "unstable-msc2677")]
             override_: indexset![
                 ConditionalPushRule::master(),
                 ConditionalPushRule::suppress_notices(),
@@ -32,7 +32,7 @@ impl Ruleset {
                 ConditionalPushRule::roomnotif(),
                 ConditionalPushRule::reaction(),
             ],
-            #[cfg(not(feature = "unstable-pre-spec"))]
+            #[cfg(not(feature = "unstable-msc2677"))]
             override_: indexset![
                 ConditionalPushRule::master(),
                 ConditionalPushRule::suppress_notices(),
@@ -161,7 +161,7 @@ impl ConditionalPushRule {
 
     /// Matches emoji reactions to a message
     /// MSC2677: Annotations and Reactions
-    #[cfg(feature = "unstable-pre-spec")]
+    #[cfg(feature = "unstable-msc2677")]
     pub fn reaction() -> Self {
         Self {
             actions: vec![DontNotify],

--- a/crates/ruma-common/src/thirdparty.rs
+++ b/crates/ruma-common/src/thirdparty.rs
@@ -88,6 +88,8 @@ pub struct ProtocolInstance {
     pub network_id: String,
 
     /// A unique identifier across all instances.
+    ///
+    /// See [matrix-doc#3203](https://github.com/matrix-org/matrix-doc/issues/3203).
     #[cfg(feature = "unstable-pre-spec")]
     pub instance_id: String,
 }
@@ -109,6 +111,8 @@ pub struct ProtocolInstanceInit {
     pub network_id: String,
 
     /// A unique identifier across all instances.
+    ///
+    /// See [matrix-doc#3203](https://github.com/matrix-org/matrix-doc/issues/3203).
     #[cfg(feature = "unstable-pre-spec")]
     pub instance_id: String,
 }

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -121,7 +121,10 @@ unstable-msc2448 = [
 ]
 unstable-msc2675 = ["ruma-events/unstable-msc2675"]
 unstable-msc2676 = ["ruma-events/unstable-msc2676"]
-unstable-msc2677 = ["ruma-events/unstable-msc2677"]
+unstable-msc2677 = [
+    "ruma-common/unstable-msc2677",
+    "ruma-events/unstable-msc2677",
+]
 unstable-msc3618 = ["ruma-federation-api/unstable-msc3618"]
 
 [dependencies]


### PR DESCRIPTION
- Move `SignedKey::new_fallback` out of `unstable-pre-spec`: part of #849.
- Add link to matrix-doc issue for `ProtocolInstance`'s `instance_id` field.
- Move `reaction` pushrule to unstable-msc2677 feature: part of #820. It's not clear if it is actually [MSC2153](https://github.com/matrix-org/matrix-doc/pull/2153) as both document it without refering to the other, but it'll be easier to use with this feature as it already has the other reaction implementations.

I didn't put those changes in the changelog because I wasn't sure when these where added as they don't appear in it.
 
Based on #884 to avoid a conflict in `ruma/Cargo.toml`.