### PR TITLE
client-api: Add device_id and is_guest to account::whoami::Response

### DIFF
--- a/crates/ruma-client-api/src/account/whoami.rs
+++ b/crates/ruma-client-api/src/account/whoami.rs
@@ -30,6 +30,10 @@ pub mod v3 {
             /// The device ID associated with the access token, if any.
             #[serde(skip_serializing_if = "Option::is_none")]
             pub device_id: Option<Box<DeviceId>>,
+
+            /// If `true`, the user is a guest user.
+            #[serde(default, skip_serializing_if = "ruma_serde::is_default")]
+            pub is_guest: bool,
         }
 
         error: crate::Error
@@ -44,8 +48,8 @@ pub mod v3 {
 
     impl Response {
         /// Creates a new `Response` with the given user ID.
-        pub fn new(user_id: Box<UserId>) -> Self {
-            Self { user_id, device_id: None }
+        pub fn new(user_id: Box<UserId>, is_guest: bool) -> Self {
+            Self { user_id, device_id: None, is_guest }
         }
     }
 }

--- a/crates/ruma-client-api/src/account/whoami.rs
+++ b/crates/ruma-client-api/src/account/whoami.rs
@@ -6,7 +6,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/v1.2/client-server-api/#get_matrixclientv3accountwhoami
 
     use ruma_api::ruma_api;
-    use ruma_identifiers::UserId;
+    use ruma_identifiers::{DeviceId, UserId};
 
     ruma_api! {
         metadata: {
@@ -26,6 +26,10 @@ pub mod v3 {
         response: {
             /// The id of the user that owns the access token.
             pub user_id: Box<UserId>,
+
+            /// The device ID associated with the access token, if any.
+            #[serde(skip_serializing_if = "Option::is_none")]
+            pub device_id: Option<Box<DeviceId>>,
         }
 
         error: crate::Error
@@ -41,7 +45,7 @@ pub mod v3 {
     impl Response {
         /// Creates a new `Response` with the given user ID.
         pub fn new(user_id: Box<UserId>) -> Self {
-            Self { user_id }
+            Self { user_id, device_id: None }
         }
     }
 }


### PR DESCRIPTION
- First commit from [MSC2033](https://github.com/matrix-org/matrix-doc/pull/2033), part of #808.
- Second commit from [MSC3069](https://github.com/matrix-org/matrix-doc/pull/3069), part of #849.