### PR TITLE
Small improvements to MatrixUri

### DIFF
--- a/crates/ruma-common/src/identifiers/matrix_uri.rs
+++ b/crates/ruma-common/src/identifiers/matrix_uri.rs
@@ -42,7 +42,7 @@ const RESERVED: &AsciiSet = &CONTROLS
     .add(b'=');
 
 /// All Matrix Identifiers that can be represented as a Matrix URI.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum MatrixId {
     /// A room ID.

--- a/crates/ruma/src/lib.rs
+++ b/crates/ruma/src/lib.rs
@@ -165,7 +165,7 @@ pub use ruma_common::{
     serde::Incoming, server_name, server_signing_key_id, thirdparty, to_device, user_id,
     ClientSecret, DeviceId, DeviceKeyAlgorithm, DeviceKeyId, DeviceSignatures, DeviceSigningKeyId,
     EntitySignatures, EventEncryptionAlgorithm, EventId, IdParseError, KeyId, KeyName, MatrixToUri,
-    MilliSecondsSinceUnixEpoch, MxcUri, PrivOwnedStr, RoomAliasId, RoomId, RoomName, RoomOrAliasId,
-    RoomVersionId, SecondsSinceUnixEpoch, ServerName, ServerSignatures, ServerSigningKeyId,
-    SessionId, Signatures, SigningKeyAlgorithm, TransactionId, UserId,
+    MatrixUri, MilliSecondsSinceUnixEpoch, MxcUri, PrivOwnedStr, RoomAliasId, RoomId, RoomName,
+    RoomOrAliasId, RoomVersionId, SecondsSinceUnixEpoch, ServerName, ServerSignatures,
+    ServerSigningKeyId, SessionId, Signatures, SigningKeyAlgorithm, TransactionId, UserId,
 };


### PR DESCRIPTION
I'm pretty sure those were omissions:

- Derive `Clone` for `MatrixId` (quite useful if we want an owned version from a URI).
- Re-export `MatrixUri` from the ruma root. I don't know why we would re-export `MatrixToUri` and not `MatrixUri`.