### PR TITLE
client-api: Add error kinds encountered for restricted rooms

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -9,6 +9,7 @@ Breaking changes:
 Improvements:
 
 * Add unstable support for refresh tokens (MSC2918)
+* Add `ErrorKind::{UnableToAuthorizeJoin, UnableToGrantJoin}` encountered for restricted rooms
 
 # 0.14.1
 

--- a/crates/ruma-client-api/src/error.rs
+++ b/crates/ruma-client-api/src/error.rs
@@ -141,6 +141,12 @@ pub enum ErrorKind {
     /// M_WEAK_PASSWORD
     WeakPassword,
 
+    /// M_UNABLE_TO_AUTHORISE_JOIN
+    UnableToAuthorizeJoin,
+
+    /// M_UNABLE_TO_GRANT_JOIN
+    UnableToGrantJoin,
+
     /// FI.MAU.MSC2246_NOT_YET_UPLOADED
     #[cfg(feature = "unstable-msc2246")]
     NotYetUploaded,
@@ -193,6 +199,8 @@ impl AsRef<str> for ErrorKind {
             Self::ResourceLimitExceeded { .. } => "M_RESOURCE_LIMIT_EXCEEDED",
             Self::CannotLeaveServerNoticeRoom => "M_CANNOT_LEAVE_SERVER_NOTICE_ROOM",
             Self::WeakPassword => "M_WEAK_PASSWORD",
+            Self::UnableToAuthorizeJoin => "M_UNABLE_TO_AUTHORISE_JOIN",
+            Self::UnableToGrantJoin => "M_UNABLE_TO_GRANT_JOIN",
             #[cfg(feature = "unstable-msc2246")]
             Self::NotYetUploaded => "FI.MAU.MSC2246_NOT_YET_UPLOADED",
             #[cfg(feature = "unstable-msc2246")]


### PR DESCRIPTION
According to [MSC3083](https://github.com/matrix-org/matrix-spec-proposals/pull/3083).

Closes #818.

Without this we are actually not fully v1.2 compliant :scream:!