### PR TITLE
client-api: Use a stronger type for send_state_event::Request::new

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -3,3 +3,5 @@
 # Or if we're able to ignore certain lines.
 NAX = "NAX"
 Nd = "Nd"
+# thead html tag is not a typo, upstream PR pending
+thead = "thead"

--- a/crates/ruma-client-api/src/state/send_state_event.rs
+++ b/crates/ruma-client-api/src/state/send_state_event.rs
@@ -5,6 +5,8 @@ pub mod v3 {
     //!
     //! [spec]: https://spec.matrix.org/v1.2/client-server-api/#put_matrixclientv3roomsroomidstateeventtypestatekey
 
+    use std::borrow::Borrow;
+
     use ruma_common::{
         api::ruma_api,
         events::{AnyStateEventContent, StateEventContent, StateEventType},
@@ -69,17 +71,19 @@ pub mod v3 {
         ///
         /// Since `Request` stores the request body in serialized form, this function can fail if
         /// `T`s [`Serialize`][serde::Serialize] implementation can fail.
-        pub fn new<T>(
+        pub fn new<T, K>(
             room_id: &'a RoomId,
-            state_key: &'a str,
+            state_key: &'a K,
             content: &'a T,
         ) -> serde_json::Result<Self>
         where
             T: StateEventContent,
+            T::StateKey: Borrow<K>,
+            K: AsRef<str> + ?Sized,
         {
             Ok(Self {
                 room_id,
-                state_key,
+                state_key: state_key.as_ref(),
                 event_type: content.event_type(),
                 body: Raw::from_json(to_raw_json_value(content)?),
                 timestamp: None,


### PR DESCRIPTION








<!-- Replace -->
----
Preview: https://pr-1259--ruma-docs.surge.sh
<!-- Replace -->
