### PR TITLE
client-api: Add support for notifications for threads

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -16,6 +16,7 @@ Improvements:
 * Add support for the threads list API (MSC3856 / Matrix 1.4)
 * Stabilize support for private read receipts
 * Add support for the pagination direction parameter to `/relations` (MSC3715 / Matrix 1.4)
+* Add support for notifications for threads (MSC3773 / Matrix 1.4)
 
 # 0.15.1
 

--- a/crates/ruma-client-api/src/filter.rs
+++ b/crates/ruma-client-api/src/filter.rs
@@ -97,6 +97,15 @@ pub struct RoomEventFilter<'a> {
     /// Defaults to `LazyLoadOptions::Disabled`.
     #[serde(flatten)]
     pub lazy_load_options: LazyLoadOptions,
+
+    /// Whether to enable [per-thread notification counts].
+    ///
+    /// Only applies to the [`sync_events`] endpoint.
+    ///
+    /// [per-thread notification counts]: https://spec.matrix.org/v1.4/client-server-api/#receiving-notifications
+    /// [`sync_events`]: crate::sync::sync_events
+    #[serde(default, skip_serializing_if = "ruma_common::serde::is_default")]
+    pub unread_thread_notifications: bool,
 }
 
 impl<'a> RoomEventFilter<'a> {
@@ -123,6 +132,7 @@ impl<'a> RoomEventFilter<'a> {
             && self.types.is_none()
             && self.url_filter.is_none()
             && self.lazy_load_options.is_disabled()
+            && !self.unread_thread_notifications
     }
 }
 
@@ -138,6 +148,7 @@ impl IncomingRoomEventFilter {
             && self.types.is_none()
             && self.url_filter.is_none()
             && self.lazy_load_options.is_disabled()
+            && !self.unread_thread_notifications
     }
 }
 

--- a/crates/ruma-client-api/src/sync/sync_events.rs
+++ b/crates/ruma-client-api/src/sync/sync_events.rs
@@ -13,11 +13,11 @@ pub mod v4;
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct UnreadNotificationsCount {
-    /// The number of unread notifications for this room with the highlight flag set.
+    /// The number of unread notifications with the highlight flag set.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub highlight_count: Option<UInt>,
 
-    /// The total number of unread notifications for this room.
+    /// The total number of unread notifications.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub notification_count: Option<UInt>,
 }


### PR DESCRIPTION
According to [MSC3773](https://github.com/matrix-org/matrix-spec-proposals/pull/3773) and https://github.com/matrix-org/matrix-spec/pull/1255.

Closes #1308.







<!-- Replace -->
----
Preview: https://pr-1324--ruma-docs.surge.sh
<!-- Replace -->
