### PR TITLE
events: Rename MessageEvent to MessageLikeEvent

### DIFF
--- a/crates/ruma-client-api/src/message/send_message_event.rs
+++ b/crates/ruma-client-api/src/message/send_message_event.rs
@@ -6,7 +6,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/v1.2/client-server-api/#put_matrixclientv3roomsroomidsendeventtypetxnid
 
     use ruma_api::ruma_api;
-    use ruma_events::{AnyMessageEventContent, MessageEventContent};
+    use ruma_events::{AnyMessageLikeEventContent, MessageLikeEventContent};
     use ruma_identifiers::{EventId, RoomId, TransactionId};
     use ruma_serde::Raw;
     use serde_json::value::to_raw_value as to_raw_json_value;
@@ -42,7 +42,7 @@ pub mod v3 {
 
             /// The event content to send.
             #[ruma_api(body)]
-            pub body: Raw<AnyMessageEventContent>,
+            pub body: Raw<AnyMessageLikeEventContent>,
         }
 
         response: {
@@ -60,7 +60,7 @@ pub mod v3 {
         ///
         /// Since `Request` stores the request body in serialized form, this function can fail if
         /// `T`s [`Serialize`][serde::Serialize] implementation can fail.
-        pub fn new<T: MessageEventContent>(
+        pub fn new<T: MessageLikeEventContent>(
             room_id: &'a RoomId,
             txn_id: &'a TransactionId,
             content: &'a T,
@@ -79,7 +79,7 @@ pub mod v3 {
             room_id: &'a RoomId,
             txn_id: &'a TransactionId,
             event_type: &'a str,
-            body: Raw<AnyMessageEventContent>,
+            body: Raw<AnyMessageLikeEventContent>,
         ) -> Self {
             Self { room_id, event_type, txn_id, body }
         }

--- a/crates/ruma-events-macros/src/event.rs
+++ b/crates/ruma-events-macros/src/event.rs
@@ -51,7 +51,7 @@ pub fn expand_event(input: DeriveInput) -> syn::Result<TokenStream> {
         res.extend(expand_sync_from_into_full(&input, kind, var, &fields, &ruma_events));
     }
 
-    if matches!(kind, EventKind::Message | EventKind::State)
+    if matches!(kind, EventKind::MessageLike | EventKind::State)
         && matches!(var, EventKindVariation::Full | EventKindVariation::Sync)
     {
         res.extend(expand_redact_event(&input, kind, var, &fields, &ruma_events));

--- a/crates/ruma-events-macros/src/event_enum.rs
+++ b/crates/ruma-events-macros/src/event_enum.rs
@@ -30,7 +30,7 @@ pub fn expand_event_enums(input: &EventEnumDecl) -> syn::Result<TokenStream> {
     res.extend(expand_event_enum(kind, V::Full, events, attrs, variants, ruma_events));
     res.extend(expand_content_enum(kind, events, attrs, variants, ruma_events));
 
-    if matches!(kind, EventKind::Ephemeral | EventKind::Message | EventKind::State) {
+    if matches!(kind, EventKind::Ephemeral | EventKind::MessageLike | EventKind::State) {
         res.extend(expand_event_enum(kind, V::Sync, events, attrs, variants, ruma_events));
         res.extend(expand_from_full_event(kind, V::Full, variants));
         res.extend(expand_into_full_event(kind, V::Sync, variants, ruma_events));
@@ -41,7 +41,7 @@ pub fn expand_event_enums(input: &EventEnumDecl) -> syn::Result<TokenStream> {
         res.extend(expand_event_enum(kind, V::Initial, events, attrs, variants, ruma_events));
     }
 
-    if matches!(kind, EventKind::Message | EventKind::State) {
+    if matches!(kind, EventKind::MessageLike | EventKind::State) {
         res.extend(expand_event_enum(kind, V::Redacted, events, attrs, variants, ruma_events));
         res.extend(expand_event_enum(kind, V::RedactedSync, events, attrs, variants, ruma_events));
         res.extend(expand_redact(kind, V::Full, variants, ruma_events));
@@ -407,7 +407,7 @@ fn expand_possibly_redacted_enum(
 fn expand_marker_trait_impl(kind: EventKind, ruma_events: &TokenStream) -> TokenStream {
     let marker_trait = match kind {
         EventKind::State => quote! { StateEventContent },
-        EventKind::Message => quote! { MessageEventContent },
+        EventKind::MessageLike => quote! { MessageLikeEventContent },
         EventKind::Ephemeral => quote! { EphemeralRoomEventContent },
         EventKind::GlobalAccountData => quote! { GlobalAccountDataEventContent },
         EventKind::RoomAccountData => quote! { RoomAccountDataEventContent },

--- a/crates/ruma-events-macros/src/event_parse.rs
+++ b/crates/ruma-events-macros/src/event_parse.rs
@@ -80,7 +80,7 @@ pub enum EventKind {
     GlobalAccountData,
     RoomAccountData,
     Ephemeral,
-    Message,
+    MessageLike,
     State,
     ToDevice,
     RoomRedaction,
@@ -94,7 +94,7 @@ impl fmt::Display for EventKind {
             EventKind::GlobalAccountData => write!(f, "GlobalAccountDataEvent"),
             EventKind::RoomAccountData => write!(f, "RoomAccountDataEvent"),
             EventKind::Ephemeral => write!(f, "EphemeralRoomEvent"),
-            EventKind::Message => write!(f, "MessageEvent"),
+            EventKind::MessageLike => write!(f, "MessageLikeEvent"),
             EventKind::State => write!(f, "StateEvent"),
             EventKind::ToDevice => write!(f, "ToDeviceEvent"),
             EventKind::RoomRedaction => write!(f, "RoomRedactionEvent"),
@@ -130,8 +130,11 @@ impl EventKind {
 
         match (self, var) {
             (_, V::Full)
-            | (Self::Message | Self::RoomRedaction | Self::State | Self::Ephemeral, V::Sync)
-            | (Self::Message | Self::RoomRedaction | Self::State, V::Redacted | V::RedactedSync)
+            | (Self::MessageLike | Self::RoomRedaction | Self::State | Self::Ephemeral, V::Sync)
+            | (
+                Self::MessageLike | Self::RoomRedaction | Self::State,
+                V::Redacted | V::RedactedSync,
+            )
             | (Self::State, V::Stripped | V::Initial) => Some(format_ident!("{}{}", var, self)),
             _ => None,
         }
@@ -160,7 +163,7 @@ impl Parse for EventKind {
             "GlobalAccountData" => EventKind::GlobalAccountData,
             "RoomAccountData" => EventKind::RoomAccountData,
             "EphemeralRoom" => EventKind::Ephemeral,
-            "Message" => EventKind::Message,
+            "MessageLike" => EventKind::MessageLike,
             "State" => EventKind::State,
             "ToDevice" => EventKind::ToDevice,
             id => {
@@ -168,7 +171,7 @@ impl Parse for EventKind {
                     ident,
                     format!(
                         "valid event kinds are GlobalAccountData, RoomAccountData, EphemeralRoom, \
-                        Message, State, ToDevice found `{}`",
+                        MessageLike, State, ToDevice found `{}`",
                         id
                     ),
                 ));
@@ -187,10 +190,12 @@ pub fn to_kind_variation(ident: &Ident) -> Option<(EventKind, EventKindVariation
         "RoomAccountDataEvent" => Some((EventKind::RoomAccountData, EventKindVariation::Full)),
         "EphemeralRoomEvent" => Some((EventKind::Ephemeral, EventKindVariation::Full)),
         "SyncEphemeralRoomEvent" => Some((EventKind::Ephemeral, EventKindVariation::Sync)),
-        "MessageEvent" => Some((EventKind::Message, EventKindVariation::Full)),
-        "SyncMessageEvent" => Some((EventKind::Message, EventKindVariation::Sync)),
-        "RedactedMessageEvent" => Some((EventKind::Message, EventKindVariation::Redacted)),
-        "RedactedSyncMessageEvent" => Some((EventKind::Message, EventKindVariation::RedactedSync)),
+        "MessageLikeEvent" => Some((EventKind::MessageLike, EventKindVariation::Full)),
+        "SyncMessageLikeEvent" => Some((EventKind::MessageLike, EventKindVariation::Sync)),
+        "RedactedMessageLikeEvent" => Some((EventKind::MessageLike, EventKindVariation::Redacted)),
+        "RedactedSyncMessageLikeEvent" => {
+            Some((EventKind::MessageLike, EventKindVariation::RedactedSync))
+        }
         "StateEvent" => Some((EventKind::State, EventKindVariation::Full)),
         "SyncStateEvent" => Some((EventKind::State, EventKindVariation::Sync)),
         "StrippedStateEvent" => Some((EventKind::State, EventKindVariation::Stripped)),

--- a/crates/ruma-events-macros/src/event_type.rs
+++ b/crates/ruma-events-macros/src/event_type.rs
@@ -22,7 +22,7 @@ pub fn expand_event_type_enum(
             EventKind::GlobalAccountData => global_account.push(&event.events),
             EventKind::RoomAccountData => room_account.push(&event.events),
             EventKind::Ephemeral => ephemeral.push(&event.events),
-            EventKind::Message => {
+            EventKind::MessageLike => {
                 message.push(&event.events);
                 room.push(&event.events);
             }
@@ -62,7 +62,7 @@ pub fn expand_event_type_enum(
 
     let (message_event_types, message_str_ev_types) = generate_variants(&message)?;
     let message = generate_enum(
-        format_ident!("MessageEventType"),
+        format_ident!("MessageLikeEventType"),
         message_str_ev_types,
         message_event_types,
         &ruma_serde,

--- a/crates/ruma-events-macros/src/util.rs
+++ b/crates/ruma-events-macros/src/util.rs
@@ -1,7 +1,7 @@
 use crate::event_parse::{EventKind, EventKindVariation};
 
 pub(crate) fn is_non_stripped_room_event(kind: EventKind, var: EventKindVariation) -> bool {
-    matches!(kind, EventKind::Message | EventKind::State)
+    matches!(kind, EventKind::MessageLike | EventKind::State)
         && matches!(
             var,
             EventKindVariation::Full
@@ -24,12 +24,12 @@ pub(crate) type EventKindFn = fn(EventKind, EventKindVariation) -> bool;
 pub(crate) const EVENT_FIELDS: &[(&str, EventKindFn)] = &[
     ("origin_server_ts", is_non_stripped_room_event),
     ("room_id", |kind, var| {
-        matches!(kind, EventKind::Message | EventKind::State | EventKind::Ephemeral)
+        matches!(kind, EventKind::MessageLike | EventKind::State | EventKind::Ephemeral)
             && matches!(var, EventKindVariation::Full | EventKindVariation::Redacted)
     }),
     ("event_id", is_non_stripped_room_event),
     ("sender", |kind, var| {
-        matches!(kind, EventKind::Message | EventKind::State | EventKind::ToDevice)
+        matches!(kind, EventKind::MessageLike | EventKind::State | EventKind::ToDevice)
             && var != EventKindVariation::Initial
     }),
     ("state_key", |kind, _| matches!(kind, EventKind::State)),

--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [unreleased]
 
+Breaking changes:
+
+* Rename `MessageEvent` and the associated types and traits to `MessageLikeEvent`
+
 # 0.26.0
 
 Breaking changes:

--- a/crates/ruma-events/src/_custom.rs
+++ b/crates/ruma-events/src/_custom.rs
@@ -4,7 +4,7 @@ use serde_json::value::RawValue as RawJsonValue;
 
 use crate::{
     EphemeralRoomEventContent, EventContent, GlobalAccountDataEventContent, HasDeserializeFields,
-    MessageEventContent, RedactContent, RedactedEventContent, RedactedMessageEventContent,
+    MessageLikeEventContent, RedactContent, RedactedEventContent, RedactedMessageLikeEventContent,
     RedactedStateEventContent, RoomAccountDataEventContent, StateEventContent,
     ToDeviceEventContent,
 };
@@ -54,7 +54,7 @@ impl GlobalAccountDataEventContent for CustomEventContent {}
 impl RoomAccountDataEventContent for CustomEventContent {}
 impl ToDeviceEventContent for CustomEventContent {}
 impl EphemeralRoomEventContent for CustomEventContent {}
-impl MessageEventContent for CustomEventContent {}
+impl MessageLikeEventContent for CustomEventContent {}
 impl StateEventContent for CustomEventContent {}
-impl RedactedMessageEventContent for CustomEventContent {}
+impl RedactedMessageLikeEventContent for CustomEventContent {}
 impl RedactedStateEventContent for CustomEventContent {}

--- a/crates/ruma-events/src/call/answer.rs
+++ b/crates/ruma-events/src/call/answer.rs
@@ -13,7 +13,7 @@ use super::SessionDescription;
 /// This event is sent by the callee when they wish to answer the call.
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-#[ruma_event(type = "m.call.answer", kind = Message)]
+#[ruma_event(type = "m.call.answer", kind = MessageLike)]
 pub struct CallAnswerEventContent {
     /// The VoIP session description object.
     ///

--- a/crates/ruma-events/src/call/candidates.rs
+++ b/crates/ruma-events/src/call/candidates.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 /// purpose is to give the other party additional ICE candidates to try using to communicate.
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-#[ruma_event(type = "m.call.candidates", kind = Message)]
+#[ruma_event(type = "m.call.candidates", kind = MessageLike)]
 pub struct CallCandidatesEventContent {
     /// The ID of the call this event relates to.
     pub call_id: String,

--- a/crates/ruma-events/src/call/hangup.rs
+++ b/crates/ruma-events/src/call/hangup.rs
@@ -15,7 +15,7 @@ use crate::PrivOwnedStr;
 /// call has has been established or before to abort the call.
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-#[ruma_event(type = "m.call.hangup", kind = Message)]
+#[ruma_event(type = "m.call.hangup", kind = MessageLike)]
 pub struct CallHangupEventContent {
     /// The ID of the call this event relates to.
     pub call_id: String,

--- a/crates/ruma-events/src/call/invite.rs
+++ b/crates/ruma-events/src/call/invite.rs
@@ -13,7 +13,7 @@ use super::SessionDescription;
 /// This event is sent by the caller when they wish to establish a call.
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-#[ruma_event(type = "m.call.invite", kind = Message)]
+#[ruma_event(type = "m.call.invite", kind = MessageLike)]
 pub struct CallInviteEventContent {
     /// A unique identifier for the call.
     pub call_id: String,

--- a/crates/ruma-events/src/event_kinds.rs
+++ b/crates/ruma-events/src/event_kinds.rs
@@ -6,8 +6,8 @@ use ruma_identifiers::{EventId, RoomId, UserId};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    EphemeralRoomEventContent, GlobalAccountDataEventContent, MessageEventContent,
-    RedactedMessageEventContent, RedactedStateEventContent, RedactedUnsigned,
+    EphemeralRoomEventContent, GlobalAccountDataEventContent, MessageLikeEventContent,
+    RedactedMessageLikeEventContent, RedactedStateEventContent, RedactedUnsigned,
     RoomAccountDataEventContent, StateEventContent, ToDeviceEventContent, Unsigned,
 };
 
@@ -42,12 +42,12 @@ pub struct SyncEphemeralRoomEvent<C: EphemeralRoomEventContent> {
     pub content: C,
 }
 
-/// A message event.
+/// A message-like event.
 ///
-/// `MessageEvent` implements the comparison traits using only the `event_id` field, a sorted list
-/// would be sorted lexicographically based on the event's `EventId`.
+/// `MessageLikeEvent` implements the comparison traits using only the `event_id` field, a sorted
+/// list would be sorted lexicographically based on the event's `EventId`.
 #[derive(Clone, Debug, Event)]
-pub struct MessageEvent<C: MessageEventContent> {
+pub struct MessageLikeEvent<C: MessageLikeEventContent> {
     /// Data specific to the event type.
     pub content: C,
 
@@ -67,12 +67,12 @@ pub struct MessageEvent<C: MessageEventContent> {
     pub unsigned: Unsigned,
 }
 
-/// A message event without a `room_id`.
+/// A message-like event without a `room_id`.
 ///
-/// `SyncMessageEvent` implements the comparison traits using only the `event_id` field, a sorted
-/// list would be sorted lexicographically based on the event's `EventId`.
+/// `SyncMessageLikeEvent` implements the comparison traits using only the `event_id` field, a
+/// sorted list would be sorted lexicographically based on the event's `EventId`.
 #[derive(Clone, Debug, Event)]
-pub struct SyncMessageEvent<C: MessageEventContent> {
+pub struct SyncMessageLikeEvent<C: MessageLikeEventContent> {
     /// Data specific to the event type.
     pub content: C,
 
@@ -89,12 +89,12 @@ pub struct SyncMessageEvent<C: MessageEventContent> {
     pub unsigned: Unsigned,
 }
 
-/// A redacted message event.
+/// A redacted message-like event.
 ///
-/// `RedactedMessageEvent` implements the comparison traits using only the `event_id` field, a
+/// `RedactedMessageLikeEvent` implements the comparison traits using only the `event_id` field, a
 /// sorted list would be sorted lexicographically based on the event's `EventId`.
 #[derive(Clone, Debug, Event)]
-pub struct RedactedMessageEvent<C: RedactedMessageEventContent> {
+pub struct RedactedMessageLikeEvent<C: RedactedMessageLikeEventContent> {
     /// Data specific to the event type.
     pub content: C,
 
@@ -114,12 +114,12 @@ pub struct RedactedMessageEvent<C: RedactedMessageEventContent> {
     pub unsigned: RedactedUnsigned,
 }
 
-/// A redacted message event without a `room_id`.
+/// A redacted message-like event without a `room_id`.
 ///
-/// `RedactedSyncMessageEvent` implements the comparison traits using only the `event_id` field, a
-/// sorted list would be sorted lexicographically based on the event's `EventId`.
+/// `RedactedSyncMessageLikeEvent` implements the comparison traits using only the `event_id` field,
+/// a sorted list would be sorted lexicographically based on the event's `EventId`.
 #[derive(Clone, Debug, Event)]
-pub struct RedactedSyncMessageEvent<C: RedactedMessageEventContent> {
+pub struct RedactedSyncMessageLikeEvent<C: RedactedMessageLikeEventContent> {
     /// Data specific to the event type.
     pub content: C,
 
@@ -304,7 +304,7 @@ pub struct ToDeviceEvent<C: ToDeviceEventContent> {
 
 /// The decrypted payload of an `m.olm.v1.curve25519-aes-sha2` event.
 #[derive(Clone, Debug, Event)]
-pub struct DecryptedOlmV1Event<C: MessageEventContent> {
+pub struct DecryptedOlmV1Event<C: MessageLikeEventContent> {
     /// Data specific to the event type.
     pub content: C,
 
@@ -330,7 +330,7 @@ pub struct OlmV1Keys {
 
 /// The decrypted payload of an `m.megolm.v1.aes-sha2` event.
 #[derive(Clone, Debug, Event)]
-pub struct DecryptedMegolmV1Event<C: MessageEventContent> {
+pub struct DecryptedMegolmV1Event<C: MessageLikeEventContent> {
     /// Data specific to the event type.
     pub content: C,
 

--- a/crates/ruma-events/src/key/verification/accept.rs
+++ b/crates/ruma-events/src/key/verification/accept.rs
@@ -44,7 +44,7 @@ impl ToDeviceKeyVerificationAcceptEventContent {
 ///
 /// Accepts a previously sent `m.key.verification.start` message.
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
-#[ruma_event(type = "m.key.verification.accept", kind = Message)]
+#[ruma_event(type = "m.key.verification.accept", kind = MessageLike)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct KeyVerificationAcceptEventContent {
     /// The method specific content.

--- a/crates/ruma-events/src/key/verification/cancel.rs
+++ b/crates/ruma-events/src/key/verification/cancel.rs
@@ -42,7 +42,7 @@ impl ToDeviceKeyVerificationCancelEventContent {
 /// Cancels a key verification process/request.
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-#[ruma_event(type = "m.key.verification.cancel", kind = Message)]
+#[ruma_event(type = "m.key.verification.cancel", kind = MessageLike)]
 pub struct KeyVerificationCancelEventContent {
     /// A human readable description of the `code`.
     ///

--- a/crates/ruma-events/src/key/verification/done.rs
+++ b/crates/ruma-events/src/key/verification/done.rs
@@ -33,7 +33,7 @@ impl ToDeviceKeyVerificationDoneEventContent {
 /// Event signaling that the interactive key verification has successfully concluded.
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-#[ruma_event(type = "m.key.verification.done", kind = Message)]
+#[ruma_event(type = "m.key.verification.done", kind = MessageLike)]
 pub struct KeyVerificationDoneEventContent {
     /// Relation signaling which verification request this event is responding to.
     #[serde(rename = "m.relates_to")]

--- a/crates/ruma-events/src/key/verification/key.rs
+++ b/crates/ruma-events/src/key/verification/key.rs
@@ -38,7 +38,7 @@ impl ToDeviceKeyVerificationKeyEventContent {
 /// Sends the ephemeral public key for a device to the partner device.
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-#[ruma_event(type = "m.key.verification.key", kind = Message)]
+#[ruma_event(type = "m.key.verification.key", kind = MessageLike)]
 pub struct KeyVerificationKeyEventContent {
     /// The device's ephemeral public key, encoded as unpadded base64.
     pub key: Base64,

--- a/crates/ruma-events/src/key/verification/mac.rs
+++ b/crates/ruma-events/src/key/verification/mac.rs
@@ -50,7 +50,7 @@ impl ToDeviceKeyVerificationMacEventContent {
 /// Sends the MAC of a device's key to the partner device.
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-#[ruma_event(type = "m.key.verification.mac", kind = Message)]
+#[ruma_event(type = "m.key.verification.mac", kind = MessageLike)]
 pub struct KeyVerificationMacEventContent {
     /// A map of the key ID to the MAC of the key, using the algorithm in the verification process.
     ///

--- a/crates/ruma-events/src/key/verification/ready.rs
+++ b/crates/ruma-events/src/key/verification/ready.rs
@@ -46,7 +46,7 @@ impl ToDeviceKeyVerificationReadyEventContent {
 /// Response to a previously sent `m.key.verification.request` message.
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-#[ruma_event(type = "m.key.verification.ready", kind = Message)]
+#[ruma_event(type = "m.key.verification.ready", kind = MessageLike)]
 pub struct KeyVerificationReadyEventContent {
     /// The device ID which is initiating the request.
     pub from_device: Box<DeviceId>,

--- a/crates/ruma-events/src/key/verification/start.rs
+++ b/crates/ruma-events/src/key/verification/start.rs
@@ -54,7 +54,7 @@ impl ToDeviceKeyVerificationStartEventContent {
 /// Begins an SAS key verification process.
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-#[ruma_event(type = "m.key.verification.start", kind = Message)]
+#[ruma_event(type = "m.key.verification.start", kind = MessageLike)]
 pub struct KeyVerificationStartEventContent {
     /// The device ID which is initiating the process.
     pub from_device: Box<DeviceId>,

--- a/crates/ruma-events/src/lib.rs
+++ b/crates/ruma-events/src/lib.rs
@@ -25,7 +25,7 @@
 //! ruma-events includes Rust types for every one of the event types in the Matrix specification.
 //! To better organize the crate, these types live in separate modules with a hierarchy that
 //! matches the reverse domain name notation of the event type.
-//! For example, the `m.room.message` event lives at `ruma_events::room::message::MessageEvent`.
+//! For example, the `m.room.message` event lives at `ruma_events::room::message::MessageLikeEvent`.
 //! Each type's module also contains a Rust type for that event type's `content` field, and any
 //! other supporting types required by the event's other fields.
 //!
@@ -49,10 +49,10 @@
 //! `ruma::api::client::state::send_state_event`'s `Request`.
 //!
 //! As a more advanced example we create a reaction message event. For this event we will use a
-//! `SyncMessageEvent` struct but any `MessageEvent` struct would work.
+//! `SyncMessageLikeEvent` struct but any `MessageLikeEvent` struct would work.
 //!
 //! ```rust
-//! use ruma_events::{macros::EventContent, SyncMessageEvent};
+//! use ruma_events::{macros::EventContent, SyncMessageLikeEvent};
 //! use ruma_identifiers::EventId;
 //! use serde::{Deserialize, Serialize};
 //!
@@ -75,7 +75,7 @@
 //!
 //! /// The payload for our reaction event.
 //! #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
-//! #[ruma_event(type = "m.reaction", kind = Message)]
+//! #[ruma_event(type = "m.reaction", kind = MessageLike)]
 //! pub struct ReactionEventContent {
 //!     #[serde(rename = "m.relates_to")]
 //!     pub relates_to: RelatesTo,
@@ -101,8 +101,8 @@
 //! // The downside of this event is we cannot use it with event enums,
 //! // but could be deserialized from a `Raw<_>` that has failed to deserialize.
 //! matches::assert_matches!(
-//!     serde_json::from_value::<SyncMessageEvent<ReactionEventContent>>(json),
-//!     Ok(SyncMessageEvent {
+//!     serde_json::from_value::<SyncMessageLikeEvent<ReactionEventContent>>(json),
+//!     Ok(SyncMessageLikeEvent {
 //!         content: ReactionEventContent {
 //!             relates_to: RelatesTo::Annotation { key, .. },
 //!         },
@@ -267,8 +267,8 @@ pub trait RoomAccountDataEventContent: EventContent {}
 /// Marker trait for the content of a to device event.
 pub trait ToDeviceEventContent: EventContent {}
 
-/// Marker trait for the content of a message event.
-pub trait MessageEventContent: EventContent {}
+/// Marker trait for the content of a message-like event.
+pub trait MessageLikeEventContent: EventContent {}
 
 /// Marker trait for the content of a state event.
 pub trait StateEventContent: EventContent {}
@@ -277,7 +277,7 @@ pub trait StateEventContent: EventContent {}
 ///
 /// This trait's associated functions and methods should not be used to build
 /// redacted events, prefer the `redact` method on `AnyStateEvent` and
-/// `AnyMessageEvent` and their "sync" and "stripped" counterparts. The
+/// `AnyMessageLikeEvent` and their "sync" and "stripped" counterparts. The
 /// `RedactedEventContent` trait is an implementation detail, ruma makes no
 /// API guarantees.
 pub trait RedactedEventContent: EventContent {
@@ -298,8 +298,8 @@ pub trait RedactedEventContent: EventContent {
     fn has_deserialize_fields() -> HasDeserializeFields;
 }
 
-/// Marker trait for the content of a redacted message event.
-pub trait RedactedMessageEventContent: RedactedEventContent {}
+/// Marker trait for the content of a redacted message-like event.
+pub trait RedactedMessageLikeEventContent: RedactedEventContent {}
 
 /// Marker trait for the content of a redacted state event.
 pub trait RedactedStateEventContent: RedactedEventContent {}
@@ -333,11 +333,12 @@ pub enum EventKind {
     /// Ephemeral room event kind.
     EphemeralRoomData,
 
-    /// Message event kind.
+    /// Message-like event kind.
     ///
-    /// Since redacted / non-redacted message events are used in the same places bu have different
-    /// sets of fields, these two variations are treated as two closely-related event kinds.
-    Message {
+    /// Since redacted / non-redacted message-like events are used in the same places bu have
+    /// different sets of fields, these two variations are treated as two closely-related event
+    /// kinds.
+    MessageLike {
         /// Redacted variation?
         redacted: bool,
     },

--- a/crates/ruma-events/src/reaction.rs
+++ b/crates/ruma-events/src/reaction.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 /// A reaction to another event.
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-#[ruma_event(type = "m.reaction", kind = Message)]
+#[ruma_event(type = "m.reaction", kind = MessageLike)]
 pub struct ReactionEventContent {
     /// Information about the related event.
     #[serde(rename = "m.relates_to")]

--- a/crates/ruma-events/src/room/encrypted.rs
+++ b/crates/ruma-events/src/room/encrypted.rs
@@ -16,7 +16,7 @@ mod relation_serde;
 /// The content of an `m.room.encrypted` event.
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-#[ruma_event(type = "m.room.encrypted", kind = Message, kind = ToDevice)]
+#[ruma_event(type = "m.room.encrypted", kind = MessageLike, kind = ToDevice)]
 pub struct RoomEncryptedEventContent {
     /// Algorithm-specific fields.
     #[serde(flatten)]

--- a/crates/ruma-events/src/room/message.rs
+++ b/crates/ruma-events/src/room/message.rs
@@ -28,7 +28,7 @@ pub use reply::ReplyBaseEvent;
 /// Messages are not limited to be text.
 #[derive(Clone, Debug, Serialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-#[ruma_event(type = "m.room.message", kind = Message)]
+#[ruma_event(type = "m.room.message", kind = MessageLike)]
 pub struct RoomMessageEventContent {
     /// A key which identifies the type of message being sent.
     ///
@@ -103,7 +103,7 @@ impl RoomMessageEventContent {
     /// Different from `text_reply_plain`, this constructor requires specifically a
     /// [`RoomMessageEvent`] since it creates a permalink to the previous message, for which the
     /// room ID is required. If you want to reply to a [`SyncRoomMessageEvent`], you have to convert
-    /// it first by calling [`.into_full_event()`][crate::SyncMessageEvent::into_full_event].
+    /// it first by calling [`.into_full_event()`][crate::SyncMessageLikeEvent::into_full_event].
     pub fn text_reply_html(
         reply: impl fmt::Display,
         html_reply: impl fmt::Display,
@@ -144,7 +144,7 @@ impl RoomMessageEventContent {
     /// Different from `notice_reply_plain`, this constructor requires specifically a
     /// [`RoomMessageEvent`] since it creates a permalink to the previous message, for which the
     /// room ID is required. If you want to reply to a [`SyncRoomMessageEvent`], you have to convert
-    /// it first by calling [`.into_full_event()`][crate::SyncMessageEvent::into_full_event].
+    /// it first by calling [`.into_full_event()`][crate::SyncMessageLikeEvent::into_full_event].
     pub fn notice_reply_html(
         reply: impl fmt::Display,
         html_reply: impl fmt::Display,

--- a/crates/ruma-events/src/room/message/feedback.rs
+++ b/crates/ruma-events/src/room/message/feedback.rs
@@ -17,7 +17,7 @@ use crate::PrivOwnedStr;
 /// not recognize this event.
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-#[ruma_event(type = "m.room.message.feedback", kind = Message)]
+#[ruma_event(type = "m.room.message.feedback", kind = MessageLike)]
 pub struct RoomMessageFeedbackEventContent {
     /// The event that this feedback is related to.
     pub target_event_id: Box<EventId>,

--- a/crates/ruma-events/src/room/message/reply.rs
+++ b/crates/ruma-events/src/room/message/reply.rs
@@ -7,8 +7,9 @@ use super::{
 
 /// An event that can be replied to.
 ///
-/// This trait only exists to allow the plain-text `reply` constructors on `MessageEventContent` to
-/// use either a [`RoomMessageEvent`] or a [`SyncRoomMessageEvent`] as the event being replied to.
+/// This trait only exists to allow the plain-text `reply` constructors on `MessageLikeEventContent`
+/// to use either a [`RoomMessageEvent`] or a [`SyncRoomMessageEvent`] as the event being replied
+/// to.
 pub trait ReplyBaseEvent {
     #[doc(hidden)]
     fn event_id(&self) -> &EventId;

--- a/crates/ruma-events/src/room/redaction.rs
+++ b/crates/ruma-events/src/room/redaction.rs
@@ -151,7 +151,7 @@ pub struct RedactedSyncRoomRedactionEvent {
 /// A redaction of an event.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-#[ruma_event(type = "m.room.redaction", kind = Message)]
+#[ruma_event(type = "m.room.redaction", kind = MessageLike)]
 pub struct RoomRedactionEventContent {
     /// The reason for the redaction, if any.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/ruma-events/src/sticker.rs
+++ b/crates/ruma-events/src/sticker.rs
@@ -13,7 +13,7 @@ use crate::room::ImageInfo;
 /// A sticker message.
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-#[ruma_event(type = "m.sticker", kind = Message)]
+#[ruma_event(type = "m.sticker", kind = MessageLike)]
 pub struct StickerEventContent {
     /// A textual representation or associated description of the sticker image.
     ///

--- a/crates/ruma-events/tests/enums.rs
+++ b/crates/ruma-events/tests/enums.rs
@@ -11,10 +11,11 @@ use ruma_events::{
         message::{MessageType, RoomMessageEventContent, TextMessageEventContent},
         power_levels::RoomPowerLevelsEventContent,
     },
-    AnyEphemeralRoomEvent, AnyMessageEvent, AnyRoomEvent, AnyStateEvent, AnyStateEventContent,
-    AnySyncMessageEvent, AnySyncRoomEvent, AnySyncStateEvent, EphemeralRoomEventType, EventType,
-    GlobalAccountDataEventType, MessageEvent, MessageEventType, RoomAccountDataEventType,
-    StateEvent, StateEventType, SyncMessageEvent, SyncStateEvent, ToDeviceEventType, Unsigned,
+    AnyEphemeralRoomEvent, AnyMessageLikeEvent, AnyRoomEvent, AnyStateEvent, AnyStateEventContent,
+    AnySyncMessageLikeEvent, AnySyncRoomEvent, AnySyncStateEvent, EphemeralRoomEventType,
+    EventType, GlobalAccountDataEventType, MessageLikeEvent, MessageLikeEventType,
+    RoomAccountDataEventType, StateEvent, StateEventType, SyncMessageLikeEvent, SyncStateEvent,
+    ToDeviceEventType, Unsigned,
 };
 
 fn message_event() -> JsonValue {
@@ -139,8 +140,8 @@ fn message_event_sync_deserialization() {
 
     assert_matches!(
         from_json_value::<AnySyncRoomEvent>(json_data),
-        Ok(AnySyncRoomEvent::Message(
-            AnySyncMessageEvent::RoomMessage(SyncMessageEvent {
+        Ok(AnySyncRoomEvent::MessageLike(
+            AnySyncMessageLikeEvent::RoomMessage(SyncMessageLikeEvent {
                 content: RoomMessageEventContent {
                     msgtype: MessageType::Text(TextMessageEventContent {
                         body,
@@ -181,8 +182,8 @@ fn message_room_event_deserialization() {
 
     assert_matches!(
         from_json_value::<AnyRoomEvent>(json_data),
-        Ok(AnyRoomEvent::Message(
-            AnyMessageEvent::RoomMessage(MessageEvent {
+        Ok(AnyRoomEvent::MessageLike(
+            AnyMessageLikeEvent::RoomMessage(MessageLikeEvent {
                 content: RoomMessageEventContent {
                     msgtype: MessageType::Text(TextMessageEventContent {
                         body,
@@ -200,7 +201,7 @@ fn message_room_event_deserialization() {
 
 #[test]
 fn message_event_serialization() {
-    let event = MessageEvent {
+    let event = MessageLikeEvent {
         content: RoomMessageEventContent::text_plain("test"),
         event_id: event_id!("$1234:example.com").to_owned(),
         origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(0)),
@@ -240,8 +241,8 @@ fn message_event_deserialization() {
 
     assert_matches!(
         from_json_value::<AnyRoomEvent>(json_data),
-        Ok(AnyRoomEvent::Message(
-            AnyMessageEvent::RoomMessage(MessageEvent {
+        Ok(AnyRoomEvent::MessageLike(
+            AnyMessageLikeEvent::RoomMessage(MessageLikeEvent {
                 content: RoomMessageEventContent {
                     msgtype: MessageType::Text(TextMessageEventContent {
                         body,
@@ -323,7 +324,7 @@ fn ephemeral_event_deserialization() {
 #[test]
 fn serialize_and_deserialize_from_display_form() {
     serde_json_eq(EventType::CallAnswer, json!("m.call.answer"));
-    serde_json_eq(MessageEventType::CallAnswer, json!("m.call.answer"));
+    serde_json_eq(MessageLikeEventType::CallAnswer, json!("m.call.answer"));
     serde_json_eq(EventType::CallCandidates, json!("m.call.candidates"));
     serde_json_eq(EventType::CallHangup, json!("m.call.hangup"));
     serde_json_eq(EventType::CallInvite, json!("m.call.invite"));

--- a/crates/ruma-events/tests/event_enums.rs
+++ b/crates/ruma-events/tests/event_enums.rs
@@ -6,7 +6,7 @@ use serde_json::{from_value as from_json_value, json};
 
 use ruma_events::{
     call::{answer::CallAnswerEventContent, SessionDescription, SessionDescriptionType},
-    AnyMessageEvent, MessageEvent,
+    AnyMessageLikeEvent, MessageLikeEvent,
 };
 
 #[test]
@@ -36,9 +36,9 @@ fn deserialize_message_event() {
     });
 
     assert_matches!(
-        from_json_value::<AnyMessageEvent>(json_data)
+        from_json_value::<AnyMessageLikeEvent>(json_data)
             .unwrap(),
-        AnyMessageEvent::CallAnswer(MessageEvent {
+        AnyMessageLikeEvent::CallAnswer(MessageLikeEvent {
             content: CallAnswerEventContent {
                 answer: SessionDescription {
                     session_type: SessionDescriptionType::Answer,

--- a/crates/ruma-events/tests/message_event.rs
+++ b/crates/ruma-events/tests/message_event.rs
@@ -6,7 +6,8 @@ use ruma_events::{
     call::{answer::CallAnswerEventContent, SessionDescription, SessionDescriptionType},
     room::{ImageInfo, ThumbnailInfo},
     sticker::StickerEventContent,
-    AnyMessageEvent, AnyMessageEventContent, AnySyncMessageEvent, MessageEvent, RawExt, Unsigned,
+    AnyMessageLikeEvent, AnyMessageLikeEventContent, AnySyncMessageLikeEvent, MessageLikeEvent,
+    RawExt, Unsigned,
 };
 use ruma_identifiers::{event_id, mxc_uri, room_id, user_id};
 use ruma_serde::Raw;
@@ -14,7 +15,7 @@ use serde_json::{from_value as from_json_value, json, to_value as to_json_value}
 
 #[test]
 fn message_serialize_sticker() {
-    let aliases_event = MessageEvent {
+    let aliases_event = MessageLikeEvent {
         content: StickerEventContent::new(
             "Hello".into(),
             assign!(ImageInfo::new(), {
@@ -80,11 +81,11 @@ fn deserialize_message_call_answer_content() {
     });
 
     assert_matches!(
-        from_json_value::<Raw<AnyMessageEventContent>>(json_data)
+        from_json_value::<Raw<AnyMessageLikeEventContent>>(json_data)
             .unwrap()
             .deserialize_content("m.call.answer")
             .unwrap(),
-        AnyMessageEventContent::CallAnswer(CallAnswerEventContent {
+        AnyMessageLikeEventContent::CallAnswer(CallAnswerEventContent {
             answer: SessionDescription {
                 session_type: SessionDescriptionType::Answer,
                 sdp,
@@ -116,8 +117,8 @@ fn deserialize_message_call_answer() {
     });
 
     assert_matches!(
-        from_json_value::<AnyMessageEvent>(json_data).unwrap(),
-        AnyMessageEvent::CallAnswer(MessageEvent {
+        from_json_value::<AnyMessageLikeEvent>(json_data).unwrap(),
+        AnyMessageLikeEvent::CallAnswer(MessageLikeEvent {
             content: CallAnswerEventContent {
                 answer: SessionDescription {
                     session_type: SessionDescriptionType::Answer,
@@ -170,8 +171,8 @@ fn deserialize_message_sticker() {
     });
 
     assert_matches!(
-        from_json_value::<AnyMessageEvent>(json_data).unwrap(),
-        AnyMessageEvent::Sticker(MessageEvent {
+        from_json_value::<AnyMessageLikeEvent>(json_data).unwrap(),
+        AnyMessageLikeEvent::Sticker(MessageLikeEvent {
             content: StickerEventContent {
                 body,
                 info: ImageInfo {
@@ -240,11 +241,11 @@ fn deserialize_message_then_convert_to_full() {
         "type": "m.call.answer"
     });
 
-    let sync_ev: AnySyncMessageEvent = from_json_value(json_data).unwrap();
+    let sync_ev: AnySyncMessageLikeEvent = from_json_value(json_data).unwrap();
 
     assert_matches!(
         sync_ev.into_full_event(rid.to_owned()),
-        AnyMessageEvent::CallAnswer(MessageEvent {
+        AnyMessageLikeEvent::CallAnswer(MessageLikeEvent {
             content: CallAnswerEventContent {
                 answer: SessionDescription {
                     session_type: SessionDescriptionType::Answer,

--- a/crates/ruma-events/tests/redacted.rs
+++ b/crates/ruma-events/tests/redacted.rs
@@ -8,10 +8,10 @@ use ruma_events::{
         message::{RedactedRoomMessageEventContent, RoomMessageEventContent},
         redaction::{RoomRedactionEventContent, SyncRoomRedactionEvent},
     },
-    AnyMessageEvent, AnyRedactedMessageEvent, AnyRedactedSyncMessageEvent,
+    AnyMessageLikeEvent, AnyRedactedMessageLikeEvent, AnyRedactedSyncMessageLikeEvent,
     AnyRedactedSyncStateEvent, AnyRoomEvent, AnySyncRoomEvent, EventContent, Redact, RedactContent,
-    RedactedMessageEvent, RedactedSyncMessageEvent, RedactedSyncStateEvent, RedactedUnsigned,
-    Unsigned,
+    RedactedMessageLikeEvent, RedactedSyncMessageLikeEvent, RedactedSyncStateEvent,
+    RedactedUnsigned, Unsigned,
 };
 use ruma_identifiers::{event_id, room_id, user_id, RoomVersionId};
 use serde_json::{
@@ -35,7 +35,7 @@ fn unsigned() -> RedactedUnsigned {
 
 #[test]
 fn redacted_message_event_serialize() {
-    let redacted = RedactedSyncMessageEvent {
+    let redacted = RedactedSyncMessageLikeEvent {
         content: RedactedRoomMessageEventContent::new(),
         event_id: event_id!("$h29iv0s8:example.com").to_owned(),
         origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(1)),
@@ -144,7 +144,7 @@ fn redacted_deserialize_any_room() {
 
     assert_matches!(
         from_json_value::<AnyRoomEvent>(actual).unwrap(),
-        AnyRoomEvent::RedactedMessage(AnyRedactedMessageEvent::RoomMessage(RedactedMessageEvent {
+        AnyRoomEvent::RedactedMessageLike(AnyRedactedMessageLikeEvent::RoomMessage(RedactedMessageLikeEvent {
             content: RedactedRoomMessageEventContent { .. },
             event_id, room_id, ..
         })) if event_id == event_id!("$h29iv0s8:example.com")
@@ -179,8 +179,8 @@ fn redacted_deserialize_any_room_sync() {
 
     assert_matches!(
         from_json_value::<AnySyncRoomEvent>(actual).unwrap(),
-        AnySyncRoomEvent::RedactedMessage(AnyRedactedSyncMessageEvent::RoomMessage(
-            RedactedSyncMessageEvent {
+        AnySyncRoomEvent::RedactedMessageLike(AnyRedactedSyncMessageLikeEvent::RoomMessage(
+            RedactedSyncMessageLikeEvent {
                 content: RedactedRoomMessageEventContent { .. },
                 event_id,
                 ..
@@ -267,11 +267,11 @@ fn redact_method_properly_redacts() {
         unsigned: Unsigned::default(),
     };
 
-    let event: AnyMessageEvent = from_json_value(ev).unwrap();
+    let event: AnyMessageLikeEvent = from_json_value(ev).unwrap();
 
     assert_matches!(
         event.redact(redaction, &RoomVersionId::V6),
-        AnyRedactedMessageEvent::RoomMessage(RedactedMessageEvent {
+        AnyRedactedMessageLikeEvent::RoomMessage(RedactedMessageLikeEvent {
             content: RedactedRoomMessageEventContent { .. },
             event_id,
             room_id,

--- a/crates/ruma-events/tests/redaction.rs
+++ b/crates/ruma-events/tests/redaction.rs
@@ -3,7 +3,7 @@ use matches::assert_matches;
 use ruma_common::MilliSecondsSinceUnixEpoch;
 use ruma_events::{
     room::redaction::{RoomRedactionEvent, RoomRedactionEventContent},
-    AnyMessageEvent, Unsigned,
+    AnyMessageLikeEvent, Unsigned,
 };
 use ruma_identifiers::{event_id, room_id, user_id};
 use serde_json::{
@@ -47,8 +47,8 @@ fn deserialize_redaction() {
     let json_data = redaction();
 
     assert_matches!(
-        from_json_value::<AnyMessageEvent>(json_data).unwrap(),
-        AnyMessageEvent::RoomRedaction(RoomRedactionEvent {
+        from_json_value::<AnyMessageLikeEvent>(json_data).unwrap(),
+        AnyMessageLikeEvent::RoomRedaction(RoomRedactionEvent {
             content: RoomRedactionEventContent { reason: Some(reas), .. },
             redacts,
             event_id,

--- a/crates/ruma-events/tests/ui/09-enum-invalid-kind.stderr
+++ b/crates/ruma-events/tests/ui/09-enum-invalid-kind.stderr
@@ -1,4 +1,4 @@
-error: valid event kinds are GlobalAccountData, RoomAccountData, EphemeralRoom, Message, State, ToDevice found `NotReal`
+error: valid event kinds are GlobalAccountData, RoomAccountData, EphemeralRoom, MessageLike, State, ToDevice found `NotReal`
  --> $DIR/09-enum-invalid-kind.rs:4:10
   |
 4 |     enum NotReal {

--- a/crates/ruma/examples/message_log.rs
+++ b/crates/ruma/examples/message_log.rs
@@ -5,7 +5,7 @@ use ruma::{
     api::client::{filter::FilterDefinition, sync::sync_events},
     events::{
         room::message::{MessageType, RoomMessageEventContent, TextMessageEventContent},
-        AnySyncMessageEvent, AnySyncRoomEvent, SyncMessageEvent,
+        AnySyncMessageLikeEvent, AnySyncRoomEvent, SyncMessageLikeEvent,
     },
     presence::PresenceState,
 };
@@ -42,8 +42,8 @@ async fn log_messages(
         for (room_id, room) in res.rooms.join {
             for event in room.timeline.events.into_iter().flat_map(|r| r.deserialize()) {
                 // Filter out the text messages
-                if let AnySyncRoomEvent::Message(AnySyncMessageEvent::RoomMessage(
-                    SyncMessageEvent {
+                if let AnySyncRoomEvent::MessageLike(AnySyncMessageLikeEvent::RoomMessage(
+                    SyncMessageLikeEvent {
                         content:
                             RoomMessageEventContent {
                                 msgtype:

--- a/examples/joke_bot/src/main.rs
+++ b/examples/joke_bot/src/main.rs
@@ -9,7 +9,7 @@ use ruma::{
     assign, client,
     events::{
         room::message::{MessageType, RoomMessageEventContent},
-        AnySyncMessageEvent, AnySyncRoomEvent,
+        AnySyncMessageLikeEvent, AnySyncRoomEvent,
     },
     identifiers::TransactionId,
     presence::PresenceState,
@@ -147,7 +147,9 @@ async fn handle_message(
     room_id: &RoomId,
     bot_user_id: &UserId,
 ) -> Result<(), Box<dyn Error>> {
-    if let Ok(AnySyncRoomEvent::Message(AnySyncMessageEvent::RoomMessage(m))) = e.deserialize() {
+    if let Ok(AnySyncRoomEvent::MessageLike(AnySyncMessageLikeEvent::RoomMessage(m))) =
+        e.deserialize()
+    {
         // workaround because Conduit does not implement filtering.
         if m.sender == bot_user_id {
             return Ok(());


### PR DESCRIPTION
Renames the associated types and traits too.

This is to avoid collision with the new `m.message` type introduced by MSC1767.