### PR TITLE
Remove leftover unstable prefixes

### DIFF
--- a/crates/ruma-client-api/src/account/register.rs
+++ b/crates/ruma-client-api/src/account/register.rs
@@ -90,8 +90,7 @@ pub mod v3 {
             #[serde(
                 default,
                 skip_serializing_if = "ruma_common::serde::is_default",
-                rename = "org.matrix.msc2918.refresh_token",
-                alias = "refresh_token",
+                alias = "org.matrix.msc2918.refresh_token",
             )]
             pub refresh_token: bool,
         }

--- a/crates/ruma-client-api/src/keys/upload_keys.rs
+++ b/crates/ruma-client-api/src/keys/upload_keys.rs
@@ -40,7 +40,7 @@ pub mod v3 {
             pub one_time_keys: BTreeMap<OwnedDeviceKeyId, Raw<OneTimeKey>>,
 
             /// Fallback public keys for "pre-key" messages.
-            #[serde(default, skip_serializing_if = "BTreeMap::is_empty", rename = "org.matrix.msc2732.fallback_keys")]
+            #[serde(default, skip_serializing_if = "BTreeMap::is_empty", alias = "org.matrix.msc2732.fallback_keys")]
             pub fallback_keys: BTreeMap<OwnedDeviceKeyId, Raw<OneTimeKey>>,
         }
 

--- a/crates/ruma-client-api/src/session/login.rs
+++ b/crates/ruma-client-api/src/session/login.rs
@@ -53,8 +53,7 @@ pub mod v3 {
             #[serde(
                 default,
                 skip_serializing_if = "ruma_common::serde::is_default",
-                rename = "org.matrix.msc2918.refresh_token",
-                alias = "refresh_token",
+                alias = "org.matrix.msc2918.refresh_token",
             )]
             pub refresh_token: bool,
         }

--- a/crates/ruma-federation-api/src/transactions/edu.rs
+++ b/crates/ruma-federation-api/src/transactions/edu.rs
@@ -14,10 +14,6 @@ use ruma_common::{
 use serde::{de, Deserialize, Serialize};
 use serde_json::{value::RawValue as RawJsonValue, Value as JsonValue};
 
-// There is one more edu_type synapse recognizes with the note:
-// FIXME: switch to "m.signing_key_update" when MSC1756 is merged into the
-// spec from "org.matrix.signing_key_update"
-
 /// Type for passing ephemeral data to homeservers.
 #[derive(Clone, Debug, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]


### PR DESCRIPTION
I noticed when working on refresh tokens in the SDK that they still use the unstable prefix, although they're stable since v1.3. I must have forgotten to switch that part.

I also did a search for `org.matrix` to see if there where others and I found another one from v1.2. I also found an obsolete comment from long ago.




<!-- Replace -->
----
Preview Removed
<!-- Replace -->
