### PR TITLE
Add Endpoint History Macro work

### DIFF
--- a/crates/ruma-common/tests/api/ui/01-api-sanity-check.rs
+++ b/crates/ruma-common/tests/api/ui/01-api-sanity-check.rs
@@ -17,6 +17,18 @@ ruma_api! {
         added: 1.0,
         deprecated: 1.1,
         removed: 1.2,
+
+        history: {
+            unstable => "/a/path",
+            unstable => "/another/path",
+
+            1.0 => "/1.0",
+            1.1 => "/1.1",
+            1.2 => "/1.2",
+
+            1.3 => deprecated,
+            1.4 => removed,
+        }
     }
 
     request: {

--- a/crates/ruma-macros/src/api/api_metadata.rs
+++ b/crates/ruma-macros/src/api/api_metadata.rs
@@ -318,6 +318,8 @@ impl Parse for FieldValue {
 }
 
 #[derive(Debug)]
+// TODO(j0j0): remove after endpoint history is complete
+#[allow(dead_code)]
 pub struct History {
     entries: Vec<HistoryEntry>,
 
@@ -332,7 +334,7 @@ pub enum MiscVersioning {
 }
 
 fn set_ref_version(set: &mut BTreeSet<(u8, u8)>, value: &MatrixVersionLiteral) -> syn::Result<()> {
-    if let Some(_) = set.get(&value.to_parts()) {
+    if set.contains(&value.to_parts()) {
         Err(syn::Error::new_spanned(value, "duplicate version reference"))
     } else {
         set.insert(value.to_parts());

--- a/crates/ruma-macros/src/api/api_metadata.rs
+++ b/crates/ruma-macros/src/api/api_metadata.rs
@@ -331,11 +331,11 @@ pub enum MiscVersioning {
     Removed { deprecated: MatrixVersionLiteral, removed: MatrixVersionLiteral },
 }
 
-fn ref_version(set: &mut BTreeSet<(u8, u8)>, value: MatrixVersionLiteral) -> syn::Result<()> {
-    if let Some(_) = set.get(&value.into_parts()) {
+fn set_ref_version(set: &mut BTreeSet<(u8, u8)>, value: &MatrixVersionLiteral) -> syn::Result<()> {
+    if let Some(_) = set.get(&value.to_parts()) {
         Err(syn::Error::new_spanned(value, "duplicate version reference"))
     } else {
-        set.insert(value.into_parts());
+        set.insert(value.to_parts());
         Ok(())
     }
 }
@@ -358,15 +358,15 @@ impl Parse for History {
         for entry in &entries {
             match entry {
                 HistoryEntry::Deprecated { version } => {
-                    ref_version(&mut versions, version.clone())?;
+                    set_ref_version(&mut versions, version)?;
                     set_field(&mut deprecated, version.clone())?;
                 }
                 HistoryEntry::Removed { version } => {
-                    ref_version(&mut versions, version.clone())?;
+                    set_ref_version(&mut versions, version)?;
                     set_field(&mut removed, version.clone())?;
                 }
                 HistoryEntry::Stable { version, path: _ } => {
-                    ref_version(&mut versions, version.clone())?;
+                    set_ref_version(&mut versions, version)?;
                 }
                 _ => {}
             }
@@ -396,8 +396,8 @@ impl Parse for History {
         // Sort so that the order is [Unstable, Unstable, 1.0, 1.1, 1.2, 2.0, 2.1]
         // for optimized method purposes.
         entries.sort_by(|a, b| {
-            let a = a.version().map(|v| v.into_parts()).unwrap_or((0, 0));
-            let b = b.version().map(|v| v.into_parts()).unwrap_or((0, 0));
+            let a = a.version().map(|v| v.to_parts()).unwrap_or((0, 0));
+            let b = b.version().map(|v| v.to_parts()).unwrap_or((0, 0));
 
             a.cmp(&b)
         });

--- a/crates/ruma-macros/src/api/api_metadata.rs
+++ b/crates/ruma-macros/src/api/api_metadata.rs
@@ -397,12 +397,7 @@ impl Parse for History {
 
         // Sort so that the order is [Unstable, Unstable, 1.0, 1.1, 1.2, 2.0, 2.1]
         // for optimized method purposes.
-        entries.sort_by(|a, b| {
-            let a = a.version().map(|v| v.to_parts()).unwrap_or((0, 0));
-            let b = b.version().map(|v| v.to_parts()).unwrap_or((0, 0));
-
-            a.cmp(&b)
-        });
+        entries.sort_by_key(|a| a.version().map(|v| v.to_parts()).unwrap_or((0, 0)));
 
         Ok(History { entries, misc })
     }

--- a/crates/ruma-macros/src/api/version.rs
+++ b/crates/ruma-macros/src/api/version.rs
@@ -11,7 +11,7 @@ pub struct MatrixVersionLiteral {
 }
 
 impl MatrixVersionLiteral {
-    pub(crate) fn into_parts(&self) -> (u8, u8) {
+    pub(crate) fn to_parts(&self) -> (u8, u8) {
         (self.major.into(), self.minor)
     }
 }

--- a/crates/ruma-macros/src/api/version.rs
+++ b/crates/ruma-macros/src/api/version.rs
@@ -4,10 +4,16 @@ use proc_macro2::TokenStream;
 use quote::{format_ident, quote, ToTokens};
 use syn::{parse::Parse, Error, LitFloat};
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct MatrixVersionLiteral {
     pub(crate) major: NonZeroU8,
     pub(crate) minor: u8,
+}
+
+impl MatrixVersionLiteral {
+    pub(crate) fn into_parts(&self) -> (u8, u8) {
+        (self.major.into(), self.minor)
+    }
 }
 
 impl Parse for MatrixVersionLiteral {


### PR DESCRIPTION
Part of https://github.com/ruma/ruma/issues/1118

This adds the `history` macro field, some sanity checks, and some reordering checks.

This doesn't yet add this to `Metadata`, as i want to mesh that with https://github.com/ruma/ruma/issues/1067 in a future PR.

The scope of this PR is to get a functional but noop macro.