### PR TITLE
identity-api: Add room_type to store_invitation::Request

### DIFF
--- a/crates/ruma-client-api/src/room/create_room.rs
+++ b/crates/ruma-client-api/src/room/create_room.rs
@@ -7,9 +7,10 @@ pub mod v3 {
 
     use assign::assign;
     use ruma_api::ruma_api;
+    use ruma_common::room::RoomType;
     use ruma_events::{
         room::{
-            create::{PreviousRoom, RoomCreateEventContent, RoomType},
+            create::{PreviousRoom, RoomCreateEventContent},
             power_levels::RoomPowerLevelsEventContent,
         },
         AnyInitialStateEvent,

--- a/crates/ruma-common/src/lib.rs
+++ b/crates/ruma-common/src/lib.rs
@@ -12,6 +12,7 @@ pub mod power_levels;
 pub mod presence;
 pub mod push;
 pub mod receipt;
+pub mod room;
 pub mod thirdparty;
 mod time;
 pub mod to_device;

--- a/crates/ruma-common/src/room.rs
+++ b/crates/ruma-common/src/room.rs
@@ -1,0 +1,28 @@
+//! Common types for rooms.
+
+use ruma_serde::StringEnum;
+
+use crate::PrivOwnedStr;
+
+/// An enum of possible room types.
+///
+/// This type can hold an arbitrary string. To check for room types that are not available as a
+/// documented variant here, use its string representation, obtained through `.as_str()`.
+#[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
+#[non_exhaustive]
+pub enum RoomType {
+    /// Defines the room as a space.
+    #[ruma_enum(rename = "m.space")]
+    Space,
+
+    /// Defines the room as a custom type.
+    #[doc(hidden)]
+    _Custom(PrivOwnedStr),
+}
+
+impl RoomType {
+    /// Creates a string slice from this `RoomType`.
+    pub fn as_str(&self) -> &str {
+        self.as_ref()
+    }
+}

--- a/crates/ruma-events/src/room/create.rs
+++ b/crates/ruma-events/src/room/create.rs
@@ -2,12 +2,10 @@
 //!
 //! [`m.room.create`]: https://spec.matrix.org/v1.2/client-server-api/#mroomcreate
 
+use ruma_common::room::RoomType;
 use ruma_events_macros::EventContent;
 use ruma_identifiers::{EventId, RoomId, RoomVersionId, UserId};
-use ruma_serde::StringEnum;
 use serde::{Deserialize, Serialize};
-
-use crate::PrivOwnedStr;
 
 /// The content of an `m.room.create` event.
 ///
@@ -59,29 +57,6 @@ impl RoomCreateEventContent {
             predecessor: None,
             room_type: None,
         }
-    }
-}
-
-/// An enum of possible room types.
-///
-/// This type can hold an arbitrary string. To check for formats that are not available as a
-/// documented variant here, use its string representation, obtained through `.as_str()`.
-#[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
-#[non_exhaustive]
-pub enum RoomType {
-    /// Defines the room as a space.
-    #[ruma_enum(rename = "m.space")]
-    Space,
-
-    /// Defines the room as a custom type.
-    #[doc(hidden)]
-    _Custom(PrivOwnedStr),
-}
-
-impl RoomType {
-    /// Creates a string slice from this `RoomType`.
-    pub fn as_str(&self) -> &str {
-        self.as_ref()
     }
 }
 

--- a/crates/ruma-identity-service-api/src/invitation/store_invitation.rs
+++ b/crates/ruma-identity-service-api/src/invitation/store_invitation.rs
@@ -8,7 +8,7 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/v1.2/identity-service-api/#post_matrixidentityv2store-invite
 
     use ruma_api::ruma_api;
-    use ruma_common::thirdparty::Medium;
+    use ruma_common::{room::RoomType, thirdparty::Medium};
     use ruma_identifiers::{MxcUri, RoomAliasId, RoomId, RoomName, UserId};
     use serde::{ser::SerializeSeq, Deserialize, Serialize};
 
@@ -62,6 +62,12 @@ pub mod v2 {
             #[serde(skip_serializing_if = "Option::is_none")]
             pub room_name: Option<&'a RoomName>,
 
+            /// The type of the room to which the user is invited.
+            ///
+            /// This should be retrieved from the `m.room.create` state event.
+            #[serde(skip_serializing_if = "Option::is_none")]
+            pub room_type: Option<&'a RoomType>,
+
             /// The display name of the user ID initiating the invite.
             #[serde(skip_serializing_if = "Option::is_none")]
             pub sender_display_name: Option<&'a str>,
@@ -105,6 +111,7 @@ pub mod v2 {
                 room_avatar_url: None,
                 room_join_rules: None,
                 room_name: None,
+                room_type: None,
                 sender_display_name: None,
                 sender_avatar_url: None,
             }


### PR DESCRIPTION
Moves `ruma_events::room::create::RoomType` to `ruma_common::room::RoomType`.

According to [MSC3288](https://github.com/matrix-org/matrix-doc/pull/3288).

Part of #849.