### PR TITLE
Fix new partial-eq lint

### DIFF
--- a/crates/ruma-appservice-api/src/lib.rs
+++ b/crates/ruma-appservice-api/src/lib.rs
@@ -16,7 +16,7 @@ pub mod thirdparty;
 /// A namespace defined by an application service.
 ///
 /// Used for [appservice registration](https://spec.matrix.org/v1.2/application-service-api/#registration).
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct Namespace {
     /// Whether this application service has exclusive access to events within this namespace.

--- a/crates/ruma-client-api/src/device.rs
+++ b/crates/ruma-client-api/src/device.rs
@@ -10,7 +10,7 @@ pub mod get_devices;
 pub mod update_device;
 
 /// Information about a registered device.
-#[derive(Clone, Debug, Deserialize, Hash, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Hash, Eq, PartialEq, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct Device {
     /// Device ID

--- a/crates/ruma-client-api/src/discovery/discover_homeserver.rs
+++ b/crates/ruma-client-api/src/discovery/discover_homeserver.rs
@@ -88,7 +88,7 @@ impl IdentityServerInfo {
 
 /// Information about a discovered map tile server.
 #[cfg(feature = "unstable-msc3488")]
-#[derive(Clone, Debug, Deserialize, Hash, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Debug, Deserialize, Hash, Eq, PartialEq, PartialOrd, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct TileServerInfo {
     /// The URL of a map tile server's `style.json` file.

--- a/crates/ruma-client-api/src/discovery/discover_homeserver.rs
+++ b/crates/ruma-client-api/src/discovery/discover_homeserver.rs
@@ -57,7 +57,7 @@ impl Response {
 }
 
 /// Information about a discovered homeserver.
-#[derive(Clone, Debug, Deserialize, Hash, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Debug, Deserialize, Hash, Eq, PartialEq, PartialOrd, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct HomeserverInfo {
     /// The base URL for the homeserver for client-server connections.
@@ -72,7 +72,7 @@ impl HomeserverInfo {
 }
 
 /// Information about a discovered identity server.
-#[derive(Clone, Debug, Deserialize, Hash, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Debug, Deserialize, Hash, Eq, PartialEq, PartialOrd, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct IdentityServerInfo {
     /// The base URL for the identity server for client-server connections.

--- a/crates/ruma-client-api/src/error.rs
+++ b/crates/ruma-client-api/src/error.rs
@@ -199,7 +199,7 @@ impl fmt::Display for ErrorKind {
 /// A Matrix Error without a status code.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[allow(clippy::exhaustive_structs)]
-#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct ErrorBody {
     /// A value which can be used to handle an error message.
     #[serde(flatten)]

--- a/crates/ruma-client-api/src/membership.rs
+++ b/crates/ruma-client-api/src/membership.rs
@@ -54,9 +54,9 @@ impl<'a> ThirdPartySigned<'a> {
 ///
 /// To create an instance of this type, first create a `Invite3pidInit` and convert it via
 /// `Invite3pid::from` / `.into()`.
-#[derive(Clone, Debug, PartialEq, Incoming, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Incoming, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-#[incoming_derive(PartialEq)]
+#[incoming_derive(Eq, PartialEq)]
 pub struct Invite3pid<'a> {
     /// Hostname and port of identity server to be used for account lookups.
     pub id_server: &'a str,

--- a/crates/ruma-client-api/src/membership/invite_user.rs
+++ b/crates/ruma-client-api/src/membership/invite_user.rs
@@ -62,9 +62,9 @@ pub mod v3 {
     }
 
     /// Distinguishes between invititations by Matrix or third party identifiers.
-    #[derive(Clone, Debug, PartialEq, Incoming, Serialize)]
+    #[derive(Clone, Debug, Eq, PartialEq, Incoming, Serialize)]
     #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-    #[incoming_derive(PartialEq)]
+    #[incoming_derive(Eq, PartialEq)]
     #[serde(untagged)]
     pub enum InvitationRecipient<'a> {
         /// Used to invite user by their Matrix identifier.

--- a/crates/ruma-common/src/events/call.rs
+++ b/crates/ruma-common/src/events/call.rs
@@ -12,7 +12,7 @@ pub mod hangup;
 pub mod invite;
 
 /// A VoIP session description.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct SessionDescription {
     /// The type of session description.

--- a/crates/ruma-common/src/identifiers/room_or_room_alias_id.rs
+++ b/crates/ruma-common/src/identifiers/room_or_room_alias_id.rs
@@ -64,7 +64,7 @@ impl RoomOrAliasId {
     }
 }
 
-#[derive(PartialEq)]
+#[derive(Eq, PartialEq)]
 enum Variant {
     RoomId,
     RoomAliasId,

--- a/crates/ruma-common/src/power_levels.rs
+++ b/crates/ruma-common/src/power_levels.rs
@@ -6,7 +6,7 @@ use js_int::{int, Int};
 use serde::{Deserialize, Serialize};
 
 /// The power level requirements for specific notification types.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct NotificationPowerLevels {
     /// The level required to trigger an `@room` notification.

--- a/crates/ruma-common/src/push/action.rs
+++ b/crates/ruma-common/src/push/action.rs
@@ -127,13 +127,13 @@ mod tweak_serde {
         },
     }
 
-    #[derive(Clone, PartialEq, Deserialize, Serialize)]
+    #[derive(Clone, Eq, PartialEq, Deserialize, Serialize)]
     #[serde(tag = "set_tweak", rename = "sound")]
     pub(crate) struct SoundTweak {
         value: String,
     }
 
-    #[derive(Clone, PartialEq, Deserialize, Serialize)]
+    #[derive(Clone, Eq, PartialEq, Deserialize, Serialize)]
     #[serde(tag = "set_tweak", rename = "highlight")]
     pub(crate) struct HighlightTweak {
         #[serde(

--- a/crates/ruma-common/src/serde/duration/opt_ms.rs
+++ b/crates/ruma-common/src/serde/duration/opt_ms.rs
@@ -47,7 +47,7 @@ mod tests {
     use serde::{Deserialize, Serialize};
     use serde_json::json;
 
-    #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+    #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
     struct DurationTest {
         #[serde(with = "super", default, skip_serializing_if = "Option::is_none")]
         timeout: Option<Duration>,

--- a/crates/ruma-common/src/serde/duration/secs.rs
+++ b/crates/ruma-common/src/serde/duration/secs.rs
@@ -43,7 +43,7 @@ mod tests {
     use serde::{Deserialize, Serialize};
     use serde_json::json;
 
-    #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+    #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
     struct DurationTest {
         #[serde(with = "super")]
         timeout: Duration,

--- a/crates/ruma-common/src/serde/raw.rs
+++ b/crates/ruma-common/src/serde/raw.rs
@@ -238,7 +238,7 @@ mod tests {
 
     #[test]
     fn get_field() -> serde_json::Result<()> {
-        #[derive(Debug, PartialEq, Deserialize)]
+        #[derive(Debug, Eq, PartialEq, Deserialize)]
         struct A<'a> {
             #[serde(borrow)]
             b: Vec<&'a str>,

--- a/crates/ruma-common/src/thirdparty.rs
+++ b/crates/ruma-common/src/thirdparty.rs
@@ -247,7 +247,7 @@ impl Medium {
 /// this type using `ThirdPartyIdentifier::Init` / `.into()`.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct ThirdPartyIdentifier {
     /// The third party identifier address.
     pub address: String,

--- a/crates/ruma-common/tests/serde/empty_strings.rs
+++ b/crates/ruma-common/tests/serde/empty_strings.rs
@@ -2,7 +2,7 @@ mod string {
     use serde::{Deserialize, Serialize};
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
-    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    #[derive(Serialize, Deserialize, Eq, PartialEq, Debug)]
     struct StringStruct {
         #[serde(
             default,
@@ -59,7 +59,7 @@ mod user {
         user_id!("@carl:example.com")
     }
 
-    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    #[derive(Serialize, Deserialize, Eq, PartialEq, Debug)]
     struct User {
         #[serde(
             default,

--- a/crates/ruma-common/tests/serde/enum_derive.rs
+++ b/crates/ruma-common/tests/serde/enum_derive.rs
@@ -1,10 +1,10 @@
 use ruma_common::serde::StringEnum;
 use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 struct PrivOwnedStr(Box<str>);
 
-#[derive(Debug, PartialEq, StringEnum)]
+#[derive(Debug, Eq, PartialEq, StringEnum)]
 #[ruma_enum(rename_all = "snake_case")]
 enum MyEnum {
     First,

--- a/crates/ruma-common/tests/serde/url_deserialize.rs
+++ b/crates/ruma-common/tests/serde/url_deserialize.rs
@@ -77,7 +77,7 @@ fn deserialize_unit_type() {
     assert_eq!(urlencoded::from_str(""), Ok(()));
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize)]
 struct Params<'a> {
     a: usize,
     b: &'a str,
@@ -105,7 +105,7 @@ fn deserialize_list_of_str() {
 
 #[test]
 fn deserialize_multiple_lists() {
-    #[derive(Debug, PartialEq, Deserialize)]
+    #[derive(Debug, Eq, PartialEq, Deserialize)]
     struct Lists {
         xs: Vec<bool>,
         ys: Vec<u32>,
@@ -124,7 +124,7 @@ fn deserialize_multiple_lists() {
 
 #[test]
 fn deserialize_with_serde_attributes() {
-    #[derive(Debug, PartialEq, Deserialize)]
+    #[derive(Debug, Eq, PartialEq, Deserialize)]
     struct FieldsWithAttributes {
         #[serde(default)]
         xs: Vec<bool>,
@@ -178,19 +178,19 @@ struct Wrapper<T> {
     item: T,
 }
 
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Deserialize)]
 struct NewStruct<'a> {
     #[serde(borrow)]
     list: Vec<&'a str>,
 }
 
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Deserialize)]
 struct Struct<'a> {
     #[serde(borrow)]
     list: Vec<Option<&'a str>>,
 }
 
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Deserialize)]
 struct NumList {
     list: Vec<u8>,
 }
@@ -217,7 +217,7 @@ struct Nested<T> {
     item: T,
 }
 
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, Eq, PartialEq)]
 struct Inner<'a> {
     c: &'a str,
     a: usize,

--- a/crates/ruma-macros/src/serde/case.rs
+++ b/crates/ruma-macros/src/serde/case.rs
@@ -10,7 +10,7 @@ use std::str::FromStr;
 use self::RenameRule::*;
 
 /// The different possible ways to change case of fields in a struct, or variants in an enum.
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq)]
 pub enum RenameRule {
     /// Don't apply a default rename rule.
     None,

--- a/crates/ruma-push-gateway-api/src/send_event_notification.rs
+++ b/crates/ruma-push-gateway-api/src/send_event_notification.rs
@@ -176,7 +176,7 @@ pub mod v1 {
     }
 
     /// Type for passing information about notification counts.
-    #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
+    #[derive(Clone, Debug, Default, Deserialize, Serialize, Eq, PartialEq)]
     #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     pub struct NotificationCounts {
         /// The number of unread messages a user has across all of the rooms they

--- a/crates/ruma-signatures/src/verification.rs
+++ b/crates/ruma-signatures/src/verification.rs
@@ -24,7 +24,7 @@ pub trait Verifier {
 }
 
 /// A verifier for Ed25519 digital signatures.
-#[derive(Debug, Default, PartialEq)]
+#[derive(Debug, Default, Eq, PartialEq)]
 pub struct Ed25519Verifier;
 
 impl Verifier for Ed25519Verifier {
@@ -49,7 +49,7 @@ impl Verifier for Ed25519Verifier {
 /// calculated during verification. This is not necessarily an error condition, as it may indicate
 /// that the event has been redacted. In this case, receiving homeservers should store a redacted
 /// version of the event.
-#[derive(Clone, Debug, Hash, PartialEq)]
+#[derive(Clone, Debug, Hash, Eq, PartialEq)]
 #[allow(clippy::exhaustive_enums)]
 pub enum Verified {
     /// All signatures are valid and the content hashes match.

--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -176,7 +176,7 @@ pub struct Dependency {
 }
 
 /// The kind of a cargo package dependency.
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum DependencyKind {
     /// A dev dependency.


### PR DESCRIPTION
Nightly added this, and so `main` broke since the last CI run, this fixes it.