### PR TITLE
API error improvements

### DIFF
--- a/crates/ruma-common/src/api/error.rs
+++ b/crates/ruma-common/src/api/error.rs
@@ -131,21 +131,21 @@ pub enum FromHttpResponseError<E> {
     Deserialization(DeserializationError),
 
     /// The server returned a non-success status
-    Http(ServerError<E>),
+    Server(ServerError<E>),
 }
 
 impl<E: fmt::Display> fmt::Display for FromHttpResponseError<E> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Deserialization(err) => write!(f, "deserialization failed: {}", err),
-            Self::Http(err) => write!(f, "the server returned an error: {}", err),
+            Self::Server(err) => write!(f, "the server returned an error: {}", err),
         }
     }
 }
 
 impl<E> From<ServerError<E>> for FromHttpResponseError<E> {
     fn from(err: ServerError<E>) -> Self {
-        Self::Http(err)
+        Self::Server(err)
     }
 }
 

--- a/crates/ruma-common/tests/api/manual_endpoint_impl.rs
+++ b/crates/ruma-common/tests/api/manual_endpoint_impl.rs
@@ -129,7 +129,7 @@ impl IncomingResponse for Response {
         if http_response.status().as_u16() < 400 {
             Ok(Response)
         } else {
-            Err(FromHttpResponseError::Http(ServerError::Known(
+            Err(FromHttpResponseError::Server(ServerError::Known(
                 <MatrixError as EndpointError>::try_from_http_response(http_response)?,
             )))
         }


### PR DESCRIPTION
This should make it easy enough to implement any of the ideas from matrix-org/matrix-rust-sdk#543. Without this, it would be annoying to do because `FromHttpResponseError` is non-exhaustive.