### PR TITLE
ruma: Remove common module (ruma-common export)

### DIFF
--- a/crates/ruma-common/src/identifiers/macros.rs
+++ b/crates/ruma-common/src/identifiers/macros.rs
@@ -90,7 +90,6 @@ macro_rules! owned_identifier {
             }
         }
 
-        #[cfg(feature = "serde")]
         impl serde::Serialize for $owned {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
             where
@@ -309,7 +308,6 @@ macro_rules! opaque_identifier {
             }
         }
 
-        #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for $owned {
             fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
             where
@@ -385,7 +383,6 @@ macro_rules! opaque_identifier_validated {
             }
         }
 
-        #[cfg(feature = "serde")]
         impl<'de> serde::Deserialize<'de> for $owned {
             fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
             where

--- a/crates/ruma/src/lib.rs
+++ b/crates/ruma/src/lib.rs
@@ -71,8 +71,6 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 #[doc(inline)]
-pub use ruma_common as common;
-#[doc(inline)]
 pub use ruma_common::serde;
 
 #[cfg(feature = "client")]

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -2,9 +2,8 @@ use std::{convert::TryFrom, env, process::exit};
 
 use ruma::{
     api::client::{alias::get_alias, membership::join_room_by_id, message::send_message_event},
-    common::TransactionId,
     events::room::message::RoomMessageEventContent,
-    RoomAliasId,
+    RoomAliasId, TransactionId,
 };
 
 type HttpClient = ruma::client::http_client::HyperNativeTls;


### PR DESCRIPTION
The things in there are all re-exported directly, and having two possible import paths just leads to confusion.