### PR TITLE
Add `history` field to `ruma_api!` `metadata`

### DIFF
--- a/crates/ruma-common/tests/api/ui/01-api-sanity-check.rs
+++ b/crates/ruma-common/tests/api/ui/01-api-sanity-check.rs
@@ -16,8 +16,18 @@ ruma_api! {
         rate_limited: false,
         authentication: None,
         added: 1.0,
-        deprecated: 1.1,
-        removed: 1.2,
+        deprecated: 1.2,
+        removed: 1.3,
+
+        history: {
+            unstable => "/_matrix/some/msc1234/endpoint/:baz",
+
+            1.0 => "/_matrix/some/r0/endpoint/:baz",
+            1.1 => "/_matrix/some/v3/endpoint/:baz",
+
+            1.2 => deprecated,
+            1.3 => removed,
+        }
     }
 
     request: {
@@ -71,6 +81,6 @@ fn main() {
     );
 
     assert_eq!(METADATA.history.added_version(), Some(MatrixVersion::V1_0));
-    assert_eq!(METADATA.history.deprecated, Some(MatrixVersion::V1_1));
-    assert_eq!(METADATA.history.removed, Some(MatrixVersion::V1_2));
+    assert_eq!(METADATA.history.deprecated, Some(MatrixVersion::V1_2));
+    assert_eq!(METADATA.history.removed, Some(MatrixVersion::V1_3));
 }

--- a/crates/ruma-macros/src/api/api_metadata.rs
+++ b/crates/ruma-macros/src/api/api_metadata.rs
@@ -395,10 +395,10 @@ impl Parse for History {
             set: &mut BTreeSet<(u8, u8)>,
             value: &MatrixVersionLiteral,
         ) -> syn::Result<()> {
-            if set.contains(&value.into()) {
+            if set.contains(&value.to_parts()) {
                 Err(syn::Error::new_spanned(value, "duplicate version reference"))
             } else {
-                set.insert(value.into());
+                set.insert(value.to_parts());
                 Ok(())
             }
         }
@@ -462,7 +462,7 @@ impl Parse for History {
 
         // Sort so that the order is [Unstable, Unstable, 1.0, 1.1, 1.2, 2.0, 2.1]
         // for optimized method purposes.
-        entries.sort_by_key(|a| a.version().map(Into::into).unwrap_or((0, 0)));
+        entries.sort_by_key(|a| a.version().map(MatrixVersionLiteral::to_parts).unwrap_or((0, 0)));
 
         // Check if all path arguments are equal, and in order.
         let mut last_args = None;

--- a/crates/ruma-macros/src/api/version.rs
+++ b/crates/ruma-macros/src/api/version.rs
@@ -4,7 +4,7 @@ use proc_macro2::TokenStream;
 use quote::{format_ident, quote, ToTokens};
 use syn::{parse::Parse, Error, LitFloat};
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MatrixVersionLiteral {
     pub(crate) major: NonZeroU8,
     pub(crate) minor: u8,
@@ -15,6 +15,20 @@ const ONE: NonZeroU8 = unsafe { NonZeroU8::new_unchecked(1) };
 impl MatrixVersionLiteral {
     pub const V1_0: Self = Self { major: ONE, minor: 0 };
     pub const V1_1: Self = Self { major: ONE, minor: 1 };
+}
+
+impl Into<(u8, u8)> for &MatrixVersionLiteral {
+    fn into(self) -> (u8, u8) {
+        (self.major.into(), self.minor)
+    }
+}
+
+impl TryFrom<(u8, u8)> for MatrixVersionLiteral {
+    type Error = std::num::TryFromIntError;
+
+    fn try_from(value: (u8, u8)) -> Result<Self, Self::Error> {
+        Ok(MatrixVersionLiteral { major: value.0.try_into()?, minor: value.1 })
+    }
 }
 
 impl Parse for MatrixVersionLiteral {

--- a/crates/ruma-macros/src/api/version.rs
+++ b/crates/ruma-macros/src/api/version.rs
@@ -15,10 +15,8 @@ const ONE: NonZeroU8 = unsafe { NonZeroU8::new_unchecked(1) };
 impl MatrixVersionLiteral {
     pub const V1_0: Self = Self { major: ONE, minor: 0 };
     pub const V1_1: Self = Self { major: ONE, minor: 1 };
-}
 
-impl Into<(u8, u8)> for &MatrixVersionLiteral {
-    fn into(self) -> (u8, u8) {
+    pub(super) fn to_parts(&self) -> (u8, u8) {
         (self.major.into(), self.minor)
     }
 }


### PR DESCRIPTION
This adds `history` to the `ruma_api!` `metadata: {}` structure, as a part of https://github.com/ruma/ruma/issues/1118

This primarily extracts bits from https://github.com/ruma/ruma/pull/1298

<!-- Replace -->
----
Preview: https://pr-1347--ruma-docs.surge.sh
<!-- Replace -->
