### PR TITLE
Extensible message improvements

### DIFF
--- a/crates/ruma-common/src/events/message.rs
+++ b/crates/ruma-common/src/events/message.rs
@@ -68,6 +68,9 @@ use super::room::message::{
 /// This is the new primary type introduced in [MSC1767] and should not be sent before the end of
 /// the transition period. See the documentation of the [`message`] module for more information.
 ///
+/// To construct a `MessageEventContent` with a custom [`MessageContent`], convert it with
+/// `MessageEventContent::from()` / `.into()`.
+///
 /// `MessageEventContent` can be converted to a [`RoomMessageEventContent`] with a
 /// [`MessageType::Text`]. You can convert it back with
 /// [`MessageEventContent::from_text_room_message()`].
@@ -124,6 +127,12 @@ impl MessageEventContent {
     }
 }
 
+impl From<MessageContent> for MessageEventContent {
+    fn from(message: MessageContent) -> Self {
+        Self { message, relates_to: None }
+    }
+}
+
 impl From<MessageEventContent> for RoomMessageEventContent {
     fn from(content: MessageEventContent) -> Self {
         let MessageEventContent { message, relates_to, .. } = content;
@@ -136,6 +145,9 @@ impl From<MessageEventContent> for RoomMessageEventContent {
 ///
 /// A `MessageContent` must contain at least one message to be used as a fallback text
 /// representation.
+///
+/// To construct a `MessageContent` with custom MIME types, construct a `Vec<Text>` first and use
+/// its `.try_from()` / `.try_into()` implementation that will only fail if the `Vec` is empty.
 #[derive(Clone, Debug, Deserialize)]
 #[serde(try_from = "MessageContentSerDeHelper")]
 pub struct MessageContent(pub(crate) Vec<Text>);
@@ -231,7 +243,11 @@ impl Deref for MessageContent {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct Text {
-    /// The mime type of the `body`.
+    /// The MIME type of the `body`.
+    ///
+    /// This must follow the format defined in [RFC6838].
+    ///
+    /// [RFC6838]: https://datatracker.ietf.org/doc/html/rfc6838
     #[serde(default = "Text::default_mimetype")]
     pub mimetype: String,
 
@@ -249,24 +265,24 @@ pub struct Text {
 }
 
 impl Text {
-    /// Creates a new plain text message body.
-    pub fn plain(body: impl Into<String>) -> Self {
+    /// Creates a new `Text` with the given MIME type and body.
+    pub fn new(mimetype: impl Into<String>, body: impl Into<String>) -> Self {
         Self {
-            mimetype: "text/plain".to_owned(),
+            mimetype: mimetype.into(),
             body: body.into(),
             #[cfg(feature = "unstable-msc3554")]
             lang: None,
         }
     }
 
+    /// Creates a new plain text message body.
+    pub fn plain(body: impl Into<String>) -> Self {
+        Self::new("text/plain", body)
+    }
+
     /// Creates a new HTML-formatted message body.
     pub fn html(body: impl Into<String>) -> Self {
-        Self {
-            mimetype: "text/html".to_owned(),
-            body: body.into(),
-            #[cfg(feature = "unstable-msc3554")]
-            lang: None,
-        }
+        Self::new("text/html", body)
     }
 
     /// Creates a new HTML-formatted message body by parsing the Markdown in `body`.

--- a/crates/ruma-common/tests/events/audio.rs
+++ b/crates/ruma-common/tests/events/audio.rs
@@ -172,10 +172,8 @@ fn event_serialization() {
         to_json_value(&event).unwrap(),
         json!({
             "content": {
-                "org.matrix.msc1767.message": [
-                    { "body": "Upload: <strong>my_mix.mp3</strong>", "mimetype": "text/html"},
-                    { "body": "Upload: my_mix.mp3", "mimetype": "text/plain"},
-                ],
+                "org.matrix.msc1767.html": "Upload: <strong>my_mix.mp3</strong>",
+                "org.matrix.msc1767.text": "Upload: my_mix.mp3",
                 "m.file": {
                     "url": "mxc://notareal.hs/abcdef",
                     "name": "my_mix.mp3",

--- a/crates/ruma-common/tests/events/file.rs
+++ b/crates/ruma-common/tests/events/file.rs
@@ -126,10 +126,8 @@ fn file_event_serialization() {
         to_json_value(&event).unwrap(),
         json!({
             "content": {
-                "org.matrix.msc1767.message": [
-                    { "body": "Upload: <strong>my_file.txt</strong>", "mimetype": "text/html"},
-                    { "body": "Upload: my_file.txt", "mimetype": "text/plain"},
-                ],
+                "org.matrix.msc1767.html": "Upload: <strong>my_file.txt</strong>",
+                "org.matrix.msc1767.text": "Upload: my_file.txt",
                 "m.file": {
                     "url": "mxc://notareal.hs/abcdef",
                     "name": "my_file.txt",

--- a/crates/ruma-common/tests/events/image.rs
+++ b/crates/ruma-common/tests/events/image.rs
@@ -147,10 +147,8 @@ fn image_event_serialization() {
         to_json_value(&event).unwrap(),
         json!({
             "content": {
-                "org.matrix.msc1767.message": [
-                    { "body": "Upload: <strong>my_house.jpg</strong>", "mimetype": "text/html"},
-                    { "body": "Upload: my_house.jpg", "mimetype": "text/plain"},
-                ],
+                "org.matrix.msc1767.html": "Upload: <strong>my_house.jpg</strong>",
+                "org.matrix.msc1767.text": "Upload: my_house.jpg",
                 "m.file": {
                     "url": "mxc://notareal.hs/abcdef",
                     "name": "my_house.jpg",

--- a/crates/ruma-common/tests/events/location.rs
+++ b/crates/ruma-common/tests/events/location.rs
@@ -70,16 +70,8 @@ fn event_serialization() {
         to_json_value(&event).unwrap(),
         json!({
             "content": {
-                "org.matrix.msc1767.message": [
-                    {
-                        "body": "Alice was at <strong>geo:51.5008,0.1247;u=35</strong> as of <em>Sat Nov 13 18:50:58 2021</em>",
-                        "mimetype": "text/html",
-                    },
-                    {
-                        "body": "Alice was at geo:51.5008,0.1247;u=35 as of Sat Nov 13 18:50:58 2021",
-                        "mimetype": "text/plain",
-                    },
-                ],
+                "org.matrix.msc1767.html": "Alice was at <strong>geo:51.5008,0.1247;u=35</strong> as of <em>Sat Nov 13 18:50:58 2021</em>",
+                "org.matrix.msc1767.text": "Alice was at geo:51.5008,0.1247;u=35 as of Sat Nov 13 18:50:58 2021",
                 "m.location": {
                     "uri": "geo:51.5008,0.1247;u=35",
                     "description": "Alice's whereabouts",

--- a/crates/ruma-common/tests/events/message.rs
+++ b/crates/ruma-common/tests/events/message.rs
@@ -37,10 +37,8 @@ fn html_content_serialization() {
     assert_eq!(
         to_json_value(&message_event_content).unwrap(),
         json!({
-            "org.matrix.msc1767.message": [
-                { "body": "Hello, <em>World</em>!", "mimetype": "text/html"},
-                { "body": "Hello, World!", "mimetype": "text/plain"},
-            ]
+            "org.matrix.msc1767.html": "Hello, <em>World</em>!",
+            "org.matrix.msc1767.text": "Hello, World!",
         })
     );
 }
@@ -96,10 +94,8 @@ fn markdown_content_serialization() {
     assert_eq!(
         to_json_value(&formatted_message).unwrap(),
         json!({
-            "org.matrix.msc1767.message": [
-                { "body": "<p>Testing <strong>bold</strong> and <em>italic</em>!</p>\n", "mimetype": "text/html"},
-                { "body": "Testing **bold** and _italic_!", "mimetype": "text/plain"},
-            ]
+            "org.matrix.msc1767.html": "<p>Testing <strong>bold</strong> and <em>italic</em>!</p>\n",
+            "org.matrix.msc1767.text": "Testing **bold** and _italic_!",
         })
     );
 
@@ -118,10 +114,8 @@ fn markdown_content_serialization() {
     assert_eq!(
         to_json_value(&plain_message_paragraphs).unwrap(),
         json!({
-            "org.matrix.msc1767.message": [
-                { "body": "<p>Testing</p>\n<p>Several</p>\n<p>Paragraphs.</p>\n", "mimetype": "text/html"},
-                { "body": "Testing\n\nSeveral\n\nParagraphs.", "mimetype": "text/plain"},
-            ]
+            "org.matrix.msc1767.html": "<p>Testing</p>\n<p>Several</p>\n<p>Paragraphs.</p>\n",
+            "org.matrix.msc1767.text": "Testing\n\nSeveral\n\nParagraphs.",
         })
     );
 }
@@ -198,7 +192,53 @@ fn plain_text_content_stable_deserialization() {
 }
 
 #[test]
-fn html_text_content_unstable_deserialization() {
+fn html_content_unstable_deserialization() {
+    let json_data = json!({
+        "org.matrix.msc1767.html": "Hello, <em>New World</em>!",
+    });
+
+    let content = from_json_value::<MessageEventContent>(json_data).unwrap();
+    assert_eq!(content.message.find_plain(), None);
+    assert_eq!(content.message.find_html(), Some("Hello, <em>New World</em>!"));
+}
+
+#[test]
+fn html_content_stable_deserialization() {
+    let json_data = json!({
+        "m.html": "Hello, <em>New World</em>!",
+    });
+
+    let content = from_json_value::<MessageEventContent>(json_data).unwrap();
+    assert_eq!(content.message.find_plain(), None);
+    assert_eq!(content.message.find_html(), Some("Hello, <em>New World</em>!"));
+}
+
+#[test]
+fn html_and_text_content_unstable_deserialization() {
+    let json_data = json!({
+        "org.matrix.msc1767.html": "Hello, <em>New World</em>!",
+        "org.matrix.msc1767.text": "Hello, New World!",
+    });
+
+    let content = from_json_value::<MessageEventContent>(json_data).unwrap();
+    assert_eq!(content.message.find_plain(), Some("Hello, New World!"));
+    assert_eq!(content.message.find_html(), Some("Hello, <em>New World</em>!"));
+}
+
+#[test]
+fn html_and_text_content_stable_deserialization() {
+    let json_data = json!({
+        "m.html": "Hello, <em>New World</em>!",
+        "m.text": "Hello, New World!",
+    });
+
+    let content = from_json_value::<MessageEventContent>(json_data).unwrap();
+    assert_eq!(content.message.find_plain(), Some("Hello, New World!"));
+    assert_eq!(content.message.find_html(), Some("Hello, <em>New World</em>!"));
+}
+
+#[test]
+fn message_content_unstable_deserialization() {
     let json_data = json!({
         "org.matrix.msc1767.message": [
             { "body": "Hello, <em>New World</em>!", "mimetype": "text/html"},
@@ -212,7 +252,7 @@ fn html_text_content_unstable_deserialization() {
 }
 
 #[test]
-fn html_text_content_stable_deserialization() {
+fn message_content_stable_deserialization() {
     let json_data = json!({
         "m.message": [
             { "body": "Hello, <em>New World</em>!", "mimetype": "text/html"},
@@ -315,7 +355,61 @@ fn room_message_plain_text_unstable_deserialization() {
 }
 
 #[test]
-fn room_message_html_text_stable_deserialization() {
+fn room_message_html_and_text_stable_deserialization() {
+    let json_data = json!({
+        "body": "test",
+        "formatted_body": "<h1>test</h1>",
+        "format": "org.matrix.custom.html",
+        "msgtype": "m.text",
+        "m.html": "<h1>test</h1>",
+        "m.text": "test",
+    });
+
+    let content = assert_matches!(
+        from_json_value::<RoomMessageEventContent>(json_data),
+        Ok(RoomMessageEventContent {
+            msgtype: MessageType::Text(content),
+            ..
+        }) => content
+    );
+    assert_eq!(content.body, "test");
+    let formatted = content.formatted.unwrap();
+    assert_eq!(formatted.body, "<h1>test</h1>");
+    let message = content.message.unwrap();
+    assert_eq!(message.len(), 2);
+    assert_eq!(message[0].body, "<h1>test</h1>");
+    assert_eq!(message[1].body, "test");
+}
+
+#[test]
+fn room_message_html_and_text_unstable_deserialization() {
+    let json_data = json!({
+        "body": "test",
+        "formatted_body": "<h1>test</h1>",
+        "format": "org.matrix.custom.html",
+        "msgtype": "m.text",
+        "org.matrix.msc1767.html": "<h1>test</h1>",
+        "org.matrix.msc1767.text": "test",
+    });
+
+    let content = assert_matches!(
+        from_json_value::<RoomMessageEventContent>(json_data),
+        Ok(RoomMessageEventContent {
+            msgtype: MessageType::Text(content),
+            ..
+        }) => content
+    );
+    assert_eq!(content.body, "test");
+    let formatted = content.formatted.unwrap();
+    assert_eq!(formatted.body, "<h1>test</h1>");
+    let message = content.message.unwrap();
+    assert_eq!(message.len(), 2);
+    assert_eq!(message[0].body, "<h1>test</h1>");
+    assert_eq!(message[1].body, "test");
+}
+
+#[test]
+fn room_message_message_stable_deserialization() {
     let json_data = json!({
         "body": "test",
         "formatted_body": "<h1>test</h1>",
@@ -344,7 +438,7 @@ fn room_message_html_text_stable_deserialization() {
 }
 
 #[test]
-fn room_message_html_text_unstable_deserialization() {
+fn room_message_message_unstable_deserialization() {
     let json_data = json!({
         "body": "test",
         "formatted_body": "<h1>test</h1>",
@@ -537,10 +631,8 @@ fn emote_event_serialization() {
         to_json_value(&event).unwrap(),
         json!({
             "content": {
-                "org.matrix.msc1767.message": [
-                    { "body": "is testing some <code>code</code>…", "mimetype": "text/html" },
-                    { "body": "is testing some code…", "mimetype": "text/plain" },
-                ]
+                "org.matrix.msc1767.html": "is testing some <code>code</code>…",
+                "org.matrix.msc1767.text": "is testing some code…",
             },
             "event_id": "$event:notareal.hs",
             "origin_server_ts": 134_829_848,

--- a/crates/ruma-common/tests/events/message.rs
+++ b/crates/ruma-common/tests/events/message.rs
@@ -59,6 +59,36 @@ fn plain_text_content_serialization() {
 }
 
 #[test]
+fn unknown_mimetype_content_serialization() {
+    let message_event_content = MessageEventContent::from(
+        MessageContent::try_from(vec![
+            Text::plain("> <@test:example.com> test\n\ntest reply"),
+            Text::new(
+                "application/json",
+                r#"{ "quote": "<@test:example.com> test", "reply": "test reply" }"#,
+            ),
+        ])
+        .unwrap(),
+    );
+
+    assert_eq!(
+        to_json_value(&message_event_content).unwrap(),
+        json!({
+            "org.matrix.msc1767.message": [
+                {
+                    "body": "> <@test:example.com> test\n\ntest reply",
+                    "mimetype": "text/plain",
+                },
+                {
+                    "body": r#"{ "quote": "<@test:example.com> test", "reply": "test reply" }"#,
+                    "mimetype": "application/json",
+                },
+            ]
+        })
+    );
+}
+
+#[test]
 #[cfg(feature = "markdown")]
 fn markdown_content_serialization() {
     let formatted_message = MessageEventContent::markdown("Testing **bold** and _italic_!");

--- a/crates/ruma-common/tests/events/room_message.rs
+++ b/crates/ruma-common/tests/events/room_message.rs
@@ -192,10 +192,8 @@ fn formatted_body_serialization() {
             "msgtype": "m.text",
             "format": "org.matrix.custom.html",
             "formatted_body": "Hello, <em>World</em>!",
-            "org.matrix.msc1767.message": [
-                { "body": "Hello, <em>World</em>!", "mimetype": "text/html" },
-                { "body": "Hello, World!", "mimetype": "text/plain" },
-            ],
+            "org.matrix.msc1767.html": "Hello, <em>World</em>!",
+            "org.matrix.msc1767.text": "Hello, World!",
         })
     );
 }
@@ -253,10 +251,8 @@ fn markdown_content_serialization() {
             "formatted_body": "<p>Testing <strong>bold</strong> and <em>italic</em>!</p>\n",
             "format": "org.matrix.custom.html",
             "msgtype": "m.text",
-            "org.matrix.msc1767.message": [
-                { "body": "<p>Testing <strong>bold</strong> and <em>italic</em>!</p>\n", "mimetype": "text/html" },
-                { "body": "Testing **bold** and _italic_!", "mimetype": "text/plain" },
-            ],
+            "org.matrix.msc1767.html": "<p>Testing <strong>bold</strong> and <em>italic</em>!</p>\n",
+            "org.matrix.msc1767.text": "Testing **bold** and _italic_!",
         })
     );
 
@@ -306,10 +302,8 @@ fn markdown_content_serialization() {
             "formatted_body": "<p>Testing</p>\n<p>Several</p>\n<p>Paragraphs.</p>\n",
             "format": "org.matrix.custom.html",
             "msgtype": "m.text",
-            "org.matrix.msc1767.message": [
-                { "body": "<p>Testing</p>\n<p>Several</p>\n<p>Paragraphs.</p>\n", "mimetype": "text/html" },
-                { "body": "Testing\n\nSeveral\n\nParagraphs.", "mimetype": "text/plain" },
-            ],
+            "org.matrix.msc1767.html": "<p>Testing</p>\n<p>Several</p>\n<p>Paragraphs.</p>\n",
+            "org.matrix.msc1767.text": "Testing\n\nSeveral\n\nParagraphs.",
         })
     );
 }

--- a/crates/ruma-common/tests/events/video.rs
+++ b/crates/ruma-common/tests/events/video.rs
@@ -154,10 +154,8 @@ fn event_serialization() {
         to_json_value(&event).unwrap(),
         json!({
             "content": {
-                "org.matrix.msc1767.message": [
-                    { "body": "Upload: <strong>my_lava_lamp.webm</strong>", "mimetype": "text/html"},
-                    { "body": "Upload: my_lava_lamp.webm", "mimetype": "text/plain"},
-                ],
+                "org.matrix.msc1767.html": "Upload: <strong>my_lava_lamp.webm</strong>",
+                "org.matrix.msc1767.text": "Upload: my_lava_lamp.webm",
                 "m.file": {
                     "url": "mxc://notareal.hs/abcdef",
                     "name": "my_lava_lamp.webm",


### PR DESCRIPTION
The MSC had a new commit (https://github.com/matrix-org/matrix-spec-proposals/pull/1767/commits/4afdc324151f70cfd76fb91a2a5a87a28b6cea8f) to clarify it. Among other things it confirms that the `m.html` shortcut is kept, while reading comments before I thought it was going to be removed, so we add support for it.

Working on that, I realized it's currently not possible to create a `MessageEventContent` with custom mimetypes so we also add support for that.



















<!-- Replace -->
----
Preview: https://pr-1230--ruma-docs.surge.sh
<!-- Replace -->
