### PR TITLE
events: Split SessionDescription between Answer and Offer

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -7,8 +7,7 @@ Breaking changes:
 * Remove `PartialEq` implementation for `events::call::SessionDescription`
 * Split `events::call::SessionDescription` into `AnswerSessionDescription`
   and `OfferSessionDescription`
-  * Split `SessionDescriptionType` into `AnswerSessionDescriptionType`
-    and `OfferSessionDescriptionType`
+  * Remove `SessionDescriptionType`
 
 Improvements:
 

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -5,6 +5,10 @@ Breaking changes:
 * Add `user_id` field to `PushConditionRoomCtx`
 * Remove `PartialEq` implementation on `NotificationPowerLevels`
 * Remove `PartialEq` implementation for `events::call::SessionDescription`
+* Split `events::call::SessionDescription` into `AnswerSessionDescription`
+  and `OfferSessionDescription`
+  * Split `SessionDescriptionType` into `AnswerSessionDescriptionType`
+    and `OfferSessionDescriptionType`
 
 Improvements:
 

--- a/crates/ruma-common/src/events/call.rs
+++ b/crates/ruma-common/src/events/call.rs
@@ -2,53 +2,75 @@
 //!
 //! This module also contains types shared by events in its child namespaces.
 
-use serde::{Deserialize, Serialize};
-
-use crate::{serde::StringEnum, PrivOwnedStr};
-
 pub mod answer;
 pub mod candidates;
 pub mod hangup;
 pub mod invite;
 
-/// A VoIP session description.
+use serde::{Deserialize, Serialize};
+
+use crate::{serde::StringEnum, PrivOwnedStr};
+
+/// A VoIP answer session description.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-pub struct SessionDescription {
+pub struct AnswerSessionDescription {
     /// The type of session description.
     #[serde(rename = "type")]
-    pub session_type: SessionDescriptionType,
+    pub session_type: AnswerSessionDescriptionType,
 
     /// The SDP text of the session description.
     pub sdp: String,
 }
 
-impl SessionDescription {
-    /// Creates a new `SessionDescription` with the given session type and SDP text.
-    pub fn new(session_type: SessionDescriptionType, sdp: String) -> Self {
-        Self { session_type, sdp }
+impl AnswerSessionDescription {
+    /// Creates a new `AnswerSessionDescription` with the given SDP text.
+    pub fn new(sdp: String) -> Self {
+        Self { session_type: AnswerSessionDescriptionType::Answer, sdp }
     }
 }
 
-/// The type of VoIP session description.
+/// The type of VoIP answer session description.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
 #[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
 #[ruma_enum(rename_all = "snake_case")]
 #[non_exhaustive]
-pub enum SessionDescriptionType {
+pub enum AnswerSessionDescriptionType {
     /// An answer.
     Answer,
-
-    /// An offer.
-    Offer,
 
     #[doc(hidden)]
     _Custom(PrivOwnedStr),
 }
 
-impl SessionDescriptionType {
-    /// Creates a string slice from this `SessionDescriptionType`.
-    pub fn as_str(&self) -> &str {
-        self.as_ref()
+/// A VoIP offer session description.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+pub struct OfferSessionDescription {
+    /// The type of session description.
+    #[serde(rename = "type")]
+    pub session_type: OfferSessionDescriptionType,
+
+    /// The SDP text of the session description.
+    pub sdp: String,
+}
+
+impl OfferSessionDescription {
+    /// Creates a new `OfferSessionDescription` with the given SDP text.
+    pub fn new(sdp: String) -> Self {
+        Self { session_type: OfferSessionDescriptionType::Offer, sdp }
     }
+}
+
+/// The type of VoIP offer session description.
+#[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
+#[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
+#[ruma_enum(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum OfferSessionDescriptionType {
+    /// An offer.
+    Offer,
+
+    #[doc(hidden)]
+    _Custom(PrivOwnedStr),
 }

--- a/crates/ruma-common/src/events/call.rs
+++ b/crates/ruma-common/src/events/call.rs
@@ -9,16 +9,11 @@ pub mod invite;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{serde::StringEnum, PrivOwnedStr};
-
 /// A VoIP answer session description.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+#[serde(tag = "type", rename = "answer")]
 pub struct AnswerSessionDescription {
-    /// The type of session description.
-    #[serde(rename = "type")]
-    pub session_type: AnswerSessionDescriptionType,
-
     /// The SDP text of the session description.
     pub sdp: String,
 }
@@ -26,31 +21,15 @@ pub struct AnswerSessionDescription {
 impl AnswerSessionDescription {
     /// Creates a new `AnswerSessionDescription` with the given SDP text.
     pub fn new(sdp: String) -> Self {
-        Self { session_type: AnswerSessionDescriptionType::Answer, sdp }
+        Self { sdp }
     }
-}
-
-/// The type of VoIP answer session description.
-#[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
-#[ruma_enum(rename_all = "snake_case")]
-#[non_exhaustive]
-pub enum AnswerSessionDescriptionType {
-    /// An answer.
-    Answer,
-
-    #[doc(hidden)]
-    _Custom(PrivOwnedStr),
 }
 
 /// A VoIP offer session description.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+#[serde(tag = "type", rename = "offer")]
 pub struct OfferSessionDescription {
-    /// The type of session description.
-    #[serde(rename = "type")]
-    pub session_type: OfferSessionDescriptionType,
-
     /// The SDP text of the session description.
     pub sdp: String,
 }
@@ -58,19 +37,6 @@ pub struct OfferSessionDescription {
 impl OfferSessionDescription {
     /// Creates a new `OfferSessionDescription` with the given SDP text.
     pub fn new(sdp: String) -> Self {
-        Self { session_type: OfferSessionDescriptionType::Offer, sdp }
+        Self { sdp }
     }
-}
-
-/// The type of VoIP offer session description.
-#[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, Debug, PartialEq, Eq, StringEnum)]
-#[ruma_enum(rename_all = "snake_case")]
-#[non_exhaustive]
-pub enum OfferSessionDescriptionType {
-    /// An offer.
-    Offer,
-
-    #[doc(hidden)]
-    _Custom(PrivOwnedStr),
 }

--- a/crates/ruma-common/src/events/call/answer.rs
+++ b/crates/ruma-common/src/events/call/answer.rs
@@ -6,7 +6,7 @@ use js_int::UInt;
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
-use super::SessionDescription;
+use super::AnswerSessionDescription;
 
 /// The content of an `m.call.answer` event.
 ///
@@ -16,9 +16,7 @@ use super::SessionDescription;
 #[ruma_event(type = "m.call.answer", kind = MessageLike)]
 pub struct CallAnswerEventContent {
     /// The VoIP session description object.
-    ///
-    /// The session description type must be *answer*.
-    pub answer: SessionDescription,
+    pub answer: AnswerSessionDescription,
 
     /// The ID of the call this event relates to.
     pub call_id: String,
@@ -29,7 +27,7 @@ pub struct CallAnswerEventContent {
 
 impl CallAnswerEventContent {
     /// Creates an `AnswerEventContent` with the given answer, call ID and VoIP version.
-    pub fn new(answer: SessionDescription, call_id: String, version: UInt) -> Self {
+    pub fn new(answer: AnswerSessionDescription, call_id: String, version: UInt) -> Self {
         Self { answer, call_id, version }
     }
 }

--- a/crates/ruma-common/src/events/call/invite.rs
+++ b/crates/ruma-common/src/events/call/invite.rs
@@ -6,7 +6,7 @@ use js_int::UInt;
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
-use super::SessionDescription;
+use super::OfferSessionDescription;
 
 /// The content of an `m.call.invite` event.
 ///
@@ -25,9 +25,7 @@ pub struct CallInviteEventContent {
     pub lifetime: UInt,
 
     /// The session description object.
-    ///
-    /// The session description type must be *offer*.
-    pub offer: SessionDescription,
+    pub offer: OfferSessionDescription,
 
     /// The version of the VoIP specification this messages adheres to.
     pub version: UInt,
@@ -35,7 +33,12 @@ pub struct CallInviteEventContent {
 
 impl CallInviteEventContent {
     /// Creates a new `InviteEventContent` with the given call ID, lifetime and VoIP version.
-    pub fn new(call_id: String, lifetime: UInt, offer: SessionDescription, version: UInt) -> Self {
+    pub fn new(
+        call_id: String,
+        lifetime: UInt,
+        offer: OfferSessionDescription,
+        version: UInt,
+    ) -> Self {
         Self { call_id, lifetime, offer, version }
     }
 }

--- a/crates/ruma-common/tests/events/event_enums.rs
+++ b/crates/ruma-common/tests/events/event_enums.rs
@@ -6,7 +6,9 @@ use ruma_common::{
 use serde_json::{from_value as from_json_value, json};
 
 use ruma_common::events::{
-    call::{answer::CallAnswerEventContent, SessionDescription, SessionDescriptionType},
+    call::{
+        answer::CallAnswerEventContent, AnswerSessionDescription, AnswerSessionDescriptionType,
+    },
     AnyMessageLikeEvent, OriginalMessageLikeEvent,
 };
 
@@ -41,8 +43,8 @@ fn deserialize_message_event() {
             .unwrap(),
         AnyMessageLikeEvent::CallAnswer(MessageLikeEvent::Original(OriginalMessageLikeEvent {
             content: CallAnswerEventContent {
-                answer: SessionDescription {
-                    session_type: SessionDescriptionType::Answer,
+                answer: AnswerSessionDescription {
+                    session_type: AnswerSessionDescriptionType::Answer,
                     sdp,
                     ..
                 },

--- a/crates/ruma-common/tests/events/event_enums.rs
+++ b/crates/ruma-common/tests/events/event_enums.rs
@@ -6,9 +6,7 @@ use ruma_common::{
 use serde_json::{from_value as from_json_value, json};
 
 use ruma_common::events::{
-    call::{
-        answer::CallAnswerEventContent, AnswerSessionDescription, AnswerSessionDescriptionType,
-    },
+    call::{answer::CallAnswerEventContent, AnswerSessionDescription},
     AnyMessageLikeEvent, OriginalMessageLikeEvent,
 };
 
@@ -44,7 +42,6 @@ fn deserialize_message_event() {
         AnyMessageLikeEvent::CallAnswer(MessageLikeEvent::Original(OriginalMessageLikeEvent {
             content: CallAnswerEventContent {
                 answer: AnswerSessionDescription {
-                    session_type: AnswerSessionDescriptionType::Answer,
                     sdp,
                     ..
                 },

--- a/crates/ruma-common/tests/events/message_event.rs
+++ b/crates/ruma-common/tests/events/message_event.rs
@@ -4,9 +4,7 @@ use matches::assert_matches;
 use ruma_common::{
     event_id,
     events::{
-        call::{
-            answer::CallAnswerEventContent, AnswerSessionDescription, AnswerSessionDescriptionType,
-        },
+        call::{answer::CallAnswerEventContent, AnswerSessionDescription},
         room::{ImageInfo, MediaSource, ThumbnailInfo},
         sticker::StickerEventContent,
         AnyMessageLikeEvent, AnyMessageLikeEventContent, AnySyncMessageLikeEvent, MessageLikeEvent,
@@ -139,7 +137,6 @@ fn deserialize_message_call_answer_content() {
             .unwrap(),
         AnyMessageLikeEventContent::CallAnswer(CallAnswerEventContent {
             answer: AnswerSessionDescription {
-                session_type: AnswerSessionDescriptionType::Answer,
                 sdp,
                 ..
             },
@@ -173,7 +170,6 @@ fn deserialize_message_call_answer() {
         AnyMessageLikeEvent::CallAnswer(MessageLikeEvent::Original(OriginalMessageLikeEvent {
             content: CallAnswerEventContent {
                 answer: AnswerSessionDescription {
-                    session_type: AnswerSessionDescriptionType::Answer,
                     sdp,
                     ..
                 },
@@ -299,7 +295,6 @@ fn deserialize_message_then_convert_to_full() {
         AnyMessageLikeEvent::CallAnswer(MessageLikeEvent::Original(OriginalMessageLikeEvent {
             content: CallAnswerEventContent {
                 answer: AnswerSessionDescription {
-                    session_type: AnswerSessionDescriptionType::Answer,
                     sdp,
                     ..
                 },

--- a/crates/ruma-common/tests/events/message_event.rs
+++ b/crates/ruma-common/tests/events/message_event.rs
@@ -4,7 +4,9 @@ use matches::assert_matches;
 use ruma_common::{
     event_id,
     events::{
-        call::{answer::CallAnswerEventContent, SessionDescription, SessionDescriptionType},
+        call::{
+            answer::CallAnswerEventContent, AnswerSessionDescription, AnswerSessionDescriptionType,
+        },
         room::{ImageInfo, MediaSource, ThumbnailInfo},
         sticker::StickerEventContent,
         AnyMessageLikeEvent, AnyMessageLikeEventContent, AnySyncMessageLikeEvent, MessageLikeEvent,
@@ -136,8 +138,8 @@ fn deserialize_message_call_answer_content() {
             .deserialize_content(MessageLikeEventType::CallAnswer)
             .unwrap(),
         AnyMessageLikeEventContent::CallAnswer(CallAnswerEventContent {
-            answer: SessionDescription {
-                session_type: SessionDescriptionType::Answer,
+            answer: AnswerSessionDescription {
+                session_type: AnswerSessionDescriptionType::Answer,
                 sdp,
                 ..
             },
@@ -170,8 +172,8 @@ fn deserialize_message_call_answer() {
         from_json_value::<AnyMessageLikeEvent>(json_data).unwrap(),
         AnyMessageLikeEvent::CallAnswer(MessageLikeEvent::Original(OriginalMessageLikeEvent {
             content: CallAnswerEventContent {
-                answer: SessionDescription {
-                    session_type: SessionDescriptionType::Answer,
+                answer: AnswerSessionDescription {
+                    session_type: AnswerSessionDescriptionType::Answer,
                     sdp,
                     ..
                 },
@@ -296,8 +298,8 @@ fn deserialize_message_then_convert_to_full() {
         sync_ev.into_full_event(rid.to_owned()),
         AnyMessageLikeEvent::CallAnswer(MessageLikeEvent::Original(OriginalMessageLikeEvent {
             content: CallAnswerEventContent {
-                answer: SessionDescription {
-                    session_type: SessionDescriptionType::Answer,
+                answer: AnswerSessionDescription {
+                    session_type: AnswerSessionDescriptionType::Answer,
                     sdp,
                     ..
                 },


### PR DESCRIPTION
Use stronger type instead of saying in the docs "use this variant".

Technically `SessionDescription` could be made generic over a `SessionDescriptionType` trait, I don't know which choice is best.