### PR TITLE
macros: Use import_ruma_common instead of import_ruma_api

### DIFF
--- a/crates/ruma-common/src/api.rs
+++ b/crates/ruma-common/src/api.rs
@@ -193,19 +193,6 @@ use crate::UserId;
 pub use ruma_macros::ruma_api;
 
 pub mod error;
-/// This module is used to support the generated code from ruma-macros.
-/// It is not considered part of ruma-common's public API.
-#[doc(hidden)]
-pub mod exports {
-    pub use bytes;
-    pub use http;
-    pub use percent_encoding;
-    pub use ruma_macros;
-    pub use ruma_serde;
-    pub use serde;
-    pub use serde_json;
-}
-
 mod metadata;
 
 pub use metadata::{MatrixVersion, Metadata};

--- a/crates/ruma-common/src/lib.rs
+++ b/crates/ruma-common/src/lib.rs
@@ -60,6 +60,12 @@ impl fmt::Debug for PrivOwnedStr {
 /// It is not considered part of this module's public API.
 #[doc(hidden)]
 pub mod exports {
+    #[cfg(feature = "api")]
+    pub use bytes;
+    #[cfg(feature = "api")]
+    pub use http;
+    pub use percent_encoding;
+    pub use ruma_macros;
     pub use ruma_serde;
     pub use serde;
     pub use serde_json;

--- a/crates/ruma-macros/src/api/api_request.rs
+++ b/crates/ruma-macros/src/api/api_request.rs
@@ -71,10 +71,10 @@ impl Request {
         &self,
         metadata: &Metadata,
         error_ty: &TokenStream,
-        ruma_api: &TokenStream,
+        ruma_common: &TokenStream,
     ) -> TokenStream {
-        let ruma_macros = quote! { #ruma_api::exports::ruma_macros };
-        let ruma_serde = quote! { #ruma_api::exports::ruma_serde };
+        let ruma_macros = quote! { #ruma_common::exports::ruma_macros };
+        let ruma_serde = quote! { #ruma_common::exports::ruma_serde };
 
         let docs = format!(
             "Data for a request to the `{}` API endpoint.\n\n{}",

--- a/crates/ruma-macros/src/api/request.rs
+++ b/crates/ruma-macros/src/api/request.rs
@@ -16,8 +16,9 @@ use syn::{
 use super::{
     attribute::{Meta, MetaNameValue, MetaValue},
     auth_scheme::AuthScheme,
-    util::{collect_lifetime_idents, import_ruma_api},
+    util::collect_lifetime_idents,
 };
+use crate::util::import_ruma_common;
 
 mod incoming;
 mod outgoing;
@@ -196,10 +197,10 @@ impl Request {
     }
 
     fn expand_all(&self) -> TokenStream {
-        let ruma_api = import_ruma_api();
-        let ruma_macros = quote! { #ruma_api::exports::ruma_macros };
-        let ruma_serde = quote! { #ruma_api::exports::ruma_serde };
-        let serde = quote! { #ruma_api::exports::serde };
+        let ruma_common = import_ruma_common();
+        let ruma_macros = quote! { #ruma_common::exports::ruma_macros };
+        let ruma_serde = quote! { #ruma_common::exports::ruma_serde };
+        let serde = quote! { #ruma_common::exports::serde };
 
         let request_body_struct = self.has_body_fields().then(|| {
             let serde_attr = self.has_newtype_body().then(|| quote! { #[serde(transparent)] });
@@ -253,8 +254,8 @@ impl Request {
             }
         });
 
-        let outgoing_request_impl = self.expand_outgoing(&ruma_api);
-        let incoming_request_impl = self.expand_incoming(&ruma_api);
+        let outgoing_request_impl = self.expand_outgoing(&ruma_common);
+        let incoming_request_impl = self.expand_incoming(&ruma_common);
 
         quote! {
             #request_body_struct

--- a/crates/ruma-macros/src/api/request/incoming.rs
+++ b/crates/ruma-macros/src/api/request/incoming.rs
@@ -6,11 +6,11 @@ use super::{Request, RequestField};
 use crate::api::auth_scheme::AuthScheme;
 
 impl Request {
-    pub fn expand_incoming(&self, ruma_api: &TokenStream) -> TokenStream {
-        let http = quote! { #ruma_api::exports::http };
-        let ruma_serde = quote! { #ruma_api::exports::ruma_serde };
-        let serde = quote! { #ruma_api::exports::serde };
-        let serde_json = quote! { #ruma_api::exports::serde_json };
+    pub fn expand_incoming(&self, ruma_common: &TokenStream) -> TokenStream {
+        let http = quote! { #ruma_common::exports::http };
+        let ruma_serde = quote! { #ruma_common::exports::ruma_serde };
+        let serde = quote! { #ruma_common::exports::serde };
+        let serde_json = quote! { #ruma_common::exports::serde_json };
 
         let method = &self.method;
         let error_ty = &self.error_ty;
@@ -104,7 +104,7 @@ impl Request {
                             quote! { str_value.to_owned() },
                             quote! {
                                 return Err(
-                                    #ruma_api::error::HeaderDeserializationError::MissingHeader(
+                                    #ruma_common::api::error::HeaderDeserializationError::MissingHeader(
                                         #header_name_string.into()
                                     ).into(),
                                 )
@@ -187,29 +187,29 @@ impl Request {
             quote! {
                 #[automatically_derived]
                 #[cfg(feature = "server")]
-                impl #ruma_api::IncomingNonAuthRequest for #incoming_request_type {}
+                impl #ruma_common::api::IncomingNonAuthRequest for #incoming_request_type {}
             }
         });
 
         quote! {
             #[automatically_derived]
             #[cfg(feature = "server")]
-            impl #ruma_api::IncomingRequest for #incoming_request_type {
+            impl #ruma_common::api::IncomingRequest for #incoming_request_type {
                 type EndpointError = #error_ty;
                 type OutgoingResponse = Response;
 
-                const METADATA: #ruma_api::Metadata = self::METADATA;
+                const METADATA: #ruma_common::api::Metadata = self::METADATA;
 
                 fn try_from_http_request<B, S>(
                     request: #http::Request<B>,
                     path_args: &[S],
-                ) -> ::std::result::Result<Self, #ruma_api::error::FromHttpRequestError>
+                ) -> ::std::result::Result<Self, #ruma_common::api::error::FromHttpRequestError>
                 where
                     B: ::std::convert::AsRef<[::std::primitive::u8]>,
                     S: ::std::convert::AsRef<::std::primitive::str>,
                 {
                     if request.method() != #http::Method::#method {
-                        return Err(#ruma_api::error::FromHttpRequestError::MethodMismatch {
+                        return Err(#ruma_common::api::error::FromHttpRequestError::MethodMismatch {
                             expected: #http::Method::#method,
                             received: request.method().clone(),
                         });

--- a/crates/ruma-macros/src/api/response.rs
+++ b/crates/ruma-macros/src/api/response.rs
@@ -13,10 +13,8 @@ use syn::{
     DeriveInput, Field, Generics, Ident, Lifetime, Token, Type,
 };
 
-use super::{
-    attribute::{Meta, MetaNameValue},
-    util,
-};
+use super::attribute::{Meta, MetaNameValue};
+use crate::util::import_ruma_common;
 
 mod incoming;
 mod outgoing;
@@ -95,10 +93,10 @@ impl Response {
     }
 
     fn expand_all(&self) -> TokenStream {
-        let ruma_api = util::import_ruma_api();
-        let ruma_macros = quote! { #ruma_api::exports::ruma_macros };
-        let ruma_serde = quote! { #ruma_api::exports::ruma_serde };
-        let serde = quote! { #ruma_api::exports::serde };
+        let ruma_common = import_ruma_common();
+        let ruma_macros = quote! { #ruma_common::exports::ruma_macros };
+        let ruma_serde = quote! { #ruma_common::exports::ruma_serde };
+        let serde = quote! { #ruma_common::exports::serde };
 
         let response_body_struct = (!self.has_raw_body()).then(|| {
             let serde_derives = self.manual_body_serde.not().then(|| {
@@ -121,8 +119,8 @@ impl Response {
             }
         });
 
-        let outgoing_response_impl = self.expand_outgoing(&ruma_api);
-        let incoming_response_impl = self.expand_incoming(&self.error_ty, &ruma_api);
+        let outgoing_response_impl = self.expand_outgoing(&ruma_common);
+        let incoming_response_impl = self.expand_incoming(&self.error_ty, &ruma_common);
 
         quote! {
             #response_body_struct

--- a/crates/ruma-macros/src/api/response/outgoing.rs
+++ b/crates/ruma-macros/src/api/response/outgoing.rs
@@ -4,10 +4,10 @@ use quote::quote;
 use super::{Response, ResponseField};
 
 impl Response {
-    pub fn expand_outgoing(&self, ruma_api: &TokenStream) -> TokenStream {
-        let bytes = quote! { #ruma_api::exports::bytes };
-        let http = quote! { #ruma_api::exports::http };
-        let ruma_serde = quote! { #ruma_api::exports::ruma_serde };
+    pub fn expand_outgoing(&self, ruma_common: &TokenStream) -> TokenStream {
+        let bytes = quote! { #ruma_common::exports::bytes };
+        let http = quote! { #ruma_common::exports::http };
+        let ruma_serde = quote! { #ruma_common::exports::ruma_serde };
 
         let serialize_response_headers = self.fields.iter().filter_map(|response_field| {
             response_field.as_header_field().map(|(field, header_name)| {
@@ -64,10 +64,10 @@ impl Response {
         quote! {
             #[automatically_derived]
             #[cfg(feature = "server")]
-            impl #ruma_api::OutgoingResponse for Response {
+            impl #ruma_common::api::OutgoingResponse for Response {
                 fn try_into_http_response<T: ::std::default::Default + #bytes::BufMut>(
                     self,
-                ) -> ::std::result::Result<#http::Response<T>, #ruma_api::error::IntoHttpError> {
+                ) -> ::std::result::Result<#http::Response<T>, #ruma_common::api::error::IntoHttpError> {
                     let mut resp_builder = #http::Response::builder()
                         .header(#http::header::CONTENT_TYPE, "application/json");
 

--- a/crates/ruma-macros/src/api/util.rs
+++ b/crates/ruma-macros/src/api/util.rs
@@ -3,27 +3,8 @@
 use std::collections::BTreeSet;
 
 use proc_macro2::{Ident, Span, TokenStream};
-use proc_macro_crate::{crate_name, FoundCrate};
-use quote::{format_ident, quote, ToTokens};
+use quote::{quote, ToTokens};
 use syn::{parse_quote, visit::Visit, Attribute, Lifetime, NestedMeta, Type};
-
-pub fn import_ruma_api() -> TokenStream {
-    if let Ok(FoundCrate::Name(name)) = crate_name("ruma-common") {
-        let import = format_ident!("{}", name);
-        quote! { ::#import::api }
-    } else if let Ok(FoundCrate::Name(name)) = crate_name("ruma") {
-        let import = format_ident!("{}", name);
-        quote! { ::#import::api }
-    } else if let Ok(FoundCrate::Name(name)) = crate_name("matrix-sdk") {
-        let import = format_ident!("{}", name);
-        quote! { ::#import::ruma::api }
-    } else if let Ok(FoundCrate::Name(name)) = crate_name("matrix-sdk-appservice") {
-        let import = format_ident!("{}", name);
-        quote! { ::#import::ruma::api }
-    } else {
-        quote! { ::ruma_common::api }
-    }
-}
 
 pub fn map_option_literal<T: ToTokens>(ver: &Option<T>) -> TokenStream {
     match ver {


### PR DESCRIPTION
This is gonna simplify the merge of ruma-serde into ruma-common.