### PR TITLE
macro: add #[allow(unused)] attribute to fields

### DIFF
--- a/crates/ruma-macros/src/api/request.rs
+++ b/crates/ruma-macros/src/api/request.rs
@@ -197,6 +197,7 @@ impl Request {
             let derive_deserialize = lifetimes.is_empty().then(|| quote! { #serde::Deserialize });
 
             quote! {
+                #[cfg(any(feature = "client", feature = "server"))]
                 /// Data in the request body.
                 #[derive(Debug, #ruma_macros::_FakeDeriveRumaApi, #ruma_macros::_FakeDeriveSerde)]
                 #[cfg_attr(feature = "client", derive(#serde::Serialize))]
@@ -224,6 +225,7 @@ impl Request {
             let derive_deserialize = lifetimes.is_empty().then(|| quote! { #serde::Deserialize });
 
             quote! {
+                #[cfg(any(feature = "client", feature = "server"))]
                 /// Data in the request's query string.
                 #[derive(Debug, #ruma_macros::_FakeDeriveRumaApi, #ruma_macros::_FakeDeriveSerde)]
                 #[cfg_attr(feature = "client", derive(#serde::Serialize))]

--- a/crates/ruma-macros/src/api/request.rs
+++ b/crates/ruma-macros/src/api/request.rs
@@ -197,8 +197,8 @@ impl Request {
             let derive_deserialize = lifetimes.is_empty().then(|| quote! { #serde::Deserialize });
 
             quote! {
-                #[cfg(any(feature = "client", feature = "server"))]
                 /// Data in the request body.
+                #[cfg(any(feature = "client", feature = "server"))]
                 #[derive(Debug, #ruma_macros::_FakeDeriveRumaApi, #ruma_macros::_FakeDeriveSerde)]
                 #[cfg_attr(feature = "client", derive(#serde::Serialize))]
                 #[cfg_attr(
@@ -225,8 +225,8 @@ impl Request {
             let derive_deserialize = lifetimes.is_empty().then(|| quote! { #serde::Deserialize });
 
             quote! {
-                #[cfg(any(feature = "client", feature = "server"))]
                 /// Data in the request's query string.
+                #[cfg(any(feature = "client", feature = "server"))]
                 #[derive(Debug, #ruma_macros::_FakeDeriveRumaApi, #ruma_macros::_FakeDeriveSerde)]
                 #[cfg_attr(feature = "client", derive(#serde::Serialize))]
                 #[cfg_attr(

--- a/crates/ruma-macros/src/api/response.rs
+++ b/crates/ruma-macros/src/api/response.rs
@@ -99,8 +99,8 @@ impl Response {
             let fields = self.fields.iter().filter_map(ResponseField::as_body_field);
 
             quote! {
-                #[cfg(any(feature = "client", feature = "server"))]
                 /// Data in the response body.
+                #[cfg(any(feature = "client", feature = "server"))]
                 #[derive(Debug, #ruma_macros::_FakeDeriveRumaApi, #ruma_macros::_FakeDeriveSerde)]
                 #serde_derives
                 #serde_attr

--- a/crates/ruma-macros/src/api/response.rs
+++ b/crates/ruma-macros/src/api/response.rs
@@ -99,6 +99,7 @@ impl Response {
             let fields = self.fields.iter().filter_map(ResponseField::as_body_field);
 
             quote! {
+                #[cfg(any(feature = "client", feature = "server"))]
                 /// Data in the response body.
                 #[derive(Debug, #ruma_macros::_FakeDeriveRumaApi, #ruma_macros::_FakeDeriveSerde)]
                 #serde_derives


### PR DESCRIPTION
I received a lot of warnings about unused fields in the ruma_api macro,
so I decided to add `#[allow(unused)]` to each field to suppress this
warning.

I'm not entirely sure why it doesn't show up in the CI runs, but yeah...

There are some functions left, that are still unused:

```
warning: function is never used: `serialize`
  --> crates/ruma-federation-api/src/serde/pdu_process_response.rs:16:8
   |
16 | pub fn serialize<S>(
   |        ^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: function is never used: `deserialize`
  --> crates/ruma-federation-api/src/serde/pdu_process_response.rs:37:8
   |
37 | pub fn deserialize<'de, D>(
   |        ^^^^^^^^^^^

warning: function is never used: `serialize`
  --> crates/ruma-federation-api/src/serde/v1_pdu.rs:18:8
   |
18 | pub fn serialize<T, S>(val: &T, serializer: S) -> Result<S::Ok, S::Error>
   |        ^^^^^^^^^

warning: function is never used: `deserialize`
  --> crates/ruma-federation-api/src/serde/v1_pdu.rs:29:8
   |
29 | pub fn deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>
   |        ^^^^^^^^^^^

warning: function is never used: `is_default_limit`
  --> crates/ruma-federation-api/src/event/get_missing_events.rs:86:8
   |
86 |     fn is_default_limit(val: &UInt) -> bool {
   |        ^^^^^^^^^^^^^^^^

warning: function is never used: `default_ver`
  --> crates/ruma-federation-api/src/membership/prepare_join_event.rs:51:8
   |
51 |     fn default_ver() -> Vec<RoomVersionId> {
   |        ^^^^^^^^^^^

warning: function is never used: `is_default_ver`
  --> crates/ruma-federation-api/src/membership/prepare_join_event.rs:55:8
   |
55 |     fn is_default_ver(ver: &&[RoomVersionId]) -> bool {
   |        ^^^^^^^^^^^^^^
```

I think they can be removed as well?