### PR TITLE
identifiers: Rename Error to InvalidId

### DIFF
--- a/crates/ruma-client-api/src/media/get_content.rs
+++ b/crates/ruma-client-api/src/media/get_content.rs
@@ -5,7 +5,7 @@ pub mod v3 {
     //!
     //! [spec]: https://spec.matrix.org/v1.2/client-server-api/#get_matrixmediav3downloadservernamemediaid
 
-    use ruma_common::{api::ruma_api, Error, MxcUri, ServerName};
+    use ruma_common::{api::ruma_api, IdParseError, MxcUri, ServerName};
 
     ruma_api! {
         metadata: {
@@ -65,7 +65,7 @@ pub mod v3 {
         }
 
         /// Creates a new `Request` with the given url.
-        pub fn from_url(url: &'a MxcUri) -> Result<Self, Error> {
+        pub fn from_url(url: &'a MxcUri) -> Result<Self, IdParseError> {
             let (server_name, media_id) = url.parts()?;
 
             Ok(Self { media_id, server_name, allow_remote: true })

--- a/crates/ruma-client-api/src/media/get_content_as_filename.rs
+++ b/crates/ruma-client-api/src/media/get_content_as_filename.rs
@@ -5,7 +5,7 @@ pub mod v3 {
     //!
     //! [spec]: https://spec.matrix.org/v1.2/client-server-api/#get_matrixmediav3downloadservernamemediaidfilename
 
-    use ruma_common::{api::ruma_api, Error, MxcUri, ServerName};
+    use ruma_common::{api::ruma_api, IdParseError, MxcUri, ServerName};
 
     ruma_api! {
         metadata: {
@@ -69,7 +69,7 @@ pub mod v3 {
         }
 
         /// Creates a new `Request` with the given url and filename.
-        pub fn from_url(url: &'a MxcUri, filename: &'a str) -> Result<Self, Error> {
+        pub fn from_url(url: &'a MxcUri, filename: &'a str) -> Result<Self, IdParseError> {
             let (server_name, media_id) = url.parts()?;
 
             Ok(Self { media_id, server_name, filename, allow_remote: true })

--- a/crates/ruma-client-api/src/media/get_content_thumbnail.rs
+++ b/crates/ruma-client-api/src/media/get_content_thumbnail.rs
@@ -6,7 +6,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/v1.2/client-server-api/#get_matrixmediav3thumbnailservernamemediaid
 
     use js_int::UInt;
-    use ruma_common::{api::ruma_api, serde::StringEnum, Error, MxcUri, ServerName};
+    use ruma_common::{api::ruma_api, serde::StringEnum, IdParseError, MxcUri, ServerName};
 
     use crate::PrivOwnedStr;
 
@@ -83,7 +83,7 @@ pub mod v3 {
 
         /// Creates a new `Request` with the given url, desired thumbnail width and
         /// desired thumbnail height.
-        pub fn from_url(url: &'a MxcUri, width: UInt, height: UInt) -> Result<Self, Error> {
+        pub fn from_url(url: &'a MxcUri, width: UInt, height: UInt) -> Result<Self, IdParseError> {
             let (server_name, media_id) = url.parts()?;
 
             Ok(Self { media_id, server_name, method: None, width, height, allow_remote: true })

--- a/crates/ruma-common/src/api/error.rs
+++ b/crates/ruma-common/src/api/error.rs
@@ -248,7 +248,7 @@ pub enum DeserializationError {
 
     /// Got an invalid identifier.
     #[error("{0}")]
-    Ident(#[from] crate::Error),
+    Ident(#[from] crate::IdParseError),
 
     /// Header value deserialization failed.
     #[error("{0}")]

--- a/crates/ruma-common/src/identifiers.rs
+++ b/crates/ruma-common/src/identifiers.rs
@@ -31,7 +31,7 @@ pub use self::{
     user_id::UserId,
 };
 #[doc(inline)]
-pub use ruma_identifiers_validation::error::Error;
+pub use ruma_identifiers_validation::error::Error as IdParseError;
 
 #[macro_use]
 mod macros;

--- a/crates/ruma-common/src/identifiers/device_key_id.rs
+++ b/crates/ruma-common/src/identifiers/device_key_id.rs
@@ -43,7 +43,7 @@ mod tests {
     use std::convert::TryFrom;
 
     use super::DeviceKeyId;
-    use crate::identifiers::{crypto_algorithms::DeviceKeyAlgorithm, Error};
+    use crate::identifiers::{crypto_algorithms::DeviceKeyAlgorithm, IdParseError};
 
     #[test]
     fn convert_device_key_id() {
@@ -75,7 +75,7 @@ mod tests {
     fn missing_key_algorithm() {
         assert_eq!(
             <&DeviceKeyId>::try_from(":JLAFKJWSCS").unwrap_err(),
-            Error::InvalidKeyAlgorithm
+            IdParseError::InvalidKeyAlgorithm
         );
     }
 
@@ -83,7 +83,7 @@ mod tests {
     fn missing_delimiter() {
         assert_eq!(
             <&DeviceKeyId>::try_from("ed25519|JLAFKJWSCS").unwrap_err(),
-            Error::MissingDelimiter,
+            IdParseError::MissingDelimiter,
         );
     }
 

--- a/crates/ruma-common/src/identifiers/event_id.rs
+++ b/crates/ruma-common/src/identifiers/event_id.rs
@@ -78,7 +78,7 @@ mod tests {
     use std::convert::TryFrom;
 
     use super::EventId;
-    use crate::Error;
+    use crate::IdParseError;
 
     #[test]
     fn valid_original_event_id() {
@@ -209,7 +209,7 @@ mod tests {
     fn missing_original_event_id_sigil() {
         assert_eq!(
             <&EventId>::try_from("39hvsi03hlne:example.com").unwrap_err(),
-            Error::MissingLeadingSigil
+            IdParseError::MissingLeadingSigil
         );
     }
 
@@ -217,7 +217,7 @@ mod tests {
     fn missing_base64_event_id_sigil() {
         assert_eq!(
             <&EventId>::try_from("acR1l0raoZnm60CBwAVgqbZqoO/mYU81xysh1u7XcJk").unwrap_err(),
-            Error::MissingLeadingSigil
+            IdParseError::MissingLeadingSigil
         );
     }
 
@@ -225,20 +225,23 @@ mod tests {
     fn missing_url_safe_base64_event_id_sigil() {
         assert_eq!(
             <&EventId>::try_from("Rqnc-F-dvnEYJTyHq_iKxU2bZ1CI92-kuZq3a5lr5Zg").unwrap_err(),
-            Error::MissingLeadingSigil
+            IdParseError::MissingLeadingSigil
         );
     }
 
     #[test]
     fn invalid_event_id_host() {
-        assert_eq!(<&EventId>::try_from("$39hvsi03hlne:/").unwrap_err(), Error::InvalidServerName);
+        assert_eq!(
+            <&EventId>::try_from("$39hvsi03hlne:/").unwrap_err(),
+            IdParseError::InvalidServerName
+        );
     }
 
     #[test]
     fn invalid_event_id_port() {
         assert_eq!(
             <&EventId>::try_from("$39hvsi03hlne:example.com:notaport").unwrap_err(),
-            Error::InvalidServerName
+            IdParseError::InvalidServerName
         );
     }
 }

--- a/crates/ruma-common/src/identifiers/key_id.rs
+++ b/crates/ruma-common/src/identifiers/key_id.rs
@@ -9,7 +9,7 @@ use std::{
     sync::Arc,
 };
 
-use super::{crypto_algorithms::SigningKeyAlgorithm, DeviceId, KeyName};
+use super::{crypto_algorithms::SigningKeyAlgorithm, DeviceId, IdParseError, KeyName};
 
 /// A key algorithm and key name delimited by a colon.
 #[repr(transparent)]
@@ -222,7 +222,7 @@ impl<'de, A, K: ?Sized> serde::Deserialize<'de> for Box<KeyId<A, K>> {
     }
 }
 
-fn try_from<S, A, K: ?Sized>(s: S) -> Result<Box<KeyId<A, K>>, crate::Error>
+fn try_from<S, A, K: ?Sized>(s: S) -> Result<Box<KeyId<A, K>>, IdParseError>
 where
     S: AsRef<str> + Into<Box<str>>,
 {
@@ -231,7 +231,7 @@ where
 }
 
 impl<'a, A, K: ?Sized> TryFrom<&'a str> for &'a KeyId<A, K> {
-    type Error = crate::Error;
+    type Error = IdParseError;
 
     fn try_from(s: &'a str) -> Result<Self, Self::Error> {
         (ruma_identifiers_validation::key_id::validate)(s)?;
@@ -240,7 +240,7 @@ impl<'a, A, K: ?Sized> TryFrom<&'a str> for &'a KeyId<A, K> {
 }
 
 impl<A, K: ?Sized> FromStr for Box<KeyId<A, K>> {
-    type Err = crate::Error;
+    type Err = IdParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         try_from(s)
@@ -248,7 +248,7 @@ impl<A, K: ?Sized> FromStr for Box<KeyId<A, K>> {
 }
 
 impl<A, K: ?Sized> TryFrom<&str> for Box<KeyId<A, K>> {
-    type Error = crate::Error;
+    type Error = IdParseError;
 
     fn try_from(s: &str) -> Result<Self, Self::Error> {
         try_from(s)
@@ -256,7 +256,7 @@ impl<A, K: ?Sized> TryFrom<&str> for Box<KeyId<A, K>> {
 }
 
 impl<A, K: ?Sized> TryFrom<String> for Box<KeyId<A, K>> {
-    type Error = crate::Error;
+    type Error = IdParseError;
 
     fn try_from(s: String) -> Result<Self, Self::Error> {
         try_from(s)

--- a/crates/ruma-common/src/identifiers/macros.rs
+++ b/crates/ruma-common/src/identifiers/macros.rs
@@ -222,7 +222,7 @@ macro_rules! opaque_identifier_validated {
                 ")]
                 pub fn parse(
                     s: impl AsRef<str> + Into<Box<str>>,
-                ) -> Result<Box<Self>, crate:: Error> {
+                ) -> Result<Box<Self>, crate::IdParseError> {
                     $validate_id(s.as_ref())?;
                     Ok($id::from_owned(s.into()))
                 }
@@ -232,7 +232,7 @@ macro_rules! opaque_identifier_validated {
                 #[doc = concat!("Try parsing a `&str` into an `Rc<", stringify!($id), ">`.")]
                 pub fn parse_rc(
                     s: impl AsRef<str> + Into<std::rc::Rc<str>>,
-                ) -> Result<std::rc::Rc<Self>, crate:: Error> {
+                ) -> Result<std::rc::Rc<Self>, crate::IdParseError> {
                     $validate_id(s.as_ref())?;
                     Ok($id::from_rc(s.into()))
                 }
@@ -242,7 +242,7 @@ macro_rules! opaque_identifier_validated {
                 #[doc = concat!("Try parsing a `&str` into an `Arc<", stringify!($id), ">`.")]
                 pub fn parse_arc(
                     s: impl AsRef<str> + Into<std::sync::Arc<str>>,
-                ) -> Result<std::sync::Arc<Self>, crate:: Error> {
+                ) -> Result<std::sync::Arc<Self>, crate::IdParseError> {
                     $validate_id(s.as_ref())?;
                     Ok($id::from_arc(s.into()))
                 }
@@ -274,7 +274,7 @@ macro_rules! opaque_identifier_validated {
         }
 
         impl<'a> std::convert::TryFrom<&'a str> for &'a $id {
-            type Error = crate:: Error;
+            type Error = crate::IdParseError;
 
             fn try_from(s: &'a str) -> Result<Self, Self::Error> {
                 $validate_id(s)?;
@@ -283,7 +283,7 @@ macro_rules! opaque_identifier_validated {
         }
 
         impl std::str::FromStr for Box<$id> {
-            type Err = crate:: Error;
+            type Err = crate::IdParseError;
 
             fn from_str(s: &str) -> Result<Self, Self::Err> {
                 $id::parse(s)
@@ -291,7 +291,7 @@ macro_rules! opaque_identifier_validated {
         }
 
         impl std::convert::TryFrom<&str> for Box<$id> {
-            type Error = crate:: Error;
+            type Error = crate::IdParseError;
 
             fn try_from(s: &str) -> Result<Self, Self::Error> {
                 $id::parse(s)
@@ -299,7 +299,7 @@ macro_rules! opaque_identifier_validated {
         }
 
         impl std::convert::TryFrom<String> for Box<$id> {
-            type Error = crate:: Error;
+            type Error = crate::IdParseError;
 
             fn try_from(s: String) -> Result<Self, Self::Error> {
                 $id::parse(s)

--- a/crates/ruma-common/src/identifiers/room_alias_id.rs
+++ b/crates/ruma-common/src/identifiers/room_alias_id.rs
@@ -63,7 +63,7 @@ mod tests {
     use std::convert::TryFrom;
 
     use super::RoomAliasId;
-    use crate::Error;
+    use crate::IdParseError;
 
     #[test]
     fn valid_room_alias_id() {
@@ -133,33 +133,36 @@ mod tests {
     fn missing_room_alias_id_sigil() {
         assert_eq!(
             <&RoomAliasId>::try_from("39hvsi03hlne:example.com").unwrap_err(),
-            Error::MissingLeadingSigil
+            IdParseError::MissingLeadingSigil
         );
     }
 
     #[test]
     fn missing_room_alias_id_delimiter() {
-        assert_eq!(<&RoomAliasId>::try_from("#ruma").unwrap_err(), Error::MissingDelimiter);
+        assert_eq!(<&RoomAliasId>::try_from("#ruma").unwrap_err(), IdParseError::MissingDelimiter);
     }
 
     #[test]
     fn invalid_leading_sigil() {
         assert_eq!(
             <&RoomAliasId>::try_from("!room_id:foo.bar").unwrap_err(),
-            Error::MissingLeadingSigil
+            IdParseError::MissingLeadingSigil
         );
     }
 
     #[test]
     fn invalid_room_alias_id_host() {
-        assert_eq!(<&RoomAliasId>::try_from("#ruma:/").unwrap_err(), Error::InvalidServerName);
+        assert_eq!(
+            <&RoomAliasId>::try_from("#ruma:/").unwrap_err(),
+            IdParseError::InvalidServerName
+        );
     }
 
     #[test]
     fn invalid_room_alias_id_port() {
         assert_eq!(
             <&RoomAliasId>::try_from("#ruma:example.com:notaport").unwrap_err(),
-            Error::InvalidServerName
+            IdParseError::InvalidServerName
         );
     }
 }

--- a/crates/ruma-common/src/identifiers/room_id.rs
+++ b/crates/ruma-common/src/identifiers/room_id.rs
@@ -110,7 +110,7 @@ mod tests {
     use std::convert::TryFrom;
 
     use super::RoomId;
-    use crate::Error;
+    use crate::IdParseError;
 
     #[test]
     fn valid_room_id() {
@@ -186,25 +186,31 @@ mod tests {
     fn missing_room_id_sigil() {
         assert_eq!(
             <&RoomId>::try_from("carl:example.com").unwrap_err(),
-            Error::MissingLeadingSigil
+            IdParseError::MissingLeadingSigil
         );
     }
 
     #[test]
     fn missing_room_id_delimiter() {
-        assert_eq!(<&RoomId>::try_from("!29fhd83h92h0").unwrap_err(), Error::MissingDelimiter);
+        assert_eq!(
+            <&RoomId>::try_from("!29fhd83h92h0").unwrap_err(),
+            IdParseError::MissingDelimiter
+        );
     }
 
     #[test]
     fn invalid_room_id_host() {
-        assert_eq!(<&RoomId>::try_from("!29fhd83h92h0:/").unwrap_err(), Error::InvalidServerName);
+        assert_eq!(
+            <&RoomId>::try_from("!29fhd83h92h0:/").unwrap_err(),
+            IdParseError::InvalidServerName
+        );
     }
 
     #[test]
     fn invalid_room_id_port() {
         assert_eq!(
             <&RoomId>::try_from("!29fhd83h92h0:example.com:notaport").unwrap_err(),
-            Error::InvalidServerName
+            IdParseError::InvalidServerName
         );
     }
 }

--- a/crates/ruma-common/src/identifiers/room_or_room_alias_id.rs
+++ b/crates/ruma-common/src/identifiers/room_or_room_alias_id.rs
@@ -157,7 +157,7 @@ mod tests {
     use std::convert::TryFrom;
 
     use super::RoomOrAliasId;
-    use crate::Error;
+    use crate::IdParseError;
 
     #[test]
     fn valid_room_id_or_alias_id_with_a_room_alias_id() {
@@ -183,7 +183,7 @@ mod tests {
     fn missing_sigil_for_room_id_or_alias_id() {
         assert_eq!(
             <&RoomOrAliasId>::try_from("ruma:example.com").unwrap_err(),
-            Error::MissingLeadingSigil
+            IdParseError::MissingLeadingSigil
         );
     }
 

--- a/crates/ruma-common/src/identifiers/room_version_id.rs
+++ b/crates/ruma-common/src/identifiers/room_version_id.rs
@@ -5,6 +5,8 @@ use std::{cmp::Ordering, convert::TryFrom, str::FromStr};
 use ruma_macros::DisplayAsRefStr;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
+use super::IdParseError;
+
 /// A Matrix [room version] ID.
 ///
 /// A `RoomVersionId` can be or converted or deserialized from a string slice, and can be converted
@@ -145,7 +147,7 @@ impl<'de> Deserialize<'de> for RoomVersionId {
 }
 
 /// Attempts to create a new Matrix room version ID from a string representation.
-fn try_from<S>(room_version_id: S) -> Result<RoomVersionId, crate::Error>
+fn try_from<S>(room_version_id: S) -> Result<RoomVersionId, IdParseError>
 where
     S: AsRef<str> + Into<Box<str>>,
 {
@@ -169,7 +171,7 @@ where
 }
 
 impl FromStr for RoomVersionId {
-    type Err = crate::Error;
+    type Err = IdParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         try_from(s)
@@ -177,7 +179,7 @@ impl FromStr for RoomVersionId {
 }
 
 impl TryFrom<&str> for RoomVersionId {
-    type Error = crate::Error;
+    type Error = IdParseError;
 
     fn try_from(s: &str) -> Result<Self, Self::Error> {
         try_from(s)
@@ -185,7 +187,7 @@ impl TryFrom<&str> for RoomVersionId {
 }
 
 impl TryFrom<String> for RoomVersionId {
-    type Error = crate::Error;
+    type Error = IdParseError;
 
     fn try_from(s: String) -> Result<Self, Self::Error> {
         try_from(s)
@@ -247,7 +249,7 @@ mod tests {
     use std::convert::TryFrom;
 
     use super::RoomVersionId;
-    use crate::Error;
+    use crate::IdParseError;
 
     #[test]
     fn valid_version_1_room_version_id() {
@@ -307,14 +309,14 @@ mod tests {
 
     #[test]
     fn empty_room_version_id() {
-        assert_eq!(RoomVersionId::try_from(""), Err(Error::EmptyRoomVersionId));
+        assert_eq!(RoomVersionId::try_from(""), Err(IdParseError::EmptyRoomVersionId));
     }
 
     #[test]
     fn over_max_code_point_room_version_id() {
         assert_eq!(
             RoomVersionId::try_from("0123456789012345678901234567890123456789"),
-            Err(Error::MaximumLengthExceeded)
+            Err(IdParseError::MaximumLengthExceeded)
         );
     }
 

--- a/crates/ruma-common/src/identifiers/user_id.rs
+++ b/crates/ruma-common/src/identifiers/user_id.rs
@@ -2,7 +2,7 @@
 
 use std::{rc::Rc, sync::Arc};
 
-use super::{matrix_uri::UriAction, MatrixToUri, MatrixUri, ServerName};
+use super::{matrix_uri::UriAction, IdParseError, MatrixToUri, MatrixUri, ServerName};
 
 /// A Matrix [user ID].
 ///
@@ -42,7 +42,7 @@ impl UserId {
     pub fn parse_with_server_name(
         id: impl AsRef<str> + Into<Box<str>>,
         server_name: &ServerName,
-    ) -> Result<Box<Self>, super::Error> {
+    ) -> Result<Box<Self>, IdParseError> {
         let id_str = id.as_ref();
 
         if id_str.starts_with('@') {
@@ -59,7 +59,7 @@ impl UserId {
     pub fn parse_with_server_name_rc(
         id: impl AsRef<str> + Into<Rc<str>>,
         server_name: &ServerName,
-    ) -> Result<Rc<Self>, super::Error> {
+    ) -> Result<Rc<Self>, IdParseError> {
         let id_str = id.as_ref();
 
         if id_str.starts_with('@') {
@@ -76,7 +76,7 @@ impl UserId {
     pub fn parse_with_server_name_arc(
         id: impl AsRef<str> + Into<Arc<str>>,
         server_name: &ServerName,
-    ) -> Result<Arc<Self>, super::Error> {
+    ) -> Result<Arc<Self>, IdParseError> {
         let id_str = id.as_ref();
 
         if id_str.starts_with('@') {
@@ -154,7 +154,7 @@ mod tests {
     use std::convert::TryFrom;
 
     use super::UserId;
-    use crate::{server_name, Error};
+    use crate::{server_name, IdParseError};
 
     #[test]
     fn valid_user_id_from_str() {
@@ -301,7 +301,7 @@ mod tests {
     fn invalid_characters_in_user_id_localpart() {
         assert_eq!(
             <&UserId>::try_from("@te\nst:example.com").unwrap_err(),
-            Error::InvalidCharacters
+            IdParseError::InvalidCharacters
         );
     }
 
@@ -309,25 +309,25 @@ mod tests {
     fn missing_user_id_sigil() {
         assert_eq!(
             <&UserId>::try_from("carl:example.com").unwrap_err(),
-            Error::MissingLeadingSigil
+            IdParseError::MissingLeadingSigil
         );
     }
 
     #[test]
     fn missing_user_id_delimiter() {
-        assert_eq!(<&UserId>::try_from("@carl").unwrap_err(), Error::MissingDelimiter);
+        assert_eq!(<&UserId>::try_from("@carl").unwrap_err(), IdParseError::MissingDelimiter);
     }
 
     #[test]
     fn invalid_user_id_host() {
-        assert_eq!(<&UserId>::try_from("@carl:/").unwrap_err(), Error::InvalidServerName);
+        assert_eq!(<&UserId>::try_from("@carl:/").unwrap_err(), IdParseError::InvalidServerName);
     }
 
     #[test]
     fn invalid_user_id_port() {
         assert_eq!(
             <&UserId>::try_from("@carl:example.com:notaport").unwrap_err(),
-            Error::InvalidServerName
+            IdParseError::InvalidServerName
         );
     }
 }

--- a/crates/ruma-signatures/src/error.rs
+++ b/crates/ruma-signatures/src/error.rs
@@ -175,11 +175,11 @@ impl VerificationError {
 pub enum ParseError {
     /// For user ID parsing errors.
     #[error("Could not parse User ID: {0}")]
-    UserId(#[source] ruma_common::Error),
+    UserId(#[source] ruma_common::IdParseError),
 
     /// For event ID parsing errors.
     #[error("Could not parse Event ID: {0}")]
-    EventId(#[source] ruma_common::Error),
+    EventId(#[source] ruma_common::IdParseError),
 
     /// For when an event ID, coupled with a specific room version, doesn't have a server name
     /// embedded.

--- a/crates/ruma/src/lib.rs
+++ b/crates/ruma/src/lib.rs
@@ -164,7 +164,7 @@ pub use ruma_common::{
     mxc_uri, power_levels, presence, push, receipt, room, room_alias_id, room_id, room_version_id,
     serde::Incoming, server_name, server_signing_key_id, thirdparty, to_device, user_id,
     ClientSecret, DeviceId, DeviceKeyAlgorithm, DeviceKeyId, DeviceSignatures, DeviceSigningKeyId,
-    EntitySignatures, EventEncryptionAlgorithm, EventId, KeyId, KeyName, MatrixToUri,
+    EntitySignatures, EventEncryptionAlgorithm, EventId, IdParseError, KeyId, KeyName, MatrixToUri,
     MilliSecondsSinceUnixEpoch, MxcUri, PrivOwnedStr, RoomAliasId, RoomId, RoomOrAliasId,
     RoomVersionId, SecondsSinceUnixEpoch, ServerName, ServerSignatures, ServerSigningKeyId,
     SessionId, Signatures, SigningKeyAlgorithm, TransactionId, UserId,


### PR DESCRIPTION
… because it's now exported from the ruma-common crate root.