### PR TITLE
events: Add methods to sanitize messages

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -39,7 +39,7 @@ Improvements:
 * Deserialize stringified integers for power levels without the `compat` feature
 * Add `JoinRule::KnockRestricted` (MSC3787)
 * Add `MatrixVersionId::V10` (MSC3604)
-* Add methods to sanitize messages according to the spec behind the `sanitize` feature
+* Add methods to sanitize messages according to the spec behind the `unstable-sanitize` feature
   * Can also remove rich reply fallbacks
 
 # 0.9.2

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -39,6 +39,8 @@ Improvements:
 * Deserialize stringified integers for power levels without the `compat` feature
 * Add `JoinRule::KnockRestricted` (MSC3787)
 * Add `MatrixVersionId::V10` (MSC3604)
+* Add methods to sanitize messages according to the spec behind the `sanitize` feature
+  * Can also remove rich reply fallbacks
 
 # 0.9.2
 

--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -30,7 +30,7 @@ markdown = ["pulldown-cmark"]
 # Should use dep:rand instead of the dependency being renamed, but that
 # breaks trybuild: https://github.com/dtolnay/trybuild/issues/171
 rand = ["rand_crate", "uuid"]
-sanitize = ["html5ever", "kuchiki"]
+sanitize = ["html5ever", "kuchiki", "phf"]
 unstable-exhaustive-types = []
 unstable-pdu = []
 unstable-pre-spec = []
@@ -62,6 +62,7 @@ js_int = { version = "0.2.0", features = ["serde"] }
 js_option = "0.1.0"
 kuchiki = { version = "0.8.1", optional = true }
 percent-encoding = "2.1.0"
+phf = { version = "0.10.1", features = ["macros"], optional = true }
 pulldown-cmark = { version = "0.9.1", default-features = false, optional = true }
 rand_crate = { package = "rand", version = "0.8.3", optional = true }
 regex = { version = "1.5.6", default-features = false, features = ["std", "perf"] }

--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -30,6 +30,7 @@ markdown = ["pulldown-cmark"]
 # Should use dep:rand instead of the dependency being renamed, but that
 # breaks trybuild: https://github.com/dtolnay/trybuild/issues/171
 rand = ["rand_crate", "uuid"]
+sanitize = ["ammonia"]
 unstable-exhaustive-types = []
 unstable-pdu = []
 unstable-pre-spec = []
@@ -49,6 +50,7 @@ unstable-msc3553 = ["unstable-msc3552"]
 unstable-msc3554 = ["unstable-msc1767"]
 
 [dependencies]
+ammonia = { version = "3.2.0", optional = true }
 base64 = "0.13.0"
 bytes = "1.0.1"
 form_urlencoded = "1.0.0"

--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -30,7 +30,7 @@ markdown = ["pulldown-cmark"]
 # Should use dep:rand instead of the dependency being renamed, but that
 # breaks trybuild: https://github.com/dtolnay/trybuild/issues/171
 rand = ["rand_crate", "uuid"]
-sanitize = ["scraper", "maplit"]
+sanitize = ["html5ever", "kuchiki"]
 unstable-exhaustive-types = []
 unstable-pdu = []
 unstable-pre-spec = []
@@ -55,18 +55,18 @@ bytes = "1.0.1"
 form_urlencoded = "1.0.0"
 getrandom = { version = "0.2.6", optional = true }
 http = { version = "0.2.2", optional = true }
+html5ever = { version = "0.25.2", optional = true }
 indexmap = { version = "1.6.2", features = ["serde-1"] }
 itoa = "1.0.1"
 js_int = { version = "0.2.0", features = ["serde"] }
 js_option = "0.1.0"
-maplit = { version = "1.0.2", optional = true }
+kuchiki = { version = "0.8.1", optional = true }
 percent-encoding = "2.1.0"
 pulldown-cmark = { version = "0.9.1", default-features = false, optional = true }
 rand_crate = { package = "rand", version = "0.8.3", optional = true }
 regex = { version = "1.5.6", default-features = false, features = ["std", "perf"] }
 ruma-identifiers-validation = { version = "0.8.1", path = "../ruma-identifiers-validation", default-features = false }
 ruma-macros = { version = "0.9.2", path = "../ruma-macros" }
-scraper = { version = "0.13.0", optional = true }
 serde = { version = "1.0.118", features = ["derive"] }
 serde_json = { version = "1.0.64", features = ["raw_value"] }
 thiserror = { version = "1.0.26", optional = true }

--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -30,7 +30,7 @@ markdown = ["pulldown-cmark"]
 # Should use dep:rand instead of the dependency being renamed, but that
 # breaks trybuild: https://github.com/dtolnay/trybuild/issues/171
 rand = ["rand_crate", "uuid"]
-sanitize = ["html5ever", "kuchiki", "phf"]
+sanitize = ["html5ever", "phf"]
 unstable-exhaustive-types = []
 unstable-pdu = []
 unstable-pre-spec = []
@@ -60,7 +60,6 @@ indexmap = { version = "1.6.2", features = ["serde-1"] }
 itoa = "1.0.1"
 js_int = { version = "0.2.0", features = ["serde"] }
 js_option = "0.1.0"
-kuchiki = { version = "0.8.1", optional = true }
 percent-encoding = "2.1.0"
 phf = { version = "0.10.1", features = ["macros"], optional = true }
 pulldown-cmark = { version = "0.9.1", default-features = false, optional = true }

--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -30,7 +30,7 @@ markdown = ["pulldown-cmark"]
 # Should use dep:rand instead of the dependency being renamed, but that
 # breaks trybuild: https://github.com/dtolnay/trybuild/issues/171
 rand = ["rand_crate", "uuid"]
-sanitize = ["ammonia"]
+sanitize = ["scraper", "maplit"]
 unstable-exhaustive-types = []
 unstable-pdu = []
 unstable-pre-spec = []
@@ -50,7 +50,6 @@ unstable-msc3553 = ["unstable-msc3552"]
 unstable-msc3554 = ["unstable-msc1767"]
 
 [dependencies]
-ammonia = { version = "3.2.0", optional = true }
 base64 = "0.13.0"
 bytes = "1.0.1"
 form_urlencoded = "1.0.0"
@@ -60,12 +59,14 @@ indexmap = { version = "1.6.2", features = ["serde-1"] }
 itoa = "1.0.1"
 js_int = { version = "0.2.0", features = ["serde"] }
 js_option = "0.1.0"
+maplit = { version = "1.0.2", optional = true }
 percent-encoding = "2.1.0"
 pulldown-cmark = { version = "0.9.1", default-features = false, optional = true }
 rand_crate = { package = "rand", version = "0.8.3", optional = true }
 regex = { version = "1.5.6", default-features = false, features = ["std", "perf"] }
 ruma-identifiers-validation = { version = "0.8.1", path = "../ruma-identifiers-validation", default-features = false }
 ruma-macros = { version = "0.9.2", path = "../ruma-macros" }
+scraper = { version = "0.13.0", optional = true }
 serde = { version = "1.0.118", features = ["derive"] }
 serde_json = { version = "1.0.64", features = ["raw_value"] }
 thiserror = { version = "1.0.26", optional = true }

--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -30,10 +30,10 @@ markdown = ["pulldown-cmark"]
 # Should use dep:rand instead of the dependency being renamed, but that
 # breaks trybuild: https://github.com/dtolnay/trybuild/issues/171
 rand = ["rand_crate", "uuid"]
-sanitize = ["html5ever", "phf"]
 unstable-exhaustive-types = []
 unstable-pdu = []
 unstable-pre-spec = []
+unstable-sanitize = ["html5ever", "phf"]
 unstable-msc1767 = []
 unstable-msc2448 = []
 unstable-msc2676 = []

--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -54,8 +54,8 @@ base64 = "0.13.0"
 bytes = "1.0.1"
 form_urlencoded = "1.0.0"
 getrandom = { version = "0.2.6", optional = true }
-http = { version = "0.2.2", optional = true }
 html5ever = { version = "0.25.2", optional = true }
+http = { version = "0.2.2", optional = true }
 indexmap = { version = "1.6.2", features = ["serde-1"] }
 itoa = "1.0.1"
 js_int = { version = "0.2.0", features = ["serde"] }

--- a/crates/ruma-common/src/doc/rich_reply.md
+++ b/crates/ruma-common/src/doc/rich_reply.md
@@ -1,0 +1,11 @@
+<!-- Keep this comment so the content is always included as a new paragraph -->
+This constructor requires an [`OriginalRoomMessageEvent`] since it creates a permalink to
+the previous message, for which the room ID is required. If you want to reply to an
+[`OriginalSyncRoomMessageEvent`], you have to convert it first by calling
+[`.into_full_event()`][crate::events::OriginalSyncMessageLikeEvent::into_full_event].
+
+It is recommended to enable the `sanitize` feature when using this method as this will
+clean up nested [rich reply fallbacks] in chains of replies. This uses [`sanitize_html()`]
+internally, with [`RemoveReplyFallback::Yes`].
+
+[rich reply fallbacks]: https://spec.matrix.org/v1.2/client-server-api/#fallbacks-for-rich-replies

--- a/crates/ruma-common/src/events/room/message.rs
+++ b/crates/ruma-common/src/events/room/message.rs
@@ -37,7 +37,7 @@ pub use location::{LocationInfo, LocationMessageEventContent};
 pub use notice::NoticeMessageEventContent;
 pub use sanitize::remove_plain_reply_fallback;
 #[cfg(feature = "sanitize")]
-pub use sanitize::sanitize_html;
+pub use sanitize::{sanitize_html, RemoveReplyFallback};
 pub use server_notice::{LimitType, ServerNoticeMessageEventContent, ServerNoticeType};
 pub use text::TextMessageEventContent;
 pub use video::{VideoInfo, VideoMessageEventContent};
@@ -355,7 +355,7 @@ impl RoomMessageEventContent {
     /// [tags and attributes]: https://spec.matrix.org/v1.2/client-server-api/#mroommessage-msgtypes
     /// [rich reply fallback]: https://spec.matrix.org/v1.2/client-server-api/#fallbacks-for-rich-replies
     #[cfg(feature = "sanitize")]
-    pub fn sanitize(&mut self, remove_reply_fallback: bool) {
+    pub fn sanitize(&mut self, remove_reply_fallback: RemoveReplyFallback) {
         match &mut self.msgtype {
             MessageType::Emote(EmoteMessageEventContent { body, formatted, .. })
             | MessageType::Notice(NoticeMessageEventContent { body, formatted, .. })
@@ -366,7 +366,7 @@ impl RoomMessageEventContent {
                     }
                     formatted
                 });
-                if remove_reply_fallback {
+                if remove_reply_fallback == RemoveReplyFallback::Yes {
                     *body = remove_plain_reply_fallback(body).to_owned();
                 }
             }
@@ -718,7 +718,7 @@ impl FormattedBody {
     /// [tags and attributes]: https://spec.matrix.org/v1.2/client-server-api/#mroommessage-msgtypes
     /// [rich reply fallback]: https://spec.matrix.org/v1.2/client-server-api/#fallbacks-for-rich-replies
     #[cfg(feature = "sanitize")]
-    pub fn sanitize_html(&self, remove_reply_fallback: bool) -> Option<String> {
+    pub fn sanitize_html(&self, remove_reply_fallback: RemoveReplyFallback) -> Option<String> {
         (self.format == MessageFormat::Html)
             .then(|| sanitize_html(&self.body, remove_reply_fallback))
     }

--- a/crates/ruma-common/src/events/room/message.rs
+++ b/crates/ruma-common/src/events/room/message.rs
@@ -110,8 +110,8 @@ impl RoomMessageEventContent {
     /// [`.into_full_event()`][crate::events::OriginalSyncMessageLikeEvent::into_full_event].
     ///
     /// It is recommended to enable the `sanitize` feature when using this method as this will
-    /// avoid to have deeply nested [rich reply fallbacks] in chains of replies. This uses
-    /// [`sanitize_html()`] internally, with `remove_reply_fallback` set to `true`.
+    /// clean up nested [rich reply fallbacks] in chains of replies. This uses [`sanitize_html()`]
+    /// internally, with [`RemoveReplyFallback::Yes`].
     ///
     /// [rich reply fallbacks]: https://spec.matrix.org/v1.2/client-server-api/#fallbacks-for-rich-replies
     pub fn text_reply_plain(
@@ -138,8 +138,8 @@ impl RoomMessageEventContent {
     /// [`.into_full_event()`][crate::events::OriginalSyncMessageLikeEvent::into_full_event].
     ///
     /// It is recommended to enable the `sanitize` feature when using this method as this will
-    /// avoid to have deeply nested [rich reply fallbacks] in chains of replies. This uses
-    /// [`sanitize_html()`] internally, with `remove_reply_fallback` set to `true`.
+    /// clean up nested [rich reply fallbacks] in chains of replies. This uses [`sanitize_html()`]
+    /// internally, with [`RemoveReplyFallback::Yes`].
     ///
     /// [rich reply fallbacks]: https://spec.matrix.org/v1.2/client-server-api/#fallbacks-for-rich-replies
     pub fn text_reply_html(
@@ -166,8 +166,8 @@ impl RoomMessageEventContent {
     /// [`.into_full_event()`][crate::events::OriginalSyncMessageLikeEvent::into_full_event].
     ///
     /// It is recommended to enable the `sanitize` feature when using this method as this will
-    /// avoid to have deeply nested [rich reply fallbacks] in chains of replies. This uses
-    /// [`sanitize_html()`] internally, with `remove_reply_fallback` set to `true`.
+    /// clean up nested [rich reply fallbacks] in chains of replies. This uses [`sanitize_html()`]
+    /// internally, with [`RemoveReplyFallback::Yes`].
     ///
     /// [rich reply fallbacks]: https://spec.matrix.org/v1.2/client-server-api/#fallbacks-for-rich-replies
     pub fn notice_reply_plain(
@@ -194,8 +194,8 @@ impl RoomMessageEventContent {
     /// [`.into_full_event()`][crate::events::OriginalSyncMessageLikeEvent::into_full_event].
     ///
     /// It is recommended to enable the `sanitize` feature when using this method as this will
-    /// avoid to have deeply nested [rich reply fallbacks] in chains of replies. This uses
-    /// [`sanitize_html()`] internally, with `remove_reply_fallback` set to `true`.
+    /// clean up nested [rich reply fallbacks] in chains of replies. This uses [`sanitize_html()`]
+    /// internally, with [`RemoveReplyFallback::Yes`].
     ///
     /// [rich reply fallbacks]: https://spec.matrix.org/v1.2/client-server-api/#fallbacks-for-rich-replies
     pub fn notice_reply_html(
@@ -220,8 +220,8 @@ impl RoomMessageEventContent {
     /// reply fallback.
     ///
     /// It is recommended to enable the `sanitize` feature when using this method as this will
-    /// avoid to have deeply nested [rich reply fallbacks] in chains of replies. This uses
-    /// [`sanitize_html()`] internally, with `remove_reply_fallback` set to `true`.
+    /// clean up nested [rich reply fallbacks] in chains of replies. This uses [`sanitize_html()`]
+    /// internally, with [`RemoveReplyFallback::Yes`].
     ///
     /// [rich reply fallbacks]: https://spec.matrix.org/v1.2/client-server-api/#fallbacks-for-rich-replies
     #[cfg(feature = "unstable-msc3440")]
@@ -276,8 +276,8 @@ impl RoomMessageEventContent {
     /// is modified to include the rich reply fallback.
     ///
     /// It is recommended to enable the `sanitize` feature when using this method as this will
-    /// avoid to have deeply nested [rich reply fallbacks] in chains of replies. This uses
-    /// [`sanitize_html()`] internally, with `remove_reply_fallback` set to `true`.
+    /// clean up nested [rich reply fallbacks] in chains of replies. This uses [`sanitize_html()`]
+    /// internally, with [`RemoveReplyFallback::Yes`].
     ///
     /// [rich reply fallbacks]: https://spec.matrix.org/v1.2/client-server-api/#fallbacks-for-rich-replies
     #[cfg(feature = "unstable-msc3440")]

--- a/crates/ruma-common/src/events/room/message.rs
+++ b/crates/ruma-common/src/events/room/message.rs
@@ -104,17 +104,7 @@ impl RoomMessageEventContent {
     }
 
     /// Creates a plain text reply to a message.
-    ///
-    /// This constructor requires an [`OriginalRoomMessageEvent`] since it creates a permalink to
-    /// the previous message, for which the room ID is required. If you want to reply to an
-    /// [`OriginalSyncRoomMessageEvent`], you have to convert it first by calling
-    /// [`.into_full_event()`][crate::events::OriginalSyncMessageLikeEvent::into_full_event].
-    ///
-    /// It is recommended to enable the `sanitize` feature when using this method as this will
-    /// clean up nested [rich reply fallbacks] in chains of replies. This uses [`sanitize_html()`]
-    /// internally, with [`RemoveReplyFallback::Yes`].
-    ///
-    /// [rich reply fallbacks]: https://spec.matrix.org/v1.2/client-server-api/#fallbacks-for-rich-replies
+    #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/rich_reply.md"))]
     pub fn text_reply_plain(
         reply: impl fmt::Display,
         original_message: &OriginalRoomMessageEvent,
@@ -132,17 +122,7 @@ impl RoomMessageEventContent {
     }
 
     /// Creates a html text reply to a message.
-    ///
-    /// This constructor requires an [`OriginalRoomMessageEvent`] since it creates a permalink to
-    /// the previous message, for which the room ID is required. If you want to reply to an
-    /// [`OriginalSyncRoomMessageEvent`], you have to convert it first by calling
-    /// [`.into_full_event()`][crate::events::OriginalSyncMessageLikeEvent::into_full_event].
-    ///
-    /// It is recommended to enable the `sanitize` feature when using this method as this will
-    /// clean up nested [rich reply fallbacks] in chains of replies. This uses [`sanitize_html()`]
-    /// internally, with [`RemoveReplyFallback::Yes`].
-    ///
-    /// [rich reply fallbacks]: https://spec.matrix.org/v1.2/client-server-api/#fallbacks-for-rich-replies
+    #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/rich_reply.md"))]
     pub fn text_reply_html(
         reply: impl fmt::Display,
         html_reply: impl fmt::Display,
@@ -160,17 +140,7 @@ impl RoomMessageEventContent {
     }
 
     /// Creates a plain text notice reply to a message.
-    ///
-    /// This constructor requires an [`OriginalRoomMessageEvent`] since it creates a permalink to
-    /// the previous message, for which the room ID is required. If you want to reply to an
-    /// [`OriginalSyncRoomMessageEvent`], you have to convert it first by calling
-    /// [`.into_full_event()`][crate::events::OriginalSyncMessageLikeEvent::into_full_event].
-    ///
-    /// It is recommended to enable the `sanitize` feature when using this method as this will
-    /// clean up nested [rich reply fallbacks] in chains of replies. This uses [`sanitize_html()`]
-    /// internally, with [`RemoveReplyFallback::Yes`].
-    ///
-    /// [rich reply fallbacks]: https://spec.matrix.org/v1.2/client-server-api/#fallbacks-for-rich-replies
+    #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/rich_reply.md"))]
     pub fn notice_reply_plain(
         reply: impl fmt::Display,
         original_message: &OriginalRoomMessageEvent,
@@ -188,17 +158,7 @@ impl RoomMessageEventContent {
     }
 
     /// Creates a html text notice reply to a message.
-    ///
-    /// This constructor requires an [`OriginalRoomMessageEvent`] since it creates a permalink to
-    /// the previous message, for which the room ID is required. If you want to reply to an
-    /// [`OriginalSyncRoomMessageEvent`], you have to convert it first by calling
-    /// [`.into_full_event()`][crate::events::OriginalSyncMessageLikeEvent::into_full_event].
-    ///
-    /// It is recommended to enable the `sanitize` feature when using this method as this will
-    /// clean up nested [rich reply fallbacks] in chains of replies. This uses [`sanitize_html()`]
-    /// internally, with [`RemoveReplyFallback::Yes`].
-    ///
-    /// [rich reply fallbacks]: https://spec.matrix.org/v1.2/client-server-api/#fallbacks-for-rich-replies
+    #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/rich_reply.md"))]
     pub fn notice_reply_html(
         reply: impl fmt::Display,
         html_reply: impl fmt::Display,
@@ -219,12 +179,7 @@ impl RoomMessageEventContent {
     ///
     /// If `message` is a text, an emote or a notice message, it is modified to include the rich
     /// reply fallback.
-    ///
-    /// It is recommended to enable the `sanitize` feature when using this method as this will
-    /// clean up nested [rich reply fallbacks] in chains of replies. This uses [`sanitize_html()`]
-    /// internally, with [`RemoveReplyFallback::Yes`].
-    ///
-    /// [rich reply fallbacks]: https://spec.matrix.org/v1.2/client-server-api/#fallbacks-for-rich-replies
+    #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/rich_reply.md"))]
     #[cfg(feature = "unstable-msc3440")]
     pub fn reply(
         message: MessageType,
@@ -275,12 +230,7 @@ impl RoomMessageEventContent {
     ///
     /// If `message` is a text, an emote or a notice message, and this is a reply in the thread, it
     /// is modified to include the rich reply fallback.
-    ///
-    /// It is recommended to enable the `sanitize` feature when using this method as this will
-    /// clean up nested [rich reply fallbacks] in chains of replies. This uses [`sanitize_html()`]
-    /// internally, with [`RemoveReplyFallback::Yes`].
-    ///
-    /// [rich reply fallbacks]: https://spec.matrix.org/v1.2/client-server-api/#fallbacks-for-rich-replies
+    #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/rich_reply.md"))]
     #[cfg(feature = "unstable-msc3440")]
     pub fn for_thread(
         message: MessageType,

--- a/crates/ruma-common/src/events/room/message.rs
+++ b/crates/ruma-common/src/events/room/message.rs
@@ -35,7 +35,7 @@ pub use image::ImageMessageEventContent;
 pub use key_verification_request::KeyVerificationRequestEventContent;
 pub use location::{LocationInfo, LocationMessageEventContent};
 pub use notice::NoticeMessageEventContent;
-#[cfg(feature = "sanitize")]
+#[cfg(feature = "unstable-sanitize")]
 use sanitize::{
     remove_plain_reply_fallback, sanitize_html, HtmlSanitizerMode, RemoveReplyFallback,
 };
@@ -305,7 +305,7 @@ impl RoomMessageEventContent {
     ///
     /// [tags and attributes]: https://spec.matrix.org/v1.2/client-server-api/#mroommessage-msgtypes
     /// [rich reply fallback]: https://spec.matrix.org/v1.2/client-server-api/#fallbacks-for-rich-replies
-    #[cfg(feature = "sanitize")]
+    #[cfg(feature = "unstable-sanitize")]
     pub fn sanitize(
         &mut self,
         mode: HtmlSanitizerMode,
@@ -669,7 +669,7 @@ impl FormattedBody {
     ///
     /// [tags and attributes]: https://spec.matrix.org/v1.2/client-server-api/#mroommessage-msgtypes
     /// [rich reply fallback]: https://spec.matrix.org/v1.2/client-server-api/#fallbacks-for-rich-replies
-    #[cfg(feature = "sanitize")]
+    #[cfg(feature = "unstable-sanitize")]
     pub fn sanitize_html(
         &mut self,
         mode: HtmlSanitizerMode,

--- a/crates/ruma-common/src/events/room/message.rs
+++ b/crates/ruma-common/src/events/room/message.rs
@@ -317,7 +317,7 @@ impl RoomMessageEventContent {
         {
             if let Some(formatted) = formatted {
                 formatted.sanitize_html(mode, remove_reply_fallback);
-            };
+            }
             if remove_reply_fallback == RemoveReplyFallback::Yes
                 && matches!(self.relates_to, Some(Relation::Reply { .. }))
             {
@@ -661,7 +661,7 @@ impl FormattedBody {
 
     /// Sanitize this `FormattedBody` if its format is `MessageFormat::Html`.
     ///
-    /// This removes the [tags and attributes] that are not listed in the Matrix specification.
+    /// This removes any [tags and attributes] that are not listed in the Matrix specification.
     ///
     /// It can also optionally remove the [rich reply fallback].
     ///

--- a/crates/ruma-common/src/events/room/message/reply.rs
+++ b/crates/ruma-common/src/events/room/message/reply.rs
@@ -1,8 +1,8 @@
 use std::fmt;
 
-#[cfg(feature = "sanitize")]
-use super::sanitize_html;
 use super::{remove_plain_reply_fallback, FormattedBody, MessageType, OriginalRoomMessageEvent};
+#[cfg(feature = "sanitize")]
+use super::{sanitize_html, RemoveReplyFallback};
 
 fn get_message_quote_fallbacks(original_message: &OriginalRoomMessageEvent) -> (String, String) {
     match &original_message.content.msgtype {
@@ -60,7 +60,7 @@ fn formatted_or_plain_body(formatted: Option<&FormattedBody>, body: &str) -> Str
     if let Some(formatted_body) = formatted {
         #[cfg(feature = "sanitize")]
         {
-            sanitize_html(&formatted_body.body, true)
+            sanitize_html(&formatted_body.body, RemoveReplyFallback::Yes)
         }
 
         #[cfg(not(feature = "sanitize"))]

--- a/crates/ruma-common/src/events/room/message/reply.rs
+++ b/crates/ruma-common/src/events/room/message/reply.rs
@@ -1,7 +1,8 @@
 use std::fmt;
 
 use super::{
-    remove_plain_reply_fallback, FormattedBody, MessageType, OriginalRoomMessageEvent, Relation,
+    sanitize::remove_plain_reply_fallback, FormattedBody, MessageType, OriginalRoomMessageEvent,
+    Relation,
 };
 #[cfg(feature = "sanitize")]
 use super::{sanitize_html, HtmlSanitizerMode, RemoveReplyFallback};

--- a/crates/ruma-common/src/events/room/message/reply.rs
+++ b/crates/ruma-common/src/events/room/message/reply.rs
@@ -4,7 +4,7 @@ use super::{
     sanitize::remove_plain_reply_fallback, FormattedBody, MessageType, OriginalRoomMessageEvent,
     Relation,
 };
-#[cfg(feature = "sanitize")]
+#[cfg(feature = "unstable-sanitize")]
 use super::{sanitize_html, HtmlSanitizerMode, RemoveReplyFallback};
 
 fn get_message_quote_fallbacks(original_message: &OriginalRoomMessageEvent) -> (String, String) {
@@ -66,14 +66,14 @@ fn formatted_or_plain_body(
     _is_reply: bool,
 ) -> String {
     if let Some(formatted_body) = formatted {
-        #[cfg(feature = "sanitize")]
+        #[cfg(feature = "unstable-sanitize")]
         if _is_reply {
             sanitize_html(&formatted_body.body, HtmlSanitizerMode::Strict, RemoveReplyFallback::Yes)
         } else {
             formatted_body.body.clone()
         }
 
-        #[cfg(not(feature = "sanitize"))]
+        #[cfg(not(feature = "unstable-sanitize"))]
         formatted_body.body.clone()
     } else {
         let mut escaped_body = String::with_capacity(body.len());

--- a/crates/ruma-common/src/events/room/message/sanitize.rs
+++ b/crates/ruma-common/src/events/room/message/sanitize.rs
@@ -1,0 +1,186 @@
+/// Sanitize the given HTML string.
+///
+/// This removes the [tags and attributes] that are not listed in the Matrix specification.
+///
+/// It can also optionally remove the [rich reply fallback].
+///
+/// [tags and attributes]: https://spec.matrix.org/v1.2/client-server-api/#mroommessage-msgtypes
+/// [rich reply fallback]: https://spec.matrix.org/v1.2/client-server-api/#fallbacks-for-rich-replies
+#[cfg(feature = "sanitize")]
+pub fn sanitize_html(s: &str, remove_reply_fallback: bool) -> String {
+    let allowed_tags = [
+        "font",
+        "del",
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "blockquote",
+        "p",
+        "a",
+        "ul",
+        "ol",
+        "sup",
+        "sub",
+        "li",
+        "b",
+        "i",
+        "u",
+        "strong",
+        "em",
+        "strike",
+        "code",
+        "hr",
+        "br",
+        "div",
+        "table",
+        "thead",
+        "tbody",
+        "tr",
+        "th",
+        "td",
+        "caption",
+        "pre",
+        "span",
+        "img",
+        "details",
+        "summary",
+    ];
+
+    let allowed_attributes = [
+        ("font", vec!["data-mx-bg-color", "data-mx-color", "color"]),
+        ("span", vec!["data-mx-bg-color", "data-mx-color", "data-mx-spoiler"]),
+        ("a", vec!["name", "target", "href"]),
+        ("img", vec!["width", "height", "alt", "title", "src"]),
+        ("ol", vec!["start"]),
+        ("code", vec!["class"]),
+    ];
+
+    let allowed_urls = ["http", "https", "ftp", "mailto", "magnet"];
+
+    let mut builder = ammonia::Builder::empty();
+    builder.add_url_schemes(allowed_urls).add_tags(allowed_tags).link_rel(Some("noopener"));
+
+    for (tag, attr) in allowed_attributes {
+        builder.add_tag_attributes(tag, attr);
+    }
+
+    if remove_reply_fallback {
+        builder.add_clean_content_tags(["mx-reply"]);
+    } else {
+        builder.add_tags(["mx-reply"]);
+    }
+
+    builder.clean(s).to_string()
+}
+
+/// Remove the [rich reply fallback] of the given plain text string.
+///
+/// [rich reply fallback]: https://spec.matrix.org/v1.2/client-server-api/#fallbacks-for-rich-replies
+pub fn remove_plain_reply_fallback(s: &str) -> &str {
+    if !s.starts_with("> ") {
+        s
+    } else {
+        let mut start = 0;
+        for (pos, _) in s.match_indices('\n') {
+            if !&s[pos + 1..].starts_with("> ") {
+                start = pos + 1;
+                break;
+            }
+        }
+        &s[start..]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{remove_plain_reply_fallback, sanitize_html};
+
+    #[test]
+    #[cfg(feature = "sanitize")]
+    fn sanitize() {
+        let sanitized = sanitize_html(
+            "\
+            <mx-reply>\
+                <blockquote>\
+                    <a href=\"https://matrix.to/#/!n8f893n9:example.com/$1598361704261elfgc:localhost\">In reply to</a> \
+                    <a href=\"https://matrix.to/#/@alice:example.com\">@alice:example.com</a>\
+                    <br>\
+                    Previous message\
+                </blockquote>\
+            </mx-reply>\
+            <removed>This has no tag</removed>\
+            <p>But this is inside a tag</p>\
+            ",
+            false
+        );
+
+        assert_eq!(
+            sanitized,
+            "\
+            <mx-reply>\
+                <blockquote>\
+                    <a href=\"https://matrix.to/#/!n8f893n9:example.com/$1598361704261elfgc:localhost\" rel=\"noopener\">In reply to</a> \
+                    <a href=\"https://matrix.to/#/@alice:example.com\" rel=\"noopener\">@alice:example.com</a>\
+                    <br>\
+                    Previous message\
+                </blockquote>\
+            </mx-reply>\
+            This has no tag\
+            <p>But this is inside a tag</p>\
+            "
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "sanitize")]
+    fn sanitize_without_reply() {
+        let sanitized = sanitize_html(
+            "\
+            <mx-reply>\
+                <blockquote>\
+                    <a href=\"https://matrix.to/#/!n8f893n9:example.com/$1598361704261elfgc:localhost\">In reply to</a> \
+                    <a href=\"https://matrix.to/#/@alice:example.com\">@alice:example.com</a>\
+                    <br>\
+                    Previous message\
+                </blockquote>\
+            </mx-reply>\
+            <removed>This has no tag</removed>\
+            <p>But this is inside a tag</p>\
+            ",
+            true
+        );
+
+        assert_eq!(
+            sanitized,
+            "\
+            This has no tag\
+            <p>But this is inside a tag</p>\
+            "
+        );
+    }
+
+    #[test]
+    fn remove_plain_reply() {
+        assert_eq!(
+            remove_plain_reply_fallback("No reply here\nJust a simple message"),
+            "No reply here\nJust a simple message"
+        );
+
+        assert_eq!(
+            remove_plain_reply_fallback(
+                "> <@user:notareal.hs> Replied to on\n> two lines\nThis is my reply"
+            ),
+            "This is my reply"
+        );
+
+        assert_eq!(remove_plain_reply_fallback("\n> Not on first line"), "\n> Not on first line");
+
+        assert_eq!(
+            remove_plain_reply_fallback("> <@user:notareal.hs> Previous message\n\n> New quote"),
+            "\n> New quote"
+        );
+    }
+}

--- a/crates/ruma-common/src/events/room/message/sanitize.rs
+++ b/crates/ruma-common/src/events/room/message/sanitize.rs
@@ -130,7 +130,7 @@ mod tests {
             <removed>This has no tag</removed>\
             <p>But this is inside a tag</p>\
             ",
-            RemoveReplyFallback::Yes
+            RemoveReplyFallback::No
         );
 
         assert_eq!(

--- a/crates/ruma-common/src/events/room/message/sanitize.rs
+++ b/crates/ruma-common/src/events/room/message/sanitize.rs
@@ -96,7 +96,9 @@ pub fn remove_plain_reply_fallback(s: &str) -> &str {
 
 #[cfg(test)]
 mod tests {
-    use super::{remove_plain_reply_fallback, sanitize_html};
+    use super::remove_plain_reply_fallback;
+    #[cfg(feature = "sanitize")]
+    use super::sanitize_html;
 
     #[test]
     #[cfg(feature = "sanitize")]

--- a/crates/ruma-common/src/events/room/message/sanitize.rs
+++ b/crates/ruma-common/src/events/room/message/sanitize.rs
@@ -1,14 +1,78 @@
-/// Sanitize the given HTML string.
+use std::collections::{HashMap, HashSet};
+
+use maplit::{hashmap, hashset};
+use scraper::Html;
+
+/// A sanitizer to filter [HTML tags and attributes] according to the Matrix specification.
 ///
-/// This removes the [tags and attributes] that are not listed in the Matrix specification.
-///
-/// It can also optionally remove the [rich reply fallback].
-///
-/// [tags and attributes]: https://spec.matrix.org/v1.2/client-server-api/#mroommessage-msgtypes
-/// [rich reply fallback]: https://spec.matrix.org/v1.2/client-server-api/#fallbacks-for-rich-replies
-#[cfg(feature = "sanitize")]
-pub fn sanitize_html(s: &str, remove_reply_fallback: RemoveReplyFallback) -> String {
-    let allowed_tags = [
+/// [HTML tags and attributes]: https://spec.matrix.org/v1.2/client-server-api/#mroommessage-msgtypes
+#[derive(Debug, Clone)]
+pub struct HtmlSanitizer<'a> {
+    /// HTML tags that will be left in the output of the sanitizer.
+    ///
+    /// If this is `None`, all the tags are allowed.
+    ///
+    /// If this is `Some`, tags that are not present in this list will be removed, but their
+    /// children will still be present in the output.
+    ///
+    /// To remove all tags, set this to `Some(Vec::new())`.
+    pub allowed_tags: Option<HashSet<&'a str>>,
+
+    /// HTML tags whose content will be removed.
+    ///
+    /// These tags will be removed from the output with their children.
+    ///
+    /// If a tag is both in `allowed_tags` and `remove_content_tags`, the sanitizer will panic.
+    pub remove_content_tags: HashSet<&'a str>,
+
+    /// HTML attributes per tag that will be left in the output of the sanitizer.
+    ///
+    /// If this is `None`, all the attributes are allowed on all tags.
+    ///
+    /// If this is `Some`, attributes that are not present in this list will be removed, even on
+    /// tags that are not listed.
+    ///
+    /// To remove all attributes, set this to `Some(HashMap::new())`.
+    pub allowed_attributes: Option<HashMap<&'a str, HashSet<&'a str>>>,
+
+    /// URI scheme per tag and attribute tuple that will be left in the output of the sanitizer.
+    ///
+    /// This only checks URIs in `href` and `src` attributes.
+    ///
+    /// If this is `None`, all the URIs are allowed.
+    ///
+    /// If this is `Some`, URIs that are not present in this list will be removed, even on
+    /// tags and attributes that are not listed.
+    ///
+    /// If no attribute that allows a URI is allowed, this will have no effect.
+    pub allowed_schemes: Option<HashMap<(&'a str, &'a str), HashSet<&'a str>>>,
+
+    /// Class name per tag that will be left in the output of the sanitizer.
+    ///
+    /// The class names to match allow the following wildcards:
+    ///
+    /// * `?` matches exactly one occurrence of any character.
+    /// * `*` matches arbitrary many (including zero) occurrences of any character.
+    ///
+    /// If this is `None`, all the class names are allowed.
+    ///
+    /// If this is `Some`, class names that are not present in this list will be removed, even on
+    /// tags that are not listed.
+    ///
+    /// If no `class` attribute is allowed, this will have no effect.
+    pub allowed_classes: Option<HashMap<&'a str, HashSet<&'a str>>>,
+
+    /// The maximum depth at which tags can be nested.
+    ///
+    /// If this is `None`, any depth is allowed.
+    ///
+    /// If this is `Some`, all tags deeper than this will be removed.
+    pub max_depth: Option<u32>,
+}
+
+impl<'a> HtmlSanitizer<'a> {
+    /// List of tags allowed in the Matrix specification.
+    pub const ALLOWED_TAGS_STRICT_WITH_REPLY: HashSet<&'static str> = hashset! {
         "font",
         "del",
         "h1",
@@ -47,19 +111,165 @@ pub fn sanitize_html(s: &str, remove_reply_fallback: RemoveReplyFallback) -> Str
         "img",
         "details",
         "summary",
-    ];
+        "mx-reply",
+    };
 
-    let allowed_attributes = [
-        ("font", vec!["data-mx-bg-color", "data-mx-color", "color"]),
-        ("span", vec!["data-mx-bg-color", "data-mx-color", "data-mx-spoiler"]),
-        ("a", vec!["name", "target", "href"]),
-        ("img", vec!["width", "height", "alt", "title", "src"]),
-        ("ol", vec!["start"]),
-        ("code", vec!["class"]),
-    ];
+    pub const ALLOWED_TAGS_STRICT_WITHOUT_REPLY: HashSet<&'static str> = hashset! {
+        "font",
+        "del",
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "blockquote",
+        "p",
+        "a",
+        "ul",
+        "ol",
+        "sup",
+        "sub",
+        "li",
+        "b",
+        "i",
+        "u",
+        "strong",
+        "em",
+        "strike",
+        "code",
+        "hr",
+        "br",
+        "div",
+        "table",
+        "thead",
+        "tbody",
+        "tr",
+        "th",
+        "td",
+        "caption",
+        "pre",
+        "span",
+        "img",
+        "details",
+        "summary",
+    };
 
-    let allowed_urls = ["http", "https", "ftp", "mailto", "magnet"];
+    /// The tag name for a rich reply.
+    pub const RICH_REPLY_TAG: &'static str = "mx-reply";
 
+    /// Allowed attributes per tag according to the Matrix specification.
+    pub const ALLOWED_ATTRIBUTES_STRICT: HashMap<&'static str, HashSet<&'static str>> = hashmap! {
+        "font" => hashset!{"data-mx-bg-color", "data-mx-color", "color"},
+        "span" => hashset!{"data-mx-bg-color", "data-mx-color", "data-mx-spoiler"},
+        "a" => hashset!{"name", "target", "href"},
+        "img" => hashset!{"width", "height", "alt", "title", "src"},
+        "ol" => hashset!{"start"},
+        "code" => hashset!{"class"},
+    };
+
+    /// Allowed scheme of URLs per tag according to the Matrix specification.
+    pub const ALLOWED_SCHEMES_STRICT: HashMap<(&'static str, &'static str), HashSet<&'static str>> = hashmap! {
+        ("a", "href") => hashset!{"http", "https", "ftp", "mailto", "magnet"},
+        ("img", "src") => hashset!{"mxc"},
+    };
+
+    /// Allowed scheme of URIs per tag, `STRICT_ALLOWED_SCHEME` plus the `matrix:` URI scheme for
+    /// links.
+    pub const ALLOWED_SCHEMES_COMPAT: HashMap<(&'static str, &'static str), HashSet<&'static str>> = hashmap! {
+        ("a", "href") => hashset!{"http", "https", "ftp", "mailto", "magnet", "matrix"},
+        ("img", "src") => hashset!{"mxc"},
+    };
+
+    /// Allowed classes per tag according to the Matrix specification.
+    pub const ALLOWED_CLASSES_STRICT: HashMap<&'static str, HashSet<&'static str>> = hashmap! {
+        "code" => hashset!{"language-*"},
+    };
+
+    /// Max depth of nested tags allowed by the Matrix specification.
+    pub const MAX_DEPTH_STRICT: u32 = 100;
+
+    /// Constructs a `Sanitizer` instance configured with the strict lists.
+    ///
+    /// It can also optionally remove the [rich reply fallback].
+    ///
+    /// [rich reply fallback]: https://spec.matrix.org/v1.2/client-server-api/#fallbacks-for-rich-replies
+    pub fn new(remove_reply_fallback: RemoveReplyFallback) -> Self {
+        let (allowed_tags, remove_content_tags) =
+            if remove_reply_fallback == RemoveReplyFallback::Yes {
+                (Self::ALLOWED_TAGS_STRICT_WITHOUT_REPLY, hashset! {Self::RICH_REPLY_TAG})
+            } else {
+                (Self::ALLOWED_TAGS_STRICT_WITH_REPLY, HashSet::new())
+            };
+        Self {
+            allowed_tags: Some(allowed_tags),
+            remove_content_tags,
+            allowed_attributes: Some(Self::ALLOWED_ATTRIBUTES_STRICT),
+            allowed_schemes: Some(Self::ALLOWED_SCHEMES_STRICT),
+            allowed_classes: Some(Self::ALLOWED_CLASSES_STRICT),
+            max_depth: Some(Self::MAX_DEPTH_STRICT),
+        }
+    }
+
+    /// Constructs a `Sanitizer` instance configured with the compat lists that are available.
+    ///
+    /// Defaults to using the strict lists for the parameters without compat lists.
+    ///
+    /// It can also optionally remove the [rich reply fallback].
+    ///
+    /// [rich reply fallback]: https://spec.matrix.org/v1.2/client-server-api/#fallbacks-for-rich-replies
+    pub fn compat(remove_reply_fallback: RemoveReplyFallback) -> Self {
+        let mut sanitizer = Self::new(remove_reply_fallback);
+        sanitizer.allowed_schemes = Some(Self::ALLOWED_SCHEMES_COMPAT);
+        sanitizer
+    }
+
+    /// Constructs a `Sanitizer` that does nothing.
+    pub fn empty() -> Self {
+        Self {
+            allowed_tags: None,
+            remove_content_tags: HashSet::new(),
+            allowed_attributes: None,
+            allowed_schemes: None,
+            allowed_classes: None,
+            max_depth: None,
+        }
+    }
+
+    /// Constructs a `Sanitizer` instance that only removes the [rich reply fallback].
+    ///
+    /// [rich reply fallback]: https://spec.matrix.org/v1.2/client-server-api/#fallbacks-for-rich-replies
+    pub fn remove_reply_fallback() -> Self {
+        let mut sanitizer = Self::empty();
+        sanitizer.remove_content_tags = hashset!(Self::RICH_REPLY_TAG);
+        sanitizer
+    }
+
+    /// Clean the given HTML string with this sanitizer.
+    pub fn clean(&self, html: &str) -> String {
+        let html = Html::parse_fragment(html);
+        let root = html.root_element();
+        for child in root.children() {
+            self.clean_node(child, 1)
+        }
+        root.html()
+    }
+
+    fn clean_node(&self, node: NodeRef<Node>, depth: u32) -> NodeRef<Node> {
+        node
+    }
+}
+
+/// Sanitize the given HTML string.
+///
+/// This removes the [tags and attributes] that are not listed in the Matrix specification.
+///
+/// It can also optionally remove the [rich reply fallback].
+///
+/// [tags and attributes]: https://spec.matrix.org/v1.2/client-server-api/#mroommessage-msgtypes
+/// [rich reply fallback]: https://spec.matrix.org/v1.2/client-server-api/#fallbacks-for-rich-replies
+#[cfg(feature = "sanitize")]
+pub fn sanitize_html(s: &str, remove_reply_fallback: RemoveReplyFallback) -> String {
     let mut builder = ammonia::Builder::empty();
     builder.add_url_schemes(allowed_urls).add_tags(allowed_tags).link_rel(Some("noopener"));
 

--- a/crates/ruma-common/src/events/room/message/sanitize.rs
+++ b/crates/ruma-common/src/events/room/message/sanitize.rs
@@ -1,264 +1,87 @@
-use std::collections::{HashMap, HashSet};
+//! Convenience methods and types to sanitize text messages.
 
-use maplit::{hashmap, hashset};
-use scraper::Html;
+#[cfg(feature = "sanitize")]
+mod html_sanitizer;
 
-/// A sanitizer to filter [HTML tags and attributes] according to the Matrix specification.
+#[cfg(feature = "sanitize")]
+use html_sanitizer::HtmlSanitizer;
+
+/// List of HTML tags allowed in the Matrix specification, without the rich reply fallback tag.
+pub const ALLOWED_TAGS_STRICT_WITHOUT_REPLY: [&str; 38] = [
+    "font",
+    "del",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "blockquote",
+    "p",
+    "a",
+    "ul",
+    "ol",
+    "sup",
+    "sub",
+    "li",
+    "b",
+    "i",
+    "u",
+    "strong",
+    "em",
+    "strike",
+    "code",
+    "hr",
+    "br",
+    "div",
+    "table",
+    "thead",
+    "tbody",
+    "tr",
+    "th",
+    "td",
+    "caption",
+    "pre",
+    "span",
+    "img",
+    "details",
+    "summary",
+];
+
+/// The HTML tag name for a rich reply fallback.
+pub const RICH_REPLY_TAG: &str = "mx-reply";
+
+/// Allowed attributes per HTML tag according to the Matrix specification.
+pub const ALLOWED_ATTRIBUTES_STRICT: [(&str, &[&str]); 6] = [
+    ("font", &["data-mx-bg-color", "data-mx-color", "color"]),
+    ("span", &["data-mx-bg-color", "data-mx-color", "data-mx-spoiler"]),
+    ("a", &["name", "target", "href"]),
+    ("img", &["width", "height", "alt", "title", "src"]),
+    ("ol", &["start"]),
+    ("code", &["class"]),
+];
+
+/// Allowed schemes of URIs per HTML tag and attribute tuple according to the Matrix specification.
+pub const ALLOWED_SCHEMES_STRICT: [((&str, &str), &[&str]); 2] =
+    [(("a", "href"), &["http", "https", "ftp", "mailto", "magnet"]), (("img", "src"), &["mxc"])];
+
+/// Extra allowed schemes of URIs per HTML tag and attribute tuple.
 ///
-/// [HTML tags and attributes]: https://spec.matrix.org/v1.2/client-server-api/#mroommessage-msgtypes
-#[derive(Debug, Clone)]
-pub struct HtmlSanitizer<'a> {
-    /// HTML tags that will be left in the output of the sanitizer.
-    ///
-    /// If this is `None`, all the tags are allowed.
-    ///
-    /// If this is `Some`, tags that are not present in this list will be removed, but their
-    /// children will still be present in the output.
-    ///
-    /// To remove all tags, set this to `Some(Vec::new())`.
-    pub allowed_tags: Option<HashSet<&'a str>>,
+/// This is a convenience list to add schemes that can be encountered but are not listed in the
+/// Matrix specification. It consists of:
+///
+/// * The `matrix` scheme for `a` tags (see [matrix-org/matrix-spec#1108]).
+///
+/// To get a complete list, add these to `ALLOWED_SCHEMES_STRICT`.
+///
+/// [matrix-org/matrix-spec#1108]: https://github.com/matrix-org/matrix-spec/issues/1108
+pub const ALLOWED_SCHEMES_COMPAT: [((&str, &str), &[&str]); 1] = [(("a", "href"), &["matrix"])];
 
-    /// HTML tags whose content will be removed.
-    ///
-    /// These tags will be removed from the output with their children.
-    ///
-    /// If a tag is both in `allowed_tags` and `remove_content_tags`, the sanitizer will panic.
-    pub remove_content_tags: HashSet<&'a str>,
+/// Allowed classes per HTML tag according to the Matrix specification.
+pub const ALLOWED_CLASSES_STRICT: [(&str, &[&str]); 1] = [("code", &["language-*"])];
 
-    /// HTML attributes per tag that will be left in the output of the sanitizer.
-    ///
-    /// If this is `None`, all the attributes are allowed on all tags.
-    ///
-    /// If this is `Some`, attributes that are not present in this list will be removed, even on
-    /// tags that are not listed.
-    ///
-    /// To remove all attributes, set this to `Some(HashMap::new())`.
-    pub allowed_attributes: Option<HashMap<&'a str, HashSet<&'a str>>>,
-
-    /// URI scheme per tag and attribute tuple that will be left in the output of the sanitizer.
-    ///
-    /// This only checks URIs in `href` and `src` attributes.
-    ///
-    /// If this is `None`, all the URIs are allowed.
-    ///
-    /// If this is `Some`, URIs that are not present in this list will be removed, even on
-    /// tags and attributes that are not listed.
-    ///
-    /// If no attribute that allows a URI is allowed, this will have no effect.
-    pub allowed_schemes: Option<HashMap<(&'a str, &'a str), HashSet<&'a str>>>,
-
-    /// Class name per tag that will be left in the output of the sanitizer.
-    ///
-    /// The class names to match allow the following wildcards:
-    ///
-    /// * `?` matches exactly one occurrence of any character.
-    /// * `*` matches arbitrary many (including zero) occurrences of any character.
-    ///
-    /// If this is `None`, all the class names are allowed.
-    ///
-    /// If this is `Some`, class names that are not present in this list will be removed, even on
-    /// tags that are not listed.
-    ///
-    /// If no `class` attribute is allowed, this will have no effect.
-    pub allowed_classes: Option<HashMap<&'a str, HashSet<&'a str>>>,
-
-    /// The maximum depth at which tags can be nested.
-    ///
-    /// If this is `None`, any depth is allowed.
-    ///
-    /// If this is `Some`, all tags deeper than this will be removed.
-    pub max_depth: Option<u32>,
-}
-
-impl<'a> HtmlSanitizer<'a> {
-    /// List of tags allowed in the Matrix specification.
-    pub const ALLOWED_TAGS_STRICT_WITH_REPLY: HashSet<&'static str> = hashset! {
-        "font",
-        "del",
-        "h1",
-        "h2",
-        "h3",
-        "h4",
-        "h5",
-        "h6",
-        "blockquote",
-        "p",
-        "a",
-        "ul",
-        "ol",
-        "sup",
-        "sub",
-        "li",
-        "b",
-        "i",
-        "u",
-        "strong",
-        "em",
-        "strike",
-        "code",
-        "hr",
-        "br",
-        "div",
-        "table",
-        "thead",
-        "tbody",
-        "tr",
-        "th",
-        "td",
-        "caption",
-        "pre",
-        "span",
-        "img",
-        "details",
-        "summary",
-        "mx-reply",
-    };
-
-    pub const ALLOWED_TAGS_STRICT_WITHOUT_REPLY: HashSet<&'static str> = hashset! {
-        "font",
-        "del",
-        "h1",
-        "h2",
-        "h3",
-        "h4",
-        "h5",
-        "h6",
-        "blockquote",
-        "p",
-        "a",
-        "ul",
-        "ol",
-        "sup",
-        "sub",
-        "li",
-        "b",
-        "i",
-        "u",
-        "strong",
-        "em",
-        "strike",
-        "code",
-        "hr",
-        "br",
-        "div",
-        "table",
-        "thead",
-        "tbody",
-        "tr",
-        "th",
-        "td",
-        "caption",
-        "pre",
-        "span",
-        "img",
-        "details",
-        "summary",
-    };
-
-    /// The tag name for a rich reply.
-    pub const RICH_REPLY_TAG: &'static str = "mx-reply";
-
-    /// Allowed attributes per tag according to the Matrix specification.
-    pub const ALLOWED_ATTRIBUTES_STRICT: HashMap<&'static str, HashSet<&'static str>> = hashmap! {
-        "font" => hashset!{"data-mx-bg-color", "data-mx-color", "color"},
-        "span" => hashset!{"data-mx-bg-color", "data-mx-color", "data-mx-spoiler"},
-        "a" => hashset!{"name", "target", "href"},
-        "img" => hashset!{"width", "height", "alt", "title", "src"},
-        "ol" => hashset!{"start"},
-        "code" => hashset!{"class"},
-    };
-
-    /// Allowed scheme of URLs per tag according to the Matrix specification.
-    pub const ALLOWED_SCHEMES_STRICT: HashMap<(&'static str, &'static str), HashSet<&'static str>> = hashmap! {
-        ("a", "href") => hashset!{"http", "https", "ftp", "mailto", "magnet"},
-        ("img", "src") => hashset!{"mxc"},
-    };
-
-    /// Allowed scheme of URIs per tag, `STRICT_ALLOWED_SCHEME` plus the `matrix:` URI scheme for
-    /// links.
-    pub const ALLOWED_SCHEMES_COMPAT: HashMap<(&'static str, &'static str), HashSet<&'static str>> = hashmap! {
-        ("a", "href") => hashset!{"http", "https", "ftp", "mailto", "magnet", "matrix"},
-        ("img", "src") => hashset!{"mxc"},
-    };
-
-    /// Allowed classes per tag according to the Matrix specification.
-    pub const ALLOWED_CLASSES_STRICT: HashMap<&'static str, HashSet<&'static str>> = hashmap! {
-        "code" => hashset!{"language-*"},
-    };
-
-    /// Max depth of nested tags allowed by the Matrix specification.
-    pub const MAX_DEPTH_STRICT: u32 = 100;
-
-    /// Constructs a `Sanitizer` instance configured with the strict lists.
-    ///
-    /// It can also optionally remove the [rich reply fallback].
-    ///
-    /// [rich reply fallback]: https://spec.matrix.org/v1.2/client-server-api/#fallbacks-for-rich-replies
-    pub fn new(remove_reply_fallback: RemoveReplyFallback) -> Self {
-        let (allowed_tags, remove_content_tags) =
-            if remove_reply_fallback == RemoveReplyFallback::Yes {
-                (Self::ALLOWED_TAGS_STRICT_WITHOUT_REPLY, hashset! {Self::RICH_REPLY_TAG})
-            } else {
-                (Self::ALLOWED_TAGS_STRICT_WITH_REPLY, HashSet::new())
-            };
-        Self {
-            allowed_tags: Some(allowed_tags),
-            remove_content_tags,
-            allowed_attributes: Some(Self::ALLOWED_ATTRIBUTES_STRICT),
-            allowed_schemes: Some(Self::ALLOWED_SCHEMES_STRICT),
-            allowed_classes: Some(Self::ALLOWED_CLASSES_STRICT),
-            max_depth: Some(Self::MAX_DEPTH_STRICT),
-        }
-    }
-
-    /// Constructs a `Sanitizer` instance configured with the compat lists that are available.
-    ///
-    /// Defaults to using the strict lists for the parameters without compat lists.
-    ///
-    /// It can also optionally remove the [rich reply fallback].
-    ///
-    /// [rich reply fallback]: https://spec.matrix.org/v1.2/client-server-api/#fallbacks-for-rich-replies
-    pub fn compat(remove_reply_fallback: RemoveReplyFallback) -> Self {
-        let mut sanitizer = Self::new(remove_reply_fallback);
-        sanitizer.allowed_schemes = Some(Self::ALLOWED_SCHEMES_COMPAT);
-        sanitizer
-    }
-
-    /// Constructs a `Sanitizer` that does nothing.
-    pub fn empty() -> Self {
-        Self {
-            allowed_tags: None,
-            remove_content_tags: HashSet::new(),
-            allowed_attributes: None,
-            allowed_schemes: None,
-            allowed_classes: None,
-            max_depth: None,
-        }
-    }
-
-    /// Constructs a `Sanitizer` instance that only removes the [rich reply fallback].
-    ///
-    /// [rich reply fallback]: https://spec.matrix.org/v1.2/client-server-api/#fallbacks-for-rich-replies
-    pub fn remove_reply_fallback() -> Self {
-        let mut sanitizer = Self::empty();
-        sanitizer.remove_content_tags = hashset!(Self::RICH_REPLY_TAG);
-        sanitizer
-    }
-
-    /// Clean the given HTML string with this sanitizer.
-    pub fn clean(&self, html: &str) -> String {
-        let html = Html::parse_fragment(html);
-        let root = html.root_element();
-        for child in root.children() {
-            self.clean_node(child, 1)
-        }
-        root.html()
-    }
-
-    fn clean_node(&self, node: NodeRef<Node>, depth: u32) -> NodeRef<Node> {
-        node
-    }
-}
+/// Max depth of nested HTML tags allowed by the Matrix specification.
+pub const MAX_DEPTH_STRICT: u32 = 100;
 
 /// Sanitize the given HTML string.
 ///
@@ -269,21 +92,36 @@ impl<'a> HtmlSanitizer<'a> {
 /// [tags and attributes]: https://spec.matrix.org/v1.2/client-server-api/#mroommessage-msgtypes
 /// [rich reply fallback]: https://spec.matrix.org/v1.2/client-server-api/#fallbacks-for-rich-replies
 #[cfg(feature = "sanitize")]
-pub fn sanitize_html(s: &str, remove_reply_fallback: RemoveReplyFallback) -> String {
-    let mut builder = ammonia::Builder::empty();
-    builder.add_url_schemes(allowed_urls).add_tags(allowed_tags).link_rel(Some("noopener"));
-
-    for (tag, attr) in allowed_attributes {
-        builder.add_tag_attributes(tag, attr);
-    }
-
-    if remove_reply_fallback == RemoveReplyFallback::Yes {
-        builder.add_clean_content_tags(["mx-reply"]);
+pub fn sanitize_html(
+    s: &str,
+    mode: HtmlSanitizerMode,
+    remove_reply_fallback: RemoveReplyFallback,
+) -> String {
+    let sanitizer = if mode == HtmlSanitizerMode::Compat {
+        HtmlSanitizer::compat(remove_reply_fallback)
     } else {
-        builder.add_tags(["mx-reply"]);
-    }
+        HtmlSanitizer::new(remove_reply_fallback)
+    };
+    sanitizer.clean(s)
+}
 
-    builder.clean(s).to_string()
+/// What HTML [tags and attributes] should be kept by the sanitizer.
+///
+/// [tags and attributes]: https://spec.matrix.org/v1.2/client-server-api/#mroommessage-msgtypes
+#[cfg(feature = "sanitize")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[allow(clippy::exhaustive_enums)]
+pub enum HtmlSanitizerMode {
+    /// Keep only the tags and attributes listed in the Matrix specification.
+    ///
+    /// This uses the `STRICT` constants.
+    Strict,
+
+    /// Keeps all the tags ant attributes in `Strict` mode, and others that are not in this section
+    /// of the spec, but might be encountered.
+    ///
+    /// This uses the `COMPAT` constants when available, otherwise it uses the `STRICT` constants.
+    Compat,
 }
 
 /// Whether to remove the [rich reply fallback] while sanitizing.
@@ -298,6 +136,18 @@ pub enum RemoveReplyFallback {
 
     /// Don't remove the rich reply fallback.
     No,
+}
+
+/// Remove the [rich reply fallback] of the given HTML string.
+///
+/// Due to the fact that the HTML is parsed, note that malformed HTML and comments will be stripped
+/// from the output.
+///
+/// [rich reply fallback]: https://spec.matrix.org/v1.2/client-server-api/#fallbacks-for-rich-replies
+#[cfg(feature = "sanitize")]
+pub fn remove_html_reply_fallback(s: &str) -> String {
+    let sanitizer = HtmlSanitizer::reply_fallback_remover();
+    sanitizer.clean(s)
 }
 
 /// Remove the [rich reply fallback] of the given plain text string.
@@ -322,7 +172,9 @@ pub fn remove_plain_reply_fallback(s: &str) -> &str {
 mod tests {
     use super::remove_plain_reply_fallback;
     #[cfg(feature = "sanitize")]
-    use super::{sanitize_html, RemoveReplyFallback};
+    use super::{
+        remove_html_reply_fallback, sanitize_html, HtmlSanitizerMode, RemoveReplyFallback,
+    };
 
     #[test]
     #[cfg(feature = "sanitize")]
@@ -340,6 +192,7 @@ mod tests {
             <removed>This has no tag</removed>\
             <p>But this is inside a tag</p>\
             ",
+            HtmlSanitizerMode::Strict,
             RemoveReplyFallback::No
         );
 
@@ -348,8 +201,8 @@ mod tests {
             "\
             <mx-reply>\
                 <blockquote>\
-                    <a href=\"https://matrix.to/#/!n8f893n9:example.com/$1598361704261elfgc:localhost\" rel=\"noopener\">In reply to</a> \
-                    <a href=\"https://matrix.to/#/@alice:example.com\" rel=\"noopener\">@alice:example.com</a>\
+                    <a href=\"https://matrix.to/#/!n8f893n9:example.com/$1598361704261elfgc:localhost\">In reply to</a> \
+                    <a href=\"https://matrix.to/#/@alice:example.com\">@alice:example.com</a>\
                     <br>\
                     Previous message\
                 </blockquote>\
@@ -376,6 +229,7 @@ mod tests {
             <removed>This has no tag</removed>\
             <p>But this is inside a tag</p>\
             ",
+            HtmlSanitizerMode::Strict,
             RemoveReplyFallback::Yes
         );
 
@@ -383,6 +237,33 @@ mod tests {
             sanitized,
             "\
             This has no tag\
+            <p>But this is inside a tag</p>\
+            "
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "sanitize")]
+    fn remove_html_reply() {
+        let without_reply = remove_html_reply_fallback(
+            "\
+            <mx-reply>\
+                <blockquote>\
+                    <a href=\"https://matrix.to/#/!n8f893n9:example.com/$1598361704261elfgc:localhost\">In reply to</a> \
+                    <a href=\"https://matrix.to/#/@alice:example.com\">@alice:example.com</a>\
+                    <br>\
+                    Previous message\
+                </blockquote>\
+            </mx-reply>\
+            <keep-me>This keeps its tag</keep-me>\
+            <p>But this is inside a tag</p>\
+            ",
+        );
+
+        assert_eq!(
+            without_reply,
+            "\
+            <keep-me>This keeps its tag</keep-me>\
             <p>But this is inside a tag</p>\
             "
         );

--- a/crates/ruma-common/src/events/room/message/sanitize.rs
+++ b/crates/ruma-common/src/events/room/message/sanitize.rs
@@ -70,19 +70,16 @@ pub fn remove_html_reply_fallback(s: &str) -> String {
 /// Remove the [rich reply fallback] of the given plain text string.
 ///
 /// [rich reply fallback]: https://spec.matrix.org/v1.2/client-server-api/#fallbacks-for-rich-replies
-pub fn remove_plain_reply_fallback(s: &str) -> &str {
-    if !s.starts_with("> ") {
-        s
-    } else {
-        let mut start = 0;
-        for (pos, _) in s.match_indices('\n') {
-            if !&s[pos + 1..].starts_with("> ") {
-                start = pos + 1;
-                break;
-            }
+pub fn remove_plain_reply_fallback(mut s: &str) -> &str {
+    while s.starts_with("> ") {
+        if let Some((_line, rest)) = s.split_once('\n') {
+            s = rest;
+        } else {
+            return "";
         }
-        &s[start..]
     }
+
+    s
 }
 
 #[cfg(test)]

--- a/crates/ruma-common/src/events/room/message/sanitize.rs
+++ b/crates/ruma-common/src/events/room/message/sanitize.rs
@@ -147,7 +147,7 @@ mod tests {
             <p>But this is inside a tag</p>\
             ",
             HtmlSanitizerMode::Strict,
-            RemoveReplyFallback::Yes
+            RemoveReplyFallback::Yes,
         );
 
         assert_eq!(
@@ -195,7 +195,9 @@ mod tests {
 
         assert_eq!(
             remove_plain_reply_fallback(
-                "> <@user:notareal.hs> Replied to on\n> two lines\nThis is my reply"
+                "> <@user:notareal.hs> Replied to on\n\
+                 > two lines\n\
+                 This is my reply"
             ),
             "This is my reply"
         );

--- a/crates/ruma-common/src/events/room/message/sanitize.rs
+++ b/crates/ruma-common/src/events/room/message/sanitize.rs
@@ -1,6 +1,8 @@
 //! Convenience methods and types to sanitize text messages.
 
 #[cfg(feature = "sanitize")]
+mod html_fragment;
+#[cfg(feature = "sanitize")]
 mod html_sanitizer;
 
 #[cfg(feature = "sanitize")]

--- a/crates/ruma-common/src/events/room/message/sanitize.rs
+++ b/crates/ruma-common/src/events/room/message/sanitize.rs
@@ -1,11 +1,11 @@
 //! Convenience methods and types to sanitize text messages.
 
-#[cfg(feature = "sanitize")]
+#[cfg(feature = "unstable-sanitize")]
 mod html_fragment;
-#[cfg(feature = "sanitize")]
+#[cfg(feature = "unstable-sanitize")]
 mod html_sanitizer;
 
-#[cfg(feature = "sanitize")]
+#[cfg(feature = "unstable-sanitize")]
 use html_sanitizer::HtmlSanitizer;
 
 /// Sanitize the given HTML string.
@@ -16,7 +16,7 @@ use html_sanitizer::HtmlSanitizer;
 ///
 /// [tags and attributes]: https://spec.matrix.org/v1.2/client-server-api/#mroommessage-msgtypes
 /// [rich reply fallback]: https://spec.matrix.org/v1.2/client-server-api/#fallbacks-for-rich-replies
-#[cfg(feature = "sanitize")]
+#[cfg(feature = "unstable-sanitize")]
 pub fn sanitize_html(
     s: &str,
     mode: HtmlSanitizerMode,
@@ -29,7 +29,7 @@ pub fn sanitize_html(
 /// What HTML [tags and attributes] should be kept by the sanitizer.
 ///
 /// [tags and attributes]: https://spec.matrix.org/v1.2/client-server-api/#mroommessage-msgtypes
-#[cfg(feature = "sanitize")]
+#[cfg(feature = "unstable-sanitize")]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[allow(clippy::exhaustive_enums)]
 pub enum HtmlSanitizerMode {
@@ -44,7 +44,7 @@ pub enum HtmlSanitizerMode {
 /// Whether to remove the [rich reply fallback] while sanitizing.
 ///
 /// [rich reply fallback]: https://spec.matrix.org/v1.2/client-server-api/#fallbacks-for-rich-replies
-#[cfg(feature = "sanitize")]
+#[cfg(feature = "unstable-sanitize")]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[allow(clippy::exhaustive_enums)]
 pub enum RemoveReplyFallback {
@@ -61,7 +61,7 @@ pub enum RemoveReplyFallback {
 /// from the output.
 ///
 /// [rich reply fallback]: https://spec.matrix.org/v1.2/client-server-api/#fallbacks-for-rich-replies
-#[cfg(feature = "sanitize")]
+#[cfg(feature = "unstable-sanitize")]
 pub fn remove_html_reply_fallback(s: &str) -> String {
     let sanitizer = HtmlSanitizer::reply_fallback_remover();
     sanitizer.clean(s)
@@ -85,13 +85,13 @@ pub fn remove_plain_reply_fallback(mut s: &str) -> &str {
 #[cfg(test)]
 mod tests {
     use super::remove_plain_reply_fallback;
-    #[cfg(feature = "sanitize")]
+    #[cfg(feature = "unstable-sanitize")]
     use super::{
         remove_html_reply_fallback, sanitize_html, HtmlSanitizerMode, RemoveReplyFallback,
     };
 
     #[test]
-    #[cfg(feature = "sanitize")]
+    #[cfg(feature = "unstable-sanitize")]
     fn sanitize() {
         let sanitized = sanitize_html(
             "\
@@ -128,7 +128,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "sanitize")]
+    #[cfg(feature = "unstable-sanitize")]
     fn sanitize_without_reply() {
         let sanitized = sanitize_html(
             "\
@@ -157,7 +157,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "sanitize")]
+    #[cfg(feature = "unstable-sanitize")]
     fn remove_html_reply() {
         let without_reply = remove_html_reply_fallback(
             "\

--- a/crates/ruma-common/src/events/room/message/sanitize.rs
+++ b/crates/ruma-common/src/events/room/message/sanitize.rs
@@ -36,8 +36,8 @@ pub enum HtmlSanitizerMode {
     /// Keep only the tags and attributes listed in the Matrix specification.
     Strict,
 
-    /// Keeps all the tags and attributes in `Strict` mode, and others that are not in this section
-    /// of the spec, but might be encountered.
+    /// Like `Strict` mode, with additional tags and attributes that are not yet included in
+    /// the spec, but are reasonable to keep.
     Compat,
 }
 

--- a/crates/ruma-common/src/events/room/message/sanitize/html_fragment.rs
+++ b/crates/ruma-common/src/events/room/message/sanitize/html_fragment.rs
@@ -376,3 +376,21 @@ pub struct ElementData {
     /// The attributes of the element.
     pub attrs: BTreeSet<Attribute>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Fragment;
+
+    #[test]
+    fn sanity() {
+        let html = "\
+            <h1>Title</h1>\
+            <div>\
+                <p>This is some <em>text</em></p>\
+            </div>\
+        ";
+        assert_eq!(Fragment::parse_html(html).to_string(), html);
+
+        assert_eq!(Fragment::parse_html("").to_string(), "");
+    }
+}

--- a/crates/ruma-common/src/events/room/message/sanitize/html_fragment.rs
+++ b/crates/ruma-common/src/events/room/message/sanitize/html_fragment.rs
@@ -11,7 +11,7 @@ use tracing::warn;
 
 /// An HTML fragment.
 ///
-/// To get the serialized HTML, use its `ToString` implementation.
+/// To get the serialized HTML, use its `Display` implementation.
 #[derive(Debug)]
 pub struct Fragment {
     pub nodes: Vec<Node>,

--- a/crates/ruma-common/src/events/room/message/sanitize/html_fragment.rs
+++ b/crates/ruma-common/src/events/room/message/sanitize/html_fragment.rs
@@ -7,6 +7,7 @@ use html5ever::{
     tree_builder::{NodeOrText, TreeSink},
     Attribute, ParseOpts, QualName,
 };
+use tracing::warn;
 
 /// An HTML fragment.
 ///
@@ -106,7 +107,9 @@ impl TreeSink for Fragment {
         self
     }
 
-    fn parse_error(&mut self, _msg: std::borrow::Cow<'static, str>) {}
+    fn parse_error(&mut self, msg: std::borrow::Cow<'static, str>) {
+        warn!("HTML parse error: {msg}");
+    }
 
     fn get_document(&mut self) -> Self::Handle {
         0

--- a/crates/ruma-common/src/events/room/message/sanitize/html_fragment.rs
+++ b/crates/ruma-common/src/events/room/message/sanitize/html_fragment.rs
@@ -1,0 +1,375 @@
+use std::{collections::BTreeSet, fmt, io};
+
+use html5ever::{
+    local_name, namespace_url, ns, parse_fragment,
+    serialize::{serialize, Serialize, SerializeOpts, Serializer, TraversalScope},
+    tendril::{StrTendril, TendrilSink},
+    tree_builder::{NodeOrText, TreeSink},
+    Attribute, ParseOpts, QualName,
+};
+
+/// An HTML fragment.
+///
+/// To get the serialized HTML, use its `ToString` implementation.
+#[derive(Debug)]
+pub struct Fragment {
+    pub nodes: Vec<Node>,
+}
+
+impl Fragment {
+    /// Construct a new `Fragment` by parsing the given HTML.
+    pub fn parse_html(html: &str) -> Self {
+        let sink = Self::default();
+        let mut parser = parse_fragment(
+            sink,
+            ParseOpts::default(),
+            QualName::new(None, ns!(html), local_name!("div")),
+            Vec::new(),
+        );
+        parser.process(html.into());
+        parser.finish()
+    }
+
+    /// Construct a new `Node` with the given data and add it to this `Fragment`.
+    ///
+    /// Returns the index of the new node.
+    pub fn new_node(&mut self, data: NodeData) -> usize {
+        self.nodes.push(Node::new(data));
+        self.nodes.len() - 1
+    }
+
+    /// Append the given node to the given parent in this `Fragment`.
+    ///
+    /// The node is detached from its previous position.
+    pub fn append_node(&mut self, parent_id: usize, node_id: usize) {
+        self.detach(node_id);
+
+        self.nodes[node_id].parent = Some(parent_id);
+        if let Some(last_child) = self.nodes[parent_id].last_child.take() {
+            self.nodes[node_id].prev_sibling = Some(last_child);
+            self.nodes[last_child].next_sibling = Some(node_id);
+        } else {
+            self.nodes[parent_id].first_child = Some(node_id);
+        }
+        self.nodes[parent_id].last_child = Some(node_id);
+    }
+
+    /// Insert the given node before the given sibling in this `Fragment`.
+    ///
+    /// The node is detached from its previous position.
+    pub fn insert_before(&mut self, sibling_id: usize, node_id: usize) {
+        self.detach(node_id);
+
+        self.nodes[node_id].parent = self.nodes[sibling_id].parent;
+        self.nodes[node_id].next_sibling = Some(sibling_id);
+        if let Some(prev_sibling) = self.nodes[sibling_id].prev_sibling.take() {
+            self.nodes[node_id].prev_sibling = Some(prev_sibling);
+            self.nodes[prev_sibling].next_sibling = Some(node_id);
+        } else if let Some(parent) = self.nodes[sibling_id].parent {
+            self.nodes[parent].first_child = Some(node_id);
+        }
+        self.nodes[sibling_id].prev_sibling = Some(node_id);
+    }
+
+    /// Detach the given node from this `Fragment`.
+    pub fn detach(&mut self, node_id: usize) {
+        let (parent, prev_sibling, next_sibling) = {
+            let node = &mut self.nodes[node_id];
+            (node.parent.take(), node.prev_sibling.take(), node.next_sibling.take())
+        };
+
+        if let Some(next_sibling) = next_sibling {
+            self.nodes[next_sibling].prev_sibling = prev_sibling;
+        } else if let Some(parent) = parent {
+            self.nodes[parent].last_child = prev_sibling;
+        }
+
+        if let Some(prev_sibling) = prev_sibling {
+            self.nodes[prev_sibling].next_sibling = next_sibling;
+        } else if let Some(parent) = parent {
+            self.nodes[parent].first_child = next_sibling;
+        }
+    }
+}
+
+impl Default for Fragment {
+    fn default() -> Self {
+        Self { nodes: vec![Node::new(NodeData::Document)] }
+    }
+}
+
+impl TreeSink for Fragment {
+    type Handle = usize;
+    type Output = Self;
+
+    fn finish(self) -> Self::Output {
+        self
+    }
+
+    fn parse_error(&mut self, _msg: std::borrow::Cow<'static, str>) {}
+
+    fn get_document(&mut self) -> Self::Handle {
+        0
+    }
+
+    fn elem_name<'a>(&'a self, target: &'a Self::Handle) -> html5ever::ExpandedName<'a> {
+        self.nodes[*target].as_element().expect("not an element").name.expanded()
+    }
+
+    fn create_element(
+        &mut self,
+        name: QualName,
+        attrs: Vec<Attribute>,
+        _flags: html5ever::tree_builder::ElementFlags,
+    ) -> Self::Handle {
+        self.new_node(NodeData::Element(ElementData { name, attrs: attrs.into_iter().collect() }))
+    }
+
+    fn create_comment(&mut self, _text: StrTendril) -> Self::Handle {
+        self.new_node(NodeData::Other)
+    }
+
+    fn create_pi(&mut self, _target: StrTendril, _data: StrTendril) -> Self::Handle {
+        self.new_node(NodeData::Other)
+    }
+
+    fn append(&mut self, parent: &Self::Handle, child: NodeOrText<Self::Handle>) {
+        match child {
+            NodeOrText::AppendNode(index) => self.append_node(*parent, index),
+            NodeOrText::AppendText(text) => {
+                // If the previous sibling is also text, add this text to it.
+                if let Some(sibling) =
+                    self.nodes[*parent].last_child.and_then(|child| self.nodes[child].as_text_mut())
+                {
+                    sibling.push_tendril(&text);
+                } else {
+                    let index = self.new_node(NodeData::Text(text));
+                    self.append_node(*parent, index);
+                }
+            }
+        }
+    }
+
+    fn append_based_on_parent_node(
+        &mut self,
+        element: &Self::Handle,
+        prev_element: &Self::Handle,
+        child: NodeOrText<Self::Handle>,
+    ) {
+        if self.nodes[*element].parent.is_some() {
+            self.append_before_sibling(element, child)
+        } else {
+            self.append(prev_element, child)
+        }
+    }
+
+    fn append_doctype_to_document(
+        &mut self,
+        _name: StrTendril,
+        _public_id: StrTendril,
+        _system_id: StrTendril,
+    ) {
+    }
+
+    fn get_template_contents(&mut self, target: &Self::Handle) -> Self::Handle {
+        *target
+    }
+
+    fn same_node(&self, x: &Self::Handle, y: &Self::Handle) -> bool {
+        x == y
+    }
+
+    fn set_quirks_mode(&mut self, _mode: html5ever::tree_builder::QuirksMode) {}
+
+    fn append_before_sibling(
+        &mut self,
+        sibling: &Self::Handle,
+        new_node: NodeOrText<Self::Handle>,
+    ) {
+        match new_node {
+            NodeOrText::AppendNode(index) => self.insert_before(*sibling, index),
+            NodeOrText::AppendText(text) => {
+                // If the previous sibling is also text, add this text to it.
+                if let Some(prev_text) = self.nodes[*sibling]
+                    .prev_sibling
+                    .and_then(|prev| self.nodes[prev].as_text_mut())
+                {
+                    prev_text.push_tendril(&text);
+                } else {
+                    let index = self.new_node(NodeData::Text(text));
+                    self.insert_before(*sibling, index)
+                }
+            }
+        }
+    }
+
+    fn add_attrs_if_missing(&mut self, target: &Self::Handle, attrs: Vec<html5ever::Attribute>) {
+        let target = self.nodes[*target].as_element_mut().unwrap();
+        target.attrs.extend(attrs.into_iter())
+    }
+
+    fn remove_from_parent(&mut self, target: &Self::Handle) {
+        self.detach(*target);
+    }
+
+    fn reparent_children(&mut self, node: &Self::Handle, new_parent: &Self::Handle) {
+        let mut next_child = self.nodes[*node].first_child;
+        while let Some(child) = next_child {
+            next_child = self.nodes[child].next_sibling;
+            self.append_node(*new_parent, child);
+        }
+    }
+}
+
+impl Serialize for Fragment {
+    fn serialize<S>(&self, serializer: &mut S, traversal_scope: TraversalScope) -> io::Result<()>
+    where
+        S: Serializer,
+    {
+        match traversal_scope {
+            TraversalScope::IncludeNode => {
+                let root = self.nodes[0].first_child.unwrap();
+
+                let mut next_child = self.nodes[root].first_child;
+                while let Some(child) = next_child {
+                    let child = &self.nodes[child];
+                    child.serialize(self, serializer)?;
+                    next_child = child.next_sibling;
+                }
+
+                Ok(())
+            }
+            TraversalScope::ChildrenOnly(_) => Ok(()),
+        }
+    }
+}
+
+impl fmt::Display for Fragment {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut u8_vec = Vec::new();
+        serialize(
+            &mut u8_vec,
+            self,
+            SerializeOpts { traversal_scope: TraversalScope::IncludeNode, ..Default::default() },
+        )
+        .unwrap();
+
+        f.write_str(&String::from_utf8(u8_vec).unwrap())?;
+
+        Ok(())
+    }
+}
+
+/// An HTML node.
+#[derive(Debug)]
+pub struct Node {
+    pub parent: Option<usize>,
+    pub prev_sibling: Option<usize>,
+    pub next_sibling: Option<usize>,
+    pub first_child: Option<usize>,
+    pub last_child: Option<usize>,
+    pub data: NodeData,
+}
+
+impl Node {
+    /// Constructs a new `Node` with the given data.
+    pub fn new(data: NodeData) -> Self {
+        Self {
+            parent: None,
+            prev_sibling: None,
+            next_sibling: None,
+            first_child: None,
+            last_child: None,
+            data,
+        }
+    }
+
+    /// Returns the `ElementData` of this `Node` if it is a `NodeData::Element`.
+    pub fn as_element(&self) -> Option<&ElementData> {
+        match &self.data {
+            NodeData::Element(data) => Some(data),
+            _ => None,
+        }
+    }
+
+    /// Returns the mutable `ElementData` of this `Node` if it is a `NodeData::Element`.
+    pub fn as_element_mut(&mut self) -> Option<&mut ElementData> {
+        match &mut self.data {
+            NodeData::Element(data) => Some(data),
+            _ => None,
+        }
+    }
+
+    /// Returns the mutable text content of this `Node`, if it is a `NodeData::Text`.
+    pub fn as_text_mut(&mut self) -> Option<&mut StrTendril> {
+        match &mut self.data {
+            NodeData::Text(data) => Some(data),
+            _ => None,
+        }
+    }
+}
+
+impl Node {
+    pub fn serialize<S>(&self, fragment: &Fragment, serializer: &mut S) -> io::Result<()>
+    where
+        S: Serializer,
+    {
+        match &self.data {
+            NodeData::Element(ref data) => {
+                serializer.start_elem(
+                    data.name.clone(),
+                    data.attrs.iter().map(|attr| (&attr.name, &*attr.value)),
+                )?;
+
+                let mut next_child = self.first_child;
+                while let Some(child) = next_child {
+                    let child = &fragment.nodes[child];
+                    child.serialize(fragment, serializer)?;
+                    next_child = child.next_sibling;
+                }
+
+                serializer.end_elem(data.name.clone())?;
+
+                Ok(())
+            }
+            NodeData::Document => {
+                let mut next_child = self.first_child;
+                while let Some(child) = next_child {
+                    let child = &fragment.nodes[child];
+                    child.serialize(fragment, serializer)?;
+                    next_child = child.next_sibling;
+                }
+
+                Ok(())
+            }
+            NodeData::Text(ref text) => serializer.write_text(&**text),
+            _ => Ok(()),
+        }
+    }
+}
+
+/// The data of a `Node`.
+#[derive(Debug)]
+pub enum NodeData {
+    /// The root node of the `Fragment`.
+    Document,
+
+    /// A text node.
+    Text(StrTendril),
+
+    /// An HTML element (aka a tag).
+    Element(ElementData),
+
+    /// Other types (comment, processing instruction, …).
+    Other,
+}
+
+/// The data of an HTML element.
+#[derive(Debug)]
+pub struct ElementData {
+    /// The qualified name of the element.
+    pub name: QualName,
+
+    /// The attributes of the element.
+    pub attrs: BTreeSet<Attribute>,
+}

--- a/crates/ruma-common/src/events/room/message/sanitize/html_fragment.rs
+++ b/crates/ruma-common/src/events/room/message/sanitize/html_fragment.rs
@@ -7,7 +7,7 @@ use html5ever::{
     tree_builder::{NodeOrText, TreeSink},
     Attribute, ParseOpts, QualName,
 };
-use tracing::warn;
+use tracing::debug;
 
 /// An HTML fragment.
 ///
@@ -108,7 +108,7 @@ impl TreeSink for Fragment {
     }
 
     fn parse_error(&mut self, msg: std::borrow::Cow<'static, str>) {
-        warn!("HTML parse error: {msg}");
+        debug!("HTML parse error: {msg}");
     }
 
     fn get_document(&mut self) -> Self::Handle {

--- a/crates/ruma-common/src/events/room/message/sanitize/html_sanitizer.rs
+++ b/crates/ruma-common/src/events/room/message/sanitize/html_sanitizer.rs
@@ -1,0 +1,547 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use html5ever::{local_name, namespace_url, ns, QualName};
+use kuchiki::{parse_fragment, traits::TendrilSink, Attributes, ElementData, NodeData, NodeRef};
+use wildmatch::WildMatch;
+
+use super::{
+    RemoveReplyFallback, ALLOWED_ATTRIBUTES_STRICT, ALLOWED_CLASSES_STRICT, ALLOWED_SCHEMES_COMPAT,
+    ALLOWED_SCHEMES_STRICT, ALLOWED_TAGS_STRICT_WITHOUT_REPLY, MAX_DEPTH_STRICT, RICH_REPLY_TAG,
+};
+
+/// A sanitizer to filter [HTML tags and attributes] according to the Matrix specification.
+///
+/// [HTML tags and attributes]: https://spec.matrix.org/v1.2/client-server-api/#mroommessage-msgtypes
+#[derive(Debug, Clone)]
+pub struct HtmlSanitizer<'a> {
+    /// HTML tags that will be left in the output of the sanitizer.
+    ///
+    /// If this is `None`, all the tags are allowed.
+    ///
+    /// If this is `Some`, tags that are not present in this list will be removed, but their
+    /// children will still be present in the output.
+    ///
+    /// To remove all tags, set this to `Some(Vec::new())`.
+    pub allowed_tags: Option<BTreeSet<&'a str>>,
+
+    /// HTML tags whose content will be removed.
+    ///
+    /// These tags will be removed from the output with their children.
+    ///
+    /// If a tag is both in `allowed_tags` and `remove_content_tags`, the behavior is unexpected.
+    pub remove_content_tags: BTreeSet<&'a str>,
+
+    /// HTML attributes per tag that will be left in the output of the sanitizer.
+    ///
+    /// If this is `None`, all the attributes are allowed on all tags.
+    ///
+    /// If this is `Some`, attributes that are not present in this list will be removed, even on
+    /// tags that are not listed.
+    ///
+    /// To remove all attributes, set this to `Some(BTreeMap::new())`.
+    pub allowed_attributes: Option<BTreeMap<&'a str, BTreeSet<&'a str>>>,
+
+    /// URI scheme per tag and attribute tuple that will be left in the output of the sanitizer.
+    ///
+    /// If this is `None`, all the URIs are allowed.
+    ///
+    /// If this is `Some`, URIs that are not present in this list will be removed. Tags and
+    /// attributes tuples that are not in this list are ignored.
+    ///
+    /// If no attribute that allows a URI is allowed, this will have no effect.
+    pub allowed_schemes: Option<BTreeMap<(&'a str, &'a str), BTreeSet<&'a str>>>,
+
+    /// Class name per tag that will be left in the output of the sanitizer.
+    ///
+    /// The class names to match allow the following wildcards:
+    ///
+    /// * `?` matches exactly one occurrence of any character.
+    /// * `*` matches arbitrary many (including zero) occurrences of any character.
+    ///
+    /// If this is `None`, all the class names are allowed.
+    ///
+    /// If this is `Some`, class names that are not present in this list will be removed. Tags that
+    /// are not in this list are ignored.
+    ///
+    /// If no `class` attribute is allowed, this will have no effect.
+    pub allowed_classes: Option<BTreeMap<&'a str, BTreeSet<&'a str>>>,
+
+    /// The maximum depth at which tags can be nested.
+    ///
+    /// If this is `None`, any depth is allowed.
+    ///
+    /// If this is `Some`, all tags deeper than this will be removed.
+    pub max_depth: Option<u32>,
+}
+
+impl<'a> HtmlSanitizer<'a> {
+    /// Constructs a `HTMLSanitizer` configured with the strict lists.
+    ///
+    /// It can also optionally remove the [rich reply fallback].
+    ///
+    /// [rich reply fallback]: https://spec.matrix.org/v1.2/client-server-api/#fallbacks-for-rich-replies
+    pub fn new(remove_reply_fallback: RemoveReplyFallback) -> Self {
+        let (allowed_tags, remove_content_tags) =
+            if remove_reply_fallback == RemoveReplyFallback::Yes {
+                let allowed_tags = BTreeSet::from(ALLOWED_TAGS_STRICT_WITHOUT_REPLY);
+                let remove_content_tags = BTreeSet::from([RICH_REPLY_TAG]);
+                (allowed_tags, remove_content_tags)
+            } else {
+                let allowed_tags = BTreeSet::from_iter(
+                    ALLOWED_TAGS_STRICT_WITHOUT_REPLY.into_iter().chain([RICH_REPLY_TAG]),
+                );
+                let remove_content_tags = BTreeSet::new();
+                (allowed_tags, remove_content_tags)
+            };
+
+        let allowed_attributes = BTreeMap::from_iter(
+            ALLOWED_ATTRIBUTES_STRICT
+                .into_iter()
+                .map(|(s, attrs)| (s, BTreeSet::from_iter(attrs.iter().copied()))),
+        );
+        let allowed_schemes = BTreeMap::from_iter(
+            ALLOWED_SCHEMES_STRICT
+                .into_iter()
+                .map(|(s, attrs)| (s, BTreeSet::from_iter(attrs.iter().copied()))),
+        );
+        let allowed_classes = BTreeMap::from_iter(
+            ALLOWED_CLASSES_STRICT
+                .into_iter()
+                .map(|(s, attrs)| (s, BTreeSet::from_iter(attrs.iter().copied()))),
+        );
+        Self {
+            allowed_tags: Some(allowed_tags),
+            remove_content_tags,
+            allowed_attributes: Some(allowed_attributes),
+            allowed_schemes: Some(allowed_schemes),
+            allowed_classes: Some(allowed_classes),
+            max_depth: Some(MAX_DEPTH_STRICT),
+        }
+    }
+
+    /// Constructs a `HTMLSanitizer` configured with the compat lists.
+    ///
+    /// Defaults to using the strict lists for the fields without compat lists.
+    ///
+    /// It can also optionally remove the [rich reply fallback].
+    ///
+    /// [rich reply fallback]: https://spec.matrix.org/v1.2/client-server-api/#fallbacks-for-rich-replies
+    pub fn compat(remove_reply_fallback: RemoveReplyFallback) -> Self {
+        let mut sanitizer = Self::new(remove_reply_fallback);
+        if let Some(allowed_schemes) = sanitizer.allowed_schemes.as_mut() {
+            for (key, schemes) in ALLOWED_SCHEMES_COMPAT {
+                allowed_schemes.entry(key).or_default().extend(schemes.iter().copied());
+            }
+        }
+        sanitizer
+    }
+
+    /// Constructs a `HTMLSanitizer` that does nothing.
+    pub fn empty() -> Self {
+        Self {
+            allowed_tags: None,
+            remove_content_tags: BTreeSet::new(),
+            allowed_attributes: None,
+            allowed_schemes: None,
+            allowed_classes: None,
+            max_depth: None,
+        }
+    }
+
+    /// Constructs a `HTMLSanitizer` instance that only removes the [rich reply fallback].
+    ///
+    /// [rich reply fallback]: https://spec.matrix.org/v1.2/client-server-api/#fallbacks-for-rich-replies
+    pub fn reply_fallback_remover() -> Self {
+        let mut sanitizer = Self::empty();
+        sanitizer.remove_content_tags = BTreeSet::from([RICH_REPLY_TAG]);
+        sanitizer
+    }
+
+    /// Clean the given HTML string with this sanitizer.
+    pub fn clean(&self, html: &str) -> String {
+        let mut parser =
+            parse_fragment(QualName::new(None, ns!(html), local_name!("div")), Vec::new());
+        parser.process(html.into());
+        let dom = parser.finish();
+        let root = dom.first_child().unwrap();
+
+        for child in root.children() {
+            self.clean_node(child, 0);
+        }
+
+        let mut buf: Vec<u8> = Vec::new();
+        for child in root.children() {
+            child.serialize(&mut buf).unwrap();
+        }
+
+        String::from_utf8(buf).unwrap()
+    }
+
+    fn clean_node(&self, node: NodeRef, depth: u32) {
+        match node.data() {
+            NodeData::Element(ElementData { name, attributes, .. }) => {
+                let tag: &str = &name.local;
+                let action = self.element_action(tag, &attributes.borrow(), depth);
+
+                if action != ElementAction::Remove {
+                    for child in node.children() {
+                        if action == ElementAction::Ignore {
+                            node.insert_before(child.clone());
+                        }
+                        self.clean_node(child, depth + 1);
+                    }
+                }
+
+                if matches!(action, ElementAction::Ignore | ElementAction::Remove) {
+                    node.detach();
+                } else {
+                    self.clean_attributes(&mut attributes.borrow_mut(), tag);
+                }
+            }
+            NodeData::Text(_) => {}
+            _ => node.detach(),
+        }
+    }
+
+    fn element_action(&self, tag: &str, attributes: &Attributes, depth: u32) -> ElementAction {
+        if self.remove_content_tags.contains(tag)
+            || self.max_depth.filter(|d| *d <= depth).is_some()
+        {
+            ElementAction::Remove
+        } else if self.allowed_tags.as_ref().filter(|tags| !tags.contains(tag)).is_some() {
+            ElementAction::Ignore
+        } else if let Some(allowed_schemes) = &self.allowed_schemes {
+            for (name, val) in &attributes.map {
+                let attr: &str = &name.local;
+
+                // Check if there is a (tag, attr) tuple entry.
+                if let Some(schemes) = allowed_schemes.get(&(tag, attr)) {
+                    // Check if the scheme is allowed.
+                    if !schemes.iter().any(|scheme| val.value.starts_with(&format!("{scheme}:"))) {
+                        return ElementAction::Ignore;
+                    }
+                }
+            }
+            ElementAction::None
+        } else {
+            ElementAction::None
+        }
+    }
+
+    fn clean_attributes(&self, attributes: &mut Attributes, tag: &str) {
+        let removed_attributes: Vec<_> = attributes
+            .map
+            .iter_mut()
+            .filter_map(|(name, mut val)| {
+                let attr: &str = &name.local;
+
+                if let Some(allowed_attributes) = &self.allowed_attributes {
+                    if allowed_attributes.get(tag).filter(|attrs| attrs.contains(attr)).is_none() {
+                        return Some(attr.to_owned());
+                    }
+                }
+
+                if let Some(allowed_classes) =
+                    self.allowed_classes.as_ref().filter(|_| attr == "class")
+                {
+                    if let Some(classes) = allowed_classes.get(tag) {
+                        let attr_classes = val.value.split_whitespace().filter(|attr_class| {
+                            for class in classes.iter() {
+                                if WildMatch::new(class).matches(attr_class) {
+                                    return true;
+                                }
+                            }
+                            false
+                        });
+                        let folded_classes = attr_classes.fold(String::new(), |mut a, b| {
+                            a.reserve(b.len() + 1);
+                            a.push_str(b);
+                            a.push('\n');
+                            a
+                        });
+                        let final_classes = folded_classes.trim_end();
+
+                        if final_classes.is_empty() {
+                            return Some(attr.to_owned());
+                        } else if val.value != final_classes {
+                            val.value = final_classes.to_owned();
+                        }
+                    }
+                }
+
+                None
+            })
+            .collect();
+
+        for name in removed_attributes {
+            attributes.remove(name);
+        }
+    }
+}
+
+/// The possible actions to apply to an element node.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ElementAction {
+    /// Don't do anything.
+    None,
+
+    /// Remove the element but keep its children.
+    Ignore,
+
+    /// Remove the element and its children.
+    Remove,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{HtmlSanitizer, RemoveReplyFallback};
+
+    #[test]
+    fn valid_input() {
+        let sanitizer = HtmlSanitizer::new(RemoveReplyFallback::Yes);
+        let sanitized = sanitizer.clean(
+            "\
+            <ul><li>This</li><li>has</li><li>no</li><li>tag</li></ul>\
+            <p>This is a paragraph <span data-mx-color=\"green\">with some color</span></p>\
+            <img src=\"mxc://notareal.hs/abcdef\">\
+            <code class=\"language-html\">&lt;mx-reply&gt;This is a fake reply&lt;/mx-reply&gt;</code>\
+            ",
+        );
+
+        assert_eq!(
+            sanitized,
+            "\
+            <ul><li>This</li><li>has</li><li>no</li><li>tag</li></ul>\
+            <p>This is a paragraph <span data-mx-color=\"green\">with some color</span></p>\
+            <img src=\"mxc://notareal.hs/abcdef\">\
+            <code class=\"language-html\">&lt;mx-reply&gt;This is a fake reply&lt;/mx-reply&gt;</code>\
+            "
+        );
+    }
+
+    #[test]
+    fn tags_remove() {
+        let sanitizer = HtmlSanitizer::new(RemoveReplyFallback::No);
+        let sanitized = sanitizer.clean(
+            "\
+            <mx-reply>\
+                <blockquote>\
+                    <a href=\"https://matrix.to/#/!n8f893n9:example.com/$1598361704261elfgc:localhost\">In reply to</a> \
+                    <a href=\"https://matrix.to/#/@alice:example.com\">@alice:example.com</a>\
+                    <br>\
+                    Previous message\
+                </blockquote>\
+            </mx-reply>\
+            <removed>This has no tag</removed>\
+            <p>But this is inside a tag</p>\
+            ",
+        );
+
+        assert_eq!(
+            sanitized,
+            "\
+            <mx-reply>\
+                <blockquote>\
+                    <a href=\"https://matrix.to/#/!n8f893n9:example.com/$1598361704261elfgc:localhost\">In reply to</a> \
+                    <a href=\"https://matrix.to/#/@alice:example.com\">@alice:example.com</a>\
+                    <br>\
+                    Previous message\
+                </blockquote>\
+            </mx-reply>\
+            This has no tag\
+            <p>But this is inside a tag</p>\
+            "
+        );
+    }
+
+    #[test]
+    fn tags_remove_without_reply() {
+        let sanitizer = HtmlSanitizer::new(RemoveReplyFallback::Yes);
+        let sanitized = sanitizer.clean(
+            "\
+            <mx-reply>\
+                <blockquote>\
+                    <a href=\"https://matrix.to/#/!n8f893n9:example.com/$1598361704261elfgc:localhost\">In reply to</a> \
+                    <a href=\"https://matrix.to/#/@alice:example.com\">@alice:example.com</a>\
+                    <br>\
+                    Previous message\
+                </blockquote>\
+            </mx-reply>\
+            <removed>This has no tag</removed>\
+            <p>But this is inside a tag</p>\
+            ",
+        );
+
+        assert_eq!(
+            sanitized,
+            "\
+            This has no tag\
+            <p>But this is inside a tag</p>\
+            "
+        );
+    }
+
+    #[test]
+    fn tags_remove_only_reply_fallback() {
+        let sanitizer = HtmlSanitizer::reply_fallback_remover();
+        let sanitized = sanitizer.clean(
+            "\
+            <mx-reply>\
+                <blockquote>\
+                    <a href=\"https://matrix.to/#/!n8f893n9:example.com/$1598361704261elfgc:localhost\">In reply to</a> \
+                    <a href=\"https://matrix.to/#/@alice:example.com\">@alice:example.com</a>\
+                    <br>\
+                    Previous message\
+                </blockquote>\
+            </mx-reply>\
+            <keep-me>This keeps its tag</keep-me>\
+            <p>But this is inside a tag</p>\
+            ",
+        );
+
+        assert_eq!(
+            sanitized,
+            "\
+            <keep-me>This keeps its tag</keep-me>\
+            <p>But this is inside a tag</p>\
+            "
+        );
+    }
+
+    #[test]
+    fn attrs_remove() {
+        let sanitizer = HtmlSanitizer::new(RemoveReplyFallback::No);
+        let sanitized = sanitizer.clean(
+            "\
+            <h1 id=\"anchor1\">Title for important stuff</h1>\
+            <p class=\"important\">Look at <font color=\"blue\" size=20>me!</font></p>\
+            ",
+        );
+
+        assert_eq!(
+            sanitized,
+            "\
+            <h1>Title for important stuff</h1>\
+            <p>Look at <font color=\"blue\">me!</font></p>\
+            "
+        );
+    }
+
+    #[test]
+    fn img_remove_scheme() {
+        let sanitizer = HtmlSanitizer::new(RemoveReplyFallback::No);
+        let sanitized = sanitizer.clean(
+            "\
+            <p>Look at that picture:</p>\
+            <img src=\"https://notareal.hs/abcdef\">\
+            ",
+        );
+
+        assert_eq!(
+            sanitized,
+            "\
+            <p>Look at that picture:</p>\
+            "
+        );
+    }
+
+    #[test]
+    fn link_remove_scheme() {
+        let sanitizer = HtmlSanitizer::new(RemoveReplyFallback::No);
+        let sanitized = sanitizer.clean(
+            "\
+            <p>Go see <a href=\"file://local/file.html\">my local website</a></p>\
+            ",
+        );
+
+        assert_eq!(
+            sanitized,
+            "\
+            <p>Go see my local website</p>\
+            "
+        );
+    }
+
+    #[test]
+    fn link_compat_scheme() {
+        let sanitizer = HtmlSanitizer::new(RemoveReplyFallback::No);
+        let sanitized = sanitizer.clean(
+            "\
+            <p>Join <a href=\"matrix:r/myroom:notareal.hs\">my room</a></p>\
+            <p>To talk about <a href=\"https://mycat.org\">my cat</a></p>\
+            ",
+        );
+        assert_eq!(
+            sanitized,
+            "\
+            <p>Join my room</p>\
+            <p>To talk about <a href=\"https://mycat.org\">my cat</a></p>\
+            "
+        );
+
+        let sanitizer = HtmlSanitizer::compat(RemoveReplyFallback::No);
+        let sanitized = sanitizer.clean(
+            "\
+            <p>Join <a href=\"matrix:r/myroom:notareal.hs\">my room</a></p>\
+            <p>To talk about <a href=\"https://mycat.org\">my cat</a></p>\
+            ",
+        );
+        assert_eq!(
+            sanitized,
+            "\
+            <p>Join <a href=\"matrix:r/myroom:notareal.hs\">my room</a></p>\
+            <p>To talk about <a href=\"https://mycat.org\">my cat</a></p>\
+            "
+        );
+    }
+
+    #[test]
+    fn class_remove() {
+        let sanitizer = HtmlSanitizer::new(RemoveReplyFallback::No);
+        let sanitized = sanitizer.clean(
+            "\
+            <pre><code class=\"language-rust custom-class\">
+                type StringList = Vec&lt;String&gt;;
+            </code></pre>\
+            <p>What do you think of the name <code class=\"fake-language-rust\">StringList</code>?</p>\
+            ",
+        );
+
+        assert_eq!(
+            sanitized,
+            "\
+            <pre><code class=\"language-rust\">
+                type StringList = Vec&lt;String&gt;;
+            </code></pre>\
+            <p>What do you think of the name <code>StringList</code>?</p>\
+            "
+        );
+    }
+
+    #[test]
+    fn depth_remove() {
+        let mut sanitizer = HtmlSanitizer::new(RemoveReplyFallback::No);
+        sanitizer.max_depth = Some(2);
+        let sanitized = sanitizer.clean(
+            "\
+            <div>\
+                <p>\
+                    <span>I am in too deep!</span>\
+                    I should be fine.\
+                </p>\
+            </div>\
+            ",
+        );
+
+        assert_eq!(
+            sanitized,
+            "\
+            <div>\
+                <p>\
+                    I should be fine.\
+                </p>\
+            </div>\
+            "
+        );
+    }
+}

--- a/crates/ruma-common/tests/events/room_message.rs
+++ b/crates/ruma-common/tests/events/room_message.rs
@@ -492,6 +492,8 @@ fn content_deserialization_failure() {
 #[test]
 #[cfg(feature = "sanitize")]
 fn reply_sanitize() {
+    use ruma_common::events::room::message::TextMessageEventContent;
+
     let first_message = OriginalRoomMessageEvent {
         content: RoomMessageEventContent::text_html(
             "# This is the first message",

--- a/crates/ruma-common/tests/events/room_message.rs
+++ b/crates/ruma-common/tests/events/room_message.rs
@@ -490,7 +490,7 @@ fn content_deserialization_failure() {
 }
 
 #[test]
-#[cfg(feature = "sanitize")]
+#[cfg(feature = "unstable-sanitize")]
 fn reply_sanitize() {
     use ruma_common::events::room::message::TextMessageEventContent;
 

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -61,7 +61,6 @@ js = ["ruma-common/js"]
 # Convenience features
 rand = ["ruma-common/rand"]
 markdown = ["ruma-common/markdown"]
-sanitize = ["ruma-common/sanitize"]
 
 # Everything except compat, js and unstable features
 full = [
@@ -78,7 +77,6 @@ full = [
     "push-gateway-api",
     "rand",
     "markdown",
-    "sanitize",
 ]
 
 # Increase compatibility with other parts of the Matrix ecosystem, at the
@@ -118,6 +116,7 @@ unstable-pre-spec = [
     "ruma-federation-api?/unstable-pre-spec",
     "ruma-push-gateway-api?/unstable-pre-spec",
 ]
+unstable-sanitize = ["ruma-common/unstable-sanitize"]
 unstable-msc1767 = ["ruma-common/unstable-msc1767"]
 unstable-msc2246 = ["ruma-client-api?/unstable-msc2246"]
 unstable-msc2448 = [
@@ -159,6 +158,7 @@ unstable-msc3723 = ["ruma-federation-api?/unstable-msc3723"]
 __ci = [
     "full",
     "unstable-pre-spec",
+    "unstable-sanitize",
     "unstable-msc1767",
     "unstable-msc2448",
     "unstable-msc2666",

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -61,6 +61,7 @@ js = ["ruma-common/js"]
 # Convenience features
 rand = ["ruma-common/rand"]
 markdown = ["ruma-common/markdown"]
+sanitize = ["ruma-common/sanitize"]
 
 # Everything except compat, js and unstable features
 full = [
@@ -77,6 +78,7 @@ full = [
     "push-gateway-api",
     "rand",
     "markdown",
+    "sanitize",
 ]
 
 # Increase compatibility with other parts of the Matrix ecosystem, at the

--- a/crates/ruma/src/lib.rs
+++ b/crates/ruma/src/lib.rs
@@ -37,9 +37,9 @@
 //!
 //! These features are only useful if you want to use a method that requires it:
 //!
-//! * `either`
 //! * `rand`
 //! * `markdown`
+//! * `sanitize`
 //!
 //! # Unstable features
 //!

--- a/crates/ruma/src/lib.rs
+++ b/crates/ruma/src/lib.rs
@@ -39,7 +39,6 @@
 //!
 //! * `rand`
 //! * `markdown`
-//! * `sanitize`
 //!
 //! # Unstable features
 //!
@@ -51,6 +50,8 @@
 //! * `unstable-mscXXXX`, where `XXXX` is the MSC number -- Upcoming Matrix features that may be
 //!   subject to change or removal.
 //! * `unstable-pre-spec` -- Undocumented Matrix features that may be subject to change or removal.
+//! * `unstable-sanitize` -- Convenience methods for spec-compliant HTML sanitization that have not
+//!   been thoroughly tested.
 //!
 //! # Common features
 //!


### PR DESCRIPTION
Can also remove rich reply fallbacks.

Behind the `unstable-sanitize` feature.




























<!-- Replace -->
Preview removed
<!-- Replace -->
