### PR TITLE
events: Add RoomMessageEventContent::make_reply_to

### DIFF
--- a/crates/ruma-common/src/doc/rich_reply.md
+++ b/crates/ruma-common/src/doc/rich_reply.md
@@ -1,5 +1,5 @@
 <!-- Keep this comment so the content is always included as a new paragraph -->
-This constructor requires an [`OriginalRoomMessageEvent`] since it creates a permalink to
+This function requires an [`OriginalRoomMessageEvent`] since it creates a permalink to
 the previous message, for which the room ID is required. If you want to reply to an
 [`OriginalSyncRoomMessageEvent`], you have to convert it first by calling
 [`.into_full_event()`][crate::events::OriginalSyncMessageLikeEvent::into_full_event].

--- a/crates/ruma-common/src/events/room/message/reply.rs
+++ b/crates/ruma-common/src/events/room/message/reply.rs
@@ -8,59 +8,44 @@ use super::{
 use super::{sanitize_html, HtmlSanitizerMode, RemoveReplyFallback};
 
 fn get_message_quote_fallbacks(original_message: &OriginalRoomMessageEvent) -> (String, String) {
+    let get_quotes = |body: &str, formatted: Option<&FormattedBody>, is_emote: bool| {
+        let OriginalRoomMessageEvent { room_id, event_id, sender, content, .. } = original_message;
+        let is_reply = matches!(content.relates_to, Some(Relation::Reply { .. }));
+        let emote_sign = is_emote.then(|| "* ").unwrap_or_default();
+        let body = is_reply.then(|| remove_plain_reply_fallback(body)).unwrap_or(body);
+        #[cfg(feature = "unstable-sanitize")]
+        let html_body = formatted_or_plain_body(formatted, body, is_reply);
+        #[cfg(not(feature = "unstable-sanitize"))]
+        let html_body = formatted_or_plain_body(formatted, body);
+
+        (
+            format!("> {emote_sign}<{sender}> {body}").replace('\n', "\n> "),
+            format!(
+                "<mx-reply>\
+                        <blockquote>\
+                            <a href=\"https://matrix.to/#/{room_id}/{event_id}\">In reply to</a> \
+                            {emote_sign}<a href=\"https://matrix.to/#/{sender}\">{sender}</a>\
+                            <br>\
+                            {html_body}\
+                        </blockquote>\
+                    </mx-reply>"
+            ),
+        )
+    };
+
     match &original_message.content.msgtype {
-        MessageType::Audio(_) => get_quotes("sent an audio file.", None, original_message, false),
-        MessageType::Emote(content) => {
-            get_quotes(&content.body, content.formatted.as_ref(), original_message, true)
-        }
-        MessageType::File(_) => get_quotes("sent a file.", None, original_message, false),
-        MessageType::Image(_) => get_quotes("sent an image.", None, original_message, false),
-        MessageType::Location(_) => get_quotes("sent a location.", None, original_message, false),
-        MessageType::Notice(content) => {
-            get_quotes(&content.body, content.formatted.as_ref(), original_message, false)
-        }
-        MessageType::ServerNotice(content) => {
-            get_quotes(&content.body, None, original_message, false)
-        }
-        MessageType::Text(content) => {
-            get_quotes(&content.body, content.formatted.as_ref(), original_message, false)
-        }
-        MessageType::Video(_) => get_quotes("sent a video.", None, original_message, false),
-        MessageType::_Custom(content) => get_quotes(&content.body, None, original_message, false),
-        MessageType::VerificationRequest(content) => {
-            get_quotes(&content.body, None, original_message, false)
-        }
+        MessageType::Audio(_) => get_quotes("sent an audio file.", None, false),
+        MessageType::Emote(c) => get_quotes(&c.body, c.formatted.as_ref(), true),
+        MessageType::File(_) => get_quotes("sent a file.", None, false),
+        MessageType::Image(_) => get_quotes("sent an image.", None, false),
+        MessageType::Location(_) => get_quotes("sent a location.", None, false),
+        MessageType::Notice(c) => get_quotes(&c.body, c.formatted.as_ref(), false),
+        MessageType::ServerNotice(c) => get_quotes(&c.body, None, false),
+        MessageType::Text(c) => get_quotes(&c.body, c.formatted.as_ref(), false),
+        MessageType::Video(_) => get_quotes("sent a video.", None, false),
+        MessageType::VerificationRequest(content) => get_quotes(&content.body, None, false),
+        MessageType::_Custom(content) => get_quotes(&content.body, None, false),
     }
-}
-
-fn get_quotes(
-    body: &str,
-    formatted: Option<&FormattedBody>,
-    original_message: &OriginalRoomMessageEvent,
-    is_emote: bool,
-) -> (String, String) {
-    let OriginalRoomMessageEvent { room_id, event_id, sender, content, .. } = original_message;
-    let is_reply = matches!(content.relates_to, Some(Relation::Reply { .. }));
-    let emote_sign = is_emote.then(|| "* ").unwrap_or_default();
-    let body = is_reply.then(|| remove_plain_reply_fallback(body)).unwrap_or(body);
-    #[cfg(feature = "unstable-sanitize")]
-    let html_body = formatted_or_plain_body(formatted, body, is_reply);
-    #[cfg(not(feature = "unstable-sanitize"))]
-    let html_body = formatted_or_plain_body(formatted, body);
-
-    (
-        format!("> {emote_sign}<{sender}> {body}").replace('\n', "\n> "),
-        format!(
-            "<mx-reply>\
-                <blockquote>\
-                    <a href=\"https://matrix.to/#/{room_id}/{event_id}\">In reply to</a> \
-                    {emote_sign}<a href=\"https://matrix.to/#/{sender}\">{sender}</a>\
-                    <br>\
-                    {html_body}\
-                </blockquote>\
-            </mx-reply>"
-        ),
-    )
 }
 
 fn formatted_or_plain_body(
@@ -119,10 +104,9 @@ pub fn plain_and_formatted_reply_body(
     let (quoted, quoted_html) = get_message_quote_fallbacks(original_message);
 
     let plain = format!("{quoted}\n{body}");
-    let html = if let Some(formatted) = formatted {
-        format!("{quoted_html}{formatted}")
-    } else {
-        format!("{quoted_html}{body}")
+    let html = match formatted {
+        Some(formatted) => format!("{quoted_html}{formatted}"),
+        None => format!("{quoted_html}{body}"),
     };
 
     (plain, html)
@@ -160,7 +144,7 @@ mod tests {
                     <br>\
                     multi<br>line\
                 </blockquote>\
-            </mx-reply>"
+            </mx-reply>",
         );
     }
 }

--- a/crates/ruma-common/tests/events/room_message.rs
+++ b/crates/ruma-common/tests/events/room_message.rs
@@ -500,22 +500,22 @@ fn reply_sanitize() {
         unsigned: MessageLikeUnsigned::default(),
     };
     let second_message = OriginalRoomMessageEvent {
-        content: RoomMessageEventContent::text_reply_html(
+        content: RoomMessageEventContent::text_html(
             "This is the _second_ message",
             "This is the <em>second</em> message",
-            &first_message,
-        ),
+        )
+        .make_reply_to(&first_message),
         event_id: event_id!("$143273582443PhrSn:example.org").to_owned(),
         origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(10_000)),
         room_id: room_id!("!testroomid:example.org").to_owned(),
         sender: user_id!("@user:example.org").to_owned(),
         unsigned: MessageLikeUnsigned::default(),
     };
-    let final_reply = RoomMessageEventContent::text_reply_html(
+    let final_reply = RoomMessageEventContent::text_html(
         "This is **my** reply",
         "This is <strong>my</strong> reply",
-        &second_message,
-    );
+    )
+    .make_reply_to(&second_message);
 
     let (body, formatted) = assert_matches!(
         first_message.content.msgtype,


### PR DESCRIPTION
… and deprecate reply constructors.

For consistency we'll probably also want to update the `reply` constructor somehow and add (non-reply) emote constructors. Wdyt?

I made this because I was made aware of the fact that making a reply using Markdown is unnecessarily hard, and I didn't want to introduce even more constructors for `RoomMessageEventContent`.




<!-- Replace -->
----
Preview Removed
<!-- Replace -->
