### PR TITLE
Add metadata! macro

### DIFF
--- a/crates/ruma-common/src/api.rs
+++ b/crates/ruma-common/src/api.rs
@@ -480,7 +480,8 @@ macro_rules! metadata {
     };
 
     // Simple literal case: used for description, name, rate_limited
-    ( @field $_field:ident: $rhs:literal ) => { $rhs };
+    // Also used by ruma_api! while it still exists, for the history field
+    ( @field $_field:ident: $rhs:expr ) => { $rhs };
 
     ( @history_impl
         [ $($unstable_path:literal),* ]

--- a/crates/ruma-common/tests/api/ui/01-api-sanity-check.rs
+++ b/crates/ruma-common/tests/api/ui/01-api-sanity-check.rs
@@ -16,8 +16,8 @@ ruma_api! {
         rate_limited: false,
         authentication: None,
         added: 1.0,
-        deprecated: 1.1,
-        removed: 1.2,
+        deprecated: 1.2,
+        removed: 1.3,
     }
 
     request: {
@@ -71,6 +71,6 @@ fn main() {
     );
 
     assert_eq!(METADATA.history.added_version(), Some(MatrixVersion::V1_0));
-    assert_eq!(METADATA.history.deprecated, Some(MatrixVersion::V1_1));
-    assert_eq!(METADATA.history.removed, Some(MatrixVersion::V1_2));
+    assert_eq!(METADATA.history.deprecated, Some(MatrixVersion::V1_2));
+    assert_eq!(METADATA.history.removed, Some(MatrixVersion::V1_3));
 }

--- a/crates/ruma-macros/src/api.rs
+++ b/crates/ruma-macros/src/api.rs
@@ -109,16 +109,6 @@ impl Api {
         })?;
         let path_args = path.args();
 
-        for extra_path in path_iter {
-            let extra_path_args = extra_path.args();
-            if extra_path_args != path_args {
-                return Err(syn::Error::new(
-                    Span::call_site(),
-                    "paths have different path parameters",
-                ));
-            }
-        }
-
         if let Some(req) = &self.request {
             let path_field_names: Vec<_> = req
                 .fields

--- a/crates/ruma-macros/src/api.rs
+++ b/crates/ruma-macros/src/api.rs
@@ -59,7 +59,6 @@ impl Api {
         let maybe_path_error = self.check_paths().err().map(syn::Error::into_compile_error);
 
         let ruma_common = import_ruma_common();
-        let http = quote! { #ruma_common::exports::http };
 
         let metadata = &self.metadata;
         let description = &metadata.description;
@@ -83,14 +82,17 @@ impl Api {
             #maybe_feature_error
             #maybe_path_error
 
+            // For some reason inlining the expression causes issues with macro parsing
+            const _RUMA_API_VERSION_HISTORY: #ruma_common::api::VersionHistory = #history;
+
             #[doc = #metadata_doc]
-            pub const METADATA: #ruma_common::api::Metadata = #ruma_common::api::Metadata {
+            pub const METADATA: #ruma_common::api::Metadata = #ruma_common::metadata! {
                 description: #description,
-                method: #http::Method::#method,
+                method: #method,
                 name: #name,
                 rate_limited: #rate_limited,
-                authentication: #ruma_common::api::AuthScheme::#authentication,
-                history: #history,
+                authentication: #authentication,
+                history: _RUMA_API_VERSION_HISTORY,
             };
 
             #request

--- a/crates/ruma-macros/src/api/api_metadata.rs
+++ b/crates/ruma-macros/src/api/api_metadata.rs
@@ -369,12 +369,12 @@ impl ToTokens for History {
         let removed = util::map_option_literal(&removed);
 
         tokens.extend(quote! {
-            ::ruma_common::api::VersionHistory {
-                unstable_paths: &[ #(#unstable),* ],
-                stable_paths: &[ #(#versioned),* ],
-                deprecated: #deprecated,
-                removed: #removed,
-            }
+            ::ruma_common::api::VersionHistory::new(
+                &[ #(#unstable),* ],
+                &[ #(#versioned),* ],
+                #deprecated,
+                #removed,
+            )
         });
     }
 }

--- a/crates/ruma/src/lib.rs
+++ b/crates/ruma/src/lib.rs
@@ -95,7 +95,10 @@ pub use ruma_state_res as state_res;
 /// [apis]: https://spec.matrix.org/v1.4/#matrix-apis
 #[cfg(feature = "api")]
 pub mod api {
-    pub use ruma_common::api::*;
+    // The metadata macro is also exported at the crate root because `#[macro_export]` always
+    // places things at the crate root of the defining crate and we do a glob re-export of
+    // `ruma_common`, but here is the more logical (preferred) location.
+    pub use ruma_common::{api::*, metadata};
 
     #[cfg(any(feature = "appservice-api-c", feature = "appservice-api-s"))]
     #[doc(inline)]


### PR DESCRIPTION
Based on #1354. Part of #1348.

One thing this actually currently allows that it probably shouldn't is Matrix versions that aren't float literals. I guess we could do some `const _: f64 = $lit;` type assertions.







<!-- Replace -->
----
Preview Removed
<!-- Replace -->
