### PR TITLE
client-api: Move reason in membership requests out of unstable-pre-spec

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -24,7 +24,7 @@ Breaking changes:
 
 Improvements:
 
-* Add unstable support for reasons in the membership endpoints:
+* Add support for reasons in the membership endpoints:
 
   ```rust
   r0::membership::{
@@ -43,6 +43,7 @@ Improvements:
   includes:
   * The `r0::session::get_login_types::{IdentityProvider, IdentityProviderBrand}` types
   * The `session::sso_login_with_provider::v3` endpoint
+* Move reason support for leaving room out of `unstable-pre-spec`
 
 # 0.12.3
 

--- a/crates/ruma-client-api/src/r0/membership/invite_user.rs
+++ b/crates/ruma-client-api/src/r0/membership/invite_user.rs
@@ -34,7 +34,6 @@ ruma_api! {
         pub recipient: InvitationRecipient<'a>,
 
         /// Optional reason for inviting the user.
-        #[cfg(feature = "unstable-pre-spec")]
         #[serde(skip_serializing_if = "Option::is_none")]
         pub reason: Option<&'a str>,
     }
@@ -48,12 +47,7 @@ ruma_api! {
 impl<'a> Request<'a> {
     /// Creates a new `Request` with the given room ID and invitation recipient.
     pub fn new(room_id: &'a RoomId, recipient: InvitationRecipient<'a>) -> Self {
-        Self {
-            room_id,
-            recipient,
-            #[cfg(feature = "unstable-pre-spec")]
-            reason: None,
-        }
+        Self { room_id, recipient, reason: None }
     }
 }
 

--- a/crates/ruma-client-api/src/r0/membership/join_room_by_id.rs
+++ b/crates/ruma-client-api/src/r0/membership/join_room_by_id.rs
@@ -26,7 +26,6 @@ ruma_api! {
         pub third_party_signed: Option<ThirdPartySigned<'a>>,
 
         /// Optional reason for joining the room.
-        #[cfg(feature = "unstable-pre-spec")]
         #[serde(skip_serializing_if = "Option::is_none")]
         pub reason: Option<&'a str>,
     }
@@ -42,12 +41,7 @@ ruma_api! {
 impl<'a> Request<'a> {
     /// Creates a new `Request` with the given room id.
     pub fn new(room_id: &'a RoomId) -> Self {
-        Self {
-            room_id,
-            third_party_signed: None,
-            #[cfg(feature = "unstable-pre-spec")]
-            reason: None,
-        }
+        Self { room_id, third_party_signed: None, reason: None }
     }
 }
 

--- a/crates/ruma-client-api/src/r0/membership/join_room_by_id_or_alias.rs
+++ b/crates/ruma-client-api/src/r0/membership/join_room_by_id_or_alias.rs
@@ -33,7 +33,6 @@ ruma_api! {
         pub third_party_signed: Option<ThirdPartySigned<'a>>,
 
         /// Optional reason for joining the room.
-        #[cfg(feature = "unstable-pre-spec")]
         #[serde(skip_serializing_if = "Option::is_none")]
         pub reason: Option<&'a str>,
     }
@@ -49,13 +48,7 @@ ruma_api! {
 impl<'a> Request<'a> {
     /// Creates a new `Request` with the given room ID or alias ID.
     pub fn new(room_id_or_alias: &'a RoomOrAliasId) -> Self {
-        Self {
-            room_id_or_alias,
-            server_name: &[],
-            third_party_signed: None,
-            #[cfg(feature = "unstable-pre-spec")]
-            reason: None,
-        }
+        Self { room_id_or_alias, server_name: &[], third_party_signed: None, reason: None }
     }
 }
 

--- a/crates/ruma-client-api/src/r0/membership/leave_room.rs
+++ b/crates/ruma-client-api/src/r0/membership/leave_room.rs
@@ -19,7 +19,6 @@ ruma_api! {
         pub room_id: &'a RoomId,
 
         /// Optional reason to be included as the `reason` on the subsequent membership event.
-        #[cfg(feature = "unstable-pre-spec")]
         #[serde(skip_serializing_if = "Option::is_none")]
         pub reason: Option<&'a str>,
     }
@@ -33,11 +32,7 @@ ruma_api! {
 impl<'a> Request<'a> {
     /// Creates a new `Request` with the given room id.
     pub fn new(room_id: &'a RoomId) -> Self {
-        Self {
-            room_id,
-            #[cfg(feature = "unstable-pre-spec")]
-            reason: None,
-        }
+        Self { room_id, reason: None }
     }
 }
 

--- a/crates/ruma-client-api/src/r0/membership/unban_user.rs
+++ b/crates/ruma-client-api/src/r0/membership/unban_user.rs
@@ -22,7 +22,6 @@ ruma_api! {
         pub user_id: &'a UserId,
 
         /// Optional reason for unbanning the user.
-        #[cfg(feature = "unstable-pre-spec")]
         #[serde(skip_serializing_if = "Option::is_none")]
         pub reason: Option<&'a str>,
     }
@@ -36,12 +35,7 @@ ruma_api! {
 impl<'a> Request<'a> {
     /// Creates a new `Request` with the given room id and room id.
     pub fn new(room_id: &'a RoomId, user_id: &'a UserId) -> Self {
-        Self {
-            room_id,
-            user_id,
-            #[cfg(feature = "unstable-pre-spec")]
-            reason: None,
-        }
+        Self { room_id, user_id, reason: None }
     }
 }
 


### PR DESCRIPTION
Part of #808.