### PR TITLE
federation-api: Add the `event` field to `RoomState`

### DIFF
--- a/crates/ruma-federation-api/CHANGELOG.md
+++ b/crates/ruma-federation-api/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [unreleased]
 
+Bug fixes:
+
+* Add the `event` field to `RoomState` according to MSC3083 / Matrix v1.2
+
 # 0.6.0
 
 Breaking changes:

--- a/crates/ruma-federation-api/src/membership/create_join_event.rs
+++ b/crates/ruma-federation-api/src/membership/create_join_event.rs
@@ -22,6 +22,13 @@ pub struct RoomState {
 
     /// The room state.
     pub state: Vec<Box<RawJsonValue>>,
+
+    /// The signed copy of the membership event sent to other servers by the
+    /// resident server, including the resident server's signature.
+    ///
+    /// Required if the room version supports restricted join rules.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub event: Option<Box<RawJsonValue>>,
 }
 
 #[cfg(feature = "unstable-unspecified")]
@@ -38,7 +45,7 @@ impl RoomState {
     /// With the `unstable-unspecified` feature, this method doesn't take any parameters.
     /// See [matrix-spec#374](https://github.com/matrix-org/matrix-spec/issues/374).
     pub fn new(origin: String) -> Self {
-        Self { origin, auth_chain: Vec::new(), state: Vec::new() }
+        Self { origin, auth_chain: Vec::new(), state: Vec::new(), event: None }
     }
 
     #[cfg(feature = "unstable-unspecified")]
@@ -47,6 +54,6 @@ impl RoomState {
     /// Without the `unstable-unspecified` feature, this method takes a parameter for the origin
     /// See [matrix-spec#374](https://github.com/matrix-org/matrix-spec/issues/374).
     pub fn new() -> Self {
-        Self { auth_chain: Vec::new(), state: Vec::new() }
+        Self { auth_chain: Vec::new(), state: Vec::new(), event: None }
     }
 }

--- a/crates/ruma-federation-api/src/serde/v1_pdu.rs
+++ b/crates/ruma-federation-api/src/serde/v1_pdu.rs
@@ -87,16 +87,21 @@ mod tests {
             }
         ]);
 
-        let RoomState { origin, auth_chain, state } = deserialize(response).unwrap();
+        let RoomState { origin, auth_chain, state, event } = deserialize(response).unwrap();
         assert_eq!(origin, "example.com");
         assert_matches!(auth_chain.as_slice(), []);
         assert_matches!(state.as_slice(), []);
+        assert_matches!(event, None);
     }
 
     #[test]
     fn serialize_response() {
-        let room_state =
-            RoomState { origin: "matrix.org".into(), auth_chain: Vec::new(), state: Vec::new() };
+        let room_state = RoomState {
+            origin: "matrix.org".into(),
+            auth_chain: Vec::new(),
+            state: Vec::new(),
+            event: None,
+        };
 
         let serialized = serialize(&room_state, serde_json::value::Serializer).unwrap();
         let expected = to_json_value(&json!(
@@ -142,9 +147,10 @@ mod tests {
     #[test]
     fn too_long_array() {
         let json = json!([200, { "origin": "", "auth_chain": [], "state": [] }, 200]);
-        let RoomState { origin, auth_chain, state } = deserialize(json).unwrap();
+        let RoomState { origin, auth_chain, state, event } = deserialize(json).unwrap();
         assert_eq!(origin, "");
         assert_matches!(auth_chain.as_slice(), []);
         assert_matches!(state.as_slice(), []);
+        assert_matches!(event, None);
     }
 }


### PR DESCRIPTION
According to [MSC3083](https://github.com/matrix-org/matrix-spec-proposals/pull/3083) / Matrix v1.2.




<!-- Replace -->
----
Preview Removed
<!-- Replace -->
