### PR TITLE
ruma-common: split test assertions

### DIFF
--- a/crates/ruma-common/src/events/ignored_user_list.rs
+++ b/crates/ruma-common/src/events/ignored_user_list.rs
@@ -28,12 +28,14 @@ impl IgnoredUserListEventContent {
 
 #[cfg(test)]
 mod tests {
-    use crate::user_id;
     use assert_matches::assert_matches;
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
-    use super::{IgnoredUserListEvent, IgnoredUserListEventContent};
-    use crate::events::{AnyGlobalAccountDataEvent, GlobalAccountDataEvent};
+    use super::IgnoredUserListEventContent;
+    use crate::{
+        events::{AnyGlobalAccountDataEvent, GlobalAccountDataEvent},
+        user_id,
+    };
 
     #[test]
     fn serialization() {
@@ -66,15 +68,10 @@ mod tests {
             "type": "m.ignored_user_list"
         });
 
-        assert_matches!(
-            from_json_value::<AnyGlobalAccountDataEvent>(json).unwrap(),
-            AnyGlobalAccountDataEvent::IgnoredUserList(
-                IgnoredUserListEvent {
-                    content: IgnoredUserListEventContent {
-                        ignored_users
-                    },
-                })
-         if ignored_users == vec![user_id!("@carl:example.com")]
+        let ev = assert_matches!(
+            from_json_value::<AnyGlobalAccountDataEvent>(json),
+            Ok(AnyGlobalAccountDataEvent::IgnoredUserList(ev)) => ev
         );
+        assert_eq!(ev.content.ignored_users, vec![user_id!("@carl:example.com")]);
     }
 }

--- a/crates/ruma-common/src/events/key/verification/done.rs
+++ b/crates/ruma-common/src/events/key/verification/done.rs
@@ -49,12 +49,10 @@ impl KeyVerificationDoneEventContent {
 
 #[cfg(test)]
 mod tests {
-    use crate::event_id;
-    use assert_matches::assert_matches;
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     use super::KeyVerificationDoneEventContent;
-    use crate::events::key::verification::Relation;
+    use crate::{event_id, events::key::verification::Relation};
 
     #[test]
     fn serialization() {
@@ -74,22 +72,14 @@ mod tests {
 
     #[test]
     fn deserialization() {
-        let id = event_id!("$1598361704261elfgc:localhost");
-
         let json_data = json!({
             "m.relates_to": {
                 "rel_type": "m.reference",
-                "event_id": id,
+                "event_id": "$1598361704261elfgc:localhost",
             }
         });
 
-        assert_matches!(
-            from_json_value::<KeyVerificationDoneEventContent>(json_data).unwrap(),
-            KeyVerificationDoneEventContent {
-                relates_to: Relation {
-                    event_id
-                },
-            } if *event_id == *id
-        );
+        let content = from_json_value::<KeyVerificationDoneEventContent>(json_data).unwrap();
+        assert_eq!(content.relates_to.event_id, "$1598361704261elfgc:localhost");
     }
 }

--- a/crates/ruma-common/src/events/key/verification/ready.rs
+++ b/crates/ruma-common/src/events/key/verification/ready.rs
@@ -74,12 +74,14 @@ impl KeyVerificationReadyEventContent {
 
 #[cfg(test)]
 mod tests {
-    use crate::{event_id, OwnedDeviceId};
-    use assert_matches::assert_matches;
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     use super::{KeyVerificationReadyEventContent, ToDeviceKeyVerificationReadyEventContent};
-    use crate::events::key::verification::{Relation, VerificationMethod};
+    use crate::{
+        event_id,
+        events::key::verification::{Relation, VerificationMethod},
+        OwnedDeviceId,
+    };
 
     #[test]
     fn serialization() {
@@ -120,46 +122,30 @@ mod tests {
 
     #[test]
     fn deserialization() {
-        let id = event_id!("$1598361704261elfgc:localhost");
-        let device: OwnedDeviceId = "123".into();
-
         let json_data = json!({
-            "from_device": device,
+            "from_device": "123",
             "methods": ["m.sas.v1"],
             "m.relates_to": {
                 "rel_type": "m.reference",
-                "event_id": id,
+                "event_id": "$1598361704261elfgc:localhost",
             }
         });
 
-        assert_matches!(
-            from_json_value::<KeyVerificationReadyEventContent>(json_data).unwrap(),
-            KeyVerificationReadyEventContent {
-                from_device,
-                relates_to: Relation {
-                    event_id
-                },
-                methods,
-            } if from_device == device
-                && methods == vec![VerificationMethod::SasV1]
-                && event_id == id
-        );
+        let content = from_json_value::<KeyVerificationReadyEventContent>(json_data).unwrap();
+        assert_eq!(content.from_device, "123");
+        assert_eq!(content.methods, vec![VerificationMethod::SasV1]);
+        assert_eq!(content.relates_to.event_id, "$1598361704261elfgc:localhost");
 
         let json_data = json!({
-            "from_device": device,
+            "from_device": "123",
             "methods": ["m.sas.v1"],
             "transaction_id": "456",
         });
 
-        assert_matches!(
-            from_json_value::<ToDeviceKeyVerificationReadyEventContent>(json_data).unwrap(),
-            ToDeviceKeyVerificationReadyEventContent {
-                from_device,
-                transaction_id,
-                methods,
-            } if from_device == device
-                && methods == vec![VerificationMethod::SasV1]
-                && transaction_id == "456"
-        );
+        let content =
+            from_json_value::<ToDeviceKeyVerificationReadyEventContent>(json_data).unwrap();
+        assert_eq!(content.from_device, "123");
+        assert_eq!(content.methods, vec![VerificationMethod::SasV1]);
+        assert_eq!(content.transaction_id, "456");
     }
 }

--- a/crates/ruma-common/src/events/key/verification/start.rs
+++ b/crates/ruma-common/src/events/key/verification/start.rs
@@ -199,7 +199,6 @@ impl From<SasV1ContentInit> for SasV1Content {
 mod tests {
     use std::collections::BTreeMap;
 
-    use crate::{event_id, serde::Base64, user_id};
     use assert_matches::assert_matches;
     use serde_json::{
         from_value as from_json_value, json, to_value as to_json_value, Value as JsonValue,
@@ -207,11 +206,16 @@ mod tests {
 
     use super::{
         HashAlgorithm, KeyAgreementProtocol, KeyVerificationStartEventContent,
-        MessageAuthenticationCode, ReciprocateV1Content, SasV1Content, SasV1ContentInit,
+        MessageAuthenticationCode, ReciprocateV1Content, SasV1ContentInit,
         ShortAuthenticationString, StartMethod, ToDeviceKeyVerificationStartEventContent,
         _CustomContent,
     };
-    use crate::events::{key::verification::Relation, ToDeviceEvent};
+    use crate::{
+        event_id,
+        events::{key::verification::Relation, ToDeviceEvent},
+        serde::Base64,
+        user_id,
+    };
 
     #[test]
     fn serialization() {
@@ -366,26 +370,21 @@ mod tests {
         });
 
         // Deserialize the content struct separately to verify `TryFromRaw` is implemented for it.
-        assert_matches!(
-            from_json_value::<ToDeviceKeyVerificationStartEventContent>(json).unwrap(),
-            ToDeviceKeyVerificationStartEventContent {
-                from_device,
-                transaction_id,
-                method: StartMethod::SasV1(SasV1Content {
-                    hashes,
-                    key_agreement_protocols,
-                    message_authentication_codes,
-                    short_authentication_string,
-                })
-            } if from_device == "123"
-                && transaction_id == "456"
-                && hashes == vec![HashAlgorithm::Sha256]
-                && key_agreement_protocols == vec![KeyAgreementProtocol::Curve25519]
-                && message_authentication_codes == vec![MessageAuthenticationCode::HkdfHmacSha256]
-                && short_authentication_string == vec![ShortAuthenticationString::Decimal]
-        );
+        let content = from_json_value::<ToDeviceKeyVerificationStartEventContent>(json).unwrap();
+        assert_eq!(content.from_device, "123");
+        assert_eq!(content.transaction_id, "456");
 
-        let sender = user_id!("@example:localhost");
+        let sas = assert_matches!(
+            content.method,
+            StartMethod::SasV1(sas) => sas
+        );
+        assert_eq!(sas.hashes, vec![HashAlgorithm::Sha256]);
+        assert_eq!(sas.key_agreement_protocols, vec![KeyAgreementProtocol::Curve25519]);
+        assert_eq!(
+            sas.message_authentication_codes,
+            vec![MessageAuthenticationCode::HkdfHmacSha256]
+        );
+        assert_eq!(sas.short_authentication_string, vec![ShortAuthenticationString::Decimal]);
 
         let json = json!({
             "content": {
@@ -398,33 +397,26 @@ mod tests {
                 "short_authentication_string": ["decimal"]
             },
             "type": "m.key.verification.start",
-            "sender": sender
+            "sender": "@example:localhost",
         });
 
-        assert_matches!(
-            from_json_value::<ToDeviceEvent<ToDeviceKeyVerificationStartEventContent>>(json).unwrap(),
-            ToDeviceEvent {
-                sender,
-                content: ToDeviceKeyVerificationStartEventContent {
-                    from_device,
-                    transaction_id,
-                    method: StartMethod::SasV1(SasV1Content {
-                        hashes,
-                        key_agreement_protocols,
-                        message_authentication_codes,
-                        short_authentication_string,
-                    })
-                }
-            } if from_device == "123"
-                && sender == user_id!("@example:localhost")
-                && transaction_id == "456"
-                && hashes == vec![HashAlgorithm::Sha256]
-                && key_agreement_protocols == vec![KeyAgreementProtocol::Curve25519]
-                && message_authentication_codes == vec![MessageAuthenticationCode::HkdfHmacSha256]
-                && short_authentication_string == vec![ShortAuthenticationString::Decimal]
-        );
+        let ev = from_json_value::<ToDeviceEvent<ToDeviceKeyVerificationStartEventContent>>(json)
+            .unwrap();
+        assert_eq!(ev.sender, "@example:localhost");
+        assert_eq!(ev.content.from_device, "123");
+        assert_eq!(ev.content.transaction_id, "456");
 
-        let sender = user_id!("@example:localhost");
+        let sas = assert_matches!(
+            ev.content.method,
+            StartMethod::SasV1(sas) => sas
+        );
+        assert_eq!(sas.hashes, vec![HashAlgorithm::Sha256]);
+        assert_eq!(sas.key_agreement_protocols, vec![KeyAgreementProtocol::Curve25519]);
+        assert_eq!(
+            sas.message_authentication_codes,
+            vec![MessageAuthenticationCode::HkdfHmacSha256]
+        );
+        assert_eq!(sas.short_authentication_string, vec![ShortAuthenticationString::Decimal]);
 
         let json = json!({
             "content": {
@@ -434,58 +426,48 @@ mod tests {
                 "test": "field",
             },
             "type": "m.key.verification.start",
-            "sender": sender,
+            "sender": "@example:localhost",
         });
 
-        assert_matches!(
-            from_json_value::<ToDeviceEvent<ToDeviceKeyVerificationStartEventContent>>(json).unwrap(),
-            ToDeviceEvent {
-                sender,
-                content: ToDeviceKeyVerificationStartEventContent {
-                    from_device,
-                    transaction_id,
-                    method: StartMethod::_Custom(_CustomContent { method, data })
-                }
-            } if from_device == "123"
-                && sender == user_id!("@example:localhost")
-                && transaction_id == "456"
-                && method == "m.sas.custom"
-                && data.get("test").unwrap() == &JsonValue::from("field")
+        let ev = from_json_value::<ToDeviceEvent<ToDeviceKeyVerificationStartEventContent>>(json)
+            .unwrap();
+        assert_eq!(ev.sender, "@example:localhost");
+        assert_eq!(ev.content.from_device, "123");
+        assert_eq!(ev.content.transaction_id, "456");
+
+        let custom = assert_matches!(
+            ev.content.method,
+            StartMethod::_Custom(custom) => custom
         );
+        assert_eq!(custom.method, "m.sas.custom");
+        assert_eq!(custom.data.get("test"), Some(&JsonValue::from("field")));
 
-        {
-            let json = json!({
-                "content": {
-                    "from_device": "123",
-                    "method": "m.reciprocate.v1",
-                    "secret": "c2VjcmV0Cg",
-                    "transaction_id": "456",
-                },
-                "type": "m.key.verification.start",
-                "sender": sender,
-            });
+        let json = json!({
+            "content": {
+                "from_device": "123",
+                "method": "m.reciprocate.v1",
+                "secret": "c2VjcmV0Cg",
+                "transaction_id": "456",
+            },
+            "type": "m.key.verification.start",
+            "sender": "@example:localhost",
+        });
 
-            assert_matches!(
-                from_json_value::<ToDeviceEvent<ToDeviceKeyVerificationStartEventContent>>(json).unwrap(),
-                ToDeviceEvent {
-                    sender,
-                    content: ToDeviceKeyVerificationStartEventContent {
-                        from_device,
-                        transaction_id,
-                        method: StartMethod::ReciprocateV1(ReciprocateV1Content { secret }),
-                    }
-                } if from_device == "123"
-                    && sender == user_id!("@example:localhost")
-                    && transaction_id == "456"
-                    && secret.encode() == "c2VjcmV0Cg"
-            );
-        }
+        let ev = from_json_value::<ToDeviceEvent<ToDeviceKeyVerificationStartEventContent>>(json)
+            .unwrap();
+        assert_eq!(ev.sender, "@example:localhost");
+        assert_eq!(ev.content.from_device, "123");
+        assert_eq!(ev.content.transaction_id, "456");
+
+        let reciprocate = assert_matches!(
+            ev.content.method,
+            StartMethod::ReciprocateV1(reciprocate) => reciprocate
+        );
+        assert_eq!(reciprocate.secret.encode(), "c2VjcmV0Cg");
     }
 
     #[test]
     fn in_room_deserialization() {
-        let id = event_id!("$1598361704261elfgc:localhost");
-
         let json = json!({
             "from_device": "123",
             "method": "m.sas.v1",
@@ -495,29 +477,26 @@ mod tests {
             "short_authentication_string": ["decimal"],
             "m.relates_to": {
                 "rel_type": "m.reference",
-                "event_id": id,
+                "event_id": "$1598361704261elfgc:localhost",
             }
         });
 
         // Deserialize the content struct separately to verify `TryFromRaw` is implemented for it.
-        assert_matches!(
-            from_json_value::<KeyVerificationStartEventContent>(json).unwrap(),
-            KeyVerificationStartEventContent {
-                from_device,
-                relates_to: Relation { event_id },
-                method: StartMethod::SasV1(SasV1Content {
-                    hashes,
-                    key_agreement_protocols,
-                    message_authentication_codes,
-                    short_authentication_string,
-                })
-            } if from_device == "123"
-                && event_id == id
-                && hashes == vec![HashAlgorithm::Sha256]
-                && key_agreement_protocols == vec![KeyAgreementProtocol::Curve25519]
-                && message_authentication_codes == vec![MessageAuthenticationCode::HkdfHmacSha256]
-                && short_authentication_string == vec![ShortAuthenticationString::Decimal]
+        let content = from_json_value::<KeyVerificationStartEventContent>(json).unwrap();
+        assert_eq!(content.from_device, "123");
+        assert_eq!(content.relates_to.event_id, "$1598361704261elfgc:localhost");
+
+        let sas = assert_matches!(
+            content.method,
+            StartMethod::SasV1(sas) => sas
         );
+        assert_eq!(sas.hashes, vec![HashAlgorithm::Sha256]);
+        assert_eq!(sas.key_agreement_protocols, vec![KeyAgreementProtocol::Curve25519]);
+        assert_eq!(
+            sas.message_authentication_codes,
+            vec![MessageAuthenticationCode::HkdfHmacSha256]
+        );
+        assert_eq!(sas.short_authentication_string, vec![ShortAuthenticationString::Decimal]);
 
         let json = json!({
             "from_device": "123",
@@ -525,19 +504,18 @@ mod tests {
             "secret": "c2VjcmV0Cg",
             "m.relates_to": {
                 "rel_type": "m.reference",
-                "event_id": id,
+                "event_id": "$1598361704261elfgc:localhost",
             }
         });
 
-        assert_matches!(
-            from_json_value::<KeyVerificationStartEventContent>(json).unwrap(),
-            KeyVerificationStartEventContent {
-                from_device,
-                relates_to: Relation { event_id },
-                method: StartMethod::ReciprocateV1(ReciprocateV1Content { secret }),
-            } if from_device == "123"
-                && event_id == id
-                && secret.encode() == "c2VjcmV0Cg"
+        let content = from_json_value::<KeyVerificationStartEventContent>(json).unwrap();
+        assert_eq!(content.from_device, "123");
+        assert_eq!(content.relates_to.event_id, "$1598361704261elfgc:localhost");
+
+        let reciprocate = assert_matches!(
+            content.method,
+            StartMethod::ReciprocateV1(reciprocate) => reciprocate
         );
+        assert_eq!(reciprocate.secret.encode(), "c2VjcmV0Cg");
     }
 }

--- a/crates/ruma-common/src/events/presence.rs
+++ b/crates/ruma-common/src/events/presence.rs
@@ -79,12 +79,11 @@ impl StaticEventContent for PresenceEventContent {
 
 #[cfg(test)]
 mod tests {
-    use crate::{mxc_uri, presence::PresenceState, user_id};
-    use assert_matches::assert_matches;
     use js_int::uint;
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     use super::{PresenceEvent, PresenceEventContent};
+    use crate::{mxc_uri, presence::PresenceState, user_id};
 
     #[test]
     fn serialization() {
@@ -129,27 +128,21 @@ mod tests {
             "type": "m.presence"
         });
 
-        assert_matches!(
-            from_json_value::<PresenceEvent>(json).unwrap(),
-            PresenceEvent {
-                content: PresenceEventContent {
-                    avatar_url: Some(avatar_url),
-                    currently_active: Some(false),
-                    displayname: None,
-                    last_active_ago: Some(last_active_ago),
-                    presence: PresenceState::Online,
-                    status_msg: Some(status_msg),
-                },
-                sender,
-            } if avatar_url == "mxc://localhost/wefuiwegh8742w"
-                && status_msg == "Making cupcakes"
-                && sender == "@example:localhost"
-                && last_active_ago == uint!(2_478_593)
+        let ev = from_json_value::<PresenceEvent>(json).unwrap();
+        assert_eq!(
+            ev.content.avatar_url.as_deref(),
+            Some(mxc_uri!("mxc://localhost/wefuiwegh8742w"))
         );
+        assert_eq!(ev.content.currently_active, Some(false));
+        assert_eq!(ev.content.displayname, None);
+        assert_eq!(ev.content.last_active_ago, Some(uint!(2_478_593)));
+        assert_eq!(ev.content.presence, PresenceState::Online);
+        assert_eq!(ev.content.status_msg.as_deref(), Some("Making cupcakes"));
+        assert_eq!(ev.sender, "@example:localhost");
 
         #[cfg(feature = "compat")]
-        assert_matches!(
-            from_json_value::<PresenceEvent>(json!({
+        {
+            let json = json!({
                 "content": {
                     "avatar_url": "",
                     "currently_active": false,
@@ -159,20 +152,16 @@ mod tests {
                 },
                 "sender": "@example:localhost",
                 "type": "m.presence"
-            })).unwrap(),
-            PresenceEvent {
-                content: PresenceEventContent {
-                    avatar_url: None,
-                    currently_active: Some(false),
-                    displayname: None,
-                    last_active_ago: Some(last_active_ago),
-                    presence: PresenceState::Online,
-                    status_msg: Some(status_msg),
-                },
-                sender,
-            } if status_msg == "Making cupcakes"
-                && sender == "@example:localhost"
-                && last_active_ago == uint!(2_478_593)
-        );
+            });
+
+            let ev = from_json_value::<PresenceEvent>(json).unwrap();
+            assert_eq!(ev.content.avatar_url, None);
+            assert_eq!(ev.content.currently_active, Some(false));
+            assert_eq!(ev.content.displayname, None);
+            assert_eq!(ev.content.last_active_ago, Some(uint!(2_478_593)));
+            assert_eq!(ev.content.presence, PresenceState::Online);
+            assert_eq!(ev.content.status_msg.as_deref(), Some("Making cupcakes"));
+            assert_eq!(ev.sender, "@example:localhost");
+        }
     }
 }

--- a/crates/ruma-common/src/events/reaction.rs
+++ b/crates/ruma-common/src/events/reaction.rs
@@ -58,28 +58,26 @@ impl Relation {
 
 #[cfg(test)]
 mod tests {
-    use crate::event_id;
     use assert_matches::assert_matches;
     use serde_json::{from_value as from_json_value, json};
 
-    use super::{ReactionEventContent, Relation};
+    use super::ReactionEventContent;
 
     #[test]
     fn deserialize() {
-        let ev_id = event_id!("$1598361704261elfgc:localhost");
-
         let json = json!({
             "m.relates_to": {
                 "rel_type": "m.annotation",
-                "event_id": ev_id,
+                "event_id": "$1598361704261elfgc:localhost",
                 "key": "🦛",
             }
         });
 
-        assert_matches!(
-            from_json_value::<ReactionEventContent>(json).unwrap(),
-            ReactionEventContent { relates_to: Relation { event_id, key } }
-            if event_id == ev_id && key == "🦛"
+        let relates_to = assert_matches!(
+            from_json_value::<ReactionEventContent>(json),
+            Ok(ReactionEventContent { relates_to }) => relates_to
         );
+        assert_eq!(relates_to.event_id, "$1598361704261elfgc:localhost");
+        assert_eq!(relates_to.key, "🦛");
     }
 }

--- a/crates/ruma-common/src/events/room/create.rs
+++ b/crates/ruma-common/src/events/room/create.rs
@@ -140,16 +140,12 @@ mod tests {
             "room_version": "4"
         });
 
-        assert_matches!(
-            from_json_value::<RoomCreateEventContent>(json).unwrap(),
-            RoomCreateEventContent {
-                creator,
-                federate: true,
-                room_version: RoomVersionId::V4,
-                predecessor: None,
-                room_type: None,
-            } if creator == "@carl:example.com"
-        );
+        let content = from_json_value::<RoomCreateEventContent>(json).unwrap();
+        assert_eq!(content.creator, "@carl:example.com");
+        assert!(content.federate);
+        assert_eq!(content.room_version, RoomVersionId::V4);
+        assert_matches!(content.predecessor, None);
+        assert_eq!(content.room_type, None);
     }
 
     #[test]
@@ -161,15 +157,11 @@ mod tests {
             "type": "m.space"
         });
 
-        assert_matches!(
-            from_json_value::<RoomCreateEventContent>(json).unwrap(),
-            RoomCreateEventContent {
-                creator,
-                federate: true,
-                room_version: RoomVersionId::V4,
-                predecessor: None,
-                room_type
-            } if creator == "@carl:example.com" && room_type == Some(RoomType::Space)
-        );
+        let content = from_json_value::<RoomCreateEventContent>(json).unwrap();
+        assert_eq!(content.creator, "@carl:example.com");
+        assert!(content.federate);
+        assert_eq!(content.room_version, RoomVersionId::V4);
+        assert_matches!(content.predecessor, None);
+        assert_eq!(content.room_type, Some(RoomType::Space));
     }
 }

--- a/crates/ruma-common/src/events/room/member.rs
+++ b/crates/ruma-common/src/events/room/member.rs
@@ -456,10 +456,10 @@ mod tests {
     use maplit::btreemap;
     use serde_json::{from_value as from_json_value, json};
 
-    use super::{MembershipState, RoomMemberEventContent, SignedContent, ThirdPartyInvite};
+    use super::{MembershipState, RoomMemberEventContent};
     use crate::{
-        events::{OriginalStateEvent, StateUnsigned},
-        server_name, server_signing_key_id, MilliSecondsSinceUnixEpoch,
+        events::OriginalStateEvent, mxc_uri, server_name, server_signing_key_id, user_id,
+        MilliSecondsSinceUnixEpoch,
     };
 
     #[test]
@@ -476,30 +476,19 @@ mod tests {
             "state_key": "@carl:example.com"
         });
 
-        assert_matches!(
-            from_json_value::<OriginalStateEvent<RoomMemberEventContent>>(json).unwrap(),
-            OriginalStateEvent {
-                content: RoomMemberEventContent {
-                    avatar_url: None,
-                    displayname: None,
-                    is_direct: None,
-                    membership: MembershipState::Join,
-                    third_party_invite: None,
-                    ..
-                },
-                event_id,
-                origin_server_ts,
-                room_id,
-                sender,
-                state_key,
-                unsigned,
-            } if event_id == "$h29iv0s8:example.com"
-                && origin_server_ts == MilliSecondsSinceUnixEpoch(uint!(1))
-                && room_id == "!n8f893n9:example.com"
-                && sender == "@carl:example.com"
-                && state_key == "@carl:example.com"
-                && unsigned.is_empty()
-        );
+        let ev = from_json_value::<OriginalStateEvent<RoomMemberEventContent>>(json).unwrap();
+        assert_eq!(ev.event_id, "$h29iv0s8:example.com");
+        assert_eq!(ev.origin_server_ts, MilliSecondsSinceUnixEpoch(uint!(1)));
+        assert_eq!(ev.room_id, "!n8f893n9:example.com");
+        assert_eq!(ev.sender, "@carl:example.com");
+        assert_eq!(ev.state_key, "@carl:example.com");
+        assert!(ev.unsigned.is_empty());
+
+        assert_eq!(ev.content.avatar_url, None);
+        assert_eq!(ev.content.displayname, None);
+        assert_eq!(ev.content.is_direct, None);
+        assert_eq!(ev.content.membership, MembershipState::Join);
+        assert_matches!(ev.content.third_party_invite, None);
     }
 
     #[test]
@@ -522,39 +511,24 @@ mod tests {
         });
 
         let ev = from_json_value::<OriginalStateEvent<RoomMemberEventContent>>(json).unwrap();
-
-        assert_matches!(
-            ev.content,
-            RoomMemberEventContent {
-                avatar_url: None,
-                displayname: None,
-                is_direct: None,
-                membership: MembershipState::Join,
-                third_party_invite: None,
-                ..
-            }
-        );
-
         assert_eq!(ev.event_id, "$h29iv0s8:example.com");
         assert_eq!(ev.origin_server_ts, MilliSecondsSinceUnixEpoch(uint!(1)));
         assert_eq!(ev.room_id, "!n8f893n9:example.com");
         assert_eq!(ev.sender, "@carl:example.com");
         assert_eq!(ev.state_key, "@carl:example.com");
 
-        assert_matches!(
-            ev.unsigned,
-            StateUnsigned {
-                prev_content: Some(RoomMemberEventContent {
-                    avatar_url: None,
-                    displayname: None,
-                    is_direct: None,
-                    membership: MembershipState::Join,
-                    third_party_invite: None,
-                    ..
-                }),
-                ..
-            }
-        );
+        assert_eq!(ev.content.avatar_url, None);
+        assert_eq!(ev.content.displayname, None);
+        assert_eq!(ev.content.is_direct, None);
+        assert_eq!(ev.content.membership, MembershipState::Join);
+        assert_matches!(ev.content.third_party_invite, None);
+
+        let prev_content = ev.unsigned.prev_content.unwrap();
+        assert_eq!(prev_content.avatar_url, None);
+        assert_eq!(prev_content.displayname, None);
+        assert_eq!(prev_content.is_direct, None);
+        assert_eq!(prev_content.membership, MembershipState::Join);
+        assert_matches!(prev_content.third_party_invite, None);
     }
 
     #[test]
@@ -586,43 +560,34 @@ mod tests {
             "state_key": "@alice:example.org"
         });
 
-        assert_matches!(
-            from_json_value::<OriginalStateEvent<RoomMemberEventContent>>(json).unwrap(),
-            OriginalStateEvent {
-                content: RoomMemberEventContent {
-                    avatar_url: Some(avatar_url),
-                    displayname: Some(displayname),
-                    is_direct: Some(true),
-                    membership: MembershipState::Invite,
-                    third_party_invite: Some(ThirdPartyInvite {
-                        display_name: third_party_displayname,
-                        signed: SignedContent { mxid, signatures, token },
-                    }),
-                    ..
-                },
-                event_id,
-                origin_server_ts,
-                room_id,
-                sender,
-                state_key,
-                unsigned,
-            } if avatar_url == "mxc://example.org/SEsfnsuifSDFSSEF"
-                && displayname == "Alice Margatroid"
-                && third_party_displayname == "alice"
-                && mxid == "@alice:example.org"
-                && signatures == btreemap! {
-                    server_name!("magic.forest").to_owned() => btreemap! {
-                        server_signing_key_id!("ed25519:3").to_owned() => "foobar".to_owned()
-                    }
-                }
-                && token == "abc123"
-                && event_id == "$143273582443PhrSn:example.org"
-                && origin_server_ts == MilliSecondsSinceUnixEpoch(uint!(233))
-                && room_id == "!jEsUZKDJdhlrceRyVU:example.org"
-                && sender == "@alice:example.org"
-                && state_key == "@alice:example.org"
-                && unsigned.is_empty()
+        let ev = from_json_value::<OriginalStateEvent<RoomMemberEventContent>>(json).unwrap();
+        assert_eq!(ev.event_id, "$143273582443PhrSn:example.org");
+        assert_eq!(ev.origin_server_ts, MilliSecondsSinceUnixEpoch(uint!(233)));
+        assert_eq!(ev.room_id, "!jEsUZKDJdhlrceRyVU:example.org");
+        assert_eq!(ev.sender, "@alice:example.org");
+        assert_eq!(ev.state_key, "@alice:example.org");
+        assert!(ev.unsigned.is_empty());
+
+        assert_eq!(
+            ev.content.avatar_url.as_deref(),
+            Some(mxc_uri!("mxc://example.org/SEsfnsuifSDFSSEF"))
         );
+        assert_eq!(ev.content.displayname.as_deref(), Some("Alice Margatroid"));
+        assert_eq!(ev.content.is_direct, Some(true));
+        assert_eq!(ev.content.membership, MembershipState::Invite);
+
+        let third_party_invite = ev.content.third_party_invite.unwrap();
+        assert_eq!(third_party_invite.display_name, "alice");
+        assert_eq!(third_party_invite.signed.mxid, "@alice:example.org");
+        assert_eq!(
+            third_party_invite.signed.signatures,
+            btreemap! {
+                server_name!("magic.forest").to_owned() => btreemap! {
+                    server_signing_key_id!("ed25519:3").to_owned() => "foobar".to_owned()
+                }
+            }
+        );
+        assert_eq!(third_party_invite.signed.token, "abc123");
     }
 
     #[test]
@@ -659,52 +624,40 @@ mod tests {
             },
         });
 
-        assert_matches!(
-            from_json_value::<OriginalStateEvent<RoomMemberEventContent>>(json).unwrap(),
-            OriginalStateEvent {
-                content: RoomMemberEventContent {
-                    avatar_url: None,
-                    displayname: None,
-                    is_direct: None,
-                    membership: MembershipState::Join,
-                    third_party_invite: None,
-                    ..
-                },
-                event_id,
-                origin_server_ts,
-                room_id,
-                sender,
-                state_key,
-                unsigned: StateUnsigned {
-                    prev_content: Some(RoomMemberEventContent {
-                        avatar_url: Some(avatar_url),
-                        displayname: Some(displayname),
-                        is_direct: Some(true),
-                        membership: MembershipState::Invite,
-                        third_party_invite: Some(ThirdPartyInvite {
-                            display_name: third_party_displayname,
-                            signed: SignedContent { mxid, signatures, token },
-                        }),
-                        ..
-                    }),
-                    ..
-                },
-            } if event_id == "$143273582443PhrSn:example.org"
-                && origin_server_ts == MilliSecondsSinceUnixEpoch(uint!(233))
-                && room_id == "!jEsUZKDJdhlrceRyVU:example.org"
-                && sender == "@alice:example.org"
-                && state_key == "@alice:example.org"
-                && avatar_url == "mxc://example.org/SEsfnsuifSDFSSEF"
-                && displayname == "Alice Margatroid"
-                && third_party_displayname == "alice"
-                && mxid == "@alice:example.org"
-                && signatures == btreemap! {
-                    server_name!("magic.forest").to_owned() => btreemap! {
-                        server_signing_key_id!("ed25519:3").to_owned() => "foobar".to_owned()
-                    }
-                }
-                && token == "abc123"
+        let ev = from_json_value::<OriginalStateEvent<RoomMemberEventContent>>(json).unwrap();
+        assert_eq!(ev.event_id, "$143273582443PhrSn:example.org");
+        assert_eq!(ev.origin_server_ts, MilliSecondsSinceUnixEpoch(uint!(233)));
+        assert_eq!(ev.room_id, "!jEsUZKDJdhlrceRyVU:example.org");
+        assert_eq!(ev.sender, "@alice:example.org");
+        assert_eq!(ev.state_key, "@alice:example.org");
+
+        assert_eq!(ev.content.avatar_url, None);
+        assert_eq!(ev.content.displayname, None);
+        assert_eq!(ev.content.is_direct, None);
+        assert_eq!(ev.content.membership, MembershipState::Join);
+        assert_matches!(ev.content.third_party_invite, None);
+
+        let prev_content = ev.unsigned.prev_content.unwrap();
+        assert_eq!(
+            prev_content.avatar_url.as_deref(),
+            Some(mxc_uri!("mxc://example.org/SEsfnsuifSDFSSEF"))
         );
+        assert_eq!(prev_content.displayname.as_deref(), Some("Alice Margatroid"));
+        assert_eq!(prev_content.is_direct, Some(true));
+        assert_eq!(prev_content.membership, MembershipState::Invite);
+
+        let third_party_invite = prev_content.third_party_invite.unwrap();
+        assert_eq!(third_party_invite.display_name, "alice");
+        assert_eq!(third_party_invite.signed.mxid, "@alice:example.org");
+        assert_eq!(
+            third_party_invite.signed.signatures,
+            btreemap! {
+                server_name!("magic.forest").to_owned() => btreemap! {
+                    server_signing_key_id!("ed25519:3").to_owned() => "foobar".to_owned()
+                }
+            }
+        );
+        assert_eq!(third_party_invite.signed.token, "abc123");
     }
 
     #[test]
@@ -722,31 +675,22 @@ mod tests {
             "state_key": "@carl:example.com"
         });
 
-        assert_matches!(
-            from_json_value::<OriginalStateEvent<RoomMemberEventContent>>(json).unwrap(),
-            OriginalStateEvent {
-                content: RoomMemberEventContent {
-                    avatar_url: None,
-                    displayname: None,
-                    is_direct: None,
-                    membership: MembershipState::Join,
-                    third_party_invite: None,
-                    join_authorized_via_users_server: Some(authed),
-                    ..
-                },
-                event_id,
-                origin_server_ts,
-                room_id,
-                sender,
-                state_key,
-                unsigned,
-            } if event_id == "$h29iv0s8:example.com"
-                && origin_server_ts == MilliSecondsSinceUnixEpoch(uint!(1))
-                && room_id == "!n8f893n9:example.com"
-                && sender == "@carl:example.com"
-                && authed == "@notcarl:example.com"
-                && state_key == "@carl:example.com"
-                && unsigned.is_empty()
+        let ev = from_json_value::<OriginalStateEvent<RoomMemberEventContent>>(json).unwrap();
+        assert_eq!(ev.event_id, "$h29iv0s8:example.com");
+        assert_eq!(ev.origin_server_ts, MilliSecondsSinceUnixEpoch(uint!(1)));
+        assert_eq!(ev.room_id, "!n8f893n9:example.com");
+        assert_eq!(ev.sender, "@carl:example.com");
+        assert_eq!(ev.state_key, "@carl:example.com");
+        assert!(ev.unsigned.is_empty());
+
+        assert_eq!(ev.content.avatar_url, None);
+        assert_eq!(ev.content.displayname, None);
+        assert_eq!(ev.content.is_direct, None);
+        assert_eq!(ev.content.membership, MembershipState::Join);
+        assert_matches!(ev.content.third_party_invite, None);
+        assert_eq!(
+            ev.content.join_authorized_via_users_server.as_deref(),
+            Some(user_id!("@notcarl:example.com"))
         );
     }
 }

--- a/crates/ruma-common/src/events/room/thumbnail_source_serde.rs
+++ b/crates/ruma-common/src/events/room/thumbnail_source_serde.rs
@@ -71,11 +71,11 @@ mod tests {
     fn deserialize_plain() {
         let json = json!({ "thumbnail_url": "mxc://notareal.hs/abcdef" });
 
-        assert_matches!(
-            serde_json::from_value::<ThumbnailSourceTest>(json).unwrap(),
-            ThumbnailSourceTest { source: Some(MediaSource::Plain(url)) }
-            if url == "mxc://notareal.hs/abcdef"
+        let url = assert_matches!(
+            serde_json::from_value::<ThumbnailSourceTest>(json),
+            Ok(ThumbnailSourceTest { source: Some(MediaSource::Plain(url)) }) => url
         );
+        assert_eq!(url, "mxc://notareal.hs/abcdef");
     }
 
     #[test]
@@ -98,11 +98,11 @@ mod tests {
             },
         });
 
-        assert_matches!(
-            serde_json::from_value::<ThumbnailSourceTest>(json).unwrap(),
-            ThumbnailSourceTest { source: Some(MediaSource::Encrypted(file)) }
-            if file.url == "mxc://notareal.hs/abcdef"
+        let file = assert_matches!(
+            serde_json::from_value::<ThumbnailSourceTest>(json),
+            Ok(ThumbnailSourceTest { source: Some(MediaSource::Encrypted(file)) }) => file
         );
+        assert_eq!(file.url, "mxc://notareal.hs/abcdef");
     }
 
     #[test]

--- a/crates/ruma-common/src/events/secret/request.rs
+++ b/crates/ruma-common/src/events/secret/request.rs
@@ -219,19 +219,14 @@ mod test {
             "request_id": "randomly_generated_id_9573"
         });
 
-        assert_matches!(
-            from_json_value(json).unwrap(),
-            ToDeviceSecretRequestEventContent {
-                action: RequestAction::Request(
-                    secret
-                ),
-                requesting_device_id,
-                request_id,
-            }
-            if secret == "org.example.some.secret".into()
-                    && requesting_device_id == "ABCDEFG"
-                    && request_id == "randomly_generated_id_9573"
+        let content = from_json_value::<ToDeviceSecretRequestEventContent>(json).unwrap();
+        assert_eq!(content.requesting_device_id, "ABCDEFG");
+        assert_eq!(content.request_id, "randomly_generated_id_9573");
+        let secret = assert_matches!(
+            content.action,
+            RequestAction::Request(secret) => secret
         );
+        assert_eq!(secret.as_str(), "org.example.some.secret");
     }
 
     #[test]
@@ -242,16 +237,10 @@ mod test {
             "request_id": "randomly_generated_id_9573"
         });
 
-        assert_matches!(
-            from_json_value(json).unwrap(),
-            ToDeviceSecretRequestEventContent {
-                action: RequestAction::RequestCancellation,
-                requesting_device_id,
-                request_id,
-            }
-            if requesting_device_id.as_str() == "ABCDEFG"
-                    && request_id == "randomly_generated_id_9573"
-        );
+        let content = from_json_value::<ToDeviceSecretRequestEventContent>(json).unwrap();
+        assert_eq!(content.requesting_device_id, "ABCDEFG");
+        assert_eq!(content.request_id, "randomly_generated_id_9573");
+        assert_matches!(content.action, RequestAction::RequestCancellation);
     }
 
     #[test]
@@ -263,18 +252,14 @@ mod test {
             "request_id": "this_is_a_request_id"
         });
 
-        assert_matches!(
-            from_json_value(json).unwrap(),
-            ToDeviceSecretRequestEventContent {
-                action: RequestAction::Request(
-                    SecretName::RecoveryKey
-                ),
-                requesting_device_id,
-                request_id,
-            }
-            if requesting_device_id == "XYZxyz"
-                    && request_id == "this_is_a_request_id"
+        let content = from_json_value::<ToDeviceSecretRequestEventContent>(json).unwrap();
+        assert_eq!(content.requesting_device_id, "XYZxyz");
+        assert_eq!(content.request_id, "this_is_a_request_id");
+        let secret = assert_matches!(
+            content.action,
+            RequestAction::Request(secret) => secret
         );
+        assert_eq!(secret, SecretName::RecoveryKey);
     }
 
     #[test]
@@ -285,16 +270,9 @@ mod test {
             "request_id": "this_is_a_request_id"
         });
 
-        assert_matches!(
-            from_json_value::<ToDeviceSecretRequestEventContent>(json).unwrap(),
-            ToDeviceSecretRequestEventContent {
-                action,
-                requesting_device_id,
-                request_id,
-            }
-            if action == RequestAction::_Custom(PrivOwnedStr("my_custom_action".into()))
-                && requesting_device_id == "XYZxyz"
-                && request_id == "this_is_a_request_id"
-        );
+        let content = from_json_value::<ToDeviceSecretRequestEventContent>(json).unwrap();
+        assert_eq!(content.requesting_device_id, "XYZxyz");
+        assert_eq!(content.request_id, "this_is_a_request_id");
+        assert_eq!(content.action, RequestAction::_Custom(PrivOwnedStr("my_custom_action".into())));
     }
 }

--- a/crates/ruma-common/src/events/secret_storage/key.rs
+++ b/crates/ruma-common/src/events/secret_storage/key.rs
@@ -133,21 +133,19 @@ mod tests {
             "mac": "aWRvbnRrbm93d2hhdGFtYWNsb29rc2xpa2U"
         });
 
-        assert_matches!(
-            from_json_value(json).unwrap(),
-            SecretStorageKeyEventContent {
-                key_id: _,
-                name,
-                algorithm: SecretEncryptionAlgorithm::SecretStorageV1AesHmacSha2 {
-                    iv,
-                    mac,
-                },
-                passphrase: None,
-            }
-            if name == *"my_key"
-                && iv == Base64::parse("YWJjZGVmZ2hpamtsbW5vcA").unwrap()
-                && mac == Base64::parse("aWRvbnRrbm93d2hhdGFtYWNsb29rc2xpa2U").unwrap()
+        let content = from_json_value::<SecretStorageKeyEventContent>(json).unwrap();
+        assert_eq!(content.name, "my_key");
+        assert_matches!(content.passphrase, None);
+
+        let (iv, mac) = assert_matches!(
+            content.algorithm,
+            SecretEncryptionAlgorithm::SecretStorageV1AesHmacSha2 {
+                iv,
+                mac,
+            } => (iv, mac)
         );
+        assert_eq!(iv.encode(), "YWJjZGVmZ2hpamtsbW5vcA");
+        assert_eq!(mac.encode(), "aWRvbnRrbm93d2hhdGFtYWNsb29rc2xpa2U");
     }
 
     #[test]
@@ -194,29 +192,24 @@ mod tests {
             }
         });
 
-        assert_matches!(
-            from_json_value(json).unwrap(),
-            SecretStorageKeyEventContent {
-                key_id: _key,
-                name,
-                algorithm: SecretEncryptionAlgorithm::SecretStorageV1AesHmacSha2 {
-                    iv,
-                    mac,
-                },
-                passphrase: Some(PassPhrase {
-                    algorithm: KeyDerivationAlgorithm::Pbkfd2,
-                    salt,
-                    iterations,
-                    bits
-                })
-            }
-            if name == *"my_key"
-                && iv == Base64::parse("YWJjZGVmZ2hpamtsbW5vcA").unwrap()
-                && mac == Base64::parse("aWRvbnRrbm93d2hhdGFtYWNsb29rc2xpa2U").unwrap()
-                && salt == *"rocksalt"
-                && iterations == uint!(8)
-                && bits == uint!(256)
+        let content = from_json_value::<SecretStorageKeyEventContent>(json).unwrap();
+        assert_eq!(content.name, "my_key");
+
+        let passphrase = content.passphrase.unwrap();
+        assert_eq!(passphrase.algorithm, KeyDerivationAlgorithm::Pbkfd2);
+        assert_eq!(passphrase.salt, "rocksalt");
+        assert_eq!(passphrase.iterations, uint!(8));
+        assert_eq!(passphrase.bits, uint!(256));
+
+        let (iv, mac) = assert_matches!(
+            content.algorithm,
+            SecretEncryptionAlgorithm::SecretStorageV1AesHmacSha2 {
+                iv,
+                mac,
+            } => (iv, mac)
         );
+        assert_eq!(iv.encode(), "YWJjZGVmZ2hpamtsbW5vcA");
+        assert_eq!(mac.encode(), "aWRvbnRrbm93d2hhdGFtYWNsb29rc2xpa2U");
     }
 
     #[test]
@@ -257,23 +250,20 @@ mod tests {
             }
         });
 
-        assert_matches!(
-            from_json_value(json).unwrap(),
-            GlobalAccountDataEvent {
-                content: SecretStorageKeyEventContent {
-                    key_id,
-                    name,
-                    algorithm: SecretEncryptionAlgorithm::SecretStorageV1AesHmacSha2 {
-                        iv,
-                        mac,
-                    },
-                    passphrase: None,
-                }
-            }
-            if key_id == *"my_key_id"
-                && name == *"my_key"
-                && iv == Base64::parse("YWJjZGVmZ2hpamtsbW5vcA").unwrap()
-                && mac == Base64::parse("aWRvbnRrbm93d2hhdGFtYWNsb29rc2xpa2U").unwrap()
+        let ev =
+            from_json_value::<GlobalAccountDataEvent<SecretStorageKeyEventContent>>(json).unwrap();
+        assert_eq!(ev.content.key_id, "my_key_id");
+        assert_eq!(ev.content.name, "my_key");
+        assert_matches!(ev.content.passphrase, None);
+
+        let (iv, mac) = assert_matches!(
+            ev.content.algorithm,
+            SecretEncryptionAlgorithm::SecretStorageV1AesHmacSha2 {
+                iv,
+                mac,
+            } => (iv, mac)
         );
+        assert_eq!(iv.encode(), "YWJjZGVmZ2hpamtsbW5vcA");
+        assert_eq!(mac.encode(), "aWRvbnRrbm93d2hhdGFtYWNsb29rc2xpa2U");
     }
 }

--- a/crates/ruma-common/src/events/secret_storage/secret.rs
+++ b/crates/ruma-common/src/events/secret_storage/secret.rs
@@ -47,9 +47,8 @@ mod tests {
     use assert_matches::assert_matches;
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
-    use crate::serde::Base64;
-
     use super::{SecretEncryptedData, SecretEventContent};
+    use crate::serde::Base64;
 
     #[test]
     fn test_secret_serialization() {
@@ -90,19 +89,18 @@ mod tests {
         });
 
         let deserialized: SecretEventContent = from_json_value(json).unwrap();
+        let secret_data = deserialized.encrypted.get("key_one").unwrap();
 
-        if let Some(secret_data) = deserialized.encrypted.get("key_one") {
-            assert_matches!(
-                secret_data,
-                SecretEncryptedData::AesHmacSha2EncryptedData {
-                    iv,
-                    ciphertext,
-                    mac
-                }
-                if iv == &Base64::parse("YWJjZGVmZ2hpamtsbW5vcA").unwrap()
-                    && ciphertext == &Base64::parse("dGhpc2lzZGVmaW5pdGVseWNpcGhlcnRleHQ").unwrap()
-                    && mac == &Base64::parse("aWRvbnRrbm93d2hhdGFtYWNsb29rc2xpa2U").unwrap()
-            );
-        }
+        let (iv, ciphertext, mac) = assert_matches!(
+            secret_data,
+            SecretEncryptedData::AesHmacSha2EncryptedData {
+                iv,
+                ciphertext,
+                mac
+            } => (iv, ciphertext, mac)
+        );
+        assert_eq!(iv.encode(), "YWJjZGVmZ2hpamtsbW5vcA");
+        assert_eq!(ciphertext.encode(), "dGhpc2lzZGVmaW5pdGVseWNpcGhlcnRleHQ");
+        assert_eq!(mac.encode(), "aWRvbnRrbm93d2hhdGFtYWNsb29rc2xpa2U");
     }
 }

--- a/crates/ruma-common/src/events/space/child.rs
+++ b/crates/ruma-common/src/events/space/child.rs
@@ -71,7 +71,6 @@ pub struct HierarchySpaceChildEvent {
 
 #[cfg(test)]
 mod tests {
-    use assert_matches::assert_matches;
     use js_int::uint;
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
@@ -145,21 +144,14 @@ mod tests {
             "type": "m.space.child"
         });
 
-        assert_matches!(
-            from_json_value::<HierarchySpaceChildEvent>(json).unwrap(),
-            HierarchySpaceChildEvent {
-                content: SpaceChildEventContent {
-                    via: Some(via),
-                    order: None,
-                    suggested: None,
-                },
-                origin_server_ts,
-                sender,
-                state_key,
-            } if via[0] == "example.org"
-                && origin_server_ts.get() == uint!(1_629_413_349)
-                && sender == "@alice:example.org"
-                && state_key == "!a:example.org"
-        );
+        let ev = from_json_value::<HierarchySpaceChildEvent>(json).unwrap();
+        assert_eq!(ev.origin_server_ts, MilliSecondsSinceUnixEpoch(uint!(1_629_413_349)));
+        assert_eq!(ev.sender, "@alice:example.org");
+        assert_eq!(ev.state_key, "!a:example.org");
+        let via = ev.content.via.unwrap();
+        assert_eq!(via.len(), 1);
+        assert_eq!(via[0], "example.org");
+        assert_eq!(ev.content.order, None);
+        assert_eq!(ev.content.suggested, None);
     }
 }

--- a/crates/ruma-common/src/push.rs
+++ b/crates/ruma-common/src/push.rs
@@ -537,7 +537,7 @@ mod tests {
         assert_eq!(rule.unwrap().rule_id, ".m.rule.call");
 
         let rule = set.override_.get(".m.rule.doesntexist");
-        assert!(rule.is_none());
+        assert_matches!(rule, None);
     }
 
     #[test]
@@ -569,29 +569,29 @@ mod tests {
 
         let rule_opt = iter.next();
         assert!(rule_opt.is_some());
-        assert_matches!(
+        let rule_id = assert_matches!(
             rule_opt.unwrap(),
-            AnyPushRule::Override(ConditionalPushRule { rule_id, .. })
-            if rule_id == ".m.rule.call"
+            AnyPushRule::Override(ConditionalPushRule { rule_id, .. }) => rule_id
         );
+        assert_eq!(rule_id, ".m.rule.call");
 
         let rule_opt = iter.next();
         assert!(rule_opt.is_some());
-        assert_matches!(
+        let rule_id = assert_matches!(
             rule_opt.unwrap(),
-            AnyPushRule::Override(ConditionalPushRule { rule_id, .. })
-            if rule_id == "!roomid:matrix.org"
+            AnyPushRule::Override(ConditionalPushRule { rule_id, .. }) => rule_id
         );
+        assert_eq!(rule_id, "!roomid:matrix.org");
 
         let rule_opt = iter.next();
         assert!(rule_opt.is_some());
-        assert_matches!(
+        let rule_id = assert_matches!(
             rule_opt.unwrap(),
-            AnyPushRule::Override(ConditionalPushRule { rule_id, .. })
-            if rule_id == ".m.rule.suppress_notices"
+            AnyPushRule::Override(ConditionalPushRule { rule_id, .. }) => rule_id
         );
+        assert_eq!(rule_id, ".m.rule.suppress_notices");
 
-        assert!(iter.next().is_none());
+        assert_matches!(iter.next(), None);
     }
 
     #[test]
@@ -815,7 +815,7 @@ mod tests {
 
     #[test]
     fn deserialize_patterned_push_rule() {
-        let rule = from_json_value(json!({
+        let rule = from_json_value::<PatternedPushRule>(json!({
             "actions": [
                 "notify",
                 {
@@ -833,21 +833,18 @@ mod tests {
             "enabled": true
         }))
         .unwrap();
-        assert_matches!(
-            rule,
-            PatternedPushRule {
-                actions: _,
-                default: true,
-                enabled: true,
-                pattern,
-                rule_id,
-            }
-            if pattern == "user_id" && rule_id == ".m.rule.contains_user_name"
-        );
+        assert!(rule.default);
+        assert!(rule.enabled);
+        assert_eq!(rule.pattern, "user_id");
+        assert_eq!(rule.rule_id, ".m.rule.contains_user_name");
 
         let mut iter = rule.actions.iter();
         assert_matches!(iter.next(), Some(Action::Notify));
-        assert_matches!(iter.next(), Some(Action::SetTweak(Tweak::Sound(sound))) if sound == "default");
+        let sound = assert_matches!(
+            iter.next(),
+            Some(Action::SetTweak(Tweak::Sound(sound))) => sound
+        );
+        assert_eq!(sound, "default");
         assert_matches!(iter.next(), Some(Action::SetTweak(Tweak::Highlight(true))));
         assert_matches!(iter.next(), None);
     }
@@ -912,53 +909,53 @@ mod tests {
 
         let rule_opt = iter.next();
         assert!(rule_opt.is_some());
-        assert_matches!(
+        let rule_id = assert_matches!(
             rule_opt.unwrap(),
-            AnyPushRule::Override(ConditionalPushRule { rule_id, .. })
-            if rule_id == "!roomid:server.name"
+            AnyPushRule::Override(ConditionalPushRule { rule_id, .. }) => rule_id
         );
+        assert_eq!(rule_id, "!roomid:server.name");
 
         let rule_opt = iter.next();
         assert!(rule_opt.is_some());
-        assert_matches!(
+        let rule_id = assert_matches!(
             rule_opt.unwrap(),
-            AnyPushRule::Override(ConditionalPushRule { rule_id, .. })
-            if rule_id == ".m.rule.call"
+            AnyPushRule::Override(ConditionalPushRule { rule_id, .. }) => rule_id
         );
+        assert_eq!(rule_id, ".m.rule.call");
 
         let rule_opt = iter.next();
         assert!(rule_opt.is_some());
-        assert_matches!(
+        let rule_id = assert_matches!(
             rule_opt.unwrap(),
-            AnyPushRule::Content(PatternedPushRule { rule_id, .. })
-            if rule_id == ".m.rule.contains_user_name"
+            AnyPushRule::Content(PatternedPushRule { rule_id, .. }) => rule_id
         );
+        assert_eq!(rule_id, ".m.rule.contains_user_name");
 
         let rule_opt = iter.next();
         assert!(rule_opt.is_some());
-        assert_matches!(
+        let rule_id = assert_matches!(
             rule_opt.unwrap(),
-            AnyPushRule::Content(PatternedPushRule { rule_id, .. })
-            if rule_id == "ruma"
+            AnyPushRule::Content(PatternedPushRule { rule_id, .. }) => rule_id
         );
+        assert_eq!(rule_id, "ruma");
 
         let rule_opt = iter.next();
         assert!(rule_opt.is_some());
-        assert_matches!(
+        let rule_id = assert_matches!(
             rule_opt.unwrap(),
-            AnyPushRule::Room(SimplePushRule { rule_id, .. })
-            if rule_id == "!roomid:server.name"
+            AnyPushRule::Room(SimplePushRule { rule_id, .. }) => rule_id
         );
+        assert_eq!(rule_id, "!roomid:server.name");
 
         let rule_opt = iter.next();
         assert!(rule_opt.is_some());
-        assert_matches!(
+        let rule_id = assert_matches!(
             rule_opt.unwrap(),
-            AnyPushRule::Underride(ConditionalPushRule { rule_id, .. })
-            if rule_id == ".m.rule.room_one_to_one"
+            AnyPushRule::Underride(ConditionalPushRule { rule_id, .. }) => rule_id
         );
+        assert_eq!(rule_id, ".m.rule.room_one_to_one");
 
-        assert!(iter.next().is_none());
+        assert_matches!(iter.next(), None);
     }
 
     #[test]
@@ -1172,11 +1169,11 @@ mod tests {
         });
         set.add(three_conditions);
 
-        assert_matches!(
+        let sound = assert_matches!(
             set.get_actions(&message, context_one_to_one),
-            [Action::SetTweak(Tweak::Sound(sound))]
-            if sound == "content"
+            [Action::SetTweak(Tweak::Sound(sound))] => sound
         );
+        assert_eq!(sound, "content");
 
         let new_message = serde_json::from_str::<Raw<JsonValue>>(
             r#"{
@@ -1190,10 +1187,10 @@ mod tests {
         )
         .unwrap();
 
-        assert_matches!(
+        let sound = assert_matches!(
             set.get_actions(&new_message, context_one_to_one),
-            [Action::SetTweak(Tweak::Sound(sound))]
-            if sound == "three"
+            [Action::SetTweak(Tweak::Sound(sound))] => sound
         );
+        assert_eq!(sound, "three");
     }
 }

--- a/crates/ruma-common/src/push/condition.rs
+++ b/crates/ruma-common/src/push/condition.rs
@@ -311,7 +311,6 @@ impl FlattenedJson {
 mod tests {
     use std::collections::BTreeMap;
 
-    use crate::{room_id, serde::Raw, user_id};
     use assert_matches::assert_matches;
     use js_int::{int, uint};
     use maplit::btreemap;
@@ -320,7 +319,7 @@ mod tests {
     };
 
     use super::{FlattenedJson, PushCondition, PushConditionRoomCtx, RoomMemberCountIs, StrExt};
-    use crate::power_levels::NotificationPowerLevels;
+    use crate::{power_levels::NotificationPowerLevels, room_id, serde::Raw, user_id};
 
     #[test]
     fn serialize_event_match_condition() {
@@ -382,11 +381,12 @@ mod tests {
             "kind": "event_match",
             "pattern": "m.notice"
         });
-        assert_matches!(
+        let (key, pattern) = assert_matches!(
             from_json_value::<PushCondition>(json_data).unwrap(),
-            PushCondition::EventMatch { key, pattern }
-            if key == "content.msgtype" && pattern == "m.notice"
+            PushCondition::EventMatch { key, pattern } => (key, pattern)
         );
+        assert_eq!(key, "content.msgtype");
+        assert_eq!(pattern, "m.notice");
     }
 
     #[test]
@@ -403,11 +403,11 @@ mod tests {
             "is": "2",
             "kind": "room_member_count"
         });
-        assert_matches!(
+        let is = assert_matches!(
             from_json_value::<PushCondition>(json_data).unwrap(),
-            PushCondition::RoomMemberCount { is }
-            if is == RoomMemberCountIs::from(uint!(2))
+            PushCondition::RoomMemberCount { is } => is
         );
+        assert_eq!(is, RoomMemberCountIs::from(uint!(2)));
     }
 
     #[test]
@@ -416,12 +416,11 @@ mod tests {
             "key": "room",
             "kind": "sender_notification_permission"
         });
-        assert_matches!(
+        let key = assert_matches!(
             from_json_value::<PushCondition>(json_data).unwrap(),
-            PushCondition::SenderNotificationPermission {
-                key
-            } if key == "room"
+            PushCondition::SenderNotificationPermission { key } => key
         );
+        assert_eq!(key, "room");
     }
 
     #[test]

--- a/crates/ruma-common/src/serde/strings.rs
+++ b/crates/ruma-common/src/serde/strings.rs
@@ -179,7 +179,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use assert_matches::assert_matches;
     use js_int::{int, Int};
     use serde::Deserialize;
 
@@ -192,32 +191,25 @@ mod tests {
     }
 
     #[test]
-    fn int_or_string() -> serde_json::Result<()> {
-        assert_matches!(
-            serde_json::from_value::<Test>(serde_json::json!({ "num": "0" }))?,
-            Test { num } if num == int!(0)
-        );
-
-        Ok(())
+    fn int_or_string() {
+        let test = serde_json::from_value::<Test>(serde_json::json!({ "num": "0" })).unwrap();
+        assert_eq!(test.num, int!(0));
     }
 
     #[test]
-    fn weird_plus_string() -> serde_json::Result<()> {
-        assert_matches!(
-            serde_json::from_value::<Test>(serde_json::json!({ "num": "  +0000000001000   " }))?,
-            Test { num } if num == int!(1000)
-        );
-
-        Ok(())
+    fn weird_plus_string() {
+        let test =
+            serde_json::from_value::<Test>(serde_json::json!({ "num": "  +0000000001000   " }))
+                .unwrap();
+        assert_eq!(test.num, int!(1000));
     }
 
     #[test]
-    fn weird_minus_string() -> serde_json::Result<()> {
-        assert_matches!(
-            serde_json::from_value::<Test>(serde_json::json!({ "num": "  \n\n-0000000000000001000   " }))?,
-            Test { num } if num == int!(-1000)
-        );
-
-        Ok(())
+    fn weird_minus_string() {
+        let test = serde_json::from_value::<Test>(
+            serde_json::json!({ "num": "  \n\n-0000000000000001000   " }),
+        )
+        .unwrap();
+        assert_eq!(test.num, int!(-1000));
     }
 }

--- a/crates/ruma-common/src/serde/urlencoded/de/val_or_vec.rs
+++ b/crates/ruma-common/src/serde/urlencoded/de/val_or_vec.rs
@@ -238,7 +238,8 @@ mod tests {
         let mut x = ValOrVec::Val(Cow::Borrowed("a"));
         x.push(Cow::Borrowed("b"));
         x.push(Cow::Borrowed("c"));
-        assert_matches!(x, ValOrVec::Vec(v) if v == vec!["a", "b", "c"]);
+        let v = assert_matches!(x, ValOrVec::Vec(v) => v);
+        assert_eq!(v, vec!["a", "b", "c"]);
     }
 
     #[test]
@@ -246,9 +247,10 @@ mod tests {
         let mut x = ValOrVec::Val(Cow::from("a".to_owned()));
         x.push(Cow::from("b".to_owned()));
         x.push(Cow::from("c".to_owned()));
-        assert_matches!(
+        let v = assert_matches!(
             x,
-            ValOrVec::Vec(v) if v == vec!["a".to_owned(), "b".to_owned(), "c".to_owned()]
+            ValOrVec::Vec(v) => v
         );
+        assert_eq!(v, vec!["a".to_owned(), "b".to_owned(), "c".to_owned()]);
     }
 }

--- a/crates/ruma-common/src/time.rs
+++ b/crates/ruma-common/src/time.rs
@@ -89,7 +89,6 @@ fn f64_to_uint(val: f64) -> UInt {
 mod tests {
     use std::time::{Duration, UNIX_EPOCH};
 
-    use assert_matches::assert_matches;
     use js_int::uint;
     use serde::{Deserialize, Serialize};
     use serde_json::json;
@@ -106,12 +105,9 @@ mod tests {
     fn deserialize() {
         let json = json!({ "millis": 3000, "secs": 60 });
 
-        assert_matches!(
-            serde_json::from_value::<SystemTimeTest>(json),
-            Ok(SystemTimeTest { millis, secs })
-            if millis.to_system_time() == Some(UNIX_EPOCH + Duration::from_millis(3000))
-                && secs.to_system_time() == Some(UNIX_EPOCH + Duration::from_secs(60))
-        );
+        let time = serde_json::from_value::<SystemTimeTest>(json).unwrap();
+        assert_eq!(time.millis.to_system_time(), Some(UNIX_EPOCH + Duration::from_millis(3000)));
+        assert_eq!(time.secs.to_system_time(), Some(UNIX_EPOCH + Duration::from_secs(60)));
     }
 
     #[test]
@@ -121,9 +117,7 @@ mod tests {
                 .unwrap(),
             secs: SecondsSinceUnixEpoch(uint!(0)),
         };
-        assert_matches!(
-            serde_json::to_value(&request),
-            Ok(value) if value == json!({ "millis": 2000, "secs": 0 })
-        );
+
+        assert_eq!(serde_json::to_value(&request).unwrap(), json!({ "millis": 2000, "secs": 0 }));
     }
 }


### PR DESCRIPTION
It should be the last batch for ruma-common.

Note that I don't look at every test, I'm just looking at uses of `assert_matches!` and look in the same files if there are other things to clean up.