### PR TITLE
identifiers: Add MatrixVersionId::V10

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -33,6 +33,7 @@ Improvements:
 * Move the `relations` field of `events::unsigned` types out of `unstable-msc2675`
 * Deserialize stringified integers for power levels without the `compat` feature
 * Add `JoinRule::KnockRestricted` (MSC3787)
+* Add `MatrixVersionId::V10` (MSC3604)
 
 # 0.9.2
 

--- a/crates/ruma-common/src/events/room/member.rs
+++ b/crates/ruma-common/src/events/room/member.rs
@@ -144,7 +144,7 @@ impl RedactContent for RoomMemberEventContent {
         RedactedRoomMemberEventContent {
             membership: self.membership,
             join_authorized_via_users_server: match _version {
-                RoomVersionId::V9 => self.join_authorized_via_users_server,
+                RoomVersionId::V9 | RoomVersionId::V10 => self.join_authorized_via_users_server,
                 _ => None,
             },
         }

--- a/crates/ruma-common/src/identifiers/room_version_id.rs
+++ b/crates/ruma-common/src/identifiers/room_version_id.rs
@@ -53,6 +53,9 @@ pub enum RoomVersionId {
     /// A version 9 room.
     V9,
 
+    /// A version 10 room.
+    V10,
+
     #[doc(hidden)]
     _Custom(CustomRoomVersion),
 }
@@ -72,6 +75,7 @@ impl RoomVersionId {
             Self::V7 => "7",
             Self::V8 => "8",
             Self::V9 => "9",
+            Self::V10 => "10",
             Self::_Custom(version) => version.as_str(),
         }
     }
@@ -94,6 +98,7 @@ impl From<RoomVersionId> for String {
             RoomVersionId::V7 => "7".to_owned(),
             RoomVersionId::V8 => "8".to_owned(),
             RoomVersionId::V9 => "9".to_owned(),
+            RoomVersionId::V10 => "10".to_owned(),
             RoomVersionId::_Custom(version) => version.into(),
         }
     }
@@ -160,6 +165,7 @@ where
         "7" => RoomVersionId::V7,
         "8" => RoomVersionId::V8,
         "9" => RoomVersionId::V9,
+        "10" => RoomVersionId::V10,
         custom => {
             ruma_identifiers_validation::room_version_id::validate(custom)?;
             RoomVersionId::_Custom(CustomRoomVersion(room_version_id.into()))

--- a/crates/ruma-signatures/src/functions.rs
+++ b/crates/ruma-signatures/src/functions.rs
@@ -45,12 +45,14 @@ static ALLOWED_KEYS: &[&str] = &[
 fn allowed_content_keys_for(event_type: &str, version: &RoomVersionId) -> &'static [&'static str] {
     match event_type {
         "m.room.member" => match version {
-            RoomVersionId::V9 => &["membership", "join_authorised_via_users_server"],
+            RoomVersionId::V9 | RoomVersionId::V10 => {
+                &["membership", "join_authorised_via_users_server"]
+            }
             _ => &["membership"],
         },
         "m.room.create" => &["creator"],
         "m.room.join_rules" => match version {
-            RoomVersionId::V8 | RoomVersionId::V9 => &["join_rule", "allow"],
+            RoomVersionId::V8 | RoomVersionId::V9 | RoomVersionId::V10 => &["join_rule", "allow"],
             _ => &["join_rule"],
         },
         "m.room.power_levels" => &[
@@ -844,7 +846,7 @@ fn servers_to_check_signatures(
         | RoomVersionId::V6
         | RoomVersionId::V7 => {}
         // TODO: And for all future versions that have join_authorised_via_users_server
-        RoomVersionId::V8 | RoomVersionId::V9 => {
+        RoomVersionId::V8 | RoomVersionId::V9 | RoomVersionId::V10 => {
             if let Some(authorized_user) = object
                 .get("content")
                 .and_then(|c| c.as_object())


### PR DESCRIPTION
According to [MSC3604](https://github.com/matrix-org/matrix-spec-proposals/pull/3604).

I hope I didn't forget anything, I just looked for occurrences of `MatrixVersionId::V9` because this version does not change anything compared to it outside of `state-res`.

Part of #1174.




<!-- Replace -->
Preview removed
<!-- Replace -->
