### PR TITLE
xtask: Clean up doc output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 members = ["crates/*", "examples/*", "xtask"]
-# xtask should only be compiled when invoked explicitly
-default-members = ["crates/*", "examples/*"]
+# Only compile / check / document the public crates by default
+default-members = ["crates/*"]
 
 resolver = "2"
 

--- a/xtask/src/doc.rs
+++ b/xtask/src/doc.rs
@@ -20,16 +20,8 @@ impl DocTask {
             rustdocflags += " -Dwarnings";
         }
 
-        // Keep in sync with .github/workflows/docs.yml
-        let mut cmd = cmd!(
-            "
-            rustup run nightly cargo doc --all-features --no-deps --workspace
-            --exclude ruma-macros --exclude ruma-identifiers-validation --exclude xtask
-            "
-        )
-        // Work around https://github.com/rust-lang/cargo/issues/10744
-        .env("CARGO_TARGET_APPLIES_TO_HOST", "true")
-        .env("RUSTDOCFLAGS", rustdocflags);
+        let mut cmd = cmd!("rustup run nightly cargo doc --all-features --no-deps")
+            .env("RUSTDOCFLAGS", rustdocflags);
 
         if self.open {
             cmd = cmd.arg("--open");


### PR DESCRIPTION
* Don't render docs for examples
* Don't include a workaround for a problematic nightly feature we no longer use




<!-- Replace -->
----
Preview Removed
<!-- Replace -->
