### PR TITLE
ruma: Finalize moving MSCs to unstable-mscXXXX features

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,11 @@ them. Check out the documentation [on docs.rs][docs] (or on
 As of 2022-01-31, we support all events and REST endpoints of the v1 version of
 the Matrix specification, with v1.1 and v1.2 coverage in progress.
 
-Various changes from in-progress MSCs, finished MSCs, and a few less formalized
-things are also implemented, gated behind the `unstable-pre-spec` Cargo feature.
+Various changes from in-progress or finished MSCs are also implemented, gated
+behind the `unstable-mscXXXX` (where `XXXX` is the MSC number) Cargo features.
+
+A few less formalized things are gated behind the `unstable-pre-spec` Cargo
+feature.
 
 ## Contributing
 

--- a/crates/ruma-state-res/Cargo.toml
+++ b/crates/ruma-state-res/Cargo.toml
@@ -19,7 +19,7 @@ compat = []
 unstable-exhaustive-types = []
 
 # Private, only used in test / benchmarking code
-__unstable-pre-spec = ["ruma-events/unstable-pre-spec"]
+__ci = ["ruma-events/unstable-pre-spec"]
 
 [dependencies]
 itertools = "0.10.0"

--- a/crates/ruma-state-res/benches/state_res_bench.rs
+++ b/crates/ruma-state-res/benches/state_res_bench.rs
@@ -394,7 +394,7 @@ where
             content,
             redacts: None,
             unsigned: btreemap! {},
-            #[cfg(not(feature = "__unstable-pre-spec"))]
+            #[cfg(not(feature = "__ci"))]
             origin: "foo".into(),
             auth_events,
             prev_events,

--- a/crates/ruma-state-res/src/test_utils.rs
+++ b/crates/ruma-state-res/src/test_utils.rs
@@ -401,7 +401,7 @@ pub fn to_init_pdu_event(
             content,
             redacts: None,
             unsigned: BTreeMap::new(),
-            #[cfg(not(feature = "__unstable-pre-spec"))]
+            #[cfg(not(feature = "__ci"))]
             origin: "foo".into(),
             auth_events: vec![],
             prev_events: vec![],
@@ -441,7 +441,7 @@ where
             content,
             redacts: None,
             unsigned: BTreeMap::new(),
-            #[cfg(not(feature = "__unstable-pre-spec"))]
+            #[cfg(not(feature = "__ci"))]
             origin: "foo".into(),
             auth_events,
             prev_events,

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -112,7 +112,6 @@ unstable-pre-spec = [
     "ruma-common/unstable-pre-spec",
     "ruma-events/unstable-pre-spec",
     "ruma-federation-api/unstable-pre-spec",
-    "ruma-state-res/__unstable-pre-spec", # for tests
 ]
 unstable-msc2448 = [
     "ruma-client-api/unstable-msc2448",
@@ -126,6 +125,18 @@ unstable-msc2677 = [
     "ruma-events/unstable-msc2677",
 ]
 unstable-msc3618 = ["ruma-federation-api/unstable-msc3618"]
+
+# Private feature, only used in test / benchmarking code
+__ci = [
+    "full",
+    "unstable-pre-spec",
+    "unstable-msc2448",
+    "unstable-msc2675",
+    "unstable-msc2676",
+    "unstable-msc2677",
+    "unstable-msc3618",
+    "ruma-state-res/__ci", 
+]
 
 [dependencies]
 assign = "1.1.1"

--- a/crates/ruma/src/lib.rs
+++ b/crates/ruma/src/lib.rs
@@ -45,7 +45,9 @@
 //! * `unstable-exhaustive-types` -- Most types in Ruma are marked as non-exhaustive to avoid
 //!   breaking changes when new fields are added in the specification. This feature compiles all
 //!   types as exhaustive.
-//! * `unstable-pre-spec` -- Upcoming Matrix features that may be subject to change or removal.
+//! * `unstable-mscXXXX`, where `XXXX` is the MSC number -- Upcoming Matrix features that may be
+//!   subject to change or removal.
+//! * `unstable-pre-spec` -- Undocumented Matrix features that may be subject to change or removal.
 //!
 //! # Common features
 //!

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -71,9 +71,7 @@ impl CiTask {
         cmd!("rustup run stable cargo check -p ruma-identifiers --no-default-features").run()?;
 
         // 2. Run tests
-        let workspace_res =
-            cmd!("rustup run stable cargo test --workspace --features full,unstable-pre-spec")
-                .run();
+        let workspace_res = cmd!("rustup run stable cargo test --workspace --features __ci").run();
         let events_compat_res =
             cmd!("rustup run stable cargo test -p ruma-events --features compat compat").run();
 
@@ -98,7 +96,7 @@ impl CiTask {
         let clippy_all_res = cmd!(
             "
             rustup run nightly cargo clippy
-                --workspace --all-targets --features=full,compat,unstable-pre-spec -- -D warnings
+                --workspace --all-targets --features=__ci,compat -- -D warnings
             "
         )
         .run();


### PR DESCRIPTION
- Document the new feature flags.
- Add a `__ci` feature to test all the MSCs.

Closes #820.