### PR TITLE
Remove the Outgoing trait

### DIFF
--- a/crates/ruma-client-api/src/account.rs
+++ b/crates/ruma-client-api/src/account.rs
@@ -19,13 +19,13 @@ pub mod request_registration_token_via_msisdn;
 pub mod unbind_3pid;
 pub mod whoami;
 
-use ruma_common::serde::{Outgoing, StringEnum};
+use ruma_common::serde::{Incoming, StringEnum};
 use serde::Serialize;
 
 use crate::PrivOwnedStr;
 
 /// Additional authentication information for requestToken endpoints.
-#[derive(Clone, Debug, Outgoing, Serialize)]
+#[derive(Clone, Debug, Incoming, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct IdentityServerInfo<'a> {
     /// The ID server to send the onward request to as a hostname with an

--- a/crates/ruma-client-api/src/filter.rs
+++ b/crates/ruma-client-api/src/filter.rs
@@ -8,7 +8,7 @@ mod url;
 
 use js_int::UInt;
 use ruma_common::{
-    serde::{Outgoing, StringEnum},
+    serde::{Incoming, StringEnum},
     RoomId, UserId,
 };
 use serde::Serialize;
@@ -83,7 +83,7 @@ impl RelationType {
 }
 
 /// Filters to be applied to room events.
-#[derive(Clone, Debug, Default, Outgoing, Serialize)]
+#[derive(Clone, Debug, Default, Incoming, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[incoming_derive(Clone, Default, Serialize)]
 pub struct RoomEventFilter<'a> {
@@ -226,7 +226,7 @@ impl IncomingRoomEventFilter {
 }
 
 /// Filters to be applied to room data.
-#[derive(Clone, Debug, Default, Outgoing, Serialize)]
+#[derive(Clone, Debug, Default, Incoming, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[incoming_derive(Clone, Default, Serialize)]
 pub struct RoomFilter<'a> {
@@ -308,7 +308,7 @@ impl IncomingRoomFilter {
 }
 
 /// Filter for non-room data.
-#[derive(Clone, Debug, Default, Outgoing, Serialize)]
+#[derive(Clone, Debug, Default, Incoming, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[incoming_derive(Clone, Default, Serialize)]
 pub struct Filter<'a> {
@@ -380,7 +380,7 @@ impl IncomingFilter {
 }
 
 /// A filter definition
-#[derive(Clone, Debug, Default, Outgoing, Serialize)]
+#[derive(Clone, Debug, Default, Incoming, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[incoming_derive(Clone, Default, Serialize)]
 pub struct FilterDefinition<'a> {

--- a/crates/ruma-client-api/src/membership.rs
+++ b/crates/ruma-client-api/src/membership.rs
@@ -14,12 +14,12 @@ pub mod unban_user;
 
 use std::collections::BTreeMap;
 
-use ruma_common::{serde::Outgoing, thirdparty::Medium, ServerName, ServerSigningKeyId, UserId};
+use ruma_common::{serde::Incoming, thirdparty::Medium, ServerName, ServerSigningKeyId, UserId};
 use serde::Serialize;
 
 /// A signature of an `m.third_party_invite` token to prove that this user owns a third party
 /// identity which has been invited to the room.
-#[derive(Clone, Debug, Outgoing, Serialize)]
+#[derive(Clone, Debug, Incoming, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct ThirdPartySigned<'a> {
     /// The Matrix ID of the user who issued the invite.
@@ -52,7 +52,7 @@ impl<'a> ThirdPartySigned<'a> {
 ///
 /// To create an instance of this type, first create a `Invite3pidInit` and convert it via
 /// `Invite3pid::from` / `.into()`.
-#[derive(Clone, Debug, PartialEq, Outgoing, Serialize)]
+#[derive(Clone, Debug, PartialEq, Incoming, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[incoming_derive(PartialEq)]
 pub struct Invite3pid<'a> {

--- a/crates/ruma-client-api/src/membership/invite_user.rs
+++ b/crates/ruma-client-api/src/membership/invite_user.rs
@@ -10,7 +10,7 @@ pub mod v3 {
     //! [spec-mxid]: https://spec.matrix.org/v1.2/client-server-api/#post_matrixclientv3roomsroomidinvite
     //! [spec-3pid]: https://spec.matrix.org/v1.2/client-server-api/#post_matrixclientv3roomsroomidinvite-1
 
-    use ruma_common::{api::ruma_api, serde::Outgoing, RoomId, UserId};
+    use ruma_common::{api::ruma_api, serde::Incoming, RoomId, UserId};
     use serde::Serialize;
 
     use crate::membership::{IncomingInvite3pid, Invite3pid};
@@ -62,7 +62,7 @@ pub mod v3 {
     }
 
     /// Distinguishes between invititations by Matrix or third party identifiers.
-    #[derive(Clone, Debug, PartialEq, Outgoing, Serialize)]
+    #[derive(Clone, Debug, PartialEq, Incoming, Serialize)]
     #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     #[incoming_derive(PartialEq)]
     #[serde(untagged)]

--- a/crates/ruma-client-api/src/search/search_events.rs
+++ b/crates/ruma-client-api/src/search/search_events.rs
@@ -11,7 +11,7 @@ pub mod v3 {
     use ruma_common::{
         api::ruma_api,
         events::{AnyRoomEvent, AnyStateEvent},
-        serde::{Outgoing, Raw, StringEnum},
+        serde::{Incoming, Raw, StringEnum},
         EventId, MxcUri, RoomId, UserId,
     };
     use serde::{Deserialize, Serialize};
@@ -67,7 +67,7 @@ pub mod v3 {
     }
 
     /// Categories of events that can be searched for.
-    #[derive(Clone, Debug, Default, Outgoing, Serialize)]
+    #[derive(Clone, Debug, Default, Incoming, Serialize)]
     #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     pub struct Categories<'a> {
         /// Criteria for searching room events.
@@ -83,7 +83,7 @@ pub mod v3 {
     }
 
     /// Criteria for searching a category of events.
-    #[derive(Clone, Debug, Outgoing, Serialize)]
+    #[derive(Clone, Debug, Incoming, Serialize)]
     #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     pub struct Criteria<'a> {
         /// The string to search events for.
@@ -275,7 +275,7 @@ pub mod v3 {
     }
 
     /// Requests that the server partitions the result set based on the provided list of keys.
-    #[derive(Clone, Default, Debug, Outgoing, Serialize)]
+    #[derive(Clone, Default, Debug, Incoming, Serialize)]
     #[incoming_derive(Default)]
     #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     pub struct Groupings<'a> {

--- a/crates/ruma-client-api/src/session/login.rs
+++ b/crates/ruma-client-api/src/session/login.rs
@@ -268,10 +268,6 @@ pub mod v3 {
         extra: JsonObject,
     }
 
-    impl Outgoing for CustomLoginInfo<'_> {
-        type Incoming = IncomingCustomLoginInfo;
-    }
-
     /// Client configuration provided by the server.
     #[derive(Clone, Debug, Deserialize, Serialize)]
     #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]

--- a/crates/ruma-client-api/src/session/login.rs
+++ b/crates/ruma-client-api/src/session/login.rs
@@ -7,7 +7,7 @@ pub mod v3 {
 
     use ruma_common::{
         api::ruma_api,
-        serde::{JsonObject, Outgoing},
+        serde::{Incoming, JsonObject},
         DeviceId, ServerName, UserId,
     };
     use serde::{
@@ -94,7 +94,7 @@ pub mod v3 {
     ///
     /// To construct the custom `LoginInfo` variant you first have to construct
     /// [`IncomingLoginInfo::new`] and then call [`IncomingLoginInfo::to_outgoing`] on it.
-    #[derive(Clone, Debug, Outgoing, Serialize)]
+    #[derive(Clone, Debug, Incoming, Serialize)]
     #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     #[incoming_derive(!Deserialize)]
     #[serde(untagged)]
@@ -177,7 +177,7 @@ pub mod v3 {
     }
 
     /// An identifier and password to supply as authentication.
-    #[derive(Clone, Debug, Outgoing, Serialize)]
+    #[derive(Clone, Debug, Incoming, Serialize)]
     #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     #[serde(tag = "type", rename = "m.login.password")]
     pub struct Password<'a> {
@@ -203,7 +203,7 @@ pub mod v3 {
     }
 
     /// A token to supply as authentication.
-    #[derive(Clone, Debug, Outgoing, Serialize)]
+    #[derive(Clone, Debug, Incoming, Serialize)]
     #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     #[serde(tag = "type", rename = "m.login.token")]
     pub struct Token<'a> {
@@ -226,7 +226,7 @@ pub mod v3 {
     }
 
     /// An identifier to supply for Application Service authentication.
-    #[derive(Clone, Debug, Outgoing, Serialize)]
+    #[derive(Clone, Debug, Incoming, Serialize)]
     #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     #[serde(tag = "type", rename = "m.login.application_service")]
     pub struct ApplicationService<'a> {

--- a/crates/ruma-client-api/src/state/get_state_events_for_key.rs
+++ b/crates/ruma-client-api/src/state/get_state_events_for_key.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     use ruma_common::{
         api::ruma_api,
         events::{AnyStateEventContent, StateEventType},
-        serde::{Outgoing, Raw},
+        serde::{Incoming, Raw},
         RoomId,
     };
 
@@ -39,7 +39,7 @@ pub mod v3 {
     /// Data for a request to the `get_state_events_for_key` API endpoint.
     ///
     /// Get state events associated with a given key.
-    #[derive(Clone, Debug, Outgoing)]
+    #[derive(Clone, Debug, Incoming)]
     #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     #[incoming_derive(!Deserialize)]
     pub struct Request<'a> {

--- a/crates/ruma-client-api/src/state/get_state_events_for_key.rs
+++ b/crates/ruma-client-api/src/state/get_state_events_for_key.rs
@@ -70,7 +70,7 @@ pub mod v3 {
     #[cfg(feature = "client")]
     impl<'a> ruma_common::api::OutgoingRequest for Request<'a> {
         type EndpointError = crate::Error;
-        type IncomingResponse = <Response as ruma_common::serde::Outgoing>::Incoming;
+        type IncomingResponse = Response;
 
         const METADATA: ruma_common::api::Metadata = METADATA;
 

--- a/crates/ruma-client-api/src/state/send_state_event.rs
+++ b/crates/ruma-client-api/src/state/send_state_event.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     use ruma_common::{
         api::ruma_api,
         events::{AnyStateEventContent, EventContent, StateEventType},
-        serde::{Outgoing, Raw},
+        serde::{Incoming, Raw},
         EventId, RoomId,
     };
     use serde_json::value::to_raw_value as to_raw_json_value;
@@ -36,7 +36,7 @@ pub mod v3 {
     /// Data for a request to the `send_state_event` API endpoint.
     ///
     /// Send a state event to a room associated with a given state key.
-    #[derive(Clone, Debug, Outgoing)]
+    #[derive(Clone, Debug, Incoming)]
     #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     #[incoming_derive(!Deserialize)]
     pub struct Request<'a> {

--- a/crates/ruma-client-api/src/sync/sync_events.rs
+++ b/crates/ruma-client-api/src/sync/sync_events.rs
@@ -16,7 +16,7 @@ pub mod v3 {
             AnyToDeviceEvent,
         },
         presence::PresenceState,
-        serde::{Outgoing, Raw},
+        serde::{Incoming, Raw},
         DeviceKeyAlgorithm, RoomId, UserId,
     };
     use serde::{Deserialize, Serialize};
@@ -138,7 +138,7 @@ pub mod v3 {
     }
 
     /// A filter represented either as its full JSON definition or the ID of a saved filter.
-    #[derive(Clone, Debug, Outgoing, Serialize)]
+    #[derive(Clone, Debug, Incoming, Serialize)]
     #[allow(clippy::large_enum_variant)]
     #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     #[serde(untagged)]

--- a/crates/ruma-client-api/src/uiaa.rs
+++ b/crates/ruma-client-api/src/uiaa.rs
@@ -560,10 +560,6 @@ pub struct IncomingCustomAuthData {
     extra: JsonObject,
 }
 
-impl Outgoing for CustomAuthData<'_> {
-    type Incoming = IncomingCustomAuthData;
-}
-
 /// Identification information for the user.
 #[derive(Clone, Debug, PartialEq, Eq, Outgoing, Serialize)]
 #[serde(from = "user_serde::IncomingUserIdentifier", into = "user_serde::UserIdentifier<'_>")]

--- a/crates/ruma-client-api/src/uiaa.rs
+++ b/crates/ruma-client-api/src/uiaa.rs
@@ -10,7 +10,7 @@ use ruma_common::{
         error::{DeserializationError, IntoHttpError},
         EndpointError, OutgoingResponse,
     },
-    serde::{from_raw_json_value, JsonObject, Outgoing, StringEnum},
+    serde::{from_raw_json_value, Incoming, JsonObject, StringEnum},
     thirdparty::Medium,
     ClientSecret, SessionId,
 };
@@ -34,7 +34,7 @@ mod user_serde;
 ///
 /// To construct the custom `AuthData` variant you first have to construct [`IncomingAuthData::new`]
 /// and then call [`IncomingAuthData::to_outgoing`] on it.
-#[derive(Clone, Debug, Outgoing, Serialize)]
+#[derive(Clone, Debug, Incoming, Serialize)]
 #[non_exhaustive]
 #[incoming_derive(!Deserialize)]
 #[serde(untagged)]
@@ -342,7 +342,7 @@ pub enum AuthType {
 /// See [the spec] for how to use this.
 ///
 /// [the spec]: https://spec.matrix.org/v1.2/client-server-api/#password-based
-#[derive(Clone, Debug, Outgoing, Serialize)]
+#[derive(Clone, Debug, Incoming, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[serde(tag = "type", rename = "m.login.password")]
 pub struct Password<'a> {
@@ -379,7 +379,7 @@ impl IncomingPassword {
 /// See [the spec] for how to use this.
 ///
 /// [the spec]: https://spec.matrix.org/v1.2/client-server-api/#google-recaptcha
-#[derive(Clone, Debug, Outgoing, Serialize)]
+#[derive(Clone, Debug, Incoming, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[serde(tag = "type", rename = "m.login.recaptcha")]
 pub struct ReCaptcha<'a> {
@@ -409,7 +409,7 @@ impl IncomingReCaptcha {
 /// See [the spec] for how to use this.
 ///
 /// [the spec]: https://spec.matrix.org/v1.2/client-server-api/#email-based-identity--homeserver
-#[derive(Clone, Debug, Outgoing, Serialize)]
+#[derive(Clone, Debug, Incoming, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[serde(tag = "type", rename = "m.login.email.identity")]
 pub struct EmailIdentity<'a> {
@@ -436,7 +436,7 @@ impl IncomingEmailIdentity {
 /// See [the spec] for how to use this.
 ///
 /// [the spec]: https://spec.matrix.org/v1.2/client-server-api/#phone-numbermsisdn-based-identity--homeserver
-#[derive(Clone, Debug, Outgoing, Serialize)]
+#[derive(Clone, Debug, Incoming, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[serde(tag = "type", rename = "m.login.msisdn")]
 pub struct Msisdn<'a> {
@@ -460,7 +460,7 @@ impl IncomingMsisdn {
 /// See [the spec] for how to use this.
 ///
 /// [the spec]: https://spec.matrix.org/v1.2/client-server-api/#dummy-auth
-#[derive(Clone, Debug, Default, Outgoing, Serialize)]
+#[derive(Clone, Debug, Default, Incoming, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[serde(tag = "type", rename = "m.login.dummy")]
 pub struct Dummy<'a> {
@@ -487,7 +487,7 @@ impl IncomingDummy {
 /// See [the spec] for how to use this.
 ///
 /// [the spec]: https://spec.matrix.org/v1.2/client-server-api/#token-authenticated-registration
-#[derive(Clone, Debug, Outgoing, Serialize)]
+#[derive(Clone, Debug, Incoming, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[serde(tag = "type", rename = "m.login.registration_token")]
 pub struct RegistrationToken<'a> {
@@ -517,7 +517,7 @@ impl IncomingRegistrationToken {
 /// See [the spec] for how to use this.
 ///
 /// [the spec]: https://spec.matrix.org/v1.2/client-server-api/#fallback
-#[derive(Clone, Debug, Outgoing, Serialize)]
+#[derive(Clone, Debug, Incoming, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct FallbackAcknowledgement<'a> {
     /// The value of the session key given by the homeserver.
@@ -561,7 +561,7 @@ pub struct IncomingCustomAuthData {
 }
 
 /// Identification information for the user.
-#[derive(Clone, Debug, PartialEq, Eq, Outgoing, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Incoming, Serialize)]
 #[serde(from = "user_serde::IncomingUserIdentifier", into = "user_serde::UserIdentifier<'_>")]
 #[allow(clippy::exhaustive_enums)]
 pub enum UserIdentifier<'a> {

--- a/crates/ruma-client-api/src/uiaa/user_serde.rs
+++ b/crates/ruma-client-api/src/uiaa/user_serde.rs
@@ -1,12 +1,12 @@
 //! Helper module for the Serialize / Deserialize impl's for the User struct
 //! in the parent module.
 
-use ruma_common::{serde::Outgoing, thirdparty::Medium};
+use ruma_common::{serde::Incoming, thirdparty::Medium};
 use serde::Serialize;
 
 // The following structs could just be used in place of the one in the parent module, but
 // that one is arguably much easier to deal with.
-#[derive(Clone, Debug, PartialEq, Eq, Outgoing, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Incoming, Serialize)]
 #[serde(tag = "type")]
 pub(crate) enum UserIdentifier<'a> {
     #[serde(rename = "m.id.user")]

--- a/crates/ruma-common/src/directory.rs
+++ b/crates/ruma-common/src/directory.rs
@@ -2,7 +2,7 @@
 
 use std::fmt;
 
-use crate::serde::{Outgoing, StringEnum};
+use crate::serde::{Incoming, StringEnum};
 use js_int::UInt;
 use serde::{
     de::{Error, MapAccess, Visitor},
@@ -108,7 +108,7 @@ impl From<PublicRoomsChunkInit> for PublicRoomsChunk {
 }
 
 /// A filter for public rooms lists
-#[derive(Clone, Debug, Default, Outgoing, Serialize)]
+#[derive(Clone, Debug, Default, Incoming, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[incoming_derive(Default)]
 pub struct Filter<'a> {
@@ -131,7 +131,7 @@ impl Filter<'_> {
 
 /// Information about which networks/protocols from application services on the
 /// homeserver from which to request rooms.
-#[derive(Clone, Debug, PartialEq, Eq, Outgoing)]
+#[derive(Clone, Debug, PartialEq, Eq, Incoming)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[incoming_derive(Clone, PartialEq, Eq, !Deserialize)]
 pub enum RoomNetwork<'a> {

--- a/crates/ruma-common/src/serde.rs
+++ b/crates/ruma-common/src/serde.rs
@@ -73,6 +73,6 @@ where
 }
 
 pub use ruma_macros::{
-    AsRefStr, DeserializeFromCowStr, DisplayAsRefStr, FromString, OrdAsRefStr, Outgoing,
+    AsRefStr, DeserializeFromCowStr, DisplayAsRefStr, FromString, Incoming, OrdAsRefStr,
     PartialEqAsRefStr, PartialOrdAsRefStr, SerializeAsRefStr, StringEnum, _FakeDeriveSerde,
 };

--- a/crates/ruma-common/src/serde.rs
+++ b/crates/ruma-common/src/serde.rs
@@ -72,22 +72,6 @@ where
     serde_json::from_str(val.get()).map_err(E::custom)
 }
 
-/// A type that can be sent to another party that understands the matrix protocol.
-///
-/// If any of the fields of `Self` don't implement serde's `Deserialize`, you can derive this trait
-/// to generate a corresponding 'Incoming' type that supports deserialization. This is useful for
-/// things like `ruma_common::events::EventResult`. For more details, see the
-/// [derive macro's documentation][doc].
-///
-/// [doc]: derive.Outgoing.html
-// TODO: Better explain how this trait relates to serde's traits
-pub trait Outgoing {
-    /// The 'Incoming' variant of `Self`.
-    type Incoming;
-}
-
-// -- Everything below is macro-related --
-
 pub use ruma_macros::{
     AsRefStr, DeserializeFromCowStr, DisplayAsRefStr, FromString, OrdAsRefStr, Outgoing,
     PartialEqAsRefStr, PartialOrdAsRefStr, SerializeAsRefStr, StringEnum, _FakeDeriveSerde,

--- a/crates/ruma-common/tests/api/manual_endpoint_impl.rs
+++ b/crates/ruma-common/tests/api/manual_endpoint_impl.rs
@@ -12,7 +12,6 @@ use ruma_common::{
         AuthScheme, EndpointError, IncomingRequest, IncomingResponse, MatrixVersion, Metadata,
         OutgoingRequest, OutgoingResponse, SendAccessToken,
     },
-    serde::Outgoing,
     RoomAliasId, RoomId,
 };
 use serde::{Deserialize, Serialize};
@@ -22,10 +21,6 @@ use serde::{Deserialize, Serialize};
 pub struct Request {
     pub room_id: Box<RoomId>,         // body
     pub room_alias: Box<RoomAliasId>, // path
-}
-
-impl Outgoing for Request {
-    type Incoming = Self;
 }
 
 const METADATA: Metadata = Metadata {
@@ -115,10 +110,6 @@ struct RequestBody {
 /// The response to a request to create a new room alias.
 #[derive(Clone, Copy, Debug)]
 pub struct Response;
-
-impl Outgoing for Response {
-    type Incoming = Self;
-}
 
 impl IncomingResponse for Response {
     type EndpointError = MatrixError;

--- a/crates/ruma-common/tests/api/path_arg_ordering.rs
+++ b/crates/ruma-common/tests/api/path_arg_ordering.rs
@@ -1,4 +1,4 @@
-use ruma_common::api::{ruma_api, IncomingRequest};
+use ruma_common::api::{ruma_api, IncomingRequest as _};
 
 ruma_api! {
     metadata: {

--- a/crates/ruma-common/tests/api/ruma_api_lifetime.rs
+++ b/crates/ruma-common/tests/api/ruma_api_lifetime.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::exhaustive_structs)]
 
-#[derive(Copy, Clone, Debug, ruma_common::serde::Outgoing, serde::Serialize)]
+#[derive(Copy, Clone, Debug, ruma_common::serde::Incoming, serde::Serialize)]
 pub struct OtherThing<'t> {
     pub some: &'t str,
     pub t: &'t [u8],

--- a/crates/ruma-common/tests/api/ui/05-request-only.rs
+++ b/crates/ruma-common/tests/api/ui/05-request-only.rs
@@ -1,10 +1,7 @@
 use bytes::BufMut;
-use ruma_common::{
-    api::{
-        error::{FromHttpResponseError, IntoHttpError, MatrixError},
-        ruma_api, IncomingResponse, OutgoingResponse,
-    },
-    serde::Incoming,
+use ruma_common::api::{
+    error::{FromHttpResponseError, IntoHttpError, MatrixError},
+    ruma_api, IncomingResponse, OutgoingResponse,
 };
 
 ruma_api! {
@@ -25,7 +22,6 @@ ruma_api! {
     }
 }
 
-#[derive(Incoming)]
 pub struct Response;
 
 impl IncomingResponse for Response {

--- a/crates/ruma-common/tests/api/ui/05-request-only.rs
+++ b/crates/ruma-common/tests/api/ui/05-request-only.rs
@@ -4,7 +4,7 @@ use ruma_common::{
         error::{FromHttpResponseError, IntoHttpError, MatrixError},
         ruma_api, IncomingResponse, OutgoingResponse,
     },
-    serde::Outgoing,
+    serde::Incoming,
 };
 
 ruma_api! {
@@ -25,7 +25,7 @@ ruma_api! {
     }
 }
 
-#[derive(Outgoing)]
+#[derive(Incoming)]
 pub struct Response;
 
 impl IncomingResponse for Response {

--- a/crates/ruma-macros/src/api/api_request.rs
+++ b/crates/ruma-macros/src/api/api_request.rs
@@ -99,7 +99,7 @@ impl Request {
                 Clone,
                 Debug,
                 #ruma_macros::Request,
-                #ruma_common::serde::Outgoing,
+                #ruma_common::serde::Incoming,
                 #ruma_common::serde::_FakeDeriveSerde,
             )]
             #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]

--- a/crates/ruma-macros/src/api/api_response.rs
+++ b/crates/ruma-macros/src/api/api_response.rs
@@ -39,7 +39,7 @@ impl Response {
                 Clone,
                 Debug,
                 #ruma_macros::Response,
-                #ruma_common::serde::Outgoing,
+                #ruma_common::serde::Incoming,
                 #ruma_common::serde::_FakeDeriveSerde,
             )]
             #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]

--- a/crates/ruma-macros/src/api/request.rs
+++ b/crates/ruma-macros/src/api/request.rs
@@ -217,10 +217,10 @@ impl Request {
                 #[derive(
                     Debug,
                     #ruma_macros::_FakeDeriveRumaApi,
-                    #ruma_common::serde::Outgoing,
                     #serde::Serialize,
                     #derive_deserialize
                 )]
+                #[cfg_attr(feature = "server", derive(#ruma_common::serde::Outgoing))]
                 #serde_attr
                 struct RequestBody< #(#lifetimes),* > { #(#fields),* }
             }
@@ -245,10 +245,10 @@ impl Request {
                 #[derive(
                     Debug,
                     #ruma_macros::_FakeDeriveRumaApi,
-                    #ruma_common::serde::Outgoing,
                     #serde::Serialize,
                     #derive_deserialize
                 )]
+                #[cfg_attr(feature = "server", derive(#ruma_common::serde::Outgoing))]
                 struct RequestQuery< #(#lifetimes),* > #def
             }
         });

--- a/crates/ruma-macros/src/api/request.rs
+++ b/crates/ruma-macros/src/api/request.rs
@@ -220,7 +220,7 @@ impl Request {
                     #serde::Serialize,
                     #derive_deserialize
                 )]
-                #[cfg_attr(feature = "server", derive(#ruma_common::serde::Outgoing))]
+                #[cfg_attr(feature = "server", derive(#ruma_common::serde::Incoming))]
                 #serde_attr
                 struct RequestBody< #(#lifetimes),* > { #(#fields),* }
             }
@@ -248,7 +248,7 @@ impl Request {
                     #serde::Serialize,
                     #derive_deserialize
                 )]
-                #[cfg_attr(feature = "server", derive(#ruma_common::serde::Outgoing))]
+                #[cfg_attr(feature = "server", derive(#ruma_common::serde::Incoming))]
                 struct RequestQuery< #(#lifetimes),* > #def
             }
         });

--- a/crates/ruma-macros/src/api/request/outgoing.rs
+++ b/crates/ruma-macros/src/api/request/outgoing.rs
@@ -186,7 +186,7 @@ impl Request {
             #[cfg(feature = "client")]
             impl #impl_generics #ruma_common::api::OutgoingRequest for Request #ty_generics #where_clause {
                 type EndpointError = #error_ty;
-                type IncomingResponse = <Response as #ruma_common::serde::Outgoing>::Incoming;
+                type IncomingResponse = Response;
 
                 const METADATA: #ruma_common::api::Metadata = self::METADATA;
 

--- a/crates/ruma-macros/src/api/response.rs
+++ b/crates/ruma-macros/src/api/response.rs
@@ -110,7 +110,7 @@ impl Response {
                 #[derive(
                     Debug,
                     #ruma_macros::_FakeDeriveRumaApi,
-                    #ruma_common::serde::Outgoing,
+                    #ruma_common::serde::Incoming,
                     #serde_derives
                 )]
                 #serde_attr

--- a/crates/ruma-macros/src/api/response/incoming.rs
+++ b/crates/ruma-macros/src/api/response/incoming.rs
@@ -17,10 +17,7 @@ impl Response {
 
         let typed_response_body_decl = self.has_body_fields().then(|| {
             quote! {
-                let response_body: <
-                    ResponseBody
-                    as #ruma_common::serde::Outgoing
-                >::Incoming = {
+                let response_body: ResponseBody = {
                     let body = ::std::convert::AsRef::<[::std::primitive::u8]>::as_ref(
                         response.body(),
                     );

--- a/crates/ruma-macros/src/lib.rs
+++ b/crates/ruma-macros/src/lib.rs
@@ -37,8 +37,8 @@ use self::{
         enum_as_ref_str::expand_enum_as_ref_str,
         enum_from_string::expand_enum_from_string,
         eq_as_ref_str::expand_partial_eq_as_ref_str,
+        incoming::expand_derive_incoming,
         ord_as_ref_str::{expand_ord_as_ref_str, expand_partial_ord_as_ref_str},
-        outgoing::expand_derive_outgoing,
         serialize_as_ref_str::expand_serialize_as_ref_str,
     },
     util::import_ruma_common,
@@ -232,55 +232,13 @@ pub fn user_id(input: TokenStream) -> TokenStream {
     output.into()
 }
 
-/// Derive the `Outgoing` trait, possibly generating an 'Incoming' version of the struct this
-/// derive macro is used on.
+/// Generating an 'Incoming' version of the type this derive macro is used on.
 ///
-/// Specifically, if no lifetime variables are used on any of the fields of the struct, this simple
-/// implementation will be generated:
-///
-/// ```ignore
-/// # // TODO: "ignore" this doctest until it is more extensively documented. (See #541)
-/// impl Outgoing for MyType {
-///     type Incoming = Self;
-/// }
-/// ```
-/*
-
-TODO: Extend docs. Previously:
-
-If, however, `#[wrap_incoming]` is used (which is the only reason you should ever use this
-derive macro manually), a new struct `IncomingT` (where `T` is the type this derive is used on)
-is generated, with all of the fields with `#[wrap_incoming]` replaced:
-
-```ignore
-#[derive(Outgoing)]
-struct MyType {
-    pub foo: Foo,
-    #[wrap_incoming]
-    pub bar: Bar,
-    #[wrap_incoming(Baz)]
-    pub baz: Option<Baz>,
-    #[wrap_incoming(with EventResult)]
-    pub x: XEvent,
-    #[wrap_incoming(YEvent with EventResult)]
-    pub ys: Vec<YEvent>,
-}
-
-// generated
-struct IncomingMyType {
-    pub foo: Foo,
-    pub bar: IncomingBar,
-    pub baz: Option<IncomingBaz>,
-    pub x: EventResult<XEvent>,
-    pub ys: Vec<EventResult<YEvent>>,
-}
-```
-
-*/
-#[proc_macro_derive(Outgoing, attributes(incoming_derive))]
-pub fn derive_outgoing(input: TokenStream) -> TokenStream {
+/// This type will be a fully-owned version of the input type, using no lifetime generics.
+#[proc_macro_derive(Incoming, attributes(incoming_derive))]
+pub fn derive_incoming(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
-    expand_derive_outgoing(input).unwrap_or_else(syn::Error::into_compile_error).into()
+    expand_derive_incoming(input).unwrap_or_else(syn::Error::into_compile_error).into()
 }
 
 /// Derive the `AsRef<str>` trait for an enum.

--- a/crates/ruma-macros/src/serde.rs
+++ b/crates/ruma-macros/src/serde.rs
@@ -7,7 +7,7 @@ pub mod display_as_ref_str;
 pub mod enum_as_ref_str;
 pub mod enum_from_string;
 pub mod eq_as_ref_str;
+pub mod incoming;
 pub mod ord_as_ref_str;
-pub mod outgoing;
 pub mod serialize_as_ref_str;
 mod util;

--- a/crates/ruma-macros/src/serde/incoming.rs
+++ b/crates/ruma-macros/src/serde/incoming.rs
@@ -22,7 +22,7 @@ enum DataKind {
     Unit,
 }
 
-pub fn expand_derive_outgoing(input: DeriveInput) -> syn::Result<TokenStream> {
+pub fn expand_derive_incoming(input: DeriveInput) -> syn::Result<TokenStream> {
     let ruma_common = import_ruma_common();
 
     let mut derives = vec![quote! { Debug }];
@@ -56,7 +56,7 @@ pub fn expand_derive_outgoing(input: DeriveInput) -> syn::Result<TokenStream> {
         input.attrs.iter().filter(|attr| filter_input_attrs(attr)).collect::<Vec<_>>();
 
     let data = match input.data.clone() {
-        Data::Union(_) => panic!("#[derive(Outgoing)] does not support Union types"),
+        Data::Union(_) => panic!("#[derive(Incoming)] does not support Union types"),
         Data::Enum(e) => DataKind::Enum(e.variants.into_iter().collect()),
         Data::Struct(s) => match s.fields {
             Fields::Named(fs) => {

--- a/crates/ruma-macros/src/serde/incoming.rs
+++ b/crates/ruma-macros/src/serde/incoming.rs
@@ -4,32 +4,49 @@ use syn::{
     parse::{Parse, ParseStream},
     parse_quote,
     punctuated::Punctuated,
-    AngleBracketedGenericArguments, Attribute, Data, DeriveInput, Field, Fields, GenericArgument,
-    GenericParam, Generics, Ident, ImplGenerics, ParenthesizedGenericArguments, Path,
-    PathArguments, Token, Type, TypeGenerics, TypePath, TypeReference, TypeSlice, Variant,
+    AngleBracketedGenericArguments, Attribute, Data, DeriveInput, GenericArgument, GenericParam,
+    Generics, Ident, ParenthesizedGenericArguments, Path, PathArguments, Token, Type, TypePath,
+    TypeReference, TypeSlice,
 };
 
 use crate::util::import_ruma_common;
 
-enum StructKind {
-    Struct,
-    Tuple,
-}
-
-enum DataKind {
-    Struct(Vec<Field>, StructKind),
-    Enum(Vec<Variant>),
-    Unit,
-}
-
-pub fn expand_derive_incoming(input: DeriveInput) -> syn::Result<TokenStream> {
+pub fn expand_derive_incoming(mut ty_def: DeriveInput) -> syn::Result<TokenStream> {
     let ruma_common = import_ruma_common();
+
+    let mut found_lifetime = false;
+    match &mut ty_def.data {
+        Data::Union(_) => panic!("#[derive(Incoming)] does not support Union types"),
+        Data::Enum(e) => {
+            for var in &mut e.variants {
+                for field in &mut var.fields {
+                    if strip_lifetimes(&mut field.ty) {
+                        found_lifetime = true;
+                    }
+                }
+            }
+        }
+        Data::Struct(s) => {
+            for field in &mut s.fields {
+                if !matches!(field.vis, syn::Visibility::Public(_)) {
+                    return Err(syn::Error::new_spanned(field, "All fields must be marked `pub`"));
+                }
+                if strip_lifetimes(&mut field.ty) {
+                    found_lifetime = true;
+                }
+            }
+        }
+    }
+
+    if !found_lifetime {
+        return Ok(TokenStream::new());
+    }
 
     let mut derives = vec![quote! { Debug }];
     let mut derive_deserialize = true;
 
     derives.extend(
-        input
+        ty_def
             .attrs
             .iter()
             .filter(|attr| attr.path.is_ident("incoming_derive"))
@@ -52,86 +69,17 @@ pub fn expand_derive_incoming(input: DeriveInput) -> syn::Result<TokenStream> {
         quote! { #ruma_common::serde::_FakeDeriveSerde }
     });
 
-    let input_attrs =
-        input.attrs.iter().filter(|attr| filter_input_attrs(attr)).collect::<Vec<_>>();
+    ty_def.attrs.retain(filter_input_attrs);
+    clean_generics(&mut ty_def.generics);
 
-    let data = match input.data.clone() {
-        Data::Union(_) => panic!("#[derive(Incoming)] does not support Union types"),
-        Data::Enum(e) => DataKind::Enum(e.variants.into_iter().collect()),
-        Data::Struct(s) => match s.fields {
-            Fields::Named(fs) => {
-                DataKind::Struct(fs.named.into_iter().collect(), StructKind::Struct)
-            }
-            Fields::Unnamed(fs) => {
-                DataKind::Struct(fs.unnamed.into_iter().collect(), StructKind::Tuple)
-            }
-            Fields::Unit => DataKind::Unit,
-        },
-    };
+    let doc = format!("'Incoming' variant of [{}].", &ty_def.ident);
+    ty_def.ident = format_ident!("Incoming{}", ty_def.ident, span = Span::call_site());
 
-    match data {
-        DataKind::Unit => Ok(TokenStream::new()),
-        DataKind::Enum(mut vars) => {
-            let mut found_lifetime = false;
-            for var in &mut vars {
-                for field in &mut var.fields {
-                    if strip_lifetimes(&mut field.ty) {
-                        found_lifetime = true;
-                    }
-                }
-            }
-
-            if !found_lifetime {
-                return Ok(TokenStream::new());
-            }
-
-            let vis = input.vis;
-            let doc = format!("'Incoming' variant of [{ty}](enum.{ty}.html).", ty = &input.ident);
-            let incoming_ident = format_ident!("Incoming{}", input.ident, span = Span::call_site());
-            let mut gen_copy = input.generics.clone();
-            let (_, ty_gen) = split_for_impl_lifetime_less(&mut gen_copy);
-
-            Ok(quote! {
-                #[doc = #doc]
-                #[derive( #( #derives ),* )]
-                #( #input_attrs )*
-                #vis enum #incoming_ident #ty_gen { #( #vars, )* }
-            })
-        }
-        DataKind::Struct(mut fields, struct_kind) => {
-            let mut found_lifetime = false;
-            for field in &mut fields {
-                if !matches!(field.vis, syn::Visibility::Public(_)) {
-                    return Err(syn::Error::new_spanned(field, "All fields must be marked `pub`"));
-                }
-                if strip_lifetimes(&mut field.ty) {
-                    found_lifetime = true;
-                }
-            }
-
-            if !found_lifetime {
-                return Ok(TokenStream::new());
-            }
-
-            let vis = input.vis;
-            let doc = format!("'Incoming' variant of [{ty}](struct.{ty}.html).", ty = &input.ident);
-            let incoming_ident = format_ident!("Incoming{}", input.ident, span = Span::call_site());
-            let mut gen_copy = input.generics.clone();
-            let (_, ty_gen) = split_for_impl_lifetime_less(&mut gen_copy);
-
-            let struct_def = match struct_kind {
-                StructKind::Struct => quote! { { #(#fields,)* } },
-                StructKind::Tuple => quote! { ( #(#fields,)* ); },
-            };
-
-            Ok(quote! {
-                #[doc = #doc]
-                #[derive( #( #derives ),* )]
-                #( #input_attrs )*
-                #vis struct #incoming_ident #ty_gen #struct_def
-            })
-        }
-    }
+    Ok(quote! {
+        #[doc = #doc]
+        #[derive( #( #derives ),* )]
+        #ty_def
+    })
 }
 
 /// Keep any `cfg`, `cfg_attr`, `serde` or `non_exhaustive` attributes found and pass them to the
@@ -144,16 +92,13 @@ fn filter_input_attrs(attr: &Attribute) -> bool {
         || attr.path.is_ident("allow")
 }
 
-fn split_for_impl_lifetime_less(generics: &mut Generics) -> (ImplGenerics<'_>, TypeGenerics<'_>) {
+fn clean_generics(generics: &mut Generics) {
     generics.params = generics
         .params
         .clone()
         .into_iter()
         .filter(|param| !matches!(param, GenericParam::Lifetime(_)))
         .collect();
-
-    let (impl_gen, ty_gen, _) = generics.split_for_impl();
-    (impl_gen, ty_gen)
 }
 
 fn strip_lifetimes(field_type: &mut Type) -> bool {

--- a/crates/ruma-push-gateway-api/src/send_event_notification.rs
+++ b/crates/ruma-push-gateway-api/src/send_event_notification.rs
@@ -13,7 +13,7 @@ pub mod v1 {
         api::ruma_api,
         events::RoomEventType,
         push::{PusherData, Tweak},
-        serde::{Outgoing, StringEnum},
+        serde::{Incoming, StringEnum},
         EventId, RoomAliasId, RoomId, RoomName, SecondsSinceUnixEpoch, UserId,
     };
     use serde::{Deserialize, Serialize};
@@ -65,7 +65,7 @@ pub mod v1 {
     }
 
     /// Type for passing information about a push notification
-    #[derive(Clone, Debug, Default, Outgoing, Serialize)]
+    #[derive(Clone, Debug, Default, Incoming, Serialize)]
     #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     pub struct Notification<'a> {
         /// The Matrix event ID of the event being notified about.
@@ -196,7 +196,7 @@ pub mod v1 {
     }
 
     /// Type for passing information about devices.
-    #[derive(Clone, Debug, Deserialize, Outgoing, Serialize)]
+    #[derive(Clone, Debug, Deserialize, Incoming, Serialize)]
     #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     pub struct Device {
         /// The `app_id` given when the pusher was created.

--- a/crates/ruma/src/lib.rs
+++ b/crates/ruma/src/lib.rs
@@ -162,7 +162,7 @@ pub use ruma_client::Client;
 pub use ruma_common::{
     authentication, device_id, device_key_id, directory, encryption, event_id, matrix_uri, mxc_uri,
     power_levels, presence, push, receipt, room, room_alias_id, room_id, room_version_id,
-    serde::Outgoing, server_name, server_signing_key_id, thirdparty, to_device, user_id,
+    serde::Incoming, server_name, server_signing_key_id, thirdparty, to_device, user_id,
     ClientSecret, DeviceId, DeviceKeyAlgorithm, DeviceKeyId, DeviceSignatures, DeviceSigningKeyId,
     EntitySignatures, EventEncryptionAlgorithm, EventId, KeyId, KeyName, MatrixToUri,
     MilliSecondsSinceUnixEpoch, MxcUri, PrivOwnedStr, RoomAliasId, RoomId, RoomOrAliasId,

--- a/crates/ruma/tests/outgoing.rs
+++ b/crates/ruma/tests/outgoing.rs
@@ -4,7 +4,7 @@
 
 #![allow(clippy::exhaustive_structs, clippy::redundant_allocation)]
 
-use ruma::{Outgoing, UserId};
+use ruma::{Incoming, UserId};
 
 #[allow(unused)]
 pub struct Thing<'t, T> {
@@ -20,14 +20,14 @@ pub struct IncomingThing<T> {
 }
 
 #[allow(unused)]
-#[derive(Copy, Clone, Debug, Outgoing, serde::Serialize)]
+#[derive(Copy, Clone, Debug, Incoming, serde::Serialize)]
 #[serde(crate = "serde")]
 pub struct OtherThing<'t> {
     pub some: &'t str,
     pub t: &'t [u8],
 }
 
-#[derive(Outgoing)]
+#[derive(Incoming)]
 #[incoming_derive(!Deserialize)]
 #[non_exhaustive]
 pub struct FakeRequest<'a, T> {
@@ -45,7 +45,7 @@ pub struct FakeRequest<'a, T> {
     pub triple_ref: &'a &'a &'a str,
 }
 
-#[derive(Outgoing)]
+#[derive(Incoming)]
 #[incoming_derive(!Deserialize)]
 #[non_exhaustive]
 pub enum EnumThing<'a, T> {


### PR DESCRIPTION
As you can see by the simple diff, we didn't really need this trait at all (anymore).

This PR gets rid of the unnecessary abstraction.