### PR TITLE
Update sliding sync to latest

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [unreleased]
 
+
+Breaking changes:
+
+*  `DeviceList` has moved from `sync::sync_events::v3` to `sync::sync_events`
+
 # 0.15.0
 
 Breaking changes:

--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -1,9 +1,10 @@
 # [unreleased]
 
 
-Breaking changes:
+Improvements:
 
-*  `DeviceList` has moved from `sync::sync_events::v3` to `sync::sync_events`
+* `DeviceLists` has moved from `sync::sync_events::v3` to `sync::sync_events`
+  * It is still available under the old location for backwards compatibility
 
 # 0.15.0
 

--- a/crates/ruma-client-api/src/sync/sync_events.rs
+++ b/crates/ruma-client-api/src/sync/sync_events.rs
@@ -34,7 +34,6 @@ impl UnreadNotificationsCount {
     }
 }
 
-
 /// Information on E2E device updates.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]

--- a/crates/ruma-client-api/src/sync/sync_events.rs
+++ b/crates/ruma-client-api/src/sync/sync_events.rs
@@ -40,12 +40,12 @@ impl UnreadNotificationsCount {
 pub struct DeviceLists {
     /// List of users who have updated their device identity keys or who now
     /// share an encrypted room with the client since the previous sync.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, deserialize_with = "deserialize_null_default", skip_serializing_if = "Vec::is_empty")]
     pub changed: Vec<OwnedUserId>,
 
     /// List of users who no longer share encrypted rooms since the previous sync
     /// response.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, deserialize_with = "deserialize_null_default", skip_serializing_if = "Vec::is_empty")]
     pub left: Vec<OwnedUserId>,
 }
 
@@ -59,4 +59,15 @@ impl DeviceLists {
     pub fn is_empty(&self) -> bool {
         self.changed.is_empty() && self.left.is_empty()
     }
+}
+
+// FIXME: hack until https://github.com/matrix-org/sliding-sync/issues/45 is fixed
+use serde::Deserializer;
+pub(crate) fn deserialize_null_default<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    T: Default + Deserialize<'de>,
+    D: Deserializer<'de>,
+{
+    let opt = Option::deserialize(deserializer)?;
+    Ok(opt.unwrap_or_default())
 }

--- a/crates/ruma-client-api/src/sync/sync_events.rs
+++ b/crates/ruma-client-api/src/sync/sync_events.rs
@@ -40,20 +40,12 @@ impl UnreadNotificationsCount {
 pub struct DeviceLists {
     /// List of users who have updated their device identity keys or who now
     /// share an encrypted room with the client since the previous sync.
-    #[serde(
-        default,
-        deserialize_with = "deserialize_null_default",
-        skip_serializing_if = "Vec::is_empty"
-    )]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub changed: Vec<OwnedUserId>,
 
     /// List of users who no longer share encrypted rooms since the previous sync
     /// response.
-    #[serde(
-        default,
-        deserialize_with = "deserialize_null_default",
-        skip_serializing_if = "Vec::is_empty"
-    )]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub left: Vec<OwnedUserId>,
 }
 
@@ -67,15 +59,4 @@ impl DeviceLists {
     pub fn is_empty(&self) -> bool {
         self.changed.is_empty() && self.left.is_empty()
     }
-}
-
-// FIXME: hack until https://github.com/matrix-org/sliding-sync/issues/45 is fixed
-use serde::Deserializer;
-pub(crate) fn deserialize_null_default<'de, D, T>(deserializer: D) -> Result<T, D::Error>
-where
-    T: Default + Deserialize<'de>,
-    D: Deserializer<'de>,
-{
-    let opt = Option::deserialize(deserializer)?;
-    Ok(opt.unwrap_or_default())
 }

--- a/crates/ruma-client-api/src/sync/sync_events.rs
+++ b/crates/ruma-client-api/src/sync/sync_events.rs
@@ -39,7 +39,7 @@ impl UnreadNotificationsCount {
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct DeviceLists {
     /// List of users who have updated their device identity keys or who now
-    /// share an encrypted room with the client since the previous sync
+    /// share an encrypted room with the client since the previous sync.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub changed: Vec<OwnedUserId>,
 

--- a/crates/ruma-client-api/src/sync/sync_events.rs
+++ b/crates/ruma-client-api/src/sync/sync_events.rs
@@ -1,6 +1,7 @@
 //! `GET /_matrix/client/*/sync`
 
 use js_int::UInt;
+use ruma_common::OwnedUserId;
 use serde::{self, Deserialize, Serialize};
 
 pub mod v3;
@@ -30,5 +31,33 @@ impl UnreadNotificationsCount {
     /// Returns true if there are no notification count updates.
     pub fn is_empty(&self) -> bool {
         self.highlight_count.is_none() && self.notification_count.is_none()
+    }
+}
+
+
+/// Information on E2E device updates.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+pub struct DeviceLists {
+    /// List of users who have updated their device identity keys or who now
+    /// share an encrypted room with the client since the previous sync
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub changed: Vec<OwnedUserId>,
+
+    /// List of users who no longer share encrypted rooms since the previous sync
+    /// response.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub left: Vec<OwnedUserId>,
+}
+
+impl DeviceLists {
+    /// Creates an empty `DeviceLists`.
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Returns true if there are no device list updates.
+    pub fn is_empty(&self) -> bool {
+        self.changed.is_empty() && self.left.is_empty()
     }
 }

--- a/crates/ruma-client-api/src/sync/sync_events.rs
+++ b/crates/ruma-client-api/src/sync/sync_events.rs
@@ -40,12 +40,20 @@ impl UnreadNotificationsCount {
 pub struct DeviceLists {
     /// List of users who have updated their device identity keys or who now
     /// share an encrypted room with the client since the previous sync.
-    #[serde(default, deserialize_with = "deserialize_null_default", skip_serializing_if = "Vec::is_empty")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_null_default",
+        skip_serializing_if = "Vec::is_empty"
+    )]
     pub changed: Vec<OwnedUserId>,
 
     /// List of users who no longer share encrypted rooms since the previous sync
     /// response.
-    #[serde(default, deserialize_with = "deserialize_null_default", skip_serializing_if = "Vec::is_empty")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_null_default",
+        skip_serializing_if = "Vec::is_empty"
+    )]
     pub left: Vec<OwnedUserId>,
 }
 

--- a/crates/ruma-client-api/src/sync/sync_events/v3.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v3.rs
@@ -4,7 +4,7 @@
 
 use std::{collections::BTreeMap, time::Duration};
 
-use super::UnreadNotificationsCount;
+use super::{UnreadNotificationsCount, DeviceLists};
 use js_int::UInt;
 use ruma_common::{
     api::ruma_api,
@@ -15,7 +15,7 @@ use ruma_common::{
     },
     presence::PresenceState,
     serde::{Incoming, Raw},
-    DeviceKeyAlgorithm, OwnedRoomId, OwnedUserId,
+    DeviceKeyAlgorithm, OwnedRoomId,
 };
 use serde::{Deserialize, Serialize};
 
@@ -576,33 +576,6 @@ impl ToDevice {
     /// Returns true if there are no to-device events.
     pub fn is_empty(&self) -> bool {
         self.events.is_empty()
-    }
-}
-
-/// Information on E2E device updates.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-pub struct DeviceLists {
-    /// List of users who have updated their device identity keys or who now
-    /// share an encrypted room with the client since the previous sync
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub changed: Vec<OwnedUserId>,
-
-    /// List of users who no longer share encrypted rooms since the previous sync
-    /// response.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub left: Vec<OwnedUserId>,
-}
-
-impl DeviceLists {
-    /// Creates an empty `DeviceLists`.
-    pub fn new() -> Self {
-        Default::default()
-    }
-
-    /// Returns true if there are no device list updates.
-    pub fn is_empty(&self) -> bool {
-        self.changed.is_empty() && self.left.is_empty()
     }
 }
 

--- a/crates/ruma-client-api/src/sync/sync_events/v3.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v3.rs
@@ -4,7 +4,8 @@
 
 use std::{collections::BTreeMap, time::Duration};
 
-use super::{DeviceLists, UnreadNotificationsCount};
+pub use super::DeviceLists;
+use super::UnreadNotificationsCount;
 use js_int::UInt;
 use ruma_common::{
     api::ruma_api,

--- a/crates/ruma-client-api/src/sync/sync_events/v3.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v3.rs
@@ -4,7 +4,7 @@
 
 use std::{collections::BTreeMap, time::Duration};
 
-use super::{UnreadNotificationsCount, DeviceLists};
+use super::{DeviceLists, UnreadNotificationsCount};
 use js_int::UInt;
 use ruma_common::{
     api::ruma_api,

--- a/crates/ruma-client-api/src/sync/sync_events/v4.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v4.rs
@@ -169,7 +169,7 @@ pub struct SyncRequestListFilters {
     ///
     /// Same as "room_types" but inverted. This can be used to filter out spaces from the room
     /// list.
-    #[serde(default, skip_serializing_if = "<[_]>::is_empty")]
+    #[serde(skip_serializing_if = "<[_]>::is_empty")]
     pub not_room_types: Vec<String>,
 
     /// Only list rooms matching the given string, or all.
@@ -177,6 +177,18 @@ pub struct SyncRequestListFilters {
     /// Filter the room name. Case-insensitive partial matching e.g 'foo' matches 'abFooab'.
     /// The term 'like' is inspired by SQL 'LIKE', and the text here is similar to '%foo%'.
     pub room_name_like: Option<String>,
+
+    /// Filter the room based on its room tags. If multiple tags are present, a room can have
+    /// any one of the listed tags (OR'd).
+    #[serde(skip_serializing_if = "<[_]>::is_empty")]
+    pub tags: Vec<String>,
+
+    /// Filter the room based on its room tags. Takes priority over `tags`. For example, a room
+    /// with tags A and B with filters tags:[A] not_tags:[B] would NOT be included because not_tags
+    /// takes priority over `tags`. This filter is useful if your Rooms list does NOT include the
+    /// list of favourite rooms again.
+    #[serde(skip_serializing_if = "<[_]>::is_empty")]
+    pub not_tags: Vec<String>,
 
     /// Extensions may add further fields to the filters.
     #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]

--- a/crates/ruma-client-api/src/sync/sync_events/v4.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v4.rs
@@ -60,8 +60,8 @@ ruma_api! {
         pub unsubscribe_rooms: &'a [OwnedRoomId],
 
         /// Extensions API.
-        #[serde(skip_serializing_if = "BTreeMap::is_empty")]
-        pub extensions: BTreeMap<String, serde_json::Value>,
+        #[serde(skip_serializing_if = "ExtensionsRequest::is_empty")]
+        pub extensions: ExtensionsRequest,
     }
 
     response: {
@@ -80,6 +80,10 @@ ruma_api! {
         /// The updates on rooms.
         #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
         pub rooms: BTreeMap<OwnedRoomId, SlidingSyncRoom>,
+
+        /// Extensions API.
+        #[serde(default)]
+        pub extensions: ExtensionsResponse,
     }
 
     error: crate::Error
@@ -100,9 +104,11 @@ impl Response {
             pos,
             lists: Default::default(),
             rooms: Default::default(),
+            extensions: Default::default(),
         }
     }
 }
+
 /// Filter for a sliding sync list, set at request.
 ///
 /// All fields are applied with AND operators, hence if `is_dm`  is `true` and `is_encrypted` is
@@ -356,4 +362,71 @@ impl SlidingSyncRoom {
     pub fn new() -> Self {
         Default::default()
     }
+}
+
+/// Configure Sliding-Sync extensions.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+pub struct ExtensionsRequest {
+    /// Request to devices messages with the given config.
+    pub to_device: Option<ToDeviceRequest>,
+    /// Configure the end-to-end-encryption extension.
+    pub e2ee: Option<E2EERequest>,
+    /// Configure the account data extension.
+    pub account_data: Option<AccountDataRequest>,
+    /// Extensions may add further fields to the list.
+    #[serde(flatten, default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub other: BTreeMap<String, serde_json::Value>,
+}
+
+impl ExtensionsRequest {
+    fn is_empty(&self) -> bool {
+        !(self.to_device.is_some() || self.e2ee.is_some() || self.account_data.is_some() || !self.other.is_empty())
+    }
+}
+
+/// Extensions specific response data.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+pub struct ExtensionsResponse {
+    to_device: Option<ToDeviceResponse>,
+    e2ee: Option<E2EEResponse>,
+    account_data: Option<AccountDataResponse>,
+}
+
+/// ToDevice Messages Extension request.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+pub struct ToDeviceRequest {
+}
+
+/// ToDevice Messages Extension response.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+pub struct ToDeviceResponse {
+}
+
+/// E2EE Extension request.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+pub struct E2EERequest {
+}
+
+/// E2EE Extension response.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+pub struct E2EEResponse {
+}
+
+
+/// AccountData Extension request.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+pub struct AccountDataRequest {
+}
+
+/// AccountData Extension response.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+pub struct AccountDataResponse {
 }

--- a/crates/ruma-client-api/src/sync/sync_events/v4.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v4.rs
@@ -509,7 +509,7 @@ pub struct AccountDataConfig {
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct AccountData {
     /// The global private data created by this user.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, deserialize_with = "super::deserialize_null_default", skip_serializing_if = "Vec::is_empty")]
     pub global: Vec<Raw<AnyGlobalAccountDataEvent>>,
 
     /// The private data that this user has attached to each room.

--- a/crates/ruma-client-api/src/sync/sync_events/v4.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v4.rs
@@ -402,7 +402,7 @@ pub struct ExtensionsResponse {
 
 /// ToDevice Messages Extension request.
 ///
-/// Currently unspecc'ed. Taken from the reference implementation
+/// Not yet part of the spec proposal. Taken from the reference implementation
 /// <https://github.com/matrix-org/sliding-sync/blob/d77e21138d4886d27b3888d36cf3627f54f67590/sync3/extensions/todevice.go>
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
@@ -417,7 +417,7 @@ pub struct ToDeviceRequest {
 
 /// ToDevice Messages Extension response.
 ///
-/// Currently unspecc'ed. Taken from the reference implementation
+/// Not yet part of the spec proposal. Taken from the reference implementation
 /// <https://github.com/matrix-org/sliding-sync/blob/d77e21138d4886d27b3888d36cf3627f54f67590/sync3/extensions/todevice.go>
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
@@ -431,7 +431,7 @@ pub struct ToDeviceResponse {
 
 /// E2EE Extension request.
 ///
-/// Currently unspecc'ed. Taken from the reference implementation
+/// Not yet part of the spec proposal. Taken from the reference implementation
 /// <https://github.com/matrix-org/sliding-sync/blob/d77e21138d4886d27b3888d36cf3627f54f67590/sync3/extensions/e2ee.go>
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
@@ -442,7 +442,7 @@ pub struct E2EERequest {
 
 /// E2EE Extension response.
 ///
-/// Currently unspecc'ed. Taken from the reference implementation
+/// Not yet part of the spec proposal. Taken from the reference implementation
 /// <https://github.com/matrix-org/sliding-sync/blob/d77e21138d4886d27b3888d36cf3627f54f67590/sync3/extensions/e2ee.go>
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
@@ -466,7 +466,7 @@ pub struct E2EEResponse {
 
 /// AccountData Extension request.
 ///
-/// Currently unspecc'ed. Taken from the reference implementation
+/// Not yet part of the spec proposal. Taken from the reference implementation
 /// <https://github.com/matrix-org/sliding-sync/blob/d77e21138d4886d27b3888d36cf3627f54f67590/sync3/extensions/account_data.go>
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
@@ -477,7 +477,7 @@ pub struct AccountDataRequest {
 
 /// AccountData Extension response.
 ///
-/// Currently unspecc'ed. Taken from the reference implementation
+/// Not yet part of the spec proposal. Taken from the reference implementation
 /// <https://github.com/matrix-org/sliding-sync/blob/d77e21138d4886d27b3888d36cf3627f54f67590/sync3/extensions/account_data.go>
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]

--- a/crates/ruma-client-api/src/sync/sync_events/v4.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v4.rs
@@ -509,7 +509,11 @@ pub struct AccountDataConfig {
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct AccountData {
     /// The global private data created by this user.
-    #[serde(default, deserialize_with = "super::deserialize_null_default", skip_serializing_if = "Vec::is_empty")]
+    #[serde(
+        default,
+        deserialize_with = "super::deserialize_null_default",
+        skip_serializing_if = "Vec::is_empty"
+    )]
     pub global: Vec<Raw<AnyGlobalAccountDataEvent>>,
 
     /// The private data that this user has attached to each room.

--- a/crates/ruma-client-api/src/sync/sync_events/v4.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v4.rs
@@ -193,9 +193,9 @@ pub struct SyncRequestListFilters {
     pub tags: Vec<String>,
 
     /// Filter the room based on its room tags. Takes priority over `tags`. For example, a room
-    /// with tags A and B with filters tags:[A] not_tags:[B] would NOT be included because not_tags
-    /// takes priority over `tags`. This filter is useful if your Rooms list does NOT include the
-    /// list of favourite rooms again.
+    /// with tags A and B with filters `tags:[A]` `not_tags:[B]` would NOT be included because
+    /// `not_tags` takes priority over `tags`. This filter is useful if your Rooms list does
+    /// NOT include the list of favourite rooms again.
     #[serde(skip_serializing_if = "<[_]>::is_empty")]
     pub not_tags: Vec<String>,
 

--- a/crates/ruma-client-api/src/sync/sync_events/v4.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v4.rs
@@ -353,7 +353,7 @@ pub struct SlidingSyncRoom {
     pub prev_batch: Option<String>,
 
     /// True if the number of events returned was limited by the limit on the filter.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "ruma_common::serde::is_default")]
     pub limited: bool,
 
     /// The number of users with membership of `join`, including the client’s own user ID.

--- a/crates/ruma-client-api/src/sync/sync_events/v4.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v4.rs
@@ -337,6 +337,18 @@ pub struct SlidingSyncRoom {
     /// The prev_batch allowing you to paginate through the messages before the given ones.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub prev_batch: Option<String>,
+
+    /// True if the number of events returned was limited by the limit on the filter.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limited: Option<bool>,
+
+    /// The number of users with membership of `join`, including the client’s own user ID.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub joined_count: Option<UInt>,
+
+    /// The number of users with membership of `invite`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub invited_count: Option<UInt>,
 }
 
 impl SlidingSyncRoom {

--- a/crates/ruma-client-api/src/sync/sync_events/v4.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v4.rs
@@ -2,13 +2,13 @@
 
 use std::{collections::BTreeMap, time::Duration};
 
-use super::UnreadNotificationsCount;
+use super::{UnreadNotificationsCount, DeviceLists};
 use js_int::UInt;
 use ruma_common::{
     api::ruma_api,
     events::{AnyStrippedStateEvent, AnySyncStateEvent, AnySyncTimelineEvent, RoomEventType, AnyToDeviceEvent},
     serde::{duration::opt_ms, Raw},
-    OwnedRoomId,
+    DeviceKeyAlgorithm, OwnedRoomId,
 };
 use serde::{Deserialize, Serialize};
 
@@ -424,15 +424,38 @@ pub struct ToDeviceResponse {
 }
 
 /// E2EE Extension request.
+///
+/// Currently unspecc'ed. Taken from the reference implementation
+/// <https://github.com/matrix-org/sliding-sync/blob/d77e21138d4886d27b3888d36cf3627f54f67590/sync3/extensions/e2ee.go>
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct E2EERequest {
+    /// Activate or deactivate this extension. Sticky.
+    pub enabled: Option<bool>,
 }
 
 /// E2EE Extension response.
+///
+/// Currently unspecc'ed. Taken from the reference implementation
+/// <https://github.com/matrix-org/sliding-sync/blob/d77e21138d4886d27b3888d36cf3627f54f67590/sync3/extensions/e2ee.go>
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct E2EEResponse {
+    /// Information on E2E device updates.
+    ///
+    /// Only present on an incremental sync.
+    #[serde(default, skip_serializing_if = "DeviceLists::is_empty")]
+    pub device_lists: DeviceLists,
+    /// For each key algorithm, the number of unclaimed one-time keys
+    /// currently held on the server for a device.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub device_one_time_keys_count: BTreeMap<DeviceKeyAlgorithm, UInt>,
+    /// For each key algorithm, the number of unclaimed one-time keys
+    /// currently held on the server for a device.
+    ///
+    /// The presence of this field indicates that the server supports
+    /// fallback keys.
+    pub device_unused_fallback_key_types: Option<Vec<DeviceKeyAlgorithm>>,
 }
 
 

--- a/crates/ruma-client-api/src/sync/sync_events/v4.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v4.rs
@@ -420,7 +420,10 @@ pub struct Extensions {
 }
 
 impl Extensions {
-    fn is_empty(&self) -> bool {
+    /// Whether extension data was given.
+    ///
+    /// True if neither to-device, e2ee nor account data are to be found.
+    pub fn is_empty(&self) -> bool {
         self.to_device.is_none() && self.e2ee.is_none() && self.account_data.is_none()
     }
 }

--- a/crates/ruma-client-api/src/sync/sync_events/v4.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v4.rs
@@ -6,7 +6,7 @@ use super::UnreadNotificationsCount;
 use js_int::UInt;
 use ruma_common::{
     api::ruma_api,
-    events::{AnyStrippedStateEvent, AnySyncStateEvent, AnySyncTimelineEvent, RoomEventType},
+    events::{AnyStrippedStateEvent, AnySyncStateEvent, AnySyncTimelineEvent, RoomEventType, AnyToDeviceEvent},
     serde::{duration::opt_ms, Raw},
     OwnedRoomId,
 };
@@ -395,15 +395,32 @@ pub struct ExtensionsResponse {
 }
 
 /// ToDevice Messages Extension request.
+///
+/// Currently unspecc'ed. Taken from the reference implementation
+/// <https://github.com/matrix-org/sliding-sync/blob/d77e21138d4886d27b3888d36cf3627f54f67590/sync3/extensions/todevice.go>
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct ToDeviceRequest {
+    /// Activate or deactivate this extension. Sticky.
+    pub enabled: Option<bool>,
+    /// Max number of to-device messages per response.
+    pub limit: Option<UInt>,
+    /// Give messages since this token only.
+    pub since: Option<String>,
 }
 
 /// ToDevice Messages Extension response.
+///
+/// Currently unspecc'ed. Taken from the reference implementation
+/// <https://github.com/matrix-org/sliding-sync/blob/d77e21138d4886d27b3888d36cf3627f54f67590/sync3/extensions/todevice.go>
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct ToDeviceResponse {
+    /// Fetch the next batch from this entry.
+    pub next_batch: String,
+    /// The ToDevice Events.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub events: Vec<Raw<AnyToDeviceEvent>>,
 }
 
 /// E2EE Extension request.

--- a/crates/ruma-client-api/src/sync/sync_events/v4.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v4.rs
@@ -457,11 +457,7 @@ pub struct ToDevice {
     pub next_batch: String,
 
     /// The to-device Events.
-    #[serde(
-        default,
-        deserialize_with = "super::deserialize_null_default",
-        skip_serializing_if = "Vec::is_empty"
-    )]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub events: Vec<Raw<AnyToDeviceEvent>>,
 }
 
@@ -485,20 +481,12 @@ pub struct E2EE {
     /// Information on E2EE device updates.
     ///
     /// Only present on an incremental sync.
-    #[serde(
-        default,
-        deserialize_with = "super::deserialize_null_default",
-        skip_serializing_if = "DeviceLists::is_empty"
-    )]
+    #[serde(default, skip_serializing_if = "DeviceLists::is_empty")]
     pub device_lists: DeviceLists,
 
     /// For each key algorithm, the number of unclaimed one-time keys
     /// currently held on the server for a device.
-    #[serde(
-        default,
-        deserialize_with = "super::deserialize_null_default",
-        skip_serializing_if = "BTreeMap::is_empty"
-    )]
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub device_one_time_keys_count: BTreeMap<DeviceKeyAlgorithm, UInt>,
 
     /// For each key algorithm, the number of unclaimed one-time keys
@@ -530,18 +518,10 @@ pub struct AccountDataConfig {
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct AccountData {
     /// The global private data created by this user.
-    #[serde(
-        default,
-        deserialize_with = "super::deserialize_null_default",
-        skip_serializing_if = "Vec::is_empty"
-    )]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub global: Vec<Raw<AnyGlobalAccountDataEvent>>,
 
     /// The private data that this user has attached to each room.
-    #[serde(
-        default,
-        deserialize_with = "super::deserialize_null_default",
-        skip_serializing_if = "BTreeMap::is_empty"
-    )]
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub rooms: BTreeMap<OwnedRoomId, Vec<Raw<AnyRoomAccountDataEvent>>>,
 }

--- a/crates/ruma-client-api/src/sync/sync_events/v4.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v4.rs
@@ -419,6 +419,12 @@ pub struct Extensions {
     pub account_data: Option<AccountData>,
 }
 
+impl Extensions {
+    fn is_empty(&self) -> bool {
+        self.to_device.is_none() && self.e2ee.is_none() && self.account_data.is_none()
+    }
+}
+
 /// To-device messages extension configuration.
 ///
 /// According to [MSC3885](https://github.com/matrix-org/matrix-spec-proposals/pull/3885).

--- a/crates/ruma-client-api/src/sync/sync_events/v4.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v4.rs
@@ -353,8 +353,8 @@ pub struct SlidingSyncRoom {
     pub prev_batch: Option<String>,
 
     /// True if the number of events returned was limited by the limit on the filter.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub limited: Option<bool>,
+    #[serde(default)]
+    pub limited: bool,
 
     /// The number of users with membership of `join`, including the client’s own user ID.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/ruma-client-api/src/sync/sync_events/v4.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v4.rs
@@ -454,7 +454,11 @@ pub struct ToDevice {
     pub next_batch: String,
 
     /// The to-device Events.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(
+        default,
+        deserialize_with = "super::deserialize_null_default",
+        skip_serializing_if = "Vec::is_empty"
+    )]
     pub events: Vec<Raw<AnyToDeviceEvent>>,
 }
 
@@ -478,12 +482,20 @@ pub struct E2EE {
     /// Information on E2EE device updates.
     ///
     /// Only present on an incremental sync.
-    #[serde(default, skip_serializing_if = "DeviceLists::is_empty")]
+    #[serde(
+        default,
+        deserialize_with = "super::deserialize_null_default",
+        skip_serializing_if = "DeviceLists::is_empty"
+    )]
     pub device_lists: DeviceLists,
 
     /// For each key algorithm, the number of unclaimed one-time keys
     /// currently held on the server for a device.
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    #[serde(
+        default,
+        deserialize_with = "super::deserialize_null_default",
+        skip_serializing_if = "BTreeMap::is_empty"
+    )]
     pub device_one_time_keys_count: BTreeMap<DeviceKeyAlgorithm, UInt>,
 
     /// For each key algorithm, the number of unclaimed one-time keys
@@ -523,6 +535,10 @@ pub struct AccountData {
     pub global: Vec<Raw<AnyGlobalAccountDataEvent>>,
 
     /// The private data that this user has attached to each room.
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    #[serde(
+        default,
+        deserialize_with = "super::deserialize_null_default",
+        skip_serializing_if = "BTreeMap::is_empty"
+    )]
     pub rooms: BTreeMap<OwnedRoomId, Vec<Raw<AnyRoomAccountDataEvent>>>,
 }


### PR DESCRIPTION
This adds support for the latest spec proposal updates of MSC 3575 ("Sliding Sync") for:
 - [x] `tags` and `not_tags` filters
 - [x] `resolve_tombstones` flag
 - [x] `limited`, `joined_count` and `invited_count` responses taken over from v3

This also adds the current state of existing extensions. These are not yet specified, even within the proposal but are not likely to change much going forward. Those are:

 - [x] ToDevice Messages
 - [x] End-to-end-encryption messages
 - [x] AccountData, globally as well as for specific rooms. 
 
 This is all still behind the same feature-flag as before.

<!-- Replace -->
----
Preview Removed
<!-- Replace -->
