### PR TITLE
client-api: Fix thirdparty_id_creds according to clarification in spec

### DIFF
--- a/crates/ruma-client-api/src/uiaa.rs
+++ b/crates/ruma-client-api/src/uiaa.rs
@@ -412,12 +412,8 @@ impl IncomingReCaptcha {
 #[serde(tag = "type", rename = "m.login.email.identity")]
 pub struct EmailIdentity<'a> {
     /// Thirdparty identifier credentials.
-    #[serde(rename = "threepidCreds")]
-    #[cfg_attr(
-        feature = "compat",
-        serde(alias = "threepid_creds", deserialize_with = "deserialize_thirdparty_id_creds")
-    )]
-    pub thirdparty_id_creds: &'a [ThirdpartyIdCredentials],
+    #[serde(rename = "threepid_creds")]
+    pub thirdparty_id_creds: &'a ThirdpartyIdCredentials,
 
     /// The value of the session key given by the homeserver, if any.
     pub session: Option<&'a str>,
@@ -443,12 +439,8 @@ impl IncomingEmailIdentity {
 #[serde(tag = "type", rename = "m.login.msisdn")]
 pub struct Msisdn<'a> {
     /// Thirdparty identifier credentials.
-    #[serde(rename = "threepidCreds")]
-    #[cfg_attr(
-        feature = "compat",
-        serde(alias = "threepid_creds", deserialize_with = "deserialize_thirdparty_id_creds")
-    )]
-    pub thirdparty_id_creds: &'a [ThirdpartyIdCredentials],
+    #[serde(rename = "threepid_creds")]
+    pub thirdparty_id_creds: &'a ThirdpartyIdCredentials,
 
     /// The value of the session key given by the homeserver, if any.
     pub session: Option<&'a str>,
@@ -745,41 +737,4 @@ impl OutgoingResponse for UiaaResponse {
             UiaaResponse::MatrixError(error) => error.try_into_http_response(),
         }
     }
-}
-
-#[cfg(feature = "compat")]
-fn deserialize_thirdparty_id_creds<'de, D>(
-    deserializer: D,
-) -> Result<Vec<ThirdpartyIdCredentials>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    use de::value::{MapAccessDeserializer, SeqAccessDeserializer};
-
-    struct CredsVisitor;
-
-    impl<'de> de::Visitor<'de> for CredsVisitor {
-        type Value = Vec<ThirdpartyIdCredentials>;
-
-        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-            formatter.write_str("an array or object")
-        }
-
-        fn visit_seq<A>(self, seq: A) -> Result<Self::Value, A::Error>
-        where
-            A: de::SeqAccess<'de>,
-        {
-            <Vec<ThirdpartyIdCredentials>>::deserialize(SeqAccessDeserializer::new(seq))
-        }
-
-        fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
-        where
-            A: de::MapAccess<'de>,
-        {
-            let creds = ThirdpartyIdCredentials::deserialize(MapAccessDeserializer::new(map))?;
-            Ok(vec![creds])
-        }
-    }
-
-    deserializer.deserialize_any(CredsVisitor)
 }


### PR DESCRIPTION
The field name is `threepid_creds` and it is an object.
Details are in https://github.com/matrix-org/matrix-doc/pull/3471.

This is aligned with Synapse's behavior so the compatibility code is removed.

Part of #808.