### PR TITLE
client-api: Move support for fallback keys out unstable-pre-spec

### DIFF
--- a/crates/ruma-client-api/src/r0/sync/sync_events.rs
+++ b/crates/ruma-client-api/src/r0/sync/sync_events.rs
@@ -99,8 +99,6 @@ ruma_api! {
         ///
         /// The presence of this field indicates that the server supports
         /// fallback keys.
-        #[cfg(feature = "unstable-pre-spec")]
-        #[serde(rename = "org.matrix.msc2732.device_unused_fallback_key_types")]
         pub device_unused_fallback_key_types: Option<Vec<DeviceKeyAlgorithm>>,
     }
 
@@ -125,7 +123,6 @@ impl Response {
             to_device: Default::default(),
             device_lists: Default::default(),
             device_one_time_keys_count: BTreeMap::new(),
-            #[cfg(feature = "unstable-pre-spec")]
             device_unused_fallback_key_types: None,
         }
     }


### PR DESCRIPTION
Part of #849.