### PR TITLE
Remove msrv from .clippy.toml

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,4 +1,3 @@
-msrv = "1.60"
 avoid-breaking-exported-api = false
 disallowed-methods = [
     # https://github.com/serde-rs/json/issues/160

--- a/crates/ruma-state-res/.clippy.toml
+++ b/crates/ruma-state-res/.clippy.toml
@@ -1,4 +1,3 @@
-msrv = "1.60"
 avoid-breaking-exported-api = false
 disallowed-methods = [
     # https://github.com/serde-rs/json/issues/160


### PR DESCRIPTION
Clippy now respects the rust-version field in Cargo manifests:
https://github.com/rust-lang/rust-clippy/pull/8774




<!-- Replace -->
----
Preview Removed
<!-- Replace -->
