### PR TITLE
client-api: Refactor get / set pusher endpoints

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -7,6 +7,9 @@ Breaking changes:
 * `fully_read` field in `read_marker::set_read_marker` is no longer required
   * Remove the `fully_read` argument from `read_marker::set_read_marker::Request::new`
 * Move `message::get_message_events::v3::Direction` to the root of the crate
+* Make `push::set_pusher::v3::Request` use an enum to differentiate when deleting a pusher
+  * Move `push::get_pushers::v3::Pusher` to `push` and make it use the new `PusherIds` type
+  * Remove `push::set_pusher::v3::Pusher` and use the common type instead
 
 Improvements:
 

--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -10,6 +10,7 @@ Breaking changes:
 * Make `push::set_pusher::v3::Request` use an enum to differentiate when deleting a pusher
   * Move `push::get_pushers::v3::Pusher` to `push` and make it use the new `PusherIds` type
   * Remove `push::set_pusher::v3::Pusher` and use the common type instead
+* Make `push::PusherKind` contain the pusher's `data`
 
 Improvements:
 

--- a/crates/ruma-client-api/Cargo.toml
+++ b/crates/ruma-client-api/Cargo.toml
@@ -35,6 +35,7 @@ assign = { workspace = true }
 bytes = "1.0.1"
 http = { workspace = true }
 js_int = { workspace = true, features = ["serde"] }
+js_option = "0.1.1"
 maplit = { workspace = true }
 percent-encoding = "2.1.0"
 ruma-common = { version = "0.10.5", path = "../ruma-common", features = ["api", "events"] }

--- a/crates/ruma-client-api/src/push.rs
+++ b/crates/ruma-client-api/src/push.rs
@@ -204,3 +204,100 @@ pub enum PusherKind {
     #[doc(hidden)]
     _Custom(PrivOwnedStr),
 }
+
+/// Defines a pusher.
+///
+/// To create an instance of this type, first create a `PusherInit` and convert it via
+/// `Pusher::from` / `.into()`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+pub struct Pusher {
+    /// Identifiers for this pusher.
+    #[serde(flatten)]
+    pub ids: PusherIds,
+
+    /// The kind of the pusher.
+    pub kind: PusherKind,
+
+    /// A string that will allow the user to identify what application owns this pusher.
+    pub app_display_name: String,
+
+    /// A string that will allow the user to identify what device owns this pusher.
+    pub device_display_name: String,
+
+    /// Determines which set of device specific rules this pusher executes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profile_tag: Option<String>,
+
+    /// The preferred language for receiving notifications (e.g. 'en' or 'en-US')
+    pub lang: String,
+
+    /// Information for the pusher implementation itself.
+    pub data: PusherData,
+}
+
+/// Initial set of fields of `Pusher`.
+///
+/// This struct will not be updated even if additional fields are added to `Pusher` in a new
+/// (non-breaking) release of the Matrix specification.
+#[derive(Debug)]
+#[allow(clippy::exhaustive_structs)]
+pub struct PusherInit {
+    /// Identifiers for this pusher.
+    pub ids: PusherIds,
+
+    /// The kind of the pusher.
+    pub kind: PusherKind,
+
+    /// A string that will allow the user to identify what application owns this pusher.
+    pub app_display_name: String,
+
+    /// A string that will allow the user to identify what device owns this pusher.
+    pub device_display_name: String,
+
+    /// Determines which set of device-specific rules this pusher executes.
+    pub profile_tag: Option<String>,
+
+    /// The preferred language for receiving notifications (e.g. 'en' or 'en-US').
+    pub lang: String,
+
+    /// Information for the pusher implementation itself.
+    pub data: PusherData,
+}
+
+impl From<PusherInit> for Pusher {
+    fn from(init: PusherInit) -> Self {
+        let PusherInit {
+            ids,
+            kind,
+            app_display_name,
+            device_display_name,
+            profile_tag,
+            lang,
+            data,
+        } = init;
+        Self { ids, kind, app_display_name, device_display_name, profile_tag, lang, data }
+    }
+}
+
+/// Strings to uniquely identify a `Pusher`.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+pub struct PusherIds {
+    /// A unique identifier for the pusher.
+    ///
+    /// The maximum allowed length is 512 bytes.
+    pub pushkey: String,
+
+    /// A reverse-DNS style identifier for the application.
+    ///
+    /// The maximum allowed length is 64 bytes.
+    pub app_id: String,
+}
+
+impl PusherIds {
+    /// Creates a new `PusherIds` with the given pushkey and application ID.
+    pub fn new(pushkey: String, app_id: String) -> Self {
+        Self { pushkey, app_id }
+    }
+}

--- a/crates/ruma-client-api/src/push/get_pushers.rs
+++ b/crates/ruma-client-api/src/push/get_pushers.rs
@@ -6,9 +6,8 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3pushers
 
     use ruma_common::api::ruma_api;
-    use serde::{Deserialize, Serialize};
 
-    use crate::push::{PusherData, PusherKind};
+    use crate::push::Pusher;
 
     ruma_api! {
         metadata: {
@@ -44,104 +43,6 @@ pub mod v3 {
         /// Creates a new `Response` with the given pushers.
         pub fn new(pushers: Vec<Pusher>) -> Self {
             Self { pushers }
-        }
-    }
-
-    /// Defines a pusher.
-    ///
-    /// To create an instance of this type, first create a `PusherInit` and convert it via
-    /// `Pusher::from` / `.into()`.
-    #[derive(Clone, Debug, Serialize, Deserialize)]
-    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-    pub struct Pusher {
-        /// A unique identifier for this pusher.
-        ///
-        /// The maximum allowed length is 512 bytes.
-        pub pushkey: String,
-
-        /// The kind of the pusher.
-        pub kind: PusherKind,
-
-        /// A reverse-DNS style identifier for the application.
-        ///
-        /// The maximum allowed length is 64 bytes.
-        pub app_id: String,
-
-        /// A string that will allow the user to identify what application owns this pusher.
-        pub app_display_name: String,
-
-        /// A string that will allow the user to identify what device owns this pusher.
-        pub device_display_name: String,
-
-        /// Determines which set of device specific rules this pusher executes.
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub profile_tag: Option<String>,
-
-        /// The preferred language for receiving notifications (e.g. 'en' or 'en-US')
-        pub lang: String,
-
-        /// Information for the pusher implementation itself.
-        pub data: PusherData,
-    }
-
-    /// Initial set of fields of `Pusher`.
-    ///
-    /// This struct will not be updated even if additional fields are added to `Pusher` in a new
-    /// (non-breaking) release of the Matrix specification.
-    #[derive(Debug)]
-    #[allow(clippy::exhaustive_structs)]
-    pub struct PusherInit {
-        /// A unique identifier for this pusher.
-        ///
-        /// The maximum allowed length is 512 bytes.
-        pub pushkey: String,
-
-        /// The kind of the pusher.
-        pub kind: PusherKind,
-
-        /// A reverse-DNS style identifier for the application.
-        ///
-        /// The maximum allowed length is 64 bytes.
-        pub app_id: String,
-
-        /// A string that will allow the user to identify what application owns this pusher.
-        pub app_display_name: String,
-
-        /// A string that will allow the user to identify what device owns this pusher.
-        pub device_display_name: String,
-
-        /// Determines which set of device-specific rules this pusher executes.
-        pub profile_tag: Option<String>,
-
-        /// The preferred language for receiving notifications (e.g. 'en' or 'en-US').
-        pub lang: String,
-
-        /// Information for the pusher implementation itself.
-        pub data: PusherData,
-    }
-
-    impl From<PusherInit> for Pusher {
-        fn from(init: PusherInit) -> Self {
-            let PusherInit {
-                pushkey,
-                kind,
-                app_id,
-                app_display_name,
-                device_display_name,
-                profile_tag,
-                lang,
-                data,
-            } = init;
-            Self {
-                pushkey,
-                kind,
-                app_id,
-                app_display_name,
-                device_display_name,
-                profile_tag,
-                lang,
-                data,
-            }
         }
     }
 }

--- a/crates/ruma-client-api/src/push/pusher_serde.rs
+++ b/crates/ruma-client-api/src/push/pusher_serde.rs
@@ -1,0 +1,173 @@
+use ruma_common::serde::{from_raw_json_value, JsonObject};
+use serde::{de, ser::SerializeStruct, Deserialize, Serialize};
+use serde_json::value::RawValue as RawJsonValue;
+
+use super::{EmailPusherData, Pusher, PusherIds, PusherKind};
+
+#[derive(Debug, Deserialize)]
+struct PusherDeHelper {
+    #[serde(flatten)]
+    ids: PusherIds,
+    app_display_name: String,
+    device_display_name: String,
+    profile_tag: Option<String>,
+    lang: String,
+}
+
+impl<'de> Deserialize<'de> for Pusher {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        let json = Box::<RawJsonValue>::deserialize(deserializer)?;
+
+        let PusherDeHelper { ids, app_display_name, device_display_name, profile_tag, lang } =
+            from_raw_json_value(&json)?;
+        let kind = from_raw_json_value(&json)?;
+
+        Ok(Self { ids, kind, app_display_name, device_display_name, profile_tag, lang })
+    }
+}
+
+impl Serialize for PusherKind {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut st = serializer.serialize_struct("PusherAction", 3)?;
+
+        match self {
+            PusherKind::Http(data) => {
+                st.serialize_field("kind", &"http")?;
+                st.serialize_field("data", data)?;
+            }
+            PusherKind::Email(_) => {
+                st.serialize_field("kind", &"email")?;
+                st.serialize_field("data", &JsonObject::new())?;
+            }
+            PusherKind::_Custom(custom) => {
+                st.serialize_field("kind", &custom.kind)?;
+                st.serialize_field("data", &custom.data)?;
+            }
+        }
+
+        st.end()
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct PusherKindDeHelper {
+    kind: String,
+    data: Box<RawJsonValue>,
+}
+
+impl<'de> Deserialize<'de> for PusherKind {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        let json = Box::<RawJsonValue>::deserialize(deserializer)?;
+        let PusherKindDeHelper { kind, data } = from_raw_json_value(&json)?;
+
+        match kind.as_ref() {
+            "http" => from_raw_json_value(&data).map(Self::Http),
+            "email" => Ok(Self::Email(EmailPusherData)),
+            _ => from_raw_json_value(&json).map(Self::_Custom),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_matches::assert_matches;
+    use ruma_common::{push::HttpPusherData, serde::JsonObject};
+    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+
+    use crate::push::{CustomPusherData, EmailPusherData, PusherKind};
+
+    #[test]
+    fn serialize_email() {
+        let action = PusherKind::Email(EmailPusherData::new());
+
+        assert_eq!(
+            to_json_value(action).unwrap(),
+            json!({
+                "kind": "email",
+                "data": {},
+            })
+        );
+    }
+
+    #[test]
+    fn serialize_http() {
+        let action = PusherKind::Http(HttpPusherData::new("http://localhost".to_owned()));
+
+        assert_eq!(
+            to_json_value(action).unwrap(),
+            json!({
+                "kind": "http",
+                "data": {
+                    "url": "http://localhost",
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn serialize_custom() {
+        let action = PusherKind::_Custom(CustomPusherData {
+            kind: "my.custom.kind".to_owned(),
+            data: JsonObject::new(),
+        });
+
+        assert_eq!(
+            to_json_value(action).unwrap(),
+            json!({
+                "kind": "my.custom.kind",
+                "data": {}
+            })
+        );
+    }
+
+    #[test]
+    fn deserialize_email() {
+        let json = json!({
+            "kind": "email",
+            "data": {},
+        });
+
+        assert_matches!(from_json_value(json).unwrap(), PusherKind::Email(_));
+    }
+
+    #[test]
+    fn deserialize_http() {
+        let json = json!({
+            "kind": "http",
+            "data": {
+                "url": "http://localhost",
+            },
+        });
+
+        let data = assert_matches!(
+            from_json_value(json).unwrap(),
+            PusherKind::Http(data) => data
+        );
+
+        assert_eq!(data.url, "http://localhost");
+        assert_eq!(data.format, None);
+    }
+
+    #[test]
+    fn deserialize_custom() {
+        let json = json!({
+            "kind": "my.custom.kind",
+            "data": {}
+        });
+
+        let custom =
+            assert_matches!(from_json_value(json).unwrap(), PusherKind::_Custom(custom) => custom);
+
+        assert_eq!(custom.kind, "my.custom.kind");
+        assert!(custom.data.is_empty());
+    }
+}

--- a/crates/ruma-client-api/src/push/set_pusher.rs
+++ b/crates/ruma-client-api/src/push/set_pusher.rs
@@ -1,6 +1,6 @@
 //! `POST /_matrix/client/*/pushers/set`
 
-mod pusher_action_serde;
+mod set_pusher_serde;
 
 pub mod v3 {
     //! `/v3/` ([spec])
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3pushersset
 
     use ruma_common::api::ruma_api;
-    use serde::{Deserialize, Serialize};
+    use serde::Serialize;
 
     use crate::push::{Pusher, PusherIds};
 
@@ -72,7 +72,7 @@ pub mod v3 {
     }
 
     /// Data necessary to create or update a pusher.
-    #[derive(Clone, Debug, Serialize, Deserialize)]
+    #[derive(Clone, Debug, Serialize)]
     #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     pub struct PusherPostData {
         /// The pusher to configure.
@@ -83,7 +83,7 @@ pub mod v3 {
         /// are already others for other users.
         ///
         /// Defaults to `false`. See the spec for more details.
-        #[serde(default, skip_serializing_if = "ruma_common::serde::is_default")]
+        #[serde(skip_serializing_if = "ruma_common::serde::is_default")]
         pub append: bool,
     }
 }

--- a/crates/ruma-client-api/src/push/set_pusher/pusher_action_serde.rs
+++ b/crates/ruma-client-api/src/push/set_pusher/pusher_action_serde.rs
@@ -1,0 +1,149 @@
+use js_option::JsOption;
+use ruma_common::serde::from_raw_json_value;
+use serde::{de, ser::SerializeStruct, Deserialize, Serialize};
+use serde_json::value::RawValue as RawJsonValue;
+
+use crate::push::PusherKind;
+
+use super::v3::PusherAction;
+
+impl Serialize for PusherAction {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            PusherAction::Post(pusher) => pusher.serialize(serializer),
+            PusherAction::Delete(ids) => {
+                let mut st = serializer.serialize_struct("PusherAction", 3)?;
+                st.serialize_field("pushkey", &ids.pushkey)?;
+                st.serialize_field("app_id", &ids.app_id)?;
+                st.serialize_field("kind", &None::<&str>)?;
+                st.end()
+            }
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct PusherActionDeHelper {
+    kind: JsOption<PusherKind>,
+}
+
+impl<'de> Deserialize<'de> for PusherAction {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        let json = Box::<RawJsonValue>::deserialize(deserializer)?;
+        let PusherActionDeHelper { kind } = from_raw_json_value(&json)?;
+
+        match kind {
+            JsOption::Some(_) => Ok(Self::Post(from_raw_json_value(&json)?)),
+            JsOption::Null => Ok(Self::Delete(from_raw_json_value(&json)?)),
+            // This is unreachable because we don't use `#[serde(default)]` on the field.
+            JsOption::Undefined => Err(de::Error::missing_field("kind")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_matches::assert_matches;
+    use ruma_common::push::PusherData;
+    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+
+    use super::PusherAction;
+    use crate::push::{set_pusher::v3::PusherPostData, Pusher, PusherIds, PusherKind};
+
+    #[test]
+    fn serialize_post() {
+        let action = PusherAction::Post(PusherPostData {
+            pusher: Pusher {
+                ids: PusherIds::new("abcdef".to_owned(), "my.matrix.app".to_owned()),
+                kind: PusherKind::Email,
+                app_display_name: "My Matrix App".to_owned(),
+                device_display_name: "My Phone".to_owned(),
+                profile_tag: None,
+                lang: "en".to_owned(),
+                data: PusherData::new(),
+            },
+            append: false,
+        });
+
+        assert_eq!(
+            to_json_value(action).unwrap(),
+            json!({
+                "pushkey": "abcdef",
+                "app_id": "my.matrix.app",
+                "kind": "email",
+                "app_display_name": "My Matrix App",
+                "device_display_name": "My Phone",
+                "lang": "en",
+                "data": {}
+            })
+        );
+    }
+
+    #[test]
+    fn serialize_delete() {
+        let action =
+            PusherAction::Delete(PusherIds::new("abcdef".to_owned(), "my.matrix.app".to_owned()));
+
+        assert_eq!(
+            to_json_value(action).unwrap(),
+            json!({
+                "pushkey": "abcdef",
+                "app_id": "my.matrix.app",
+                "kind": null,
+            })
+        );
+    }
+
+    #[test]
+    fn deserialize_post() {
+        let json = json!({
+            "pushkey": "abcdef",
+            "app_id": "my.matrix.app",
+            "kind": "email",
+            "app_display_name": "My Matrix App",
+            "device_display_name": "My Phone",
+            "lang": "en",
+            "data": {}
+        });
+
+        let post_data = assert_matches!(
+            from_json_value(json).unwrap(),
+            PusherAction::Post(post_data) => post_data
+        );
+
+        assert!(!post_data.append);
+
+        let pusher = post_data.pusher;
+        assert_eq!(pusher.ids.pushkey, "abcdef");
+        assert_eq!(pusher.ids.app_id, "my.matrix.app");
+        assert_eq!(pusher.kind, PusherKind::Email);
+        assert_eq!(pusher.app_display_name, "My Matrix App");
+        assert_eq!(pusher.device_display_name, "My Phone");
+        assert_eq!(pusher.profile_tag, None);
+        assert_eq!(pusher.lang, "en");
+        assert!(pusher.data.is_empty());
+    }
+
+    #[test]
+    fn deserialize_delete() {
+        let json = json!({
+            "pushkey": "abcdef",
+            "app_id": "my.matrix.app",
+            "kind": null,
+        });
+
+        let ids = assert_matches!(
+            from_json_value(json).unwrap(),
+            PusherAction::Delete(ids) => ids
+        );
+
+        assert_eq!(ids.pushkey, "abcdef");
+        assert_eq!(ids.app_id, "my.matrix.app");
+    }
+}

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -17,6 +17,7 @@ Breaking changes:
     the module calling the macro.
 * Make `name` optional on `SecretStorageKeyEventContent`. Default constructor has been
   adjusted as well to not require this field.
+* Rename `push::PusherData` to `HttpPusherData` and make the `url` field required
 
 Improvements:
 

--- a/crates/ruma-common/src/push.rs
+++ b/crates/ruma-common/src/push.rs
@@ -401,15 +401,14 @@ impl Equivalent<PatternedPushRule> for str {
     }
 }
 
-/// Information for the pusher implementation itself.
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+/// Information for a pusher using the Push Gateway API.
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-pub struct PusherData {
+pub struct HttpPusherData {
     /// The URL to use to send notifications to.
     ///
     /// Required if the pusher's kind is http.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
+    pub url: String,
 
     /// The format to use when sending notifications to the Push Gateway.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -427,28 +426,20 @@ pub struct PusherData {
     pub default_payload: JsonValue,
 }
 
-impl PusherData {
-    /// Creates an empty `PusherData`.
-    pub fn new() -> Self {
-        Default::default()
-    }
-
-    /// Returns `true` if all fields are `None`.
-    pub fn is_empty(&self) -> bool {
-        #[cfg(not(feature = "unstable-unspecified"))]
-        {
-            self.url.is_none() && self.format.is_none()
-        }
-
-        #[cfg(feature = "unstable-unspecified")]
-        {
-            self.url.is_none() && self.format.is_none() && self.default_payload.is_null()
+impl HttpPusherData {
+    /// Creates a new `HttpPusherData` with the given URL.
+    pub fn new(url: String) -> Self {
+        Self {
+            url,
+            format: None,
+            #[cfg(feature = "unstable-unspecified")]
+            default_payload: JsonValue::default(),
         }
     }
 }
 
 /// A special format that the homeserver should use when sending notifications to a Push Gateway.
-/// Currently, only "event_id_only" is supported as of [Push Gateway API r0.1.1][spec].
+/// Currently, only `event_id_only` is supported, see the [Push Gateway API][spec].
 ///
 /// [spec]: https://spec.matrix.org/v1.4/push-gateway-api/#homeserver-behaviour
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]

--- a/crates/ruma-push-gateway-api/src/send_event_notification.rs
+++ b/crates/ruma-push-gateway-api/src/send_event_notification.rs
@@ -236,7 +236,8 @@ pub mod v1 {
     ///
     /// This is the data dictionary passed in at pusher creation minus the `url` key.
     ///
-    /// It can be constructed from [`ruma_common::push::PusherData`] with `::from()` / `.into()`.
+    /// It can be constructed from [`ruma_common::push::HttpPusherData`] with `::from()` /
+    /// `.into()`.
     #[derive(Clone, Debug, Default, Serialize, Deserialize)]
     #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     pub struct PusherData {
@@ -276,9 +277,9 @@ pub mod v1 {
         }
     }
 
-    impl From<ruma_common::push::PusherData> for PusherData {
-        fn from(data: ruma_common::push::PusherData) -> Self {
-            let ruma_common::push::PusherData {
+    impl From<ruma_common::push::HttpPusherData> for PusherData {
+        fn from(data: ruma_common::push::HttpPusherData) -> Self {
+            let ruma_common::push::HttpPusherData {
                 format,
                 #[cfg(feature = "unstable-unspecified")]
                 default_payload,


### PR DESCRIPTION
It seems the custom deserialize implementations for `Pusher` and `PusherPostData` are required.

Closes #521.\
Closes #907.













<!-- Replace -->
----
Preview: https://pr-1369--ruma-docs.surge.sh
<!-- Replace -->
