### PR TITLE
client-api: Send CORP headers by default for media responses

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -17,6 +17,7 @@ Improvements:
 * Stabilize support for private read receipts
 * Add support for the pagination direction parameter to `/relations` (MSC3715 / Matrix 1.4)
 * Add support for notifications for threads (MSC3773 / Matrix 1.4)
+* Send CORP headers by default for media responses (MSC3828 / Matrix 1.4)
 
 # 0.15.1
 

--- a/crates/ruma-client-api/src/http_headers.rs
+++ b/crates/ruma-client-api/src/http_headers.rs
@@ -1,0 +1,10 @@
+//! Custom HTTP headers not defined in the `http` crate.
+#![allow(clippy::declare_interior_mutable_const)]
+
+use http::header::HeaderName;
+
+/// The [`Cross-Origin-Resource-Policy`] HTTP response header.
+///
+/// [`Cross-Origin-Resource-Policy`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Resource-Policy
+pub const CROSS_ORIGIN_RESOURCE_POLICY: HeaderName =
+    HeaderName::from_static("cross-origin-resource-policy");

--- a/crates/ruma-client-api/src/lib.rs
+++ b/crates/ruma-client-api/src/lib.rs
@@ -20,6 +20,7 @@ pub mod directory;
 pub mod discovery;
 pub mod error;
 pub mod filter;
+pub mod http_headers;
 pub mod keys;
 pub mod knock;
 pub mod media;

--- a/crates/ruma-client-api/src/media/create_content.rs
+++ b/crates/ruma-client-api/src/media/create_content.rs
@@ -5,6 +5,7 @@ pub mod v3 {
     //!
     //! [spec]: https://spec.matrix.org/v1.2/client-server-api/#post_matrixmediav3upload
 
+    use http::header::CONTENT_TYPE;
     use ruma_common::{api::ruma_api, OwnedMxcUri};
 
     ruma_api! {

--- a/crates/ruma-client-api/src/media/create_content_async.rs
+++ b/crates/ruma-client-api/src/media/create_content_async.rs
@@ -5,6 +5,7 @@ pub mod unstable {
     //!
     //! [spec]: https://github.com/tulir/matrix-doc/blob/asynchronous_uploads/proposals/2246-asynchronous-uploads.md
 
+    use http::header::CONTENT_TYPE;
     use ruma_common::{api::ruma_api, IdParseError, MxcUri, ServerName};
 
     ruma_api! {

--- a/crates/ruma-client-api/src/media/get_content.rs
+++ b/crates/ruma-client-api/src/media/get_content.rs
@@ -10,6 +10,8 @@ pub mod v3 {
     use js_int::UInt;
     use ruma_common::{api::ruma_api, IdParseError, MxcUri, ServerName};
 
+    use crate::http_headers::CROSS_ORIGIN_RESOURCE_POLICY;
+
     ruma_api! {
         metadata: {
             description: "Retrieve content from the media store.",
@@ -71,6 +73,14 @@ pub mod v3 {
             /// [MDN]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition#Syntax
             #[ruma_api(header = CONTENT_DISPOSITION)]
             pub content_disposition: Option<String>,
+
+            /// The value of the `Cross-Origin-Resource-Policy` HTTP header.
+            ///
+            /// See [MDN] for the syntax.
+            ///
+            /// [MDN]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Resource-Policy#syntax
+            #[ruma_api(header = CROSS_ORIGIN_RESOURCE_POLICY)]
+            pub cross_origin_resource_policy: Option<String>,
         }
 
         error: crate::Error
@@ -98,8 +108,15 @@ pub mod v3 {
 
     impl Response {
         /// Creates a new `Response` with the given file contents.
+        ///
+        /// The Cross-Origin Resource Policy defaults to `cross-origin`.
         pub fn new(file: Vec<u8>) -> Self {
-            Self { file, content_type: None, content_disposition: None }
+            Self {
+                file,
+                content_type: None,
+                content_disposition: None,
+                cross_origin_resource_policy: Some("cross-origin".to_owned()),
+            }
         }
     }
 }

--- a/crates/ruma-client-api/src/media/get_content.rs
+++ b/crates/ruma-client-api/src/media/get_content.rs
@@ -5,6 +5,7 @@ pub mod v3 {
     //!
     //! [spec]: https://spec.matrix.org/v1.2/client-server-api/#get_matrixmediav3downloadservernamemediaid
 
+    use http::header::{CONTENT_DISPOSITION, CONTENT_TYPE};
     #[cfg(feature = "unstable-msc2246")]
     use js_int::UInt;
     use ruma_common::{api::ruma_api, IdParseError, MxcUri, ServerName};

--- a/crates/ruma-client-api/src/media/get_content_as_filename.rs
+++ b/crates/ruma-client-api/src/media/get_content_as_filename.rs
@@ -5,6 +5,7 @@ pub mod v3 {
     //!
     //! [spec]: https://spec.matrix.org/v1.2/client-server-api/#get_matrixmediav3downloadservernamemediaidfilename
 
+    use http::header::{CONTENT_DISPOSITION, CONTENT_TYPE};
     use ruma_common::{api::ruma_api, IdParseError, MxcUri, ServerName};
 
     ruma_api! {

--- a/crates/ruma-client-api/src/media/get_content_as_filename.rs
+++ b/crates/ruma-client-api/src/media/get_content_as_filename.rs
@@ -8,6 +8,8 @@ pub mod v3 {
     use http::header::{CONTENT_DISPOSITION, CONTENT_TYPE};
     use ruma_common::{api::ruma_api, IdParseError, MxcUri, ServerName};
 
+    use crate::http_headers::CROSS_ORIGIN_RESOURCE_POLICY;
+
     ruma_api! {
         metadata: {
             description: "Retrieve content from the media store, specifying a filename to return.",
@@ -58,6 +60,14 @@ pub mod v3 {
             /// [MDN]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition#Syntax
             #[ruma_api(header = CONTENT_DISPOSITION)]
             pub content_disposition: Option<String>,
+
+            /// The value of the `Cross-Origin-Resource-Policy` HTTP header.
+            ///
+            /// See [MDN] for the syntax.
+            ///
+            /// [MDN]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Resource-Policy#syntax
+            #[ruma_api(header = CROSS_ORIGIN_RESOURCE_POLICY)]
+            pub cross_origin_resource_policy: Option<String>,
         }
 
         error: crate::Error
@@ -79,8 +89,15 @@ pub mod v3 {
 
     impl Response {
         /// Creates a new `Response` with the given file.
+        ///
+        /// The Cross-Origin Resource Policy defaults to `cross-origin`.
         pub fn new(file: Vec<u8>) -> Self {
-            Self { file, content_type: None, content_disposition: None }
+            Self {
+                file,
+                content_type: None,
+                content_disposition: None,
+                cross_origin_resource_policy: Some("cross-origin".to_owned()),
+            }
         }
     }
 }

--- a/crates/ruma-client-api/src/media/get_content_thumbnail.rs
+++ b/crates/ruma-client-api/src/media/get_content_thumbnail.rs
@@ -9,7 +9,7 @@ pub mod v3 {
     use js_int::UInt;
     use ruma_common::{api::ruma_api, serde::StringEnum, IdParseError, MxcUri, ServerName};
 
-    use crate::PrivOwnedStr;
+    use crate::{http_headers::CROSS_ORIGIN_RESOURCE_POLICY, PrivOwnedStr};
 
     ruma_api! {
         metadata: {
@@ -79,6 +79,14 @@ pub mod v3 {
             /// The content type of the thumbnail.
             #[ruma_api(header = CONTENT_TYPE)]
             pub content_type: Option<String>,
+
+            /// The value of the `Cross-Origin-Resource-Policy` HTTP header.
+            ///
+            /// See [MDN] for the syntax.
+            ///
+            /// [MDN]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Resource-Policy#syntax
+            #[ruma_api(header = CROSS_ORIGIN_RESOURCE_POLICY)]
+            pub cross_origin_resource_policy: Option<String>,
         }
 
         error: crate::Error
@@ -116,8 +124,14 @@ pub mod v3 {
 
     impl Response {
         /// Creates a new `Response` with the given thumbnail.
+        ///
+        /// The Cross-Origin Resource Policy defaults to `cross-origin`.
         pub fn new(file: Vec<u8>) -> Self {
-            Self { file, content_type: None }
+            Self {
+                file,
+                content_type: None,
+                cross_origin_resource_policy: Some("cross-origin".to_owned()),
+            }
         }
     }
 

--- a/crates/ruma-client-api/src/media/get_content_thumbnail.rs
+++ b/crates/ruma-client-api/src/media/get_content_thumbnail.rs
@@ -5,6 +5,7 @@ pub mod v3 {
     //!
     //! [spec]: https://spec.matrix.org/v1.2/client-server-api/#get_matrixmediav3thumbnailservernamemediaid
 
+    use http::header::CONTENT_TYPE;
     use js_int::UInt;
     use ruma_common::{api::ruma_api, serde::StringEnum, IdParseError, MxcUri, ServerName};
 

--- a/crates/ruma-client-api/src/session/sso_login.rs
+++ b/crates/ruma-client-api/src/session/sso_login.rs
@@ -5,6 +5,7 @@ pub mod v3 {
     //!
     //! [spec]: https://spec.matrix.org/v1.2/client-server-api/#get_matrixclientv3loginssoredirect
 
+    use http::header::LOCATION;
     use ruma_common::api::ruma_api;
 
     ruma_api! {

--- a/crates/ruma-client-api/src/session/sso_login_with_provider.rs
+++ b/crates/ruma-client-api/src/session/sso_login_with_provider.rs
@@ -7,6 +7,7 @@ pub mod v3 {
     //!
     //! [spec]: https://spec.matrix.org/v1.2/client-server-api/#get_matrixclientv3loginssoredirectidpid
 
+    use http::header::LOCATION;
     use ruma_common::api::ruma_api;
 
     ruma_api! {

--- a/crates/ruma-client-api/src/uiaa/get_uiaa_fallback_page.rs
+++ b/crates/ruma-client-api/src/uiaa/get_uiaa_fallback_page.rs
@@ -5,6 +5,7 @@ pub mod v3 {
     //!
     //! [spec]: https://spec.matrix.org/v1.2/client-server-api/#fallback
 
+    use http::header::LOCATION;
     use ruma_common::api::ruma_api;
 
     ruma_api! {

--- a/crates/ruma-client-api/src/user_directory/search_users.rs
+++ b/crates/ruma-client-api/src/user_directory/search_users.rs
@@ -5,6 +5,7 @@ pub mod v3 {
     //!
     //! [spec]: https://spec.matrix.org/v1.2/client-server-api/#post_matrixclientv3user_directorysearch
 
+    use http::header::ACCEPT_LANGUAGE;
     use js_int::{uint, UInt};
     use ruma_common::{api::ruma_api, OwnedMxcUri, OwnedUserId};
     use serde::{Deserialize, Serialize};

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -6,6 +6,10 @@ Breaking changes:
 * Remove deprecated constructors for `RoomMessageEventContent`
 * Remove `serde::vec_as_map_of_empty` from the public API
 * Remove the `api::AuthScheme::QueryOnlyAccessToken` variant, which is no longer used
+* The `#[ruma_api(header)]` attribute of the `ruma_api` macro now accepts an arbitrary
+  `http::header::HeaderName`
+  * To continue using constants from `http::header`, they must be imported in
+    the module calling the macro.
 
 Improvements:
 

--- a/crates/ruma-common/src/api.rs
+++ b/crates/ruma-common/src/api.rs
@@ -78,8 +78,9 @@ use crate::UserId;
 ///
 /// * `#[ruma_api(header = HEADER_NAME)]`: Fields with this attribute will be treated as HTTP
 ///   headers on the request. The value must implement `AsRef<str>`. Generally this is a
-///   `String`. The attribute value shown above as `HEADER_NAME` must be a header name constant
-///   from `http::header`, e.g. `CONTENT_TYPE`.
+///   `String`. The attribute value shown above as `HEADER_NAME` must be a `const` expression
+///   of the type `http::header::HeaderName`, like one of the constants from `http::header`,
+///   e.g. `CONTENT_TYPE`.
 /// * `#[ruma_api(path)]`: Fields with this attribute will be inserted into the matching path
 ///   component of the request URL.
 /// * `#[ruma_api(query)]`: Fields with this attribute will be inserting into the URL's query
@@ -123,6 +124,7 @@ use crate::UserId;
 ///
 /// ```
 /// pub mod some_endpoint {
+///     use http::header::CONTENT_TYPE;
 ///     use ruma_common::api::ruma_api;
 ///
 ///     ruma_api! {

--- a/crates/ruma-common/tests/api/conversions.rs
+++ b/crates/ruma-common/tests/api/conversions.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::exhaustive_structs)]
 
+use http::header::CONTENT_TYPE;
 use ruma_common::{
     api::{
         ruma_api, IncomingRequest as _, MatrixVersion, OutgoingRequest as _,
@@ -121,7 +122,7 @@ fn request_with_user_id_serde() {
 mod without_query {
     use ruma_common::{api::MatrixVersion, OwnedUserId};
 
-    use super::{ruma_api, user_id, OutgoingRequestAppserviceExt, SendAccessToken};
+    use super::{ruma_api, user_id, OutgoingRequestAppserviceExt, SendAccessToken, CONTENT_TYPE};
 
     ruma_api! {
         metadata: {

--- a/crates/ruma-common/tests/api/header_override.rs
+++ b/crates/ruma-common/tests/api/header_override.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::exhaustive_structs)]
 
-use http::header::{Entry, CONTENT_TYPE};
+use http::header::{Entry, CONTENT_TYPE, LOCATION};
 use ruma_common::api::{
     ruma_api, MatrixVersion, OutgoingRequest as _, OutgoingResponse as _, SendAccessToken,
 };

--- a/crates/ruma-common/tests/api/optional_headers.rs
+++ b/crates/ruma-common/tests/api/optional_headers.rs
@@ -1,3 +1,4 @@
+use http::header::LOCATION;
 use ruma_common::api::ruma_api;
 
 ruma_api! {

--- a/crates/ruma-common/tests/api/ruma_api_lifetime.rs
+++ b/crates/ruma-common/tests/api/ruma_api_lifetime.rs
@@ -58,6 +58,7 @@ mod nested_types {
 }
 
 mod full_request_response {
+    use http::header::CONTENT_TYPE;
     use ruma_common::api::ruma_api;
 
     use super::{IncomingOtherThing, OtherThing};
@@ -92,6 +93,7 @@ mod full_request_response {
 }
 
 mod full_request_response_with_query_map {
+    use http::header::CONTENT_TYPE;
     use ruma_common::api::ruma_api;
 
     ruma_api! {

--- a/crates/ruma-common/tests/api/ruma_api_macros.rs
+++ b/crates/ruma-common/tests/api/ruma_api_macros.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::exhaustive_structs)]
 
 pub mod some_endpoint {
+    use http::header::CONTENT_TYPE;
     use ruma_common::{
         api::ruma_api,
         events::{tag::TagEvent, AnyTimelineEvent},

--- a/crates/ruma-common/tests/api/ui/01-api-sanity-check.rs
+++ b/crates/ruma-common/tests/api/ui/01-api-sanity-check.rs
@@ -1,3 +1,4 @@
+use http::header::CONTENT_TYPE;
 use ruma_common::{
     api::ruma_api,
     events::{tag::TagEvent, AnyTimelineEvent},

--- a/crates/ruma-common/tests/api/ui/03-move-value.rs
+++ b/crates/ruma-common/tests/api/ui/03-move-value.rs
@@ -2,6 +2,7 @@
 // consume the request/response.
 
 mod newtype_body {
+    use http::header::CONTENT_TYPE;
     use ruma_common::{api::ruma_api, OwnedUserId};
 
     #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
@@ -42,6 +43,7 @@ mod newtype_body {
 }
 
 mod raw_body {
+    use http::header::CONTENT_TYPE;
     use ruma_common::{api::ruma_api, OwnedUserId};
 
     ruma_api! {
@@ -79,6 +81,7 @@ mod raw_body {
 }
 
 mod plain {
+    use http::header::CONTENT_TYPE;
     use ruma_common::{api::ruma_api, OwnedUserId};
 
     #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]

--- a/crates/ruma-common/tests/api/ui/04-attributes.rs
+++ b/crates/ruma-common/tests/api/ui/04-attributes.rs
@@ -1,3 +1,4 @@
+use http::header::CONTENT_TYPE;
 use ruma_common::api::ruma_api;
 
 ruma_api! {

--- a/crates/ruma-common/tests/api/ui/04-attributes.stderr
+++ b/crates/ruma-common/tests/api/ui/04-attributes.stderr
@@ -1,5 +1,5 @@
 error: cannot find attribute `not_a_real_attribute_should_fail` in this scope
-  --> $DIR/04-attributes.rs:13:7
+  --> $DIR/04-attributes.rs:14:7
    |
-13 |     #[not_a_real_attribute_should_fail]
+14 |     #[not_a_real_attribute_should_fail]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/ruma-macros/src/api/request/incoming.rs
+++ b/crates/ruma-macros/src/api/request/incoming.rs
@@ -113,7 +113,7 @@ impl Request {
 
                     let decl = quote! {
                         #( #cfg_attrs )*
-                        let #field_name = match headers.get(#http::header::#header_name) {
+                        let #field_name = match headers.get(#header_name) {
                             Some(header_value) => {
                                 let str_value = header_value.to_str()?;
                                 #some_case

--- a/crates/ruma-macros/src/api/request/outgoing.rs
+++ b/crates/ruma-macros/src/api/request/outgoing.rs
@@ -88,7 +88,7 @@ impl Request {
                     quote! {
                         if let Some(header_val) = self.#field_name.as_ref() {
                             req_headers.insert(
-                                #http::header::#header_name,
+                                #header_name,
                                 #http::header::HeaderValue::from_str(header_val)?,
                             );
                         }
@@ -96,7 +96,7 @@ impl Request {
                 }
                 _ => quote! {
                     req_headers.insert(
-                        #http::header::#header_name,
+                        #header_name,
                         #http::header::HeaderValue::from_str(self.#field_name.as_ref())?,
                     );
                 },

--- a/crates/ruma-macros/src/api/response/incoming.rs
+++ b/crates/ruma-macros/src/api/response/incoming.rs
@@ -60,7 +60,7 @@ impl Response {
                                 quote! {
                                     #( #cfg_attrs )*
                                     #field_name: {
-                                        headers.remove(#http::header::#header_name)
+                                        headers.remove(#header_name)
                                             .map(|h| h.to_str().map(|s| s.to_owned()))
                                             .transpose()?
                                     }
@@ -69,7 +69,7 @@ impl Response {
                             _ => quote! {
                                 #( #cfg_attrs )*
                                 #field_name: {
-                                    headers.remove(#http::header::#header_name)
+                                    headers.remove(#header_name)
                                         .expect("response missing expected header")
                                         .to_str()?
                                         .to_owned()

--- a/crates/ruma-macros/src/api/response/outgoing.rs
+++ b/crates/ruma-macros/src/api/response/outgoing.rs
@@ -20,7 +20,7 @@ impl Response {
                         quote! {
                             if let Some(header) = self.#field_name {
                                 headers.insert(
-                                    #http::header::#header_name,
+                                    #header_name,
                                     header.parse()?,
                                 );
                             }
@@ -28,7 +28,7 @@ impl Response {
                     }
                     _ => quote! {
                         headers.insert(
-                            #http::header::#header_name,
+                            #header_name,
                             self.#field_name.parse()?,
                         );
                     },


### PR DESCRIPTION
According to [MSC3828](https://github.com/matrix-org/matrix-spec-proposals/pull/3828) and https://github.com/matrix-org/matrix-spec/pull/1197.

I had to find a workaround for the fact that the `Cross-Origin-Resource-Policy` is not defined in the `http` crate, so now the `ruma_api` macro accepts any `HeaderName`.

Closes #1188.










<!-- Replace -->
----
Preview: https://pr-1326--ruma-docs.surge.sh
<!-- Replace -->
