### PR TITLE
ci: Fix deploying previews for forked repositories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,10 +253,7 @@ jobs:
       - name: Compress docs
         if: github.event_name == 'pull_request'
         run: |
-          cd target
-          tar --zstd -cf docs.tar.zstd doc
-          cd ..
-          mv target/docs.tar.zstd .
+          tar --zstd -cf docs.tar.zstd -C target doc
 
       - name: Upload docs as artifact
         if: github.event_name == 'pull_request'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,27 +249,21 @@ jobs:
 
       - name: Build docs
         run: target/debug/xtask doc --deny-warnings
-
-      - name: Deploy PR preview
-        id: deploy_preview
+      
+      - name: Compress docs
         if: github.event_name == 'pull_request'
-        continue-on-error: true
-        uses: dswistowski/surge-sh-action@v1.0.1
-        with:
-          domain: pr-${{ github.event.number }}--ruma-docs.surge.sh
-          project: target/doc
-          login: ${{ secrets.SURGE_LOGIN }}
-          token: ${{ secrets.SURGE_TOKEN }}
+        run: |
+          cd target
+          tar --zstd -cf docs.tar.zstd doc
+          cd ..
+          mv target/docs.tar.zstd .
 
-      - name: Comment deploy PR preview URL
-        if: steps.deploy_preview.outcome == 'success'
-        uses: Beakyn/gha-comment-pull-request@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+      - name: Upload docs as artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v3
         with:
-          description-message: |
-            ----
-            Preview: https://pr-${{ github.event.number }}--ruma-docs.surge.sh
+          name: docs
+          path: docs.tar.zstd
 
       - name: Deploy to docs repo
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -56,6 +56,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
+          pull-request-number: ${{ github.event.workflow_run.pull_requests[0].number }}
           description-message: |
             ----
             Preview: https://pr-${{ github.event.workflow_run.pull_requests[0].number }}--ruma-docs.surge.sh

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.pull_requests[0] != null  
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.pull_requests[0] != null
     steps:
       - name: Download artifact
         uses: actions/github-script@v6

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -24,7 +24,7 @@ jobs:
                 run_id: context.payload.workflow_run.id,
             });
             let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == "docs"
+              return artifact.name == "docs";
             })[0];
             let download = await github.rest.actions.downloadArtifact({
                 owner: context.repo.owner,

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -1,0 +1,59 @@
+name: Docs Preview
+
+env:
+  CARGO_TERM_COLOR: always
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types:
+      - completed
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.pull_requests[0] != null  
+    steps:
+      - name: Download artifact
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "docs"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                artifact_id: matchArtifact.id,
+                archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/docs.zip`, Buffer.from(download.data));
+      
+      - name: Unzip artifact
+        run: |
+          unzip docs.zip
+          tar -xf docs.tar.zstd
+
+      - name: Deploy PR preview
+        continue-on-error: true
+        uses: dswistowski/surge-sh-action@v1.0.1
+        with:
+          domain: pr-${{ github.event.workflow_run.pull_requests[0].number }}--ruma-docs.surge.sh
+          project: doc
+          login: ${{ secrets.SURGE_LOGIN }}
+          token: ${{ secrets.SURGE_TOKEN }}
+
+      - name: Comment PR preview URL
+        uses: Beakyn/gha-comment-pull-request@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          description-message: |
+            ----
+            Preview: https://pr-${{ github.event.workflow_run.pull_requests[0].number }}--ruma-docs.surge.sh

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -42,6 +42,7 @@ jobs:
 
       - name: Deploy PR preview
         continue-on-error: true
+        id: deploy_preview
         uses: dswistowski/surge-sh-action@v1.0.1
         with:
           domain: pr-${{ github.event.workflow_run.pull_requests[0].number }}--ruma-docs.surge.sh
@@ -50,6 +51,7 @@ jobs:
           token: ${{ secrets.SURGE_TOKEN }}
 
       - name: Comment PR preview URL
+        if: steps.deploy_preview.outcome == 'success'
         uses: Beakyn/gha-comment-pull-request@v1.0.2
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/docs-remove-preview.yml
+++ b/.github/workflows/docs-remove-preview.yml
@@ -1,0 +1,56 @@
+name: Docs Remove Preview
+
+env:
+  CARGO_TERM_COLOR: always
+
+on:
+  workflow_run:
+    workflows: [PR Closed]
+    types:
+      - completed
+
+jobs:
+  teardown:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request'
+    steps:
+      - name: Get PR number
+        uses: actions/github-script@v6
+        id: get-pr
+        continue-on-error: true
+        with:
+          script: |
+            let login = context.payload.workflow_run.head_repository.owner.login;
+            let branch = context.payload.workflow_run.head_branch;
+            let head = `${login}:${branch}`;
+            let prs = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "closed",
+              head,
+            });
+            if (prs.data.length > 0) {
+              core.setOutput("prnumber", prs.data[0].number);
+            } else {
+              core.setFailed("Could not find PR");
+            }
+      
+      - name: Teardown preview
+        if: steps.get-pr.outcome == 'success'
+        continue-on-error: true
+        uses: adrianjost/actions-surge.sh-teardown@v1.0.3
+        with:
+          regex: pr-${{ steps.get-pr.outputs.prnumber }}--ruma-docs.surge.sh
+        env:
+          SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
+          SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
+
+      - name: Remove PR preview URL
+        if: steps.get-pr.outcome == 'success'
+        uses: Beakyn/gha-comment-pull-request@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          description-message: |
+            ----
+            Preview Removed

--- a/.github/workflows/docs-remove-preview.yml
+++ b/.github/workflows/docs-remove-preview.yml
@@ -51,6 +51,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
+          pull-request-number: ${{ steps.get_pr.outputs.prnumber }}
           description-message: |
             ----
             Preview Removed

--- a/.github/workflows/docs-remove-preview.yml
+++ b/.github/workflows/docs-remove-preview.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Get PR number
         uses: actions/github-script@v6
-        id: get-pr
+        id: get_pr
         continue-on-error: true
         with:
           script: |
@@ -36,17 +36,17 @@ jobs:
             }
       
       - name: Teardown preview
-        if: steps.get-pr.outcome == 'success'
+        if: steps.get_pr.outcome == 'success'
         continue-on-error: true
         uses: adrianjost/actions-surge.sh-teardown@v1.0.3
         with:
-          regex: pr-${{ steps.get-pr.outputs.prnumber }}--ruma-docs.surge.sh
+          regex: pr-${{ steps.get_pr.outputs.prnumber }}--ruma-docs.surge.sh
         env:
           SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
           SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
 
       - name: Remove PR preview URL
-        if: steps.get-pr.outcome == 'success'
+        if: steps.get_pr.outcome == 'success'
         uses: Beakyn/gha-comment-pull-request@v1.0.2
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -7,20 +7,7 @@ on:
 
 jobs:
   docs:
-    name: Remove Docs Preview
+    name: Trigger
     runs-on: ubuntu-latest
     steps:
-      - name: Teardown
-        uses: adrianjost/actions-surge.sh-teardown@v1.0.3
-        with:
-          regex: pr-${{ github.event.number }}--ruma-docs.surge.sh
-        env:
-          SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
-          SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
-
-      - name: Remove preview URL
-        uses: Beakyn/gha-comment-pull-request@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          description-message: Preview removed
+      - run: 'echo "PR number: ${{ github.event.number }}"'


### PR DESCRIPTION
I'm assuming it works as I've tested parts of it on a dummy repo. We have to merge this and then create a PR from a forked repo to make sure…

**The unnecessary hard parts**
- finding the artifact, because the default action for that only works in the same workflow I believe. The Matrix spec preview uses an action but I found this script in the Github docs so at least I know what it's doing.
- finding the PR number that triggered the workflow, because we don't have it when the PR has been closed. Here I copied the way of the Matrix spec to get the PR number from the branch that triggered the workflow, which means you can get several pull requests as a result if you opened several PRs in the past on a branch that has the same name. We assume the latest one is the proper one. I find it weird that you can't seem to just get which PR triggered a workflow, no matter its state.

**The bad things**
- The preview is only deployed when the whole CI workflow is finished, which means it'll take a little more time than previously to get the preview. It doesn't seem it's possible to make a workflow start at the end of a particular job.

**The good things**
- Don't deploy the preview if the PR was closed before the workflow was launched, it was unnecessary anyway.
- Don't teardown the preview if the PR was re-opened before the workflow was launched.
- Failure in any of those stage doesn't trigger a failure of the workflow.

<!-- Replace -->
----
Preview Removed
<!-- Replace -->
