### PR TITLE
xtask: Fix release changelog generation

### DIFF
--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -96,7 +96,7 @@ impl Package {
             ..self.version.clone()
         };
 
-        let update = if changelog.starts_with(&format!("# {version}\n")) {
+        let update = if changelog.contains(&format!("# {version}\n")) {
             false
         } else if changelog.starts_with(&format!("# {version} (unreleased)\n"))
             || changelog.starts_with("# [unreleased]\n")


### PR DESCRIPTION
The version title might exist after the "unreleased" title if the release failed after the changelog was updated.

This makes the matching loser as it's highly unlikely we'll find the version title anywhere else than expected.