### PR TITLE
identifiers: Allow via on RoomId::matrix_to_event_uri()

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -41,6 +41,7 @@ Improvements:
 * Add `MatrixVersionId::V10` (MSC3604)
 * Add methods to sanitize messages according to the spec behind the `unstable-sanitize` feature
   * Can also remove rich reply fallbacks
+* Implement `From<Owned*Id>` for `identifiers::matrix_uri::MatrixId`
 
 # 0.9.2
 

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -22,6 +22,7 @@ Breaking changes:
 * Remove `RoomMessageFeedbackEvent` and associated types and variants according to MSC3582
 * Move `CanonicalJson`, `CanonicalJsonObject` and `CanonicalJsonError` out of
   the `serde` module and behind the cargo feature flag `canonical-json`
+* Make identifiers matrix URI constructors generic over owned parameters
 
 [spec]: https://github.com/matrix-org/matrix-spec-proposals/pull/3669
 

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -23,6 +23,7 @@ Breaking changes:
 * Move `CanonicalJson`, `CanonicalJsonObject` and `CanonicalJsonError` out of
   the `serde` module and behind the cargo feature flag `canonical-json`
 * Make identifiers matrix URI constructors generic over owned parameters
+* Allow to add routing servers to `RoomId::matrix_to_event_uri()`
 
 [spec]: https://github.com/matrix-org/matrix-spec-proposals/pull/3669
 

--- a/crates/ruma-common/src/identifiers/matrix_uri.rs
+++ b/crates/ruma-common/src/identifiers/matrix_uri.rs
@@ -11,7 +11,7 @@ use url::Url;
 
 use super::{
     EventId, OwnedEventId, OwnedRoomAliasId, OwnedRoomId, OwnedRoomOrAliasId, OwnedServerName,
-    OwnedUserId, RoomAliasId, RoomId, RoomOrAliasId, ServerName, UserId,
+    OwnedUserId, RoomAliasId, RoomId, RoomOrAliasId, UserId,
 };
 use crate::PrivOwnedStr;
 
@@ -282,8 +282,8 @@ pub struct MatrixToUri {
 }
 
 impl MatrixToUri {
-    pub(crate) fn new(id: MatrixId, via: Vec<&ServerName>) -> Self {
-        Self { id, via: via.into_iter().map(ToOwned::to_owned).collect() }
+    pub(crate) fn new(id: MatrixId, via: Vec<OwnedServerName>) -> Self {
+        Self { id, via }
     }
 
     /// The identifier represented by this `matrix.to` URI.
@@ -446,8 +446,8 @@ pub struct MatrixUri {
 }
 
 impl MatrixUri {
-    pub(crate) fn new(id: MatrixId, via: Vec<&ServerName>, action: Option<UriAction>) -> Self {
-        Self { id, via: via.into_iter().map(ToOwned::to_owned).collect(), action }
+    pub(crate) fn new(id: MatrixId, via: Vec<OwnedServerName>, action: Option<UriAction>) -> Self {
+        Self { id, via, action }
     }
 
     /// The identifier represented by this `matrix:` URI.
@@ -544,7 +544,7 @@ mod tests {
     use super::{MatrixId, MatrixToUri, MatrixUri};
     use crate::{
         event_id, matrix_uri::UriAction, room_alias_id, room_id, server_name, user_id,
-        RoomOrAliasId,
+        OwnedServerName, RoomOrAliasId,
     };
 
     #[test]
@@ -818,7 +818,7 @@ mod tests {
         );
         assert_eq!(
             room_id!("!ruma:notareal.hs")
-                .matrix_event_uri(event_id!("$event:notareal.hs"), vec![])
+                .matrix_event_uri(event_id!("$event:notareal.hs"), Vec::<OwnedServerName>::new())
                 .to_string(),
             "matrix:roomid/ruma:notareal.hs/e/event:notareal.hs"
         );

--- a/crates/ruma-common/src/identifiers/matrix_uri.rs
+++ b/crates/ruma-common/src/identifiers/matrix_uri.rs
@@ -197,39 +197,75 @@ impl MatrixId {
     }
 }
 
+impl From<OwnedRoomId> for MatrixId {
+    fn from(room_id: OwnedRoomId) -> Self {
+        Self::Room(room_id)
+    }
+}
+
 impl From<&RoomId> for MatrixId {
     fn from(room_id: &RoomId) -> Self {
-        Self::Room(room_id.into())
+        room_id.to_owned().into()
+    }
+}
+
+impl From<OwnedRoomAliasId> for MatrixId {
+    fn from(room_alias: OwnedRoomAliasId) -> Self {
+        Self::RoomAlias(room_alias)
     }
 }
 
 impl From<&RoomAliasId> for MatrixId {
     fn from(room_alias: &RoomAliasId) -> Self {
-        Self::RoomAlias(room_alias.into())
+        room_alias.to_owned().into()
+    }
+}
+
+impl From<OwnedUserId> for MatrixId {
+    fn from(user_id: OwnedUserId) -> Self {
+        Self::User(user_id)
     }
 }
 
 impl From<&UserId> for MatrixId {
     fn from(user_id: &UserId) -> Self {
-        Self::User(user_id.into())
+        user_id.to_owned().into()
+    }
+}
+
+impl From<(OwnedRoomOrAliasId, OwnedEventId)> for MatrixId {
+    fn from(ids: (OwnedRoomOrAliasId, OwnedEventId)) -> Self {
+        Self::Event(ids.0, ids.1)
     }
 }
 
 impl From<(&RoomOrAliasId, &EventId)> for MatrixId {
     fn from(ids: (&RoomOrAliasId, &EventId)) -> Self {
-        Self::Event(ids.0.into(), ids.1.into())
+        (ids.0.to_owned(), ids.1.to_owned()).into()
+    }
+}
+
+impl From<(OwnedRoomId, OwnedEventId)> for MatrixId {
+    fn from(ids: (OwnedRoomId, OwnedEventId)) -> Self {
+        Self::Event(ids.0.into(), ids.1)
     }
 }
 
 impl From<(&RoomId, &EventId)> for MatrixId {
     fn from(ids: (&RoomId, &EventId)) -> Self {
-        Self::Event(<&RoomOrAliasId>::from(ids.0).into(), ids.1.into())
+        (ids.0.to_owned(), ids.1.to_owned()).into()
+    }
+}
+
+impl From<(OwnedRoomAliasId, OwnedEventId)> for MatrixId {
+    fn from(ids: (OwnedRoomAliasId, OwnedEventId)) -> Self {
+        Self::Event(ids.0.into(), ids.1)
     }
 }
 
 impl From<(&RoomAliasId, &EventId)> for MatrixId {
     fn from(ids: (&RoomAliasId, &EventId)) -> Self {
-        Self::Event(<&RoomOrAliasId>::from(ids.0).into(), ids.1.into())
+        (ids.0.to_owned(), ids.1.to_owned()).into()
     }
 }
 

--- a/crates/ruma-common/src/identifiers/matrix_uri.rs
+++ b/crates/ruma-common/src/identifiers/matrix_uri.rs
@@ -571,9 +571,18 @@ mod tests {
         );
         assert_eq!(
             room_id!("!ruma:notareal.hs")
-                .matrix_to_event_uri(event_id!("$event:notareal.hs"))
+                .matrix_to_event_uri(event_id!("$event:notareal.hs"), Vec::<OwnedServerName>::new())
                 .to_string(),
             "https://matrix.to/#/%21ruma%3Anotareal.hs/%24event%3Anotareal.hs"
+        );
+        assert_eq!(
+            room_id!("!ruma:notareal.hs")
+                .matrix_to_event_uri(
+                    event_id!("$event:notareal.hs"),
+                    vec![server_name!("notareal.hs")]
+                )
+                .to_string(),
+            "https://matrix.to/#/%21ruma%3Anotareal.hs/%24event%3Anotareal.hs?via=notareal.hs"
         );
     }
 
@@ -821,6 +830,15 @@ mod tests {
                 .matrix_event_uri(event_id!("$event:notareal.hs"), Vec::<OwnedServerName>::new())
                 .to_string(),
             "matrix:roomid/ruma:notareal.hs/e/event:notareal.hs"
+        );
+        assert_eq!(
+            room_id!("!ruma:notareal.hs")
+                .matrix_event_uri(
+                    event_id!("$event:notareal.hs"),
+                    vec![server_name!("notareal.hs")]
+                )
+                .to_string(),
+            "matrix:roomid/ruma:notareal.hs/e/event:notareal.hs?via=notareal.hs"
         );
     }
 

--- a/crates/ruma-common/src/identifiers/room_alias_id.rs
+++ b/crates/ruma-common/src/identifiers/room_alias_id.rs
@@ -2,7 +2,7 @@
 
 use ruma_macros::IdZst;
 
-use super::{matrix_uri::UriAction, server_name::ServerName, EventId, MatrixToUri, MatrixUri};
+use super::{matrix_uri::UriAction, server_name::ServerName, MatrixToUri, MatrixUri, OwnedEventId};
 
 /// A Matrix [room alias ID].
 ///
@@ -37,8 +37,8 @@ impl RoomAliasId {
     }
 
     /// Create a `matrix.to` URI for an event scoped under this room alias ID.
-    pub fn matrix_to_event_uri(&self, ev_id: &EventId) -> MatrixToUri {
-        MatrixToUri::new((self, ev_id).into(), Vec::new())
+    pub fn matrix_to_event_uri(&self, ev_id: impl Into<OwnedEventId>) -> MatrixToUri {
+        MatrixToUri::new((self.to_owned(), ev_id.into()).into(), Vec::new())
     }
 
     /// Create a `matrix:` URI for this room alias ID.
@@ -49,8 +49,8 @@ impl RoomAliasId {
     }
 
     /// Create a `matrix:` URI for an event scoped under this room alias ID.
-    pub fn matrix_event_uri(&self, ev_id: &EventId) -> MatrixUri {
-        MatrixUri::new((self, ev_id).into(), Vec::new(), None)
+    pub fn matrix_event_uri(&self, ev_id: impl Into<OwnedEventId>) -> MatrixUri {
+        MatrixUri::new((self.to_owned(), ev_id.into()).into(), Vec::new(), None)
     }
 
     fn colon_idx(&self) -> usize {

--- a/crates/ruma-common/src/identifiers/room_id.rs
+++ b/crates/ruma-common/src/identifiers/room_id.rs
@@ -67,8 +67,15 @@ impl RoomId {
     }
 
     /// Create a `matrix.to` URI for an event scoped under this room ID.
-    pub fn matrix_to_event_uri(&self, ev_id: impl Into<OwnedEventId>) -> MatrixToUri {
-        MatrixToUri::new((self.to_owned(), ev_id.into()).into(), Vec::new())
+    pub fn matrix_to_event_uri<T>(&self, ev_id: impl Into<OwnedEventId>, via: T) -> MatrixToUri
+    where
+        T: IntoIterator,
+        T::Item: Into<OwnedServerName>,
+    {
+        MatrixToUri::new(
+            (self.to_owned(), ev_id.into()).into(),
+            via.into_iter().map(Into::into).collect(),
+        )
     }
 
     /// Create a `matrix:` URI for this room ID.


### PR DESCRIPTION
A room ID always should have some routing to be able to resolve it.













<!-- Replace -->
Preview removed
<!-- Replace -->
