### PR TITLE
common: Add join_rule to directory::PublicRoomsChunk

### DIFF
--- a/crates/ruma-common/src/directory.rs
+++ b/crates/ruma-common/src/directory.rs
@@ -59,6 +59,10 @@ pub struct PublicRoomsChunk {
         serde(default, deserialize_with = "ruma_serde::empty_string_as_none")
     )]
     pub avatar_url: Option<Box<MxcUri>>,
+
+    /// The join rule of the room.
+    #[serde(default, skip_serializing_if = "ruma_serde::is_default")]
+    pub join_rule: PublicRoomJoinRule,
 }
 
 /// Initial set of mandatory fields of `PublicRoomsChunk`.
@@ -97,6 +101,7 @@ impl From<PublicRoomsChunkInit> for PublicRoomsChunk {
             world_readable,
             guest_can_join,
             avatar_url: None,
+            join_rule: PublicRoomJoinRule::default(),
         }
     }
 }
@@ -220,6 +225,29 @@ impl<'de> Visitor<'de> for RoomNetworkVisitor {
                 None => IncomingRoomNetwork::Matrix,
             })
         }
+    }
+}
+
+/// The rule used for users wishing to join a public room.
+///
+/// This type can hold an arbitrary string. To check for formats that are not available as a
+/// documented variant here, use its string representation, obtained through `.as_str()`.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+#[serde(tag = "join_rule")]
+pub enum PublicRoomJoinRule {
+    /// Users can request an invite to the room.
+    #[serde(rename = "knock")]
+    Knock,
+
+    /// Anyone can join the room without any prior action.
+    #[serde(rename = "public")]
+    Public,
+}
+
+impl Default for PublicRoomJoinRule {
+    fn default() -> Self {
+        Self::Public
     }
 }
 

--- a/crates/ruma-common/src/directory.rs
+++ b/crates/ruma-common/src/directory.rs
@@ -4,13 +4,15 @@ use std::fmt;
 
 use js_int::UInt;
 use ruma_identifiers::{MxcUri, RoomAliasId, RoomId, RoomName};
-use ruma_serde::Outgoing;
+use ruma_serde::{Outgoing, StringEnum};
 use serde::{
     de::{Error, MapAccess, Visitor},
     ser::SerializeStruct,
     Deserialize, Deserializer, Serialize, Serializer,
 };
 use serde_json::Value as JsonValue;
+
+use crate::PrivOwnedStr;
 
 /// A chunk of a room list response, describing one room.
 ///
@@ -230,19 +232,27 @@ impl<'de> Visitor<'de> for RoomNetworkVisitor {
 
 /// The rule used for users wishing to join a public room.
 ///
-/// This type can hold an arbitrary string. To check for formats that are not available as a
+/// This type can hold an arbitrary string. To check for join rules that are not available as a
 /// documented variant here, use its string representation, obtained through `.as_str()`.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
+#[ruma_enum(rename_all = "snake_case")]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-#[serde(tag = "join_rule")]
 pub enum PublicRoomJoinRule {
     /// Users can request an invite to the room.
-    #[serde(rename = "knock")]
     Knock,
 
     /// Anyone can join the room without any prior action.
-    #[serde(rename = "public")]
     Public,
+
+    #[doc(hidden)]
+    _Custom(PrivOwnedStr),
+}
+
+impl PublicRoomJoinRule {
+    /// Returns the string name of this `PublicRoomJoinRule`.
+    pub fn as_str(&self) -> &str {
+        self.as_ref()
+    }
 }
 
 impl Default for PublicRoomJoinRule {


### PR DESCRIPTION
Creates a new `PublicRoomJoinRule` type as only two values are expected.

According to [MSC2403](https://github.com/matrix-org/matrix-doc/pull/2403).

Part of #808.