### PR TITLE
ci: Fix typos release not found

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: Swatinem/rust-cache@v1
 
       - name: Check spelling
-        uses: crate-ci/typos@master
+        uses: crate-ci/typos@v1.12.12
 
       - name: Install cargo-sort
         uses: actions-rs/install@v0.1


### PR DESCRIPTION
It seems like they made a new tag without making a release, so the action won't build now. This locks typos to the previous version.

Upstream issue: https://github.com/crate-ci/typos/issues/610




<!-- Replace -->
----
Preview: https://pr-1370--ruma-docs.surge.sh
<!-- Replace -->
