### PR TITLE
common: Create an enum for a media's source

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [unreleased]
 
+Breaking changes:
+
+* Change `events::room` media types to accept either a plain file or an
+  encrypted file
+
 # 0.8.0
 
 Breaking changes:

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -3,7 +3,7 @@
 Breaking changes:
 
 * Change `events::room` media types to accept either a plain file or an
-  encrypted file
+  encrypted file, not both simultaneously
 
 # 0.8.0
 

--- a/crates/ruma-common/src/events/room.rs
+++ b/crates/ruma-common/src/events/room.rs
@@ -29,6 +29,7 @@ pub mod power_levels;
 pub mod redaction;
 pub mod server_acl;
 pub mod third_party_invite;
+mod thumbnail_src_serde;
 pub mod tombstone;
 pub mod topic;
 
@@ -70,8 +71,8 @@ pub struct ImageInfo {
     pub thumbnail_info: Option<Box<ThumbnailInfo>>,
 
     /// The source of the thumbnail of the image.
-    #[serde(flatten, skip_serializing_if = "Option::is_none")]
-    pub thumbnail_src: Option<ThumbnailSource>,
+    #[serde(flatten, with = "thumbnail_src_serde", skip_serializing_if = "Option::is_none")]
+    pub thumbnail_src: Option<MediaSource>,
 
     /// The [BlurHash](https://blurha.sh) for this image.
     ///
@@ -91,19 +92,6 @@ impl ImageInfo {
     pub fn new() -> Self {
         Self::default()
     }
-}
-
-/// The source of a thumbnail.
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-pub enum ThumbnailSource {
-    /// The MXC URI to the unencrypted media file.
-    #[serde(rename = "thumbnail_url")]
-    Plain(Box<MxcUri>),
-
-    /// The encryption info of the encrypted media file.
-    #[serde(rename = "thumbnail_file")]
-    Encrypted(Box<EncryptedFile>),
 }
 
 /// Metadata about a thumbnail.

--- a/crates/ruma-common/src/events/room.rs
+++ b/crates/ruma-common/src/events/room.rs
@@ -32,6 +32,19 @@ pub mod third_party_invite;
 pub mod tombstone;
 pub mod topic;
 
+/// The source of a media file.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+pub enum MediaSource {
+    /// The MXC URI to the unencrypted media file.
+    #[serde(rename = "url")]
+    Plain(Box<MxcUri>),
+
+    /// The encryption info of the encrypted media file.
+    #[serde(rename = "file")]
+    Encrypted(Box<EncryptedFile>),
+}
+
 /// Metadata about an image.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
@@ -52,21 +65,13 @@ pub struct ImageInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub size: Option<UInt>,
 
-    /// Metadata about the image referred to in `thumbnail_url`.
+    /// Metadata about the image referred to in `thumbnail_src`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub thumbnail_info: Option<Box<ThumbnailInfo>>,
 
-    /// The URL to the thumbnail of the image.
-    ///
-    /// Only present if the thumbnail is unencrypted.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub thumbnail_url: Option<Box<MxcUri>>,
-
-    /// Information on the encrypted thumbnail image.
-    ///
-    /// Only present if the thumbnail is encrypted.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub thumbnail_file: Option<Box<EncryptedFile>>,
+    /// The source of the thumbnail of the image.
+    #[serde(flatten, skip_serializing_if = "Option::is_none")]
+    pub thumbnail_src: Option<ThumbnailSource>,
 
     /// The [BlurHash](https://blurha.sh) for this image.
     ///
@@ -86,6 +91,19 @@ impl ImageInfo {
     pub fn new() -> Self {
         Self::default()
     }
+}
+
+/// The source of a thumbnail.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+pub enum ThumbnailSource {
+    /// The MXC URI to the unencrypted media file.
+    #[serde(rename = "thumbnail_url")]
+    Plain(Box<MxcUri>),
+
+    /// The encryption info of the encrypted media file.
+    #[serde(rename = "thumbnail_file")]
+    Encrypted(Box<EncryptedFile>),
 }
 
 /// Metadata about a thumbnail.

--- a/crates/ruma-common/src/events/room/message.rs
+++ b/crates/ruma-common/src/events/room/message.rs
@@ -9,7 +9,7 @@ use ruma_macros::EventContent;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
-use super::{EncryptedFile, ImageInfo, MediaSource, ThumbnailInfo, ThumbnailSource};
+use super::{EncryptedFile, ImageInfo, MediaSource, ThumbnailInfo};
 #[cfg(feature = "unstable-msc1767")]
 use crate::events::{
     emote::EmoteEventContent,
@@ -644,8 +644,8 @@ pub struct FileInfo {
     pub thumbnail_info: Option<Box<ThumbnailInfo>>,
 
     /// The source of the thumbnail of the file.
-    #[serde(flatten, skip_serializing_if = "Option::is_none")]
-    pub thumbnail_src: Option<ThumbnailSource>,
+    #[serde(flatten, with = "super::thumbnail_src_serde", skip_serializing_if = "Option::is_none")]
+    pub thumbnail_src: Option<MediaSource>,
 }
 
 impl FileInfo {
@@ -718,8 +718,8 @@ impl LocationMessageEventContent {
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct LocationInfo {
     /// The URL to a thumbnail of the location.
-    #[serde(flatten, skip_serializing_if = "Option::is_none")]
-    pub thumbnail_src: Option<ThumbnailSource>,
+    #[serde(flatten, with = "super::thumbnail_src_serde", skip_serializing_if = "Option::is_none")]
+    pub thumbnail_src: Option<MediaSource>,
 
     /// Metadata about the image referred to in `thumbnail_src.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1065,8 +1065,8 @@ pub struct VideoInfo {
     pub thumbnail_info: Option<Box<ThumbnailInfo>>,
 
     /// The source of the thumbnail of the video clip.
-    #[serde(flatten, skip_serializing_if = "Option::is_none")]
-    pub thumbnail_src: Option<ThumbnailSource>,
+    #[serde(flatten, with = "super::thumbnail_src_serde", skip_serializing_if = "Option::is_none")]
+    pub thumbnail_src: Option<MediaSource>,
 
     /// The [BlurHash](https://blurha.sh) for this video.
     ///

--- a/crates/ruma-common/src/events/room/thumbnail_src_serde.rs
+++ b/crates/ruma-common/src/events/room/thumbnail_src_serde.rs
@@ -1,0 +1,207 @@
+//! De-/serialization functions for `Option<MediaSource>` objects representing a thumbnail source.
+
+use serde::{
+    de::Deserializer,
+    ser::{SerializeStruct, Serializer},
+    Deserialize,
+};
+
+use crate::MxcUri;
+
+use super::{EncryptedFile, MediaSource};
+
+/// Serializes a MediaSource to a thumbnail source.
+pub fn serialize<S>(src: &Option<MediaSource>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    if let Some(src) = src {
+        let mut st = serializer.serialize_struct("ThumbnailSource", 1)?;
+        match src {
+            MediaSource::Plain(url) => st.serialize_field("thumbnail_url", url)?,
+            MediaSource::Encrypted(file) => st.serialize_field("thumbnail_file", file)?,
+        }
+        st.end()
+    } else {
+        serializer.serialize_none()
+    }
+}
+
+/// Deserializes a thumbnail source to a MediaSource.
+pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<MediaSource>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Option::<ThumbnailSource>::deserialize(deserializer).map(|src| src.map(Into::into))
+}
+
+#[derive(Clone, Debug, Deserialize)]
+enum ThumbnailSource {
+    /// The MXC URI to the unencrypted media file.
+    #[serde(rename = "thumbnail_url")]
+    Plain(Box<MxcUri>),
+
+    /// The encryption info of the encrypted media file.
+    #[serde(rename = "thumbnail_file")]
+    Encrypted(Box<EncryptedFile>),
+}
+
+impl From<ThumbnailSource> for MediaSource {
+    fn from(src: ThumbnailSource) -> Self {
+        match src {
+            ThumbnailSource::Plain(url) => Self::Plain(url),
+            ThumbnailSource::Encrypted(file) => Self::Encrypted(file),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use matches::assert_matches;
+    use serde::{Deserialize, Serialize};
+    use serde_json::json;
+
+    use crate::{
+        events::room::{EncryptedFileInit, JsonWebKeyInit, MediaSource},
+        mxc_uri,
+        serde::Base64,
+    };
+
+    #[derive(Clone, Debug, Deserialize, Serialize)]
+    struct ThumbnailSourceTest {
+        #[serde(flatten, with = "super", default, skip_serializing_if = "Option::is_none")]
+        src: Option<MediaSource>,
+    }
+
+    #[test]
+    fn deserialize_plain() {
+        let json = json!({ "thumbnail_url": "mxc://notareal.hs/abcdef" });
+
+        assert_matches!(
+            serde_json::from_value::<ThumbnailSourceTest>(json).unwrap(),
+            ThumbnailSourceTest { src: Some(MediaSource::Plain(url)) }
+            if url == "mxc://notareal.hs/abcdef"
+        );
+    }
+
+    #[test]
+    fn deserialize_encrypted() {
+        let json = json!({
+            "thumbnail_file": {
+                "url": "mxc://notareal.hs/abcdef",
+                "key": {
+                    "kty": "oct",
+                    "key_ops": ["encrypt", "decrypt"],
+                    "alg": "A256CTR",
+                    "k": "TLlG_OpX807zzQuuwv4QZGJ21_u7weemFGYJFszMn9A",
+                    "ext": true
+                },
+                "iv": "S22dq3NAX8wAAAAAAAAAAA",
+                "hashes": {
+                    "sha256": "aWOHudBnDkJ9IwaR1Nd8XKoI7DOrqDTwt6xDPfVGN6Q"
+                },
+                "v": "v2",
+            },
+        });
+
+        assert_matches!(
+            serde_json::from_value::<ThumbnailSourceTest>(json).unwrap(),
+            ThumbnailSourceTest { src: Some(MediaSource::Encrypted(file)) }
+            if file.url == "mxc://notareal.hs/abcdef"
+        );
+    }
+
+    #[test]
+    fn deserialize_none_by_absence() {
+        let json = json!({});
+
+        assert_matches!(
+            serde_json::from_value::<ThumbnailSourceTest>(json).unwrap(),
+            ThumbnailSourceTest { src: None }
+        );
+    }
+
+    #[test]
+    fn deserialize_none_by_null_plain() {
+        let json = json!({ "thumbnail_url": null });
+
+        assert_matches!(
+            serde_json::from_value::<ThumbnailSourceTest>(json).unwrap(),
+            ThumbnailSourceTest { src: None }
+        );
+    }
+
+    #[test]
+    fn deserialize_none_by_null_encrypted() {
+        let json = json!({ "thumbnail_file": null });
+
+        assert_matches!(
+            serde_json::from_value::<ThumbnailSourceTest>(json).unwrap(),
+            ThumbnailSourceTest { src: None }
+        );
+    }
+
+    #[test]
+    fn serialize_plain() {
+        let request = ThumbnailSourceTest {
+            src: Some(MediaSource::Plain(mxc_uri!("mxc://notareal.hs/abcdef").into())),
+        };
+        assert_eq!(
+            serde_json::to_value(&request).unwrap(),
+            json!({ "thumbnail_url": "mxc://notareal.hs/abcdef" })
+        );
+    }
+
+    #[test]
+    fn serialize_encrypted() {
+        let request = ThumbnailSourceTest {
+            src: Some(MediaSource::Encrypted(Box::new(
+                EncryptedFileInit {
+                    url: mxc_uri!("mxc://notareal.hs/abcdef").to_owned(),
+                    key: JsonWebKeyInit {
+                        kty: "oct".to_owned(),
+                        key_ops: vec!["encrypt".to_owned(), "decrypt".to_owned()],
+                        alg: "A256CTR".to_owned(),
+                        k: Base64::parse("TLlG_OpX807zzQuuwv4QZGJ21_u7weemFGYJFszMn9A").unwrap(),
+                        ext: true,
+                    }
+                    .into(),
+                    iv: Base64::parse("S22dq3NAX8wAAAAAAAAAAA").unwrap(),
+                    hashes: [(
+                        "sha256".to_owned(),
+                        Base64::parse("aWOHudBnDkJ9IwaR1Nd8XKoI7DOrqDTwt6xDPfVGN6Q").unwrap(),
+                    )]
+                    .into(),
+                    v: "v2".to_owned(),
+                }
+                .into(),
+            ))),
+        };
+        assert_eq!(
+            serde_json::to_value(&request).unwrap(),
+            json!({
+                "thumbnail_file": {
+                    "url": "mxc://notareal.hs/abcdef",
+                    "key": {
+                        "kty": "oct",
+                        "key_ops": ["encrypt", "decrypt"],
+                        "alg": "A256CTR",
+                        "k": "TLlG_OpX807zzQuuwv4QZGJ21_u7weemFGYJFszMn9A",
+                        "ext": true
+                    },
+                    "iv": "S22dq3NAX8wAAAAAAAAAAA",
+                    "hashes": {
+                        "sha256": "aWOHudBnDkJ9IwaR1Nd8XKoI7DOrqDTwt6xDPfVGN6Q"
+                    },
+                    "v": "v2",
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn serialize_none() {
+        let request = ThumbnailSourceTest { src: None };
+        assert_eq!(serde_json::to_value(&request).unwrap(), json!({}));
+    }
+}

--- a/crates/ruma-common/src/events/room/thumbnail_src_serde.rs
+++ b/crates/ruma-common/src/events/room/thumbnail_src_serde.rs
@@ -69,7 +69,7 @@ mod tests {
 
     #[derive(Clone, Debug, Deserialize, Serialize)]
     struct ThumbnailSourceTest {
-        #[serde(flatten, with = "super", default, skip_serializing_if = "Option::is_none")]
+        #[serde(flatten, with = "super", skip_serializing_if = "Option::is_none")]
         src: Option<MediaSource>,
     }
 

--- a/crates/ruma-common/tests/events/message_event.rs
+++ b/crates/ruma-common/tests/events/message_event.rs
@@ -5,7 +5,7 @@ use ruma_common::{
     event_id,
     events::{
         call::{answer::CallAnswerEventContent, SessionDescription, SessionDescriptionType},
-        room::{ImageInfo, ThumbnailInfo, ThumbnailSource},
+        room::{ImageInfo, MediaSource, ThumbnailInfo},
         sticker::StickerEventContent,
         AnyMessageLikeEvent, AnyMessageLikeEventContent, AnySyncMessageLikeEvent, MessageLikeEvent,
         MessageLikeEventType, MessageLikeUnsigned,
@@ -32,7 +32,7 @@ fn message_serialize_sticker() {
                     mimetype: Some("image/png".into()),
                     size: UInt::new(82595),
                 }))),
-                thumbnail_src: Some(ThumbnailSource::Plain(mxc_uri!("mxc://matrix.org/irsns989Rrsn").to_owned())),
+                thumbnail_src: Some(MediaSource::Plain(mxc_uri!("mxc://matrix.org/irsns989Rrsn").to_owned())),
             }),
             mxc_uri!("mxc://matrix.org/rnsldl8srs98IRrs").to_owned(),
         ),
@@ -184,7 +184,7 @@ fn deserialize_message_sticker() {
                     mimetype: Some(mimetype),
                     size,
                     thumbnail_info: Some(thumbnail_info),
-                    thumbnail_src: Some(ThumbnailSource::Plain(thumbnail_url)),
+                    thumbnail_src: Some(MediaSource::Plain(thumbnail_url)),
                     #[cfg(feature = "unstable-msc2448")]
                     blurhash: None,
                     ..

--- a/crates/ruma-common/tests/events/message_event.rs
+++ b/crates/ruma-common/tests/events/message_event.rs
@@ -5,7 +5,7 @@ use ruma_common::{
     event_id,
     events::{
         call::{answer::CallAnswerEventContent, SessionDescription, SessionDescriptionType},
-        room::{ImageInfo, ThumbnailInfo},
+        room::{ImageInfo, ThumbnailInfo, ThumbnailSource},
         sticker::StickerEventContent,
         AnyMessageLikeEvent, AnyMessageLikeEventContent, AnySyncMessageLikeEvent, MessageLikeEvent,
         MessageLikeEventType, MessageLikeUnsigned,
@@ -32,7 +32,7 @@ fn message_serialize_sticker() {
                     mimetype: Some("image/png".into()),
                     size: UInt::new(82595),
                 }))),
-                thumbnail_url: Some(mxc_uri!("mxc://matrix.org/irsns989Rrsn").to_owned()),
+                thumbnail_src: Some(ThumbnailSource::Plain(mxc_uri!("mxc://matrix.org/irsns989Rrsn").to_owned())),
             }),
             mxc_uri!("mxc://matrix.org/rnsldl8srs98IRrs").to_owned(),
         ),
@@ -184,8 +184,7 @@ fn deserialize_message_sticker() {
                     mimetype: Some(mimetype),
                     size,
                     thumbnail_info: Some(thumbnail_info),
-                    thumbnail_url: Some(thumbnail_url),
-                    thumbnail_file: None,
+                    thumbnail_src: Some(ThumbnailSource::Plain(thumbnail_url)),
                     #[cfg(feature = "unstable-msc2448")]
                     blurhash: None,
                     ..

--- a/crates/ruma-common/tests/events/room_message.rs
+++ b/crates/ruma-common/tests/events/room_message.rs
@@ -12,9 +12,12 @@ use ruma_common::{
     event_id,
     events::{
         key::verification::VerificationMethod,
-        room::message::{
-            AudioMessageEventContent, KeyVerificationRequestEventContent, MessageType,
-            RoomMessageEvent, RoomMessageEventContent, TextMessageEventContent,
+        room::{
+            message::{
+                AudioMessageEventContent, KeyVerificationRequestEventContent, MessageType,
+                RoomMessageEvent, RoomMessageEventContent, TextMessageEventContent,
+            },
+            MediaSource,
         },
         MessageLikeUnsigned,
     },
@@ -443,8 +446,7 @@ fn content_deserialization() {
             msgtype: MessageType::Audio(AudioMessageEventContent {
                 body,
                 info: None,
-                url: Some(url),
-                file: None,
+                src: MediaSource::Plain(url),
                 ..
             }),
             ..


### PR DESCRIPTION
Have stricter media types that accept either an encrypted or plain file.