### PR TITLE
api: Use VersionHistory::new from ruma_api!

### DIFF
--- a/crates/ruma-common/tests/api/ui/01-api-sanity-check.rs
+++ b/crates/ruma-common/tests/api/ui/01-api-sanity-check.rs
@@ -16,8 +16,8 @@ ruma_api! {
         rate_limited: false,
         authentication: None,
         added: 1.0,
-        deprecated: 1.1,
-        removed: 1.2,
+        deprecated: 1.2,
+        removed: 1.3,
     }
 
     request: {
@@ -71,6 +71,6 @@ fn main() {
     );
 
     assert_eq!(METADATA.history.added_version(), Some(MatrixVersion::V1_0));
-    assert_eq!(METADATA.history.deprecated, Some(MatrixVersion::V1_1));
-    assert_eq!(METADATA.history.removed, Some(MatrixVersion::V1_2));
+    assert_eq!(METADATA.history.deprecated, Some(MatrixVersion::V1_2));
+    assert_eq!(METADATA.history.removed, Some(MatrixVersion::V1_3));
 }

--- a/crates/ruma-macros/src/api.rs
+++ b/crates/ruma-macros/src/api.rs
@@ -109,16 +109,6 @@ impl Api {
         })?;
         let path_args = path.args();
 
-        for extra_path in path_iter {
-            let extra_path_args = extra_path.args();
-            if extra_path_args != path_args {
-                return Err(syn::Error::new(
-                    Span::call_site(),
-                    "paths have different path parameters",
-                ));
-            }
-        }
-
         if let Some(req) = &self.request {
             let path_field_names: Vec<_> = req
                 .fields

--- a/crates/ruma-macros/src/api/api_metadata.rs
+++ b/crates/ruma-macros/src/api/api_metadata.rs
@@ -369,12 +369,12 @@ impl ToTokens for History {
         let removed = util::map_option_literal(&removed);
 
         tokens.extend(quote! {
-            ::ruma_common::api::VersionHistory {
-                unstable_paths: &[ #(#unstable),* ],
-                stable_paths: &[ #(#versioned),* ],
-                deprecated: #deprecated,
-                removed: #removed,
-            }
+            ::ruma_common::api::VersionHistory::new(
+                &[ #(#unstable),* ],
+                &[ #(#versioned),* ],
+                #deprecated,
+                #removed,
+            )
         });
     }
 }


### PR DESCRIPTION
… and remove a now-redundant check from the macro code.

Part of #1348. 




<!-- Replace -->
----
Preview Removed
<!-- Replace -->
