### PR TITLE
api: Get the default room version for a Matrix version

### DIFF
--- a/crates/ruma-common/src/api/metadata.rs
+++ b/crates/ruma-common/src/api/metadata.rs
@@ -6,6 +6,7 @@ use std::{
 use http::Method;
 
 use super::{error::UnknownVersionError, AuthScheme};
+use crate::RoomVersionId;
 
 /// Metadata about an API endpoint.
 #[derive(Clone, Debug)]
@@ -226,6 +227,20 @@ impl MatrixVersion {
             (1, 2) => Ok(MatrixVersion::V1_2),
             (1, 3) => Ok(MatrixVersion::V1_3),
             _ => Err(UnknownVersionError),
+        }
+    }
+
+    /// Get the default [`RoomVersionId`] for this `MatrixVersion`.
+    pub fn default_room_version(&self) -> RoomVersionId {
+        match self {
+            // <https://matrix.org/docs/spec/index.html#complete-list-of-room-versions>
+            MatrixVersion::V1_0
+            // <https://spec.matrix.org/v1.1/rooms/#complete-list-of-room-versions>
+            | MatrixVersion::V1_1
+            // <https://spec.matrix.org/v1.2/rooms/#complete-list-of-room-versions>
+            | MatrixVersion::V1_2 => RoomVersionId::V6,
+            // <https://spec.matrix.org/v1.3/rooms/#complete-list-of-room-versions>
+            MatrixVersion::V1_3 => RoomVersionId::V9,
         }
     }
 }

--- a/xtask/src/ci/spec_links.rs
+++ b/xtask/src/ci/spec_links.rs
@@ -6,6 +6,10 @@ use std::{
 
 use crate::Result;
 
+/// Authorized links to the old specs.
+const WHITELIST: &[&str] =
+    &["https://matrix.org/docs/spec/index.html#complete-list-of-room-versions"];
+
 pub(crate) fn check_spec_links(path: &Path) -> Result<()> {
     println!("Checking Matrix Spec links are up-to-date...");
     walk_dirs(path, "https://matrix.org/docs/spec/", |_| false)?;
@@ -33,7 +37,9 @@ fn walk_dirs(path: &Path, split: &str, version_match: fn(&str) -> bool) -> Resul
                 while content.read_line(&mut buf)? > 0 {
                     // If for some reason a line has 2 spec links
                     for (idx, _) in buf.match_indices(split) {
-                        if !version_match(&buf[idx + split.len()..]) {
+                        if !WHITELIST.iter().any(|url| buf[idx..].starts_with(url))
+                            && !version_match(&buf[idx + split.len()..])
+                        {
                             return err(&path, &buf);
                         }
                     }


### PR DESCRIPTION
Closes #1144.

For v1.0 I used the latest value as seen [here](https://matrix.org/docs/spec/index.html#complete-list-of-room-versions).



















<!-- Replace -->
Preview removed
<!-- Replace -->
