### PR TITLE
api: Make EndpointError construction infallible

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -13,6 +13,8 @@ Breaking changes:
 * Make `push::PusherKind` contain the pusher's `data`
 * Use an enum for the `scope` of the `push` endpoints
 * Use `NewPushRule` to construct a `push::set_pushrule::v3::Request`
+* `Error` is now an enum because endpoint error construction is infallible (see changelog for
+  `ruma-common`); the previous fields are in the `Standard` variant
 
 Improvements:
 

--- a/crates/ruma-client-api/tests/uiaa.rs
+++ b/crates/ruma-client-api/tests/uiaa.rs
@@ -205,8 +205,8 @@ fn try_uiaa_response_from_http_response() {
         .unwrap();
 
     let info = assert_matches!(
-        UiaaResponse::try_from_http_response(http_response),
-        Ok(UiaaResponse::AuthResponse(info)) => info
+        UiaaResponse::from_http_response(http_response),
+        UiaaResponse::AuthResponse(info) => info
     );
     assert_eq!(info.completed, vec![AuthType::ReCaptcha]);
     assert_eq!(info.flows.len(), 2);

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -21,6 +21,11 @@ Breaking changes:
   adjusted as well to not require this field.
 * Rename `push::PusherData` to `HttpPusherData` and make the `url` field required
 * Remove `Ruleset::add` and the implementation of `Extend<AnyPushRule>` for `Ruleset`
+* Make `EndpointError` construction infallible
+  * `EndpointError::try_from_http_request` has been replaced by `EndpointError::from_http_request`
+  * `FromHttpResponseError<E>::Server` now contains `E` instead of `ServerError<E>`
+  * `ServerError<E>` has been removed
+  * `MatrixError` is now an enum with the `Json` variant containing the previous fields
 
 Improvements:
 

--- a/crates/ruma-common/src/api.rs
+++ b/crates/ruma-common/src/api.rs
@@ -584,9 +584,7 @@ pub trait EndpointError: OutgoingResponse + StdError + Sized + Send + 'static {
     ///
     /// This will always return `Err` variant when no `error` field is defined in
     /// the `ruma_api` macro.
-    fn try_from_http_response<T: AsRef<[u8]>>(
-        response: http::Response<T>,
-    ) -> Result<Self, error::DeserializationError>;
+    fn from_http_response<T: AsRef<[u8]>>(response: http::Response<T>) -> Self;
 }
 
 /// Authentication scheme used by the endpoint.

--- a/crates/ruma-common/tests/api/manual_endpoint_impl.rs
+++ b/crates/ruma-common/tests/api/manual_endpoint_impl.rs
@@ -6,9 +6,7 @@ use bytes::BufMut;
 use http::{header::CONTENT_TYPE, method::Method};
 use ruma_common::{
     api::{
-        error::{
-            FromHttpRequestError, FromHttpResponseError, IntoHttpError, MatrixError, ServerError,
-        },
+        error::{FromHttpRequestError, FromHttpResponseError, IntoHttpError, MatrixError},
         AuthScheme, EndpointError, IncomingRequest, IncomingResponse, MatrixVersion, Metadata,
         OutgoingRequest, OutgoingResponse, SendAccessToken, VersionHistory,
     },
@@ -119,9 +117,7 @@ impl IncomingResponse for Response {
         if http_response.status().as_u16() < 400 {
             Ok(Response)
         } else {
-            Err(FromHttpResponseError::Server(ServerError::Known(
-                <MatrixError as EndpointError>::try_from_http_response(http_response)?,
-            )))
+            Err(FromHttpResponseError::Server(MatrixError::from_http_response(http_response)))
         }
     }
 }

--- a/crates/ruma-macros/src/api/response/incoming.rs
+++ b/crates/ruma-macros/src/api/response/incoming.rs
@@ -124,16 +124,11 @@ impl Response {
                             #response_init_fields
                         })
                     } else {
-                        match <#error_ty as #ruma_common::api::EndpointError>::try_from_http_response(
-                            response
-                        ) {
-                            ::std::result::Result::Ok(err) => {
-                                Err(#ruma_common::api::error::ServerError::Known(err).into())
-                            }
-                            ::std::result::Result::Err(response_err) => {
-                                Err(#ruma_common::api::error::ServerError::Unknown(response_err).into())
-                            }
-                        }
+                        Err(#ruma_common::api::error::FromHttpResponseError::Server(
+                            <#error_ty as #ruma_common::api::EndpointError>::from_http_response(
+                                response,
+                            )
+                        ))
                     }
                 }
             }


### PR DESCRIPTION
Simplifies error matching and preserves more information for non-spec-compliant server errors.







<!-- Replace -->
----
Preview Removed
<!-- Replace -->
