### PR TITLE
events: Add support for knocking in membership_changes

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -26,6 +26,7 @@ Improvements:
   * Remove `BundledReaction`
 * Add unstable support for polls (MSC3381)
 * Add unstable support for Improved Signalling for 1:1 VoIP (MSC2746)
+* Add support for knocking in `events::room::member::MembershipChange`
 
 # 0.9.2
 


### PR DESCRIPTION
Closes #1092.

Related to #1141: Allowing `invite->knock` is taken care of, but `external->kick` did not change anything in the table. See [the spec PR's diff](https://github.com/matrix-org/matrix-spec-proposals/pull/3730/files#diff-c040cded61d2c8e80f89415186fc272b77e13107caf9d9aa81a81ade5e4191be).