### PR TITLE
events: Stabilize deserializing stringified integers for PLs

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -30,6 +30,7 @@ Improvements:
 * Add `MatrixVersion::V1_3`
 * Deprecate the `sender_key` and `device_id` fields for encrypted events (MSC3700)
 * Move the `relations` field of `events::unsigned` types out of `unstable-msc2675`
+* Deserialize stringified integers for power levels without the `compat` feature
 
 # 0.9.2
 

--- a/crates/ruma-common/src/events/room/power_levels.rs
+++ b/crates/ruma-common/src/events/room/power_levels.rs
@@ -22,113 +22,86 @@ use crate::{
 #[ruma_event(type = "m.room.power_levels", kind = State, state_key_type = EmptyStateKey)]
 pub struct RoomPowerLevelsEventContent {
     /// The level required to ban a user.
-    ///
-    /// If you activate the `compat` feature, deserialization will work for stringified
-    /// integers too.
-    #[cfg_attr(
-        feature = "compat",
-        serde(deserialize_with = "crate::serde::deserialize_v1_powerlevel")
+    #[serde(
+        default = "default_power_level",
+        skip_serializing_if = "is_default_power_level",
+        deserialize_with = "crate::serde::deserialize_v1_powerlevel"
     )]
-    #[serde(default = "default_power_level", skip_serializing_if = "is_default_power_level")]
     #[ruma_event(skip_redaction)]
     pub ban: Int,
 
     /// The level required to send specific event types.
     ///
     /// This is a mapping from event type to power level required.
-    ///
-    /// If you activate the `compat` feature, deserialization will work for stringified
-    /// integers too.
-    #[cfg_attr(
-        feature = "compat",
-        serde(deserialize_with = "crate::serde::btreemap_deserialize_v1_powerlevel_values")
+    #[serde(
+        default,
+        skip_serializing_if = "BTreeMap::is_empty",
+        deserialize_with = "crate::serde::btreemap_deserialize_v1_powerlevel_values"
     )]
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     #[ruma_event(skip_redaction)]
     pub events: BTreeMap<RoomEventType, Int>,
 
     /// The default level required to send message events.
-    ///
-    /// If you activate the `compat` feature, deserialization will work for stringified
-    /// integers too.
-    #[cfg_attr(
-        feature = "compat",
-        serde(deserialize_with = "crate::serde::deserialize_v1_powerlevel")
+    #[serde(
+        default,
+        skip_serializing_if = "crate::serde::is_default",
+        deserialize_with = "crate::serde::deserialize_v1_powerlevel"
     )]
-    #[serde(default, skip_serializing_if = "crate::serde::is_default")]
     #[ruma_event(skip_redaction)]
     pub events_default: Int,
 
     /// The level required to invite a user.
-    ///
-    /// If you activate the `compat` feature, deserialization will work for stringified
-    /// integers too.
-    #[cfg_attr(
-        feature = "compat",
-        serde(deserialize_with = "crate::serde::deserialize_v1_powerlevel")
+    #[serde(
+        default,
+        skip_serializing_if = "crate::serde::is_default",
+        deserialize_with = "crate::serde::deserialize_v1_powerlevel"
     )]
-    #[serde(default, skip_serializing_if = "crate::serde::is_default")]
     pub invite: Int,
 
     /// The level required to kick a user.
-    ///
-    /// If you activate the `compat` feature, deserialization will work for stringified
-    /// integers too.
-    #[cfg_attr(
-        feature = "compat",
-        serde(deserialize_with = "crate::serde::deserialize_v1_powerlevel")
+    #[serde(
+        default = "default_power_level",
+        skip_serializing_if = "is_default_power_level",
+        deserialize_with = "crate::serde::deserialize_v1_powerlevel"
     )]
-    #[serde(default = "default_power_level", skip_serializing_if = "is_default_power_level")]
     #[ruma_event(skip_redaction)]
     pub kick: Int,
 
     /// The level required to redact an event.
-    ///
-    /// If you activate the `compat` feature, deserialization will work for stringified
-    /// integers too.
-    #[cfg_attr(
-        feature = "compat",
-        serde(deserialize_with = "crate::serde::deserialize_v1_powerlevel")
+    #[serde(
+        default = "default_power_level",
+        skip_serializing_if = "is_default_power_level",
+        deserialize_with = "crate::serde::deserialize_v1_powerlevel"
     )]
-    #[serde(default = "default_power_level", skip_serializing_if = "is_default_power_level")]
     #[ruma_event(skip_redaction)]
     pub redact: Int,
 
     /// The default level required to send state events.
-    ///
-    /// If you activate the `compat` feature, deserialization will work for stringified
-    /// integers too.
-    #[cfg_attr(
-        feature = "compat",
-        serde(deserialize_with = "crate::serde::deserialize_v1_powerlevel")
+    #[serde(
+        default = "default_power_level",
+        skip_serializing_if = "is_default_power_level",
+        deserialize_with = "crate::serde::deserialize_v1_powerlevel"
     )]
-    #[serde(default = "default_power_level", skip_serializing_if = "is_default_power_level")]
     #[ruma_event(skip_redaction)]
     pub state_default: Int,
 
     /// The power levels for specific users.
     ///
     /// This is a mapping from `user_id` to power level for that user.
-    ///
-    /// If you activate the `compat` feature, deserialization will work for stringified
-    /// integers too.
-    #[cfg_attr(
-        feature = "compat",
-        serde(deserialize_with = "crate::serde::btreemap_deserialize_v1_powerlevel_values")
+    #[serde(
+        default,
+        skip_serializing_if = "BTreeMap::is_empty",
+        deserialize_with = "crate::serde::btreemap_deserialize_v1_powerlevel_values"
     )]
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     #[ruma_event(skip_redaction)]
     pub users: BTreeMap<OwnedUserId, Int>,
 
     /// The default power level for every user in the room.
-    ///
-    /// If you activate the `compat` feature, deserialization will work for stringified
-    /// integers too.
-    #[cfg_attr(
-        feature = "compat",
-        serde(deserialize_with = "crate::serde::deserialize_v1_powerlevel")
+    #[serde(
+        default,
+        skip_serializing_if = "crate::serde::is_default",
+        deserialize_with = "crate::serde::deserialize_v1_powerlevel"
     )]
-    #[serde(default, skip_serializing_if = "crate::serde::is_default")]
     #[ruma_event(skip_redaction)]
     pub users_default: Int,
 

--- a/crates/ruma-common/src/power_levels.rs
+++ b/crates/ruma-common/src/power_levels.rs
@@ -10,14 +10,10 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct NotificationPowerLevels {
     /// The level required to trigger an `@room` notification.
-    ///
-    /// If you activate the `compat` feature, deserialization will work for stringified
-    /// integers too.
-    #[cfg_attr(
-        feature = "compat",
-        serde(deserialize_with = "crate::serde::deserialize_v1_powerlevel")
+    #[serde(
+        default = "default_power_level",
+        deserialize_with = "crate::serde::deserialize_v1_powerlevel"
     )]
-    #[serde(default = "default_power_level")]
     pub room: Int,
 }
 


### PR DESCRIPTION
I haven't touched the part in `state-res` because there's some stuff to figure out to deny stringified integer power levels for v10 (#1174).

Part of #1145.




<!-- Replace -->
Preview removed
<!-- Replace -->
