### PR TITLE
events: Remove `ToDevice` kind on `RoomEncryptedEventContent`

### DIFF
--- a/crates/ruma-common/src/events/room/encrypted.rs
+++ b/crates/ruma-common/src/events/room/encrypted.rs
@@ -16,7 +16,7 @@ mod relation_serde;
 /// The content of an `m.room.encrypted` event.
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-#[ruma_event(type = "m.room.encrypted", kind = MessageLike, kind = ToDevice)]
+#[ruma_event(type = "m.room.encrypted", kind = MessageLike)]
 pub struct RoomEncryptedEventContent {
     /// Algorithm-specific fields.
     #[serde(flatten)]


### PR DESCRIPTION
There is `ToDeviceRoomEncryptedEventContent`.




<!-- Replace -->
----
Preview Removed
<!-- Replace -->
