### PR TITLE
Make name on SecretStorageKeyEventContent optional

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -14,6 +14,8 @@ Breaking changes:
   `http::header::HeaderName`
   * To continue using constants from `http::header`, they must be imported in
     the module calling the macro.
+* Make `name` optional on `SecretStorageKeyEventContent`. Default constructor has been
+  adjusted as well to do not require this field.
 
 Improvements:
 

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -15,7 +15,7 @@ Breaking changes:
   * To continue using constants from `http::header`, they must be imported in
     the module calling the macro.
 * Make `name` optional on `SecretStorageKeyEventContent`. Default constructor has been
-  adjusted as well to do not require this field.
+  adjusted as well to not require this field.
 
 Improvements:
 

--- a/crates/ruma-common/src/events/secret_storage/key.rs
+++ b/crates/ruma-common/src/events/secret_storage/key.rs
@@ -112,7 +112,7 @@ mod tests {
                 mac: Base64::parse("aWRvbnRrbm93d2hhdGFtYWNsb29rc2xpa2U").unwrap(),
             },
         );
-        content.name = Some("my_key".to_string());
+        content.name = Some("my_key".to_owned());
 
         let json = json!({
             "name": "my_key",
@@ -183,7 +183,7 @@ mod tests {
                 },
             )
         };
-        content.name = Some("my_key".to_string());
+        content.name = Some("my_key".to_owned());
 
         let json = json!({
             "name": "my_key",
@@ -244,7 +244,7 @@ mod tests {
                 mac: Base64::parse("aWRvbnRrbm93d2hhdGFtYWNsb29rc2xpa2U").unwrap(),
             },
         );
-        content.name = Some("my_key".to_string());
+        content.name = Some("my_key".to_owned());
         let event = GlobalAccountDataEvent { content };
 
         let json = json!({


### PR DESCRIPTION
The spec has the `name` field marked as optional for this event content. See `KeyDescription` section here: https://spec.matrix.org/v1.4/client-server-api/#key-storage

<!-- Replace -->
----
Preview Removed
<!-- Replace -->
