### PR TITLE
Add `Metadata::versioning_decision_for`

### DIFF
--- a/crates/ruma-common/src/api.rs
+++ b/crates/ruma-common/src/api.rs
@@ -195,11 +195,9 @@ pub use ruma_macros::ruma_api;
 pub mod error;
 mod metadata;
 
-pub use metadata::{MatrixVersion, Metadata};
+pub use metadata::{MatrixVersion, Metadata, VersioningDecision};
 
 use error::{FromHttpRequestError, FromHttpResponseError, IntoHttpError};
-
-use self::metadata::VersioningDecision;
 
 /// An enum to control whether an access token should be added to outgoing requests
 #[derive(Clone, Copy, Debug)]

--- a/crates/ruma-common/src/api.rs
+++ b/crates/ruma-common/src/api.rs
@@ -199,6 +199,8 @@ pub use metadata::{MatrixVersion, Metadata};
 
 use error::{FromHttpRequestError, FromHttpResponseError, IntoHttpError};
 
+use self::metadata::VersioningDecision;
+
 /// An enum to control whether an access token should be added to outgoing requests
 #[derive(Clone, Copy, Debug)]
 #[allow(clippy::exhaustive_enums)]
@@ -401,10 +403,6 @@ pub enum AuthScheme {
 // This function helps picks the right path (or an error) from a set of matrix versions.
 //
 // This function needs to be public, yet hidden, as all `try_into_http_request`s would be using it.
-//
-// Note this assumes that `versions`;
-// - at least has 1 element
-// - have all elements sorted by its `.into_parts` representation.
 #[doc(hidden)]
 pub fn select_path<'a>(
     versions: &'_ [MatrixVersion],
@@ -413,50 +411,48 @@ pub fn select_path<'a>(
     r0: Option<fmt::Arguments<'a>>,
     stable: Option<fmt::Arguments<'a>>,
 ) -> Result<fmt::Arguments<'a>, IntoHttpError> {
-    let greater_or_equal_any =
-        |version: MatrixVersion| versions.iter().any(|v| v.is_superset_of(version));
-    let greater_or_equal_all =
-        |version: MatrixVersion| versions.iter().all(|v| v.is_superset_of(version));
-
-    let is_stable_any = metadata.added.map(greater_or_equal_any).unwrap_or(false);
-
-    let is_removed_all = metadata.removed.map(greater_or_equal_all).unwrap_or(false);
-
-    // Only when all the versions (e.g. 1.6-9) are compatible with the version that added it (e.g.
-    // 1.1), yet are also "after" the version that removed it (e.g. 1.3), then we return that error.
-    // Otherwise, this all versions may fall into a different major range, such as 2.X, where
-    // "after" and "compatible" do not exist with the 1.X range, so we at least need to make sure
-    // that the versions are part of the same "range" through the `added` check.
-    if is_stable_any && is_removed_all {
-        return Err(IntoHttpError::EndpointRemoved(metadata.removed.unwrap()));
-    }
-
-    if is_stable_any {
-        let is_deprecated_any = metadata.deprecated.map(greater_or_equal_any).unwrap_or(false);
-
-        if is_deprecated_any {
-            let is_removed_any = metadata.removed.map(greater_or_equal_any).unwrap_or(false);
-
-            if is_removed_any {
-                tracing::warn!("endpoint {} is deprecated, but also removed in one of more server-passed versions: {:?}", metadata.name, versions)
-            } else {
-                tracing::warn!(
-                    "endpoint {} is deprecated in one of more server-passed versions: {:?}",
+    match metadata.versioning_decision_for(versions) {
+        VersioningDecision::Removed => {
+            return Err(IntoHttpError::EndpointRemoved(metadata.removed.unwrap()))
+        }
+        VersioningDecision::Stable { any_deprecated, all_deprecated, any_removed } => {
+            match (any_removed, all_deprecated, any_deprecated) {
+                // Some remove, all deprecate
+                (true, true, _) => tracing::warn!(
+                        "endpoint {} is deprecated in ALL (and removed in some) of the following versions: {:?}",
+                        metadata.name,
+                        versions
+                ),
+                // Some remove, some deprecate
+                (true, false, true) => tracing::warn!(
+                    "endpoint {} is deprecated (and removed) in some versions: {:?}",
                     metadata.name,
                     versions
-                )
+                ),
+                // None remove, all deprecate
+                (false, true, _) => tracing::warn!(
+                    "endpoint {} is deprecated in ALL of the following versions: {:?}",
+                    metadata.name,
+                    versions
+                ),
+                // None remove, some deprecate
+                (false, false, true) => tracing::warn!(
+                    "endpoint {} is deprecated in some versions: {:?}",
+                    metadata.name,
+                    versions
+                ),
+                _ => {}
             }
-        }
 
-        if let Some(r0) = r0 {
-            if versions.iter().all(|&v| v == MatrixVersion::V1_0) {
-                // Endpoint was added in 1.0, we return the r0 variant.
-                return Ok(r0);
+            if let Some(r0) = r0 {
+                if versions.iter().all(|&v| v == MatrixVersion::V1_0) {
+                    // Endpoint was added in 1.0, we return the r0 variant.
+                    return Ok(r0);
+                }
             }
-        }
 
-        return Ok(stable.expect("metadata.added enforces the stable path to exist"));
+            Ok(stable.expect("metadata.added enforces the stable path to exist"))
+        }
+        VersioningDecision::Unstable => unstable.ok_or(IntoHttpError::NoUnstablePath),
     }
-
-    unstable.ok_or(IntoHttpError::NoUnstablePath)
 }

--- a/crates/ruma-common/src/api/metadata.rs
+++ b/crates/ruma-common/src/api/metadata.rs
@@ -101,7 +101,12 @@ impl Metadata {
 /// A versioning "decision" derived from a set of matrix versions.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum VersioningDecision {
+    /// The unstable endpoint should be used.
     Unstable,
+    /// The stable endpoint should be used.
+    ///
+    /// Note, in the special case that all versions note [v1.0](MatrixVersion::V1_0), and the
+    /// [`r0_path`](Metadata::r0_path) is not `None`, that path should be used.
     Stable {
         /// If any version denoted deprecation.
         any_deprecated: bool,
@@ -112,7 +117,7 @@ pub enum VersioningDecision {
         /// If any version denoted removal.
         any_removed: bool,
     },
-    /// This endpoint was removed in all versions.
+    /// This endpoint was removed in all versions, it should not be used.
     Removed,
 }
 

--- a/crates/ruma-common/src/api/metadata.rs
+++ b/crates/ruma-common/src/api/metadata.rs
@@ -100,6 +100,7 @@ impl Metadata {
 
 /// A versioning "decision" derived from a set of matrix versions.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[allow(clippy::exhaustive_enums)]
 pub enum VersioningDecision {
     /// The unstable endpoint should be used.
     Unstable,


### PR DESCRIPTION
Resolves #898

This adds `Metadata::versioning_decision_for` to the public API, and alters `select_path` to use it with a single `match` statement