### PR TITLE
Remove most attributes for internal Request and Response derive macros

### DIFF
--- a/crates/ruma-common/src/api.rs
+++ b/crates/ruma-common/src/api.rs
@@ -373,12 +373,6 @@ pub trait EndpointError: OutgoingResponse + StdError + Sized + Send + 'static {
     ) -> Result<Self, error::DeserializationError>;
 }
 
-/// Marker trait for requests that don't require authentication, for the client side.
-pub trait OutgoingNonAuthRequest: OutgoingRequest {}
-
-/// Marker trait for requests that don't require authentication, for the server side.
-pub trait IncomingNonAuthRequest: IncomingRequest {}
-
 /// Authentication scheme used by the endpoint.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[allow(clippy::exhaustive_enums)]

--- a/crates/ruma-macros/src/api.rs
+++ b/crates/ruma-macros/src/api.rs
@@ -74,8 +74,8 @@ impl Api {
             |err_ty| quote! { #err_ty },
         );
 
-        let request = self.request.map(|req| req.expand(metadata, &error_ty, &ruma_common));
-        let response = self.response.map(|res| res.expand(metadata, &error_ty, &ruma_common));
+        let request = self.request.map(|req| req.expand(metadata, &ruma_common));
+        let response = self.response.map(|res| res.expand(metadata, &ruma_common));
 
         let metadata_doc = format!("Metadata for the `{}` API endpoint.", name.value());
 
@@ -93,11 +93,11 @@ impl Api {
                 history: #history,
             };
 
+            #[allow(unused)]
+            type EndpointError = #error_ty;
+
             #request
             #response
-
-            #[cfg(not(any(feature = "client", feature = "server")))]
-            type _SilenceUnusedError = #error_ty;
         }
     }
 

--- a/crates/ruma-macros/src/api/api_request.rs
+++ b/crates/ruma-macros/src/api/api_request.rs
@@ -82,7 +82,6 @@ impl Request {
         );
         let struct_attributes = &self.attributes;
 
-        let method = &metadata.method;
         let authentication = &metadata.authentication;
 
         let request_ident = Ident::new("Request", self.request_kw.span());
@@ -101,11 +100,7 @@ impl Request {
             )]
             #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
             #[incoming_derive(!Deserialize, #ruma_macros::_FakeDeriveRumaApi)]
-            #[ruma_api(
-                method = #method,
-                authentication = #authentication,
-                error_ty = #error_ty,
-            )]
+            #[ruma_api(authentication = #authentication, error_ty = #error_ty)]
             #( #struct_attributes )*
             pub struct #request_ident < #(#lifetimes),* > {
                 #fields

--- a/crates/ruma-macros/src/api/api_request.rs
+++ b/crates/ruma-macros/src/api/api_request.rs
@@ -77,8 +77,6 @@ impl Request {
         );
         let struct_attributes = &self.attributes;
 
-        let authentication = &metadata.authentication;
-
         let request_ident = Ident::new("Request", self.request_kw.span());
         let lifetimes = self.all_lifetimes();
         let lifetimes = lifetimes.iter().map(|(lt, attr)| quote! { #attr #lt });
@@ -95,7 +93,6 @@ impl Request {
             )]
             #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
             #[incoming_derive(!Deserialize, #ruma_macros::_FakeDeriveRumaApi)]
-            #[ruma_api(authentication = #authentication)]
             #( #struct_attributes )*
             pub struct #request_ident < #(#lifetimes),* > {
                 #fields

--- a/crates/ruma-macros/src/api/api_request.rs
+++ b/crates/ruma-macros/src/api/api_request.rs
@@ -67,12 +67,7 @@ impl Request {
         lifetimes
     }
 
-    pub(super) fn expand(
-        &self,
-        metadata: &Metadata,
-        error_ty: &TokenStream,
-        ruma_common: &TokenStream,
-    ) -> TokenStream {
+    pub(super) fn expand(&self, metadata: &Metadata, ruma_common: &TokenStream) -> TokenStream {
         let ruma_macros = quote! { #ruma_common::exports::ruma_macros };
 
         let docs = format!(
@@ -100,7 +95,7 @@ impl Request {
             )]
             #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
             #[incoming_derive(!Deserialize, #ruma_macros::_FakeDeriveRumaApi)]
-            #[ruma_api(authentication = #authentication, error_ty = #error_ty)]
+            #[ruma_api(authentication = #authentication)]
             #( #struct_attributes )*
             pub struct #request_ident < #(#lifetimes),* > {
                 #fields

--- a/crates/ruma-macros/src/api/api_response.rs
+++ b/crates/ruma-macros/src/api/api_response.rs
@@ -19,12 +19,7 @@ pub(crate) struct Response {
 }
 
 impl Response {
-    pub(super) fn expand(
-        &self,
-        metadata: &Metadata,
-        error_ty: &TokenStream,
-        ruma_common: &TokenStream,
-    ) -> TokenStream {
+    pub(super) fn expand(&self, metadata: &Metadata, ruma_common: &TokenStream) -> TokenStream {
         let ruma_macros = quote! { #ruma_common::exports::ruma_macros };
 
         let docs =
@@ -44,7 +39,6 @@ impl Response {
             )]
             #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
             #[incoming_derive(!Deserialize, #ruma_macros::_FakeDeriveRumaApi)]
-            #[ruma_api(error_ty = #error_ty)]
             #( #struct_attributes )*
             pub struct #response_ident {
                 #fields

--- a/crates/ruma-macros/src/api/attribute.rs
+++ b/crates/ruma-macros/src/api/attribute.rs
@@ -13,7 +13,6 @@ mod kw {
     syn::custom_keyword!(query_map);
     syn::custom_keyword!(header);
     syn::custom_keyword!(authentication);
-    syn::custom_keyword!(error_ty);
     syn::custom_keyword!(manual_body_serde);
 }
 
@@ -56,7 +55,6 @@ impl Parse for RequestMeta {
 
 pub enum DeriveRequestMeta {
     Authentication(Type),
-    ErrorTy(Type),
 }
 
 impl Parse for DeriveRequestMeta {
@@ -66,10 +64,6 @@ impl Parse for DeriveRequestMeta {
             let _: kw::authentication = input.parse()?;
             let _: Token![=] = input.parse()?;
             input.parse().map(Self::Authentication)
-        } else if lookahead.peek(kw::error_ty) {
-            let _: kw::error_ty = input.parse()?;
-            let _: Token![=] = input.parse()?;
-            input.parse().map(Self::ErrorTy)
         } else {
             Err(lookahead.error())
         }
@@ -104,7 +98,6 @@ impl Parse for ResponseMeta {
 #[allow(clippy::large_enum_variant)]
 pub enum DeriveResponseMeta {
     ManualBodySerde,
-    ErrorTy(Type),
 }
 
 impl Parse for DeriveResponseMeta {
@@ -113,10 +106,6 @@ impl Parse for DeriveResponseMeta {
         if lookahead.peek(kw::manual_body_serde) {
             let _: kw::manual_body_serde = input.parse()?;
             Ok(Self::ManualBodySerde)
-        } else if lookahead.peek(kw::error_ty) {
-            let _: kw::error_ty = input.parse()?;
-            let _: Token![=] = input.parse()?;
-            input.parse().map(Self::ErrorTy)
         } else {
             Err(lookahead.error())
         }

--- a/crates/ruma-macros/src/api/attribute.rs
+++ b/crates/ruma-macros/src/api/attribute.rs
@@ -2,7 +2,7 @@
 
 use syn::{
     parse::{Parse, ParseStream},
-    Ident, Token, Type,
+    Ident, Token,
 };
 
 mod kw {
@@ -12,7 +12,6 @@ mod kw {
     syn::custom_keyword!(query);
     syn::custom_keyword!(query_map);
     syn::custom_keyword!(header);
-    syn::custom_keyword!(authentication);
     syn::custom_keyword!(manual_body_serde);
 }
 
@@ -47,23 +46,6 @@ impl Parse for RequestMeta {
             let _: kw::header = input.parse()?;
             let _: Token![=] = input.parse()?;
             input.parse().map(Self::Header)
-        } else {
-            Err(lookahead.error())
-        }
-    }
-}
-
-pub enum DeriveRequestMeta {
-    Authentication(Type),
-}
-
-impl Parse for DeriveRequestMeta {
-    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
-        let lookahead = input.lookahead1();
-        if lookahead.peek(kw::authentication) {
-            let _: kw::authentication = input.parse()?;
-            let _: Token![=] = input.parse()?;
-            input.parse().map(Self::Authentication)
         } else {
             Err(lookahead.error())
         }

--- a/crates/ruma-macros/src/api/attribute.rs
+++ b/crates/ruma-macros/src/api/attribute.rs
@@ -12,7 +12,6 @@ mod kw {
     syn::custom_keyword!(query);
     syn::custom_keyword!(query_map);
     syn::custom_keyword!(header);
-    syn::custom_keyword!(manual_body_serde);
 }
 
 pub enum RequestMeta {
@@ -71,23 +70,6 @@ impl Parse for ResponseMeta {
             let _: kw::header = input.parse()?;
             let _: Token![=] = input.parse()?;
             input.parse().map(Self::Header)
-        } else {
-            Err(lookahead.error())
-        }
-    }
-}
-
-#[allow(clippy::large_enum_variant)]
-pub enum DeriveResponseMeta {
-    ManualBodySerde,
-}
-
-impl Parse for DeriveResponseMeta {
-    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
-        let lookahead = input.lookahead1();
-        if lookahead.peek(kw::manual_body_serde) {
-            let _: kw::manual_body_serde = input.parse()?;
-            Ok(Self::ManualBodySerde)
         } else {
             Err(lookahead.error())
         }

--- a/crates/ruma-macros/src/api/attribute.rs
+++ b/crates/ruma-macros/src/api/attribute.rs
@@ -13,7 +13,6 @@ mod kw {
     syn::custom_keyword!(query_map);
     syn::custom_keyword!(header);
     syn::custom_keyword!(authentication);
-    syn::custom_keyword!(method);
     syn::custom_keyword!(error_ty);
     syn::custom_keyword!(manual_body_serde);
 }
@@ -57,7 +56,6 @@ impl Parse for RequestMeta {
 
 pub enum DeriveRequestMeta {
     Authentication(Type),
-    Method(Type),
     ErrorTy(Type),
 }
 
@@ -68,10 +66,6 @@ impl Parse for DeriveRequestMeta {
             let _: kw::authentication = input.parse()?;
             let _: Token![=] = input.parse()?;
             input.parse().map(Self::Authentication)
-        } else if lookahead.peek(kw::method) {
-            let _: kw::method = input.parse()?;
-            let _: Token![=] = input.parse()?;
-            input.parse().map(Self::Method)
         } else if lookahead.peek(kw::error_ty) {
             let _: kw::error_ty = input.parse()?;
             let _: Token![=] = input.parse()?;

--- a/crates/ruma-macros/src/api/request.rs
+++ b/crates/ruma-macros/src/api/request.rs
@@ -6,7 +6,7 @@ use syn::{
     parse::{Parse, ParseStream},
     parse_quote,
     punctuated::Punctuated,
-    DeriveInput, Field, Generics, Ident, Lifetime, Token, Type,
+    DeriveInput, Field, Generics, Ident, Lifetime, Token,
 };
 
 use super::{
@@ -47,7 +47,6 @@ pub fn expand_derive_request(input: DeriveInput) -> syn::Result<TokenStream> {
         .collect::<syn::Result<_>>()?;
 
     let mut authentication = None;
-    let mut error_ty = None;
 
     for attr in input.attrs {
         if !attr.path.is_ident("ruma_api") {
@@ -59,7 +58,6 @@ pub fn expand_derive_request(input: DeriveInput) -> syn::Result<TokenStream> {
         for meta in metas {
             match meta {
                 DeriveRequestMeta::Authentication(t) => authentication = Some(parse_quote!(#t)),
-                DeriveRequestMeta::ErrorTy(t) => error_ty = Some(t),
             }
         }
     }
@@ -70,7 +68,6 @@ pub fn expand_derive_request(input: DeriveInput) -> syn::Result<TokenStream> {
         fields,
         lifetimes,
         authentication: authentication.expect("missing authentication attribute"),
-        error_ty: error_ty.expect("missing error_ty attribute"),
     };
 
     let ruma_common = import_ruma_common();
@@ -98,7 +95,6 @@ struct Request {
     fields: Vec<RequestField>,
 
     authentication: AuthScheme,
-    error_ty: Type,
 }
 
 impl Request {

--- a/crates/ruma-macros/src/api/request/incoming.rs
+++ b/crates/ruma-macros/src/api/request/incoming.rs
@@ -11,7 +11,6 @@ impl Request {
         let serde = quote! { #ruma_common::exports::serde };
         let serde_json = quote! { #ruma_common::exports::serde_json };
 
-        let method = &self.method;
         let error_ty = &self.error_ty;
 
         let incoming_request_type = if self.has_lifetimes() {
@@ -203,9 +202,9 @@ impl Request {
                     B: ::std::convert::AsRef<[::std::primitive::u8]>,
                     S: ::std::convert::AsRef<::std::primitive::str>,
                 {
-                    if request.method() != #http::Method::#method {
+                    if request.method() != METADATA.method {
                         return Err(#ruma_common::api::error::FromHttpRequestError::MethodMismatch {
-                            expected: #http::Method::#method,
+                            expected: METADATA.method,
                             received: request.method().clone(),
                         });
                     }

--- a/crates/ruma-macros/src/api/request/incoming.rs
+++ b/crates/ruma-macros/src/api/request/incoming.rs
@@ -11,8 +11,6 @@ impl Request {
         let serde = quote! { #ruma_common::exports::serde };
         let serde_json = quote! { #ruma_common::exports::serde_json };
 
-        let error_ty = &self.error_ty;
-
         let incoming_request_type = if self.has_lifetimes() {
             quote! { IncomingRequest }
         } else {
@@ -189,7 +187,7 @@ impl Request {
             #[automatically_derived]
             #[cfg(feature = "server")]
             impl #ruma_common::api::IncomingRequest for #incoming_request_type {
-                type EndpointError = #error_ty;
+                type EndpointError = self::EndpointError;
                 type OutgoingResponse = Response;
 
                 const METADATA: #ruma_common::api::Metadata = METADATA;

--- a/crates/ruma-macros/src/api/request/incoming.rs
+++ b/crates/ruma-macros/src/api/request/incoming.rs
@@ -193,7 +193,7 @@ impl Request {
                 type EndpointError = #error_ty;
                 type OutgoingResponse = Response;
 
-                const METADATA: #ruma_common::api::Metadata = self::METADATA;
+                const METADATA: #ruma_common::api::Metadata = METADATA;
 
                 fn try_from_http_request<B, S>(
                     request: #http::Request<B>,

--- a/crates/ruma-macros/src/api/request/incoming.rs
+++ b/crates/ruma-macros/src/api/request/incoming.rs
@@ -3,7 +3,6 @@ use quote::quote;
 use syn::Field;
 
 use super::{Request, RequestField};
-use crate::api::auth_scheme::AuthScheme;
 
 impl Request {
     pub fn expand_incoming(&self, ruma_common: &TokenStream) -> TokenStream {
@@ -175,14 +174,6 @@ impl Request {
             vars(self.body_fields(), quote! { request_body })
         };
 
-        let non_auth_impl = matches!(self.authentication, AuthScheme::None(_)).then(|| {
-            quote! {
-                #[automatically_derived]
-                #[cfg(feature = "server")]
-                impl #ruma_common::api::IncomingNonAuthRequest for #incoming_request_type {}
-            }
-        });
-
         quote! {
             #[automatically_derived]
             #[cfg(feature = "server")]
@@ -222,8 +213,6 @@ impl Request {
                     })
                 }
             }
-
-            #non_auth_impl
         }
     }
 }

--- a/crates/ruma-macros/src/api/request/outgoing.rs
+++ b/crates/ruma-macros/src/api/request/outgoing.rs
@@ -161,7 +161,7 @@ impl Request {
                 type EndpointError = #error_ty;
                 type IncomingResponse = Response;
 
-                const METADATA: #ruma_common::api::Metadata = self::METADATA;
+                const METADATA: #ruma_common::api::Metadata = METADATA;
 
                 fn try_into_http_request<T: ::std::default::Default + #bytes::BufMut>(
                     self,
@@ -169,11 +169,9 @@ impl Request {
                     access_token: #ruma_common::api::SendAccessToken<'_>,
                     considering_versions: &'_ [#ruma_common::api::MatrixVersion],
                 ) -> ::std::result::Result<#http::Request<T>, #ruma_common::api::error::IntoHttpError> {
-                    let metadata = self::METADATA;
-
                     let mut req_builder = #http::Request::builder()
                         .method(#http::Method::#method)
-                        .uri(metadata.make_endpoint_url(
+                        .uri(METADATA.make_endpoint_url(
                             considering_versions,
                             base_url,
                             &[ #( &self.#path_fields ),* ],

--- a/crates/ruma-macros/src/api/request/outgoing.rs
+++ b/crates/ruma-macros/src/api/request/outgoing.rs
@@ -10,8 +10,6 @@ impl Request {
         let bytes = quote! { #ruma_common::exports::bytes };
         let http = quote! { #ruma_common::exports::http };
 
-        let error_ty = &self.error_ty;
-
         let path_fields =
             self.path_fields().map(|f| f.ident.as_ref().expect("path fields have a name"));
 
@@ -155,7 +153,7 @@ impl Request {
             #[automatically_derived]
             #[cfg(feature = "client")]
             impl #impl_generics #ruma_common::api::OutgoingRequest for Request #ty_generics #where_clause {
-                type EndpointError = #error_ty;
+                type EndpointError = self::EndpointError;
                 type IncomingResponse = Response;
 
                 const METADATA: #ruma_common::api::Metadata = METADATA;

--- a/crates/ruma-macros/src/api/request/outgoing.rs
+++ b/crates/ruma-macros/src/api/request/outgoing.rs
@@ -10,7 +10,6 @@ impl Request {
         let bytes = quote! { #ruma_common::exports::bytes };
         let http = quote! { #ruma_common::exports::http };
 
-        let method = &self.method;
         let error_ty = &self.error_ty;
 
         let path_fields =
@@ -137,10 +136,8 @@ impl Request {
             quote! {
                 #ruma_common::serde::json_to_buf(&RequestBody { #initializers })?
             }
-        } else if method == "GET" {
-            quote! { <T as ::std::default::Default>::default() }
         } else {
-            quote! { #ruma_common::serde::slice_to_buf(b"{}") }
+            quote! { METADATA.empty_request_body::<T>() }
         };
 
         let (impl_generics, ty_generics, where_clause) = self.generics.split_for_impl();
@@ -170,7 +167,7 @@ impl Request {
                     considering_versions: &'_ [#ruma_common::api::MatrixVersion],
                 ) -> ::std::result::Result<#http::Request<T>, #ruma_common::api::error::IntoHttpError> {
                     let mut req_builder = #http::Request::builder()
-                        .method(#http::Method::#method)
+                        .method(METADATA.method)
                         .uri(METADATA.make_endpoint_url(
                             considering_versions,
                             base_url,

--- a/crates/ruma-macros/src/api/request/outgoing.rs
+++ b/crates/ruma-macros/src/api/request/outgoing.rs
@@ -140,15 +140,6 @@ impl Request {
 
         let (impl_generics, ty_generics, where_clause) = self.generics.split_for_impl();
 
-        let non_auth_impl = matches!(self.authentication, AuthScheme::None(_)).then(|| {
-            quote! {
-                #[automatically_derived]
-                #[cfg(feature = "client")]
-                impl #impl_generics #ruma_common::api::OutgoingNonAuthRequest
-                    for Request #ty_generics #where_clause {}
-            }
-        });
-
         quote! {
             #[automatically_derived]
             #[cfg(feature = "client")]
@@ -182,8 +173,6 @@ impl Request {
                     Ok(http_request)
                 }
             }
-
-            #non_auth_impl
         }
     }
 }

--- a/crates/ruma-macros/src/api/response/incoming.rs
+++ b/crates/ruma-macros/src/api/response/incoming.rs
@@ -1,11 +1,10 @@
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::Type;
 
 use super::{Response, ResponseFieldKind};
 
 impl Response {
-    pub fn expand_incoming(&self, error_ty: &Type, ruma_common: &TokenStream) -> TokenStream {
+    pub fn expand_incoming(&self, ruma_common: &TokenStream) -> TokenStream {
         let http = quote! { #ruma_common::exports::http };
         let serde_json = quote! { #ruma_common::exports::serde_json };
 
@@ -104,37 +103,41 @@ impl Response {
             }
         };
 
+        let method_body = quote! {
+            if response.status().as_u16() < 400 {
+                #extract_response_headers
+                #typed_response_body_decl
+
+                ::std::result::Result::Ok(Self {
+                    #response_init_fields
+                })
+            } else {
+                match <EndpointError as #ruma_common::api::EndpointError>::try_from_http_response(
+                    response
+                ) {
+                    ::std::result::Result::Ok(err) => {
+                        Err(#ruma_common::api::error::ServerError::Known(err).into())
+                    }
+                    ::std::result::Result::Err(response_err) => {
+                        Err(#ruma_common::api::error::ServerError::Unknown(response_err).into())
+                    }
+                }
+            }
+        };
+
         quote! {
             #[automatically_derived]
             #[cfg(feature = "client")]
             impl #ruma_common::api::IncomingResponse for Response {
-                type EndpointError = #error_ty;
+                type EndpointError = EndpointError;
 
                 fn try_from_http_response<T: ::std::convert::AsRef<[::std::primitive::u8]>>(
                     response: #http::Response<T>,
                 ) -> ::std::result::Result<
                     Self,
-                    #ruma_common::api::error::FromHttpResponseError<#error_ty>,
+                    #ruma_common::api::error::FromHttpResponseError<EndpointError>,
                 > {
-                    if response.status().as_u16() < 400 {
-                        #extract_response_headers
-                        #typed_response_body_decl
-
-                        ::std::result::Result::Ok(Self {
-                            #response_init_fields
-                        })
-                    } else {
-                        match <#error_ty as #ruma_common::api::EndpointError>::try_from_http_response(
-                            response
-                        ) {
-                            ::std::result::Result::Ok(err) => {
-                                Err(#ruma_common::api::error::ServerError::Known(err).into())
-                            }
-                            ::std::result::Result::Err(response_err) => {
-                                Err(#ruma_common::api::error::ServerError::Unknown(response_err).into())
-                            }
-                        }
-                    }
+                    #method_body
                 }
             }
         }


### PR DESCRIPTION
A few notes:

- the removed `NonAuth` traits were added for Fractal, but are no longer used there AFAICT (I used GitLab's search)
- I expected the `error_ty` change to cause either visibility errors or degrade docs, but it just worked 🙌







<!-- Replace -->
----
Preview Removed
<!-- Replace -->
