### PR TITLE
events: Markdown improvements

### DIFF
--- a/crates/ruma-common/src/events/message.rs
+++ b/crates/ruma-common/src/events/message.rs
@@ -238,12 +238,9 @@ impl Text {
     /// Returns `None` if no Markdown formatting was found.
     #[cfg(feature = "markdown")]
     pub fn markdown(body: impl AsRef<str>) -> Option<Self> {
-        let body = body.as_ref();
-        let mut html_body = String::new();
+        use super::room::message::parse_markdown;
 
-        pulldown_cmark::html::push_html(&mut html_body, pulldown_cmark::Parser::new(body));
-
-        (html_body != format!("<p>{}</p>\n", body)).then(|| Self::html(html_body))
+        parse_markdown(body.as_ref()).map(Self::html)
     }
 
     fn default_mimetype() -> String {

--- a/crates/ruma-common/src/events/room/message.rs
+++ b/crates/ruma-common/src/events/room/message.rs
@@ -634,11 +634,13 @@ pub struct CustomEventContent {
 
 #[cfg(feature = "markdown")]
 pub(crate) fn parse_markdown(text: &str) -> Option<String> {
-    use pulldown_cmark::{Event, Parser, Tag};
+    use pulldown_cmark::{Event, Options, Parser, Tag};
+
+    const OPTIONS: Options = Options::ENABLE_TABLES.union(Options::ENABLE_STRIKETHROUGH);
 
     let mut found_first_paragraph = false;
 
-    let has_markdown = Parser::new(text).any(|ref event| {
+    let has_markdown = Parser::new_ext(text, OPTIONS).any(|ref event| {
         let is_text = matches!(event, Event::Text(_));
         let is_break = matches!(event, Event::SoftBreak | Event::HardBreak);
         let is_first_paragraph_start = if matches!(event,
@@ -667,7 +669,7 @@ pub(crate) fn parse_markdown(text: &str) -> Option<String> {
     }
 
     let mut html_body = String::new();
-    pulldown_cmark::html::push_html(&mut html_body, Parser::new(text));
+    pulldown_cmark::html::push_html(&mut html_body, Parser::new_ext(text, OPTIONS));
 
     Some(html_body)
 }

--- a/crates/ruma-common/tests/events/room_message.rs
+++ b/crates/ruma-common/tests/events/room_message.rs
@@ -303,6 +303,28 @@ fn markdown_content_serialization() {
 }
 
 #[test]
+#[cfg(feature = "markdown")]
+fn markdown_detection() {
+    use ruma_common::events::room::message::FormattedBody;
+
+    // No markdown
+    let formatted_body = FormattedBody::markdown("A simple message.");
+    assert_matches!(formatted_body, None);
+
+    // Multiple paragraphs trigger markdown
+    let formatted_body = FormattedBody::markdown("A message\nwith\n\nmultiple\n\nparagraphs");
+    formatted_body.unwrap();
+
+    // HTML entities don't trigger markdown.
+    let formatted_body = FormattedBody::markdown("A message with & HTML < entities");
+    assert_matches!(formatted_body, None);
+
+    // HTML triggers markdown.
+    let formatted_body = FormattedBody::markdown("<span>An HTML message</span>");
+    formatted_body.unwrap();
+}
+
+#[test]
 fn verification_request_deserialization() {
     let user_id = user_id!("@example2:localhost");
     let device_id: OwnedDeviceId = "XOWLHHFSWM".into();

--- a/crates/ruma-common/tests/events/room_message.rs
+++ b/crates/ruma-common/tests/events/room_message.rs
@@ -325,6 +325,31 @@ fn markdown_detection() {
 }
 
 #[test]
+#[cfg(feature = "markdown")]
+fn markdown_options() {
+    use ruma_common::events::room::message::FormattedBody;
+
+    // Tables
+    let formatted_body = FormattedBody::markdown(
+        "|head1|head2|\n\
+        |---|---|\n\
+        |body1|body2|\
+        ",
+    );
+    assert_eq!(
+        formatted_body.unwrap().body,
+        "<table>\
+            <thead><tr><th>head1</th><th>head2</th></tr></thead>\
+            <tbody>\n<tr><td>body1</td><td>body2</td></tr>\n</tbody>\
+        </table>\n"
+    );
+
+    // Strikethrough
+    let formatted_body = FormattedBody::markdown("A message with a ~~strike~~");
+    assert_eq!(formatted_body.unwrap().body, "<p>A message with a <del>strike</del></p>\n");
+}
+
+#[test]
 fn verification_request_deserialization() {
     let user_id = user_id!("@example2:localhost");
     let device_id: OwnedDeviceId = "XOWLHHFSWM".into();


### PR DESCRIPTION
- Improve detection of markdown.
- Enable strikethrough and tables.

Closes #1297.
















<!-- Replace -->
----
Preview: https://pr-1343--ruma-docs.surge.sh
<!-- Replace -->
