### PR TITLE
Some events cleanup

### DIFF
--- a/crates/ruma-common/src/events/room/power_levels.rs
+++ b/crates/ruma-common/src/events/room/power_levels.rs
@@ -142,8 +142,8 @@ pub struct RoomPowerLevelsEventContent {
 impl RoomPowerLevelsEventContent {
     /// Creates a new `RoomPowerLevelsEventContent` with all-default values.
     pub fn new() -> Self {
-        // events_default and users_default having a default of 0 while the others have a default
-        // of 50 is not an oversight, these defaults are from the Matrix specification.
+        // events_default, users_default and invite having a default of 0 while the others have a
+        // default of 50 is not an oversight, these defaults are from the Matrix specification.
         Self {
             ban: default_power_level(),
             events: BTreeMap::new(),

--- a/crates/ruma-common/src/events/room/redaction.rs
+++ b/crates/ruma-common/src/events/room/redaction.rs
@@ -75,8 +75,6 @@ impl Redact for OriginalRoomRedactionEvent {
     ) -> Self::Redacted {
         RedactedRoomRedactionEvent {
             content: self.content.redact(version),
-            // There is no released room version where this isn't redacted yet
-            redacts: None,
             event_id: self.event_id,
             sender: self.sender,
             origin_server_ts: self.origin_server_ts,
@@ -92,9 +90,6 @@ impl Redact for OriginalRoomRedactionEvent {
 pub struct RedactedRoomRedactionEvent {
     /// Data specific to the event type.
     pub content: RedactedRoomRedactionEventContent,
-
-    /// The ID of the event that was redacted.
-    pub redacts: Option<Box<EventId>>,
 
     /// The globally unique event identifier for the user who sent the event.
     pub event_id: Box<EventId>,
@@ -145,8 +140,6 @@ impl Redact for OriginalSyncRoomRedactionEvent {
     ) -> Self::Redacted {
         RedactedSyncRoomRedactionEvent {
             content: self.content.redact(version),
-            // There is no released room version where this isn't redacted yet
-            redacts: None,
             event_id: self.event_id,
             sender: self.sender,
             origin_server_ts: self.origin_server_ts,
@@ -161,9 +154,6 @@ impl Redact for OriginalSyncRoomRedactionEvent {
 pub struct RedactedSyncRoomRedactionEvent {
     /// Data specific to the event type.
     pub content: RedactedRoomRedactionEventContent,
-
-    /// The ID of the event that was redacted.
-    pub redacts: Option<Box<EventId>>,
 
     /// The globally unique event identifier for the user who sent the event.
     pub event_id: Box<EventId>,


### PR DESCRIPTION
I wanted to add some convenience functionality that the SDK could use to handle redacted / unredacted events like power levels the same, but haven't found a good solution so far :/

Anyways, these small fixes came out of it at least.