### PR TITLE
identifiers-validation: Ensure the Error type doesn't get too big

### DIFF
--- a/crates/ruma-identifiers-validation/src/error.rs
+++ b/crates/ruma-identifiers-validation/src/error.rs
@@ -172,3 +172,15 @@ pub enum MatrixUriError {
     #[error("unknown query item")]
     UnknownQueryItem,
 }
+
+#[cfg(test)]
+mod tests {
+    use std::mem::size_of;
+
+    use super::Error;
+
+    #[test]
+    fn small_error_type() {
+        assert!(size_of::<Error>() <= 8);
+    }
+}


### PR DESCRIPTION
I wanted to do this for more types but I've been pretty busy. Since I already wrote this commit, might as well integrate it into `main` 🙂 