### PR TITLE
Add matrix.to URI parsing

### DIFF
--- a/crates/ruma-identifiers-validation/Cargo.toml
+++ b/crates/ruma-identifiers-validation/Cargo.toml
@@ -15,3 +15,4 @@ compat = []
 
 [dependencies]
 thiserror = "1.0.26"
+url = "2.2.2"

--- a/crates/ruma-identifiers-validation/src/error.rs
+++ b/crates/ruma-identifiers-validation/src/error.rs
@@ -1,5 +1,7 @@
 //! Error conditions.
 
+use std::str::Utf8Error;
+
 /// An error encountered when trying to parse an invalid ID string.
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, thiserror::Error)]
 #[non_exhaustive]
@@ -30,6 +32,14 @@ pub enum Error {
     #[error("key ID version contains invalid characters")]
     InvalidKeyVersion,
 
+    /// The string isn't a valid Matrix ID.
+    #[error("invalid matrix ID: {0}")]
+    InvalidMatrixId(#[from] MatrixIdError),
+
+    /// The string isn't a valid Matrix.to URI.
+    #[error("invalid matrix.to URI: {0}")]
+    InvalidMatrixToRef(#[from] MatrixToError),
+
     /// The mxc:// isn't a valid Matrix Content URI.
     #[error("invalid Matrix Content URI: {0}")]
     InvalidMxcUri(#[from] MxcUriError),
@@ -37,6 +47,14 @@ pub enum Error {
     /// The server name part of the the ID string is not a valid server name.
     #[error("server name is not a valid IP address or domain name")]
     InvalidServerName,
+
+    /// The string isn't a valid URI.
+    #[error("invalid URI")]
+    InvalidUri,
+
+    /// The string isn't valid UTF-8.
+    #[error("invalid UTF-8")]
+    InvalidUtf8,
 
     /// The ID exceeds 255 bytes (or 32 codepoints for a room version ID).
     #[error("ID exceeds 255 bytes")]
@@ -50,6 +68,18 @@ pub enum Error {
     /// The ID is missing the correct leading sigil.
     #[error("leading sigil is incorrect or missing")]
     MissingLeadingSigil,
+}
+
+impl From<Utf8Error> for Error {
+    fn from(_: Utf8Error) -> Self {
+        Self::InvalidUtf8
+    }
+}
+
+impl From<url::ParseError> for Error {
+    fn from(_: url::ParseError) -> Self {
+        Self::InvalidUri
+    }
 }
 
 /// An error occurred while validating an MXC URI.
@@ -74,4 +104,42 @@ pub enum MxcUriError {
     /// Server identifier malformed: invalid IP or domain name.
     #[error("invalid Server Name")]
     ServerNameMalformed,
+}
+
+/// An error occurred while validating a `MatrixId`.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, thiserror::Error)]
+#[non_exhaustive]
+pub enum MatrixIdError {
+    /// The string is missing a room ID or alias.
+    #[error("missing room ID or alias")]
+    MissingRoom,
+
+    /// The string contains no identifier.
+    #[error("no identifier")]
+    NoIdentifier,
+
+    /// The string contains too many identifiers.
+    #[error("too many identifiers")]
+    TooManyIdentifiers,
+
+    /// The string contains an unknown identifier.
+    #[error("unknown identifier")]
+    UnknownIdentifier,
+
+    /// The string contains two identifiers that cannot be paired.
+    #[error("unknown identifier pair")]
+    UnknownIdentifierPair,
+}
+
+/// An error occurred while validating an MXC URI.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, thiserror::Error)]
+#[non_exhaustive]
+pub enum MatrixToError {
+    /// String did not start with `https://matrix.to/#/`.
+    #[error("base URL is not https://matrix.to/#/")]
+    WrongBaseUrl,
+
+    /// String has an unknown additional argument.
+    #[error("unknown additional argument")]
+    UnknownArgument,
 }

--- a/crates/ruma-identifiers/CHANGELOG.md
+++ b/crates/ruma-identifiers/CHANGELOG.md
@@ -15,6 +15,7 @@ Breaking changes:
 Improvements:
 
 * Add `host`, `port` and `is_ip_literal` methods to `ServerName`
+* Add `matrix_uri::MatrixToUri` to build `matrix.to` URIs
 
 Bug fixes:
 

--- a/crates/ruma-identifiers/Cargo.toml
+++ b/crates/ruma-identifiers/Cargo.toml
@@ -30,6 +30,7 @@ ruma-serde = { version = "0.5.0", path = "../ruma-serde", optional = true }
 ruma-serde-macros = { version = "0.5.0", path = "../ruma-serde-macros" }
 # Renamed so we can have a serde feature.
 serde1 = { package = "serde", version = "1.0.126", optional = true, features = ["derive"] }
+url = "2.2.2"
 uuid = { version = "0.8.2", optional = true, features = ["v4"] }
 
 [dev-dependencies]

--- a/crates/ruma-identifiers/src/lib.rs
+++ b/crates/ruma-identifiers/src/lib.rs
@@ -32,7 +32,7 @@ pub use crate::{
     event_id::EventId,
     key_id::{DeviceSigningKeyId, KeyId, ServerSigningKeyId, SigningKeyId},
     key_name::KeyName,
-    matrix_to::MatrixToRef,
+    matrix_uri::MatrixToUri,
     mxc_uri::MxcUri,
     room_alias_id::RoomAliasId,
     room_id::RoomId,
@@ -51,6 +51,7 @@ pub use ruma_identifiers_validation::error::Error;
 #[macro_use]
 mod macros;
 
+pub mod matrix_uri;
 pub mod user_id;
 
 mod client_secret;
@@ -60,7 +61,6 @@ mod device_key_id;
 mod event_id;
 mod key_id;
 mod key_name;
-mod matrix_to;
 mod mxc_uri;
 mod room_alias_id;
 mod room_id;

--- a/crates/ruma-identifiers/src/matrix_uri.rs
+++ b/crates/ruma-identifiers/src/matrix_uri.rs
@@ -1,3 +1,5 @@
+//! Matrix URIs.
+
 use std::fmt;
 
 use percent_encoding::{percent_encode, AsciiSet, CONTROLS};
@@ -33,13 +35,13 @@ const TO_ENCODE: &AsciiSet = &CONTROLS
 /// Turn it into a `matrix.to` URL through its `Display` implementation (i.e. by
 /// interpolating it in a formatting macro or via `.to_string()`).
 #[derive(Debug, PartialEq, Eq)]
-pub struct MatrixToRef<'a> {
+pub struct MatrixToUri<'a> {
     id: &'a str,
     event_id: Option<&'a EventId>,
     via: Vec<&'a ServerName>,
 }
 
-impl<'a> MatrixToRef<'a> {
+impl<'a> MatrixToUri<'a> {
     pub(crate) fn new(id: &'a str, via: Vec<&'a ServerName>) -> Self {
         Self { id, event_id: None, via }
     }
@@ -49,7 +51,7 @@ impl<'a> MatrixToRef<'a> {
     }
 }
 
-impl<'a> fmt::Display for MatrixToRef<'a> {
+impl<'a> fmt::Display for MatrixToUri<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(BASE_URL)?;
         write!(f, "{}", percent_encode(self.id.as_bytes(), TO_ENCODE))?;
@@ -75,7 +77,7 @@ mod tests {
     use crate::user_id;
 
     #[test]
-    fn matrix_to_ref() {
+    fn matrix_to_uri() {
         assert_eq!(
             user_id!("@jplatte:notareal.hs").matrix_to_url().to_string(),
             "https://matrix.to/#/%40jplatte%3Anotareal.hs"

--- a/crates/ruma-identifiers/src/matrix_uri.rs
+++ b/crates/ruma-identifiers/src/matrix_uri.rs
@@ -1,8 +1,13 @@
 //! Matrix URIs.
 
-use std::fmt;
+use std::{convert::TryFrom, fmt};
 
-use percent_encoding::{percent_encode, AsciiSet, CONTROLS};
+use percent_encoding::{percent_decode_str, percent_encode, AsciiSet, CONTROLS};
+use ruma_identifiers_validation::{
+    error::{MatrixIdError, MatrixToError},
+    Error,
+};
+use url::Url;
 
 use crate::{EventId, RoomAliasId, RoomId, RoomOrAliasId, ServerName, UserId};
 
@@ -48,6 +53,54 @@ pub enum MatrixId {
 }
 
 impl MatrixId {
+    /// Try parsing a `&str` with sigils into a `MatrixId`.
+    ///
+    /// The identifiers are expected to start with a sigil and to be percent
+    /// encoded. Slashes at the beginning and the end are stripped.
+    ///
+    /// For events, the room ID or alias and the event ID should be separated by
+    /// a slash and they can be in any order.
+    pub(crate) fn parse_with_sigil(s: &str) -> Result<Self, Error> {
+        let s = if let Some(stripped) = s.strip_prefix('/') { stripped } else { s };
+        let s = if let Some(stripped) = s.strip_suffix('/') { stripped } else { s };
+        if s.is_empty() {
+            return Err(MatrixIdError::NoIdentifier.into());
+        }
+
+        if s.matches('/').count() > 1 {
+            return Err(MatrixIdError::TooManyIdentifiers.into());
+        }
+
+        if let Some((first_raw, second_raw)) = s.split_once('/') {
+            let first = percent_decode_str(first_raw).decode_utf8()?;
+            let second = percent_decode_str(second_raw).decode_utf8()?;
+
+            match first.as_bytes()[0] {
+                b'!' | b'#' if second.as_bytes()[0] == b'$' => {
+                    let room_id = <&RoomOrAliasId>::try_from(first.as_ref())?;
+                    let event_id = <&EventId>::try_from(second.as_ref())?;
+                    Ok((room_id, event_id).into())
+                }
+                b'$' if matches!(second.as_bytes()[0], b'!' | b'#') => {
+                    let room_id = <&RoomOrAliasId>::try_from(second.as_ref())?;
+                    let event_id = <&EventId>::try_from(first.as_ref())?;
+                    Ok((room_id, event_id).into())
+                }
+                _ => Err(MatrixIdError::UnknownIdentifierPair.into()),
+            }
+        } else {
+            let id = percent_decode_str(s).decode_utf8()?;
+
+            match id.as_bytes()[0] {
+                b'@' => Ok(<&UserId>::try_from(id.as_ref())?.into()),
+                b'!' => Ok(<&RoomId>::try_from(id.as_ref())?.into()),
+                b'#' => Ok(<&RoomAliasId>::try_from(id.as_ref())?.into()),
+                b'$' => Err(MatrixIdError::MissingRoom.into()),
+                _ => Err(MatrixIdError::UnknownIdentifier.into()),
+            }
+        }
+    }
+
     /// Construct a string with sigils from `self`.
     ///
     /// The identifiers will start with a sigil and be percent encoded.
@@ -130,6 +183,30 @@ impl MatrixToUri {
     pub fn via(&self) -> &[Box<ServerName>] {
         &self.via
     }
+
+    /// Try parsing a `&str` into a `MatrixToUri`.
+    pub fn parse(s: &str) -> Result<Self, Error> {
+        let without_base = if let Some(stripped) = s.strip_prefix(MATRIX_TO_BASE_URL) {
+            stripped
+        } else {
+            return Err(MatrixToError::WrongBaseUrl.into());
+        };
+
+        let url = Url::parse(MATRIX_TO_BASE_URL.trim_end_matches("#/"))?.join(without_base)?;
+
+        let id = MatrixId::parse_with_sigil(url.path())?;
+        let mut via = vec![];
+
+        for (key, value) in url.query_pairs() {
+            if key.as_ref() == "via" {
+                via.push(ServerName::parse(value)?);
+            } else {
+                return Err(MatrixToError::UnknownArgument.into());
+            }
+        }
+
+        Ok(Self { id, via })
+    }
 }
 
 impl fmt::Display for MatrixToUri {
@@ -151,7 +228,14 @@ impl fmt::Display for MatrixToUri {
 
 #[cfg(test)]
 mod tests {
-    use crate::{event_id, room_alias_id, room_id, server_name, user_id};
+    use matches::assert_matches;
+    use ruma_identifiers_validation::{
+        error::{MatrixIdError, MatrixToError},
+        Error,
+    };
+
+    use super::{MatrixId, MatrixToUri};
+    use crate::{event_id, room_alias_id, room_id, server_name, user_id, RoomOrAliasId};
 
     #[test]
     fn display_matrixtouri() {
@@ -181,5 +265,205 @@ mod tests {
                 .to_string(),
             "https://matrix.to/#/%21ruma%3Anotareal.hs/%24event%3Anotareal.hs"
         );
+    }
+
+    #[test]
+    fn parse_valid_matrixid_with_sigil() {
+        assert_eq!(
+            MatrixId::parse_with_sigil("@user:imaginary.hs").expect("Failed to create MatrixId."),
+            MatrixId::User(user_id!("@user:imaginary.hs").into())
+        );
+        assert_eq!(
+            MatrixId::parse_with_sigil("!roomid:imaginary.hs").expect("Failed to create MatrixId."),
+            MatrixId::Room(room_id!("!roomid:imaginary.hs").into())
+        );
+        assert_eq!(
+            MatrixId::parse_with_sigil("#roomalias:imaginary.hs")
+                .expect("Failed to create MatrixId."),
+            MatrixId::RoomAlias(room_alias_id!("#roomalias:imaginary.hs").into())
+        );
+        assert_eq!(
+            MatrixId::parse_with_sigil("!roomid:imaginary.hs/$event:imaginary.hs")
+                .expect("Failed to create MatrixId."),
+            MatrixId::Event(
+                <&RoomOrAliasId>::from(room_id!("!roomid:imaginary.hs")).into(),
+                event_id!("$event:imaginary.hs").into()
+            )
+        );
+        assert_eq!(
+            MatrixId::parse_with_sigil("#roomalias:imaginary.hs/$event:imaginary.hs")
+                .expect("Failed to create MatrixId."),
+            MatrixId::Event(
+                <&RoomOrAliasId>::from(room_alias_id!("#roomalias:imaginary.hs")).into(),
+                event_id!("$event:imaginary.hs").into()
+            )
+        );
+        // Invert the order of the event and the room.
+        assert_eq!(
+            MatrixId::parse_with_sigil("$event:imaginary.hs/!roomid:imaginary.hs")
+                .expect("Failed to create MatrixId."),
+            MatrixId::Event(
+                <&RoomOrAliasId>::from(room_id!("!roomid:imaginary.hs")).into(),
+                event_id!("$event:imaginary.hs").into()
+            )
+        );
+        assert_eq!(
+            MatrixId::parse_with_sigil("$event:imaginary.hs/#roomalias:imaginary.hs")
+                .expect("Failed to create MatrixId."),
+            MatrixId::Event(
+                <&RoomOrAliasId>::from(room_alias_id!("#roomalias:imaginary.hs")).into(),
+                event_id!("$event:imaginary.hs").into()
+            )
+        );
+        // Starting with a slash
+        assert_eq!(
+            MatrixId::parse_with_sigil("/@user:imaginary.hs").expect("Failed to create MatrixId."),
+            MatrixId::User(user_id!("@user:imaginary.hs").into())
+        );
+        // Ending with a slash
+        assert_eq!(
+            MatrixId::parse_with_sigil("!roomid:imaginary.hs/")
+                .expect("Failed to create MatrixId."),
+            MatrixId::Room(room_id!("!roomid:imaginary.hs").into())
+        );
+        // Starting and ending with a slash
+        assert_eq!(
+            MatrixId::parse_with_sigil("/#roomalias:imaginary.hs/")
+                .expect("Failed to create MatrixId."),
+            MatrixId::RoomAlias(room_alias_id!("#roomalias:imaginary.hs").into())
+        );
+    }
+
+    #[test]
+    fn parse_matrixid_no_identifier() {
+        assert_eq!(MatrixId::parse_with_sigil("").unwrap_err(), MatrixIdError::NoIdentifier.into());
+        assert_eq!(
+            MatrixId::parse_with_sigil("/").unwrap_err(),
+            MatrixIdError::NoIdentifier.into()
+        );
+    }
+
+    #[test]
+    fn parse_matrixid_too_many_identifiers() {
+        assert_eq!(
+            MatrixId::parse_with_sigil(
+                "@user:imaginary.hs/#room:imaginary.hs/$event1:imaginary.hs"
+            )
+            .unwrap_err(),
+            MatrixIdError::TooManyIdentifiers.into()
+        );
+    }
+
+    #[test]
+    fn parse_matrixid_unknown_identifier_pair() {
+        assert_eq!(
+            MatrixId::parse_with_sigil("!roomid:imaginary.hs/@user:imaginary.hs").unwrap_err(),
+            MatrixIdError::UnknownIdentifierPair.into()
+        );
+        assert_eq!(
+            MatrixId::parse_with_sigil("#roomalias:imaginary.hs/notanidentifier").unwrap_err(),
+            MatrixIdError::UnknownIdentifierPair.into()
+        );
+        assert_eq!(
+            MatrixId::parse_with_sigil("$event:imaginary.hs/$otherevent:imaginary.hs").unwrap_err(),
+            MatrixIdError::UnknownIdentifierPair.into()
+        );
+        assert_eq!(
+            MatrixId::parse_with_sigil("notanidentifier/neitheristhis").unwrap_err(),
+            MatrixIdError::UnknownIdentifierPair.into()
+        );
+    }
+
+    #[test]
+    fn parse_matrixid_missing_room() {
+        assert_eq!(
+            MatrixId::parse_with_sigil("$event:imaginary.hs").unwrap_err(),
+            MatrixIdError::MissingRoom.into()
+        );
+    }
+
+    #[test]
+    fn parse_matrixid_unknown_identifier() {
+        assert_eq!(
+            MatrixId::parse_with_sigil("event:imaginary.hs").unwrap_err(),
+            MatrixIdError::UnknownIdentifier.into()
+        );
+        assert_eq!(
+            MatrixId::parse_with_sigil("notanidentifier").unwrap_err(),
+            MatrixIdError::UnknownIdentifier.into()
+        );
+    }
+
+    #[test]
+    fn parse_matrixtouri_valid_uris() {
+        let matrix_to = MatrixToUri::parse("https://matrix.to/#/%40jplatte%3Anotareal.hs")
+            .expect("Failed to create MatrixToUri.");
+        assert_eq!(matrix_to.id(), &user_id!("@jplatte:notareal.hs").into());
+
+        let matrix_to = MatrixToUri::parse("https://matrix.to/#/%23ruma%3Anotareal.hs")
+            .expect("Failed to create MatrixToUri.");
+        assert_eq!(matrix_to.id(), &room_alias_id!("#ruma:notareal.hs").into());
+
+        let matrix_to =
+            MatrixToUri::parse("https://matrix.to/#/%21ruma%3Anotareal.hs?via=notareal.hs")
+                .expect("Failed to create MatrixToUri.");
+        assert_eq!(matrix_to.id(), &room_id!("!ruma:notareal.hs").into());
+        assert_eq!(matrix_to.via(), &vec![server_name!("notareal.hs").to_owned()]);
+
+        let matrix_to =
+            MatrixToUri::parse("https://matrix.to/#/%23ruma%3Anotareal.hs/%24event%3Anotareal.hs")
+                .expect("Failed to create MatrixToUri.");
+        assert_eq!(
+            matrix_to.id(),
+            &(room_alias_id!("#ruma:notareal.hs"), event_id!("$event:notareal.hs")).into()
+        );
+
+        let matrix_to =
+            MatrixToUri::parse("https://matrix.to/#/%21ruma%3Anotareal.hs/%24event%3Anotareal.hs")
+                .expect("Failed to create MatrixToUri.");
+        assert_eq!(
+            matrix_to.id(),
+            &(room_id!("!ruma:notareal.hs"), event_id!("$event:notareal.hs")).into()
+        );
+        assert!(matrix_to.via().is_empty());
+    }
+
+    #[test]
+    fn parse_matrixtouri_wrong_base_url() {
+        assert_eq!(MatrixToUri::parse("").unwrap_err(), MatrixToError::WrongBaseUrl.into());
+        assert_eq!(
+            MatrixToUri::parse("https://notreal.to/#/").unwrap_err(),
+            MatrixToError::WrongBaseUrl.into()
+        );
+    }
+
+    #[test]
+    fn parse_matrixtouri_wrong_identifier() {
+        assert_matches!(
+            MatrixToUri::parse("https://matrix.to/#/notanidentifier").unwrap_err(),
+            Error::InvalidMatrixId(_)
+        );
+        assert_matches!(
+            MatrixToUri::parse("https://matrix.to/#/").unwrap_err(),
+            Error::InvalidMatrixId(_)
+        );
+        assert_matches!(
+            MatrixToUri::parse(
+                "https://matrix.to/#/%40jplatte%3Anotareal.hs/%24event%3Anotareal.hs"
+            )
+            .unwrap_err(),
+            Error::InvalidMatrixId(_)
+        );
+    }
+
+    #[test]
+    fn parse_matrixtouri_unknown_arguments() {
+        assert_eq!(
+            MatrixToUri::parse(
+                "https://matrix.to/#/%21ruma%3Anotareal.hs?via=notareal.hs&custom=data"
+            )
+            .unwrap_err(),
+            MatrixToError::UnknownArgument.into()
+        )
     }
 }

--- a/crates/ruma-identifiers/src/matrix_uri.rs
+++ b/crates/ruma-identifiers/src/matrix_uri.rs
@@ -4,9 +4,9 @@ use std::fmt;
 
 use percent_encoding::{percent_encode, AsciiSet, CONTROLS};
 
-use crate::{EventId, ServerName};
+use crate::{EventId, RoomAliasId, RoomId, RoomOrAliasId, ServerName, UserId};
 
-const BASE_URL: &str = "https://matrix.to/#/";
+const MATRIX_TO_BASE_URL: &str = "https://matrix.to/#/";
 // Controls + Space + reserved characters from RFC 3986. In practice only the
 // reserved characters will be encountered most likely, but better be safe.
 // https://datatracker.ietf.org/doc/html/rfc3986/#page-13
@@ -30,35 +30,112 @@ const TO_ENCODE: &AsciiSet = &CONTROLS
     .add(b';')
     .add(b'=');
 
-/// A reference to a user, room or event.
-///
-/// Turn it into a `matrix.to` URL through its `Display` implementation (i.e. by
-/// interpolating it in a formatting macro or via `.to_string()`).
+/// All Matrix Identifiers that can be represented as a Matrix URI.
 #[derive(Debug, PartialEq, Eq)]
-pub struct MatrixToUri<'a> {
-    id: &'a str,
-    event_id: Option<&'a EventId>,
-    via: Vec<&'a ServerName>,
+#[non_exhaustive]
+pub enum MatrixId {
+    /// A room ID.
+    Room(Box<RoomId>),
+
+    /// A room alias.
+    RoomAlias(Box<RoomAliasId>),
+
+    /// A user ID.
+    User(Box<UserId>),
+
+    /// An event ID.
+    Event(Box<RoomOrAliasId>, Box<EventId>),
 }
 
-impl<'a> MatrixToUri<'a> {
-    pub(crate) fn new(id: &'a str, via: Vec<&'a ServerName>) -> Self {
-        Self { id, event_id: None, via }
-    }
-
-    pub(crate) fn event(id: &'a str, event_id: &'a EventId, via: Vec<&'a ServerName>) -> Self {
-        Self { id, event_id: Some(event_id), via }
-    }
-}
-
-impl<'a> fmt::Display for MatrixToUri<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(BASE_URL)?;
-        write!(f, "{}", percent_encode(self.id.as_bytes(), TO_ENCODE))?;
-
-        if let Some(ev_id) = self.event_id {
-            write!(f, "/{}", percent_encode(ev_id.as_bytes(), TO_ENCODE))?;
+impl MatrixId {
+    /// Construct a string with sigils from `self`.
+    ///
+    /// The identifiers will start with a sigil and be percent encoded.
+    ///
+    /// For events, the room ID or alias and the event ID will be separated by
+    /// a slash.
+    pub(crate) fn to_string_with_sigil(&self) -> String {
+        match self {
+            Self::Room(room_id) => percent_encode(room_id.as_bytes(), TO_ENCODE).to_string(),
+            Self::RoomAlias(room_alias) => {
+                percent_encode(room_alias.as_bytes(), TO_ENCODE).to_string()
+            }
+            Self::User(user_id) => percent_encode(user_id.as_bytes(), TO_ENCODE).to_string(),
+            Self::Event(room_id, event_id) => format!(
+                "{}/{}",
+                percent_encode(room_id.as_bytes(), TO_ENCODE),
+                percent_encode(event_id.as_bytes(), TO_ENCODE),
+            ),
         }
+    }
+}
+
+impl From<&RoomId> for MatrixId {
+    fn from(room_id: &RoomId) -> Self {
+        Self::Room(room_id.into())
+    }
+}
+
+impl From<&RoomAliasId> for MatrixId {
+    fn from(room_alias: &RoomAliasId) -> Self {
+        Self::RoomAlias(room_alias.into())
+    }
+}
+
+impl From<&UserId> for MatrixId {
+    fn from(user_id: &UserId) -> Self {
+        Self::User(user_id.into())
+    }
+}
+
+impl From<(&RoomOrAliasId, &EventId)> for MatrixId {
+    fn from(ids: (&RoomOrAliasId, &EventId)) -> Self {
+        Self::Event(ids.0.into(), ids.1.into())
+    }
+}
+
+impl From<(&RoomId, &EventId)> for MatrixId {
+    fn from(ids: (&RoomId, &EventId)) -> Self {
+        Self::Event(<&RoomOrAliasId>::from(ids.0).into(), ids.1.into())
+    }
+}
+
+impl From<(&RoomAliasId, &EventId)> for MatrixId {
+    fn from(ids: (&RoomAliasId, &EventId)) -> Self {
+        Self::Event(<&RoomOrAliasId>::from(ids.0).into(), ids.1.into())
+    }
+}
+
+/// The `matrix.to` URI representation of a user, room or event.
+///
+/// Get the URI through its `Display` implementation (i.e. by interpolating it
+/// in a formatting macro or via `.to_string()`).
+#[derive(Debug, PartialEq, Eq)]
+pub struct MatrixToUri {
+    id: MatrixId,
+    via: Vec<Box<ServerName>>,
+}
+
+impl MatrixToUri {
+    pub(crate) fn new(id: MatrixId, via: Vec<&ServerName>) -> Self {
+        Self { id, via: via.into_iter().map(ToOwned::to_owned).collect() }
+    }
+
+    /// The identifier represented by this `matrix.to` URI.
+    pub fn id(&self) -> &MatrixId {
+        &self.id
+    }
+
+    /// Matrix servers usable to route a `RoomId`.
+    pub fn via(&self) -> &[Box<ServerName>] {
+        &self.via
+    }
+}
+
+impl fmt::Display for MatrixToUri {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(MATRIX_TO_BASE_URL)?;
+        write!(f, "{}", self.id().to_string_with_sigil())?;
 
         let mut first = true;
         for server_name in &self.via {
@@ -74,13 +151,35 @@ impl<'a> fmt::Display for MatrixToUri<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::user_id;
+    use crate::{event_id, room_alias_id, room_id, server_name, user_id};
 
     #[test]
-    fn matrix_to_uri() {
+    fn display_matrixtouri() {
         assert_eq!(
             user_id!("@jplatte:notareal.hs").matrix_to_url().to_string(),
             "https://matrix.to/#/%40jplatte%3Anotareal.hs"
+        );
+        assert_eq!(
+            room_alias_id!("#ruma:notareal.hs").matrix_to_url().to_string(),
+            "https://matrix.to/#/%23ruma%3Anotareal.hs"
+        );
+        assert_eq!(
+            room_id!("!ruma:notareal.hs")
+                .matrix_to_url(vec![server_name!("notareal.hs")])
+                .to_string(),
+            "https://matrix.to/#/%21ruma%3Anotareal.hs?via=notareal.hs"
+        );
+        assert_eq!(
+            room_alias_id!("#ruma:notareal.hs")
+                .matrix_to_event_url(event_id!("$event:notareal.hs"))
+                .to_string(),
+            "https://matrix.to/#/%23ruma%3Anotareal.hs/%24event%3Anotareal.hs"
+        );
+        assert_eq!(
+            room_id!("!ruma:notareal.hs")
+                .matrix_to_event_url(event_id!("$event:notareal.hs"))
+                .to_string(),
+            "https://matrix.to/#/%21ruma%3Anotareal.hs/%24event%3Anotareal.hs"
         );
     }
 }

--- a/crates/ruma-identifiers/src/room_alias_id.rs
+++ b/crates/ruma-identifiers/src/room_alias_id.rs
@@ -1,6 +1,6 @@
 //! Matrix room alias identifiers.
 
-use crate::{server_name::ServerName, EventId, MatrixToRef};
+use crate::{server_name::ServerName, EventId, MatrixToUri};
 
 /// A Matrix room alias ID.
 ///
@@ -30,13 +30,13 @@ impl RoomAliasId {
     }
 
     /// Create a `matrix.to` reference for this room alias ID.
-    pub fn matrix_to_url(&self) -> MatrixToRef<'_> {
-        MatrixToRef::new(self.as_str(), Vec::new())
+    pub fn matrix_to_url(&self) -> MatrixToUri<'_> {
+        MatrixToUri::new(self.as_str(), Vec::new())
     }
 
     /// Create a `matrix.to` reference for an event scoped under this room alias ID.
-    pub fn matrix_to_event_url<'a>(&'a self, ev_id: &'a EventId) -> MatrixToRef<'a> {
-        MatrixToRef::event(self.as_str(), ev_id, Vec::new())
+    pub fn matrix_to_event_url<'a>(&'a self, ev_id: &'a EventId) -> MatrixToUri<'a> {
+        MatrixToUri::event(self.as_str(), ev_id, Vec::new())
     }
 
     fn colon_idx(&self) -> usize {

--- a/crates/ruma-identifiers/src/room_alias_id.rs
+++ b/crates/ruma-identifiers/src/room_alias_id.rs
@@ -30,13 +30,13 @@ impl RoomAliasId {
     }
 
     /// Create a `matrix.to` reference for this room alias ID.
-    pub fn matrix_to_url(&self) -> MatrixToUri<'_> {
-        MatrixToUri::new(self.as_str(), Vec::new())
+    pub fn matrix_to_url(&self) -> MatrixToUri {
+        MatrixToUri::new(self.into(), Vec::new())
     }
 
     /// Create a `matrix.to` reference for an event scoped under this room alias ID.
-    pub fn matrix_to_event_url<'a>(&'a self, ev_id: &'a EventId) -> MatrixToUri<'a> {
-        MatrixToUri::event(self.as_str(), ev_id, Vec::new())
+    pub fn matrix_to_event_url(&self, ev_id: &EventId) -> MatrixToUri {
+        MatrixToUri::new((self, ev_id).into(), Vec::new())
     }
 
     fn colon_idx(&self) -> usize {

--- a/crates/ruma-identifiers/src/room_id.rs
+++ b/crates/ruma-identifiers/src/room_id.rs
@@ -1,6 +1,6 @@
 //! Matrix room identifiers.
 
-use crate::{EventId, MatrixToRef, ServerName};
+use crate::{EventId, MatrixToUri, ServerName};
 
 /// A Matrix room ID.
 ///
@@ -55,13 +55,13 @@ impl RoomId {
     pub fn matrix_to_url<'a>(
         &'a self,
         via: impl IntoIterator<Item = &'a ServerName>,
-    ) -> MatrixToRef<'a> {
-        MatrixToRef::new(self.as_str(), via.into_iter().collect())
+    ) -> MatrixToUri<'a> {
+        MatrixToUri::new(self.as_str(), via.into_iter().collect())
     }
 
     /// Create a `matrix.to` reference for an event scoped under this room ID.
-    pub fn matrix_to_event_url<'a>(&'a self, ev_id: &'a EventId) -> MatrixToRef<'a> {
-        MatrixToRef::event(self.as_str(), ev_id, Vec::new())
+    pub fn matrix_to_event_url<'a>(&'a self, ev_id: &'a EventId) -> MatrixToUri<'a> {
+        MatrixToUri::event(self.as_str(), ev_id, Vec::new())
     }
 
     fn colon_idx(&self) -> usize {

--- a/crates/ruma-identifiers/src/room_id.rs
+++ b/crates/ruma-identifiers/src/room_id.rs
@@ -52,16 +52,13 @@ impl RoomId {
     ///     "https://matrix.to/#/%21somewhere%3Aexample.org?via=example.org&via=alt.example.org"
     /// );
     /// ```
-    pub fn matrix_to_url<'a>(
-        &'a self,
-        via: impl IntoIterator<Item = &'a ServerName>,
-    ) -> MatrixToUri<'a> {
-        MatrixToUri::new(self.as_str(), via.into_iter().collect())
+    pub fn matrix_to_url<'a>(&self, via: impl IntoIterator<Item = &'a ServerName>) -> MatrixToUri {
+        MatrixToUri::new(self.into(), via.into_iter().collect())
     }
 
     /// Create a `matrix.to` reference for an event scoped under this room ID.
-    pub fn matrix_to_event_url<'a>(&'a self, ev_id: &'a EventId) -> MatrixToUri<'a> {
-        MatrixToUri::event(self.as_str(), ev_id, Vec::new())
+    pub fn matrix_to_event_url(&self, ev_id: &EventId) -> MatrixToUri {
+        MatrixToUri::new((self, ev_id).into(), Vec::new())
     }
 
     fn colon_idx(&self) -> usize {

--- a/crates/ruma-identifiers/src/user_id.rs
+++ b/crates/ruma-identifiers/src/user_id.rs
@@ -2,7 +2,7 @@
 
 use std::{rc::Rc, sync::Arc};
 
-use crate::{MatrixToRef, ServerName};
+use crate::{MatrixToUri, ServerName};
 
 /// A Matrix user ID.
 ///
@@ -116,8 +116,8 @@ impl UserId {
     ///     display_name = "jplatte",
     /// );
     /// ```
-    pub fn matrix_to_url(&self) -> MatrixToRef<'_> {
-        MatrixToRef::new(self.as_str(), Vec::new())
+    pub fn matrix_to_url(&self) -> MatrixToUri<'_> {
+        MatrixToUri::new(self.as_str(), Vec::new())
     }
 
     fn colon_idx(&self) -> usize {

--- a/crates/ruma-identifiers/src/user_id.rs
+++ b/crates/ruma-identifiers/src/user_id.rs
@@ -116,8 +116,8 @@ impl UserId {
     ///     display_name = "jplatte",
     /// );
     /// ```
-    pub fn matrix_to_url(&self) -> MatrixToUri<'_> {
-        MatrixToUri::new(self.as_str(), Vec::new())
+    pub fn matrix_to_url(&self) -> MatrixToUri {
+        MatrixToUri::new(self.into(), Vec::new())
     }
 
     fn colon_idx(&self) -> usize {

--- a/crates/ruma/src/lib.rs
+++ b/crates/ruma/src/lib.rs
@@ -84,12 +84,12 @@ pub use ruma_serde as serde;
 pub use ruma_serde::Outgoing;
 
 pub use ruma_identifiers::{
-    device_id, device_key_id, event_id, mxc_uri, room_alias_id, room_id, room_version_id,
-    server_name, server_signing_key_id, user_id, ClientSecret, DeviceId, DeviceKeyAlgorithm,
-    DeviceKeyId, DeviceSignatures, DeviceSigningKeyId, EntitySignatures, EventEncryptionAlgorithm,
-    EventId, KeyId, KeyName, MxcUri, RoomAliasId, RoomId, RoomOrAliasId, RoomVersionId, ServerName,
-    ServerSignatures, ServerSigningKeyId, SessionId, Signatures, SigningKeyAlgorithm,
-    TransactionId, UserId,
+    device_id, device_key_id, event_id, matrix_uri, mxc_uri, room_alias_id, room_id,
+    room_version_id, server_name, server_signing_key_id, user_id, ClientSecret, DeviceId,
+    DeviceKeyAlgorithm, DeviceKeyId, DeviceSignatures, DeviceSigningKeyId, EntitySignatures,
+    EventEncryptionAlgorithm, EventId, KeyId, KeyName, MatrixToUri, MxcUri, RoomAliasId, RoomId,
+    RoomOrAliasId, RoomVersionId, ServerName, ServerSignatures, ServerSigningKeyId, SessionId,
+    Signatures, SigningKeyAlgorithm, TransactionId, UserId,
 };
 
 #[cfg(feature = "client")]


### PR DESCRIPTION
In the process:
- Rename `MatrixToRef` to `matrix_uri::MatrixToUri`
- Add the `MatrixId` enum to own the identifier.