### PR TITLE
events: Add convenience methods

### DIFF
--- a/crates/ruma-common/src/events/room/guest_access.rs
+++ b/crates/ruma-common/src/events/room/guest_access.rs
@@ -28,6 +28,26 @@ impl RoomGuestAccessEventContent {
     }
 }
 
+impl RoomGuestAccessEvent {
+    /// Obtain the guest access policy, regardless of whether this event is redacted.
+    pub fn guest_access(&self) -> &GuestAccess {
+        match self {
+            Self::Original(ev) => &ev.content.guest_access,
+            Self::Redacted(_) => &GuestAccess::Forbidden,
+        }
+    }
+}
+
+impl SyncRoomGuestAccessEvent {
+    /// Obtain the guest access policy, regardless of whether this event is redacted.
+    pub fn guest_access(&self) -> &GuestAccess {
+        match self {
+            Self::Original(ev) => &ev.content.guest_access,
+            Self::Redacted(_) => &GuestAccess::Forbidden,
+        }
+    }
+}
+
 /// A policy for guest user access to a room.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
 #[derive(Clone, Debug, PartialEq, Eq, StringEnum)]

--- a/crates/ruma-common/src/events/room/history_visibility.rs
+++ b/crates/ruma-common/src/events/room/history_visibility.rs
@@ -27,6 +27,26 @@ impl RoomHistoryVisibilityEventContent {
     }
 }
 
+impl RoomHistoryVisibilityEvent {
+    /// Obtain the history visibility, regardless of whether this event is redacted.
+    pub fn history_visibility(&self) -> &HistoryVisibility {
+        match self {
+            Self::Original(ev) => &ev.content.history_visibility,
+            Self::Redacted(ev) => &ev.content.history_visibility,
+        }
+    }
+}
+
+impl SyncRoomHistoryVisibilityEvent {
+    /// Obtain the history visibility, regardless of whether this event is redacted.
+    pub fn history_visibility(&self) -> &HistoryVisibility {
+        match self {
+            Self::Original(ev) => &ev.content.history_visibility,
+            Self::Redacted(ev) => &ev.content.history_visibility,
+        }
+    }
+}
+
 /// Who can see a room's history.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
 #[derive(Clone, Debug, PartialEq, Eq, StringEnum)]

--- a/crates/ruma-common/src/events/room/join_rules.rs
+++ b/crates/ruma-common/src/events/room/join_rules.rs
@@ -49,6 +49,26 @@ impl<'de> Deserialize<'de> for RoomJoinRulesEventContent {
     }
 }
 
+impl RoomJoinRulesEvent {
+    /// Obtain the join rule, regardless of whether this event is redacted.
+    pub fn join_rule(&self) -> &JoinRule {
+        match self {
+            Self::Original(ev) => &ev.content.join_rule,
+            Self::Redacted(ev) => &ev.content.join_rule,
+        }
+    }
+}
+
+impl SyncRoomJoinRulesEvent {
+    /// Obtain the join rule, regardless of whether this event is redacted.
+    pub fn join_rule(&self) -> &JoinRule {
+        match self {
+            Self::Original(ev) => &ev.content.join_rule,
+            Self::Redacted(ev) => &ev.content.join_rule,
+        }
+    }
+}
+
 /// The rule used for users wishing to join this room.
 ///
 /// This type can hold an arbitrary string. To check for formats that are not available as a

--- a/crates/ruma-common/src/events/room/power_levels.rs
+++ b/crates/ruma-common/src/events/room/power_levels.rs
@@ -2,7 +2,7 @@
 //!
 //! [`m.room.power_levels`]: https://spec.matrix.org/v1.2/client-server-api/#mroompower_levels
 
-use std::collections::BTreeMap;
+use std::{cmp::max, collections::BTreeMap};
 
 use js_int::{int, Int};
 use ruma_macros::EventContent;
@@ -236,6 +236,18 @@ pub struct RoomPowerLevels {
     ///
     /// This is a mapping from `key` to power level for that notifications key.
     pub notifications: NotificationPowerLevels,
+}
+
+impl RoomPowerLevels {
+    /// Get the power level of a specific user.
+    pub fn for_user(&self, user_id: &UserId) -> Int {
+        self.users.get(user_id).map_or(self.users_default, |pl| *pl)
+    }
+
+    /// Get the maximum power level of any user.
+    pub fn max(&self) -> Int {
+        self.users.values().fold(self.users_default, |max_pl, user_pl| max(max_pl, *user_pl))
+    }
 }
 
 impl From<RoomPowerLevelsEventContent> for RoomPowerLevels {

--- a/crates/ruma-common/src/events/room/power_levels.rs
+++ b/crates/ruma-common/src/events/room/power_levels.rs
@@ -202,61 +202,34 @@ impl SyncRoomPowerLevelsEvent {
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct RoomPowerLevels {
     /// The level required to ban a user.
-    ///
-    /// If you activate the `compat` feature, deserialization will work for stringified
-    /// integers too.
     pub ban: Int,
 
     /// The level required to send specific event types.
     ///
     /// This is a mapping from event type to power level required.
-    ///
-    /// If you activate the `compat` feature, deserialization will work for stringified
-    /// integers too.
     pub events: BTreeMap<RoomEventType, Int>,
 
     /// The default level required to send message events.
-    ///
-    /// If you activate the `compat` feature, deserialization will work for stringified
-    /// integers too.
     pub events_default: Int,
 
     /// The level required to invite a user.
-    ///
-    /// If you activate the `compat` feature, deserialization will work for stringified
-    /// integers too.
     pub invite: Int,
 
     /// The level required to kick a user.
-    ///
-    /// If you activate the `compat` feature, deserialization will work for stringified
-    /// integers too.
     pub kick: Int,
 
     /// The level required to redact an event.
-    ///
-    /// If you activate the `compat` feature, deserialization will work for stringified
-    /// integers too.
     pub redact: Int,
 
     /// The default level required to send state events.
-    ///
-    /// If you activate the `compat` feature, deserialization will work for stringified
-    /// integers too.
     pub state_default: Int,
 
     /// The power levels for specific users.
     ///
     /// This is a mapping from `user_id` to power level for that user.
-    ///
-    /// If you activate the `compat` feature, deserialization will work for stringified
-    /// integers too.
     pub users: BTreeMap<Box<UserId>, Int>,
 
     /// The default power level for every user in the room.
-    ///
-    /// If you activate the `compat` feature, deserialization will work for stringified
-    /// integers too.
     pub users_default: Int,
 
     /// The power level requirements for specific notification types.


### PR DESCRIPTION
These are small snippets currently sprinked across the Matrix Rust SDK codebase that can trivially be methods on the Ruma types instead.