### PR TITLE
state-res: Allow invite->knock membership transition

### DIFF
--- a/crates/ruma-state-res/CHANGELOG.md
+++ b/crates/ruma-state-res/CHANGELOG.md
@@ -5,6 +5,9 @@ Bug fixes:
 * Fix third party invite event authorization. The event was not allowed even
   after passing all the required checks, so it could fail further down the
   algorithm.
+* Allow `invite` -> `knock` membership transition
+  * The spec was determined to be wrong about rejecting it:
+    <https://github.com/matrix-org/matrix-spec/pull/1175>
 
 # 0.8.0
 

--- a/crates/ruma-state-res/src/event_auth.rs
+++ b/crates/ruma-state-res/src/event_auth.rs
@@ -676,7 +676,7 @@ fn valid_membership_change(
                 false
             } else {
                 // 2. If `sender` does not match `state_key`, reject.
-                // 3. If the `sender`'s current membership is not `ban`, `invite`, or `join`, allow.
+                // 3. If the `sender`'s current membership is not `ban` or `join`, allow.
                 // 4. Otherwise, reject.
                 if sender != target_user {
                     warn!(
@@ -685,13 +685,11 @@ fn valid_membership_change(
                         "Can't make another user join, sender did not match target"
                     );
                     false
-                } else if matches!(
-                    sender_membership,
-                    MembershipState::Ban | MembershipState::Invite | MembershipState::Join
-                ) {
+                } else if matches!(sender_membership, MembershipState::Ban | MembershipState::Join)
+                {
                     warn!(
                         ?target_user_membership_event_id,
-                        "Membership state of ban, invite, or join are invalid",
+                        "Membership state of ban or join are invalid",
                     );
                     false
                 } else {


### PR DESCRIPTION
According to spec clarification: https://github.com/matrix-org/matrix-spec/pull/1175.










<!-- Replace -->
----
Preview: https://pr-1311--ruma-docs.surge.sh
<!-- Replace -->
