### PR TITLE
Add request attribute macro

### DIFF
--- a/crates/ruma-common/src/api.rs
+++ b/crates/ruma-common/src/api.rs
@@ -194,6 +194,44 @@ use crate::UserId;
 /// ```
 pub use ruma_macros::ruma_api;
 
+/// Generates [`OutgoingRequest`] and [`IncomingRequest`] implementations.
+///
+/// The `OutgoingRequest` impl is be on the `Request` type this attribute is used on. It is
+/// feature-gated behind `cfg(feature = "client")`.
+///
+/// The `IncomingRequest` impl is be on `IncomingRequest`, which is either a type alias to
+/// `Request` or a fully-owned version of the same, depending of whether `Request` has any
+/// lifetime parameters.
+///
+/// The generated code expects a `METADATA` constant of type [`Metadata`] to be in scope,
+/// alongside a `Response` type that implements both [`OutgoingResponse`] and
+/// [`IncomingResponse`].
+///
+/// ## Attributes
+///
+/// To declare which part of the request a field belongs to:
+///
+/// * `#[ruma_api(header = HEADER_NAME)]`: Fields with this attribute will be treated as HTTP
+///   headers on the request. The value must implement `AsRef<str>`. Generally this is a
+///   `String`. The attribute value shown above as `HEADER_NAME` must be a `const` expression
+///   of the type `http::header::HeaderName`, like one of the constants from `http::header`,
+///   e.g. `CONTENT_TYPE`.
+/// * `#[ruma_api(path)]`: Fields with this attribute will be inserted into the matching path
+///   component of the request URL.
+/// * `#[ruma_api(query)]`: Fields with this attribute will be inserting into the URL's query
+///   string.
+/// * `#[ruma_api(query_map)]`: Instead of individual query fields, one query_map field, of any
+///   type that implements `IntoIterator<Item = (String, String)>` (e.g. `HashMap<String,
+///   String>`, can be used for cases where an endpoint supports arbitrary query parameters.
+/// * `#[ruma_api(body)]`: Use this if multiple endpoints should share a request body type, or
+///   the request body is better expressed as an `enum` rather than a `struct`. The value of
+///   the field will be used as the JSON body (rather than being a field in the request body
+///   object).
+/// * `#[ruma_api(raw_body)]`: Like `body` in that the field annotated with it represents the
+///   entire request body, but this attribute is for endpoints where the body can be anything,
+///   not just JSON. The field type must be `Vec<u8>`.
+pub use ruma_macros::request;
+
 pub mod error;
 mod metadata;
 

--- a/crates/ruma-macros/src/api.rs
+++ b/crates/ruma-macros/src/api.rs
@@ -74,8 +74,8 @@ impl Api {
             |err_ty| quote! { #err_ty },
         );
 
-        let request = self.request.map(|req| req.expand(metadata, &ruma_common));
-        let response = self.response.map(|res| res.expand(metadata, &ruma_common));
+        let request = self.request.map(|req| req.expand(metadata, &error_ty, &ruma_common));
+        let response = self.response.map(|res| res.expand(metadata, &error_ty, &ruma_common));
 
         let metadata_doc = format!("Metadata for the `{}` API endpoint.", name.value());
 
@@ -93,11 +93,11 @@ impl Api {
                 history: #history,
             };
 
-            #[allow(unused)]
-            type EndpointError = #error_ty;
-
             #request
             #response
+
+            #[cfg(not(any(feature = "client", feature = "server")))]
+            type _SilenceUnusedError = #error_ty;
         }
     }
 

--- a/crates/ruma-macros/src/api/api_request.rs
+++ b/crates/ruma-macros/src/api/api_request.rs
@@ -67,7 +67,12 @@ impl Request {
         lifetimes
     }
 
-    pub(super) fn expand(&self, metadata: &Metadata, ruma_common: &TokenStream) -> TokenStream {
+    pub(super) fn expand(
+        &self,
+        metadata: &Metadata,
+        error_ty: &TokenStream,
+        ruma_common: &TokenStream,
+    ) -> TokenStream {
         let ruma_macros = quote! { #ruma_common::exports::ruma_macros };
 
         let docs = format!(
@@ -93,6 +98,7 @@ impl Request {
             )]
             #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
             #[incoming_derive(!Deserialize, #ruma_macros::_FakeDeriveRumaApi)]
+            #[ruma_api(error_ty = #error_ty)]
             #( #struct_attributes )*
             pub struct #request_ident < #(#lifetimes),* > {
                 #fields

--- a/crates/ruma-macros/src/api/api_request.rs
+++ b/crates/ruma-macros/src/api/api_request.rs
@@ -89,16 +89,7 @@ impl Request {
 
         quote! {
             #[doc = #docs]
-            #[derive(
-                Clone,
-                Debug,
-                #ruma_macros::Request,
-                #ruma_common::serde::Incoming,
-                #ruma_common::serde::_FakeDeriveSerde,
-            )]
-            #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-            #[incoming_derive(!Deserialize, #ruma_macros::_FakeDeriveRumaApi)]
-            #[ruma_api(error = #error_ty)]
+            #[#ruma_macros::request(error = #error_ty)]
             #( #struct_attributes )*
             pub struct #request_ident < #(#lifetimes),* > {
                 #fields

--- a/crates/ruma-macros/src/api/api_request.rs
+++ b/crates/ruma-macros/src/api/api_request.rs
@@ -98,7 +98,7 @@ impl Request {
             )]
             #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
             #[incoming_derive(!Deserialize, #ruma_macros::_FakeDeriveRumaApi)]
-            #[ruma_api(error_ty = #error_ty)]
+            #[ruma_api(error = #error_ty)]
             #( #struct_attributes )*
             pub struct #request_ident < #(#lifetimes),* > {
                 #fields

--- a/crates/ruma-macros/src/api/api_response.rs
+++ b/crates/ruma-macros/src/api/api_response.rs
@@ -44,7 +44,7 @@ impl Response {
             )]
             #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
             #[incoming_derive(!Deserialize, #ruma_macros::_FakeDeriveRumaApi)]
-            #[ruma_api(error_ty = #error_ty)]
+            #[ruma_api(error = #error_ty)]
             #( #struct_attributes )*
             pub struct #response_ident {
                 #fields

--- a/crates/ruma-macros/src/api/api_response.rs
+++ b/crates/ruma-macros/src/api/api_response.rs
@@ -19,7 +19,12 @@ pub(crate) struct Response {
 }
 
 impl Response {
-    pub(super) fn expand(&self, metadata: &Metadata, ruma_common: &TokenStream) -> TokenStream {
+    pub(super) fn expand(
+        &self,
+        metadata: &Metadata,
+        error_ty: &TokenStream,
+        ruma_common: &TokenStream,
+    ) -> TokenStream {
         let ruma_macros = quote! { #ruma_common::exports::ruma_macros };
 
         let docs =
@@ -39,6 +44,7 @@ impl Response {
             )]
             #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
             #[incoming_derive(!Deserialize, #ruma_macros::_FakeDeriveRumaApi)]
+            #[ruma_api(error_ty = #error_ty)]
             #( #struct_attributes )*
             pub struct #response_ident {
                 #fields

--- a/crates/ruma-macros/src/api/attribute.rs
+++ b/crates/ruma-macros/src/api/attribute.rs
@@ -12,7 +12,7 @@ mod kw {
     syn::custom_keyword!(query);
     syn::custom_keyword!(query_map);
     syn::custom_keyword!(header);
-    syn::custom_keyword!(error_ty);
+    syn::custom_keyword!(error);
     syn::custom_keyword!(manual_body_serde);
 }
 
@@ -54,16 +54,16 @@ impl Parse for RequestMeta {
 }
 
 pub enum DeriveRequestMeta {
-    ErrorTy(Type),
+    Error(Type),
 }
 
 impl Parse for DeriveRequestMeta {
     fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
         let lookahead = input.lookahead1();
-        if lookahead.peek(kw::error_ty) {
-            let _: kw::error_ty = input.parse()?;
+        if lookahead.peek(kw::error) {
+            let _: kw::error = input.parse()?;
             let _: Token![=] = input.parse()?;
-            input.parse().map(Self::ErrorTy)
+            input.parse().map(Self::Error)
         } else {
             Err(lookahead.error())
         }
@@ -98,7 +98,7 @@ impl Parse for ResponseMeta {
 #[allow(clippy::large_enum_variant)]
 pub enum DeriveResponseMeta {
     ManualBodySerde,
-    ErrorTy(Type),
+    Error(Type),
 }
 
 impl Parse for DeriveResponseMeta {
@@ -107,10 +107,10 @@ impl Parse for DeriveResponseMeta {
         if lookahead.peek(kw::manual_body_serde) {
             let _: kw::manual_body_serde = input.parse()?;
             Ok(Self::ManualBodySerde)
-        } else if lookahead.peek(kw::error_ty) {
-            let _: kw::error_ty = input.parse()?;
+        } else if lookahead.peek(kw::error) {
+            let _: kw::error = input.parse()?;
             let _: Token![=] = input.parse()?;
-            input.parse().map(Self::ErrorTy)
+            input.parse().map(Self::Error)
         } else {
             Err(lookahead.error())
         }

--- a/crates/ruma-macros/src/api/request.rs
+++ b/crates/ruma-macros/src/api/request.rs
@@ -55,7 +55,7 @@ pub fn expand_derive_request(input: DeriveInput) -> syn::Result<TokenStream> {
             attr.parse_args_with(Punctuated::<DeriveRequestMeta, Token![,]>::parse_terminated)?;
         for meta in metas {
             match meta {
-                DeriveRequestMeta::ErrorTy(t) => error_ty = Some(t),
+                DeriveRequestMeta::Error(t) => error_ty = Some(t),
             }
         }
     }

--- a/crates/ruma-macros/src/api/request/incoming.rs
+++ b/crates/ruma-macros/src/api/request/incoming.rs
@@ -10,6 +10,8 @@ impl Request {
         let serde = quote! { #ruma_common::exports::serde };
         let serde_json = quote! { #ruma_common::exports::serde_json };
 
+        let error_ty = &self.error_ty;
+
         let incoming_request_type = if self.has_lifetimes() {
             quote! { IncomingRequest }
         } else {
@@ -178,7 +180,7 @@ impl Request {
             #[automatically_derived]
             #[cfg(feature = "server")]
             impl #ruma_common::api::IncomingRequest for #incoming_request_type {
-                type EndpointError = self::EndpointError;
+                type EndpointError = #error_ty;
                 type OutgoingResponse = Response;
 
                 const METADATA: #ruma_common::api::Metadata = METADATA;

--- a/crates/ruma-macros/src/api/request/outgoing.rs
+++ b/crates/ruma-macros/src/api/request/outgoing.rs
@@ -9,6 +9,8 @@ impl Request {
         let bytes = quote! { #ruma_common::exports::bytes };
         let http = quote! { #ruma_common::exports::http };
 
+        let error_ty = &self.error_ty;
+
         let path_fields =
             self.path_fields().map(|f| f.ident.as_ref().expect("path fields have a name"));
 
@@ -122,7 +124,7 @@ impl Request {
             #[automatically_derived]
             #[cfg(feature = "client")]
             impl #impl_generics #ruma_common::api::OutgoingRequest for Request #ty_generics #where_clause {
-                type EndpointError = self::EndpointError;
+                type EndpointError = #error_ty;
                 type IncomingResponse = Response;
 
                 const METADATA: #ruma_common::api::Metadata = METADATA;

--- a/crates/ruma-macros/src/api/response.rs
+++ b/crates/ruma-macros/src/api/response.rs
@@ -34,7 +34,7 @@ pub fn expand_derive_response(input: DeriveInput) -> syn::Result<TokenStream> {
         for meta in metas {
             match meta {
                 DeriveResponseMeta::ManualBodySerde => manual_body_serde = true,
-                DeriveResponseMeta::ErrorTy(t) => error_ty = Some(t),
+                DeriveResponseMeta::Error(t) => error_ty = Some(t),
             }
         }
     }

--- a/crates/ruma-macros/src/lib.rs
+++ b/crates/ruma-macros/src/lib.rs
@@ -25,7 +25,11 @@ mod serde;
 mod util;
 
 use self::{
-    api::{request::expand_derive_request, response::expand_derive_response, Api},
+    api::{
+        request::{expand_derive_request, expand_request},
+        response::expand_derive_response,
+        Api,
+    },
     events::{
         event::expand_event,
         event_content::expand_event_content,
@@ -382,6 +386,15 @@ pub fn fake_derive_serde(_input: TokenStream) -> TokenStream {
 pub fn ruma_api(input: TokenStream) -> TokenStream {
     let api = parse_macro_input!(input as Api);
     api.expand_all().into()
+}
+
+/// > ⚠ If this is the only documentation you see, please navigate to the docs for
+/// > `ruma_common::api::request`, where actual documentation can be found.
+#[proc_macro_attribute]
+pub fn request(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let attr = parse_macro_input!(attr);
+    let item = parse_macro_input!(item);
+    expand_request(attr, item).into()
 }
 
 /// Internal helper taking care of the request-specific parts of `ruma_api!`.


### PR DESCRIPTION
Part of #1348.

I made `ruma_api!` emit the new attribute to validate that it works, but this will make compile times worse (extra roundtrip through the compiler parsing the macro output and then re-serializing it to pass it onto the next macro). I guess that is fine because we should be able to convert everything before the next release.

I re-instantiated the `error = Type` thing for the derive macros because I think `#[request(error = crate::Error)]` is cleaner than the macros depending on there being an `ErrorTy` type alias in scope.




<!-- Replace -->
----
Preview Removed
<!-- Replace -->
