### PR TITLE
Use *EventType in more places

### DIFF
--- a/crates/ruma-client-api/src/config/set_global_account_data.rs
+++ b/crates/ruma-client-api/src/config/set_global_account_data.rs
@@ -7,7 +7,7 @@ pub mod v3 {
 
     use ruma_common::{
         api::ruma_api,
-        events::{AnyGlobalAccountDataEventContent, GlobalAccountDataEventContent},
+        events::{AnyGlobalAccountDataEventContent, EventContent, GlobalAccountDataEventType},
         serde::Raw,
         UserId,
     };
@@ -58,10 +58,10 @@ pub mod v3 {
         ///
         /// Since `Request` stores the request body in serialized form, this function can fail if
         /// `T`s [`Serialize`][serde::Serialize] implementation can fail.
-        pub fn new<T: GlobalAccountDataEventContent>(
-            data: &'a T,
-            user_id: &'a UserId,
-        ) -> serde_json::Result<Self> {
+        pub fn new<T>(data: &'a T, user_id: &'a UserId) -> serde_json::Result<Self>
+        where
+            T: EventContent<EventType = GlobalAccountDataEventType>,
+        {
             Ok(Self {
                 user_id,
                 event_type: data.event_type(),

--- a/crates/ruma-client-api/src/config/set_global_account_data.rs
+++ b/crates/ruma-client-api/src/config/set_global_account_data.rs
@@ -36,7 +36,7 @@ pub mod v3 {
             ///
             /// Custom types should be namespaced to avoid clashes.
             #[ruma_api(path)]
-            pub event_type: &'a str,
+            pub event_type: GlobalAccountDataEventType,
 
             /// Arbitrary JSON to store as config data.
             ///
@@ -72,7 +72,7 @@ pub mod v3 {
         /// Creates a new `Request` with the given raw data, event type and user ID.
         pub fn new_raw(
             data: Raw<AnyGlobalAccountDataEventContent>,
-            event_type: &'a str,
+            event_type: GlobalAccountDataEventType,
             user_id: &'a UserId,
         ) -> Self {
             Self { user_id, event_type, data }

--- a/crates/ruma-client-api/src/config/set_room_account_data.rs
+++ b/crates/ruma-client-api/src/config/set_room_account_data.rs
@@ -36,7 +36,7 @@ pub mod v3 {
             ///
             /// Custom types should be namespaced to avoid clashes.
             #[ruma_api(path)]
-            pub event_type: &'a str,
+            pub event_type: RoomAccountDataEventType,
 
             /// The ID of the room to set account_data on.
             #[ruma_api(path)]
@@ -81,7 +81,7 @@ pub mod v3 {
         /// Creates a new `Request` with the given raw data, event type, room ID and user ID.
         pub fn new_raw(
             data: Raw<AnyRoomAccountDataEventContent>,
-            event_type: &'a str,
+            event_type: RoomAccountDataEventType,
             room_id: &'a RoomId,
             user_id: &'a UserId,
         ) -> Self {

--- a/crates/ruma-client-api/src/config/set_room_account_data.rs
+++ b/crates/ruma-client-api/src/config/set_room_account_data.rs
@@ -7,7 +7,7 @@ pub mod v3 {
 
     use ruma_common::{
         api::ruma_api,
-        events::{AnyRoomAccountDataEventContent, RoomAccountDataEventContent},
+        events::{AnyRoomAccountDataEventContent, EventContent, RoomAccountDataEventType},
         serde::Raw,
         RoomId, UserId,
     };
@@ -62,11 +62,14 @@ pub mod v3 {
         ///
         /// Since `Request` stores the request body in serialized form, this function can fail if
         /// `T`s [`Serialize`][serde::Serialize] implementation can fail.
-        pub fn new<T: RoomAccountDataEventContent>(
+        pub fn new<T>(
             data: &'a T,
             room_id: &'a RoomId,
             user_id: &'a UserId,
-        ) -> serde_json::Result<Self> {
+        ) -> serde_json::Result<Self>
+        where
+            T: EventContent<EventType = RoomAccountDataEventType>,
+        {
             Ok(Self {
                 data: Raw::from_json(to_raw_json_value(data)?),
                 event_type: data.event_type(),

--- a/crates/ruma-client-api/src/message/send_message_event.rs
+++ b/crates/ruma-client-api/src/message/send_message_event.rs
@@ -7,7 +7,7 @@ pub mod v3 {
 
     use ruma_common::{
         api::ruma_api,
-        events::{AnyMessageLikeEventContent, MessageLikeEventContent},
+        events::{AnyMessageLikeEventContent, EventContent, MessageLikeEventType},
         serde::Raw,
         EventId, RoomId, TransactionId,
     };
@@ -62,11 +62,14 @@ pub mod v3 {
         ///
         /// Since `Request` stores the request body in serialized form, this function can fail if
         /// `T`s [`Serialize`][serde::Serialize] implementation can fail.
-        pub fn new<T: MessageLikeEventContent>(
+        pub fn new<T>(
             room_id: &'a RoomId,
             txn_id: &'a TransactionId,
             content: &'a T,
-        ) -> serde_json::Result<Self> {
+        ) -> serde_json::Result<Self>
+        where
+            T: EventContent<EventType = MessageLikeEventType>,
+        {
             Ok(Self {
                 room_id,
                 txn_id,

--- a/crates/ruma-client-api/src/message/send_message_event.rs
+++ b/crates/ruma-client-api/src/message/send_message_event.rs
@@ -32,7 +32,7 @@ pub mod v3 {
 
             /// The type of event to send.
             #[ruma_api(path)]
-            pub event_type: &'a str,
+            pub event_type: MessageLikeEventType,
 
             /// The transaction ID for this event.
             ///
@@ -83,7 +83,7 @@ pub mod v3 {
         pub fn new_raw(
             room_id: &'a RoomId,
             txn_id: &'a TransactionId,
-            event_type: &'a str,
+            event_type: MessageLikeEventType,
             body: Raw<AnyMessageLikeEventContent>,
         ) -> Self {
             Self { room_id, event_type, txn_id, body }

--- a/crates/ruma-client-api/src/state/get_state_events_for_key.rs
+++ b/crates/ruma-client-api/src/state/get_state_events_for_key.rs
@@ -7,7 +7,7 @@ pub mod v3 {
 
     use ruma_common::{
         api::ruma_api,
-        events::{AnyStateEventContent, EventType},
+        events::{AnyStateEventContent, StateEventType},
         serde::{Outgoing, Raw},
         RoomId,
     };
@@ -47,7 +47,7 @@ pub mod v3 {
         pub room_id: &'a RoomId,
 
         /// The type of state to look up.
-        pub event_type: EventType,
+        pub event_type: StateEventType,
 
         /// The key of the state to look up.
         pub state_key: &'a str,
@@ -55,7 +55,7 @@ pub mod v3 {
 
     impl<'a> Request<'a> {
         /// Creates a new `Request` with the given room ID, event type and state key.
-        pub fn new(room_id: &'a RoomId, event_type: EventType, state_key: &'a str) -> Self {
+        pub fn new(room_id: &'a RoomId, event_type: StateEventType, state_key: &'a str) -> Self {
             Self { room_id, event_type, state_key }
         }
     }
@@ -144,7 +144,7 @@ pub mod v3 {
         {
             // FIXME: find a way to make this if-else collapse with serde recognizing trailing
             // Option
-            let (room_id, event_type, state_key): (Box<RoomId>, EventType, String) =
+            let (room_id, event_type, state_key): (Box<RoomId>, StateEventType, String) =
                 if path_args.len() == 3 {
                     serde::Deserialize::deserialize(serde::de::value::SeqDeserializer::<
                         _,

--- a/crates/ruma-client-api/src/state/send_state_event.rs
+++ b/crates/ruma-client-api/src/state/send_state_event.rs
@@ -44,7 +44,7 @@ pub mod v3 {
         pub room_id: &'a RoomId,
 
         /// The type of event to send.
-        pub event_type: &'a str,
+        pub event_type: StateEventType,
 
         /// The state_key for the state to send.
         pub state_key: &'a str,
@@ -80,7 +80,7 @@ pub mod v3 {
         /// content.
         pub fn new_raw(
             room_id: &'a RoomId,
-            event_type: &'a str,
+            event_type: StateEventType,
             state_key: &'a str,
             body: Raw<AnyStateEventContent>,
         ) -> Self {
@@ -114,7 +114,8 @@ pub mod v3 {
             use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 
             let room_id_percent = utf8_percent_encode(self.room_id.as_str(), NON_ALPHANUMERIC);
-            let event_type_percent = utf8_percent_encode(self.event_type, NON_ALPHANUMERIC);
+            let event_type_percent =
+                utf8_percent_encode(self.event_type.as_str(), NON_ALPHANUMERIC);
 
             let mut url = format!(
                 "{}{}",
@@ -173,25 +174,25 @@ pub mod v3 {
         {
             // FIXME: find a way to make this if-else collapse with serde recognizing trailing
             // Option
-            let (room_id, event_type, state_key): (Box<RoomId>, String, String) = if path_args.len()
-                == 3
-            {
-                serde::Deserialize::deserialize(serde::de::value::SeqDeserializer::<
-                    _,
-                    serde::de::value::Error,
-                >::new(
-                    path_args.iter().map(::std::convert::AsRef::as_ref),
-                ))?
-            } else {
-                let (a, b) = serde::Deserialize::deserialize(serde::de::value::SeqDeserializer::<
-                    _,
-                    serde::de::value::Error,
-                >::new(
-                    path_args.iter().map(::std::convert::AsRef::as_ref),
-                ))?;
+            let (room_id, event_type, state_key): (Box<RoomId>, StateEventType, String) =
+                if path_args.len() == 3 {
+                    serde::Deserialize::deserialize(serde::de::value::SeqDeserializer::<
+                        _,
+                        serde::de::value::Error,
+                    >::new(
+                        path_args.iter().map(::std::convert::AsRef::as_ref),
+                    ))?
+                } else {
+                    let (a, b) =
+                        serde::Deserialize::deserialize(serde::de::value::SeqDeserializer::<
+                            _,
+                            serde::de::value::Error,
+                        >::new(
+                            path_args.iter().map(::std::convert::AsRef::as_ref),
+                        ))?;
 
-                (a, b, "".into())
-            };
+                    (a, b, "".into())
+                };
 
             let body = serde_json::from_slice(request.body().as_ref())?;
 

--- a/crates/ruma-client-api/src/state/send_state_event.rs
+++ b/crates/ruma-client-api/src/state/send_state_event.rs
@@ -7,7 +7,7 @@ pub mod v3 {
 
     use ruma_common::{
         api::ruma_api,
-        events::{AnyStateEventContent, StateEventContent},
+        events::{AnyStateEventContent, EventContent, StateEventType},
         serde::{Outgoing, Raw},
         EventId, RoomId,
     };
@@ -60,11 +60,14 @@ pub mod v3 {
         ///
         /// Since `Request` stores the request body in serialized form, this function can fail if
         /// `T`s [`Serialize`][serde::Serialize] implementation can fail.
-        pub fn new<T: StateEventContent>(
+        pub fn new<T>(
             room_id: &'a RoomId,
             state_key: &'a str,
             content: &'a T,
-        ) -> serde_json::Result<Self> {
+        ) -> serde_json::Result<Self>
+        where
+            T: EventContent<EventType = StateEventType>,
+        {
             Ok(Self {
                 room_id,
                 state_key,

--- a/crates/ruma-common/src/events.rs
+++ b/crates/ruma-common/src/events.rs
@@ -200,10 +200,10 @@ pub use self::{
 /// Use [`macros::EventContent`] to derive this traits. It is not meant to be implemented manually.
 pub trait EventContent: Sized + Serialize {
     /// The Rust enum for the event kind's known types.
-    type EventType;
+    type EventType: AsRef<str>;
 
     /// Get the event's type, like `m.room.message`.
-    fn event_type(&self) -> &str;
+    fn event_type(&self) -> Self::EventType;
 
     /// Constructs the given event content.
     #[doc(hidden)]
@@ -238,8 +238,8 @@ pub trait RedactContent {
 
 impl<T: EventContent> Raw<T> {
     /// Try to deserialize the JSON as an event's content.
-    pub fn deserialize_content(&self, event_type: &str) -> serde_json::Result<T> {
-        T::from_parts(event_type, self.json())
+    pub fn deserialize_content(&self, event_type: T::EventType) -> serde_json::Result<T> {
+        T::from_parts(event_type.as_ref(), self.json())
     }
 }
 

--- a/crates/ruma-common/src/events.rs
+++ b/crates/ruma-common/src/events.rs
@@ -197,12 +197,16 @@ pub use self::{
 
 /// The base trait that all event content types implement.
 ///
-/// Implementing this trait allows content types to be serialized as well as deserialized.
+/// Use [`macros::EventContent`] to derive this traits. It is not meant to be implemented manually.
 pub trait EventContent: Sized + Serialize {
-    /// A matrix event identifier, like `m.room.message`.
+    /// The Rust enum for the event kind's known types.
+    type EventType;
+
+    /// Get the event's type, like `m.room.message`.
     fn event_type(&self) -> &str;
 
     /// Constructs the given event content.
+    #[doc(hidden)]
     fn from_parts(event_type: &str, content: &RawJsonValue) -> serde_json::Result<Self>;
 }
 
@@ -239,24 +243,6 @@ impl<T: EventContent> Raw<T> {
     }
 }
 
-/// Marker trait for the content of an ephemeral room event.
-pub trait EphemeralRoomEventContent: EventContent {}
-
-/// Marker trait for the content of a global account data event.
-pub trait GlobalAccountDataEventContent: EventContent {}
-
-/// Marker trait for the content of a room account data event.
-pub trait RoomAccountDataEventContent: EventContent {}
-
-/// Marker trait for the content of a to device event.
-pub trait ToDeviceEventContent: EventContent {}
-
-/// Marker trait for the content of a message-like event.
-pub trait MessageLikeEventContent: EventContent {}
-
-/// Marker trait for the content of a state event.
-pub trait StateEventContent: EventContent {}
-
 /// The base trait that all redacted event content types implement.
 ///
 /// This trait's associated functions and methods should not be used to build
@@ -281,12 +267,6 @@ pub trait RedactedEventContent: EventContent {
     #[doc(hidden)]
     fn has_deserialize_fields() -> HasDeserializeFields;
 }
-
-/// Marker trait for the content of a redacted message-like event.
-pub trait RedactedMessageLikeEventContent: RedactedEventContent {}
-
-/// Marker trait for the content of a redacted state event.
-pub trait RedactedStateEventContent: RedactedEventContent {}
 
 /// Trait for abstracting over event content structs.
 ///

--- a/crates/ruma-common/src/events/_custom.rs
+++ b/crates/ruma-common/src/events/_custom.rs
@@ -2,59 +2,69 @@ use serde::Serialize;
 use serde_json::value::RawValue as RawJsonValue;
 
 use super::{
-    EphemeralRoomEventContent, EventContent, GlobalAccountDataEventContent, HasDeserializeFields,
-    MessageLikeEventContent, RedactContent, RedactedEventContent, RedactedMessageLikeEventContent,
-    RedactedStateEventContent, RoomAccountDataEventContent, StateEventContent,
-    ToDeviceEventContent,
+    EphemeralRoomEventType, EventContent, GlobalAccountDataEventType, HasDeserializeFields,
+    MessageLikeEventType, RedactContent, RedactedEventContent, RoomAccountDataEventType,
+    StateEventType, ToDeviceEventType,
 };
 use crate::RoomVersionId;
 
-/// A custom event's type. Used for event enum `_Custom` variants.
-// FIXME: Serialize shouldn't be required here, but it's currently a supertrait of EventContent
-#[derive(Clone, Debug, Serialize)]
-#[allow(clippy::exhaustive_structs)]
-pub struct CustomEventContent {
-    #[serde(skip)]
-    event_type: Box<str>,
+macro_rules! custom_event_content {
+    ($i:ident, $evt:ident) => {
+        /// A custom event's type. Used for event enum `_Custom` variants.
+        // FIXME: Serialize shouldn't be required here, but it's currently a supertrait of
+        // EventContent
+        #[derive(Clone, Debug, Serialize)]
+        #[allow(clippy::exhaustive_structs)]
+        pub struct $i {
+            #[serde(skip)]
+            event_type: Box<str>,
+        }
+
+        impl EventContent for $i {
+            type EventType = $evt;
+
+            fn event_type(&self) -> &str {
+                &self.event_type
+            }
+
+            fn from_parts(event_type: &str, _content: &RawJsonValue) -> serde_json::Result<Self> {
+                Ok(Self { event_type: event_type.into() })
+            }
+        }
+    };
 }
 
-impl RedactContent for CustomEventContent {
-    type Redacted = Self;
+macro_rules! custom_room_event_content {
+    ($i:ident, $evt:ident) => {
+        custom_event_content!($i, $evt);
 
-    fn redact(self, _: &RoomVersionId) -> Self {
-        self
-    }
+        impl RedactContent for $i {
+            type Redacted = Self;
+
+            fn redact(self, _: &RoomVersionId) -> Self {
+                self
+            }
+        }
+
+        impl RedactedEventContent for $i {
+            fn empty(event_type: &str) -> serde_json::Result<Self> {
+                Ok(Self { event_type: event_type.into() })
+            }
+
+            fn has_serialize_fields(&self) -> bool {
+                false
+            }
+
+            fn has_deserialize_fields() -> HasDeserializeFields {
+                HasDeserializeFields::False
+            }
+        }
+    };
 }
 
-impl EventContent for CustomEventContent {
-    fn event_type(&self) -> &str {
-        &self.event_type
-    }
-
-    fn from_parts(event_type: &str, _content: &RawJsonValue) -> serde_json::Result<Self> {
-        Ok(Self { event_type: event_type.into() })
-    }
-}
-
-impl RedactedEventContent for CustomEventContent {
-    fn empty(event_type: &str) -> serde_json::Result<Self> {
-        Ok(Self { event_type: event_type.into() })
-    }
-
-    fn has_serialize_fields(&self) -> bool {
-        false
-    }
-
-    fn has_deserialize_fields() -> HasDeserializeFields {
-        HasDeserializeFields::False
-    }
-}
-
-impl GlobalAccountDataEventContent for CustomEventContent {}
-impl RoomAccountDataEventContent for CustomEventContent {}
-impl ToDeviceEventContent for CustomEventContent {}
-impl EphemeralRoomEventContent for CustomEventContent {}
-impl MessageLikeEventContent for CustomEventContent {}
-impl StateEventContent for CustomEventContent {}
-impl RedactedMessageLikeEventContent for CustomEventContent {}
-impl RedactedStateEventContent for CustomEventContent {}
+custom_event_content!(CustomGlobalAccountDataEventContent, GlobalAccountDataEventType);
+custom_event_content!(CustomRoomAccountDataEventContent, RoomAccountDataEventType);
+custom_event_content!(CustomEphemeralRoomEventContent, EphemeralRoomEventType);
+custom_room_event_content!(CustomMessageLikeEventContent, MessageLikeEventType);
+custom_room_event_content!(CustomStateEventContent, StateEventType);
+custom_event_content!(CustomToDeviceEventContent, ToDeviceEventType);

--- a/crates/ruma-common/src/events/_custom.rs
+++ b/crates/ruma-common/src/events/_custom.rs
@@ -23,8 +23,8 @@ macro_rules! custom_event_content {
         impl EventContent for $i {
             type EventType = $evt;
 
-            fn event_type(&self) -> &str {
-                &self.event_type
+            fn event_type(&self) -> Self::EventType {
+                self.event_type[..].into()
             }
 
             fn from_parts(event_type: &str, _content: &RawJsonValue) -> serde_json::Result<Self> {

--- a/crates/ruma-common/src/events/event_kinds.rs
+++ b/crates/ruma-common/src/events/event_kinds.rs
@@ -4,29 +4,29 @@ use ruma_macros::Event;
 use serde::{Deserialize, Serialize};
 
 use super::{
-    EphemeralRoomEventContent, GlobalAccountDataEventContent, MessageLikeEventContent,
-    RedactedMessageLikeEventContent, RedactedStateEventContent, RedactedUnsigned,
-    RoomAccountDataEventContent, StateEventContent, ToDeviceEventContent, Unsigned,
+    EphemeralRoomEventType, EventContent, GlobalAccountDataEventType, MessageLikeEventType,
+    RedactedEventContent, RedactedUnsigned, RoomAccountDataEventType, StateEventType,
+    ToDeviceEventType, Unsigned,
 };
 use crate::{EventId, MilliSecondsSinceUnixEpoch, RoomId, UserId};
 
 /// A global account data event.
 #[derive(Clone, Debug, Event)]
-pub struct GlobalAccountDataEvent<C: GlobalAccountDataEventContent> {
+pub struct GlobalAccountDataEvent<C: EventContent<EventType = GlobalAccountDataEventType>> {
     /// Data specific to the event type.
     pub content: C,
 }
 
 /// A room account data event.
 #[derive(Clone, Debug, Event)]
-pub struct RoomAccountDataEvent<C: RoomAccountDataEventContent> {
+pub struct RoomAccountDataEvent<C: EventContent<EventType = RoomAccountDataEventType>> {
     /// Data specific to the event type.
     pub content: C,
 }
 
 /// An ephemeral room event.
 #[derive(Clone, Debug, Event)]
-pub struct EphemeralRoomEvent<C: EphemeralRoomEventContent> {
+pub struct EphemeralRoomEvent<C: EventContent<EventType = EphemeralRoomEventType>> {
     /// Data specific to the event type.
     pub content: C,
 
@@ -36,7 +36,7 @@ pub struct EphemeralRoomEvent<C: EphemeralRoomEventContent> {
 
 /// An ephemeral room event without a `room_id`.
 #[derive(Clone, Debug, Event)]
-pub struct SyncEphemeralRoomEvent<C: EphemeralRoomEventContent> {
+pub struct SyncEphemeralRoomEvent<C: EventContent<EventType = EphemeralRoomEventType>> {
     /// Data specific to the event type.
     pub content: C,
 }
@@ -46,7 +46,7 @@ pub struct SyncEphemeralRoomEvent<C: EphemeralRoomEventContent> {
 /// `MessageLikeEvent` implements the comparison traits using only the `event_id` field, a sorted
 /// list would be sorted lexicographically based on the event's `EventId`.
 #[derive(Clone, Debug, Event)]
-pub struct MessageLikeEvent<C: MessageLikeEventContent> {
+pub struct MessageLikeEvent<C: EventContent<EventType = MessageLikeEventType>> {
     /// Data specific to the event type.
     pub content: C,
 
@@ -71,7 +71,7 @@ pub struct MessageLikeEvent<C: MessageLikeEventContent> {
 /// `SyncMessageLikeEvent` implements the comparison traits using only the `event_id` field, a
 /// sorted list would be sorted lexicographically based on the event's `EventId`.
 #[derive(Clone, Debug, Event)]
-pub struct SyncMessageLikeEvent<C: MessageLikeEventContent> {
+pub struct SyncMessageLikeEvent<C: EventContent<EventType = MessageLikeEventType>> {
     /// Data specific to the event type.
     pub content: C,
 
@@ -93,7 +93,9 @@ pub struct SyncMessageLikeEvent<C: MessageLikeEventContent> {
 /// `RedactedMessageLikeEvent` implements the comparison traits using only the `event_id` field, a
 /// sorted list would be sorted lexicographically based on the event's `EventId`.
 #[derive(Clone, Debug, Event)]
-pub struct RedactedMessageLikeEvent<C: RedactedMessageLikeEventContent> {
+pub struct RedactedMessageLikeEvent<
+    C: EventContent<EventType = MessageLikeEventType> + RedactedEventContent,
+> {
     /// Data specific to the event type.
     pub content: C,
 
@@ -118,7 +120,9 @@ pub struct RedactedMessageLikeEvent<C: RedactedMessageLikeEventContent> {
 /// `RedactedSyncMessageLikeEvent` implements the comparison traits using only the `event_id` field,
 /// a sorted list would be sorted lexicographically based on the event's `EventId`.
 #[derive(Clone, Debug, Event)]
-pub struct RedactedSyncMessageLikeEvent<C: RedactedMessageLikeEventContent> {
+pub struct RedactedSyncMessageLikeEvent<
+    C: EventContent<EventType = MessageLikeEventType> + RedactedEventContent,
+> {
     /// Data specific to the event type.
     pub content: C,
 
@@ -140,7 +144,7 @@ pub struct RedactedSyncMessageLikeEvent<C: RedactedMessageLikeEventContent> {
 /// `StateEvent` implements the comparison traits using only the `event_id` field, a sorted list
 /// would be sorted lexicographically based on the event's `EventId`.
 #[derive(Clone, Debug, Event)]
-pub struct StateEvent<C: StateEventContent> {
+pub struct StateEvent<C: EventContent<EventType = StateEventType>> {
     /// Data specific to the event type.
     pub content: C,
 
@@ -174,7 +178,7 @@ pub struct StateEvent<C: StateEventContent> {
 /// `SyncStateEvent` implements the comparison traits using only the `event_id` field, a sorted list
 /// would be sorted lexicographically based on the event's `EventId`.
 #[derive(Clone, Debug, Event)]
-pub struct SyncStateEvent<C: StateEventContent> {
+pub struct SyncStateEvent<C: EventContent<EventType = StateEventType>> {
     /// Data specific to the event type.
     pub content: C,
 
@@ -202,7 +206,7 @@ pub struct SyncStateEvent<C: StateEventContent> {
 
 /// A stripped-down state event, used for previews of rooms the user has been invited to.
 #[derive(Clone, Debug, Event)]
-pub struct StrippedStateEvent<C: StateEventContent> {
+pub struct StrippedStateEvent<C: EventContent<EventType = StateEventType>> {
     /// Data specific to the event type.
     pub content: C,
 
@@ -218,7 +222,7 @@ pub struct StrippedStateEvent<C: StateEventContent> {
 
 /// A minimal state event, used for creating a new room.
 #[derive(Clone, Debug, Event)]
-pub struct InitialStateEvent<C: StateEventContent> {
+pub struct InitialStateEvent<C: EventContent<EventType = StateEventType>> {
     /// Data specific to the event type.
     pub content: C,
 
@@ -237,7 +241,7 @@ pub struct InitialStateEvent<C: StateEventContent> {
 /// `RedactedStateEvent` implements the comparison traits using only the `event_id` field, a sorted
 /// list would be sorted lexicographically based on the event's `EventId`.
 #[derive(Clone, Debug, Event)]
-pub struct RedactedStateEvent<C: RedactedStateEventContent> {
+pub struct RedactedStateEvent<C: EventContent<EventType = StateEventType> + RedactedEventContent> {
     /// Data specific to the event type.
     pub content: C,
 
@@ -268,7 +272,9 @@ pub struct RedactedStateEvent<C: RedactedStateEventContent> {
 /// `RedactedSyncStateEvent` implements the comparison traits using only the `event_id` field, a
 /// sorted list would be sorted lexicographically based on the event's `EventId`.
 #[derive(Clone, Debug, Event)]
-pub struct RedactedSyncStateEvent<C: RedactedStateEventContent> {
+pub struct RedactedSyncStateEvent<
+    C: EventContent<EventType = StateEventType> + RedactedEventContent,
+> {
     /// Data specific to the event type.
     pub content: C,
 
@@ -293,7 +299,7 @@ pub struct RedactedSyncStateEvent<C: RedactedStateEventContent> {
 
 /// An event sent using send-to-device messaging.
 #[derive(Clone, Debug, Event)]
-pub struct ToDeviceEvent<C: ToDeviceEventContent> {
+pub struct ToDeviceEvent<C: EventContent<EventType = ToDeviceEventType>> {
     /// Data specific to the event type.
     pub content: C,
 
@@ -303,7 +309,7 @@ pub struct ToDeviceEvent<C: ToDeviceEventContent> {
 
 /// The decrypted payload of an `m.olm.v1.curve25519-aes-sha2` event.
 #[derive(Clone, Debug, Event)]
-pub struct DecryptedOlmV1Event<C: MessageLikeEventContent> {
+pub struct DecryptedOlmV1Event<C: EventContent<EventType = MessageLikeEventType>> {
     /// Data specific to the event type.
     pub content: C,
 
@@ -329,7 +335,7 @@ pub struct OlmV1Keys {
 
 /// The decrypted payload of an `m.megolm.v1.aes-sha2` event.
 #[derive(Clone, Debug, Event)]
-pub struct DecryptedMegolmV1Event<C: MessageLikeEventContent> {
+pub struct DecryptedMegolmV1Event<C: EventContent<EventType = MessageLikeEventType>> {
     /// Data specific to the event type.
     pub content: C,
 

--- a/crates/ruma-common/src/events/pdu.rs
+++ b/crates/ruma-common/src/events/pdu.rs
@@ -14,7 +14,7 @@ use serde::{
 };
 use serde_json::{from_str as from_json_str, value::RawValue as RawJsonValue};
 
-use super::EventType;
+use super::RoomEventType;
 use crate::{EventId, MilliSecondsSinceUnixEpoch, RoomId, ServerName, ServerSigningKeyId, UserId};
 
 /// Enum for PDU schemas
@@ -53,7 +53,7 @@ pub struct RoomV1Pdu {
     // TODO: Encode event type as content enum variant, like event enums do
     /// The event's type.
     #[serde(rename = "type")]
-    pub kind: EventType,
+    pub kind: RoomEventType,
 
     /// The event's content.
     pub content: Box<RawJsonValue>,
@@ -112,7 +112,7 @@ pub struct RoomV3Pdu {
     // TODO: Encode event type as content enum variant, like event enums do
     /// The event's type.
     #[serde(rename = "type")]
-    pub kind: EventType,
+    pub kind: RoomEventType,
 
     /// The event's content.
     pub content: Box<RawJsonValue>,

--- a/crates/ruma-common/src/events/room/aliases.rs
+++ b/crates/ruma-common/src/events/room/aliases.rs
@@ -78,8 +78,8 @@ impl RedactedRoomAliasesEventContent {
 impl EventContent for RedactedRoomAliasesEventContent {
     type EventType = StateEventType;
 
-    fn event_type(&self) -> &str {
-        "m.room.aliases"
+    fn event_type(&self) -> StateEventType {
+        StateEventType::RoomAliases
     }
 
     fn from_parts(event_type: &str, content: &RawJsonValue) -> serde_json::Result<Self> {

--- a/crates/ruma-common/src/events/room/aliases.rs
+++ b/crates/ruma-common/src/events/room/aliases.rs
@@ -6,8 +6,7 @@ use serde_json::value::RawValue as RawJsonValue;
 
 use crate::{
     events::{
-        EventContent, HasDeserializeFields, RedactContent, RedactedEventContent,
-        RedactedStateEventContent,
+        EventContent, HasDeserializeFields, RedactContent, RedactedEventContent, StateEventType,
     },
     RoomAliasId, RoomVersionId,
 };
@@ -77,6 +76,8 @@ impl RedactedRoomAliasesEventContent {
 }
 
 impl EventContent for RedactedRoomAliasesEventContent {
+    type EventType = StateEventType;
+
     fn event_type(&self) -> &str {
         "m.room.aliases"
     }
@@ -104,5 +105,3 @@ impl RedactedEventContent for RedactedRoomAliasesEventContent {
         HasDeserializeFields::Optional
     }
 }
-
-impl RedactedStateEventContent for RedactedRoomAliasesEventContent {}

--- a/crates/ruma-common/src/events/room/member.rs
+++ b/crates/ruma-common/src/events/room/member.rs
@@ -10,8 +10,8 @@ use serde_json::value::RawValue as RawJsonValue;
 
 use crate::{
     events::{
-        EventContent, HasDeserializeFields, RedactContent, RedactedEventContent,
-        RedactedStateEventContent, StrippedStateEvent, SyncStateEvent,
+        EventContent, HasDeserializeFields, RedactContent, RedactedEventContent, StateEventType,
+        StrippedStateEvent, SyncStateEvent,
     },
     serde::StringEnum,
     MxcUri, PrivOwnedStr, RoomVersionId, ServerName, ServerSigningKeyId, UserId,
@@ -159,6 +159,8 @@ impl RedactedRoomMemberEventContent {
 }
 
 impl EventContent for RedactedRoomMemberEventContent {
+    type EventType = StateEventType;
+
     fn event_type(&self) -> &str {
         "m.room.member"
     }
@@ -186,8 +188,6 @@ impl RedactedEventContent for RedactedRoomMemberEventContent {
         HasDeserializeFields::Optional
     }
 }
-
-impl RedactedStateEventContent for RedactedRoomMemberEventContent {}
 
 /// The membership state of a user.
 ///

--- a/crates/ruma-common/src/events/room/member.rs
+++ b/crates/ruma-common/src/events/room/member.rs
@@ -161,8 +161,8 @@ impl RedactedRoomMemberEventContent {
 impl EventContent for RedactedRoomMemberEventContent {
     type EventType = StateEventType;
 
-    fn event_type(&self) -> &str {
-        "m.room.member"
+    fn event_type(&self) -> StateEventType {
+        StateEventType::RoomMember
     }
 
     fn from_parts(event_type: &str, content: &RawJsonValue) -> serde_json::Result<Self> {

--- a/crates/ruma-common/src/events/room/power_levels.rs
+++ b/crates/ruma-common/src/events/room/power_levels.rs
@@ -9,7 +9,7 @@ use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    events::EventType,
+    events::RoomEventType,
     power_levels::{default_power_level, NotificationPowerLevels},
     UserId,
 };
@@ -45,7 +45,7 @@ pub struct RoomPowerLevelsEventContent {
     )]
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     #[ruma_event(skip_redaction)]
-    pub events: BTreeMap<EventType, Int>,
+    pub events: BTreeMap<RoomEventType, Int>,
 
     /// The default level required to send message events.
     ///
@@ -182,7 +182,7 @@ mod tests {
     use serde_json::{json, to_value as to_json_value};
 
     use super::{default_power_level, NotificationPowerLevels, RoomPowerLevelsEventContent};
-    use crate::events::{EventType, StateEvent, Unsigned};
+    use crate::events::{StateEvent, Unsigned};
 
     #[test]
     fn serialization_with_optional_fields_as_none() {
@@ -231,7 +231,7 @@ mod tests {
             content: RoomPowerLevelsEventContent {
                 ban: int!(23),
                 events: btreemap! {
-                    EventType::Dummy => int!(23)
+                    "m.dummy".into() => int!(23)
                 },
                 events_default: int!(23),
                 invite: int!(23),
@@ -250,7 +250,7 @@ mod tests {
                 // Make just one field different so we at least know they're two different objects.
                 ban: int!(42),
                 events: btreemap! {
-                    EventType::Dummy => int!(42)
+                    "m.dummy".into() => int!(42)
                 },
                 events_default: int!(42),
                 invite: int!(42),

--- a/crates/ruma-common/tests/events/enums.rs
+++ b/crates/ruma-common/tests/events/enums.rs
@@ -299,7 +299,7 @@ fn alias_event_field_access() {
     } else {
         panic!("the `Any*Event` enum's accessor methods may have been altered")
     }
-    assert_eq!(deser.event_type(), "m.room.aliases");
+    assert_eq!(deser.event_type().as_str(), "m.room.aliases");
 }
 
 #[test]

--- a/crates/ruma-common/tests/events/enums.rs
+++ b/crates/ruma-common/tests/events/enums.rs
@@ -12,9 +12,9 @@ use ruma_common::{
         },
         AnyEphemeralRoomEvent, AnyMessageLikeEvent, AnyRoomEvent, AnyStateEvent,
         AnyStateEventContent, AnySyncMessageLikeEvent, AnySyncRoomEvent, AnySyncStateEvent,
-        EphemeralRoomEventType, EventType, GlobalAccountDataEventType, MessageLikeEvent,
-        MessageLikeEventType, RoomAccountDataEventType, StateEvent, StateEventType,
-        SyncMessageLikeEvent, SyncStateEvent, ToDeviceEventType, Unsigned,
+        EphemeralRoomEventType, GlobalAccountDataEventType, MessageLikeEvent, MessageLikeEventType,
+        RoomAccountDataEventType, StateEvent, StateEventType, SyncMessageLikeEvent, SyncStateEvent,
+        ToDeviceEventType, Unsigned,
     },
     MilliSecondsSinceUnixEpoch,
 };
@@ -323,7 +323,10 @@ fn ephemeral_event_deserialization() {
 }
 
 #[test]
+#[allow(deprecated)]
 fn serialize_and_deserialize_from_display_form() {
+    use ruma_common::events::EventType;
+
     serde_json_eq(EventType::CallAnswer, json!("m.call.answer"));
     serde_json_eq(MessageLikeEventType::CallAnswer, json!("m.call.answer"));
     serde_json_eq(EventType::CallCandidates, json!("m.call.candidates"));

--- a/crates/ruma-common/tests/events/message_event.rs
+++ b/crates/ruma-common/tests/events/message_event.rs
@@ -8,7 +8,7 @@ use ruma_common::{
         room::{ImageInfo, ThumbnailInfo},
         sticker::StickerEventContent,
         AnyMessageLikeEvent, AnyMessageLikeEventContent, AnySyncMessageLikeEvent, MessageLikeEvent,
-        Unsigned,
+        MessageLikeEventType, Unsigned,
     },
     mxc_uri, room_id,
     serde::Raw,
@@ -86,7 +86,7 @@ fn deserialize_message_call_answer_content() {
     assert_matches!(
         from_json_value::<Raw<AnyMessageLikeEventContent>>(json_data)
             .unwrap()
-            .deserialize_content("m.call.answer")
+            .deserialize_content(MessageLikeEventType::CallAnswer)
             .unwrap(),
         AnyMessageLikeEventContent::CallAnswer(CallAnswerEventContent {
             answer: SessionDescription {

--- a/crates/ruma-common/tests/events/pdu.rs
+++ b/crates/ruma-common/tests/events/pdu.rs
@@ -6,7 +6,7 @@ use ruma_common::{
     event_id,
     events::{
         pdu::{EventHash, Pdu, RoomV1Pdu, RoomV3Pdu},
-        EventType,
+        RoomEventType,
     },
     room_id, server_name, server_signing_key_id, user_id, MilliSecondsSinceUnixEpoch,
 };
@@ -34,7 +34,7 @@ fn serialize_pdu_as_v1() {
         sender: user_id!("@sender:example.com").to_owned(),
         origin: "matrix.org".into(),
         origin_server_ts: MilliSecondsSinceUnixEpoch(1_592_050_773_658_u64.try_into().unwrap()),
-        kind: EventType::RoomPowerLevels,
+        kind: RoomEventType::RoomPowerLevels,
         content: to_raw_json_value(&json!({ "testing": 123 })).unwrap(),
         state_key: Some("state".into()),
         prev_events: vec![(
@@ -100,7 +100,7 @@ fn serialize_pdu_as_v3() {
         sender: user_id!("@sender:example.com").to_owned(),
         origin: "matrix.org".into(),
         origin_server_ts: MilliSecondsSinceUnixEpoch(1_592_050_773_658_u64.try_into().unwrap()),
-        kind: EventType::RoomPowerLevels,
+        kind: RoomEventType::RoomPowerLevels,
         content: to_raw_json_value(&json!({ "testing": 123 })).unwrap(),
         state_key: Some("state".into()),
         prev_events: vec![event_id!("$previousevent:matrix.org").to_owned()],

--- a/crates/ruma-common/tests/events/state_event.rs
+++ b/crates/ruma-common/tests/events/state_event.rs
@@ -9,7 +9,7 @@ use ruma_common::{
             ThumbnailInfo,
         },
         AnyRoomEvent, AnyStateEvent, AnyStateEventContent, AnySyncStateEvent, StateEvent,
-        SyncStateEvent, Unsigned,
+        StateEventType, SyncStateEvent, Unsigned,
     },
     mxc_uri, room_alias_id, room_id,
     serde::Raw,
@@ -99,7 +99,7 @@ fn deserialize_aliases_content() {
     assert_matches!(
         from_json_value::<Raw<AnyStateEventContent>>(json_data)
             .unwrap()
-            .deserialize_content("m.room.aliases")
+            .deserialize_content(StateEventType::RoomAliases)
             .unwrap(),
         AnyStateEventContent::RoomAliases(content)
         if content.aliases == vec![room_alias_id!("#somewhere:localhost")]

--- a/crates/ruma-common/tests/events/ui/04-event-sanity-check.rs
+++ b/crates/ruma-common/tests/events/ui/04-event-sanity-check.rs
@@ -4,14 +4,14 @@
 extern crate serde;
 
 use ruma_common::{
-    events::{StateEventContent, Unsigned},
+    events::{EventContent, StateEventType, Unsigned},
     EventId, MilliSecondsSinceUnixEpoch, RoomId, UserId,
 };
 use ruma_macros::Event;
 
 /// State event.
 #[derive(Clone, Debug, Event)]
-pub struct StateEvent<C: StateEventContent> {
+pub struct StateEvent<C: EventContent<EventType = StateEventType>> {
     pub content: C,
     pub event_id: Box<EventId>,
     pub sender: Box<UserId>,

--- a/crates/ruma-common/tests/events/ui/05-named-fields.rs
+++ b/crates/ruma-common/tests/events/ui/05-named-fields.rs
@@ -1,8 +1,8 @@
-use ruma_common::events::StateEventContent;
+use ruma_common::events::{EventContent, StateEventType};
 use ruma_macros::Event;
 
 /// State event.
 #[derive(Clone, Debug, Event)]
-pub struct StateEvent<C: StateEventContent>(C);
+pub struct StateEvent<C: EventContent<EventType = StateEventType>>(C);
 
 fn main() {}

--- a/crates/ruma-common/tests/events/ui/05-named-fields.stderr
+++ b/crates/ruma-common/tests/events/ui/05-named-fields.stderr
@@ -1,5 +1,5 @@
 error: the `Event` derive only supports structs with named fields
- --> $DIR/05-named-fields.rs:6:12
+ --> tests/events/ui/05-named-fields.rs:6:12
   |
-6 | pub struct StateEvent<C: StateEventContent>(C);
+6 | pub struct StateEvent<C: EventContent<EventType = StateEventType>>(C);
   |            ^^^^^^^^^^

--- a/crates/ruma-common/tests/events/ui/06-no-content-field.rs
+++ b/crates/ruma-common/tests/events/ui/06-no-content-field.rs
@@ -1,9 +1,9 @@
-use ruma_common::events::StateEventContent;
+use ruma_common::events::{EventContent, StateEventType};
 use ruma_macros::Event;
 
 /// State event.
 #[derive(Clone, Debug, Event)]
-pub struct StateEvent<C: StateEventContent> {
+pub struct StateEvent<C: EventContent<EventType = StateEventType>> {
     pub not_content: C,
 }
 

--- a/crates/ruma-common/tests/events/ui/08-enum-invalid-path.stderr
+++ b/crates/ruma-common/tests/events/ui/08-enum-invalid-path.stderr
@@ -1,11 +1,11 @@
 error: well-known matrix events have to start with `m.` found `not.a.path`
-  --> $DIR/08-enum-invalid-path.rs:11:9
+  --> tests/events/ui/08-enum-invalid-path.rs:11:9
    |
 11 |         "not.a.path",
    |         ^^^^^^^^^^^^
 
 error[E0433]: failed to resolve: could not find `not` in `events`
- --> $DIR/08-enum-invalid-path.rs:5:9
+ --> tests/events/ui/08-enum-invalid-path.rs:5:9
   |
 5 |         "m.not.a.path",
   |         ^^^^^^^^^^^^^^ could not find `not` in `events`

--- a/crates/ruma-federation-api/src/membership/create_invite/v1.rs
+++ b/crates/ruma-federation-api/src/membership/create_invite/v1.rs
@@ -4,7 +4,7 @@
 
 use ruma_common::{
     api::ruma_api,
-    events::{room::member::RoomMemberEventContent, AnyStrippedStateEvent, EventType},
+    events::{room::member::RoomMemberEventContent, AnyStrippedStateEvent, StateEventType},
     serde::Raw,
     EventId, MilliSecondsSinceUnixEpoch, RoomId, ServerName, UserId,
 };
@@ -42,7 +42,7 @@ ruma_api! {
 
         /// The value `m.room.member`.
         #[serde(rename = "type")]
-        pub kind: EventType,
+        pub kind: StateEventType,
 
         /// The user ID of the invited member.
         pub state_key: &'a UserId,
@@ -124,7 +124,7 @@ impl<'a> From<RequestInit<'a>> for Request<'a> {
             sender: init.sender,
             origin: init.origin,
             origin_server_ts: init.origin_server_ts,
-            kind: EventType::RoomMember,
+            kind: StateEventType::RoomMember,
             state_key: init.state_key,
             content: init.content,
             unsigned: init.unsigned,

--- a/crates/ruma-federation-api/src/membership/create_leave_event/v1.rs
+++ b/crates/ruma-federation-api/src/membership/create_leave_event/v1.rs
@@ -5,7 +5,7 @@
 use js_int::UInt;
 use ruma_common::{
     api::ruma_api,
-    events::{room::member::RoomMemberEventContent, EventType},
+    events::{room::member::RoomMemberEventContent, StateEventType},
     serde::Raw,
     EventId, MilliSecondsSinceUnixEpoch, RoomId, ServerName, UserId,
 };
@@ -46,7 +46,7 @@ ruma_api! {
         /// The value `m.room.member`.
         #[ruma_api(query)]
         #[serde(rename = "type")]
-        pub event_type: EventType,
+        pub event_type: StateEventType,
 
         /// The user ID of the leaving member.
         #[ruma_api(query)]
@@ -95,7 +95,7 @@ pub struct RequestInit<'a> {
     pub origin_server_ts: MilliSecondsSinceUnixEpoch,
 
     /// The value `m.room.member`.
-    pub event_type: EventType,
+    pub event_type: StateEventType,
 
     /// The user ID of the leaving member.
     pub state_key: &'a str,

--- a/crates/ruma-federation-api/src/thirdparty/exchange_invite.rs
+++ b/crates/ruma-federation-api/src/thirdparty/exchange_invite.rs
@@ -13,7 +13,7 @@ pub mod v1 {
 
     use ruma_common::{
         api::ruma_api,
-        events::{room::member::ThirdPartyInvite, EventType},
+        events::{room::member::ThirdPartyInvite, StateEventType},
         RoomId, UserId,
     };
 
@@ -35,9 +35,9 @@ pub mod v1 {
 
             /// The event type.
             ///
-            /// Must be `EventType::RoomMember`.
+            /// Must be `StateEventType::RoomMember`.
             #[serde(rename = "type")]
-            pub kind: EventType,
+            pub kind: StateEventType,
 
             /// The user ID of the user who sent the original invite event.
             pub sender: &'a UserId,
@@ -61,7 +61,7 @@ pub mod v1 {
             state_key: &'a UserId,
             content: &'a ThirdPartyInvite,
         ) -> Self {
-            Self { room_id, kind: EventType::RoomMember, sender, state_key, content }
+            Self { room_id, kind: StateEventType::RoomMember, sender, state_key, content }
         }
     }
 

--- a/crates/ruma-federation-api/src/transactions/edu.rs
+++ b/crates/ruma-federation-api/src/transactions/edu.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeMap;
 use js_int::UInt;
 use ruma_common::{
     encryption::{CrossSigningKey, DeviceKeys},
-    events::{receipt::Receipt, AnyToDeviceEventContent, EventType},
+    events::{receipt::Receipt, AnyToDeviceEventContent, ToDeviceEventType},
     presence::PresenceState,
     serde::{from_raw_json_value, Raw},
     to_device::DeviceIdOrAllDevices,
@@ -264,7 +264,7 @@ pub struct DirectDeviceContent {
 
     /// Event type for the message.
     #[serde(rename = "type")]
-    pub ev_type: EventType,
+    pub ev_type: ToDeviceEventType,
 
     /// Unique utf8 string ID for the message, used for idempotency.
     pub message_id: Box<TransactionId>,
@@ -278,7 +278,11 @@ pub struct DirectDeviceContent {
 
 impl DirectDeviceContent {
     /// Creates a new `DirectDeviceContent` with the given `sender, `ev_type` and `message_id`.
-    pub fn new(sender: Box<UserId>, ev_type: EventType, message_id: Box<TransactionId>) -> Self {
+    pub fn new(
+        sender: Box<UserId>,
+        ev_type: ToDeviceEventType,
+        message_id: Box<TransactionId>,
+    ) -> Self {
         Self { sender, ev_type, message_id, messages: DirectDeviceMessages::new() }
     }
 }
@@ -489,7 +493,7 @@ mod test {
             Edu::DirectToDevice(DirectDeviceContent {
                 sender, ev_type, message_id, messages
             }) if sender == "@john:example.com"
-                && *ev_type == EventType::RoomKeyRequest
+                && *ev_type == ToDeviceEventType::RoomKeyRequest
                 && message_id == "hiezohf6Hoo7kaev"
                 && messages.get(user_id!("@alice:example.org")).is_some()
         );

--- a/crates/ruma-macros/src/events/event.rs
+++ b/crates/ruma-macros/src/events/event.rs
@@ -120,6 +120,8 @@ fn expand_serialize_event(
                 use #serde::ser::{SerializeStruct as _, Error as _};
 
                 let event_type = #ruma_common::events::EventContent::event_type(&self.content);
+                let event_type =
+                    ::std::convert::AsRef::<::std::primitive::str>::as_ref(&event_type);
 
                 let mut state = serializer.serialize_struct(stringify!(#ident), 7)?;
 

--- a/crates/ruma-macros/src/events/event_content.rs
+++ b/crates/ruma-macros/src/events/event_content.rs
@@ -159,7 +159,7 @@ pub fn expand_event_content(
     // We only generate redacted content structs for state and message-like events
     let redacted_event_content = needs_redacted(&content_attr, event_kind)
         .then(|| {
-            generate_redacted_event_content(ident, fields, event_type, ruma_common, event_kind)
+            generate_redacted_event_content(ident, fields, event_type, event_kind, ruma_common)
         })
         .transpose()?;
 
@@ -185,8 +185,8 @@ fn generate_redacted_event_content(
     ident: &Ident,
     fields: &syn::Fields,
     event_type: &LitStr,
-    ruma_common: &TokenStream,
     event_kind: Option<EventKind>,
+    ruma_common: &TokenStream,
 ) -> Result<TokenStream, syn::Error> {
     let serde = quote! { #ruma_common::exports::serde };
     let serde_json = quote! { #ruma_common::exports::serde_json };

--- a/crates/ruma-macros/src/events/event_content.rs
+++ b/crates/ruma-macros/src/events/event_content.rs
@@ -1,4 +1,4 @@
-//! Implementations of the MessageLikeEventContent and StateEventContent derive macro.
+//! Implementations of the EventContent derive macro.
 
 use std::borrow::Cow;
 

--- a/crates/ruma-macros/src/events/event_content.rs
+++ b/crates/ruma-macros/src/events/event_content.rs
@@ -185,7 +185,7 @@ fn generate_redacted_event_content(
     event_type: &LitStr,
     event_kind: Option<EventKind>,
     ruma_common: &TokenStream,
-) -> Result<TokenStream, syn::Error> {
+) -> syn::Result<TokenStream> {
     let serde = quote! { #ruma_common::exports::serde };
     let serde_json = quote! { #ruma_common::exports::serde_json };
 

--- a/crates/ruma-macros/src/events/event_enum.rs
+++ b/crates/ruma-macros/src/events/event_enum.rs
@@ -8,6 +8,7 @@ use super::{
     event_parse::{EventEnumDecl, EventEnumEntry, EventKind, EventKindVariation},
     util::{has_prev_content_field, EVENT_FIELDS},
 };
+use crate::util::m_prefix_name_to_type_name;
 
 /// Create a content enum from `EventEnumInput`.
 pub fn expand_event_enums(input: &EventEnumDecl) -> syn::Result<TokenStream> {
@@ -574,27 +575,6 @@ fn to_event_content_path(
     }
 }
 
-/// Splits the given `event_type` string on `.` and `_` removing the `m.room.` then
-/// camel casing to give the `Event` struct name.
-fn to_camel_case(name: &LitStr) -> syn::Result<Ident> {
-    let span = name.span();
-    let name = name.value();
-
-    if &name[..2] != "m." {
-        return Err(syn::Error::new(
-            span,
-            format!("well-known matrix events have to start with `m.` found `{}`", name),
-        ));
-    }
-
-    let s: String = name[2..]
-        .split(&['.', '_'] as &[char])
-        .map(|s| s.chars().next().unwrap().to_uppercase().to_string() + &s[1..])
-        .collect();
-
-    Ok(Ident::new(&s, span))
-}
-
 fn field_return_type(
     name: &str,
     var: EventKindVariation,
@@ -657,7 +637,7 @@ impl EventEnumVariant {
 impl EventEnumEntry {
     pub(crate) fn to_variant(&self) -> syn::Result<EventEnumVariant> {
         let attrs = self.attrs.clone();
-        let ident = to_camel_case(&self.ev_type)?;
+        let ident = m_prefix_name_to_type_name(&self.ev_type)?;
         Ok(EventEnumVariant { attrs, ident })
     }
 }

--- a/crates/ruma-macros/src/events/event_parse.rs
+++ b/crates/ruma-macros/src/events/event_parse.rs
@@ -152,6 +152,10 @@ impl EventKind {
         format_ident!("Any{}", self.to_event_ident(var))
     }
 
+    pub fn to_event_type_enum(self) -> Ident {
+        format_ident!("{}Type", self)
+    }
+
     /// `Any[kind]EventContent`
     pub fn to_content_enum(self) -> Ident {
         format_ident!("Any{}Content", self)

--- a/crates/ruma-macros/src/events/event_type.rs
+++ b/crates/ruma-macros/src/events/event_type.rs
@@ -65,6 +65,12 @@ fn generate_enum(
     let byte_doc = format!("Creates a byte slice from this `{}`.", ident);
     let enum_doc = format!("The type of `{}` this is.", ident.strip_suffix("Type").unwrap());
 
+    let deprecated_attr = (ident == "EventType").then(|| {
+        quote! {
+            #[deprecated = "use a fine-grained event type enum like RoomEventType instead"]
+        }
+    });
+
     let ident = Ident::new(ident, Span::call_site());
 
     let mut deduped: Vec<&EventEnumEntry> = vec![];
@@ -88,6 +94,7 @@ fn generate_enum(
         ///
         /// This type can hold an arbitrary string. To check for events that are not available as a
         /// documented variant here, use its string representation, obtained through `.as_str()`.
+        #deprecated_attr
         #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, #ruma_common::serde::StringEnum)]
         #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
         pub enum #ident {
@@ -100,6 +107,7 @@ fn generate_enum(
             _Custom(crate::PrivOwnedStr),
         }
 
+        #[allow(deprecated)]
         impl #ident {
             #[doc = #str_doc]
             pub fn as_str(&self) -> &str {

--- a/crates/ruma-macros/src/serde/deserialize_from_cow_str.rs
+++ b/crates/ruma-macros/src/serde/deserialize_from_cow_str.rs
@@ -7,6 +7,7 @@ pub fn expand_deserialize_from_cow_str(ident: &Ident) -> syn::Result<TokenStream
     let ruma_common = import_ruma_common();
 
     Ok(quote! {
+        #[automatically_derived]
         impl<'de> #ruma_common::exports::serde::de::Deserialize<'de> for #ident {
             fn deserialize<D>(deserializer: D) -> ::std::result::Result<Self, D::Error>
             where

--- a/crates/ruma-macros/src/serde/deserialize_from_cow_str.rs
+++ b/crates/ruma-macros/src/serde/deserialize_from_cow_str.rs
@@ -8,6 +8,7 @@ pub fn expand_deserialize_from_cow_str(ident: &Ident) -> syn::Result<TokenStream
 
     Ok(quote! {
         #[automatically_derived]
+        #[allow(deprecated)]
         impl<'de> #ruma_common::exports::serde::de::Deserialize<'de> for #ident {
             fn deserialize<D>(deserializer: D) -> ::std::result::Result<Self, D::Error>
             where

--- a/crates/ruma-macros/src/serde/display_as_ref_str.rs
+++ b/crates/ruma-macros/src/serde/display_as_ref_str.rs
@@ -4,6 +4,7 @@ use quote::quote;
 pub fn expand_display_as_ref_str(ident: &Ident) -> syn::Result<TokenStream> {
     Ok(quote! {
         #[automatically_derived]
+        #[allow(deprecated)]
         impl ::std::fmt::Display for #ident {
             fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
                 f.write_str(::std::convert::AsRef::<::std::primitive::str>::as_ref(self))

--- a/crates/ruma-macros/src/serde/enum_as_ref_str.rs
+++ b/crates/ruma-macros/src/serde/enum_as_ref_str.rs
@@ -50,6 +50,7 @@ pub fn expand_enum_as_ref_str(input: &ItemEnum) -> syn::Result<TokenStream> {
 
     Ok(quote! {
         #[automatically_derived]
+        #[allow(deprecated)]
         impl ::std::convert::AsRef<::std::primitive::str> for #enum_name {
             fn as_ref(&self) -> &::std::primitive::str {
                 match self { #(#branches),* }

--- a/crates/ruma-macros/src/serde/enum_from_string.rs
+++ b/crates/ruma-macros/src/serde/enum_from_string.rs
@@ -69,6 +69,7 @@ pub fn expand_enum_from_string(input: &ItemEnum) -> syn::Result<TokenStream> {
 
     Ok(quote! {
         #[automatically_derived]
+        #[allow(deprecated)]
         impl<T> ::std::convert::From<T> for #enum_name
         where
             T: ::std::convert::AsRef<::std::primitive::str>

--- a/crates/ruma-macros/src/serde/enum_from_string.rs
+++ b/crates/ruma-macros/src/serde/enum_from_string.rs
@@ -68,6 +68,7 @@ pub fn expand_enum_from_string(input: &ItemEnum) -> syn::Result<TokenStream> {
     }
 
     Ok(quote! {
+        #[automatically_derived]
         impl<T> ::std::convert::From<T> for #enum_name
         where
             T: ::std::convert::AsRef<::std::primitive::str>

--- a/crates/ruma-macros/src/serde/eq_as_ref_str.rs
+++ b/crates/ruma-macros/src/serde/eq_as_ref_str.rs
@@ -4,6 +4,7 @@ use quote::quote;
 pub fn expand_partial_eq_as_ref_str(ident: &Ident) -> syn::Result<TokenStream> {
     Ok(quote! {
         #[automatically_derived]
+        #[allow(deprecated)]
         impl ::std::cmp::PartialEq for #ident {
             fn eq(&self, other: &Self) -> bool {
                 let other = ::std::convert::AsRef::<::std::primitive::str>::as_ref(other);

--- a/crates/ruma-macros/src/serde/ord_as_ref_str.rs
+++ b/crates/ruma-macros/src/serde/ord_as_ref_str.rs
@@ -4,6 +4,7 @@ use quote::quote;
 pub fn expand_partial_ord_as_ref_str(ident: &Ident) -> syn::Result<TokenStream> {
     Ok(quote! {
         #[automatically_derived]
+        #[allow(deprecated)]
         impl ::std::cmp::PartialOrd for #ident {
             fn partial_cmp(&self, other: &Self) -> ::std::option::Option<::std::cmp::Ordering> {
                 let other = ::std::convert::AsRef::<::std::primitive::str>::as_ref(other);
@@ -16,6 +17,7 @@ pub fn expand_partial_ord_as_ref_str(ident: &Ident) -> syn::Result<TokenStream> 
 pub fn expand_ord_as_ref_str(ident: &Ident) -> syn::Result<TokenStream> {
     Ok(quote! {
         #[automatically_derived]
+        #[allow(deprecated)]
         impl ::std::cmp::Ord for #ident {
             fn cmp(&self, other: &Self) -> ::std::cmp::Ordering {
                 let other = ::std::convert::AsRef::<::std::primitive::str>::as_ref(other);

--- a/crates/ruma-macros/src/serde/serialize_as_ref_str.rs
+++ b/crates/ruma-macros/src/serde/serialize_as_ref_str.rs
@@ -8,6 +8,7 @@ pub fn expand_serialize_as_ref_str(ident: &Ident) -> syn::Result<TokenStream> {
 
     Ok(quote! {
         #[automatically_derived]
+        #[allow(deprecated)]
         impl #ruma_common::exports::serde::ser::Serialize for #ident {
             fn serialize<S>(&self, serializer: S) -> ::std::result::Result<S::Ok, S::Error>
             where

--- a/crates/ruma-macros/src/util.rs
+++ b/crates/ruma-macros/src/util.rs
@@ -39,14 +39,14 @@ pub(crate) fn m_prefix_name_to_type_name(name: &LitStr) -> syn::Result<Ident> {
     let span = name.span();
     let name = name.value();
 
-    if &name[..2] != "m." {
-        return Err(syn::Error::new(
+    let name = name.strip_prefix("m.").ok_or_else(|| {
+        syn::Error::new(
             span,
             format!("well-known matrix events have to start with `m.` found `{}`", name),
-        ));
-    }
+        )
+    })?;
 
-    let s: String = name[2..]
+    let s: String = name
         .split(&['.', '_'] as &[char])
         .map(|s| s.chars().next().unwrap().to_uppercase().to_string() + &s[1..])
         .collect();

--- a/crates/ruma-push-gateway-api/src/send_event_notification.rs
+++ b/crates/ruma-push-gateway-api/src/send_event_notification.rs
@@ -11,7 +11,7 @@ pub mod v1 {
     use js_int::UInt;
     use ruma_common::{
         api::ruma_api,
-        events::EventType,
+        events::RoomEventType,
         push::{PusherData, Tweak},
         serde::{Outgoing, StringEnum},
         EventId, RoomAliasId, RoomId, RoomName, SecondsSinceUnixEpoch, UserId,
@@ -84,7 +84,7 @@ pub mod v1 {
 
         /// The type of the event as in the event's `type` field.
         #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
-        pub event_type: Option<&'a EventType>,
+        pub event_type: Option<&'a RoomEventType>,
 
         /// The sender of the event as in the corresponding event field.
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -321,7 +321,7 @@ pub mod v1 {
     mod tests {
         use js_int::uint;
         use ruma_common::{
-            event_id, events::EventType, room_alias_id, room_id, user_id, SecondsSinceUnixEpoch,
+            event_id, events::RoomEventType, room_alias_id, room_id, user_id, SecondsSinceUnixEpoch,
         };
         use serde_json::{
             from_value as from_json_value, json, to_value as to_json_value, Value as JsonValue,
@@ -384,7 +384,7 @@ pub mod v1 {
             let notice = Notification {
                 event_id: Some(eid),
                 room_id: Some(rid),
-                event_type: Some(&EventType::RoomMessage),
+                event_type: Some(&RoomEventType::RoomMessage),
                 sender: Some(uid),
                 sender_display_name: Some("Major Tom"),
                 room_alias: Some(alias),

--- a/crates/ruma-state-res/benches/state_res_bench.rs
+++ b/crates/ruma-state-res/benches/state_res_bench.rs
@@ -28,7 +28,7 @@ use ruma_common::{
             join_rules::{JoinRule, RoomJoinRulesEventContent},
             member::{MembershipState, RoomMemberEventContent},
         },
-        EventType,
+        RoomEventType,
     },
     room_id, user_id, EventId, MilliSecondsSinceUnixEpoch, RoomId, RoomVersionId, UserId,
 };
@@ -240,7 +240,7 @@ impl TestStore<StateEvent> {
         let create_event = to_pdu_event::<&EventId>(
             "CREATE",
             alice(),
-            EventType::RoomCreate,
+            RoomEventType::RoomCreate,
             Some(""),
             to_raw_json_value(&json!({ "creator": alice() })).unwrap(),
             &[],
@@ -252,7 +252,7 @@ impl TestStore<StateEvent> {
         let alice_mem = to_pdu_event(
             "IMA",
             alice(),
-            EventType::RoomMember,
+            RoomEventType::RoomMember,
             Some(alice().to_string().as_str()),
             member_content_join(),
             &[cre.clone()],
@@ -263,7 +263,7 @@ impl TestStore<StateEvent> {
         let join_rules = to_pdu_event(
             "IJR",
             alice(),
-            EventType::RoomJoinRules,
+            RoomEventType::RoomJoinRules,
             Some(""),
             to_raw_json_value(&RoomJoinRulesEventContent::new(JoinRule::Public)).unwrap(),
             &[cre.clone(), alice_mem.event_id().to_owned()],
@@ -276,7 +276,7 @@ impl TestStore<StateEvent> {
         let bob_mem = to_pdu_event(
             "IMB",
             bob(),
-            EventType::RoomMember,
+            RoomEventType::RoomMember,
             Some(bob().to_string().as_str()),
             member_content_join(),
             &[cre.clone(), join_rules.event_id().to_owned()],
@@ -287,7 +287,7 @@ impl TestStore<StateEvent> {
         let charlie_mem = to_pdu_event(
             "IMC",
             charlie(),
-            EventType::RoomMember,
+            RoomEventType::RoomMember,
             Some(charlie().to_string().as_str()),
             member_content_join(),
             &[cre, join_rules.event_id().to_owned()],
@@ -367,7 +367,7 @@ fn member_content_join() -> Box<RawJsonValue> {
 fn to_pdu_event<S>(
     id: &str,
     sender: Box<UserId>,
-    ev_type: EventType,
+    ev_type: RoomEventType,
     state_key: Option<&str>,
     content: Box<RawJsonValue>,
     auth_events: &[S],
@@ -413,7 +413,7 @@ fn INITIAL_EVENTS() -> HashMap<Box<EventId>, Arc<StateEvent>> {
         to_pdu_event::<&EventId>(
             "CREATE",
             alice(),
-            EventType::RoomCreate,
+            RoomEventType::RoomCreate,
             Some(""),
             to_raw_json_value(&json!({ "creator": alice() })).unwrap(),
             &[],
@@ -422,7 +422,7 @@ fn INITIAL_EVENTS() -> HashMap<Box<EventId>, Arc<StateEvent>> {
         to_pdu_event(
             "IMA",
             alice(),
-            EventType::RoomMember,
+            RoomEventType::RoomMember,
             Some(alice().to_string().as_str()),
             member_content_join(),
             &["CREATE"],
@@ -431,7 +431,7 @@ fn INITIAL_EVENTS() -> HashMap<Box<EventId>, Arc<StateEvent>> {
         to_pdu_event(
             "IPOWER",
             alice(),
-            EventType::RoomPowerLevels,
+            RoomEventType::RoomPowerLevels,
             Some(""),
             to_raw_json_value(&json!({ "users": { alice().to_string(): 100 } })).unwrap(),
             &["CREATE", "IMA"],
@@ -440,7 +440,7 @@ fn INITIAL_EVENTS() -> HashMap<Box<EventId>, Arc<StateEvent>> {
         to_pdu_event(
             "IJR",
             alice(),
-            EventType::RoomJoinRules,
+            RoomEventType::RoomJoinRules,
             Some(""),
             to_raw_json_value(&RoomJoinRulesEventContent::new(JoinRule::Public)).unwrap(),
             &["CREATE", "IMA", "IPOWER"],
@@ -449,7 +449,7 @@ fn INITIAL_EVENTS() -> HashMap<Box<EventId>, Arc<StateEvent>> {
         to_pdu_event(
             "IMB",
             bob(),
-            EventType::RoomMember,
+            RoomEventType::RoomMember,
             Some(bob().to_string().as_str()),
             member_content_join(),
             &["CREATE", "IJR", "IPOWER"],
@@ -458,7 +458,7 @@ fn INITIAL_EVENTS() -> HashMap<Box<EventId>, Arc<StateEvent>> {
         to_pdu_event(
             "IMC",
             charlie(),
-            EventType::RoomMember,
+            RoomEventType::RoomMember,
             Some(charlie().to_string().as_str()),
             member_content_join(),
             &["CREATE", "IJR", "IPOWER"],
@@ -467,7 +467,7 @@ fn INITIAL_EVENTS() -> HashMap<Box<EventId>, Arc<StateEvent>> {
         to_pdu_event::<&EventId>(
             "START",
             charlie(),
-            EventType::RoomTopic,
+            RoomEventType::RoomTopic,
             Some(""),
             to_raw_json_value(&json!({})).unwrap(),
             &[],
@@ -476,7 +476,7 @@ fn INITIAL_EVENTS() -> HashMap<Box<EventId>, Arc<StateEvent>> {
         to_pdu_event::<&EventId>(
             "END",
             charlie(),
-            EventType::RoomTopic,
+            RoomEventType::RoomTopic,
             Some(""),
             to_raw_json_value(&json!({})).unwrap(),
             &[],
@@ -495,7 +495,7 @@ fn BAN_STATE_SET() -> HashMap<Box<EventId>, Arc<StateEvent>> {
         to_pdu_event(
             "PA",
             alice(),
-            EventType::RoomPowerLevels,
+            RoomEventType::RoomPowerLevels,
             Some(""),
             to_raw_json_value(&json!({ "users": { alice(): 100, bob(): 50 } })).unwrap(),
             &["CREATE", "IMA", "IPOWER"], // auth_events
@@ -504,7 +504,7 @@ fn BAN_STATE_SET() -> HashMap<Box<EventId>, Arc<StateEvent>> {
         to_pdu_event(
             "PB",
             alice(),
-            EventType::RoomPowerLevels,
+            RoomEventType::RoomPowerLevels,
             Some(""),
             to_raw_json_value(&json!({ "users": { alice(): 100, bob(): 50 } })).unwrap(),
             &["CREATE", "IMA", "IPOWER"],
@@ -513,7 +513,7 @@ fn BAN_STATE_SET() -> HashMap<Box<EventId>, Arc<StateEvent>> {
         to_pdu_event(
             "MB",
             alice(),
-            EventType::RoomMember,
+            RoomEventType::RoomMember,
             Some(ella().as_str()),
             member_content_ban(),
             &["CREATE", "IMA", "PB"],
@@ -522,7 +522,7 @@ fn BAN_STATE_SET() -> HashMap<Box<EventId>, Arc<StateEvent>> {
         to_pdu_event(
             "IME",
             ella(),
-            EventType::RoomMember,
+            RoomEventType::RoomMember,
             Some(ella().as_str()),
             member_content_join(),
             &["CREATE", "IJR", "PA"],
@@ -536,7 +536,7 @@ fn BAN_STATE_SET() -> HashMap<Box<EventId>, Arc<StateEvent>> {
 
 mod event {
     use ruma_common::{
-        events::{pdu::Pdu, EventType},
+        events::{pdu::Pdu, RoomEventType},
         EventId, MilliSecondsSinceUnixEpoch, RoomId, UserId,
     };
     use ruma_state_res::Event;
@@ -568,7 +568,7 @@ mod event {
             }
         }
 
-        fn event_type(&self) -> &EventType {
+        fn event_type(&self) -> &RoomEventType {
             match &self.rest {
                 Pdu::RoomV1Pdu(ev) => &ev.kind,
                 Pdu::RoomV3Pdu(ev) => &ev.kind,

--- a/crates/ruma-state-res/src/lib.rs
+++ b/crates/ruma-state-res/src/lib.rs
@@ -10,7 +10,7 @@ use js_int::{int, Int};
 use ruma_common::{
     events::{
         room::member::{MembershipState, RoomMemberEventContent},
-        EventType,
+        RoomEventType,
     },
     EventId, MilliSecondsSinceUnixEpoch, RoomVersionId, UserId,
 };
@@ -31,7 +31,7 @@ pub use room_version::RoomVersion;
 pub use state_event::Event;
 
 /// A mapping of event type and state_key to some value `T`, usually an `EventId`.
-pub type StateMap<T> = HashMap<(EventType, String), T>;
+pub type StateMap<T> = HashMap<(RoomEventType, String), T>;
 
 /// Resolve sets of state events as they come in.
 ///
@@ -132,7 +132,7 @@ where
     trace!("{:?}", events_to_resolve);
 
     // This "epochs" power level event
-    let power_event = resolved_control.get(&(EventType::RoomPowerLevels, "".into()));
+    let power_event = resolved_control.get(&(RoomEventType::RoomPowerLevels, "".into()));
 
     debug!("power event: {:?}", power_event);
 
@@ -368,7 +368,7 @@ fn get_power_level_for_sender<E: Event>(
 
     for aid in event.as_ref().map(|pdu| pdu.auth_events()).into_iter().flatten() {
         if let Some(aev) = fetch_event(aid.borrow()) {
-            if is_type_and_key(&aev, &EventType::RoomPowerLevels, "") {
+            if is_type_and_key(&aev, &RoomEventType::RoomPowerLevels, "") {
                 pl = Some(aev);
                 break;
             }
@@ -458,7 +458,7 @@ fn iterative_auth_check<E: Event + Clone>(
         // The key for this is (eventType + a state_key of the signed token not sender) so
         // search for it
         let current_third_party = auth_events.iter().find_map(|(_, pdu)| {
-            (*pdu.event_type() == EventType::RoomThirdPartyInvite).then(|| pdu)
+            (*pdu.event_type() == RoomEventType::RoomThirdPartyInvite).then(|| pdu)
         });
 
         if auth_check(room_version, &event, current_third_party, |ty, key| {
@@ -509,7 +509,7 @@ fn mainline_sort<E: Event>(
         for aid in event.auth_events() {
             let ev = fetch_event(aid.borrow())
                 .ok_or_else(|| Error::NotFound(format!("Failed to find {}", aid)))?;
-            if is_type_and_key(&ev, &EventType::RoomPowerLevels, "") {
+            if is_type_and_key(&ev, &RoomEventType::RoomPowerLevels, "") {
                 pl = Some(aid.to_owned());
                 break;
             }
@@ -568,7 +568,7 @@ fn get_mainline_depth<E: Event>(
         for aid in sort_ev.auth_events() {
             let aev = fetch_event(aid.borrow())
                 .ok_or_else(|| Error::NotFound(format!("Failed to find {}", aid)))?;
-            if is_type_and_key(&aev, &EventType::RoomPowerLevels, "") {
+            if is_type_and_key(&aev, &RoomEventType::RoomPowerLevels, "") {
                 event = Some(aev);
                 break;
             }
@@ -610,16 +610,16 @@ fn is_power_event_id<E: Event>(event_id: &EventId, fetch: impl Fn(&EventId) -> O
     }
 }
 
-fn is_type_and_key(ev: impl Event, ev_type: &EventType, state_key: &str) -> bool {
+fn is_type_and_key(ev: impl Event, ev_type: &RoomEventType, state_key: &str) -> bool {
     ev.event_type() == ev_type && ev.state_key() == Some(state_key)
 }
 
 fn is_power_event(event: impl Event) -> bool {
     match event.event_type() {
-        EventType::RoomPowerLevels | EventType::RoomJoinRules | EventType::RoomCreate => {
-            event.state_key() == Some("")
-        }
-        EventType::RoomMember => {
+        RoomEventType::RoomPowerLevels
+        | RoomEventType::RoomJoinRules
+        | RoomEventType::RoomCreate => event.state_key() == Some(""),
+        RoomEventType::RoomMember => {
             if let Ok(content) = from_json_str::<RoomMemberEventContent>(event.content().get()) {
                 if [MembershipState::Leave, MembershipState::Ban].contains(&content.membership) {
                     return Some(event.sender().as_str()) != event.state_key();
@@ -645,7 +645,7 @@ mod tests {
     use ruma_common::{
         events::{
             room::join_rules::{JoinRule, RoomJoinRulesEventContent},
-            EventType,
+            RoomEventType,
         },
         EventId, MilliSecondsSinceUnixEpoch, RoomVersionId,
     };
@@ -701,7 +701,8 @@ mod tests {
 
         events_to_sort.shuffle(&mut rand::thread_rng());
 
-        let power_level = resolved_power.get(&(EventType::RoomPowerLevels, "".to_owned())).cloned();
+        let power_level =
+            resolved_power.get(&(RoomEventType::RoomPowerLevels, "".to_owned())).cloned();
 
         let sorted_event_ids =
             crate::mainline_sort(&events_to_sort, power_level, |id| events.get(id).map(Arc::clone))
@@ -740,28 +741,28 @@ mod tests {
             to_init_pdu_event(
                 "PA",
                 alice(),
-                EventType::RoomPowerLevels,
+                RoomEventType::RoomPowerLevels,
                 Some(""),
                 to_raw_json_value(&json!({ "users": { alice(): 100, bob(): 50 } })).unwrap(),
             ),
             to_init_pdu_event(
                 "MA",
                 alice(),
-                EventType::RoomMember,
+                RoomEventType::RoomMember,
                 Some(alice().to_string().as_str()),
                 member_content_join(),
             ),
             to_init_pdu_event(
                 "MB",
                 alice(),
-                EventType::RoomMember,
+                RoomEventType::RoomMember,
                 Some(bob().to_string().as_str()),
                 member_content_ban(),
             ),
             to_init_pdu_event(
                 "PB",
                 bob(),
-                EventType::RoomPowerLevels,
+                RoomEventType::RoomPowerLevels,
                 Some(""),
                 to_raw_json_value(&json!({ "users": { alice(): 100, bob(): 50 } })).unwrap(),
             ),
@@ -787,42 +788,42 @@ mod tests {
             to_init_pdu_event(
                 "T1",
                 alice(),
-                EventType::RoomTopic,
+                RoomEventType::RoomTopic,
                 Some(""),
                 to_raw_json_value(&json!({})).unwrap(),
             ),
             to_init_pdu_event(
                 "PA1",
                 alice(),
-                EventType::RoomPowerLevels,
+                RoomEventType::RoomPowerLevels,
                 Some(""),
                 to_raw_json_value(&json!({ "users": { alice(): 100, bob(): 50 } })).unwrap(),
             ),
             to_init_pdu_event(
                 "T2",
                 alice(),
-                EventType::RoomTopic,
+                RoomEventType::RoomTopic,
                 Some(""),
                 to_raw_json_value(&json!({})).unwrap(),
             ),
             to_init_pdu_event(
                 "PA2",
                 alice(),
-                EventType::RoomPowerLevels,
+                RoomEventType::RoomPowerLevels,
                 Some(""),
                 to_raw_json_value(&json!({ "users": { alice(): 100, bob(): 0 } })).unwrap(),
             ),
             to_init_pdu_event(
                 "PB",
                 bob(),
-                EventType::RoomPowerLevels,
+                RoomEventType::RoomPowerLevels,
                 Some(""),
                 to_raw_json_value(&json!({ "users": { alice(): 100, bob(): 50 } })).unwrap(),
             ),
             to_init_pdu_event(
                 "T3",
                 bob(),
-                EventType::RoomTopic,
+                RoomEventType::RoomTopic,
                 Some(""),
                 to_raw_json_value(&json!({})).unwrap(),
             ),
@@ -848,28 +849,28 @@ mod tests {
             to_init_pdu_event(
                 "T1",
                 alice(),
-                EventType::RoomTopic,
+                RoomEventType::RoomTopic,
                 Some(""),
                 to_raw_json_value(&json!({})).unwrap(),
             ),
             to_init_pdu_event(
                 "PA",
                 alice(),
-                EventType::RoomPowerLevels,
+                RoomEventType::RoomPowerLevels,
                 Some(""),
                 to_raw_json_value(&json!({ "users": { alice(): 100, bob(): 50 } })).unwrap(),
             ),
             to_init_pdu_event(
                 "T2",
                 bob(),
-                EventType::RoomTopic,
+                RoomEventType::RoomTopic,
                 Some(""),
                 to_raw_json_value(&json!({})).unwrap(),
             ),
             to_init_pdu_event(
                 "MB",
                 alice(),
-                EventType::RoomMember,
+                RoomEventType::RoomMember,
                 Some(bob().to_string().as_str()),
                 member_content_ban(),
             ),
@@ -895,14 +896,14 @@ mod tests {
             to_init_pdu_event(
                 "JR",
                 alice(),
-                EventType::RoomJoinRules,
+                RoomEventType::RoomJoinRules,
                 Some(""),
                 to_raw_json_value(&RoomJoinRulesEventContent::new(JoinRule::Private)).unwrap(),
             ),
             to_init_pdu_event(
                 "ME",
                 ella(),
-                EventType::RoomMember,
+                RoomEventType::RoomMember,
                 Some(ella().to_string().as_str()),
                 member_content_join(),
             ),
@@ -927,14 +928,14 @@ mod tests {
             to_init_pdu_event(
                 "PA",
                 alice(),
-                EventType::RoomPowerLevels,
+                RoomEventType::RoomPowerLevels,
                 Some(""),
                 to_raw_json_value(&json!({ "users": { alice(): 100, bob(): 50 } })).unwrap(),
             ),
             to_init_pdu_event(
                 "PB",
                 bob(),
-                EventType::RoomPowerLevels,
+                RoomEventType::RoomPowerLevels,
                 Some(""),
                 to_raw_json_value(&json!({ "users": { alice(): 100, bob(): 50, charlie(): 50 } }))
                     .unwrap(),
@@ -942,7 +943,7 @@ mod tests {
             to_init_pdu_event(
                 "PC",
                 charlie(),
-                EventType::RoomPowerLevels,
+                RoomEventType::RoomPowerLevels,
                 Some(""),
                 to_raw_json_value(&json!({ "users": { alice(): 100, bob(): 50, charlie(): 0 } }))
                     .unwrap(),
@@ -968,56 +969,56 @@ mod tests {
             to_init_pdu_event(
                 "T1",
                 alice(),
-                EventType::RoomTopic,
+                RoomEventType::RoomTopic,
                 Some(""),
                 to_raw_json_value(&json!({})).unwrap(),
             ),
             to_init_pdu_event(
                 "PA1",
                 alice(),
-                EventType::RoomPowerLevels,
+                RoomEventType::RoomPowerLevels,
                 Some(""),
                 to_raw_json_value(&json!({ "users": { alice(): 100, bob(): 50 } })).unwrap(),
             ),
             to_init_pdu_event(
                 "T2",
                 alice(),
-                EventType::RoomTopic,
+                RoomEventType::RoomTopic,
                 Some(""),
                 to_raw_json_value(&json!({})).unwrap(),
             ),
             to_init_pdu_event(
                 "PA2",
                 alice(),
-                EventType::RoomPowerLevels,
+                RoomEventType::RoomPowerLevels,
                 Some(""),
                 to_raw_json_value(&json!({ "users": { alice(): 100, bob(): 0 } })).unwrap(),
             ),
             to_init_pdu_event(
                 "PB",
                 bob(),
-                EventType::RoomPowerLevels,
+                RoomEventType::RoomPowerLevels,
                 Some(""),
                 to_raw_json_value(&json!({ "users": { alice(): 100, bob(): 50 } })).unwrap(),
             ),
             to_init_pdu_event(
                 "T3",
                 bob(),
-                EventType::RoomTopic,
+                RoomEventType::RoomTopic,
                 Some(""),
                 to_raw_json_value(&json!({})).unwrap(),
             ),
             to_init_pdu_event(
                 "MZ1",
                 zara(),
-                EventType::RoomTopic,
+                RoomEventType::RoomTopic,
                 Some(""),
                 to_raw_json_value(&json!({})).unwrap(),
             ),
             to_init_pdu_event(
                 "T4",
                 alice(),
-                EventType::RoomTopic,
+                RoomEventType::RoomTopic,
                 Some(""),
                 to_raw_json_value(&json!({})).unwrap(),
             ),
@@ -1212,7 +1213,7 @@ mod tests {
             to_pdu_event(
                 "PA",
                 alice(),
-                EventType::RoomPowerLevels,
+                RoomEventType::RoomPowerLevels,
                 Some(""),
                 to_raw_json_value(&json!({ "users": { alice(): 100, bob(): 50 } })).unwrap(),
                 &["CREATE", "IMA", "IPOWER"], // auth_events
@@ -1221,7 +1222,7 @@ mod tests {
             to_pdu_event(
                 "PB",
                 alice(),
-                EventType::RoomPowerLevels,
+                RoomEventType::RoomPowerLevels,
                 Some(""),
                 to_raw_json_value(&json!({ "users": { alice(): 100, bob(): 50 } })).unwrap(),
                 &["CREATE", "IMA", "IPOWER"],
@@ -1230,7 +1231,7 @@ mod tests {
             to_pdu_event(
                 "MB",
                 alice(),
-                EventType::RoomMember,
+                RoomEventType::RoomMember,
                 Some(ella().as_str()),
                 member_content_ban(),
                 &["CREATE", "IMA", "PB"],
@@ -1239,7 +1240,7 @@ mod tests {
             to_pdu_event(
                 "IME",
                 ella(),
-                EventType::RoomMember,
+                RoomEventType::RoomMember,
                 Some(ella().as_str()),
                 member_content_join(),
                 &["CREATE", "IJR", "PA"],
@@ -1257,7 +1258,7 @@ mod tests {
             to_pdu_event(
                 "JR",
                 alice(),
-                EventType::RoomJoinRules,
+                RoomEventType::RoomJoinRules,
                 Some(""),
                 to_raw_json_value(&json!({ "join_rule": "invite" })).unwrap(),
                 &["CREATE", "IMA", "IPOWER"],
@@ -1266,7 +1267,7 @@ mod tests {
             to_pdu_event(
                 "IMZ",
                 zara(),
-                EventType::RoomPowerLevels,
+                RoomEventType::RoomPowerLevels,
                 Some(zara().as_str()),
                 member_content_join(),
                 &["CREATE", "JR", "IPOWER"],

--- a/crates/ruma-state-res/src/state_event.rs
+++ b/crates/ruma-state-res/src/state_event.rs
@@ -5,7 +5,7 @@ use std::{
     sync::Arc,
 };
 
-use ruma_common::{events::EventType, EventId, MilliSecondsSinceUnixEpoch, RoomId, UserId};
+use ruma_common::{events::RoomEventType, EventId, MilliSecondsSinceUnixEpoch, RoomId, UserId};
 use serde_json::value::RawValue as RawJsonValue;
 
 /// Abstraction of a PDU so users can have their own PDU types.
@@ -25,7 +25,7 @@ pub trait Event {
     fn origin_server_ts(&self) -> MilliSecondsSinceUnixEpoch;
 
     /// The event type.
-    fn event_type(&self) -> &EventType;
+    fn event_type(&self) -> &RoomEventType;
 
     /// The event's content.
     fn content(&self) -> &RawJsonValue;
@@ -64,7 +64,7 @@ impl<T: Event> Event for &T {
         (*self).origin_server_ts()
     }
 
-    fn event_type(&self) -> &EventType {
+    fn event_type(&self) -> &RoomEventType {
         (*self).event_type()
     }
 
@@ -108,7 +108,7 @@ impl<T: Event> Event for Arc<T> {
         (**self).origin_server_ts()
     }
 
-    fn event_type(&self) -> &EventType {
+    fn event_type(&self) -> &RoomEventType {
         (**self).event_type()
     }
 

--- a/crates/ruma-state-res/src/test_utils.rs
+++ b/crates/ruma-state-res/src/test_utils.rs
@@ -17,7 +17,7 @@ use ruma_common::{
             join_rules::{JoinRule, RoomJoinRulesEventContent},
             member::{MembershipState, RoomMemberEventContent},
         },
-        EventType,
+        RoomEventType,
     },
     room_id, user_id, EventId, MilliSecondsSinceUnixEpoch, RoomId, RoomVersionId, UserId,
 };
@@ -198,7 +198,7 @@ pub fn do_check(
                 // Filter out the dummy messages events.
                 // These act as points in time where there should be a known state to
                 // test against.
-                && **k != (EventType::RoomMessage, "dummy".to_owned())
+                && **k != (RoomEventType::RoomMessage, "dummy".to_owned())
         })
         .map(|(k, v)| (k.clone(), v.clone()))
         .collect::<StateMap<Box<EventId>>>();
@@ -252,7 +252,7 @@ impl TestStore<StateEvent> {
         let create_event = to_pdu_event::<&EventId>(
             "CREATE",
             alice(),
-            EventType::RoomCreate,
+            RoomEventType::RoomCreate,
             Some(""),
             to_raw_json_value(&json!({ "creator": alice() })).unwrap(),
             &[],
@@ -264,7 +264,7 @@ impl TestStore<StateEvent> {
         let alice_mem = to_pdu_event(
             "IMA",
             alice(),
-            EventType::RoomMember,
+            RoomEventType::RoomMember,
             Some(alice().to_string().as_str()),
             member_content_join(),
             &[cre.clone()],
@@ -275,7 +275,7 @@ impl TestStore<StateEvent> {
         let join_rules = to_pdu_event(
             "IJR",
             alice(),
-            EventType::RoomJoinRules,
+            RoomEventType::RoomJoinRules,
             Some(""),
             to_raw_json_value(&RoomJoinRulesEventContent::new(JoinRule::Public)).unwrap(),
             &[cre.clone(), alice_mem.event_id().to_owned()],
@@ -288,7 +288,7 @@ impl TestStore<StateEvent> {
         let bob_mem = to_pdu_event(
             "IMB",
             bob(),
-            EventType::RoomMember,
+            RoomEventType::RoomMember,
             Some(bob().to_string().as_str()),
             member_content_join(),
             &[cre.clone(), join_rules.event_id().to_owned()],
@@ -299,7 +299,7 @@ impl TestStore<StateEvent> {
         let charlie_mem = to_pdu_event(
             "IMC",
             charlie(),
-            EventType::RoomMember,
+            RoomEventType::RoomMember,
             Some(charlie().to_string().as_str()),
             member_content_join(),
             &[cre, join_rules.event_id().to_owned()],
@@ -384,7 +384,7 @@ pub fn member_content_join() -> Box<RawJsonValue> {
 pub fn to_init_pdu_event(
     id: &str,
     sender: Box<UserId>,
-    ev_type: EventType,
+    ev_type: RoomEventType,
     state_key: Option<&str>,
     content: Box<RawJsonValue>,
 ) -> Arc<StateEvent> {
@@ -417,7 +417,7 @@ pub fn to_init_pdu_event(
 pub fn to_pdu_event<S>(
     id: &str,
     sender: Box<UserId>,
-    ev_type: EventType,
+    ev_type: RoomEventType,
     state_key: Option<&str>,
     content: Box<RawJsonValue>,
     auth_events: &[S],
@@ -461,7 +461,7 @@ pub fn INITIAL_EVENTS() -> HashMap<Box<EventId>, Arc<StateEvent>> {
         to_pdu_event::<&EventId>(
             "CREATE",
             alice(),
-            EventType::RoomCreate,
+            RoomEventType::RoomCreate,
             Some(""),
             to_raw_json_value(&json!({ "creator": alice() })).unwrap(),
             &[],
@@ -470,7 +470,7 @@ pub fn INITIAL_EVENTS() -> HashMap<Box<EventId>, Arc<StateEvent>> {
         to_pdu_event(
             "IMA",
             alice(),
-            EventType::RoomMember,
+            RoomEventType::RoomMember,
             Some(alice().to_string().as_str()),
             member_content_join(),
             &["CREATE"],
@@ -479,7 +479,7 @@ pub fn INITIAL_EVENTS() -> HashMap<Box<EventId>, Arc<StateEvent>> {
         to_pdu_event(
             "IPOWER",
             alice(),
-            EventType::RoomPowerLevels,
+            RoomEventType::RoomPowerLevels,
             Some(""),
             to_raw_json_value(&json!({ "users": { alice().to_string(): 100 } })).unwrap(),
             &["CREATE", "IMA"],
@@ -488,7 +488,7 @@ pub fn INITIAL_EVENTS() -> HashMap<Box<EventId>, Arc<StateEvent>> {
         to_pdu_event(
             "IJR",
             alice(),
-            EventType::RoomJoinRules,
+            RoomEventType::RoomJoinRules,
             Some(""),
             to_raw_json_value(&RoomJoinRulesEventContent::new(JoinRule::Public)).unwrap(),
             &["CREATE", "IMA", "IPOWER"],
@@ -497,7 +497,7 @@ pub fn INITIAL_EVENTS() -> HashMap<Box<EventId>, Arc<StateEvent>> {
         to_pdu_event(
             "IMB",
             bob(),
-            EventType::RoomMember,
+            RoomEventType::RoomMember,
             Some(bob().to_string().as_str()),
             member_content_join(),
             &["CREATE", "IJR", "IPOWER"],
@@ -506,7 +506,7 @@ pub fn INITIAL_EVENTS() -> HashMap<Box<EventId>, Arc<StateEvent>> {
         to_pdu_event(
             "IMC",
             charlie(),
-            EventType::RoomMember,
+            RoomEventType::RoomMember,
             Some(charlie().to_string().as_str()),
             member_content_join(),
             &["CREATE", "IJR", "IPOWER"],
@@ -515,7 +515,7 @@ pub fn INITIAL_EVENTS() -> HashMap<Box<EventId>, Arc<StateEvent>> {
         to_pdu_event::<&EventId>(
             "START",
             charlie(),
-            EventType::RoomMessage,
+            RoomEventType::RoomMessage,
             Some("dummy"),
             to_raw_json_value(&json!({})).unwrap(),
             &[],
@@ -524,7 +524,7 @@ pub fn INITIAL_EVENTS() -> HashMap<Box<EventId>, Arc<StateEvent>> {
         to_pdu_event::<&EventId>(
             "END",
             charlie(),
-            EventType::RoomMessage,
+            RoomEventType::RoomMessage,
             Some("dummy"),
             to_raw_json_value(&json!({})).unwrap(),
             &[],
@@ -542,7 +542,7 @@ pub fn INITIAL_EVENTS_CREATE_ROOM() -> HashMap<Box<EventId>, Arc<StateEvent>> {
     vec![to_pdu_event::<&EventId>(
         "CREATE",
         alice(),
-        EventType::RoomCreate,
+        RoomEventType::RoomCreate,
         Some(""),
         to_raw_json_value(&json!({ "creator": alice() })).unwrap(),
         &[],
@@ -563,7 +563,7 @@ pub fn INITIAL_EDGES() -> Vec<Box<EventId>> {
 
 pub mod event {
     use ruma_common::{
-        events::{pdu::Pdu, EventType},
+        events::{pdu::Pdu, RoomEventType},
         EventId, MilliSecondsSinceUnixEpoch, RoomId, UserId,
     };
     use serde::{Deserialize, Serialize};
@@ -596,7 +596,7 @@ pub mod event {
             }
         }
 
-        fn event_type(&self) -> &EventType {
+        fn event_type(&self) -> &RoomEventType {
             match &self.rest {
                 Pdu::RoomV1Pdu(ev) => &ev.kind,
                 Pdu::RoomV3Pdu(ev) => &ev.kind,


### PR DESCRIPTION
… including the `EventContent` trait, such that the separate marker traits are no longer needed.