### PR TITLE
state-res: Add `m.federate` to the authorization rules

### DIFF
--- a/crates/ruma-state-res/CHANGELOG.md
+++ b/crates/ruma-state-res/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [unreleased]
 
+Improvements:
+
+* Add `m.federate` to `auth_check`:
+  <https://github.com/matrix-org/matrix-spec/pull/1103>
+
 # 0.7.0
 
 Breaking changes:

--- a/crates/ruma-state-res/src/event_auth.rs
+++ b/crates/ruma-state-res/src/event_auth.rs
@@ -227,6 +227,7 @@ pub fn auth_check<E: Event>(
     // the event does not match the sender domain of the create event, reject.
     #[derive(Deserialize)]
     struct RoomCreateContentFederate {
+        #[serde(rename = "m.federate", default = "ruma_common::serde::default_true")]
         federate: bool,
     }
     let room_create_content: RoomCreateContentFederate =


### PR DESCRIPTION
According to [this clarification in the spec](https://github.com/matrix-org/matrix-spec/pull/1103).

Closes #1194.







<!-- Replace -->
Preview removed
<!-- Replace -->
