### PR TITLE
ci: Create workflow for caching xtask

### DIFF
--- a/.github/workflows/xtask.yml
+++ b/.github/workflows/xtask.yml
@@ -1,0 +1,40 @@
+name: XTask
+
+env:
+  CARGO_TERM_COLOR: always
+
+on:
+  push:
+    branches: [main, next]
+  pull_request:
+    branches: [main, next]
+
+jobs:
+  build:
+    name: Get
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Check xtask cache
+        uses: actions/cache@v3
+        id: cache
+        with:
+          path: target/debug/xtask
+          key: xtask-${{ hashFiles('xtask/src/**', 'xtask/Cargo.toml') }}
+
+      - name: Install rust stable toolchain
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Build
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: -p xtask

--- a/.github/workflows/xtask.yml
+++ b/.github/workflows/xtask.yml
@@ -22,7 +22,7 @@ jobs:
         id: cache
         with:
           path: target/debug/xtask
-          key: xtask-${{ hashFiles('xtask/src/**', 'xtask/Cargo.toml') }}
+          key: xtask-${{ hashFiles('xtask/**') }}
 
       - name: Install rust stable toolchain
         if: steps.cache.outputs.cache-hit != 'true'

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -8,7 +8,9 @@ publish = false
 default = ["isahc", "semver", "toml_edit"]
 
 [dependencies]
-clap = { version = "3.1.6", features = ["derive"] }
+# Pinned because versions 3.2.0 - 3.2.1 output deprecation warnings with the Args derive
+# See <https://github.com/clap-rs/clap/issues/3822>
+clap = { version = "~3.1.18", features = ["derive"] }
 isahc = { version = "1.7.0", features = ["json"], optional = true }
 semver = { version = "1.0.6", features = ["serde"], optional = true }
 serde = { version = "1.0.136", features = ["derive"] }


### PR DESCRIPTION
This is part of #1186.

I'm making a separate PR because according to [the docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run):

> This event will only trigger a workflow run if the workflow file is on the default branch.

So we need to merge this PR before I can check if everything works fine for the other CI tasks in the other PR.