### PR TITLE
Split up some test assertions

### DIFF
--- a/crates/ruma-appservice-api/tests/appservice_registration.rs
+++ b/crates/ruma-appservice-api/tests/appservice_registration.rs
@@ -56,8 +56,9 @@ fn config_with_optional_url() {
           aliases: []
           rooms: []
         "#;
-    assert_matches!(
+    let url = assert_matches!(
         serde_yaml::from_str(registration_config).unwrap(),
-        Registration { url, .. } if url == "null"
+        Registration { url, .. } => url
     );
+    assert_eq!(url, "null");
 }

--- a/crates/ruma-client-api/src/filter.rs
+++ b/crates/ruma-client-api/src/filter.rs
@@ -516,7 +516,7 @@ mod tests {
     }
 
     #[test]
-    fn issue_366() -> serde_json::Result<()> {
+    fn issue_366() {
         let obj = json!({
             "lazy_load_members": true,
             "filter_json": { "contains_url": true, "types": ["m.room.message"] },
@@ -529,40 +529,24 @@ mod tests {
             "contains_url": true,
         });
 
-        assert_matches!(
-            from_json_value(obj)?,
-            IncomingRoomEventFilter {
-                types: Some(types),
-                not_types,
-                rooms: None,
-                not_rooms,
-                senders: None,
-                not_senders,
-                limit: None,
-                url_filter: Some(UrlFilter::EventsWithUrl),
-                lazy_load_options: LazyLoadOptions::Enabled { include_redundant_members: false },
-                #[cfg(feature = "unstable-msc3440")]
-                related_by_rel_types,
-                #[cfg(feature = "unstable-msc3440")]
-                related_by_senders
-            } if {
-                let valid = types == vec!["m.room.message".to_owned()]
-                && not_types.is_empty()
-                && not_rooms.is_empty()
-                && not_senders.is_empty();
+        let filter: IncomingRoomEventFilter = assert_matches!(from_json_value(obj), Ok(f) => f);
 
-                #[cfg(not(feature = "unstable-msc3440"))]
-                {
-                    valid
-                }
-
-                #[cfg(feature = "unstable-msc3440")]
-                {
-                    valid && related_by_rel_types.is_empty() && related_by_senders.is_empty()
-                }
-            }
+        assert_eq!(filter.types, Some(vec!["m.room.message".to_owned()]));
+        assert_eq!(filter.not_types, vec![""; 0]);
+        assert_eq!(filter.rooms, None);
+        assert_eq!(filter.not_rooms, vec![""; 0]);
+        assert_eq!(filter.senders, None);
+        assert_eq!(filter.not_senders, vec![""; 0]);
+        assert_eq!(filter.limit, None);
+        assert_eq!(filter.url_filter, Some(UrlFilter::EventsWithUrl));
+        assert_eq!(
+            filter.lazy_load_options,
+            LazyLoadOptions::Enabled { include_redundant_members: false }
         );
 
-        Ok(())
+        #[cfg(feature = "unstable-msc3440")]
+        assert_eq!(filter.related_by_rel_types, vec![]);
+        #[cfg(feature = "unstable-msc3440")]
+        assert_eq!(filter.related_by_senders, vec![""; 0]);
     }
 }

--- a/crates/ruma-client-api/src/filter/create_filter.rs
+++ b/crates/ruma-client-api/src/filter/create_filter.rs
@@ -66,7 +66,7 @@ pub mod v3 {
 
             use super::IncomingRequest;
 
-            assert_matches!(
+            let req = assert_matches!(
                 IncomingRequest::try_from_http_request(
                     http::Request::builder()
                         .method(http::Method::POST)
@@ -75,9 +75,11 @@ pub mod v3 {
                         .unwrap(),
                     &["@foo:bar.com"]
                 ),
-                Ok(IncomingRequest { user_id, filter })
-                if user_id == "@foo:bar.com" && filter.is_empty()
+                Ok(req) => req
             );
+
+            assert_eq!(req.user_id, "@foo:bar.com");
+            assert!(req.filter.is_empty());
         }
 
         #[cfg(feature = "client")]

--- a/crates/ruma-common/src/push/action.rs
+++ b/crates/ruma-common/src/push/action.rs
@@ -203,7 +203,7 @@ mod tests {
 
     #[test]
     fn deserialize_string() {
-        assert_matches!(from_json_value::<Action>(json!("notify")).unwrap(), Action::Notify);
+        assert_matches!(from_json_value::<Action>(json!("notify")), Ok(Action::Notify));
     }
 
     #[test]
@@ -212,10 +212,11 @@ mod tests {
             "set_tweak": "sound",
             "value": "default"
         });
-        assert_matches!(
-            &from_json_value::<Action>(json_data).unwrap(),
-            Action::SetTweak(Tweak::Sound(value)) if value == "default"
+        let value = assert_matches!(
+            from_json_value::<Action>(json_data),
+            Ok(Action::SetTweak(Tweak::Sound(value))) => value
         );
+        assert_eq!(value, "default");
     }
 
     #[test]
@@ -225,16 +226,16 @@ mod tests {
             "value": true
         });
         assert_matches!(
-            from_json_value::<Action>(json_data).unwrap(),
-            Action::SetTweak(Tweak::Highlight(true))
+            from_json_value::<Action>(json_data),
+            Ok(Action::SetTweak(Tweak::Highlight(true)))
         );
     }
 
     #[test]
     fn deserialize_tweak_highlight_with_default_value() {
         assert_matches!(
-            from_json_value::<Action>(json!({ "set_tweak": "highlight" })).unwrap(),
-            Action::SetTweak(Tweak::Highlight(true))
+            from_json_value::<Action>(json!({ "set_tweak": "highlight" })),
+            Ok(Action::SetTweak(Tweak::Highlight(true)))
         );
     }
 }


### PR DESCRIPTION
Just a small thing I found out about today (this only works with the `assert_matches` crate, not the `assert_matches!` macro from the `matches` crate) and wanted to share.