### PR TITLE
client-api: Finalize moving knocking support out of unstable-pre-spec

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -45,6 +45,7 @@ Improvements:
   * The `session::sso_login_with_provider::v3` endpoint
 * Move reason support for leaving room out of `unstable-pre-spec`
 * Move room type support out of `unstable-pre-spec`
+* Move knocking support out of `unstable-pre-spec`
 
 # 0.12.3
 

--- a/crates/ruma-client-api/src/r0/sync/sync_events.rs
+++ b/crates/ruma-client-api/src/r0/sync/sync_events.rs
@@ -181,7 +181,6 @@ pub struct Rooms {
     pub invite: BTreeMap<Box<RoomId>, InvitedRoom>,
 
     /// The rooms that the user has knocked on.
-    #[cfg(feature = "unstable-pre-spec")]
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub knock: BTreeMap<Box<RoomId>, KnockedRoom>,
 }
@@ -279,7 +278,6 @@ impl JoinedRoom {
 
 /// Updates to knocked rooms.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[cfg(feature = "unstable-pre-spec")]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct KnockedRoom {
     /// The knock state.
@@ -288,7 +286,6 @@ pub struct KnockedRoom {
 
 /// A mapping from a key `events` to a list of `StrippedStateEvent`.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[cfg(feature = "unstable-pre-spec")]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct KnockState {
     /// The list of events.


### PR DESCRIPTION
Part of #808.