### PR TITLE
xtask: Fix VersionExt::is_next

### DIFF
--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -416,6 +416,7 @@ impl VersionExt for Version {
                 return true;
             }
 
+            next.patch = 0;
             next.minor += 1;
             if next == *version {
                 return true;
@@ -426,6 +427,7 @@ impl VersionExt for Version {
                 return true;
             }
 
+            next.minor = 0;
             next.major += 1;
             if next == *version {
                 return true;


### PR DESCRIPTION
This seemed reasonable when I wrote it, but didn't fix the issue of getting an error when trying to release `0.(x+1).0` after `0.x.0`. Any ideas? Do we need tests for our tiny automation tool now? 😅 