### PR TITLE
state-res: Fix third party invite validation

### DIFF
--- a/crates/ruma-common/src/events/room/message/image.rs
+++ b/crates/ruma-common/src/events/room/message/image.rs
@@ -133,7 +133,7 @@ impl ImageMessageEventContent {
             #[cfg(feature = "unstable-msc3552")]
             file: Some(FileContent::encrypted(file.url.clone(), (&file).into(), None)),
             #[cfg(feature = "unstable-msc3552")]
-            image: Some(Box::new(ImageContent::default())),
+            image: Some(Box::default()),
             #[cfg(feature = "unstable-msc3552")]
             thumbnail: None,
             #[cfg(feature = "unstable-msc3552")]

--- a/crates/ruma-common/src/events/room/message/video.rs
+++ b/crates/ruma-common/src/events/room/message/video.rs
@@ -139,7 +139,7 @@ impl VideoMessageEventContent {
             #[cfg(feature = "unstable-msc3553")]
             file: Some(FileContent::encrypted(file.url.clone(), (&file).into(), None)),
             #[cfg(feature = "unstable-msc3553")]
-            video: Some(Box::new(VideoContent::default())),
+            video: Some(Box::default()),
             #[cfg(feature = "unstable-msc3553")]
             thumbnail: None,
             #[cfg(feature = "unstable-msc3553")]

--- a/crates/ruma-common/src/identifiers/user_id.rs
+++ b/crates/ruma-common/src/identifiers/user_id.rs
@@ -91,7 +91,7 @@ impl UserId {
 
     /// Returns the user's localpart.
     pub fn localpart(&self) -> &str {
-        &self.as_str()[1..self.colon_idx() as usize]
+        &self.as_str()[1..self.colon_idx()]
     }
 
     /// Returns the server name of the user ID.

--- a/crates/ruma-state-res/CHANGELOG.md
+++ b/crates/ruma-state-res/CHANGELOG.md
@@ -1,5 +1,11 @@
 # [unreleased]
 
+Bug fixes:
+
+* Fix third party invite event authorization. The event was not allowed even
+  after passing all the required checks, so it could fail further down the
+  algorithm.
+
 # 0.8.0
 
 Bug fixes:

--- a/crates/ruma-state-res/src/event_auth.rs
+++ b/crates/ruma-state-res/src/event_auth.rs
@@ -364,6 +364,9 @@ pub fn auth_check<E: Event>(
             warn!("sender's cannot send invites in this room");
             return Ok(false);
         }
+
+        info!("m.room.third_party_invite event was allowed");
+        return Ok(true);
     }
 
     // If the event type's required power level is greater than the sender's power level, reject


### PR DESCRIPTION
According to the spec:

> 6. If type is m.room.third_party_invite:
>    1. Allow if and only if sender’s current power level is greater than or equal to the invite level.

The current codebase handles the rejection, but doesn't allow the event so it keeps going down the authorization algorithm and might be rejected for the wrong reason.

Fix provided by Nyaaori: https://matrix.to/#/!bKOoBjzgyxiMyHIyLp:matrix.org/$c4inhGDuqwiH995AAzkJ_RUnq2sLQ4lLOp6I7pAFT9g?via=matrix.org&via=tedomum.net&via=flipdot.org










<!-- Replace -->
----
Preview: https://pr-1310--ruma-docs.surge.sh
<!-- Replace -->
