### PR TITLE
client-api: Move blurhash to unstable-msc2448

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -46,6 +46,7 @@ Improvements:
 * Move reason support for leaving room out of `unstable-pre-spec`
 * Move room type support out of `unstable-pre-spec`
 * Move knocking support out of `unstable-pre-spec`
+* Move blurhash support to `unstable-msc2448`
 
 # 0.12.3
 

--- a/crates/ruma-client-api/Cargo.toml
+++ b/crates/ruma-client-api/Cargo.toml
@@ -22,8 +22,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [features]
 compat = []
 unstable-exhaustive-types = []
-# feature dependency required for r0::room::create_room::CreationContent::into_event_content
-unstable-pre-spec = ["ruma-events/unstable-pre-spec"]
+unstable-msc2448 = []
 client = []
 server = []
 

--- a/crates/ruma-client-api/src/r0/media/create_content.rs
+++ b/crates/ruma-client-api/src/r0/media/create_content.rs
@@ -32,7 +32,7 @@ ruma_api! {
         /// This uses the unstable prefix in
         /// [MSC2448](https://github.com/matrix-org/matrix-doc/pull/2448).
         #[ruma_api(query)]
-        #[cfg(feature = "unstable-pre-spec")]
+        #[cfg(feature = "unstable-msc2448")]
         #[serde(default, skip_serializing_if = "ruma_serde::is_default", rename = "xyz.amorgan.blurhash")]
         pub generate_blurhash: bool,
     }
@@ -45,7 +45,7 @@ ruma_api! {
         ///
         /// This uses the unstable prefix in
         /// [MSC2448](https://github.com/matrix-org/matrix-doc/pull/2448).
-        #[cfg(feature = "unstable-pre-spec")]
+        #[cfg(feature = "unstable-msc2448")]
         #[serde(rename = "xyz.amorgan.blurhash", skip_serializing_if = "Option::is_none")]
         pub blurhash: Option<String>,
     }
@@ -60,7 +60,7 @@ impl<'a> Request<'a> {
             file,
             filename: None,
             content_type: None,
-            #[cfg(feature = "unstable-pre-spec")]
+            #[cfg(feature = "unstable-msc2448")]
             generate_blurhash: false,
         }
     }
@@ -71,7 +71,7 @@ impl Response {
     pub fn new(content_uri: Box<MxcUri>) -> Self {
         Self {
             content_uri,
-            #[cfg(feature = "unstable-pre-spec")]
+            #[cfg(feature = "unstable-msc2448")]
             blurhash: None,
         }
     }

--- a/crates/ruma-client-api/src/r0/profile/get_avatar_url.rs
+++ b/crates/ruma-client-api/src/r0/profile/get_avatar_url.rs
@@ -36,7 +36,7 @@ ruma_api! {
         ///
         /// This uses the unstable prefix in
         /// [MSC2448](https://github.com/matrix-org/matrix-doc/pull/2448).
-        #[cfg(feature = "unstable-pre-spec")]
+        #[cfg(feature = "unstable-msc2448")]
         #[serde(rename = "xyz.amorgan.blurhash", skip_serializing_if = "Option::is_none")]
         pub blurhash: Option<String>,
     }
@@ -56,7 +56,7 @@ impl Response {
     pub fn new(avatar_url: Option<Box<MxcUri>>) -> Self {
         Self {
             avatar_url,
-            #[cfg(feature = "unstable-pre-spec")]
+            #[cfg(feature = "unstable-msc2448")]
             blurhash: None,
         }
     }

--- a/crates/ruma-client-api/src/r0/profile/get_profile.rs
+++ b/crates/ruma-client-api/src/r0/profile/get_profile.rs
@@ -40,7 +40,7 @@ ruma_api! {
         ///
         /// This uses the unstable prefix in
         /// [MSC2448](https://github.com/matrix-org/matrix-doc/pull/2448).
-        #[cfg(feature = "unstable-pre-spec")]
+        #[cfg(feature = "unstable-msc2448")]
         #[serde(rename = "xyz.amorgan.blurhash", skip_serializing_if = "Option::is_none")]
         pub blurhash: Option<String>,
     }
@@ -61,7 +61,7 @@ impl Response {
         Self {
             avatar_url,
             displayname,
-            #[cfg(feature = "unstable-pre-spec")]
+            #[cfg(feature = "unstable-msc2448")]
             blurhash: None,
         }
     }

--- a/crates/ruma-client-api/src/r0/profile/set_avatar_url.rs
+++ b/crates/ruma-client-api/src/r0/profile/set_avatar_url.rs
@@ -42,7 +42,7 @@ ruma_api! {
         ///
         /// This uses the unstable prefix in
         /// [MSC2448](https://github.com/matrix-org/matrix-doc/pull/2448).
-        #[cfg(feature = "unstable-pre-spec")]
+        #[cfg(feature = "unstable-msc2448")]
         #[serde(rename = "xyz.amorgan.blurhash", skip_serializing_if = "Option::is_none")]
         pub blurhash: Option<&'a str>,
     }
@@ -59,7 +59,7 @@ impl<'a> Request<'a> {
         Self {
             user_id,
             avatar_url,
-            #[cfg(feature = "unstable-pre-spec")]
+            #[cfg(feature = "unstable-msc2448")]
             blurhash: None,
         }
     }

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -110,12 +110,12 @@ unstable-exhaustive-types = [
 unstable-pdu = ["ruma-events/unstable-pdu"]
 unstable-pre-spec = [
     "ruma-common/unstable-pre-spec",
-    "ruma-client-api/unstable-pre-spec",
     "ruma-events/unstable-pre-spec",
     "ruma-federation-api/unstable-pre-spec",
     "ruma-state-res/__unstable-pre-spec", # for tests
 ]
 unstable-msc2448 = [
+    "ruma-client-api/unstable-msc2448",
     "ruma-events/unstable-msc2448",
     "ruma-federation-api/unstable-msc2448"
 ]


### PR DESCRIPTION
Part of #820.

Removes the `unstable-pre-spec` feature.

Based on #889 to avoid a conflict in `ruma-client-api/Changelog.md`.