### PR TITLE
appservice-api: Add support for using the Authorization header 

### DIFF
--- a/crates/ruma-appservice-api/CHANGELOG.md
+++ b/crates/ruma-appservice-api/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [unreleased]
 
+Improvements:
+
+* Add support for using the Authorization header (MSC2832 / Matrix 1.4)
+
 # 0.7.0
 
 Breaking changes:

--- a/crates/ruma-appservice-api/src/event/push_events.rs
+++ b/crates/ruma-appservice-api/src/event/push_events.rs
@@ -18,7 +18,7 @@ pub mod v1 {
             name: "push_events",
             stable_path: "/_matrix/app/v1/transactions/:txn_id",
             rate_limited: false,
-            authentication: QueryOnlyAccessToken,
+            authentication: AccessToken,
             added: 1.0,
         }
 

--- a/crates/ruma-appservice-api/src/query/query_room_alias.rs
+++ b/crates/ruma-appservice-api/src/query/query_room_alias.rs
@@ -16,7 +16,7 @@ pub mod v1 {
             name: "query_room_alias",
             stable_path: "/_matrix/app/v1/rooms/:room_alias",
             rate_limited: false,
-            authentication: QueryOnlyAccessToken,
+            authentication: AccessToken,
             added: 1.0,
         }
 

--- a/crates/ruma-appservice-api/src/query/query_user_id.rs
+++ b/crates/ruma-appservice-api/src/query/query_user_id.rs
@@ -16,7 +16,7 @@ pub mod v1 {
             name: "query_user_id",
             stable_path: "/_matrix/app/v1/users/:user_id",
             rate_limited: false,
-            authentication: QueryOnlyAccessToken,
+            authentication: AccessToken,
             added: 1.0,
         }
 

--- a/crates/ruma-appservice-api/src/thirdparty/get_location_for_protocol.rs
+++ b/crates/ruma-appservice-api/src/thirdparty/get_location_for_protocol.rs
@@ -19,7 +19,7 @@ pub mod v1 {
             name: "get_location_for_protocol",
             stable_path: "/_matrix/app/v1/thirdparty/location/:protocol",
             rate_limited: false,
-            authentication: QueryOnlyAccessToken,
+            authentication: AccessToken,
             added: 1.0,
         }
 

--- a/crates/ruma-appservice-api/src/thirdparty/get_location_for_room_alias.rs
+++ b/crates/ruma-appservice-api/src/thirdparty/get_location_for_room_alias.rs
@@ -16,7 +16,7 @@ pub mod v1 {
             name: "get_location_for_room_alias",
             stable_path: "/_matrix/app/v1/thirdparty/location",
             rate_limited: false,
-            authentication: QueryOnlyAccessToken,
+            authentication: AccessToken,
             added: 1.0,
         }
 

--- a/crates/ruma-appservice-api/src/thirdparty/get_protocol.rs
+++ b/crates/ruma-appservice-api/src/thirdparty/get_protocol.rs
@@ -17,7 +17,7 @@ pub mod v1 {
             name: "get_protocol",
             stable_path: "/_matrix/app/v1/thirdparty/protocol/:protocol",
             rate_limited: false,
-            authentication: QueryOnlyAccessToken,
+            authentication: AccessToken,
             added: 1.0,
         }
 

--- a/crates/ruma-appservice-api/src/thirdparty/get_user_for_protocol.rs
+++ b/crates/ruma-appservice-api/src/thirdparty/get_user_for_protocol.rs
@@ -19,7 +19,7 @@ pub mod v1 {
             name: "get_user_for_protocol",
             stable_path: "/_matrix/app/v1/thirdparty/user/:protocol",
             rate_limited: false,
-            authentication: QueryOnlyAccessToken,
+            authentication: AccessToken,
             added: 1.0,
         }
 

--- a/crates/ruma-appservice-api/src/thirdparty/get_user_for_user_id.rs
+++ b/crates/ruma-appservice-api/src/thirdparty/get_user_for_user_id.rs
@@ -16,7 +16,7 @@ pub mod v1 {
             name: "get_user_for_user_id",
             stable_path: "/_matrix/app/v1/thirdparty/user",
             rate_limited: false,
-            authentication: QueryOnlyAccessToken,
+            authentication: AccessToken,
             added: 1.0,
         }
 

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -5,6 +5,7 @@ Breaking changes:
 * Remove deprecated `EventType` enum
 * Remove deprecated constructors for `RoomMessageEventContent`
 * Remove `serde::vec_as_map_of_empty` from the public API
+* Remove the `api::AuthScheme::QueryOnlyAccessToken` variant, which is no longer used
 
 Improvements:
 

--- a/crates/ruma-common/src/api.rs
+++ b/crates/ruma-common/src/api.rs
@@ -393,7 +393,4 @@ pub enum AuthScheme {
     /// Authentication is performed by including X-Matrix signatures in the request headers,
     /// as defined in the federation API.
     ServerSignatures,
-
-    /// Authentication is performed by setting the `access_token` query parameter.
-    QueryOnlyAccessToken,
 }

--- a/crates/ruma-macros/src/api/auth_scheme.rs
+++ b/crates/ruma-macros/src/api/auth_scheme.rs
@@ -6,14 +6,12 @@ mod kw {
     syn::custom_keyword!(None);
     syn::custom_keyword!(AccessToken);
     syn::custom_keyword!(ServerSignatures);
-    syn::custom_keyword!(QueryOnlyAccessToken);
 }
 
 pub enum AuthScheme {
     None(kw::None),
     AccessToken(kw::AccessToken),
     ServerSignatures(kw::ServerSignatures),
-    QueryOnlyAccessToken(kw::QueryOnlyAccessToken),
 }
 
 impl Parse for AuthScheme {
@@ -26,8 +24,6 @@ impl Parse for AuthScheme {
             input.parse().map(Self::AccessToken)
         } else if lookahead.peek(kw::ServerSignatures) {
             input.parse().map(Self::ServerSignatures)
-        } else if lookahead.peek(kw::QueryOnlyAccessToken) {
-            input.parse().map(Self::QueryOnlyAccessToken)
         } else {
             Err(lookahead.error())
         }
@@ -40,7 +36,6 @@ impl ToTokens for AuthScheme {
             AuthScheme::None(kw) => kw.to_tokens(tokens),
             AuthScheme::AccessToken(kw) => kw.to_tokens(tokens),
             AuthScheme::ServerSignatures(kw) => kw.to_tokens(tokens),
-            AuthScheme::QueryOnlyAccessToken(kw) => kw.to_tokens(tokens),
         }
     }
 }

--- a/crates/ruma-macros/src/api/request/outgoing.rs
+++ b/crates/ruma-macros/src/api/request/outgoing.rs
@@ -125,7 +125,7 @@ impl Request {
                     );
                 }
             },
-            AuthScheme::QueryOnlyAccessToken(_) | AuthScheme::ServerSignatures(_) => quote! {},
+            AuthScheme::ServerSignatures(_) => quote! {},
         });
 
         let request_body = if let Some(field) = self.raw_body_field() {


### PR DESCRIPTION
According to [MSC2832](https://github.com/matrix-org/matrix-spec-proposals/pull/2832) and https://github.com/matrix-org/matrix-spec/pull/1200.

Closes #1248.

I'm guessing that #314 is not needed anymore?




<!-- Replace -->
----
Preview Removed
<!-- Replace -->
