### PR TITLE
Add unstable path for MSC2432

### DIFF
--- a/crates/ruma-client-api/src/room/aliases.rs
+++ b/crates/ruma-client-api/src/room/aliases.rs
@@ -15,6 +15,7 @@ pub mod v3 {
             name: "aliases",
             r0_path: "/_matrix/client/r0/rooms/:room_id/aliases",
             stable_path: "/_matrix/client/v3/rooms/:room_id/aliases",
+            unstable_path: "/_matrix/client/unstable/org.matrix.msc2432/rooms/:room_id/aliases",
             rate_limited: true,
             authentication: AccessToken,
             added: 1.0,


### PR DESCRIPTION
Apparently shilidichat and element android uses this :shrug: (https://github.com/vector-im/element-android/issues/4830)

Made aware of this in the conduit room.