### PR TITLE
Remove origin field from PDUs

### DIFF
--- a/crates/ruma-common/src/events/pdu.rs
+++ b/crates/ruma-common/src/events/pdu.rs
@@ -42,10 +42,6 @@ pub struct RoomV1Pdu {
     /// The user id of the user who sent this event.
     pub sender: Box<UserId>,
 
-    #[cfg(not(feature = "unstable-pre-spec"))]
-    /// The `server_name` of the homeserver that created this event.
-    pub origin: String,
-
     /// Timestamp (milliseconds since the UNIX epoch) on originating homeserver
     /// of when this event was created.
     pub origin_server_ts: MilliSecondsSinceUnixEpoch,
@@ -100,10 +96,6 @@ pub struct RoomV3Pdu {
 
     /// The user id of the user who sent this event.
     pub sender: Box<UserId>,
-
-    #[cfg(not(feature = "unstable-pre-spec"))]
-    /// The `server_name` of the homeserver that created this event.
-    pub origin: String,
 
     /// Timestamp (milliseconds since the UNIX epoch) on originating homeserver
     /// of when this event was created.

--- a/crates/ruma-common/tests/events/pdu.rs
+++ b/crates/ruma-common/tests/events/pdu.rs
@@ -1,4 +1,4 @@
-#![cfg(all(feature = "unstable-pdu", not(feature = "unstable-pre-spec")))]
+#![cfg(all(feature = "unstable-pdu"))]
 
 use std::{collections::BTreeMap, convert::TryInto};
 
@@ -32,7 +32,6 @@ fn serialize_pdu_as_v1() {
         room_id: room_id!("!n8f893n9:example.com").to_owned(),
         event_id: event_id!("$somejoinevent:matrix.org").to_owned(),
         sender: user_id!("@sender:example.com").to_owned(),
-        origin: "matrix.org".into(),
         origin_server_ts: MilliSecondsSinceUnixEpoch(1_592_050_773_658_u64.try_into().unwrap()),
         kind: RoomEventType::RoomPowerLevels,
         content: to_raw_json_value(&json!({ "testing": 123 })).unwrap(),
@@ -56,7 +55,6 @@ fn serialize_pdu_as_v1() {
         "room_id": "!n8f893n9:example.com",
         "event_id": "$somejoinevent:matrix.org",
         "sender": "@sender:example.com",
-        "origin": "matrix.org",
         "origin_server_ts": 1_592_050_773_658_u64,
         "type": "m.room.power_levels",
         "content": {
@@ -98,7 +96,6 @@ fn serialize_pdu_as_v3() {
     let v3_pdu = RoomV3Pdu {
         room_id: room_id!("!n8f893n9:example.com").to_owned(),
         sender: user_id!("@sender:example.com").to_owned(),
-        origin: "matrix.org".into(),
         origin_server_ts: MilliSecondsSinceUnixEpoch(1_592_050_773_658_u64.try_into().unwrap()),
         kind: RoomEventType::RoomPowerLevels,
         content: to_raw_json_value(&json!({ "testing": 123 })).unwrap(),
@@ -115,7 +112,6 @@ fn serialize_pdu_as_v3() {
     let json = json!({
         "room_id": "!n8f893n9:example.com",
         "sender": "@sender:example.com",
-        "origin": "matrix.org",
         "origin_server_ts": 1_592_050_773_658_u64,
         "type": "m.room.power_levels",
         "content": {
@@ -158,7 +154,6 @@ fn deserialize_pdu_as_v1() {
         "hashes": {
             "sha256": "ThisHashCoversAllFieldsInCaseThisIsRedacted"
         },
-        "origin": "matrix.org",
         "origin_server_ts": 1_234_567_890,
         "prev_events": [
             [
@@ -198,7 +193,6 @@ fn deserialize_pdu_as_v1() {
     }
 }
 
-#[cfg(not(feature = "unstable-pre-spec"))]
 #[test]
 fn deserialize_pdu_as_v3() {
     let json = json!({
@@ -213,7 +207,6 @@ fn deserialize_pdu_as_v3() {
         "hashes": {
             "sha256": "ThisHashCoversAllFieldsInCaseThisIsRedacted"
         },
-        "origin": "matrix.org",
         "origin_server_ts": 1_234_567_890,
         "prev_events": [
                 "$abc123:matrix.org"

--- a/crates/ruma-state-res/Cargo.toml
+++ b/crates/ruma-state-res/Cargo.toml
@@ -17,9 +17,6 @@ all-features = true
 compat = []
 unstable-exhaustive-types = []
 
-# Private, only used in test / benchmarking code
-__ci = ["ruma-common/unstable-pre-spec"]
-
 [dependencies]
 itertools = "0.10.0"
 js_int = "0.2.0"

--- a/crates/ruma-state-res/benches/state_res_bench.rs
+++ b/crates/ruma-state-res/benches/state_res_bench.rs
@@ -395,8 +395,6 @@ where
             content,
             redacts: None,
             unsigned: btreemap! {},
-            #[cfg(not(feature = "__ci"))]
-            origin: "foo".into(),
             auth_events,
             prev_events,
             depth: uint!(0),

--- a/crates/ruma-state-res/src/test_utils.rs
+++ b/crates/ruma-state-res/src/test_utils.rs
@@ -403,8 +403,6 @@ pub fn to_init_pdu_event(
             content,
             redacts: None,
             unsigned: BTreeMap::new(),
-            #[cfg(not(feature = "__ci"))]
-            origin: "foo".into(),
             auth_events: vec![],
             prev_events: vec![],
             depth: uint!(0),
@@ -443,8 +441,6 @@ where
             content,
             redacts: None,
             unsigned: BTreeMap::new(),
-            #[cfg(not(feature = "__ci"))]
-            origin: "foo".into(),
             auth_events,
             prev_events,
             depth: uint!(0),

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -158,7 +158,6 @@ __ci = [
     "unstable-msc3554",
     "unstable-msc3618",
     "unstable-msc3723",
-    "ruma-state-res/__ci",
 ]
 
 [dependencies]


### PR DESCRIPTION
It has been removed from the spec, for details see https://github.com/matrix-org/matrix-spec/pull/998