### PR TITLE
events: Add paragraph about replies to edited events.

### DIFF
--- a/crates/ruma-common/src/doc/rich_reply.md
+++ b/crates/ruma-common/src/doc/rich_reply.md
@@ -4,6 +4,9 @@ the previous message, for which the room ID is required. If you want to reply to
 [`OriginalSyncRoomMessageEvent`], you have to convert it first by calling
 [`.into_full_event()`][crate::events::OriginalSyncMessageLikeEvent::into_full_event].
 
+If the message was edited, the previous message should be the original message that was edited,
+with the content of its replacement, to allow the fallback to be accurate at the time it is added.
+
 It is recommended to enable the `sanitize` feature when using this method as this will
 clean up nested [rich reply fallbacks] in chains of replies. This uses [`sanitize_html()`]
 internally, with [`RemoveReplyFallback::Yes`].


### PR DESCRIPTION
In the matrix room I said we should ask for the original event ID separately, but it actually makes more sense to just assume the event already contains the edited content, since that's what is supposed to happen according to [MSC2676](https://github.com/matrix-org/matrix-spec-proposals/pull/2676), and what we would probably receive from the server.




<!-- Replace -->
----
Preview Removed
<!-- Replace -->
