### PR TITLE
events: Add StrippedPowerLevelsEvent::power_levels

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -33,4 +33,6 @@ rustflags = [
     "-Wclippy::unreadable_literal",
     "-Wclippy::unseparated_literal_suffix",
     "-Wclippy::wildcard_imports",
+    # Temporary: Lint triggers in macro-generated code
+    "-Aexplicit_outlives_requirements",
 ]

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           profile: minimal
           # Needed for use of unstable options
-          toolchain: nightly-2022-03-23
+          toolchain: nightly
           override: true
 
       - uses: Swatinem/rust-cache@v1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2022-03-23
+          toolchain: nightly
           override: true
           components: ${{ matrix.components }}
 

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2022-03-23
+          toolchain: nightly
           override: true
 
       - uses: Swatinem/rust-cache@v1

--- a/crates/ruma-common/src/events/room/power_levels.rs
+++ b/crates/ruma-common/src/events/room/power_levels.rs
@@ -191,6 +191,13 @@ impl SyncRoomPowerLevelsEvent {
     }
 }
 
+impl StrippedRoomPowerLevelsEvent {
+    /// Obtain the effective power levels from this event.
+    pub fn power_levels(&self) -> RoomPowerLevels {
+        self.content.clone().into()
+    }
+}
+
 /// The effective power levels of a room.
 ///
 /// This struct contains the same fields as [`RoomPowerLevelsEventContent`] and be created from that


### PR DESCRIPTION
This is useful because we now have a handful of methods that exist on `PowerLevels` but not `RoomPowerLevelsEventContent` or `RedactedRoomPowerLevelsEventContent`.