### PR TITLE
Add unstable prefix for m.authentication.

### DIFF
--- a/crates/ruma-client-api/src/discovery/discover_homeserver.rs
+++ b/crates/ruma-client-api/src/discovery/discover_homeserver.rs
@@ -39,7 +39,11 @@ ruma_api! {
 
         /// Information about the authentication server to connect to when using OpenID Connect.
         #[cfg(feature = "unstable-msc2965")]
-        #[serde(rename = "m.authentication", skip_serializing_if = "Option::is_none")]
+        #[serde(
+            rename = "org.matrix.msc2965.authentication",
+            alias = "m.authentication",
+            skip_serializing_if = "Option::is_none"
+        )]
         pub authentication: Option<AuthenticationServerInfo>,
     }
 


### PR DESCRIPTION
This should have been included originally but was unnoticed as the test environment was returning the stable key.

<!-- Replace -->
----
Preview Removed
<!-- Replace -->
