### PR TITLE
Escape plain bodies in replies

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [unreleased]
 
+Bug fixes:
+
+* HTML-relevant characters (`<`, `>`, etc) in plaintext replies are now escaped
+  during creation of the rich reply
+
 Breaking changes:
 
 * Remove deprecated `EventType` enum


### PR DESCRIPTION
Replies generate an HTML body even if the reply itself only consists of plain text. In order to convert the plain text to HTML, it has to be escaped, which did not happen previously.

<!-- Replace -->
----
Preview Removed
<!-- Replace -->
