### PR TITLE
client-api: Rename UserIdentifier::MatrixId to UserIdOrLocalpart

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -21,6 +21,7 @@ Breaking changes:
 * Move `r0::uiaa::authorize_fallback` to `r0::uiaa::get_uiaa_fallback_page`
 * Change type of field `start` of `r0::message::get_message_events::Response` to
   `String` in accordance with the updated specification.
+* Rename `uiaa::UserIdentifier::MatrixId` variant to `uiaa::UserIdentifier::UserIdOrLocalpart`
 
 Improvements:
 

--- a/crates/ruma-client-api/src/session/login.rs
+++ b/crates/ruma-client-api/src/session/login.rs
@@ -310,7 +310,7 @@ pub mod v3 {
                     "password": "ilovebananas"
                 }))
                 .unwrap(),
-                IncomingLoginInfo::Password(IncomingPassword { identifier: IncomingUserIdentifier::MatrixId(user), password })
+                IncomingLoginInfo::Password(IncomingPassword { identifier: IncomingUserIdentifier::UserIdOrLocalpart(user), password })
                 if user == "cheeky_monkey" && password == "ilovebananas"
             );
 

--- a/crates/ruma-client-api/src/uiaa.rs
+++ b/crates/ruma-client-api/src/uiaa.rs
@@ -676,7 +676,7 @@ impl Outgoing for CustomAuthData<'_> {
 pub enum UserIdentifier<'a> {
     /// Either a fully qualified Matrix user ID, or just the localpart (as part of the 'identifier'
     /// field).
-    MatrixId(&'a str),
+    UserIdOrLocalpart(&'a str),
 
     /// Third party identifier (as part of the 'identifier' field).
     ThirdPartyId {
@@ -701,7 +701,7 @@ pub enum UserIdentifier<'a> {
 impl IncomingUserIdentifier {
     pub(crate) fn to_outgoing(&self) -> UserIdentifier<'_> {
         match self {
-            Self::MatrixId(id) => UserIdentifier::MatrixId(id),
+            Self::UserIdOrLocalpart(id) => UserIdentifier::UserIdOrLocalpart(id),
             Self::ThirdPartyId { address, medium } => {
                 UserIdentifier::ThirdPartyId { address, medium: medium.clone() }
             }

--- a/crates/ruma-client-api/src/uiaa/user_serde.rs
+++ b/crates/ruma-client-api/src/uiaa/user_serde.rs
@@ -11,7 +11,7 @@ use serde::Serialize;
 #[serde(tag = "type")]
 pub(crate) enum UserIdentifier<'a> {
     #[serde(rename = "m.id.user")]
-    MatrixId { user: &'a str },
+    UserIdOrLocalpart { user: &'a str },
     #[serde(rename = "m.id.thirdparty")]
     ThirdPartyId { medium: Medium, address: &'a str },
     #[serde(rename = "m.id.phone")]
@@ -25,7 +25,7 @@ impl<'a> From<super::UserIdentifier<'a>> for UserIdentifier<'a> {
         use super::UserIdentifier as SuperId;
 
         match id {
-            SuperId::MatrixId(user) => SerdeId::MatrixId { user },
+            SuperId::UserIdOrLocalpart(user) => SerdeId::UserIdOrLocalpart { user },
             SuperId::ThirdPartyId { address, medium } => SerdeId::ThirdPartyId { address, medium },
             SuperId::PhoneNumber { country, phone } => SerdeId::PhoneNumber { country, phone },
         }
@@ -39,7 +39,7 @@ impl From<IncomingUserIdentifier> for super::IncomingUserIdentifier {
         use super::IncomingUserIdentifier as SuperId;
 
         match id {
-            SerdeId::MatrixId { user } => SuperId::MatrixId(user),
+            SerdeId::UserIdOrLocalpart { user } => SuperId::UserIdOrLocalpart(user),
             SerdeId::ThirdPartyId { address, medium } => SuperId::ThirdPartyId { address, medium },
             SerdeId::PhoneNumber { country, phone } => SuperId::PhoneNumber { country, phone },
         }

--- a/crates/ruma-client-api/tests/uiaa.rs
+++ b/crates/ruma-client-api/tests/uiaa.rs
@@ -21,7 +21,7 @@ fn deserialize_user_identifier() {
             "user": "cheeky_monkey"
         }))
         .unwrap(),
-        IncomingUserIdentifier::MatrixId(id)
+        IncomingUserIdentifier::UserIdOrLocalpart(id)
         if id == "cheeky_monkey"
     );
 }

--- a/crates/ruma-client/src/client_api.rs
+++ b/crates/ruma-client/src/client_api.rs
@@ -30,7 +30,7 @@ impl<C: HttpClient> Client<C> {
     ) -> Result<login::v3::Response, Error<C::Error, ruma_client_api::Error>> {
         let response = self
             .send_request(assign!(login::v3::Request::new(
-                LoginInfo::Password(login::v3::Password::new(UserIdentifier::MatrixId(user), password))), {
+                LoginInfo::Password(login::v3::Password::new(UserIdentifier::UserIdOrLocalpart(user), password))), {
                 device_id,
                 initial_device_display_name,
                 }


### PR DESCRIPTION
As discussed in the matrix room