### PR TITLE
events: Make `Replacement` generic over the parent type

### DIFF
--- a/crates/ruma-common/src/events/audio.rs
+++ b/crates/ruma-common/src/events/audio.rs
@@ -36,7 +36,7 @@ use super::{
 /// [`MessageType::Audio`]: super::room::message::MessageType::Audio
 #[derive(Clone, Debug, Serialize, Deserialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-#[ruma_event(type = "m.audio", kind = MessageLike)]
+#[ruma_event(type = "m.audio", kind = MessageLike, without_relation)]
 pub struct AudioEventContent {
     /// The text representation of the message.
     #[serde(flatten)]

--- a/crates/ruma-common/src/events/audio.rs
+++ b/crates/ruma-common/src/events/audio.rs
@@ -40,7 +40,7 @@ pub struct AudioEventContent {
 
     /// Information about related messages.
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
-    pub relates_to: Option<Relation>,
+    pub relates_to: Option<Relation<AudioEventContentWithoutRelation>>,
 }
 
 impl AudioEventContent {

--- a/crates/ruma-common/src/events/emote.rs
+++ b/crates/ruma-common/src/events/emote.rs
@@ -5,24 +5,15 @@
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
-use super::{
-    message::MessageContent,
-    room::message::{EmoteMessageEventContent, MessageType, Relation, RoomMessageEventContent},
-};
+use super::{message::MessageContent, room::message::Relation};
 
 /// The payload for an extensible emote message.
 ///
 /// This is the new primary type introduced in [MSC1767] and should not be sent before the end of
 /// the transition period. See the documentation of the [`message`] module for more information.
 ///
-/// `EmoteEventContent` can be converted to a [`RoomMessageEventContent`] with a
-/// [`MessageType::Emote`]. You can convert it back with
-/// [`EmoteEventContent::from_emote_room_message()`].
-///
 /// [MSC1767]: https://github.com/matrix-org/matrix-spec-proposals/pull/1767
 /// [`message`]: super::message
-/// [`RoomMessageEventContent`]: super::room::message::RoomMessageEventContent
-/// [`MessageType::Emote`]: super::room::message::MessageType::Emote
 #[derive(Clone, Debug, Serialize, Deserialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[ruma_event(type = "m.emote", kind = MessageLike, without_relation)]
@@ -54,27 +45,5 @@ impl EmoteEventContent {
     #[cfg(feature = "markdown")]
     pub fn markdown(body: impl AsRef<str> + Into<String>) -> Self {
         Self { message: MessageContent::markdown(body), relates_to: None }
-    }
-
-    /// Create a new `EmoteEventContent` from the given `EmoteMessageEventContent` and optional
-    /// relation.
-    pub fn from_emote_room_message(
-        content: EmoteMessageEventContent,
-        relates_to: Option<Relation>,
-    ) -> Self {
-        let EmoteMessageEventContent { body, formatted, message, .. } = content;
-        if let Some(message) = message {
-            Self { message, relates_to }
-        } else {
-            Self { message: MessageContent::from_room_message_content(body, formatted), relates_to }
-        }
-    }
-}
-
-impl From<EmoteEventContent> for RoomMessageEventContent {
-    fn from(content: EmoteEventContent) -> Self {
-        let EmoteEventContent { message, relates_to, .. } = content;
-
-        Self { msgtype: MessageType::Emote(message.into()), relates_to }
     }
 }

--- a/crates/ruma-common/src/events/emote.rs
+++ b/crates/ruma-common/src/events/emote.rs
@@ -24,7 +24,7 @@ pub struct EmoteEventContent {
 
     /// Information about related messages.
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
-    pub relates_to: Option<Relation>,
+    pub relates_to: Option<Relation<EmoteEventContentWithoutRelation>>,
 }
 
 impl EmoteEventContent {

--- a/crates/ruma-common/src/events/emote.rs
+++ b/crates/ruma-common/src/events/emote.rs
@@ -25,7 +25,7 @@ use super::{
 /// [`MessageType::Emote`]: super::room::message::MessageType::Emote
 #[derive(Clone, Debug, Serialize, Deserialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-#[ruma_event(type = "m.emote", kind = MessageLike)]
+#[ruma_event(type = "m.emote", kind = MessageLike, without_relation)]
 pub struct EmoteEventContent {
     /// The message's text content.
     #[serde(flatten)]

--- a/crates/ruma-common/src/events/file.rs
+++ b/crates/ruma-common/src/events/file.rs
@@ -34,7 +34,7 @@ use crate::{serde::Base64, OwnedMxcUri};
 /// [`MessageType::File`]: super::room::message::MessageType::File
 #[derive(Clone, Debug, Serialize, Deserialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-#[ruma_event(type = "m.file", kind = MessageLike)]
+#[ruma_event(type = "m.file", kind = MessageLike, without_relation)]
 pub struct FileEventContent {
     /// The text representation of the message.
     #[serde(flatten)]

--- a/crates/ruma-common/src/events/file.rs
+++ b/crates/ruma-common/src/events/file.rs
@@ -35,7 +35,7 @@ pub struct FileEventContent {
 
     /// Information about related messages.
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
-    pub relates_to: Option<Relation>,
+    pub relates_to: Option<Relation<FileEventContentWithoutRelation>>,
 }
 
 impl FileEventContent {

--- a/crates/ruma-common/src/events/image.rs
+++ b/crates/ruma-common/src/events/image.rs
@@ -31,7 +31,7 @@ use crate::OwnedMxcUri;
 /// [`MessageType::Image`]: super::room::message::MessageType::Image
 #[derive(Clone, Debug, Serialize, Deserialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-#[ruma_event(type = "m.image", kind = MessageLike)]
+#[ruma_event(type = "m.image", kind = MessageLike, without_relation)]
 pub struct ImageEventContent {
     /// The text representation of the message.
     #[serde(flatten)]

--- a/crates/ruma-common/src/events/image.rs
+++ b/crates/ruma-common/src/events/image.rs
@@ -51,7 +51,7 @@ pub struct ImageEventContent {
 
     /// Information about related messages.
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
-    pub relates_to: Option<Relation>,
+    pub relates_to: Option<Relation<ImageEventContentWithoutRelation>>,
 }
 
 impl ImageEventContent {

--- a/crates/ruma-common/src/events/location.rs
+++ b/crates/ruma-common/src/events/location.rs
@@ -29,7 +29,7 @@ use crate::{MilliSecondsSinceUnixEpoch, PrivOwnedStr};
 /// [`MessageType::Location`]: super::room::message::MessageType::Location
 #[derive(Clone, Debug, Serialize, Deserialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-#[ruma_event(type = "m.location", kind = MessageLike)]
+#[ruma_event(type = "m.location", kind = MessageLike, without_relation)]
 pub struct LocationEventContent {
     /// The text representation of the message.
     #[serde(flatten)]

--- a/crates/ruma-common/src/events/location.rs
+++ b/crates/ruma-common/src/events/location.rs
@@ -8,10 +8,7 @@ use serde::{Deserialize, Serialize};
 
 mod zoomlevel_serde;
 
-use super::{
-    message::MessageContent,
-    room::message::{LocationMessageEventContent, MessageType, Relation, RoomMessageEventContent},
-};
+use super::{message::MessageContent, room::message::Relation};
 use crate::{MilliSecondsSinceUnixEpoch, PrivOwnedStr};
 
 /// The payload for an extensible location message.
@@ -19,14 +16,8 @@ use crate::{MilliSecondsSinceUnixEpoch, PrivOwnedStr};
 /// This is the new primary type introduced in [MSC3488] and should not be sent before the end of
 /// the transition period. See the documentation of the [`message`] module for more information.
 ///
-/// `LocationEventContent` can be converted to a [`RoomMessageEventContent`] with a
-/// [`MessageType::Location`]. You can convert it back with
-/// [`LocationEventContent::from_location_room_message()`].
-///
 /// [MSC3488]: https://github.com/matrix-org/matrix-spec-proposals/pull/3488
 /// [`message`]: super::message
-/// [`RoomMessageEventContent`]: super::room::message::RoomMessageEventContent
-/// [`MessageType::Location`]: super::room::message::MessageType::Location
 #[derive(Clone, Debug, Serialize, Deserialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[ruma_event(type = "m.location", kind = MessageLike, without_relation)]
@@ -67,35 +58,6 @@ impl LocationEventContent {
     /// Creates a new `LocationEventContent` with the given text representation and location.
     pub fn with_message(message: MessageContent, location: LocationContent) -> Self {
         Self { message, location, asset: Default::default(), ts: None, relates_to: None }
-    }
-
-    /// Create a new `LocationEventContent` from the given `LocationMessageEventContent` and
-    /// optional relation.
-    pub fn from_location_room_message(
-        content: LocationMessageEventContent,
-        relates_to: Option<Relation>,
-    ) -> Self {
-        let LocationMessageEventContent { body, geo_uri, message, location, asset, ts, .. } =
-            content;
-
-        let message = message.unwrap_or_else(|| MessageContent::plain(body));
-        let location = location.unwrap_or_else(|| LocationContent::new(geo_uri));
-        let asset = asset.unwrap_or_default();
-
-        Self { message, location, asset, ts, relates_to }
-    }
-}
-
-impl From<LocationEventContent> for RoomMessageEventContent {
-    fn from(content: LocationEventContent) -> Self {
-        let LocationEventContent { message, location, asset, ts, relates_to } = content;
-
-        Self {
-            msgtype: MessageType::Location(LocationMessageEventContent::from_extensible_content(
-                message, location, asset, ts,
-            )),
-            relates_to,
-        }
     }
 }
 

--- a/crates/ruma-common/src/events/location.rs
+++ b/crates/ruma-common/src/events/location.rs
@@ -40,7 +40,7 @@ pub struct LocationEventContent {
 
     /// Information about related messages.
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
-    pub relates_to: Option<Relation>,
+    pub relates_to: Option<Relation<LocationEventContentWithoutRelation>>,
 }
 
 impl LocationEventContent {

--- a/crates/ruma-common/src/events/message.rs
+++ b/crates/ruma-common/src/events/message.rs
@@ -73,7 +73,7 @@ pub struct MessageEventContent {
 
     /// Information about related messages.
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
-    pub relates_to: Option<Relation>,
+    pub relates_to: Option<Relation<MessageEventContentWithoutRelation>>,
 }
 
 impl MessageEventContent {

--- a/crates/ruma-common/src/events/message.rs
+++ b/crates/ruma-common/src/events/message.rs
@@ -81,7 +81,7 @@ use super::room::message::{
 /// [`MessageType::Text`]: super::room::message::MessageType::Text
 #[derive(Clone, Debug, Serialize, Deserialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-#[ruma_event(type = "m.message", kind = MessageLike)]
+#[ruma_event(type = "m.message", kind = MessageLike, without_relation)]
 pub struct MessageEventContent {
     /// The message's text content.
     #[serde(flatten)]

--- a/crates/ruma-common/src/events/notice.rs
+++ b/crates/ruma-common/src/events/notice.rs
@@ -25,7 +25,7 @@ use super::{
 /// [`MessageType::Notice`]: super::room::message::MessageType::Notice
 #[derive(Clone, Debug, Serialize, Deserialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-#[ruma_event(type = "m.notice", kind = MessageLike)]
+#[ruma_event(type = "m.notice", kind = MessageLike, without_relation)]
 pub struct NoticeEventContent {
     /// The message's text content.
     #[serde(flatten)]

--- a/crates/ruma-common/src/events/notice.rs
+++ b/crates/ruma-common/src/events/notice.rs
@@ -5,24 +5,15 @@
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
-use super::{
-    message::MessageContent,
-    room::message::{MessageType, NoticeMessageEventContent, Relation, RoomMessageEventContent},
-};
+use super::{message::MessageContent, room::message::Relation};
 
 /// The payload for an extensible notice message.
 ///
 /// This is the new primary type introduced in [MSC1767] and should not be sent before the end of
 /// the transition period. See the documentation of the [`message`] module for more information.
 ///
-/// `NoticeEventContent` can be converted to a [`RoomMessageEventContent`] with a
-/// [`MessageType::Notice`]. You can convert it back with
-/// [`NoticeEventContent::from_notice_room_message()`].
-///
 /// [MSC1767]: https://github.com/matrix-org/matrix-spec-proposals/pull/1767
 /// [`message`]: super::message
-/// [`RoomMessageEventContent`]: super::room::message::RoomMessageEventContent
-/// [`MessageType::Notice`]: super::room::message::MessageType::Notice
 #[derive(Clone, Debug, Serialize, Deserialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[ruma_event(type = "m.notice", kind = MessageLike, without_relation)]
@@ -54,27 +45,5 @@ impl NoticeEventContent {
     #[cfg(feature = "markdown")]
     pub fn markdown(body: impl AsRef<str> + Into<String>) -> Self {
         Self { message: MessageContent::markdown(body), relates_to: None }
-    }
-
-    /// Create a new `NoticeEventContent` from the given `NoticeMessageEventContent` and optional
-    /// relation.
-    pub fn from_notice_room_message(
-        content: NoticeMessageEventContent,
-        relates_to: Option<Relation>,
-    ) -> Self {
-        let NoticeMessageEventContent { body, formatted, message, .. } = content;
-        if let Some(message) = message {
-            Self { message, relates_to }
-        } else {
-            Self { message: MessageContent::from_room_message_content(body, formatted), relates_to }
-        }
-    }
-}
-
-impl From<NoticeEventContent> for RoomMessageEventContent {
-    fn from(content: NoticeEventContent) -> Self {
-        let NoticeEventContent { message, relates_to, .. } = content;
-
-        Self { msgtype: MessageType::Notice(message.into()), relates_to }
     }
 }

--- a/crates/ruma-common/src/events/notice.rs
+++ b/crates/ruma-common/src/events/notice.rs
@@ -24,7 +24,7 @@ pub struct NoticeEventContent {
 
     /// Information about related messages.
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
-    pub relates_to: Option<Relation>,
+    pub relates_to: Option<Relation<NoticeEventContentWithoutRelation>>,
 }
 
 impl NoticeEventContent {

--- a/crates/ruma-common/src/events/room.rs
+++ b/crates/ruma-common/src/events/room.rs
@@ -13,10 +13,7 @@ use serde::{de, Deserialize, Serialize};
 #[cfg(feature = "unstable-msc3551")]
 use super::file::{EncryptedContent, EncryptedContentInit, FileContent};
 #[cfg(feature = "unstable-msc3552")]
-use super::{
-    file::FileContentInfo,
-    image::{ImageContent, ThumbnailContent, ThumbnailFileContent, ThumbnailFileContentInfo},
-};
+use super::image::ThumbnailFileContent;
 #[cfg(feature = "unstable-msc3551")]
 use crate::MxcUri;
 use crate::{
@@ -165,48 +162,6 @@ impl ImageInfo {
     pub fn new() -> Self {
         Self::default()
     }
-
-    /// Create an `ImageInfo` from the given file info, image info and thumbnail.
-    ///
-    /// Returns `None` if the `ImageInfo` would be empty.
-    #[cfg(feature = "unstable-msc3552")]
-    fn from_extensible_content(
-        file_info: Option<&FileContentInfo>,
-        image: &ImageContent,
-        thumbnail: &[ThumbnailContent],
-    ) -> Option<Self> {
-        if file_info.is_none() && image.is_empty() && thumbnail.is_empty() {
-            None
-        } else {
-            let (mimetype, size) = file_info
-                .map(|info| (info.mimetype.to_owned(), info.size.to_owned()))
-                .unwrap_or_default();
-            let ImageContent { height, width } = image.to_owned();
-            let (thumbnail_source, thumbnail_info) = thumbnail
-                .get(0)
-                .map(|thumbnail| {
-                    let source = (&thumbnail.file).into();
-                    let info = ThumbnailInfo::from_extensible_content(
-                        thumbnail.file.info.as_deref(),
-                        thumbnail.image.as_deref(),
-                    )
-                    .map(Box::new);
-                    (Some(source), info)
-                })
-                .unwrap_or_default();
-
-            Some(Self {
-                height,
-                width,
-                mimetype,
-                size,
-                thumbnail_source,
-                thumbnail_info,
-                #[cfg(feature = "unstable-msc2448")]
-                blurhash: None,
-            })
-        }
-    }
 }
 
 /// Metadata about a thumbnail.
@@ -234,24 +189,6 @@ impl ThumbnailInfo {
     /// Creates an empty `ThumbnailInfo`.
     pub fn new() -> Self {
         Self::default()
-    }
-
-    /// Create a `ThumbnailInfo` with the given file info and image info.
-    ///
-    /// Returns `None` if the `ThumbnailInfo` would be empty.
-    #[cfg(feature = "unstable-msc3552")]
-    fn from_extensible_content(
-        file_info: Option<&ThumbnailFileContentInfo>,
-        image: Option<&ImageContent>,
-    ) -> Option<Self> {
-        if file_info.is_none() && image.is_none() {
-            None
-        } else {
-            let ThumbnailFileContentInfo { mimetype, size } =
-                file_info.map(ToOwned::to_owned).unwrap_or_default();
-            let ImageContent { height, width } = image.map(ToOwned::to_owned).unwrap_or_default();
-            Some(Self { height, width, mimetype, size })
-        }
     }
 }
 

--- a/crates/ruma-common/src/events/room/encrypted.rs
+++ b/crates/ruma-common/src/events/room/encrypted.rs
@@ -107,8 +107,8 @@ pub enum Relation {
     _Custom,
 }
 
-impl From<message::Relation> for Relation {
-    fn from(rel: message::Relation) -> Self {
+impl<C> From<message::Relation<C>> for Relation {
+    fn from(rel: message::Relation<C>) -> Self {
         match rel {
             message::Relation::Reply { in_reply_to } => Self::Reply { in_reply_to },
             message::Relation::Replacement(re) => {

--- a/crates/ruma-common/src/events/room/message.rs
+++ b/crates/ruma-common/src/events/room/message.rs
@@ -457,6 +457,12 @@ impl From<MessageType> for RoomMessageEventContent {
     }
 }
 
+impl From<RoomMessageEventContent> for MessageType {
+    fn from(content: RoomMessageEventContent) -> Self {
+        content.msgtype
+    }
+}
+
 /// Message event relationship.
 #[derive(Clone, Debug)]
 #[allow(clippy::manual_non_exhaustive)]

--- a/crates/ruma-common/src/events/room/message.rs
+++ b/crates/ruma-common/src/events/room/message.rs
@@ -62,7 +62,7 @@ pub struct RoomMessageEventContent {
     ///
     /// [rich replies]: https://spec.matrix.org/v1.2/client-server-api/#rich-replies
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
-    pub relates_to: Option<Relation>,
+    pub relates_to: Option<Relation<MessageType>>,
 }
 
 impl RoomMessageEventContent {
@@ -467,7 +467,7 @@ impl From<RoomMessageEventContent> for MessageType {
 #[derive(Clone, Debug)]
 #[allow(clippy::manual_non_exhaustive)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-pub enum Relation {
+pub enum Relation<C> {
     /// An `m.in_reply_to` relation indicating that the event is a reply to another event.
     Reply {
         /// Information about another message being replied to.
@@ -475,7 +475,7 @@ pub enum Relation {
     },
 
     /// An event that replaces another event.
-    Replacement(Replacement),
+    Replacement(Replacement<C>),
 
     /// An event that belongs to a thread.
     Thread(Thread),
@@ -504,17 +504,17 @@ impl InReplyTo {
 /// [replaces another event]: https://spec.matrix.org/v1.4/client-server-api/#event-replacements
 #[derive(Clone, Debug)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-pub struct Replacement {
+pub struct Replacement<C> {
     /// The ID of the event being replaced.
     pub event_id: OwnedEventId,
 
     /// New content.
-    pub new_content: Box<RoomMessageEventContent>,
+    pub new_content: C,
 }
 
-impl Replacement {
+impl<C> Replacement<C> {
     /// Creates a new `Replacement` with the given event ID and new content.
-    pub fn new(event_id: OwnedEventId, new_content: Box<RoomMessageEventContent>) -> Self {
+    pub fn new(event_id: OwnedEventId, new_content: C) -> Self {
         Self { event_id, new_content }
     }
 }

--- a/crates/ruma-common/src/events/room/message/content_serde.rs
+++ b/crates/ruma-common/src/events/room/message/content_serde.rs
@@ -47,8 +47,8 @@ impl<'de> Deserialize<'de> for RoomMessageEventContent {
     {
         let json = Box::<RawJsonValue>::deserialize(deserializer)?;
         let mut deserializer = serde_json::Deserializer::from_str(json.get());
-        let relates_to =
-            Option::<Relation>::deserialize(&mut deserializer).map_err(de::Error::custom)?;
+        let relates_to = Option::<Relation<MessageType>>::deserialize(&mut deserializer)
+            .map_err(de::Error::custom)?;
 
         Ok(Self { msgtype: from_raw_json_value(&json)?, relates_to })
     }

--- a/crates/ruma-common/src/events/room/message/file.rs
+++ b/crates/ruma-common/src/events/room/message/file.rs
@@ -98,24 +98,6 @@ impl FileMessageEventContent {
             info: None,
         }
     }
-
-    /// Create a new `FileMessageEventContent` with the given message and file info.
-    #[cfg(feature = "unstable-msc3551")]
-    pub(crate) fn from_extensible_content(message: MessageContent, file: FileContent) -> Self {
-        let body = if let Some(body) = message.find_plain() {
-            body.to_owned()
-        } else {
-            message[0].body.clone()
-        };
-        let filename = file.info.as_deref().and_then(|info| info.name.clone());
-        let info = file.info.as_deref().and_then(|info| {
-            FileInfo::from_extensible_content(info.mimetype.to_owned(), info.size.to_owned())
-                .map(Box::new)
-        });
-        let source = (&file).into();
-
-        Self { message: Some(message), file: Some(file), body, filename, source, info }
-    }
 }
 
 /// Metadata about a file.
@@ -147,17 +129,5 @@ impl FileInfo {
     /// Creates an empty `FileInfo`.
     pub fn new() -> Self {
         Self::default()
-    }
-
-    /// Creates a `FileInfo` with the given optional mimetype and size.
-    ///
-    /// Returns `None` if the `FileInfo` would be empty.
-    #[cfg(feature = "unstable-msc3551")]
-    fn from_extensible_content(mimetype: Option<String>, size: Option<UInt>) -> Option<Self> {
-        if mimetype.is_none() && size.is_none() {
-            None
-        } else {
-            Some(Self { mimetype, size, ..Default::default() })
-        }
     }
 }

--- a/crates/ruma-common/src/events/room/message/image.rs
+++ b/crates/ruma-common/src/events/room/message/image.rs
@@ -143,36 +143,4 @@ impl ImageMessageEventContent {
             info: None,
         }
     }
-
-    /// Create a new `ImageMessageEventContent` with the given message, file info, image info,
-    /// thumbnails and captions.
-    #[cfg(feature = "unstable-msc3552")]
-    pub(crate) fn from_extensible_content(
-        message: MessageContent,
-        file: FileContent,
-        image: Box<ImageContent>,
-        thumbnail: Vec<ThumbnailContent>,
-        caption: Option<MessageContent>,
-    ) -> Self {
-        let body = if let Some(body) = message.find_plain() {
-            body.to_owned()
-        } else {
-            message[0].body.clone()
-        };
-        let source = (&file).into();
-        let info = ImageInfo::from_extensible_content(file.info.as_deref(), &image, &thumbnail)
-            .map(Box::new);
-        let thumbnail = if thumbnail.is_empty() { None } else { Some(thumbnail) };
-
-        Self {
-            message: Some(message),
-            file: Some(file),
-            image: Some(image),
-            thumbnail,
-            caption,
-            body,
-            source,
-            info,
-        }
-    }
 }

--- a/crates/ruma-common/src/events/room/message/location.rs
+++ b/crates/ruma-common/src/events/room/message/location.rs
@@ -78,33 +78,6 @@ impl LocationMessageEventContent {
             info: None,
         }
     }
-
-    /// Create a new `LocationMessageEventContent` with the given message, location info, asset and
-    /// timestamp.
-    #[cfg(feature = "unstable-msc3488")]
-    pub(crate) fn from_extensible_content(
-        message: MessageContent,
-        location: LocationContent,
-        asset: AssetContent,
-        ts: Option<MilliSecondsSinceUnixEpoch>,
-    ) -> Self {
-        let body = if let Some(body) = message.find_plain() {
-            body.to_owned()
-        } else {
-            message[0].body.clone()
-        };
-        let geo_uri = location.uri.clone();
-
-        Self {
-            message: Some(message),
-            location: Some(location),
-            asset: Some(asset),
-            ts,
-            body,
-            geo_uri,
-            info: None,
-        }
-    }
 }
 
 /// Thumbnail info associated with a location.

--- a/crates/ruma-common/src/events/room/message/video.rs
+++ b/crates/ruma-common/src/events/room/message/video.rs
@@ -149,38 +149,6 @@ impl VideoMessageEventContent {
             info: None,
         }
     }
-
-    /// Create a new `VideoMessageEventContent` with the given message, file info, video info,
-    /// thumbnails and captions.
-    #[cfg(feature = "unstable-msc3553")]
-    pub(crate) fn from_extensible_content(
-        message: MessageContent,
-        file: FileContent,
-        video: Box<VideoContent>,
-        thumbnail: Vec<ThumbnailContent>,
-        caption: Option<MessageContent>,
-    ) -> Self {
-        let body = if let Some(body) = message.find_plain() {
-            body.to_owned()
-        } else {
-            message[0].body.clone()
-        };
-        let source = (&file).into();
-        let info = VideoInfo::from_extensible_content(file.info.as_deref(), &video, &thumbnail)
-            .map(Box::new);
-        let thumbnail = if thumbnail.is_empty() { None } else { Some(thumbnail) };
-
-        Self {
-            message: Some(message),
-            file: Some(file),
-            video: Some(video),
-            thumbnail,
-            caption,
-            body,
-            source,
-            info,
-        }
-    }
 }
 
 /// Metadata about a video.
@@ -236,48 +204,5 @@ impl VideoInfo {
     /// Creates an empty `VideoInfo`.
     pub fn new() -> Self {
         Self::default()
-    }
-
-    /// Create a `VideoInfo` from the given file info, video info and thumbnail.
-    ///
-    /// Returns `None` if the `VideoInfo` would be empty.
-    #[cfg(feature = "unstable-msc3553")]
-    fn from_extensible_content(
-        file_info: Option<&FileContentInfo>,
-        video: &VideoContent,
-        thumbnail: &[ThumbnailContent],
-    ) -> Option<Self> {
-        if file_info.is_none() && video.is_empty() && thumbnail.is_empty() {
-            None
-        } else {
-            let (mimetype, size) = file_info
-                .map(|info| (info.mimetype.to_owned(), info.size.to_owned()))
-                .unwrap_or_default();
-            let VideoContent { duration, height, width } = video.to_owned();
-            let (thumbnail_source, thumbnail_info) = thumbnail
-                .get(0)
-                .map(|thumbnail| {
-                    let source = (&thumbnail.file).into();
-                    let info = ThumbnailInfo::from_extensible_content(
-                        thumbnail.file.info.as_deref(),
-                        thumbnail.image.as_deref(),
-                    )
-                    .map(Box::new);
-                    (Some(source), info)
-                })
-                .unwrap_or_default();
-
-            Some(Self {
-                duration,
-                height,
-                width,
-                mimetype,
-                size,
-                thumbnail_info,
-                thumbnail_source,
-                #[cfg(feature = "unstable-msc2448")]
-                blurhash: None,
-            })
-        }
     }
 }

--- a/crates/ruma-common/src/events/video.rs
+++ b/crates/ruma-common/src/events/video.rs
@@ -9,12 +9,7 @@ use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
 use super::{
-    file::FileContent,
-    image::ThumbnailContent,
-    message::MessageContent,
-    room::message::{
-        MessageType, Relation, RoomMessageEventContent, VideoInfo, VideoMessageEventContent,
-    },
+    file::FileContent, image::ThumbnailContent, message::MessageContent, room::message::Relation,
 };
 
 /// The payload for an extensible video message.
@@ -22,14 +17,8 @@ use super::{
 /// This is the new primary type introduced in [MSC3553] and should not be sent before the end of
 /// the transition period. See the documentation of the [`message`] module for more information.
 ///
-/// `VideoEventContent` can be converted to a [`RoomMessageEventContent`] with a
-/// [`MessageType::Video`]. You can convert it back with
-/// [`VideoEventContent::from_video_room_message()`].
-///
 /// [MSC3553]: https://github.com/matrix-org/matrix-spec-proposals/pull/3553
 /// [`message`]: super::message
-/// [`RoomMessageEventContent`]: super::room::message::RoomMessageEventContent
-/// [`MessageType::Video`]: super::room::message::MessageType::Video
 #[derive(Clone, Debug, Serialize, Deserialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[ruma_event(type = "m.video", kind = MessageLike, without_relation)]
@@ -86,62 +75,6 @@ impl VideoEventContent {
             thumbnail: Default::default(),
             caption: Default::default(),
             relates_to: None,
-        }
-    }
-
-    /// Create a new `VideoEventContent` from the given `VideoMessageEventContent` and optional
-    /// relation.
-    pub fn from_video_room_message(
-        content: VideoMessageEventContent,
-        relates_to: Option<Relation>,
-    ) -> Self {
-        let VideoMessageEventContent {
-            body,
-            source,
-            info,
-            message,
-            file,
-            video,
-            thumbnail,
-            caption,
-        } = content;
-        let VideoInfo {
-            duration,
-            height,
-            width,
-            mimetype,
-            size,
-            thumbnail_info,
-            thumbnail_source,
-            ..
-        } = info.map(|info| *info).unwrap_or_default();
-
-        let message = message.unwrap_or_else(|| MessageContent::plain(body));
-        let file = file.unwrap_or_else(|| {
-            FileContent::from_room_message_content(source, None, mimetype, size)
-        });
-        let video = video.unwrap_or_else(|| {
-            Box::new(VideoContent::from_room_message_content(height, width, duration))
-        });
-        let thumbnail = thumbnail.unwrap_or_else(|| {
-            ThumbnailContent::from_room_message_content(thumbnail_source, thumbnail_info)
-                .into_iter()
-                .collect()
-        });
-
-        Self { message, file, video, thumbnail, caption, relates_to }
-    }
-}
-
-impl From<VideoEventContent> for RoomMessageEventContent {
-    fn from(content: VideoEventContent) -> Self {
-        let VideoEventContent { message, file, video, thumbnail, caption, relates_to } = content;
-
-        Self {
-            msgtype: MessageType::Video(VideoMessageEventContent::from_extensible_content(
-                message, file, video, thumbnail, caption,
-            )),
-            relates_to,
         }
     }
 }

--- a/crates/ruma-common/src/events/video.rs
+++ b/crates/ruma-common/src/events/video.rs
@@ -32,7 +32,7 @@ use super::{
 /// [`MessageType::Video`]: super::room::message::MessageType::Video
 #[derive(Clone, Debug, Serialize, Deserialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-#[ruma_event(type = "m.video", kind = MessageLike)]
+#[ruma_event(type = "m.video", kind = MessageLike, without_relation)]
 pub struct VideoEventContent {
     /// The text representation of the message.
     #[serde(flatten)]

--- a/crates/ruma-common/src/events/video.rs
+++ b/crates/ruma-common/src/events/video.rs
@@ -50,7 +50,7 @@ pub struct VideoEventContent {
 
     /// Information about related messages.
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
-    pub relates_to: Option<Relation>,
+    pub relates_to: Option<Relation<VideoEventContentWithoutRelation>>,
 }
 
 impl VideoEventContent {

--- a/crates/ruma-common/src/events/voice.rs
+++ b/crates/ruma-common/src/events/voice.rs
@@ -29,7 +29,7 @@ use super::{
 /// [`MessageType::Audio`]: super::room::message::MessageType::Audio
 #[derive(Clone, Debug, Serialize, Deserialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-#[ruma_event(type = "m.voice", kind = MessageLike)]
+#[ruma_event(type = "m.voice", kind = MessageLike, without_relation)]
 pub struct VoiceEventContent {
     /// The text representation of the message.
     #[serde(flatten)]

--- a/crates/ruma-common/src/events/voice.rs
+++ b/crates/ruma-common/src/events/voice.rs
@@ -38,7 +38,7 @@ pub struct VoiceEventContent {
 
     /// Information about related messages.
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
-    pub relates_to: Option<Relation>,
+    pub relates_to: Option<Relation<VoiceEventContentWithoutRelation>>,
 }
 
 impl VoiceEventContent {

--- a/crates/ruma-common/tests/events/event_content.rs
+++ b/crates/ruma-common/tests/events/event_content.rs
@@ -5,4 +5,6 @@ fn ui() {
     t.compile_fail("tests/events/ui/02-no-event-type.rs");
     t.compile_fail("tests/events/ui/03-invalid-event-type.rs");
     t.pass("tests/events/ui/10-content-wildcard.rs");
+    t.pass("tests/events/ui/11-content-without-relation-sanity-check.rs");
+    t.compile_fail("tests/events/ui/12-no-relates_to.rs");
 }

--- a/crates/ruma-common/tests/events/mod.rs
+++ b/crates/ruma-common/tests/events/mod.rs
@@ -25,3 +25,4 @@ mod stripped;
 mod to_device;
 mod video;
 mod voice;
+mod without_relation;

--- a/crates/ruma-common/tests/events/relations.rs
+++ b/crates/ruma-common/tests/events/relations.rs
@@ -75,7 +75,7 @@ fn replacement_serialize() {
             relates_to: Some(Relation::Replacement(
                 Replacement::new(
                     event_id!("$1598361704261elfgc").to_owned(),
-                    Box::new(RoomMessageEventContent::text_plain("This is the new content.")),
+                    RoomMessageEventContent::text_plain("This is the new content.").into(),
                 )
             ))
         }
@@ -142,7 +142,7 @@ fn replacement_deserialize() {
         }) => replacement
     );
     assert_eq!(replacement.event_id, "$1598361704261elfgc");
-    let text = assert_matches!(replacement.new_content.msgtype, MessageType::Text(text) => text);
+    let text = assert_matches!(replacement.new_content, MessageType::Text(text) => text);
     assert_eq!(text.body, "Hello! My name is bar");
 }
 

--- a/crates/ruma-common/tests/events/ui/03-invalid-event-type.stderr
+++ b/crates/ruma-common/tests/events/ui/03-invalid-event-type.stderr
@@ -6,7 +6,7 @@ error: no event type attribute found, add `#[ruma_event(type = "any.room.event",
   |
   = note: this error originates in the derive macro `EventContent` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: expected one of: `type`, `kind`, `custom_redacted`, `state_key_type`, `unsigned_type`, `alias`
+error: expected one of: `type`, `kind`, `custom_redacted`, `state_key_type`, `unsigned_type`, `alias`, `without_relation`
   --> tests/events/ui/03-invalid-event-type.rs:11:14
    |
 11 | #[ruma_event(event = "m.macro.test", kind = State)]

--- a/crates/ruma-common/tests/events/ui/11-content-without-relation-sanity-check.rs
+++ b/crates/ruma-common/tests/events/ui/11-content-without-relation-sanity-check.rs
@@ -1,0 +1,11 @@
+use ruma_macros::EventContent;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
+#[ruma_event(type = "m.macro.test", kind = MessageLike, without_relation)]
+pub struct MacroTestContent {
+    pub url: String,
+    pub relates_to: Option<String>,
+}
+
+fn main() {}

--- a/crates/ruma-common/tests/events/ui/12-no-relates_to.rs
+++ b/crates/ruma-common/tests/events/ui/12-no-relates_to.rs
@@ -1,0 +1,10 @@
+use ruma_macros::EventContent;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
+#[ruma_event(type = "m.macro.test", kind = MessageLike, without_relation)]
+pub struct MacroTestContent {
+    pub url: String,
+}
+
+fn main() {}

--- a/crates/ruma-common/tests/events/ui/12-no-relates_to.stderr
+++ b/crates/ruma-common/tests/events/ui/12-no-relates_to.stderr
@@ -1,0 +1,7 @@
+error: `without_relation` can only be used on events with a `relates_to` field
+ --> tests/events/ui/12-no-relates_to.rs:4:48
+  |
+4 | #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
+  |                                                ^^^^^^^^^^^^
+  |
+  = note: this error originates in the derive macro `EventContent` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/ruma-common/tests/events/without_relation.rs
+++ b/crates/ruma-common/tests/events/without_relation.rs
@@ -1,10 +1,7 @@
 use assert_matches::assert_matches;
 use ruma_common::{
     event_id,
-    events::room::message::{
-        InReplyTo, MessageType, Relation, RoomMessageEventContent,
-        RoomMessageEventContentWithoutRelation,
-    },
+    events::room::message::{InReplyTo, MessageType, Relation, RoomMessageEventContent},
 };
 use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
@@ -13,7 +10,7 @@ fn serialize_room_message_content_without_relation() {
     let mut content = RoomMessageEventContent::text_plain("Hello, world!");
     content.relates_to =
         Some(Relation::Reply { in_reply_to: InReplyTo::new(event_id!("$eventId").to_owned()) });
-    let without_relation = RoomMessageEventContentWithoutRelation::from(content);
+    let without_relation = MessageType::from(content);
 
     #[cfg(not(feature = "unstable-msc3246"))]
     assert_eq!(
@@ -43,8 +40,8 @@ fn deserialize_room_message_content_without_relation() {
     });
 
     let text = assert_matches!(
-        from_json_value::<RoomMessageEventContentWithoutRelation>(json_data),
-        Ok(RoomMessageEventContentWithoutRelation::Text(text)) => text
+        from_json_value::<MessageType>(json_data),
+        Ok(MessageType::Text(text)) => text
     );
     assert_eq!(text.body, "Hello, world!");
 }
@@ -54,8 +51,7 @@ fn convert_room_message_content_without_relation_to_full() {
     let mut content = RoomMessageEventContent::text_plain("Hello, world!");
     content.relates_to =
         Some(Relation::Reply { in_reply_to: InReplyTo::new(event_id!("$eventId").to_owned()) });
-    let new_content =
-        RoomMessageEventContent::from(RoomMessageEventContentWithoutRelation::from(content));
+    let new_content = RoomMessageEventContent::from(MessageType::from(content));
 
     let (text, relates_to) = assert_matches!(
         new_content,

--- a/crates/ruma-common/tests/events/without_relation.rs
+++ b/crates/ruma-common/tests/events/without_relation.rs
@@ -1,0 +1,70 @@
+use assert_matches::assert_matches;
+use ruma_common::{
+    event_id,
+    events::room::message::{
+        InReplyTo, MessageType, Relation, RoomMessageEventContent,
+        RoomMessageEventContentWithoutRelation,
+    },
+};
+use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+
+#[test]
+fn serialize_room_message_content_without_relation() {
+    let mut content = RoomMessageEventContent::text_plain("Hello, world!");
+    content.relates_to =
+        Some(Relation::Reply { in_reply_to: InReplyTo::new(event_id!("$eventId").to_owned()) });
+    let without_relation = RoomMessageEventContentWithoutRelation::from(content);
+
+    #[cfg(not(feature = "unstable-msc3246"))]
+    assert_eq!(
+        to_json_value(&without_relation).unwrap(),
+        json!({
+            "body": "Hello, world!",
+            "msgtype": "m.text",
+        })
+    );
+
+    #[cfg(feature = "unstable-msc3246")]
+    assert_eq!(
+        to_json_value(&without_relation).unwrap(),
+        json!({
+            "body": "Hello, world!",
+            "msgtype": "m.text",
+            "org.matrix.msc1767.text": "Hello, world!",
+        })
+    );
+}
+
+#[test]
+fn deserialize_room_message_content_without_relation() {
+    let json_data = json!({
+        "body": "Hello, world!",
+        "msgtype": "m.text",
+    });
+
+    let text = assert_matches!(
+        from_json_value::<RoomMessageEventContentWithoutRelation>(json_data),
+        Ok(RoomMessageEventContentWithoutRelation::Text(text)) => text
+    );
+    assert_eq!(text.body, "Hello, world!");
+}
+
+#[test]
+fn convert_room_message_content_without_relation_to_full() {
+    let mut content = RoomMessageEventContent::text_plain("Hello, world!");
+    content.relates_to =
+        Some(Relation::Reply { in_reply_to: InReplyTo::new(event_id!("$eventId").to_owned()) });
+    let new_content =
+        RoomMessageEventContent::from(RoomMessageEventContentWithoutRelation::from(content));
+
+    let (text, relates_to) = assert_matches!(
+        new_content,
+        RoomMessageEventContent {
+            msgtype: MessageType::Text(text),
+            relates_to,
+            ..
+        } => (text, relates_to)
+    );
+    assert_eq!(text.body, "Hello, world!");
+    assert_matches!(relates_to, None);
+}


### PR DESCRIPTION
Because the `new_content` must be of the same type. For this, we also need to generate types without the `relates_to` field, that is not in the `new_content`.

Part of #1278.










<!-- Replace -->
----
Preview: https://pr-1337--ruma-docs.surge.sh
<!-- Replace -->
