### PR TITLE
client-api: use from_ convention for email and add from_phone

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 Improvements:
 
-* Add `From<&UserId>` and `From<&OwnedUserId>` implementations for `UserIdentifier`
-* Add `UserIdentifier::email` constructor
+* Add `From<&str>`, `From<&UserId>` and `From<&OwnedUserId>` implementations for `UserIdentifier`
+* Add `UserIdentifier::from_email` and `UserIdentifier::from_phone` constructors
 
 # 0.14.0
 

--- a/crates/ruma-client-api/src/uiaa.rs
+++ b/crates/ruma-client-api/src/uiaa.rs
@@ -592,8 +592,14 @@ pub enum UserIdentifier<'a> {
 
 impl<'a> UserIdentifier<'a> {
     /// Creates a [`UserIdentifier::ThirdPartyId`] from an email address.
-    pub fn email(address: &'a str) -> Self {
+    pub fn from_email(address: &'a str) -> Self {
         Self::ThirdPartyId { address, medium: Medium::Email }
+    }
+
+    /// Creates a [`UserIdentifier::ThirdPartyId`] from a 2-letter country code
+    /// and a phone number.
+    pub fn from_phone(phone: &'a str) -> Self {
+        Self::ThirdPartyId { address: phone,  medium: Medium::Msisdn }
     }
 }
 


### PR DESCRIPTION
This is a small step on top of #1115 to smooth out the login experience a bit more.