### PR TITLE
client-api: Remove direct association between transaction ID and access token

### DIFF
--- a/crates/ruma-client-api/src/message/send_message_event.rs
+++ b/crates/ruma-client-api/src/message/send_message_event.rs
@@ -36,9 +36,13 @@ pub mod v3 {
 
             /// The transaction ID for this event.
             ///
-            /// Clients should generate an ID unique across requests with the
-            /// same access token; it will be used by the server to ensure
-            /// idempotency of requests.
+            /// Clients should generate a unique ID across requests within the
+            /// same session. A session is identified by an access token, and
+            /// persists when the [access token is refreshed].
+            ///
+            /// It will be used by the server to ensure idempotency of requests.
+            ///
+            /// [access token is refreshed]: https://spec.matrix.org/v1.4/client-server-api/#refreshing-access-tokens
             #[ruma_api(path)]
             pub txn_id: &'a TransactionId,
 

--- a/crates/ruma-client-api/src/redact/redact_event.rs
+++ b/crates/ruma-client-api/src/redact/redact_event.rs
@@ -30,8 +30,13 @@ pub mod v3 {
 
             /// The transaction ID for this event.
             ///
-            /// Clients should generate a unique ID; it will be used by the server to ensure idempotency
-            /// of requests.
+            /// Clients should generate a unique ID across requests within the
+            /// same session. A session is identified by an access token, and
+            /// persists when the [access token is refreshed].
+            ///
+            /// It will be used by the server to ensure idempotency of requests.
+            ///
+            /// [access token is refreshed]: https://spec.matrix.org/v1.4/client-server-api/#refreshing-access-tokens
             #[ruma_api(path)]
             pub txn_id: &'a TransactionId,
 

--- a/crates/ruma-client-api/src/to_device/send_event_to_device.rs
+++ b/crates/ruma-client-api/src/to_device/send_event_to_device.rs
@@ -29,7 +29,15 @@ pub mod v3 {
             #[ruma_api(path)]
             pub event_type: &'a str,
 
-            /// A request identifier unique to the access token used to send the request.
+            /// The transaction ID for this event.
+            ///
+            /// Clients should generate a unique ID across requests within the
+            /// same session. A session is identified by an access token, and
+            /// persists when the [access token is refreshed].
+            ///
+            /// It will be used by the server to ensure idempotency of requests.
+            ///
+            /// [access token is refreshed]: https://spec.matrix.org/v1.4/client-server-api/#refreshing-access-tokens
             #[ruma_api(path)]
             pub txn_id: &'a TransactionId,
 


### PR DESCRIPTION
According to https://github.com/matrix-org/matrix-spec/pull/1236.

Closes #1309.










<!-- Replace -->
----
Preview: https://pr-1322--ruma-docs.surge.sh
<!-- Replace -->
