### PR TITLE
ci: Fail doc generation on warnings

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,11 +29,9 @@ jobs:
 
       - name: Build docs
         uses: actions-rs/cargo@v1
-        env:
-          RUSTDOCFLAGS: "--enable-index-page -Zunstable-options --cfg docsrs"
         with:
-          command: doc
-          args: --no-deps --workspace --exclude ruma-macros --exclude ruma-identifiers-validation --exclude xtask --all-features -Zrustdoc-map
+          command: run
+          args: -p xtask -- doc --deny-warnings
 
       - name: Deploy to docs branch
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}

--- a/crates/ruma-common/src/events/content.rs
+++ b/crates/ruma-common/src/events/content.rs
@@ -13,6 +13,8 @@ use super::{
 /// The base trait that all event content types implement.
 ///
 /// Use [`macros::EventContent`] to derive this traits. It is not meant to be implemented manually.
+///
+/// [`macros::EventContent`]: super::macros::EventContent
 pub trait EventContent: Sized + Serialize {
     /// The Rust enum for the event kind's known types.
     type EventType;

--- a/crates/ruma-common/src/events/room.rs
+++ b/crates/ruma-common/src/events/room.rs
@@ -53,10 +53,10 @@ pub enum MediaSource {
     Encrypted(Box<EncryptedFile>),
 }
 
-/// Custom implementation of `Deserialize`, because serde doesn't guarantee what variant will be
-/// deserialized for "externally tagged"¹ enums where multiple "tag" fields exist.
-///
-/// ¹ https://serde.rs/enum-representations.html
+// Custom implementation of `Deserialize`, because serde doesn't guarantee what variant will be
+// deserialized for "externally tagged"¹ enums where multiple "tag" fields exist.
+//
+// ¹ https://serde.rs/enum-representations.html
 impl<'de> Deserialize<'de> for MediaSource {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where


### PR DESCRIPTION
I changed the docs of `MediaSource`'s `Deserialize` implementation to non-doc comments, because I believe it's documented for the devs rather than for the users (and otherwise it complains about the link).

Closes #1041.