### PR TITLE
MSRV 1.60

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,4 +1,4 @@
-msrv = "1.59"
+msrv = "1.60"
 avoid-breaking-exported-api = false
 disallowed-methods = [
     # https://github.com/serde-rs/json/issues/160

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -1,4 +1,4 @@
-name: Rust 1.59
+name: Rust 1.60
 
 env:
   CARGO_TERM_COLOR: always
@@ -35,11 +35,11 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      - name: Install rust 1.59 toolchain
+      - name: Install rust 1.60 toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: "1.59"
+          toolchain: "1.60"
 
       # Used to compile xtask
       - name: Install rust stable toolchain
@@ -54,7 +54,7 @@ jobs:
           # A stable compiler update should automatically not reuse old caches.
           # Add the MSRV as a stable cache key too so bumping it also gets us a
           # fresh cache.
-          sharedKey: msrv1.59
+          sharedKey: msrv1.60
 
       - name: Run checks
         uses: actions-rs/cargo@v1

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Minimum Rust version
 
-Ruma currently requires Rust 1.59. In general, we will never require beta or
+Ruma currently requires Rust 1.60. In general, we will never require beta or
 nightly for crates.io releases of our crates, and we will try to avoid releasing
 crates that depend on features that were only just stabilized.
 

--- a/crates/ruma-appservice-api/Cargo.toml
+++ b/crates/ruma-appservice-api/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 repository = "https://github.com/ruma/ruma"
 version = "0.6.0"
 edition = "2021"
-rust-version = "1.59"
+rust-version = "1.60"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/ruma-client-api/Cargo.toml
+++ b/crates/ruma-client-api/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 repository = "https://github.com/ruma/ruma"
 version = "0.14.1"
 edition = "2021"
-rust-version = "1.59"
+rust-version = "1.60"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/ruma-client/Cargo.toml
+++ b/crates/ruma-client/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 repository = "https://github.com/ruma/ruma"
 version = "0.9.0"
 edition = "2021"
-rust-version = "1.59"
+rust-version = "1.60"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/ruma-client/Cargo.toml
+++ b/crates/ruma-client/Cargo.toml
@@ -20,8 +20,8 @@ client-api = ["ruma-client-api"]
 
 # HTTP clients
 hyper-native-tls = ["hyper", "hyper-tls"]
-hyper-rustls = ["hyper", "hyper-rustls-crate"]
-isahc = ["isahc-crate", "futures-lite"]
+hyper-rustls = ["hyper", "dep:hyper-rustls"]
+isahc = ["dep:isahc", "futures-lite"]
 reqwest-native-tls = ["reqwest", "reqwest/native-tls"]
 reqwest-native-tls-alpn = ["reqwest", "reqwest/native-tls-alpn"]
 reqwest-native-tls-vendored = ["reqwest", "reqwest/native-tls-vendored"]
@@ -38,9 +38,9 @@ futures-core = "0.3.8"
 futures-lite = { version = "1.11.3", optional = true }
 http = "0.2.2"
 hyper = { version = "0.14.2", optional = true, features = ["client", "http1", "http2", "tcp"] }
-hyper-rustls-crate = { package = "hyper-rustls", version = "0.23.0", optional = true, default-features = false }
+hyper-rustls = { version = "0.23.0", optional = true, default-features = false }
 hyper-tls = { version = "0.5.0", optional = true }
-isahc-crate = { package = "isahc", version = "1.3.1", optional = true }
+isahc = { version = "1.3.1", optional = true }
 reqwest = { version = "0.11.4", optional = true, default-features = false }
 ruma-client-api = { version = "0.14.1", path = "../ruma-client-api", optional = true, features = ["client"] }
 ruma-common = { version = "0.9.2", path = "../ruma-common", features = ["api"] }

--- a/crates/ruma-client/src/lib.rs
+++ b/crates/ruma-client/src/lib.rs
@@ -108,13 +108,6 @@ use ruma_common::{
 };
 use tracing::{info_span, Instrument};
 
-// "Undo" rename from `Cargo.toml` that only serves to make crate names available as a Cargo
-// feature names.
-#[cfg(feature = "hyper-rustls")]
-extern crate hyper_rustls_crate as hyper_rustls;
-#[cfg(feature = "isahc")]
-extern crate isahc_crate as isahc;
-
 #[cfg(feature = "client-api")]
 mod client;
 mod error;

--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -24,8 +24,7 @@ server = []
 api = ["http", "thiserror"]
 compat = ["ruma-macros/compat", "ruma-identifiers-validation/compat"]
 events = ["thiserror"]
-# TODO: Use weak dependency features once MSRV >= 1.60
-js = ["js-sys", "getrandom/js", "uuid/js"]
+js = ["js-sys", "getrandom?/js", "uuid?/js"]
 markdown = ["pulldown-cmark"]
 # Should use dep:rand instead of the dependency being renamed, but that
 # breaks trybuild: https://github.com/dtolnay/trybuild/issues/171

--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/ruma/ruma"
 edition = "2021"
-rust-version = "1.59"
+rust-version = "1.60"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -27,6 +27,8 @@ events = ["thiserror"]
 # TODO: Use weak dependency features once MSRV >= 1.60
 js = ["js-sys", "getrandom/js", "uuid/js"]
 markdown = ["pulldown-cmark"]
+# Should use dep:rand instead of the dependency being renamed, but that
+# breaks trybuild: https://github.com/dtolnay/trybuild/issues/171
 rand = ["rand_crate", "uuid"]
 unstable-exhaustive-types = []
 unstable-pdu = []

--- a/crates/ruma-federation-api/Cargo.toml
+++ b/crates/ruma-federation-api/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 repository = "https://github.com/ruma/ruma"
 version = "0.5.0"
 edition = "2021"
-rust-version = "1.59"
+rust-version = "1.60"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/ruma-identifiers-validation/Cargo.toml
+++ b/crates/ruma-identifiers-validation/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/ruma/ruma"
 license = "MIT"
 version = "0.8.1"
 edition = "2021"
-rust-version = "1.59"
+rust-version = "1.60"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/ruma-identity-service-api/Cargo.toml
+++ b/crates/ruma-identity-service-api/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/ruma/ruma"
 edition = "2021"
-rust-version = "1.59"
+rust-version = "1.60"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/ruma-macros/Cargo.toml
+++ b/crates/ruma-macros/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 repository = "https://github.com/ruma/ruma"
 version = "0.9.2"
 edition = "2021"
-rust-version = "1.59"
+rust-version = "1.60"
 
 [lib]
 proc-macro = true

--- a/crates/ruma-push-gateway-api/Cargo.toml
+++ b/crates/ruma-push-gateway-api/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/ruma/ruma"
 edition = "2021"
-rust-version = "1.59"
+rust-version = "1.60"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/ruma-state-res/.clippy.toml
+++ b/crates/ruma-state-res/.clippy.toml
@@ -1,4 +1,4 @@
-msrv = "1.59"
+msrv = "1.60"
 avoid-breaking-exported-api = false
 disallowed-methods = [
     # https://github.com/serde-rs/json/issues/160

--- a/crates/ruma-state-res/Cargo.toml
+++ b/crates/ruma-state-res/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 license = "MIT"
 version = "0.7.0"
 edition = "2021"
-rust-version = "1.59"
+rust-version = "1.60"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -85,16 +85,14 @@ full = [
 # missing with this feature.
 compat = [
     "ruma-common/compat",
-    "ruma-client-api/compat",
-    "ruma-federation-api/compat",
-    "ruma-signatures/compat",
-    "ruma-state-res/compat",
+    "ruma-client-api?/compat",
+    "ruma-federation-api?/compat",
+    "ruma-signatures?/compat",
+    "ruma-state-res?/compat",
 ]
 
 # Specific compatibility for past ring public/private key documents.
-ring-compat = [
-    "ruma-signatures/ring-compat"
-]
+ring-compat = ["ruma-signatures/ring-compat"]
 
 # Helper features that aren't exactly part of the spec but could be helpful
 # for crate consumers
@@ -104,12 +102,12 @@ appservice-api-helper = ["ruma-appservice-api/helper"]
 #           otherwise provides!
 unstable-exhaustive-types = [
     "ruma-common/unstable-exhaustive-types",
-    "ruma-appservice-api/unstable-exhaustive-types",
-    "ruma-client-api/unstable-exhaustive-types",
-    "ruma-federation-api/unstable-exhaustive-types",
-    "ruma-identity-service-api/unstable-exhaustive-types",
-    "ruma-push-gateway-api/unstable-exhaustive-types",
-    "ruma-state-res/unstable-exhaustive-types"
+    "ruma-appservice-api?/unstable-exhaustive-types",
+    "ruma-client-api?/unstable-exhaustive-types",
+    "ruma-federation-api?/unstable-exhaustive-types",
+    "ruma-identity-service-api?/unstable-exhaustive-types",
+    "ruma-push-gateway-api?/unstable-exhaustive-types",
+    "ruma-state-res?/unstable-exhaustive-types"
 ]
 unstable-extensible-events = [
     "unstable-msc3246",
@@ -119,45 +117,45 @@ unstable-extensible-events = [
 unstable-pdu = ["ruma-common/unstable-pdu"]
 unstable-pre-spec = [
     "ruma-common/unstable-pre-spec",
-    "ruma-federation-api/unstable-pre-spec",
-    "ruma-push-gateway-api/unstable-pre-spec",
+    "ruma-federation-api?/unstable-pre-spec",
+    "ruma-push-gateway-api?/unstable-pre-spec",
 ]
 unstable-msc1767 = ["ruma-common/unstable-msc1767"]
-unstable-msc2246 = ["ruma-client-api/unstable-msc2246"]
+unstable-msc2246 = ["ruma-client-api?/unstable-msc2246"]
 unstable-msc2448 = [
-    "ruma-client-api/unstable-msc2448",
+    "ruma-client-api?/unstable-msc2448",
     "ruma-common/unstable-msc2448",
-    "ruma-federation-api/unstable-msc2448"
+    "ruma-federation-api?/unstable-msc2448"
 ]
-unstable-msc2654 = ["ruma-client-api/unstable-msc2654"]
+unstable-msc2654 = ["ruma-client-api?/unstable-msc2654"]
 unstable-msc2675 = ["ruma-common/unstable-msc2675"]
 unstable-msc2676 = [
-    "ruma-client-api/unstable-msc2676",
+    "ruma-client-api?/unstable-msc2676",
     "ruma-common/unstable-msc2676",
 ]
 unstable-msc2677 = [
-    "ruma-client-api/unstable-msc2677",
+    "ruma-client-api?/unstable-msc2677",
     "ruma-common/unstable-msc2677",
 ]
 unstable-msc2746 = ["ruma-common/unstable-msc2746"]
-unstable-msc2870 = ["ruma-signatures/unstable-msc2870"]
+unstable-msc2870 = ["ruma-signatures?/unstable-msc2870"]
 unstable-msc3245 = ["ruma-common/unstable-msc3245"]
 unstable-msc3246 = ["ruma-common/unstable-msc3246"]
 unstable-msc3381 = ["ruma-common/unstable-msc3381"]
 unstable-msc3440 = [
-    "ruma-client-api/unstable-msc3440",
+    "ruma-client-api?/unstable-msc3440",
     "ruma-common/unstable-msc3440",
 ]
 unstable-msc3488 = [
-    "ruma-client-api/unstable-msc3488",
+    "ruma-client-api?/unstable-msc3488",
     "ruma-common/unstable-msc3488",
 ]
 unstable-msc3551 = ["ruma-common/unstable-msc3551"]
 unstable-msc3552 = ["ruma-common/unstable-msc3552"]
 unstable-msc3553 = ["ruma-common/unstable-msc3553"]
 unstable-msc3554 = ["ruma-common/unstable-msc3554"]
-unstable-msc3618 = ["ruma-federation-api/unstable-msc3618"]
-unstable-msc3723 = ["ruma-federation-api/unstable-msc3723"]
+unstable-msc3618 = ["ruma-federation-api?/unstable-msc3618"]
+unstable-msc3723 = ["ruma-federation-api?/unstable-msc3723"]
 
 # Private feature, only used in test / benchmarking code
 __ci = [

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 license = "MIT"
 version = "0.6.3"
 edition = "2021"
-rust-version = "1.59"
+rust-version = "1.60"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -9,7 +9,7 @@ mod spec_links;
 
 use spec_links::check_spec_links;
 
-const MSRV: &str = "1.59";
+const MSRV: &str = "1.60";
 const NIGHTLY: &str = "nightly";
 
 #[derive(Args)]


### PR DESCRIPTION
Matrix Rust SDK bumped MSRV to this for the new Cargo features, I think it makes sense here as well. Conduit will probably benefit most from this, not getting extra dependencies from activating `unstable-exhaustive-types`, but it also just simplifies things a little bit.