### PR TITLE
Specify default-members for virtual workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,4 @@
 [workspace]
 members = ["crates/*", "examples/*", "xtask"]
+# xtask should only be compiled when invoked explicitly
+default-members = ["crates/*", "examples/*"]

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -71,7 +71,7 @@ impl CiTask {
         cmd!("rustup run stable cargo check -p ruma-identifiers --no-default-features").run()?;
 
         // 2. Run tests
-        let workspace_res = cmd!("rustup run stable cargo test --workspace --features __ci").run();
+        let workspace_res = cmd!("rustup run stable cargo test --features __ci").run();
         let events_compat_res =
             cmd!("rustup run stable cargo test -p ruma-events --features compat compat").run();
 


### PR DESCRIPTION
… and don't have `cargo test` compile xtask which doesn't have any tests.