### PR TITLE
common: Add support for transitional extensible text messages

### DIFF
--- a/crates/ruma-common/src/events/emote.rs
+++ b/crates/ruma-common/src/events/emote.rs
@@ -5,7 +5,10 @@
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
-use super::{message::MessageContent, room::message::Relation};
+use super::{
+    message::MessageContent,
+    room::message::{EmoteMessageEventContent, Relation},
+};
 
 /// The payload for an extensible emote message.
 #[derive(Clone, Debug, Serialize, Deserialize, EventContent)]
@@ -41,5 +44,19 @@ impl EmoteEventContent {
     #[cfg(feature = "markdown")]
     pub fn markdown(body: impl AsRef<str> + Into<String>) -> Self {
         Self { message: MessageContent::markdown(body), relates_to: None }
+    }
+
+    /// Create a new `MessageEventContent` from the given `EmoteMessageEventContent` and optional
+    /// relation.
+    pub fn from_emote_room_message(
+        content: EmoteMessageEventContent,
+        relates_to: Option<Relation>,
+    ) -> Self {
+        let EmoteMessageEventContent { body, formatted, message, .. } = content;
+        if let Some(message) = message {
+            Self { message, relates_to }
+        } else {
+            Self { message: MessageContent::from_room_message_content(body, formatted), relates_to }
+        }
     }
 }

--- a/crates/ruma-common/src/events/notice.rs
+++ b/crates/ruma-common/src/events/notice.rs
@@ -5,7 +5,10 @@
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
-use super::{message::MessageContent, room::message::Relation};
+use super::{
+    message::MessageContent,
+    room::message::{NoticeMessageEventContent, Relation},
+};
 
 /// The payload for an extensible notice message.
 #[derive(Clone, Debug, Serialize, Deserialize, EventContent)]
@@ -41,5 +44,19 @@ impl NoticeEventContent {
     #[cfg(feature = "markdown")]
     pub fn markdown(body: impl AsRef<str> + Into<String>) -> Self {
         Self { message: MessageContent::markdown(body), relates_to: None }
+    }
+
+    /// Create a new `MessageEventContent` from the given `NoticeMessageEventContent` and optional
+    /// relation.
+    pub fn from_notice_room_message(
+        content: NoticeMessageEventContent,
+        relates_to: Option<Relation>,
+    ) -> Self {
+        let NoticeMessageEventContent { body, formatted, message, .. } = content;
+        if let Some(message) = message {
+            Self { message, relates_to }
+        } else {
+            Self { message: MessageContent::from_room_message_content(body, formatted), relates_to }
+        }
     }
 }

--- a/crates/ruma-common/tests/events/enums.rs
+++ b/crates/ruma-common/tests/events/enums.rs
@@ -211,10 +211,17 @@ fn message_event_serialization() {
         unsigned: MessageLikeUnsigned::default(),
     };
 
+    #[cfg(not(feature = "unstable-msc1767"))]
     assert_eq!(
         serde_json::to_string(&event).expect("Failed to serialize message event"),
         r#"{"type":"m.room.message","content":{"msgtype":"m.text","body":"test"},"event_id":"$1234:example.com","sender":"@test:example.com","origin_server_ts":0,"room_id":"!roomid:example.com"}"#
-    )
+    );
+
+    #[cfg(feature = "unstable-msc1767")]
+    assert_eq!(
+        serde_json::to_string(&event).expect("Failed to serialize message event"),
+        r#"{"type":"m.room.message","content":{"msgtype":"m.text","body":"test","org.matrix.msc1767.text":"test"},"event_id":"$1234:example.com","sender":"@test:example.com","origin_server_ts":0,"room_id":"!roomid:example.com"}"#
+    );
 }
 
 #[test]

--- a/crates/ruma-common/tests/events/relations.rs
+++ b/crates/ruma-common/tests/events/relations.rs
@@ -36,11 +36,27 @@ fn reply_serialize() {
         relates_to: Some(Relation::Reply { in_reply_to: InReplyTo::new(event_id!("$1598361704261elfgc").to_owned()) }),
     });
 
+    #[cfg(not(feature = "unstable-msc1767"))]
     assert_eq!(
         to_json_value(content).unwrap(),
         json!({
             "msgtype": "m.text",
             "body": "This is a reply",
+            "m.relates_to": {
+                "m.in_reply_to": {
+                    "event_id": "$1598361704261elfgc",
+                },
+            },
+        })
+    );
+
+    #[cfg(feature = "unstable-msc1767")]
+    assert_eq!(
+        to_json_value(content).unwrap(),
+        json!({
+            "msgtype": "m.text",
+            "body": "This is a reply",
+            "org.matrix.msc1767.text": "This is a reply",
             "m.relates_to": {
                 "m.in_reply_to": {
                     "event_id": "$1598361704261elfgc",
@@ -67,6 +83,7 @@ fn replacement_serialize() {
         }
     );
 
+    #[cfg(not(feature = "unstable-msc1767"))]
     assert_eq!(
         to_json_value(content).unwrap(),
         json!({
@@ -75,6 +92,25 @@ fn replacement_serialize() {
             "m.new_content": {
                 "body": "This is the new content.",
                 "msgtype": "m.text",
+            },
+            "m.relates_to": {
+                "rel_type": "m.replace",
+                "event_id": "$1598361704261elfgc",
+            },
+        })
+    );
+
+    #[cfg(feature = "unstable-msc1767")]
+    assert_eq!(
+        to_json_value(content).unwrap(),
+        json!({
+            "msgtype": "m.text",
+            "body": "<text msg>",
+            "org.matrix.msc1767.text": "<text msg>",
+            "m.new_content": {
+                "body": "This is the new content.",
+                "msgtype": "m.text",
+                "org.matrix.msc1767.text": "This is the new content.",
             },
             "m.relates_to": {
                 "rel_type": "m.replace",
@@ -130,11 +166,29 @@ fn thread_plain_serialize() {
         }
     );
 
+    #[cfg(not(feature = "unstable-msc1767"))]
     assert_eq!(
         to_json_value(content).unwrap(),
         json!({
             "msgtype": "m.text",
             "body": "<text msg>",
+            "m.relates_to": {
+                "rel_type": "io.element.thread",
+                "event_id": "$1598361704261elfgc",
+                "m.in_reply_to": {
+                    "event_id": "$latesteventid",
+                },
+            },
+        })
+    );
+
+    #[cfg(feature = "unstable-msc1767")]
+    assert_eq!(
+        to_json_value(content).unwrap(),
+        json!({
+            "msgtype": "m.text",
+            "body": "<text msg>",
+            "org.matrix.msc1767.text": "<text msg>",
             "m.relates_to": {
                 "rel_type": "io.element.thread",
                 "event_id": "$1598361704261elfgc",
@@ -163,11 +217,30 @@ fn thread_reply_serialize() {
         }
     );
 
+    #[cfg(not(feature = "unstable-msc1767"))]
     assert_eq!(
         to_json_value(content).unwrap(),
         json!({
             "msgtype": "m.text",
             "body": "<text msg>",
+            "m.relates_to": {
+                "rel_type": "io.element.thread",
+                "event_id": "$1598361704261elfgc",
+                "m.in_reply_to": {
+                    "event_id": "$repliedtoeventid",
+                },
+                "io.element.show_reply": true,
+            },
+        })
+    );
+
+    #[cfg(feature = "unstable-msc1767")]
+    assert_eq!(
+        to_json_value(content).unwrap(),
+        json!({
+            "msgtype": "m.text",
+            "body": "<text msg>",
+            "org.matrix.msc1767.text": "<text msg>",
             "m.relates_to": {
                 "rel_type": "io.element.thread",
                 "event_id": "$1598361704261elfgc",

--- a/crates/ruma-common/tests/events/room_message.rs
+++ b/crates/ruma-common/tests/events/room_message.rs
@@ -1,15 +1,20 @@
 use std::borrow::Cow;
 
+#[cfg(not(feature = "unstable-msc1767"))]
 use assign::assign;
 use js_int::uint;
 use matches::assert_matches;
+#[cfg(not(feature = "unstable-msc1767"))]
+use ruma_common::events::room::message::InReplyTo;
+#[cfg(any(feature = "unstable-msc2676", not(feature = "unstable-msc1767")))]
+use ruma_common::events::room::message::Relation;
 use ruma_common::{
     event_id,
     events::{
         key::verification::VerificationMethod,
         room::message::{
-            AudioMessageEventContent, InReplyTo, KeyVerificationRequestEventContent, MessageType,
-            Relation, RoomMessageEvent, RoomMessageEventContent, TextMessageEventContent,
+            AudioMessageEventContent, KeyVerificationRequestEventContent, MessageType,
+            RoomMessageEvent, RoomMessageEventContent, TextMessageEventContent,
         },
         MessageLikeUnsigned,
     },
@@ -126,6 +131,7 @@ fn formatted_body_serialization() {
     let message_event_content =
         RoomMessageEventContent::text_html("Hello, World!", "Hello, <em>World</em>!");
 
+    #[cfg(not(feature = "unstable-msc1767"))]
     assert_eq!(
         to_json_value(&message_event_content).unwrap(),
         json!({
@@ -135,6 +141,21 @@ fn formatted_body_serialization() {
             "formatted_body": "Hello, <em>World</em>!",
         })
     );
+
+    #[cfg(feature = "unstable-msc1767")]
+    assert_eq!(
+        to_json_value(&message_event_content).unwrap(),
+        json!({
+            "body": "Hello, World!",
+            "msgtype": "m.text",
+            "format": "org.matrix.custom.html",
+            "formatted_body": "Hello, <em>World</em>!",
+            "org.matrix.msc1767.message": [
+                { "body": "Hello, <em>World</em>!", "mimetype": "text/html" },
+                { "body": "Hello, World!", "mimetype": "text/plain" },
+            ],
+        })
+    );
 }
 
 #[test]
@@ -142,11 +163,22 @@ fn plain_text_content_serialization() {
     let message_event_content =
         RoomMessageEventContent::text_plain("> <@test:example.com> test\n\ntest reply");
 
+    #[cfg(not(feature = "unstable-msc1767"))]
     assert_eq!(
         to_json_value(&message_event_content).unwrap(),
         json!({
             "body": "> <@test:example.com> test\n\ntest reply",
             "msgtype": "m.text"
+        })
+    );
+
+    #[cfg(feature = "unstable-msc1767")]
+    assert_eq!(
+        to_json_value(&message_event_content).unwrap(),
+        json!({
+            "body": "> <@test:example.com> test\n\ntest reply",
+            "msgtype": "m.text",
+            "org.matrix.msc1767.text": "> <@test:example.com> test\n\ntest reply",
         })
     );
 }
@@ -158,6 +190,7 @@ fn markdown_content_serialization() {
         TextMessageEventContent::markdown("Testing **bold** and _italic_!"),
     ));
 
+    #[cfg(not(feature = "unstable-msc1767"))]
     assert_eq!(
         to_json_value(&formatted_message).unwrap(),
         json!({
@@ -168,10 +201,26 @@ fn markdown_content_serialization() {
         })
     );
 
+    #[cfg(feature = "unstable-msc1767")]
+    assert_eq!(
+        to_json_value(&formatted_message).unwrap(),
+        json!({
+            "body": "Testing **bold** and _italic_!",
+            "formatted_body": "<p>Testing <strong>bold</strong> and <em>italic</em>!</p>\n",
+            "format": "org.matrix.custom.html",
+            "msgtype": "m.text",
+            "org.matrix.msc1767.message": [
+                { "body": "<p>Testing <strong>bold</strong> and <em>italic</em>!</p>\n", "mimetype": "text/html" },
+                { "body": "Testing **bold** and _italic_!", "mimetype": "text/plain" },
+            ],
+        })
+    );
+
     let plain_message_simple = RoomMessageEventContent::new(MessageType::Text(
         TextMessageEventContent::markdown("Testing a simple phrase…"),
     ));
 
+    #[cfg(not(feature = "unstable-msc1767"))]
     assert_eq!(
         to_json_value(&plain_message_simple).unwrap(),
         json!({
@@ -180,10 +229,21 @@ fn markdown_content_serialization() {
         })
     );
 
+    #[cfg(feature = "unstable-msc1767")]
+    assert_eq!(
+        to_json_value(&plain_message_simple).unwrap(),
+        json!({
+            "body": "Testing a simple phrase…",
+            "msgtype": "m.text",
+            "org.matrix.msc1767.text": "Testing a simple phrase…",
+        })
+    );
+
     let plain_message_paragraphs = RoomMessageEventContent::new(MessageType::Text(
         TextMessageEventContent::markdown("Testing\n\nSeveral\n\nParagraphs."),
     ));
 
+    #[cfg(not(feature = "unstable-msc1767"))]
     assert_eq!(
         to_json_value(&plain_message_paragraphs).unwrap(),
         json!({
@@ -193,9 +253,25 @@ fn markdown_content_serialization() {
             "msgtype": "m.text"
         })
     );
+
+    #[cfg(feature = "unstable-msc1767")]
+    assert_eq!(
+        to_json_value(&plain_message_paragraphs).unwrap(),
+        json!({
+            "body": "Testing\n\nSeveral\n\nParagraphs.",
+            "formatted_body": "<p>Testing</p>\n<p>Several</p>\n<p>Paragraphs.</p>\n",
+            "format": "org.matrix.custom.html",
+            "msgtype": "m.text",
+            "org.matrix.msc1767.message": [
+                { "body": "<p>Testing</p>\n<p>Several</p>\n<p>Paragraphs.</p>\n", "mimetype": "text/html" },
+                { "body": "Testing\n\nSeveral\n\nParagraphs.", "mimetype": "text/plain" },
+            ],
+        })
+    );
 }
 
 #[test]
+#[cfg(not(feature = "unstable-msc1767"))]
 fn relates_to_content_serialization() {
     let message_event_content =
         assign!(RoomMessageEventContent::text_plain("> <@test:example.com> test\n\ntest reply"), {


### PR DESCRIPTION
According to [MSC1767](https://github.com/matrix-org/matrix-spec-proposals/pull/1767).

Part of #790.