### PR TITLE
client-api: Add support for `dir` parameter to `/relations` 

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -6,6 +6,7 @@ Breaking changes:
   * Use `sync::sync_events::DeviceLists` instead
 * `fully_read` field in `read_marker::set_read_marker` is no longer required
   * Remove the `fully_read` argument from `read_marker::set_read_marker::Request::new`
+* Move `message::get_message_events::v3::Direction` to the root of the crate
 
 Improvements:
 

--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -15,6 +15,7 @@ Improvements:
   * The fields added to `RoomEventFilter` were removed by MSC3856
 * Add support for the threads list API (MSC3856 / Matrix 1.4)
 * Stabilize support for private read receipts
+* Add support for the pagination direction parameter to `/relations` (MSC3715 / Matrix 1.4)
 
 # 0.15.1
 

--- a/crates/ruma-client-api/src/lib.rs
+++ b/crates/ruma-client-api/src/lib.rs
@@ -51,6 +51,7 @@ pub mod voip;
 use std::fmt;
 
 pub use error::Error;
+use serde::{Deserialize, Serialize};
 
 // Wrapper around `Box<str>` that cannot be used in a meaningful way outside of
 // this crate. Used for string enums because their `_Custom` variant can't be
@@ -63,4 +64,18 @@ impl fmt::Debug for PrivOwnedStr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
     }
+}
+
+/// The direction to return events from.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[allow(clippy::exhaustive_enums)]
+pub enum Direction {
+    /// Return events backwards in time from the requested `from` token.
+    #[default]
+    #[serde(rename = "b")]
+    Backward,
+
+    /// Return events forwards in time from the requested `from` token.
+    #[serde(rename = "f")]
+    Forward,
 }

--- a/crates/ruma-client-api/src/message/get_message_events.rs
+++ b/crates/ruma-client-api/src/message/get_message_events.rs
@@ -12,9 +12,11 @@ pub mod v3 {
         serde::Raw,
         RoomId,
     };
-    use serde::{Deserialize, Serialize};
 
-    use crate::filter::{IncomingRoomEventFilter, RoomEventFilter};
+    use crate::{
+        filter::{IncomingRoomEventFilter, RoomEventFilter},
+        Direction,
+    };
 
     ruma_api! {
         metadata: {
@@ -169,19 +171,6 @@ pub mod v3 {
         *val == default_limit()
     }
 
-    /// The direction to return events from.
-    #[derive(Clone, Debug, Deserialize, Serialize)]
-    #[allow(clippy::exhaustive_enums)]
-    pub enum Direction {
-        /// Return events backwards in time from the requested `from` token.
-        #[serde(rename = "b")]
-        Backward,
-
-        /// Return events forwards in time from the requested `from` token.
-        #[serde(rename = "f")]
-        Forward,
-    }
-
     #[cfg(all(test, feature = "client"))]
     mod tests {
         use js_int::uint;
@@ -190,8 +179,11 @@ pub mod v3 {
             room_id,
         };
 
-        use super::{Direction, Request};
-        use crate::filter::{LazyLoadOptions, RoomEventFilter};
+        use super::Request;
+        use crate::{
+            filter::{LazyLoadOptions, RoomEventFilter},
+            Direction,
+        };
 
         #[test]
         fn serialize_some_room_event_filter() {

--- a/crates/ruma-client-api/src/relations/get_relating_events.rs
+++ b/crates/ruma-client-api/src/relations/get_relating_events.rs
@@ -10,6 +10,8 @@ pub mod v1 {
     use js_int::UInt;
     use ruma_common::{api::ruma_api, events::AnyMessageLikeEvent, serde::Raw, EventId, RoomId};
 
+    use crate::Direction;
+
     ruma_api! {
         metadata: {
             description: "Get the child events for a given parent event.",
@@ -35,8 +37,8 @@ pub mod v1 {
             ///
             /// If `None`, results start at the most recent topological event known to the server.
             ///
-            /// Can be a `next_batch` token from a previous call, or a returned  `start` token from
-            /// `/messages` or a `next_batch` token from `/sync`.
+            /// Can be a `next_batch` or `prev_batch` token from a previous call, or a returned
+            /// `start` token from `/messages` or a `next_batch` token from `/sync`.
             ///
             /// Note that when paginating the `from` token should be "after" the `to` token in
             /// terms of topological ordering, because it is only possible to paginate "backwards"
@@ -44,6 +46,13 @@ pub mod v1 {
             #[serde(skip_serializing_if = "Option::is_none")]
             #[ruma_api(query)]
             pub from: Option<&'a str>,
+
+            /// The direction to return events from.
+            ///
+            /// Defaults to [`Direction::Backward`].
+            #[serde(default, skip_serializing_if = "ruma_common::serde::is_default")]
+            #[ruma_api(query)]
+            pub dir: Direction,
 
             /// The pagination token to stop returning results at.
             ///
@@ -96,7 +105,7 @@ pub mod v1 {
     impl<'a> Request<'a> {
         /// Creates a new `Request` with the given room ID and parent event ID.
         pub fn new(room_id: &'a RoomId, event_id: &'a EventId) -> Self {
-            Self { room_id, event_id, from: None, to: None, limit: None }
+            Self { room_id, event_id, dir: Direction::default(), from: None, to: None, limit: None }
         }
     }
 


### PR DESCRIPTION
According to [MSC3715](https://github.com/matrix-org/matrix-spec-proposals/pull/3715) and https://github.com/matrix-org/matrix-spec/pull/1254.

Closes #1306.







<!-- Replace -->
----
Preview: https://pr-1317--ruma-docs.surge.sh
<!-- Replace -->
