### PR TITLE
Bump MSRV to 1.64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
         run: target/debug/xtask ci lint
 
   msrv:
-    name: Rust 1.62 / ${{ matrix.name }}
+    name: Rust 1.64 / ${{ matrix.name }}
     needs: xtask
     runs-on: ubuntu-latest
     strategy:
@@ -98,11 +98,11 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      - name: Install rust 1.62 toolchain
+      - name: Install rust 1.64 toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: "1.62"
+          toolchain: "1.64"
 
       # Used to compile xtask
       - name: Install rust stable toolchain
@@ -117,7 +117,7 @@ jobs:
           # A stable compiler update should automatically not reuse old caches.
           # Add the MSRV as a stable cache key too so bumping it also gets us a
           # fresh cache.
-          sharedKey: msrv1.62
+          sharedKey: msrv1.64
 
       - name: Get xtask
         uses: actions/cache@v3

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Minimum Rust version
 
-Ruma currently requires Rust 1.62. In general, we will never require beta or
+Ruma currently requires Rust 1.64. In general, we will never require beta or
 nightly for crates.io releases of our crates, and we will try to avoid releasing
 crates that depend on features that were only just stabilized.
 

--- a/crates/ruma-appservice-api/Cargo.toml
+++ b/crates/ruma-appservice-api/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 repository = "https://github.com/ruma/ruma"
 version = "0.7.0"
 edition = "2021"
-rust-version = "1.62"
+rust-version = "1.64"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/ruma-client-api/Cargo.toml
+++ b/crates/ruma-client-api/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 repository = "https://github.com/ruma/ruma"
 version = "0.15.3"
 edition = "2021"
-rust-version = "1.62"
+rust-version = "1.64"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/ruma-client/Cargo.toml
+++ b/crates/ruma-client/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 repository = "https://github.com/ruma/ruma"
 version = "0.10.0"
 edition = "2021"
-rust-version = "1.62"
+rust-version = "1.64"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/ruma/ruma"
 edition = "2021"
-rust-version = "1.62"
+rust-version = "1.64"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/ruma-federation-api/Cargo.toml
+++ b/crates/ruma-federation-api/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 repository = "https://github.com/ruma/ruma"
 version = "0.6.0"
 edition = "2021"
-rust-version = "1.62"
+rust-version = "1.64"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/ruma-identifiers-validation/Cargo.toml
+++ b/crates/ruma-identifiers-validation/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/ruma/ruma"
 license = "MIT"
 version = "0.9.0"
 edition = "2021"
-rust-version = "1.62"
+rust-version = "1.64"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/ruma-identity-service-api/Cargo.toml
+++ b/crates/ruma-identity-service-api/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/ruma/ruma"
 edition = "2021"
-rust-version = "1.62"
+rust-version = "1.64"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/ruma-macros/Cargo.toml
+++ b/crates/ruma-macros/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 repository = "https://github.com/ruma/ruma"
 version = "0.10.5"
 edition = "2021"
-rust-version = "1.62"
+rust-version = "1.64"
 
 [lib]
 proc-macro = true

--- a/crates/ruma-push-gateway-api/Cargo.toml
+++ b/crates/ruma-push-gateway-api/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/ruma/ruma"
 edition = "2021"
-rust-version = "1.62"
+rust-version = "1.64"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/ruma-server-util/Cargo.toml
+++ b/crates/ruma-server-util/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 repository = "https://github.com/ruma/ruma"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.62"
+rust-version = "1.64"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/ruma-state-res/Cargo.toml
+++ b/crates/ruma-state-res/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 license = "MIT"
 version = "0.8.0"
 edition = "2021"
-rust-version = "1.62"
+rust-version = "1.64"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 license = "MIT"
 version = "0.7.4"
 edition = "2021"
-rust-version = "1.62"
+rust-version = "1.64"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -9,7 +9,7 @@ mod spec_links;
 
 use spec_links::check_spec_links;
 
-const MSRV: &str = "1.62";
+const MSRV: &str = "1.64";
 const NIGHTLY: &str = "nightly";
 
 #[derive(Args)]


### PR DESCRIPTION
Unblocks https://github.com/ruma/ruma/pull/1350

This is required for ruma-common to be able to take advantage of const eval string-splitting functionality.




<!-- Replace -->
----
Preview Removed
<!-- Replace -->
