### PR TITLE
Add `knock_restricted` join rule

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -14,6 +14,7 @@ Improvements:
 * Add support for querying relating events (MSC2675)
 * Move `filter::RelationType` to `ruma_common::events::relations`
 * Add unstable support for discovering an OpenID Connect server (MSC2965)
+* Add `SpaceRoomJoinRule::KnockRestricted` (MSC3787)
 
 # 0.14.1
 

--- a/crates/ruma-client-api/src/space.rs
+++ b/crates/ruma-client-api/src/space.rs
@@ -164,6 +164,11 @@ pub enum SpaceRoomJoinRule {
     /// only be seen by users inside the room.
     Restricted,
 
+    /// Users can join the room if they are invited, or if they meet any of the conditions
+    /// described in a set of [`AllowRule`](ruma_common::events::room::join_rules::AllowRule)s, or
+    /// they can request an invite to the room.
+    KnockRestricted,
+
     /// Anyone can join the room without any prior action.
     Public,
 

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -31,6 +31,7 @@ Improvements:
 * Deprecate the `sender_key` and `device_id` fields for encrypted events (MSC3700)
 * Move the `relations` field of `events::unsigned` types out of `unstable-msc2675`
 * Deserialize stringified integers for power levels without the `compat` feature
+* Add `JoinRule::KnockRestricted` (MSC3787)
 
 # 0.9.2
 

--- a/crates/ruma-common/src/events/room/join_rules.rs
+++ b/crates/ruma-common/src/events/room/join_rules.rs
@@ -81,35 +81,29 @@ impl SyncRoomJoinRulesEvent {
 /// documented variant here, use its string representation, obtained through `.as_str()`.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-#[serde(tag = "join_rule")]
+#[serde(tag = "join_rule", rename_all = "snake_case")]
 pub enum JoinRule {
     /// A user who wishes to join the room must first receive an invite to the room from someone
     /// already inside of the room.
-    #[serde(rename = "invite")]
     Invite,
 
     /// Users can join the room if they are invited, or they can request an invite to the room.
     ///
     /// They can be allowed (invited) or denied (kicked/banned) access.
-    #[serde(rename = "knock")]
     Knock,
 
     /// Reserved but not yet implemented by the Matrix specification.
-    #[serde(rename = "private")]
     Private,
 
     /// Users can join the room if they are invited, or if they meet any of the conditions
     /// described in a set of [`AllowRule`]s.
-    #[serde(rename = "restricted")]
     Restricted(Restricted),
 
     /// Users can join the room if they are invited, or if they meet any of the conditions
     /// described in a set of [`AllowRule`]s, or they can request an invite to the room.
-    #[serde(rename = "knock_restricted")]
     KnockRestricted(Restricted),
 
     /// Anyone can join the room without any prior action.
-    #[serde(rename = "public")]
     Public,
 
     #[doc(hidden)]

--- a/crates/ruma-common/src/events/room/join_rules.rs
+++ b/crates/ruma-common/src/events/room/join_rules.rs
@@ -37,6 +37,12 @@ impl RoomJoinRulesEventContent {
     pub fn restricted(allow: Vec<AllowRule>) -> Self {
         Self { join_rule: JoinRule::Restricted(Restricted::new(allow)) }
     }
+
+    /// Creates a new `RoomJoinRulesEventContent` with the knock restricted rule and the given set
+    /// of allow rules.
+    pub fn knock_restricted(allow: Vec<AllowRule>) -> Self {
+        Self { join_rule: JoinRule::KnockRestricted(Restricted::new(allow)) }
+    }
 }
 
 impl<'de> Deserialize<'de> for RoomJoinRulesEventContent {
@@ -97,6 +103,11 @@ pub enum JoinRule {
     #[serde(rename = "restricted")]
     Restricted(Restricted),
 
+    /// Users can join the room if they are invited, or if they meet any of the conditions
+    /// described in a set of [`AllowRule`]s, or they can request an invite to the room.
+    #[serde(rename = "knock_restricted")]
+    KnockRestricted(Restricted),
+
     /// Anyone can join the room without any prior action.
     #[serde(rename = "public")]
     Public,
@@ -114,6 +125,7 @@ impl JoinRule {
             JoinRule::Knock => "knock",
             JoinRule::Private => "private",
             JoinRule::Restricted(_) => "restricted",
+            JoinRule::KnockRestricted(_) => "knock_restricted",
             JoinRule::Public => "public",
             JoinRule::_Custom(rule) => &rule.0,
         }
@@ -143,6 +155,7 @@ impl<'de> Deserialize<'de> for JoinRule {
             "knock" => Ok(Self::Knock),
             "private" => Ok(Self::Private),
             "restricted" => from_raw_json_value(&json).map(Self::Restricted),
+            "knock_restricted" => from_raw_json_value(&json).map(Self::KnockRestricted),
             "public" => Ok(Self::Public),
             _ => Ok(Self::_Custom(PrivOwnedStr(join_rule.into()))),
         }


### PR DESCRIPTION
According to [MSC3787](https://github.com/matrix-org/matrix-spec-proposals/pull/3787).

Part of #1173.







<!-- Replace -->
Preview removed
<!-- Replace -->
