### PR TITLE
push: Make `SimplePushRule` generic over the type of the `rule_id`

### DIFF
--- a/crates/ruma-client-api/src/push.rs
+++ b/crates/ruma-client-api/src/push.rs
@@ -60,9 +60,13 @@ pub struct PushRule {
     pub pattern: Option<String>,
 }
 
-impl From<SimplePushRule> for PushRule {
-    fn from(push_rule: SimplePushRule) -> Self {
+impl<T> From<SimplePushRule<T>> for PushRule
+where
+    T: Into<String>,
+{
+    fn from(push_rule: SimplePushRule<T>) -> Self {
         let SimplePushRule { actions, default, enabled, rule_id, .. } = push_rule;
+        let rule_id = rule_id.into();
         Self { actions, default, enabled, rule_id, conditions: None, pattern: None }
     }
 }
@@ -81,9 +85,13 @@ impl From<ConditionalPushRule> for PushRule {
     }
 }
 
-impl From<SimplePushRuleInit> for PushRule {
-    fn from(init: SimplePushRuleInit) -> Self {
+impl<T> From<SimplePushRuleInit<T>> for PushRule
+where
+    T: Into<String>,
+{
+    fn from(init: SimplePushRuleInit<T>) -> Self {
         let SimplePushRuleInit { actions, default, enabled, rule_id } = init;
+        let rule_id = rule_id.into();
         Self { actions, default, enabled, rule_id, pattern: None, conditions: None }
     }
 }
@@ -102,10 +110,16 @@ impl From<PatternedPushRuleInit> for PushRule {
     }
 }
 
-impl From<PushRule> for SimplePushRule {
-    fn from(push_rule: PushRule) -> Self {
+impl<T> TryFrom<PushRule> for SimplePushRule<T>
+where
+    T: TryFrom<String>,
+{
+    type Error = <T as TryFrom<String>>::Error;
+
+    fn try_from(push_rule: PushRule) -> Result<Self, Self::Error> {
         let PushRule { actions, default, enabled, rule_id, .. } = push_rule;
-        SimplePushRuleInit { actions, default, enabled, rule_id }.into()
+        let rule_id = T::try_from(rule_id)?;
+        Ok(SimplePushRuleInit { actions, default, enabled, rule_id }.into())
     }
 }
 

--- a/crates/ruma-client-api/src/push/set_pushrule.rs
+++ b/crates/ruma-client-api/src/push/set_pushrule.rs
@@ -175,11 +175,13 @@ pub mod v3 {
                 RuleKind::Sender => {
                     let SimpleRequestBody { actions } =
                         serde_json::from_slice(request.body().as_ref())?;
+                    let rule_id = rule_id.try_into()?;
                     NewPushRule::Sender(NewSimplePushRule::new(rule_id, actions))
                 }
                 RuleKind::Room => {
                     let SimpleRequestBody { actions } =
                         serde_json::from_slice(request.body().as_ref())?;
+                    let rule_id = rule_id.try_into()?;
                     NewPushRule::Room(NewSimplePushRule::new(rule_id, actions))
                 }
                 RuleKind::Content => {

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -28,6 +28,7 @@ Breaking changes:
   * `MatrixError` is now an enum with the `Json` variant containing the previous fields
 * Change the `ignored_users` field of `IgnoredUserListEventContent` to a map of empty structs, to
   allow eventual fields to be added, as intended by the spec
+* Make `SimplePushRule` and associated types generic over the expected type of the `rule_id`
 
 Improvements:
 


### PR DESCRIPTION
For now both uses of this type should be a Matrix ID, this avoids clients sending malformed push rules and takes care of validation on the server side.










<!-- Replace -->
----
Preview: https://pr-1382--ruma-docs.surge.sh
<!-- Replace -->
