### PR TITLE
events: Add support for m.identity_server account data

### DIFF
--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -55,6 +55,7 @@ indexmap = { version = "1.6.2", features = ["serde-1"] }
 indoc = { version = "1.0", optional = true }
 itoa = "1.0.1"
 js_int = { version = "0.2.0", features = ["serde"] }
+js_option = "0.1.0"
 percent-encoding = "2.1.0"
 pulldown-cmark = { version = "0.9.1", default-features = false, optional = true }
 rand_crate = { package = "rand", version = "0.8.3", optional = true }

--- a/crates/ruma-common/src/events.rs
+++ b/crates/ruma-common/src/events.rs
@@ -132,6 +132,7 @@ pub mod emote;
 pub mod file;
 pub mod forwarded_room_key;
 pub mod fully_read;
+pub mod identity_server;
 pub mod ignored_user_list;
 #[cfg(feature = "unstable-msc3552")]
 pub mod image;

--- a/crates/ruma-common/src/events/enums.rs
+++ b/crates/ruma-common/src/events/enums.rs
@@ -16,6 +16,7 @@ event_enum! {
     /// Any global account data event.
     enum GlobalAccountData {
         "m.direct",
+        "m.identity_server",
         "m.ignored_user_list",
         "m.push_rules",
         "m.secret_storage.default_key",

--- a/crates/ruma-common/src/events/identity_server.rs
+++ b/crates/ruma-common/src/events/identity_server.rs
@@ -1,0 +1,24 @@
+//! Types for the [`m.identity_server`] event.
+//!
+//! [`m.identity_server`]: https://spec.matrix.org/v1.2/client-server-api/#mdirect
+
+use js_option::JsOption;
+use ruma_macros::EventContent;
+use serde::{Deserialize, Serialize};
+
+/// The content of an `m.identity_server` event.
+///
+/// Persists the user's preferred identity server, or preference to not use an identity server at
+/// all.
+#[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+#[ruma_event(type = "m.identity_server", kind = GlobalAccountData)]
+pub struct IdentityServerEventContent {
+    /// The URL of the identity server the user prefers to use, or `Null` if the user does not want
+    /// to use an identity server.
+    ///
+    /// If this is `Undefined`, that means the user has not expressed a preference or has revoked
+    /// their preference, and any applicable default should be used.
+    #[serde(default, skip_serializing_if = "JsOption::is_undefined")]
+    pub base_url: JsOption<String>,
+}


### PR DESCRIPTION
Closes #959.