### PR TITLE
common: Add support for more transitional extensible messages

### DIFF
--- a/crates/ruma-common/src/events/audio.rs
+++ b/crates/ruma-common/src/events/audio.rs
@@ -75,7 +75,18 @@ impl AudioEventContent {
         content: AudioMessageEventContent,
         relates_to: Option<Relation>,
     ) -> Self {
-        let AudioMessageEventContent { body, source, info, message, file, audio } = content;
+        // Otherwise the `voice` field has an extra indentation
+        #[rustfmt::skip]
+        let AudioMessageEventContent {
+            body,
+            source,
+            info,
+            message,
+            file,
+            audio,
+            #[cfg(feature = "unstable-msc3245")]
+            voice: _,
+        } = content;
 
         let message = message.unwrap_or_else(|| MessageContent::plain(body));
         let file = file.unwrap_or_else(|| {

--- a/crates/ruma-common/src/events/file.rs
+++ b/crates/ruma-common/src/events/file.rs
@@ -14,124 +14,6 @@ use super::{
 };
 use crate::{serde::Base64, MxcUri};
 
-/// The encryption info of a file sent to a room with end-to-end encryption enabled.
-///
-/// To create an instance of this type, first create a `EncryptedContentInit` and convert it via
-/// `EncryptedContent::from` / `.into()`.
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-pub struct EncryptedContent {
-    /// A [JSON Web Key](https://tools.ietf.org/html/rfc7517#appendix-A.3) object.
-    pub key: JsonWebKey,
-
-    /// The 128-bit unique counter block used by AES-CTR, encoded as unpadded base64.
-    pub iv: Base64,
-
-    /// A map from an algorithm name to a hash of the ciphertext, encoded as unpadded base64.
-    ///
-    /// Clients should support the SHA-256 hash, which uses the key sha256.
-    pub hashes: BTreeMap<String, Base64>,
-
-    /// Version of the encrypted attachments protocol.
-    ///
-    /// Must be `v2`.
-    pub v: String,
-}
-
-/// Initial set of fields of `EncryptedContent`.
-///
-/// This struct will not be updated even if additional fields are added to `EncryptedContent` in a
-/// new (non-breaking) release of the Matrix specification.
-#[derive(Debug)]
-#[allow(clippy::exhaustive_structs)]
-pub struct EncryptedContentInit {
-    /// A [JSON Web Key](https://tools.ietf.org/html/rfc7517#appendix-A.3) object.
-    pub key: JsonWebKey,
-
-    /// The 128-bit unique counter block used by AES-CTR, encoded as unpadded base64.
-    pub iv: Base64,
-
-    /// A map from an algorithm name to a hash of the ciphertext, encoded as unpadded base64.
-    ///
-    /// Clients should support the SHA-256 hash, which uses the key sha256.
-    pub hashes: BTreeMap<String, Base64>,
-
-    /// Version of the encrypted attachments protocol.
-    ///
-    /// Must be `v2`.
-    pub v: String,
-}
-
-impl From<EncryptedContentInit> for EncryptedContent {
-    fn from(init: EncryptedContentInit) -> Self {
-        let EncryptedContentInit { key, iv, hashes, v } = init;
-        Self { key, iv, hashes, v }
-    }
-}
-
-/// Information about a file content.
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
-#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-pub struct FileContentInfo {
-    /// The original filename of the uploaded file.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
-
-    /// The mimetype of the file, e.g. “application/msword”.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub mimetype: Option<String>,
-
-    /// The size of the file in bytes.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub size: Option<UInt>,
-}
-
-impl FileContentInfo {
-    /// Creates an empty `FileContentInfo`.
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
-/// File content.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-pub struct FileContent {
-    /// The URL to the file.
-    pub url: Box<MxcUri>,
-
-    /// Information about the uploaded file.
-    #[serde(flatten, skip_serializing_if = "Option::is_none")]
-    pub info: Option<Box<FileContentInfo>>,
-
-    /// Information on the encrypted file.
-    ///
-    /// Required if file is encrypted.
-    #[serde(flatten, skip_serializing_if = "Option::is_none")]
-    pub encryption_info: Option<Box<EncryptedContent>>,
-}
-
-impl FileContent {
-    /// Creates a new non-encrypted `FileContent` with the given url and file info.
-    pub fn plain(url: Box<MxcUri>, info: Option<Box<FileContentInfo>>) -> Self {
-        Self { url, info, encryption_info: None }
-    }
-
-    /// Creates a new encrypted `FileContent` with the given url, encryption info and file info.
-    pub fn encrypted(
-        url: Box<MxcUri>,
-        encryption_info: EncryptedContent,
-        info: Option<Box<FileContentInfo>>,
-    ) -> Self {
-        Self { url, info, encryption_info: Some(Box::new(encryption_info)) }
-    }
-
-    /// Whether the file is encrypted.
-    pub fn is_encrypted(&self) -> bool {
-        self.encryption_info.is_some()
-    }
-}
-
 /// The payload for an extensible text message.
 #[derive(Clone, Debug, Serialize, Deserialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
@@ -201,5 +83,123 @@ impl FileEventContent {
         info: Option<Box<FileContentInfo>>,
     ) -> Self {
         Self { message, file: FileContent::encrypted(url, encryption_info, info), relates_to: None }
+    }
+}
+
+/// File content.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+pub struct FileContent {
+    /// The URL to the file.
+    pub url: Box<MxcUri>,
+
+    /// Information about the uploaded file.
+    #[serde(flatten, skip_serializing_if = "Option::is_none")]
+    pub info: Option<Box<FileContentInfo>>,
+
+    /// Information on the encrypted file.
+    ///
+    /// Required if file is encrypted.
+    #[serde(flatten, skip_serializing_if = "Option::is_none")]
+    pub encryption_info: Option<Box<EncryptedContent>>,
+}
+
+impl FileContent {
+    /// Creates a new non-encrypted `FileContent` with the given url and file info.
+    pub fn plain(url: Box<MxcUri>, info: Option<Box<FileContentInfo>>) -> Self {
+        Self { url, info, encryption_info: None }
+    }
+
+    /// Creates a new encrypted `FileContent` with the given url, encryption info and file info.
+    pub fn encrypted(
+        url: Box<MxcUri>,
+        encryption_info: EncryptedContent,
+        info: Option<Box<FileContentInfo>>,
+    ) -> Self {
+        Self { url, info, encryption_info: Some(Box::new(encryption_info)) }
+    }
+
+    /// Whether the file is encrypted.
+    pub fn is_encrypted(&self) -> bool {
+        self.encryption_info.is_some()
+    }
+}
+
+/// Information about a file content.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+pub struct FileContentInfo {
+    /// The original filename of the uploaded file.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+
+    /// The mimetype of the file, e.g. “application/msword”.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mimetype: Option<String>,
+
+    /// The size of the file in bytes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub size: Option<UInt>,
+}
+
+impl FileContentInfo {
+    /// Creates an empty `FileContentInfo`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+/// The encryption info of a file sent to a room with end-to-end encryption enabled.
+///
+/// To create an instance of this type, first create a `EncryptedContentInit` and convert it via
+/// `EncryptedContent::from` / `.into()`.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+pub struct EncryptedContent {
+    /// A [JSON Web Key](https://tools.ietf.org/html/rfc7517#appendix-A.3) object.
+    pub key: JsonWebKey,
+
+    /// The 128-bit unique counter block used by AES-CTR, encoded as unpadded base64.
+    pub iv: Base64,
+
+    /// A map from an algorithm name to a hash of the ciphertext, encoded as unpadded base64.
+    ///
+    /// Clients should support the SHA-256 hash, which uses the key sha256.
+    pub hashes: BTreeMap<String, Base64>,
+
+    /// Version of the encrypted attachments protocol.
+    ///
+    /// Must be `v2`.
+    pub v: String,
+}
+
+/// Initial set of fields of `EncryptedContent`.
+///
+/// This struct will not be updated even if additional fields are added to `EncryptedContent` in a
+/// new (non-breaking) release of the Matrix specification.
+#[derive(Debug)]
+#[allow(clippy::exhaustive_structs)]
+pub struct EncryptedContentInit {
+    /// A [JSON Web Key](https://tools.ietf.org/html/rfc7517#appendix-A.3) object.
+    pub key: JsonWebKey,
+
+    /// The 128-bit unique counter block used by AES-CTR, encoded as unpadded base64.
+    pub iv: Base64,
+
+    /// A map from an algorithm name to a hash of the ciphertext, encoded as unpadded base64.
+    ///
+    /// Clients should support the SHA-256 hash, which uses the key sha256.
+    pub hashes: BTreeMap<String, Base64>,
+
+    /// Version of the encrypted attachments protocol.
+    ///
+    /// Must be `v2`.
+    pub v: String,
+}
+
+impl From<EncryptedContentInit> for EncryptedContent {
+    fn from(init: EncryptedContentInit) -> Self {
+        let EncryptedContentInit { key, iv, hashes, v } = init;
+        Self { key, iv, hashes, v }
     }
 }

--- a/crates/ruma-common/src/events/file.rs
+++ b/crates/ruma-common/src/events/file.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use super::{
     message::MessageContent,
     room::{
-        message::{FileInfo, FileMessageEventContent, Relation, VideoInfo},
+        message::{AudioInfo, FileInfo, FileMessageEventContent, Relation, VideoInfo},
         EncryptedFile, ImageInfo, JsonWebKey, MediaSource,
     },
 };
@@ -208,6 +208,13 @@ impl FileContentInfo {
             info.name = filename;
             Some(info)
         }
+    }
+}
+
+impl From<&AudioInfo> for FileContentInfo {
+    fn from(info: &AudioInfo) -> Self {
+        let AudioInfo { mimetype, size, .. } = info;
+        Self { mimetype: mimetype.to_owned(), size: size.to_owned(), ..Default::default() }
     }
 }
 

--- a/crates/ruma-common/src/events/file.rs
+++ b/crates/ruma-common/src/events/file.rs
@@ -12,7 +12,7 @@ use super::{
     message::MessageContent,
     room::{
         message::{FileInfo, FileMessageEventContent, Relation},
-        EncryptedFile, JsonWebKey, MediaSource,
+        EncryptedFile, ImageInfo, JsonWebKey, MediaSource,
     },
 };
 use crate::{serde::Base64, MxcUri};
@@ -214,6 +214,13 @@ impl FileContentInfo {
 impl From<&FileInfo> for FileContentInfo {
     fn from(info: &FileInfo) -> Self {
         let FileInfo { mimetype, size, .. } = info;
+        Self { mimetype: mimetype.to_owned(), size: size.to_owned(), ..Default::default() }
+    }
+}
+
+impl From<&ImageInfo> for FileContentInfo {
+    fn from(info: &ImageInfo) -> Self {
+        let ImageInfo { mimetype, size, .. } = info;
         Self { mimetype: mimetype.to_owned(), size: size.to_owned(), ..Default::default() }
     }
 }

--- a/crates/ruma-common/src/events/file.rs
+++ b/crates/ruma-common/src/events/file.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use super::{
     message::MessageContent,
     room::{
-        message::{FileInfo, FileMessageEventContent, Relation},
+        message::{FileInfo, FileMessageEventContent, Relation, VideoInfo},
         EncryptedFile, ImageInfo, JsonWebKey, MediaSource,
     },
 };
@@ -221,6 +221,13 @@ impl From<&FileInfo> for FileContentInfo {
 impl From<&ImageInfo> for FileContentInfo {
     fn from(info: &ImageInfo) -> Self {
         let ImageInfo { mimetype, size, .. } = info;
+        Self { mimetype: mimetype.to_owned(), size: size.to_owned(), ..Default::default() }
+    }
+}
+
+impl From<&VideoInfo> for FileContentInfo {
+    fn from(info: &VideoInfo) -> Self {
+        let VideoInfo { mimetype, size, .. } = info;
         Self { mimetype: mimetype.to_owned(), size: size.to_owned(), ..Default::default() }
     }
 }

--- a/crates/ruma-common/src/events/file.rs
+++ b/crates/ruma-common/src/events/file.rs
@@ -10,11 +10,26 @@ use serde::{Deserialize, Serialize};
 
 use super::{
     message::MessageContent,
-    room::{message::Relation, JsonWebKey},
+    room::{
+        message::{FileInfo, FileMessageEventContent, Relation},
+        EncryptedFile, JsonWebKey, MediaSource,
+    },
 };
 use crate::{serde::Base64, MxcUri};
 
-/// The payload for an extensible text message.
+/// The payload for an extensible file message.
+///
+/// This is the new primary type introduced in [MSC3551] and should not be sent before the end of
+/// the transition period. See the documentation of the [`message`] module for more information.
+///
+/// `FileEventContent` can be converted to a [`RoomMessageEventContent`] with a
+/// [`MessageType::File`]. You can convert it back with
+/// [`FileEventContent::from_file_room_message()`].
+///
+/// [MSC3551]: https://github.com/matrix-org/matrix-spec-proposals/pull/3551
+/// [`message`]: super::message
+/// [`RoomMessageEventContent`]: super::room::message::RoomMessageEventContent
+/// [`MessageType::File`]: super::room::message::MessageType::File
 #[derive(Clone, Debug, Serialize, Deserialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[ruma_event(type = "m.file", kind = MessageLike)]
@@ -84,6 +99,22 @@ impl FileEventContent {
     ) -> Self {
         Self { message, file: FileContent::encrypted(url, encryption_info, info), relates_to: None }
     }
+
+    /// Create a new `FileEventContent` from the given `FileMessageEventContent` and optional
+    /// relation.
+    pub fn from_file_room_message(
+        content: FileMessageEventContent,
+        relates_to: Option<Relation>,
+    ) -> Self {
+        let FileMessageEventContent { body, filename, source, info, message, file } = content;
+
+        let message = message.unwrap_or_else(|| MessageContent::plain(body));
+        let file = file.unwrap_or_else(|| {
+            FileContent::from_room_message_content(source, info.as_deref(), filename)
+        });
+
+        Self { message, file, relates_to }
+    }
 }
 
 /// File content.
@@ -119,6 +150,21 @@ impl FileContent {
         Self { url, info, encryption_info: Some(Box::new(encryption_info)) }
     }
 
+    /// Create a new `FileContent` with the given media source, file info and filename.
+    pub fn from_room_message_content(
+        source: MediaSource,
+        info: Option<impl Into<FileContentInfo>>,
+        filename: Option<String>,
+    ) -> Self {
+        let (url, encryption_info) = match source {
+            MediaSource::Plain(url) => (url, None),
+            MediaSource::Encrypted(file) => (file.url.to_owned(), Some(Box::new((&*file).into()))),
+        };
+        let info = FileContentInfo::from_room_message_content(info, filename).map(Box::new);
+
+        Self { url, encryption_info, info }
+    }
+
     /// Whether the file is encrypted.
     pub fn is_encrypted(&self) -> bool {
         self.encryption_info.is_some()
@@ -146,6 +192,29 @@ impl FileContentInfo {
     /// Creates an empty `FileContentInfo`.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Create a new `FileContentInfo` with the given file info and filename.
+    ///
+    /// Returns `None` if both parameters are `None`
+    pub fn from_room_message_content(
+        info: Option<impl Into<FileContentInfo>>,
+        filename: Option<String>,
+    ) -> Option<Self> {
+        if filename.is_none() && info.is_none() {
+            None
+        } else {
+            let mut info: Self = info.map(Into::into).unwrap_or_default();
+            info.name = filename;
+            Some(info)
+        }
+    }
+}
+
+impl From<&FileInfo> for FileContentInfo {
+    fn from(info: &FileInfo) -> Self {
+        let FileInfo { mimetype, size, .. } = info;
+        Self { mimetype: mimetype.to_owned(), size: size.to_owned(), ..Default::default() }
     }
 }
 
@@ -200,6 +269,13 @@ pub struct EncryptedContentInit {
 impl From<EncryptedContentInit> for EncryptedContent {
     fn from(init: EncryptedContentInit) -> Self {
         let EncryptedContentInit { key, iv, hashes, v } = init;
+        Self { key, iv, hashes, v }
+    }
+}
+
+impl From<&EncryptedFile> for EncryptedContent {
+    fn from(encrypted: &EncryptedFile) -> Self {
+        let EncryptedFile { key, iv, hashes, v, .. } = encrypted.to_owned();
         Self { key, iv, hashes, v }
     }
 }

--- a/crates/ruma-common/src/events/image.rs
+++ b/crates/ruma-common/src/events/image.rs
@@ -76,23 +76,48 @@ impl ImageEventContent {
     }
 }
 
-/// Information about a thumbnail file content.
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+/// Image content.
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-pub struct ThumbnailFileContentInfo {
-    /// The mimetype of the thumbnail, e.g. `image/png`.
+pub struct ImageContent {
+    /// The height of the image in pixels.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub mimetype: Option<String>,
+    pub height: Option<UInt>,
 
-    /// The size of the thumbnail in bytes.
+    /// The width of the image in pixels.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub size: Option<UInt>,
+    pub width: Option<UInt>,
 }
 
-impl ThumbnailFileContentInfo {
-    /// Creates an empty `ThumbnailFileContentInfo`.
+impl ImageContent {
+    /// Creates a new empty `ImageContent`.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Creates a new `ImageContent` with the given width and height.
+    pub fn with_size(width: UInt, height: UInt) -> Self {
+        Self { height: Some(height), width: Some(width) }
+    }
+}
+
+/// Thumbnail content.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+pub struct ThumbnailContent {
+    /// The file info of the thumbnail.
+    #[serde(flatten)]
+    pub file: ThumbnailFileContent,
+
+    /// The image info of the thumbnail.
+    #[serde(flatten, skip_serializing_if = "Option::is_none")]
+    pub image: Option<Box<ImageContent>>,
+}
+
+impl ThumbnailContent {
+    /// Creates a `ThumbnailContent` with the given file and image info.
+    pub fn new(file: ThumbnailFileContent, image: Option<Box<ImageContent>>) -> Self {
+        Self { file, image }
     }
 }
 
@@ -136,47 +161,22 @@ impl ThumbnailFileContent {
     }
 }
 
-/// Thumbnail content.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+/// Information about a thumbnail file content.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-pub struct ThumbnailContent {
-    /// The file info of the thumbnail.
-    #[serde(flatten)]
-    pub file: ThumbnailFileContent,
-
-    /// The image info of the thumbnail.
-    #[serde(flatten, skip_serializing_if = "Option::is_none")]
-    pub image: Option<Box<ImageContent>>,
-}
-
-impl ThumbnailContent {
-    /// Creates a `ThumbnailContent` with the given file and image info.
-    pub fn new(file: ThumbnailFileContent, image: Option<Box<ImageContent>>) -> Self {
-        Self { file, image }
-    }
-}
-
-/// Image content.
-#[derive(Default, Clone, Debug, Serialize, Deserialize)]
-#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-pub struct ImageContent {
-    /// The height of the image in pixels.
+pub struct ThumbnailFileContentInfo {
+    /// The mimetype of the thumbnail, e.g. `image/png`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub height: Option<UInt>,
+    pub mimetype: Option<String>,
 
-    /// The width of the image in pixels.
+    /// The size of the thumbnail in bytes.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub width: Option<UInt>,
+    pub size: Option<UInt>,
 }
 
-impl ImageContent {
-    /// Creates a new empty `ImageContent`.
+impl ThumbnailFileContentInfo {
+    /// Creates an empty `ThumbnailFileContentInfo`.
     pub fn new() -> Self {
         Self::default()
-    }
-
-    /// Creates a new `ImageContent` with the given width and height.
-    pub fn with_size(width: UInt, height: UInt) -> Self {
-        Self { height: Some(height), width: Some(width) }
     }
 }

--- a/crates/ruma-common/src/events/location.rs
+++ b/crates/ruma-common/src/events/location.rs
@@ -10,10 +10,25 @@ use serde::{Deserialize, Serialize};
 
 mod zoomlevel_serde;
 
-use super::{message::MessageContent, room::message::Relation};
+use super::{
+    message::MessageContent,
+    room::message::{LocationMessageEventContent, Relation},
+};
 use crate::{MilliSecondsSinceUnixEpoch, PrivOwnedStr};
 
 /// The payload for an extensible location message.
+///
+/// This is the new primary type introduced in [MSC3488] and should not be sent before the end of
+/// the transition period. See the documentation of the [`message`] module for more information.
+///
+/// `LocationEventContent` can be converted to a [`RoomMessageEventContent`] with a
+/// [`MessageType::Location`]. You can convert it back with
+/// [`LocationEventContent::from_location_room_message()`].
+///
+/// [MSC3488]: https://github.com/matrix-org/matrix-spec-proposals/pull/3488
+/// [`message`]: super::message
+/// [`RoomMessageEventContent`]: super::room::message::RoomMessageEventContent
+/// [`MessageType::Location`]: super::room::message::MessageType::Location
 #[derive(Clone, Debug, Serialize, Deserialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[ruma_event(type = "m.location", kind = MessageLike)]
@@ -54,6 +69,22 @@ impl LocationEventContent {
     /// Creates a new `LocationEventContent` with the given text representation and location.
     pub fn with_message(message: MessageContent, location: LocationContent) -> Self {
         Self { message, location, asset: Default::default(), ts: None, relates_to: None }
+    }
+
+    /// Create a new `LocationEventContent` from the given `LocationMessageEventContent` and
+    /// optional relation.
+    pub fn from_location_room_message(
+        content: LocationMessageEventContent,
+        relates_to: Option<Relation>,
+    ) -> Self {
+        let LocationMessageEventContent { body, geo_uri, message, location, asset, ts, .. } =
+            content;
+
+        let message = message.unwrap_or_else(|| MessageContent::plain(body));
+        let location = location.unwrap_or_else(|| LocationContent::new(geo_uri));
+        let asset = asset.unwrap_or_default();
+
+        Self { message, location, asset, ts, relates_to }
     }
 }
 

--- a/crates/ruma-common/src/events/room/message/content_serde.rs
+++ b/crates/ruma-common/src/events/room/message/content_serde.rs
@@ -3,6 +3,8 @@
 use serde::{de, Deserialize};
 use serde_json::value::RawValue as RawJsonValue;
 
+#[cfg(feature = "unstable-msc3245")]
+use super::VoiceContent;
 #[cfg(feature = "unstable-msc3246")]
 use super::{AudioContent, AudioInfo, AudioMessageEventContent};
 #[cfg(feature = "unstable-msc3551")]
@@ -95,6 +97,16 @@ pub struct AudioMessageEventContentDeHelper {
     /// Extensible-event audio info of the message, with unstable name.
     #[serde(rename = "org.matrix.msc1767.audio")]
     pub audio_unstable: Option<AudioContent>,
+
+    /// Extensible-event voice flag of the message, with stable name.
+    #[cfg(feature = "unstable-msc3245")]
+    #[serde(rename = "m.voice")]
+    pub voice_stable: Option<VoiceContent>,
+
+    /// Extensible-event voice flag of the message, with unstable name.
+    #[cfg(feature = "unstable-msc3245")]
+    #[serde(rename = "org.matrix.msc3245.voice")]
+    pub voice_unstable: Option<VoiceContent>,
 }
 
 #[cfg(feature = "unstable-msc3246")]
@@ -109,12 +121,27 @@ impl From<AudioMessageEventContentDeHelper> for AudioMessageEventContent {
             file_unstable,
             audio_stable,
             audio_unstable,
+            #[cfg(feature = "unstable-msc3245")]
+            voice_stable,
+            #[cfg(feature = "unstable-msc3245")]
+            voice_unstable,
         } = helper;
 
         let file = file_stable.or(file_unstable);
         let audio = audio_stable.or(audio_unstable);
+        #[cfg(feature = "unstable-msc3245")]
+        let voice = voice_stable.or(voice_unstable);
 
-        Self { body, source, info, message, file, audio }
+        Self {
+            body,
+            source,
+            info,
+            message,
+            file,
+            audio,
+            #[cfg(feature = "unstable-msc3245")]
+            voice,
+        }
     }
 }
 

--- a/crates/ruma-common/src/events/sticker.rs
+++ b/crates/ruma-common/src/events/sticker.rs
@@ -5,6 +5,12 @@
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "unstable-msc3552")]
+use super::{
+    file::FileContent,
+    image::{ImageContent, ThumbnailContent},
+    message::MessageContent,
+};
 use crate::{events::room::ImageInfo, MxcUri};
 
 /// The content of an `m.sticker` event.
@@ -25,11 +31,80 @@ pub struct StickerEventContent {
 
     /// The URL to the sticker image.
     pub url: Box<MxcUri>,
+
+    /// Extensible-event text representation of the message.
+    ///
+    /// If present, this should be preferred over the `body` field.
+    #[cfg(feature = "unstable-msc3552")]
+    #[serde(flatten, skip_serializing_if = "Option::is_none")]
+    pub message: Option<MessageContent>,
+
+    /// Extensible-event file content of the message.
+    ///
+    /// If present, this should be preferred over the `url`, `file` and `info` fields.
+    #[cfg(feature = "unstable-msc3552")]
+    #[serde(
+        rename = "org.matrix.msc1767.file",
+        alias = "m.file",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub file: Option<FileContent>,
+
+    /// Extensible-event image info of the message.
+    ///
+    /// If present, this should be preferred over the `info` field.
+    #[cfg(feature = "unstable-msc3552")]
+    #[serde(
+        rename = "org.matrix.msc1767.image",
+        alias = "m.image",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub image: Option<Box<ImageContent>>,
+
+    /// Extensible-event thumbnails of the message.
+    ///
+    /// If present, this should be preferred over the `info` field.
+    #[cfg(feature = "unstable-msc3552")]
+    #[serde(
+        rename = "org.matrix.msc1767.thumbnail",
+        alias = "m.thumbnail",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub thumbnail: Option<Vec<ThumbnailContent>>,
+
+    /// Extensible-event captions of the message.
+    #[cfg(feature = "unstable-msc3552")]
+    #[serde(
+        rename = "org.matrix.msc1767.caption",
+        alias = "m.caption",
+        with = "super::message::content_serde::as_vec",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub caption: Option<MessageContent>,
 }
 
 impl StickerEventContent {
     /// Creates a new `StickerEventContent` with the given body, image info and URL.
     pub fn new(body: String, info: ImageInfo, url: Box<MxcUri>) -> Self {
-        Self { body, info, url }
+        Self {
+            #[cfg(feature = "unstable-msc3552")]
+            message: Some(MessageContent::plain(body.clone())),
+            #[cfg(feature = "unstable-msc3552")]
+            file: Some(FileContent::plain(url.clone(), Some(Box::new((&info).into())))),
+            #[cfg(feature = "unstable-msc3552")]
+            image: Some(Box::new((&info).into())),
+            #[cfg(feature = "unstable-msc3552")]
+            thumbnail: ThumbnailContent::from_room_message_content(
+                info.thumbnail_source.as_ref(),
+                info.thumbnail_info.as_deref(),
+            )
+            .map(|thumbnail| vec![thumbnail]),
+            #[cfg(feature = "unstable-msc3552")]
+            caption: None,
+            body,
+            info,
+            url,
+        }
     }
 }

--- a/crates/ruma-common/src/events/video.rs
+++ b/crates/ruma-common/src/events/video.rs
@@ -9,10 +9,25 @@ use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
 use super::{
-    file::FileContent, image::ThumbnailContent, message::MessageContent, room::message::Relation,
+    file::FileContent,
+    image::ThumbnailContent,
+    message::MessageContent,
+    room::message::{Relation, VideoInfo, VideoMessageEventContent},
 };
 
 /// The payload for an extensible video message.
+///
+/// This is the new primary type introduced in [MSC3553] and should not be sent before the end of
+/// the transition period. See the documentation of the [`message`] module for more information.
+///
+/// `VideoEventContent` can be converted to a [`RoomMessageEventContent`] with a
+/// [`MessageType::Video`]. You can convert it back with
+/// [`VideoEventContent::from_video_room_message()`].
+///
+/// [MSC3553]: https://github.com/matrix-org/matrix-spec-proposals/pull/3553
+/// [`message`]: super::message
+/// [`RoomMessageEventContent`]: super::room::message::RoomMessageEventContent
+/// [`MessageType::Video`]: super::room::message::MessageType::Video
 #[derive(Clone, Debug, Serialize, Deserialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[ruma_event(type = "m.video", kind = MessageLike)]
@@ -71,6 +86,45 @@ impl VideoEventContent {
             relates_to: None,
         }
     }
+
+    /// Create a new `VideoEventContent` from the given `VideoMessageEventContent` and optional
+    /// relation.
+    pub fn from_video_room_message(
+        content: VideoMessageEventContent,
+        relates_to: Option<Relation>,
+    ) -> Self {
+        let VideoMessageEventContent {
+            body,
+            source,
+            info,
+            message,
+            file,
+            video,
+            thumbnail,
+            caption,
+        } = content;
+
+        let message = message.unwrap_or_else(|| MessageContent::plain(body));
+        let file = file.unwrap_or_else(|| {
+            FileContent::from_room_message_content(source, info.as_deref(), None)
+        });
+        let video =
+            video.or_else(|| info.as_deref().map(|info| Box::new(info.into()))).unwrap_or_default();
+        let thumbnail = thumbnail
+            .or_else(|| {
+                info.as_deref()
+                    .and_then(|info| {
+                        ThumbnailContent::from_room_message_content(
+                            info.thumbnail_source.as_ref(),
+                            info.thumbnail_info.as_deref(),
+                        )
+                    })
+                    .map(|thumbnail| vec![thumbnail])
+            })
+            .unwrap_or_default();
+
+        Self { message, file, video, thumbnail, caption, relates_to }
+    }
 }
 
 /// Video content.
@@ -87,7 +141,7 @@ pub struct VideoContent {
 
     /// The duration of the video in milliseconds.
     #[serde(
-        with = "ruma_common::serde::duration::opt_ms",
+        with = "crate::serde::duration::opt_ms",
         default,
         skip_serializing_if = "Option::is_none"
     )]
@@ -98,5 +152,17 @@ impl VideoContent {
     /// Creates a new empty `VideoContent`.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Whether this `VideoContent` is empty.
+    pub fn is_empty(&self) -> bool {
+        self.height.is_none() && self.width.is_none() && self.duration.is_none()
+    }
+}
+
+impl From<&VideoInfo> for VideoContent {
+    fn from(info: &VideoInfo) -> Self {
+        let VideoInfo { height, width, duration, .. } = info;
+        Self { height: height.to_owned(), width: width.to_owned(), duration: duration.to_owned() }
     }
 }

--- a/crates/ruma-common/src/events/voice.rs
+++ b/crates/ruma-common/src/events/voice.rs
@@ -6,10 +6,25 @@ use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
 use super::{
-    audio::AudioContent, file::FileContent, message::MessageContent, room::message::Relation,
+    audio::AudioContent,
+    file::FileContent,
+    message::{MessageContent, TryFromExtensibleError},
+    room::message::{AudioMessageEventContent, Relation},
 };
 
-/// The payload for an extensible audio message.
+/// The payload for an extensible voice message.
+///
+/// This is the new primary type introduced in [MSC3245] and should not be sent before the end of
+/// the transition period. See the documentation of the [`message`] module for more information.
+///
+/// `VoiceEventContent` can be converted to a [`RoomMessageEventContent`] with a
+/// [`MessageType::Audio`] with the `m.voice` flag. You can convert it back with
+/// [`VoiceEventContent::try_from_audio_room_message()`].
+///
+/// [MSC3245]: https://github.com/matrix-org/matrix-spec-proposals/pull/3245
+/// [`message`]: super::message
+/// [`RoomMessageEventContent`]: super::room::message::RoomMessageEventContent
+/// [`MessageType::Audio`]: super::room::message::MessageType::Audio
 #[derive(Clone, Debug, Serialize, Deserialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[ruma_event(type = "m.voice", kind = MessageLike)]
@@ -56,6 +71,30 @@ impl VoiceEventContent {
             voice: Default::default(),
             relates_to: None,
         }
+    }
+
+    /// Create a new `VoiceEventContent` from the given `AudioMessageEventContent` and optional
+    /// relation.
+    ///
+    /// This can fail if the `AudioMessageEventContent` is not a voice message.
+    pub fn try_from_audio_room_message(
+        content: AudioMessageEventContent,
+        relates_to: Option<Relation>,
+    ) -> Result<Self, TryFromExtensibleError> {
+        let AudioMessageEventContent { body, source, info, message, file, audio, voice } = content;
+
+        let message = message.unwrap_or_else(|| MessageContent::plain(body));
+        let file = file.unwrap_or_else(|| {
+            FileContent::from_room_message_content(source, info.as_deref(), None)
+        });
+        let audio = audio.or_else(|| info.as_deref().map(Into::into)).unwrap_or_default();
+        let voice = if let Some(voice) = voice {
+            voice
+        } else {
+            return Err(TryFromExtensibleError::MissingField("m.voice".to_owned()));
+        };
+
+        Ok(Self { message, file, audio, voice, relates_to })
     }
 }
 

--- a/crates/ruma-common/tests/events/file.rs
+++ b/crates/ruma-common/tests/events/file.rs
@@ -9,8 +9,10 @@ use ruma_common::{
         file::{EncryptedContentInit, FileContent, FileContentInfo, FileEventContent},
         message::MessageContent,
         room::{
-            message::{InReplyTo, Relation},
-            JsonWebKeyInit,
+            message::{
+                FileMessageEventContent, InReplyTo, MessageType, Relation, RoomMessageEventContent,
+            },
+            EncryptedFileInit, JsonWebKeyInit, MediaSource,
         },
         AnyMessageLikeEvent, MessageLikeEvent, MessageLikeUnsigned,
     },
@@ -152,7 +154,7 @@ fn file_event_serialization() {
 #[test]
 fn plain_content_deserialization() {
     let json_data = json!({
-        "org.matrix.msc1767.text": "Upload: my_file.txt",
+        "m.text": "Upload: my_file.txt",
         "m.file": {
             "url": "mxc://notareal.hs/abcdef",
         }
@@ -171,7 +173,7 @@ fn plain_content_deserialization() {
 #[test]
 fn encrypted_content_deserialization() {
     let json_data = json!({
-        "org.matrix.msc1767.text": "Upload: my_file.txt",
+        "m.text": "Upload: my_file.txt",
         "m.file": {
             "url": "mxc://notareal.hs/abcdef",
             "key": {
@@ -204,7 +206,7 @@ fn encrypted_content_deserialization() {
 fn message_event_deserialization() {
     let json_data = json!({
         "content": {
-            "org.matrix.msc1767.message": [
+            "m.message": [
                 { "body": "Upload: <strong>my_file.txt</strong>", "mimetype": "text/html"},
                 { "body": "Upload: my_file.txt", "mimetype": "text/plain"},
             ],
@@ -251,4 +253,261 @@ fn message_event_deserialization() {
             && sender == user_id!("@user:notareal.hs")
             && unsigned.is_empty()
     );
+}
+
+#[test]
+fn room_message_plain_content_serialization() {
+    let message_event_content =
+        RoomMessageEventContent::new(MessageType::File(FileMessageEventContent::plain(
+            "Upload: my_file.txt".to_owned(),
+            mxc_uri!("mxc://notareal.hs/file").to_owned(),
+            None,
+        )));
+
+    assert_eq!(
+        to_json_value(&message_event_content).unwrap(),
+        json!({
+            "body": "Upload: my_file.txt",
+            "url": "mxc://notareal.hs/file",
+            "msgtype": "m.file",
+            "org.matrix.msc1767.text": "Upload: my_file.txt",
+            "org.matrix.msc1767.file": {
+                "url": "mxc://notareal.hs/file",
+            },
+        })
+    );
+}
+
+#[test]
+fn room_message_encrypted_content_serialization() {
+    let message_event_content =
+        RoomMessageEventContent::new(MessageType::File(FileMessageEventContent::encrypted(
+            "Upload: my_file.txt".to_owned(),
+            EncryptedFileInit {
+                url: mxc_uri!("mxc://notareal.hs/file").to_owned(),
+                key: JsonWebKeyInit {
+                    kty: "oct".to_owned(),
+                    key_ops: vec!["encrypt".to_owned(), "decrypt".to_owned()],
+                    alg: "A256CTR".to_owned(),
+                    k: Base64::parse("TLlG_OpX807zzQuuwv4QZGJ21_u7weemFGYJFszMn9A").unwrap(),
+                    ext: true,
+                }
+                .into(),
+                iv: Base64::parse("S22dq3NAX8wAAAAAAAAAAA").unwrap(),
+                hashes: [(
+                    "sha256".to_owned(),
+                    Base64::parse("aWOHudBnDkJ9IwaR1Nd8XKoI7DOrqDTwt6xDPfVGN6Q").unwrap(),
+                )]
+                .into(),
+                v: "v2".to_owned(),
+            }
+            .into(),
+        )));
+
+    assert_eq!(
+        to_json_value(&message_event_content).unwrap(),
+        json!({
+            "body": "Upload: my_file.txt",
+            "file": {
+                "url": "mxc://notareal.hs/file",
+                "key": {
+                    "kty": "oct",
+                    "key_ops": ["encrypt", "decrypt"],
+                    "alg": "A256CTR",
+                    "k": "TLlG_OpX807zzQuuwv4QZGJ21_u7weemFGYJFszMn9A",
+                    "ext": true
+                },
+                "iv": "S22dq3NAX8wAAAAAAAAAAA",
+                "hashes": {
+                    "sha256": "aWOHudBnDkJ9IwaR1Nd8XKoI7DOrqDTwt6xDPfVGN6Q"
+                },
+                "v": "v2",
+            },
+            "msgtype": "m.file",
+            "org.matrix.msc1767.text": "Upload: my_file.txt",
+            "org.matrix.msc1767.file": {
+                "url": "mxc://notareal.hs/file",
+                "key": {
+                    "kty": "oct",
+                    "key_ops": ["encrypt", "decrypt"],
+                    "alg": "A256CTR",
+                    "k": "TLlG_OpX807zzQuuwv4QZGJ21_u7weemFGYJFszMn9A",
+                    "ext": true
+                },
+                "iv": "S22dq3NAX8wAAAAAAAAAAA",
+                "hashes": {
+                    "sha256": "aWOHudBnDkJ9IwaR1Nd8XKoI7DOrqDTwt6xDPfVGN6Q"
+                },
+                "v": "v2",
+            },
+        })
+    );
+}
+
+#[test]
+fn room_message_plain_content_stable_deserialization() {
+    let json_data = json!({
+        "body": "Upload: my_file.txt",
+        "url": "mxc://notareal.hs/file",
+        "msgtype": "m.file",
+        "m.text": "Upload: my_file.txt",
+        "m.file": {
+            "url": "mxc://notareal.hs/file",
+        },
+    });
+
+    let event_content = from_json_value::<RoomMessageEventContent>(json_data).unwrap();
+    assert_matches!(event_content.msgtype, MessageType::File(_));
+    if let MessageType::File(content) = event_content.msgtype {
+        assert_eq!(content.body, "Upload: my_file.txt");
+        assert_matches!(content.source, MediaSource::Plain(_));
+        if let MediaSource::Plain(url) = content.source {
+            assert_eq!(url, "mxc://notareal.hs/file");
+        }
+        let message = content.message.unwrap();
+        assert_eq!(message.len(), 1);
+        assert_eq!(message[0].body, "Upload: my_file.txt");
+        let file = content.file.unwrap();
+        assert_eq!(file.url, "mxc://notareal.hs/file");
+        assert!(!file.is_encrypted());
+    }
+}
+
+#[test]
+fn room_message_plain_content_unstable_deserialization() {
+    let json_data = json!({
+        "body": "Upload: my_file.txt",
+        "url": "mxc://notareal.hs/file",
+        "msgtype": "m.file",
+        "org.matrix.msc1767.text": "Upload: my_file.txt",
+        "org.matrix.msc1767.file": {
+            "url": "mxc://notareal.hs/file",
+        },
+    });
+
+    let event_content = from_json_value::<RoomMessageEventContent>(json_data).unwrap();
+    assert_matches!(event_content.msgtype, MessageType::File(_));
+    if let MessageType::File(content) = event_content.msgtype {
+        assert_eq!(content.body, "Upload: my_file.txt");
+        assert_matches!(content.source, MediaSource::Plain(_));
+        if let MediaSource::Plain(url) = content.source {
+            assert_eq!(url, "mxc://notareal.hs/file");
+        }
+        let message = content.message.unwrap();
+        assert_eq!(message.len(), 1);
+        assert_eq!(message[0].body, "Upload: my_file.txt");
+        let file = content.file.unwrap();
+        assert_eq!(file.url, "mxc://notareal.hs/file");
+        assert!(!file.is_encrypted());
+    }
+}
+
+#[test]
+fn room_message_encrypted_content_stable_deserialization() {
+    let json_data = json!({
+        "body": "Upload: my_file.txt",
+        "file": {
+            "url": "mxc://notareal.hs/file",
+            "key": {
+                "kty": "oct",
+                "key_ops": ["encrypt", "decrypt"],
+                "alg": "A256CTR",
+                "k": "TLlG_OpX807zzQuuwv4QZGJ21_u7weemFGYJFszMn9A",
+                "ext": true
+            },
+            "iv": "S22dq3NAX8wAAAAAAAAAAA",
+            "hashes": {
+                "sha256": "aWOHudBnDkJ9IwaR1Nd8XKoI7DOrqDTwt6xDPfVGN6Q"
+            },
+            "v": "v2",
+        },
+        "msgtype": "m.file",
+        "m.text": "Upload: my_file.txt",
+        "m.file": {
+            "url": "mxc://notareal.hs/file",
+            "key": {
+                "kty": "oct",
+                "key_ops": ["encrypt", "decrypt"],
+                "alg": "A256CTR",
+                "k": "TLlG_OpX807zzQuuwv4QZGJ21_u7weemFGYJFszMn9A",
+                "ext": true
+            },
+            "iv": "S22dq3NAX8wAAAAAAAAAAA",
+            "hashes": {
+                "sha256": "aWOHudBnDkJ9IwaR1Nd8XKoI7DOrqDTwt6xDPfVGN6Q"
+            },
+            "v": "v2",
+        },
+    });
+
+    let event_content = from_json_value::<RoomMessageEventContent>(json_data).unwrap();
+    assert_matches!(event_content.msgtype, MessageType::File(_));
+    if let MessageType::File(content) = event_content.msgtype {
+        assert_eq!(content.body, "Upload: my_file.txt");
+        assert_matches!(content.source, MediaSource::Encrypted(_));
+        if let MediaSource::Encrypted(encrypted_file) = content.source {
+            assert_eq!(encrypted_file.url, "mxc://notareal.hs/file");
+        }
+        let message = content.message.unwrap();
+        assert_eq!(message.len(), 1);
+        assert_eq!(message[0].body, "Upload: my_file.txt");
+        let file = content.file.unwrap();
+        assert_eq!(file.url, "mxc://notareal.hs/file");
+        assert!(file.is_encrypted());
+    }
+}
+
+#[test]
+fn room_message_encrypted_content_unstable_deserialization() {
+    let json_data = json!({
+        "body": "Upload: my_file.txt",
+        "file": {
+            "url": "mxc://notareal.hs/file",
+            "key": {
+                "kty": "oct",
+                "key_ops": ["encrypt", "decrypt"],
+                "alg": "A256CTR",
+                "k": "TLlG_OpX807zzQuuwv4QZGJ21_u7weemFGYJFszMn9A",
+                "ext": true
+            },
+            "iv": "S22dq3NAX8wAAAAAAAAAAA",
+            "hashes": {
+                "sha256": "aWOHudBnDkJ9IwaR1Nd8XKoI7DOrqDTwt6xDPfVGN6Q"
+            },
+            "v": "v2",
+        },
+        "msgtype": "m.file",
+        "org.matrix.msc1767.text": "Upload: my_file.txt",
+        "org.matrix.msc1767.file": {
+            "url": "mxc://notareal.hs/file",
+            "key": {
+                "kty": "oct",
+                "key_ops": ["encrypt", "decrypt"],
+                "alg": "A256CTR",
+                "k": "TLlG_OpX807zzQuuwv4QZGJ21_u7weemFGYJFszMn9A",
+                "ext": true
+            },
+            "iv": "S22dq3NAX8wAAAAAAAAAAA",
+            "hashes": {
+                "sha256": "aWOHudBnDkJ9IwaR1Nd8XKoI7DOrqDTwt6xDPfVGN6Q"
+            },
+            "v": "v2",
+        },
+    });
+
+    let event_content = from_json_value::<RoomMessageEventContent>(json_data).unwrap();
+    assert_matches!(event_content.msgtype, MessageType::File(_));
+    if let MessageType::File(content) = event_content.msgtype {
+        assert_eq!(content.body, "Upload: my_file.txt");
+        assert_matches!(content.source, MediaSource::Encrypted(_));
+        if let MediaSource::Encrypted(encrypted_file) = content.source {
+            assert_eq!(encrypted_file.url, "mxc://notareal.hs/file");
+        }
+        let message = content.message.unwrap();
+        assert_eq!(message.len(), 1);
+        assert_eq!(message[0].body, "Upload: my_file.txt");
+        let file = content.file.unwrap();
+        assert_eq!(file.url, "mxc://notareal.hs/file");
+        assert!(file.is_encrypted());
+    }
 }

--- a/crates/ruma-common/tests/events/message_event.rs
+++ b/crates/ruma-common/tests/events/message_event.rs
@@ -44,6 +44,8 @@ fn message_serialize_sticker() {
     };
 
     let actual = to_json_value(&aliases_event).unwrap();
+
+    #[cfg(not(feature = "unstable-msc3552"))]
     let expected = json!({
         "content": {
             "body": "Hello",
@@ -61,6 +63,51 @@ fn message_serialize_sticker() {
                 "w": 1011
               },
             "url": "mxc://matrix.org/rnsldl8srs98IRrs"
+        },
+        "event_id": "$h29iv0s8:example.com",
+        "origin_server_ts": 1,
+        "room_id": "!roomid:room.com",
+        "sender": "@carl:example.com",
+        "type": "m.sticker",
+    });
+
+    #[cfg(feature = "unstable-msc3552")]
+    let expected = json!({
+        "content": {
+            "body": "Hello",
+            "info": {
+                "h": 423,
+                "mimetype": "image/png",
+                "size": 84242,
+                "thumbnail_info": {
+                  "h": 334,
+                  "mimetype": "image/png",
+                  "size": 82595,
+                  "w": 800
+                },
+                "thumbnail_url": "mxc://matrix.org/irsns989Rrsn",
+                "w": 1011
+              },
+            "url": "mxc://matrix.org/rnsldl8srs98IRrs",
+            "org.matrix.msc1767.text": "Hello",
+            "org.matrix.msc1767.file": {
+                "url": "mxc://matrix.org/rnsldl8srs98IRrs",
+                "mimetype": "image/png",
+                "size": 84242,
+            },
+            "org.matrix.msc1767.image": {
+                "height": 423,
+                "width": 1011,
+            },
+            "org.matrix.msc1767.thumbnail": [
+                {
+                    "url": "mxc://matrix.org/irsns989Rrsn",
+                    "mimetype": "image/png",
+                    "size": 82595,
+                    "height": 334,
+                    "width": 800,
+                }
+            ],
         },
         "event_id": "$h29iv0s8:example.com",
         "origin_server_ts": 1,

--- a/crates/ruma-common/tests/events/mod.rs
+++ b/crates/ruma-common/tests/events/mod.rs
@@ -19,6 +19,7 @@ mod redaction;
 mod relations;
 mod room_message;
 mod state_event;
+mod sticker;
 mod stripped;
 mod to_device;
 mod video;

--- a/crates/ruma-common/tests/events/room_message.rs
+++ b/crates/ruma-common/tests/events/room_message.rs
@@ -52,6 +52,7 @@ fn serialization() {
         unsigned: MessageLikeUnsigned::default(),
     };
 
+    #[cfg(not(feature = "unstable-msc3246"))]
     assert_eq!(
         to_json_value(ev).unwrap(),
         json!({
@@ -67,6 +68,28 @@ fn serialization() {
             }
         })
     );
+
+    #[cfg(feature = "unstable-msc3246")]
+    assert_eq!(
+        to_json_value(ev).unwrap(),
+        json!({
+            "type": "m.room.message",
+            "event_id": "$143273582443PhrSn:example.org",
+            "origin_server_ts": 10_000,
+            "room_id": "!testroomid:example.org",
+            "sender": "@user:example.org",
+            "content": {
+                "body": "test",
+                "msgtype": "m.audio",
+                "url": "mxc://example.org/ffed755USFFxlgbQYZGtryd",
+                "org.matrix.msc1767.text": "test",
+                "org.matrix.msc1767.file": {
+                    "url": "mxc://example.org/ffed755USFFxlgbQYZGtryd",
+                },
+                "org.matrix.msc1767.audio": {},
+            }
+        })
+    );
 }
 
 #[test]
@@ -78,12 +101,28 @@ fn content_serialization() {
             None,
         )));
 
+    #[cfg(not(feature = "unstable-msc3246"))]
     assert_eq!(
         to_json_value(&message_event_content).unwrap(),
         json!({
             "body": "test",
             "msgtype": "m.audio",
             "url": "mxc://example.org/ffed755USFFxlgbQYZGtryd"
+        })
+    );
+
+    #[cfg(feature = "unstable-msc3246")]
+    assert_eq!(
+        to_json_value(&message_event_content).unwrap(),
+        json!({
+            "body": "test",
+            "msgtype": "m.audio",
+            "url": "mxc://example.org/ffed755USFFxlgbQYZGtryd",
+            "org.matrix.msc1767.text": "test",
+            "org.matrix.msc1767.file": {
+                "url": "mxc://example.org/ffed755USFFxlgbQYZGtryd",
+            },
+            "org.matrix.msc1767.audio": {},
         })
     );
 }

--- a/crates/ruma-common/tests/events/sticker.rs
+++ b/crates/ruma-common/tests/events/sticker.rs
@@ -1,0 +1,78 @@
+#![cfg(feature = "unstable-msc3552")]
+
+use ruma_common::{
+    events::{room::ImageInfo, sticker::StickerEventContent},
+    mxc_uri,
+};
+use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+
+#[test]
+fn content_serialization() {
+    let message_event_content = StickerEventContent::new(
+        "Upload: my_image.jpg".to_owned(),
+        ImageInfo::new(),
+        mxc_uri!("mxc://notareal.hs/file").to_owned(),
+    );
+
+    assert_eq!(
+        to_json_value(&message_event_content).unwrap(),
+        json!({
+            "body": "Upload: my_image.jpg",
+            "url": "mxc://notareal.hs/file",
+            "info": {},
+            "org.matrix.msc1767.text": "Upload: my_image.jpg",
+            "org.matrix.msc1767.file": {
+                "url": "mxc://notareal.hs/file",
+            },
+            "org.matrix.msc1767.image": {},
+        })
+    );
+}
+
+#[test]
+fn content_stable_deserialization() {
+    let json_data = json!({
+        "body": "Upload: my_image.jpg",
+        "url": "mxc://notareal.hs/file",
+        "info": {},
+        "m.text": "Upload: my_image.jpg",
+        "m.file": {
+            "url": "mxc://notareal.hs/file",
+        },
+        "m.image": {},
+    });
+
+    let content = from_json_value::<StickerEventContent>(json_data).unwrap();
+    assert_eq!(content.body, "Upload: my_image.jpg");
+    assert_eq!(content.url, "mxc://notareal.hs/file");
+    let message = content.message.unwrap();
+    assert_eq!(message.len(), 1);
+    assert_eq!(message[0].body, "Upload: my_image.jpg");
+    let file = content.file.unwrap();
+    assert_eq!(file.url, "mxc://notareal.hs/file");
+    assert!(!file.is_encrypted());
+}
+
+#[test]
+fn content_unstable_deserialization() {
+    let json_data = json!({
+        "body": "Upload: my_image.jpg",
+        "url": "mxc://notareal.hs/file",
+        "info": {},
+        "org.matrix.msc1767.text": "Upload: my_image.jpg",
+        "org.matrix.msc1767.file": {
+            "url": "mxc://notareal.hs/file",
+        },
+        "org.matrix.msc1767.image": {},
+    });
+
+    let content = from_json_value::<StickerEventContent>(json_data).unwrap();
+    assert_eq!(content.body, "Upload: my_image.jpg");
+    assert_eq!(content.url, "mxc://notareal.hs/file");
+    let message = content.message.unwrap();
+    assert_eq!(message.len(), 1);
+    assert_eq!(message[0].body, "Upload: my_image.jpg");
+    let file = content.file.unwrap();
+    assert_eq!(file.url, "mxc://notareal.hs/file");
+    assert!(!file.is_encrypted());
+}

--- a/crates/ruma-common/tests/events/video.rs
+++ b/crates/ruma-common/tests/events/video.rs
@@ -12,8 +12,10 @@ use ruma_common::{
         image::{ThumbnailContent, ThumbnailFileContent, ThumbnailFileContentInfo},
         message::MessageContent,
         room::{
-            message::{InReplyTo, Relation},
-            JsonWebKeyInit,
+            message::{
+                InReplyTo, MessageType, Relation, RoomMessageEventContent, VideoMessageEventContent,
+            },
+            JsonWebKeyInit, MediaSource,
         },
         video::{VideoContent, VideoEventContent},
         AnyMessageLikeEvent, MessageLikeEvent, MessageLikeUnsigned,
@@ -198,7 +200,7 @@ fn event_serialization() {
 #[test]
 fn plain_content_deserialization() {
     let json_data = json!({
-        "org.matrix.msc1767.text": "Video: my_cat.mp4",
+        "m.text": "Video: my_cat.mp4",
         "m.file": {
             "url": "mxc://notareal.hs/abcdef",
         },
@@ -230,7 +232,7 @@ fn plain_content_deserialization() {
 #[test]
 fn encrypted_content_deserialization() {
     let json_data = json!({
-        "org.matrix.msc1767.text": "Upload: my_cat.mp4",
+        "m.text": "Upload: my_cat.mp4",
         "m.file": {
             "url": "mxc://notareal.hs/abcdef",
             "key": {
@@ -273,7 +275,7 @@ fn encrypted_content_deserialization() {
 fn message_event_deserialization() {
     let json_data = json!({
         "content": {
-            "org.matrix.msc1767.text": "Upload: my_gnome.webm",
+            "m.text": "Upload: my_gnome.webm",
             "m.file": {
                 "url": "mxc://notareal.hs/abcdef",
                 "name": "my_gnome.webm",
@@ -328,4 +330,88 @@ fn message_event_deserialization() {
             && sender == user_id!("@user:notareal.hs")
             && unsigned.is_empty()
     );
+}
+
+#[test]
+fn room_message_serialization() {
+    let message_event_content =
+        RoomMessageEventContent::new(MessageType::Video(VideoMessageEventContent::plain(
+            "Upload: my_video.mp4".to_owned(),
+            mxc_uri!("mxc://notareal.hs/file").to_owned(),
+            None,
+        )));
+
+    assert_eq!(
+        to_json_value(&message_event_content).unwrap(),
+        json!({
+            "body": "Upload: my_video.mp4",
+            "url": "mxc://notareal.hs/file",
+            "msgtype": "m.video",
+            "org.matrix.msc1767.text": "Upload: my_video.mp4",
+            "org.matrix.msc1767.file": {
+                "url": "mxc://notareal.hs/file",
+            },
+            "org.matrix.msc1767.video": {},
+        })
+    );
+}
+
+#[test]
+fn room_message_stable_deserialization() {
+    let json_data = json!({
+        "body": "Upload: my_video.mp4",
+        "url": "mxc://notareal.hs/file",
+        "msgtype": "m.video",
+        "m.text": "Upload: my_video.mp4",
+        "m.file": {
+            "url": "mxc://notareal.hs/file",
+        },
+        "m.video": {},
+    });
+
+    let event_content = from_json_value::<RoomMessageEventContent>(json_data).unwrap();
+    assert_matches!(event_content.msgtype, MessageType::Video(_));
+    if let MessageType::Video(content) = event_content.msgtype {
+        assert_eq!(content.body, "Upload: my_video.mp4");
+        assert_matches!(content.source, MediaSource::Plain(_));
+        if let MediaSource::Plain(url) = content.source {
+            assert_eq!(url, "mxc://notareal.hs/file");
+        }
+        let message = content.message.unwrap();
+        assert_eq!(message.len(), 1);
+        assert_eq!(message[0].body, "Upload: my_video.mp4");
+        let file = content.file.unwrap();
+        assert_eq!(file.url, "mxc://notareal.hs/file");
+        assert!(!file.is_encrypted());
+    }
+}
+
+#[test]
+fn room_message_unstable_deserialization() {
+    let json_data = json!({
+        "body": "Upload: my_video.mp4",
+        "url": "mxc://notareal.hs/file",
+        "msgtype": "m.video",
+        "org.matrix.msc1767.text": "Upload: my_video.mp4",
+        "org.matrix.msc1767.file": {
+            "url": "mxc://notareal.hs/file",
+        },
+        "org.matrix.msc1767.video": {},
+    });
+
+    let event_content = from_json_value::<RoomMessageEventContent>(json_data).unwrap();
+    assert_matches!(event_content.msgtype, MessageType::Video(_));
+    if let MessageType::Video(content) = event_content.msgtype {
+        assert_eq!(content.body, "Upload: my_video.mp4");
+        assert_matches!(content.source, MediaSource::Plain(_));
+        if let MediaSource::Plain(url) = content.source {
+            assert_eq!(url, "mxc://notareal.hs/file");
+        }
+        let message = content.message.unwrap();
+        assert_eq!(message.len(), 1);
+        assert_eq!(message[0].body, "Upload: my_video.mp4");
+        let file = content.file.unwrap();
+        assert_eq!(file.url, "mxc://notareal.hs/file");
+        assert!(!file.is_encrypted());
+    }
 }

--- a/crates/ruma-common/tests/events/voice.rs
+++ b/crates/ruma-common/tests/events/voice.rs
@@ -10,8 +10,13 @@ use ruma_common::{
     events::{
         audio::AudioContent,
         file::{FileContent, FileContentInfo},
-        room::message::{InReplyTo, Relation},
-        voice::VoiceEventContent,
+        room::{
+            message::{
+                AudioMessageEventContent, InReplyTo, MessageType, Relation, RoomMessageEventContent,
+            },
+            MediaSource,
+        },
+        voice::{VoiceContent, VoiceEventContent},
         AnyMessageLikeEvent, MessageLikeEvent, MessageLikeUnsigned,
     },
     mxc_uri, room_id, user_id, MilliSecondsSinceUnixEpoch,
@@ -89,7 +94,7 @@ fn event_serialization() {
 fn message_event_deserialization() {
     let json_data = json!({
         "content": {
-            "org.matrix.msc1767.text": "Voice message",
+            "m.text": "Voice message",
             "m.file": {
                 "url": "mxc://notareal.hs/abcdef",
                 "name": "voice_message.ogg",
@@ -140,4 +145,96 @@ fn message_event_deserialization() {
             && sender == user_id!("@user:notareal.hs")
             && unsigned.is_empty()
     );
+}
+
+#[test]
+fn room_message_serialization() {
+    let message_event_content = RoomMessageEventContent::new(MessageType::Audio(assign!(
+        AudioMessageEventContent::plain(
+            "Upload: voice_message.ogg".to_owned(),
+            mxc_uri!("mxc://notareal.hs/file").to_owned(),
+            None,
+        ), {
+            voice: Some(VoiceContent::new()),
+        }
+    )));
+
+    assert_eq!(
+        to_json_value(&message_event_content).unwrap(),
+        json!({
+            "body": "Upload: voice_message.ogg",
+            "url": "mxc://notareal.hs/file",
+            "msgtype": "m.audio",
+            "org.matrix.msc1767.text": "Upload: voice_message.ogg",
+            "org.matrix.msc1767.file": {
+                "url": "mxc://notareal.hs/file",
+            },
+            "org.matrix.msc1767.audio": {},
+            "org.matrix.msc3245.voice": {},
+        })
+    );
+}
+
+#[test]
+fn room_message_stable_deserialization() {
+    let json_data = json!({
+        "body": "Upload: voice_message.ogg",
+        "url": "mxc://notareal.hs/file",
+        "msgtype": "m.audio",
+        "m.text": "Upload: voice_message.ogg",
+        "m.file": {
+            "url": "mxc://notareal.hs/file",
+        },
+        "m.audio": {},
+        "m.voice": {},
+    });
+
+    let event_content = from_json_value::<RoomMessageEventContent>(json_data).unwrap();
+    assert_matches!(event_content.msgtype, MessageType::Audio(_));
+    if let MessageType::Audio(content) = event_content.msgtype {
+        assert_eq!(content.body, "Upload: voice_message.ogg");
+        assert_matches!(content.source, MediaSource::Plain(_));
+        if let MediaSource::Plain(url) = content.source {
+            assert_eq!(url, "mxc://notareal.hs/file");
+        }
+        let message = content.message.unwrap();
+        assert_eq!(message.len(), 1);
+        assert_eq!(message[0].body, "Upload: voice_message.ogg");
+        let file = content.file.unwrap();
+        assert_eq!(file.url, "mxc://notareal.hs/file");
+        assert!(!file.is_encrypted());
+        assert!(content.voice.is_some());
+    }
+}
+
+#[test]
+fn room_message_unstable_deserialization() {
+    let json_data = json!({
+        "body": "Upload: voice_message.ogg",
+        "url": "mxc://notareal.hs/file",
+        "msgtype": "m.audio",
+        "org.matrix.msc1767.text": "Upload: voice_message.ogg",
+        "org.matrix.msc1767.file": {
+            "url": "mxc://notareal.hs/file",
+        },
+        "org.matrix.msc1767.audio": {},
+        "org.matrix.msc3245.voice": {},
+    });
+
+    let event_content = from_json_value::<RoomMessageEventContent>(json_data).unwrap();
+    assert_matches!(event_content.msgtype, MessageType::Audio(_));
+    if let MessageType::Audio(content) = event_content.msgtype {
+        assert_eq!(content.body, "Upload: voice_message.ogg");
+        assert_matches!(content.source, MediaSource::Plain(_));
+        if let MediaSource::Plain(url) = content.source {
+            assert_eq!(url, "mxc://notareal.hs/file");
+        }
+        let message = content.message.unwrap();
+        assert_eq!(message.len(), 1);
+        assert_eq!(message[0].body, "Upload: voice_message.ogg");
+        let file = content.file.unwrap();
+        assert_eq!(file.url, "mxc://notareal.hs/file");
+        assert!(!file.is_encrypted());
+        assert!(content.voice.is_some());
+    }
 }


### PR DESCRIPTION
Based on #1001.

Adds all the other transitional types: file, image, sticker, video, audio, voice, location.

I went with reusing a the new types that are `flatten` with serde which means I had to implement custom deser to handle the stable aliases.

Part of #790.