### PR TITLE
Add M_BAD_ALIAS to ErrorKind

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -5,6 +5,10 @@ Breaking changes:
 * Remove `sync::sync_events::v3::DeviceLists` re-export
   * Use `sync::sync_events::DeviceLists` instead
 
+Improvements:
+
+* Add `M_BAD_ALIAS` to `error::ErrorKind`
+
 # 0.15.1
 
 Improvements:

--- a/crates/ruma-client-api/src/error.rs
+++ b/crates/ruma-client-api/src/error.rs
@@ -147,6 +147,9 @@ pub enum ErrorKind {
     /// M_UNABLE_TO_GRANT_JOIN
     UnableToGrantJoin,
 
+    /// M_BAD_ALIAS
+    BadAlias,
+
     /// FI.MAU.MSC2246_NOT_YET_UPLOADED
     #[cfg(feature = "unstable-msc2246")]
     NotYetUploaded,
@@ -201,6 +204,7 @@ impl AsRef<str> for ErrorKind {
             Self::WeakPassword => "M_WEAK_PASSWORD",
             Self::UnableToAuthorizeJoin => "M_UNABLE_TO_AUTHORISE_JOIN",
             Self::UnableToGrantJoin => "M_UNABLE_TO_GRANT_JOIN",
+            Self::BadAlias => "M_BAD_ALIAS",
             #[cfg(feature = "unstable-msc2246")]
             Self::NotYetUploaded => "FI.MAU.MSC2246_NOT_YET_UPLOADED",
             #[cfg(feature = "unstable-msc2246")]


### PR DESCRIPTION
The `M_BAD_ALIAS` error is mentioned in the spec here: https://spec.matrix.org/v1.3/client-server-api/#put_matrixclientv3roomsroomidstateeventtypestatekey

Even that, it is not mentioned in the "Other error codes" section: https://spec.matrix.org/v1.3/client-server-api/#other-error-codes

<!-- Replace -->
----
Preview Removed
<!-- Replace -->
