### PR TITLE
Mark futures returned by send_matrix_request and send_customized_matrix_request as send

### DIFF
--- a/crates/ruma-client/src/http_client.rs
+++ b/crates/ruma-client/src/http_client.rs
@@ -68,7 +68,7 @@ pub trait HttpClientExt: HttpClient {
         access_token: SendAccessToken<'_>,
         for_versions: &[MatrixVersion],
         request: R,
-    ) -> Pin<Box<dyn Future<Output = ResponseResult<Self, R>> + 'a>> {
+    ) -> Pin<Box<dyn Future<Output = ResponseResult<Self, R>> + 'a + Send>> {
         self.send_customized_matrix_request(
             homeserver_url,
             access_token,
@@ -88,7 +88,7 @@ pub trait HttpClientExt: HttpClient {
         for_versions: &[MatrixVersion],
         request: R,
         customize: F,
-    ) -> Pin<Box<dyn Future<Output = ResponseResult<Self, R>> + 'a>>
+    ) -> Pin<Box<dyn Future<Output = ResponseResult<Self, R>> + 'a + Send>>
     where
         R: OutgoingRequest + 'a,
         F: FnOnce(&mut http::Request<Self::RequestBody>) -> Result<(), ResponseError<Self, R>> + 'a,


### PR DESCRIPTION
Code:
```rust
fn is_send<T: Send>(t: T) {}
...
let blubb = ruma::client::Client::builder().homeserver_url("blubb".to_owned()).build::<HttpClient>();
is_send(blubb);
```

Before:

```
58 |     is_send(blubb);
   |             ^^^^^ future is not `Send`
   |
   = help: the trait `std::marker::Send` is not implemented for `dyn futures_core::Future<Output = Result<ruma::api::ruma_client_api::discovery::get_supported_versions::Response, ruma::ruma_client::Error<reqwest::Error, ruma::api::ruma_client_api::Error>>>`
note: required by a bound in `is_send`
  --> src/api/login.rs:45:15
   |
45 | fn is_send<T: Send>(t: T) {}
   |               ^^^^ required by this bound in `is_send`
```

After: (compiles)

<!-- Replace -->
----
Preview Removed
<!-- Replace -->
