### PR TITLE
Update pkcs8, and add ring backwards compatibility

### DIFF
--- a/crates/ruma-signatures/Cargo.toml
+++ b/crates/ruma-signatures/Cargo.toml
@@ -28,6 +28,6 @@ rand = { version = "0.7", features = ["getrandom"] }
 ruma-common = { version = "0.9.2", path = "../ruma-common" }
 serde_json = "1.0.60"
 sha2 = "0.9.5"
+subslice = { version = "0.2.3", optional = true }
 thiserror = "1.0.26"
 tracing = { version = "0.1.25", optional = true }
-subslice = { version = "0.2.3", optional = true }

--- a/crates/ruma-signatures/Cargo.toml
+++ b/crates/ruma-signatures/Cargo.toml
@@ -14,7 +14,8 @@ version = "0.11.0"
 all-features = true
 
 [features]
-compat = ["tracing", "subslice"]
+compat = ["tracing"]
+ring-compat = ["subslice"]
 unstable-exhaustive-types = []
 unstable-msc2870 = []
 

--- a/crates/ruma-signatures/Cargo.toml
+++ b/crates/ruma-signatures/Cargo.toml
@@ -14,14 +14,14 @@ version = "0.11.0"
 all-features = true
 
 [features]
-compat = ["tracing"]
+compat = ["tracing", "subslice"]
 unstable-exhaustive-types = []
 unstable-msc2870 = []
 
 [dependencies]
 base64 = "0.13.0"
 ed25519-dalek = "1.0.1"
-pkcs8 = { version = "0.7.0", features = ["alloc"] }
+pkcs8 = { version = "0.9.0", features = ["alloc"] }
 # because dalek uses an older version of rand_core
 rand = { version = "0.7", features = ["getrandom"] }
 ruma-common = { version = "0.9.2", path = "../ruma-common" }
@@ -29,3 +29,4 @@ serde_json = "1.0.60"
 sha2 = "0.9.5"
 thiserror = "1.0.26"
 tracing = { version = "0.1.25", optional = true }
+subslice = { version = "0.2.3", optional = true }

--- a/crates/ruma-signatures/src/functions.rs
+++ b/crates/ruma-signatures/src/functions.rs
@@ -115,8 +115,8 @@ static REFERENCE_HASH_FIELDS_TO_REMOVE: &[&str] = &["age_ts", "signatures", "uns
 ///
 /// ```rust
 /// const PKCS8: &str = "\
-///     MFMCAQEwBQYDK2VwBCIEINjozvdfbsGEt6DD+7Uf4PiJ/YvTNXV2mIPc/\
-///     tA0T+6toSMDIQDdM+tpNzNWQM9NFpfgr4B9S7LHszOrVRp9NfKmeXS3aQ\
+///     MFECAQEwBQYDK2VwBCIEINjozvdfbsGEt6DD+7Uf4PiJ/YvTNXV2mIPc/\
+///     tA0T+6tgSEA3TPraTczVkDPTRaX4K+AfUuyx7Mzq1UafTXypnl0t2k=\
 /// ";
 ///
 /// let document = base64::decode_config(&PKCS8, base64::STANDARD_NO_PAD).unwrap();
@@ -429,8 +429,8 @@ pub fn reference_hash(
 /// # use ruma_signatures::{hash_and_sign_event, Ed25519KeyPair};
 /// #
 /// const PKCS8: &str = "\
-///     MFMCAQEwBQYDK2VwBCIEINjozvdfbsGEt6DD+7Uf4PiJ/YvTNXV2mIPc/\
-///     tA0T+6toSMDIQDdM+tpNzNWQM9NFpfgr4B9S7LHszOrVRp9NfKmeXS3aQ\
+///     MFECAQEwBQYDK2VwBCIEINjozvdfbsGEt6DD+7Uf4PiJ/YvTNXV2mIPc/\
+///     tA0T+6tgSEA3TPraTczVkDPTRaX4K+AfUuyx7Mzq1UafTXypnl0t2k=\
 /// ";
 ///
 /// let document = base64::decode_config(&PKCS8, base64::STANDARD_NO_PAD).unwrap();

--- a/crates/ruma-signatures/src/keys.rs
+++ b/crates/ruma-signatures/src/keys.rs
@@ -302,7 +302,7 @@ mod tests {
 
     #[test]
     fn well_formed_key() {
-        let keypair = Ed25519KeyPair::from_der(&WELL_FORMED_DOC, "".to_owned()).unwrap();
+        let keypair = Ed25519KeyPair::from_der(WELL_FORMED_DOC, "".to_owned()).unwrap();
 
         assert_eq!(keypair.pubkey.as_bytes(), WELL_FORMED_PUBKEY);
     }

--- a/crates/ruma-signatures/src/keys/compat.rs
+++ b/crates/ruma-signatures/src/keys/compat.rs
@@ -1,0 +1,61 @@
+use subslice::SubsliceExt as _;
+
+#[derive(Debug)]
+pub enum CompatibleDocument<'a> {
+    WellFormed(&'a [u8]),
+    CleanedFromRing(Vec<u8>),
+}
+
+impl<'a> CompatibleDocument<'a> {
+    pub fn from_bytes(bytes: &'a [u8]) -> Self {
+        if is_ring(bytes) {
+            Self::CleanedFromRing(fix_ring_doc(bytes.to_vec()))
+        } else {
+            Self::WellFormed(bytes)
+        }
+    }
+}
+
+// Ring uses a very specific template to generate its documents,
+// and so this is essentially a sentinel value of that.
+//
+// It corresponds to CONTEXT-SPECIFIC[1](35) { BIT-STRING(32) {...} } in ASN.1
+//
+// A well-formed bit would look like just CONTEXT-SPECIFIC[1](32) { ... }
+//
+// Note: this is purely a sentinel value, don't take these bytes out of context
+// to detect or fiddle with the document.
+const RING_TEMPLATE_CONTEXT_SPECIFIC: &[u8] = &[0xA1, 0x23, 0x03, 0x21];
+
+// A checked well-formed context-specific[1] prefix.
+const WELL_FORMED_CONTEXT_ONE_PREFIX: &[u8] = &[0x81, 0x21];
+
+// If present, removes a malfunctioning pubkey suffix and adjusts the length at the start.
+fn fix_ring_doc(mut doc: Vec<u8>) -> Vec<u8> {
+    assert!(!doc.is_empty());
+    // Check if first tag is ASN.1 SEQUENCE
+    assert_eq!(doc[0], 0x30);
+    // Second byte asserts the length for the rest of the document
+    assert_eq!(doc[1] as usize, doc.len() - 2);
+
+    let idx = doc
+        .find(RING_TEMPLATE_CONTEXT_SPECIFIC)
+        .expect("Expected to find ring template in doc, but found none.");
+
+    // Snip off the malformed bit.
+    let suffix = doc.split_off(idx);
+
+    // Feed back an actual well-formed prefix.
+    doc.extend(WELL_FORMED_CONTEXT_ONE_PREFIX);
+
+    // Then give it the actual public key.
+    doc.extend(&suffix[4..]);
+
+    doc[1] = doc.len() as u8 - 2;
+
+    doc
+}
+
+fn is_ring(bytes: &[u8]) -> bool {
+    bytes.find(RING_TEMPLATE_CONTEXT_SPECIFIC).is_some()
+}

--- a/crates/ruma-signatures/src/lib.rs
+++ b/crates/ruma-signatures/src/lib.rs
@@ -105,7 +105,7 @@ mod tests {
     use std::collections::BTreeMap;
 
     use base64::{decode_config, STANDARD_NO_PAD};
-    use pkcs8::{der::Decodable, PrivateKeyInfo};
+    use pkcs8::{der::Decode, PrivateKeyInfo};
     use ruma_common::{serde::Base64, RoomVersionId};
     use serde_json::{from_str as from_json_str, to_string as to_json_string};
 
@@ -114,8 +114,8 @@ mod tests {
     };
 
     const PKCS8: &str = "\
-        MFMCAQEwBQYDK2VwBCIEINjozvdfbsGEt6DD+7Uf4PiJ/YvTNXV2mIPc/\
-        tA0T+6toSMDIQDdM+tpNzNWQM9NFpfgr4B9S7LHszOrVRp9NfKmeXS3aQ\
+        MFECAQEwBQYDK2VwBCIEINjozvdfbsGEt6DD+7Uf4PiJ/YvTNXV2mIPc/\
+        tA0T+6tgSEA3TPraTczVkDPTRaX4K+AfUuyx7Mzq1UafTXypnl0t2k=\
     ";
 
     /// Convenience method for getting the public key as a string

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -90,6 +90,11 @@ compat = [
     "ruma-state-res/compat",
 ]
 
+# Specific compatibility for past ring public/private key documents.
+ring-compat = [
+    "ruma-signatures/ring-compat"
+]
+
 # Helper features that aren't exactly part of the spec but could be helpful
 # for crate consumers
 appservice-api-helper = ["ruma-appservice-api/helper"]


### PR DESCRIPTION
Fixes https://github.com/ruma/ruma/issues/930

This adds a `ring-compat` feature which will make all previous ring-generated keys compatible to be imported by `from_der`.

It also adds a `compat` mod under `keys` to contain stuff related to this.

Furthermore, while upgrading `pkcs8`, some constants had to be updated to be compatible with the new pkcs8 library (they're the same document, just fixed)