### PR TITLE
Deserialize stable names for unstable features

### DIFF
--- a/crates/ruma-client-api/src/discovery/discover_homeserver.rs
+++ b/crates/ruma-client-api/src/discovery/discover_homeserver.rs
@@ -30,7 +30,7 @@ ruma_api! {
 
         /// Information about the tile server to use to display location data.
         #[cfg(feature = "unstable-msc3488")]
-        #[serde(rename = "org.matrix.msc3488.tile_server")]
+        #[serde(rename = "org.matrix.msc3488.tile_server", alias = "m.tile_server")]
         pub tile_server: Option<TileServerInfo>,
     }
 

--- a/crates/ruma-client-api/src/filter.rs
+++ b/crates/ruma-client-api/src/filter.rs
@@ -67,7 +67,7 @@ pub enum RelationType {
     Replacement,
 
     /// `m.thread`, a participant to a thread.
-    #[ruma_enum(rename = "io.element.thread")]
+    #[ruma_enum(rename = "io.element.thread", alias = "m.thread")]
     Thread,
 
     #[doc(hidden)]
@@ -153,6 +153,7 @@ pub struct RoomEventFilter<'a> {
     #[cfg(feature = "unstable-msc3440")]
     #[serde(
         rename = "io.element.relation_types",
+        alias = "related_by_rel_types",
         default,
         skip_serializing_if = "<[_]>::is_empty"
     )]
@@ -165,6 +166,7 @@ pub struct RoomEventFilter<'a> {
     #[cfg(feature = "unstable-msc3440")]
     #[serde(
         rename = "io.element.relation_senders",
+        alias = "related_by_senders",
         default,
         skip_serializing_if = "<[_]>::is_empty"
     )]

--- a/crates/ruma-client-api/src/media/create_content.rs
+++ b/crates/ruma-client-api/src/media/create_content.rs
@@ -39,7 +39,12 @@ pub mod v3 {
             /// [MSC2448](https://github.com/matrix-org/matrix-spec-proposals/pull/2448).
             #[ruma_api(query)]
             #[cfg(feature = "unstable-msc2448")]
-            #[serde(default, skip_serializing_if = "ruma_common::serde::is_default", rename = "xyz.amorgan.blurhash")]
+            #[serde(
+                default,
+                skip_serializing_if = "ruma_common::serde::is_default",
+                rename = "xyz.amorgan.generate_blurhash",
+                alias = "generate_blurhash"
+            )]
             pub generate_blurhash: bool,
         }
 
@@ -52,7 +57,11 @@ pub mod v3 {
             /// This uses the unstable prefix in
             /// [MSC2448](https://github.com/matrix-org/matrix-spec-proposals/pull/2448).
             #[cfg(feature = "unstable-msc2448")]
-            #[serde(rename = "xyz.amorgan.blurhash", skip_serializing_if = "Option::is_none")]
+            #[serde(
+                rename = "xyz.amorgan.blurhash",
+                alias = "blurhash",
+                skip_serializing_if = "Option::is_none"
+            )]
             pub blurhash: Option<String>,
         }
 

--- a/crates/ruma-client-api/src/profile/get_avatar_url.rs
+++ b/crates/ruma-client-api/src/profile/get_avatar_url.rs
@@ -43,7 +43,11 @@ pub mod v3 {
             /// This uses the unstable prefix in
             /// [MSC2448](https://github.com/matrix-org/matrix-spec-proposals/pull/2448).
             #[cfg(feature = "unstable-msc2448")]
-            #[serde(rename = "xyz.amorgan.blurhash", skip_serializing_if = "Option::is_none")]
+            #[serde(
+                rename = "xyz.amorgan.blurhash",
+                alias = "blurhash",
+                skip_serializing_if = "Option::is_none"
+            )]
             pub blurhash: Option<String>,
         }
 

--- a/crates/ruma-client-api/src/profile/get_profile.rs
+++ b/crates/ruma-client-api/src/profile/get_profile.rs
@@ -47,7 +47,11 @@ pub mod v3 {
             /// This uses the unstable prefix in
             /// [MSC2448](https://github.com/matrix-org/matrix-spec-proposals/pull/2448).
             #[cfg(feature = "unstable-msc2448")]
-            #[serde(rename = "xyz.amorgan.blurhash", skip_serializing_if = "Option::is_none")]
+            #[serde(
+                rename = "xyz.amorgan.blurhash",
+                alias = "blurhash",
+                skip_serializing_if = "Option::is_none"
+            )]
             pub blurhash: Option<String>,
         }
 

--- a/crates/ruma-client-api/src/profile/set_avatar_url.rs
+++ b/crates/ruma-client-api/src/profile/set_avatar_url.rs
@@ -49,7 +49,11 @@ pub mod v3 {
             /// This uses the unstable prefix in
             /// [MSC2448](https://github.com/matrix-org/matrix-spec-proposals/pull/2448).
             #[cfg(feature = "unstable-msc2448")]
-            #[serde(rename = "xyz.amorgan.blurhash", skip_serializing_if = "Option::is_none")]
+            #[serde(
+                rename = "xyz.amorgan.blurhash",
+                alias = "blurhash",
+                skip_serializing_if = "Option::is_none"
+            )]
             pub blurhash: Option<&'a str>,
         }
 

--- a/crates/ruma-common/src/events/relation.rs
+++ b/crates/ruma-common/src/events/relation.rs
@@ -135,7 +135,7 @@ pub struct Relations {
 
     /// Thread relation.
     #[cfg(feature = "unstable-msc3440")]
-    #[serde(rename = "io.element.thread")]
+    #[serde(rename = "io.element.thread", alias = "m.thread")]
     pub thread: Option<BundledThread>,
 }
 

--- a/crates/ruma-common/src/events/room.rs
+++ b/crates/ruma-common/src/events/room.rs
@@ -73,7 +73,11 @@ pub struct ImageInfo {
     /// This uses the unstable prefix in
     /// [MSC2448](https://github.com/matrix-org/matrix-spec-proposals/pull/2448).
     #[cfg(feature = "unstable-msc2448")]
-    #[serde(rename = "xyz.amorgan.blurhash", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "xyz.amorgan.blurhash",
+        alias = "blurhash",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub blurhash: Option<String>,
 }
 

--- a/crates/ruma-common/src/events/room/avatar.rs
+++ b/crates/ruma-common/src/events/room/avatar.rs
@@ -91,7 +91,11 @@ pub struct ImageInfo {
     /// This uses the unstable prefix in
     /// [MSC2448](https://github.com/matrix-org/matrix-spec-proposals/pull/2448).
     #[cfg(feature = "unstable-msc2448")]
-    #[serde(rename = "xyz.amorgan.blurhash", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "xyz.amorgan.blurhash",
+        alias = "blurhash",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub blurhash: Option<String>,
 }
 

--- a/crates/ruma-common/src/events/room/encrypted/relation_serde.rs
+++ b/crates/ruma-common/src/events/room/encrypted/relation_serde.rs
@@ -18,8 +18,10 @@ impl<'de> Deserialize<'de> for Relation {
         let ev = EventWithRelatesToJsonRepr::deserialize(deserializer)?;
 
         #[cfg(feature = "unstable-msc3440")]
-        if let Some(RelationJsonRepr::Thread(ThreadJsonRepr { event_id, is_falling_back })) =
-            ev.relates_to.relation
+        if let Some(
+            RelationJsonRepr::ThreadStable(ThreadStableJsonRepr { event_id, is_falling_back })
+            | RelationJsonRepr::ThreadUnstable(ThreadUnstableJsonRepr { event_id, is_falling_back }),
+        ) = ev.relates_to.relation
         {
             let in_reply_to = ev
                 .relates_to
@@ -27,7 +29,6 @@ impl<'de> Deserialize<'de> for Relation {
                 .ok_or_else(|| serde::de::Error::missing_field("m.in_reply_to"))?;
             return Ok(Relation::Thread(Thread { event_id, in_reply_to, is_falling_back }));
         }
-
         let rel = if let Some(in_reply_to) = ev.relates_to.in_reply_to {
             Relation::Reply { in_reply_to }
         } else if let Some(relation) = ev.relates_to.relation {
@@ -40,7 +41,9 @@ impl<'de> Deserialize<'de> for Relation {
                     Relation::Replacement(Replacement { event_id })
                 }
                 #[cfg(feature = "unstable-msc3440")]
-                RelationJsonRepr::Thread(_) => unreachable!(),
+                RelationJsonRepr::ThreadStable(_) | RelationJsonRepr::ThreadUnstable(_) => {
+                    unreachable!()
+                }
                 // FIXME: Maybe we should log this, though at this point we don't even have
                 // access to the rel_type of the unknown relation.
                 RelationJsonRepr::Unknown => Relation::_Custom,
@@ -81,7 +84,7 @@ impl Serialize for Relation {
             Relation::Thread(Thread { event_id, in_reply_to, is_falling_back }) => {
                 RelatesToJsonRepr {
                     in_reply_to: Some(in_reply_to.clone()),
-                    relation: Some(RelationJsonRepr::Thread(ThreadJsonRepr {
+                    relation: Some(RelationJsonRepr::ThreadUnstable(ThreadUnstableJsonRepr {
                         event_id: event_id.clone(),
                         is_falling_back: *is_falling_back,
                     })),
@@ -118,10 +121,23 @@ impl RelatesToJsonRepr {
     }
 }
 
-/// A thread relation without the reply fallback.
+/// A thread relation without the reply fallback, with stable names.
 #[derive(Clone, Deserialize, Serialize)]
 #[cfg(feature = "unstable-msc3440")]
-struct ThreadJsonRepr {
+struct ThreadStableJsonRepr {
+    /// The ID of the root message in the thread.
+    pub event_id: Box<EventId>,
+
+    /// Whether the `m.in_reply_to` field is a fallback for older clients or a real reply in a
+    /// thread.
+    #[serde(default, skip_serializing_if = "ruma_common::serde::is_default")]
+    pub is_falling_back: bool,
+}
+
+/// A thread relation without the reply fallback, with unstable names.
+#[derive(Clone, Deserialize, Serialize)]
+#[cfg(feature = "unstable-msc3440")]
+struct ThreadUnstableJsonRepr {
     /// The ID of the root message in the thread.
     pub event_id: Box<EventId>,
 
@@ -153,10 +169,15 @@ enum RelationJsonRepr {
     #[serde(rename = "m.replace")]
     Replacement(Replacement),
 
-    /// An event that belongs to a thread.
+    /// An event that belongs to a thread, with stable names.
+    #[cfg(feature = "unstable-msc3440")]
+    #[serde(rename = "m.thread")]
+    ThreadStable(ThreadStableJsonRepr),
+
+    /// An event that belongs to a thread, with unstable names.
     #[cfg(feature = "unstable-msc3440")]
     #[serde(rename = "io.element.thread")]
-    Thread(ThreadJsonRepr),
+    ThreadUnstable(ThreadUnstableJsonRepr),
 
     /// An unknown relation type.
     ///

--- a/crates/ruma-common/src/events/room/member.rs
+++ b/crates/ruma-common/src/events/room/member.rs
@@ -76,7 +76,11 @@ pub struct RoomMemberEventContent {
     /// This uses the unstable prefix in
     /// [MSC2448](https://github.com/matrix-org/matrix-spec-proposals/pull/2448).
     #[cfg(feature = "unstable-msc2448")]
-    #[serde(rename = "xyz.amorgan.blurhash", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "xyz.amorgan.blurhash",
+        alias = "blurhash",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub blurhash: Option<String>,
 
     /// User-supplied text for why their membership has changed.

--- a/crates/ruma-common/tests/events/relations.rs
+++ b/crates/ruma-common/tests/events/relations.rs
@@ -182,7 +182,43 @@ fn thread_reply_serialize() {
 
 #[test]
 #[cfg(feature = "unstable-msc3440")]
-fn thread_deserialize() {
+fn thread_stable_deserialize() {
+    use ruma_common::events::room::message::Thread;
+
+    let json = json!({
+        "msgtype": "m.text",
+        "body": "<text msg>",
+        "m.relates_to": {
+            "rel_type": "m.thread",
+            "event_id": "$1598361704261elfgc",
+            "m.in_reply_to": {
+                "event_id": "$latesteventid",
+            },
+        },
+    });
+
+    assert_matches!(
+        from_json_value::<RoomMessageEventContent>(json).unwrap(),
+        RoomMessageEventContent {
+            msgtype: MessageType::Text(_),
+            relates_to: Some(Relation::Thread(
+                Thread {
+                    event_id,
+                    in_reply_to: InReplyTo { event_id: reply_to_event_id, .. },
+                    is_falling_back,
+                    ..
+                },
+            )),
+            ..
+        } if event_id == "$1598361704261elfgc"
+          && reply_to_event_id == "$latesteventid"
+          && !is_falling_back
+    );
+}
+
+#[test]
+#[cfg(feature = "unstable-msc3440")]
+fn thread_unstable_deserialize() {
     use ruma_common::events::room::message::Thread;
 
     let json = json!({

--- a/crates/ruma-federation-api/src/query/get_profile_information.rs
+++ b/crates/ruma-federation-api/src/query/get_profile_information.rs
@@ -55,7 +55,11 @@ pub mod v1 {
             /// This uses the unstable prefix in
             /// [MSC2448](https://github.com/matrix-org/matrix-spec-proposals/pull/2448).
             #[cfg(feature = "unstable-msc2448")]
-            #[serde(rename = "xyz.amorgan.blurhash", skip_serializing_if = "Option::is_none")]
+            #[serde(
+                rename = "xyz.amorgan.blurhash",
+                alias = "blurhash",
+                skip_serializing_if = "Option::is_none"
+            )]
             pub blurhash: Option<String>,
         }
     }


### PR DESCRIPTION
Allows to receive incoming stable types without requiring a Ruma update.

I didn't do it for extensible events yet because this will depend on how the transitional events are structured.