### PR TITLE
Deduplicate and group relation structs in `events::relation`

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -31,6 +31,8 @@ Breaking changes:
 * Change the `ignored_users` field of `IgnoredUserListEventContent` to a map of empty structs, to
   allow eventual fields to be added, as intended by the spec
 * Make `SimplePushRule` and associated types generic over the expected type of the `rule_id`
+* Deduplicate and group relation structs in `events::relation`:
+  * Move relation structs under `events::room::message` to `events::relation`
 
 Improvements:
 

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -37,6 +37,7 @@ Breaking changes:
     duplicate types
   * Remove `events::reaction::Relation` and use `events::relation::Annotation` instead
   * Remove `events::key::verification::Relation` and use `events::relation::Reference` instead
+* Rename `events::relation::Relations` to `BundledRelations`
 
 Improvements:
 

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -36,6 +36,7 @@ Breaking changes:
   * Move common relation structs under `events::room::encrypted` to `events::relation` and remove
     duplicate types
   * Remove `events::reaction::Relation` and use `events::relation::Annotation` instead
+  * Remove `events::key::verification::Relation` and use `events::relation::Reference` instead
 
 Improvements:
 

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -35,6 +35,7 @@ Breaking changes:
   * Move relation structs under `events::room::message` to `events::relation`
   * Move common relation structs under `events::room::encrypted` to `events::relation` and remove
     duplicate types
+  * Remove `events::reaction::Relation` and use `events::relation::Annotation` instead
 
 Improvements:
 

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -33,6 +33,8 @@ Breaking changes:
 * Make `SimplePushRule` and associated types generic over the expected type of the `rule_id`
 * Deduplicate and group relation structs in `events::relation`:
   * Move relation structs under `events::room::message` to `events::relation`
+  * Move common relation structs under `events::room::encrypted` to `events::relation` and remove
+    duplicate types
 
 Improvements:
 

--- a/crates/ruma-common/src/events.rs
+++ b/crates/ruma-common/src/events.rs
@@ -172,7 +172,7 @@ pub use self::{
     content::*,
     enums::*,
     kinds::*,
-    relation::Relations,
+    relation::BundledRelations,
     state_key::EmptyStateKey,
     unsigned::{MessageLikeUnsigned, RedactedUnsigned, StateUnsigned, StateUnsignedFromParts},
 };

--- a/crates/ruma-common/src/events/enums.rs
+++ b/crates/ruma-common/src/events/enums.rs
@@ -8,9 +8,8 @@ use super::{
     Redact, Relations,
 };
 use crate::{
-    events::relation::{Annotation, Reference},
-    serde::from_raw_json_value,
-    EventId, MilliSecondsSinceUnixEpoch, OwnedRoomId, RoomId, RoomVersionId, TransactionId, UserId,
+    events::relation::Reference, serde::from_raw_json_value, EventId, MilliSecondsSinceUnixEpoch,
+    OwnedRoomId, RoomId, RoomVersionId, TransactionId, UserId,
 };
 
 event_enum! {
@@ -332,15 +331,7 @@ impl AnyMessageLikeEventContent {
                 }))
             }
             #[cfg(feature = "unstable-msc2677")]
-            Self::Reaction(ev) => {
-                use super::reaction;
-
-                let reaction::Relation { event_id, key } = &ev.relates_to;
-                Some(encrypted::Relation::Annotation(Annotation {
-                    event_id: event_id.clone(),
-                    key: key.clone(),
-                }))
-            }
+            Self::Reaction(ev) => Some(encrypted::Relation::Annotation(ev.relates_to.clone())),
             Self::RoomEncrypted(ev) => ev.relates_to.clone(),
             Self::RoomMessage(ev) => ev.relates_to.clone().map(Into::into),
             #[cfg(feature = "unstable-msc1767")]

--- a/crates/ruma-common/src/events/enums.rs
+++ b/crates/ruma-common/src/events/enums.rs
@@ -4,7 +4,7 @@ use serde_json::value::RawValue as RawJsonValue;
 
 use super::{
     room::{encrypted, redaction::SyncRoomRedactionEvent},
-    Redact, Relations,
+    BundledRelations, Redact,
 };
 use crate::{
     serde::from_raw_json_value, EventId, MilliSecondsSinceUnixEpoch, OwnedRoomId, RoomId,
@@ -181,7 +181,7 @@ impl AnyTimelineEvent {
         pub fn transaction_id(&self) -> Option<&TransactionId>;
 
         /// Returns this event's `relations` from inside `unsigned`, if that field exists.
-        pub fn relations(&self) -> Option<&Relations>;
+        pub fn relations(&self) -> Option<&BundledRelations>;
     }
 }
 
@@ -213,7 +213,7 @@ impl AnySyncTimelineEvent {
         pub fn transaction_id(&self) -> Option<&TransactionId>;
 
         /// Returns this event's `relations` from inside `unsigned`, if that field exists.
-        pub fn relations(&self) -> Option<&Relations>;
+        pub fn relations(&self) -> Option<&BundledRelations>;
     }
 
     /// Converts `self` to an `AnyTimelineEvent` by adding the given a room ID.

--- a/crates/ruma-common/src/events/enums.rs
+++ b/crates/ruma-common/src/events/enums.rs
@@ -3,7 +3,6 @@ use serde::{de, Deserialize};
 use serde_json::value::RawValue as RawJsonValue;
 
 use super::{
-    key,
     room::{encrypted, redaction::SyncRoomRedactionEvent},
     Redact, Relations,
 };
@@ -325,11 +324,8 @@ impl AnyMessageLikeEventContent {
             | Self::KeyVerificationKey(KeyVerificationKeyEventContent { relates_to, .. })
             | Self::KeyVerificationMac(KeyVerificationMacEventContent { relates_to, .. })
             | Self::KeyVerificationDone(KeyVerificationDoneEventContent { relates_to, .. }) => {
-                let key::verification::Relation { event_id } = relates_to;
-                Some(encrypted::Relation::Reference(Reference {
-                    event_id: event_id.clone(),
-                }))
-            }
+                Some(encrypted::Relation::Reference(relates_to.clone()))
+            },
             #[cfg(feature = "unstable-msc2677")]
             Self::Reaction(ev) => Some(encrypted::Relation::Annotation(ev.relates_to.clone())),
             Self::RoomEncrypted(ev) => ev.relates_to.clone(),

--- a/crates/ruma-common/src/events/enums.rs
+++ b/crates/ruma-common/src/events/enums.rs
@@ -7,8 +7,8 @@ use super::{
     Redact, Relations,
 };
 use crate::{
-    events::relation::Reference, serde::from_raw_json_value, EventId, MilliSecondsSinceUnixEpoch,
-    OwnedRoomId, RoomId, RoomVersionId, TransactionId, UserId,
+    serde::from_raw_json_value, EventId, MilliSecondsSinceUnixEpoch, OwnedRoomId, RoomId,
+    RoomVersionId, TransactionId, UserId,
 };
 
 event_enum! {
@@ -351,8 +351,7 @@ impl AnyMessageLikeEventContent {
             #[cfg(feature = "unstable-msc3381")]
             Self::PollResponse(PollResponseEventContent { relates_to, .. })
             | Self::PollEnd(PollEndEventContent { relates_to, .. }) => {
-                let super::poll::ReferenceRelation { event_id } = relates_to;
-                Some(encrypted::Relation::Reference(Reference { event_id: event_id.clone() }))
+                Some(encrypted::Relation::Reference(relates_to.clone()))
             }
             #[cfg(feature = "unstable-msc3381")]
             Self::PollStart(_) => None,

--- a/crates/ruma-common/src/events/enums.rs
+++ b/crates/ruma-common/src/events/enums.rs
@@ -8,8 +8,9 @@ use super::{
     Redact, Relations,
 };
 use crate::{
-    serde::from_raw_json_value, EventId, MilliSecondsSinceUnixEpoch, OwnedRoomId, RoomId,
-    RoomVersionId, TransactionId, UserId,
+    events::relation::{Annotation, Reference},
+    serde::from_raw_json_value,
+    EventId, MilliSecondsSinceUnixEpoch, OwnedRoomId, RoomId, RoomVersionId, TransactionId, UserId,
 };
 
 event_enum! {
@@ -326,7 +327,7 @@ impl AnyMessageLikeEventContent {
             | Self::KeyVerificationMac(KeyVerificationMacEventContent { relates_to, .. })
             | Self::KeyVerificationDone(KeyVerificationDoneEventContent { relates_to, .. }) => {
                 let key::verification::Relation { event_id } = relates_to;
-                Some(encrypted::Relation::Reference(encrypted::Reference {
+                Some(encrypted::Relation::Reference(Reference {
                     event_id: event_id.clone(),
                 }))
             }
@@ -335,7 +336,7 @@ impl AnyMessageLikeEventContent {
                 use super::reaction;
 
                 let reaction::Relation { event_id, key } = &ev.relates_to;
-                Some(encrypted::Relation::Annotation(encrypted::Annotation {
+                Some(encrypted::Relation::Annotation(Annotation {
                     event_id: event_id.clone(),
                     key: key.clone(),
                 }))
@@ -364,9 +365,7 @@ impl AnyMessageLikeEventContent {
             Self::PollResponse(PollResponseEventContent { relates_to, .. })
             | Self::PollEnd(PollEndEventContent { relates_to, .. }) => {
                 let super::poll::ReferenceRelation { event_id } = relates_to;
-                Some(encrypted::Relation::Reference(encrypted::Reference {
-                    event_id: event_id.clone(),
-                }))
+                Some(encrypted::Relation::Reference(Reference { event_id: event_id.clone() }))
             }
             #[cfg(feature = "unstable-msc3381")]
             Self::PollStart(_) => None,

--- a/crates/ruma-common/src/events/key/verification.rs
+++ b/crates/ruma-common/src/events/key/verification.rs
@@ -7,9 +7,7 @@
 //!
 //! [MSC2241]: https://github.com/matrix-org/matrix-spec-proposals/pull/2241
 
-use serde::{Deserialize, Serialize};
-
-use crate::{serde::StringEnum, OwnedEventId, PrivOwnedStr};
+use crate::{serde::StringEnum, PrivOwnedStr};
 
 pub mod accept;
 pub mod cancel;
@@ -84,22 +82,6 @@ pub enum ShortAuthenticationString {
 
     #[doc(hidden)]
     _Custom(PrivOwnedStr),
-}
-
-/// A relation which associates an `m.key.verification.request` with another key verification event.
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-#[serde(tag = "rel_type", rename = "m.reference")]
-pub struct Relation {
-    /// The event ID of a related `m.key.verification.request`.
-    pub event_id: OwnedEventId,
-}
-
-impl Relation {
-    /// Creates a new `Relation` with the given event ID.
-    pub fn new(event_id: OwnedEventId) -> Self {
-        Self { event_id }
-    }
 }
 
 /// A Short Authentication String (SAS) verification method.

--- a/crates/ruma-common/src/events/key/verification/accept.rs
+++ b/crates/ruma-common/src/events/key/verification/accept.rs
@@ -9,10 +9,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
 use super::{
-    HashAlgorithm, KeyAgreementProtocol, MessageAuthenticationCode, Relation,
-    ShortAuthenticationString,
+    HashAlgorithm, KeyAgreementProtocol, MessageAuthenticationCode, ShortAuthenticationString,
 };
-use crate::{serde::Base64, OwnedTransactionId};
+use crate::{events::relation::Reference, serde::Base64, OwnedTransactionId};
 
 /// The content of a to-device `m.key.verification.accept` event.
 ///
@@ -52,13 +51,13 @@ pub struct KeyVerificationAcceptEventContent {
 
     /// Information about the related event.
     #[serde(rename = "m.relates_to")]
-    pub relates_to: Relation,
+    pub relates_to: Reference,
 }
 
 impl KeyVerificationAcceptEventContent {
     /// Creates a new `ToDeviceKeyVerificationAcceptEventContent` with the given method-specific
-    /// content and relation.
-    pub fn new(method: AcceptMethod, relates_to: Relation) -> Self {
+    /// content and reference.
+    pub fn new(method: AcceptMethod, relates_to: Reference) -> Self {
         Self { method, relates_to }
     }
 }
@@ -176,7 +175,7 @@ mod tests {
     };
     use crate::{
         event_id,
-        events::{key::verification::Relation, ToDeviceEvent},
+        events::{relation::Reference, ToDeviceEvent},
         serde::Base64,
         user_id,
     };
@@ -248,7 +247,7 @@ mod tests {
         let event_id = event_id!("$1598361704261elfgc:localhost");
 
         let key_verification_accept_content = KeyVerificationAcceptEventContent {
-            relates_to: Relation { event_id: event_id.to_owned() },
+            relates_to: Reference { event_id: event_id.to_owned() },
             method: AcceptMethod::SasV1(SasV1Content {
                 hash: HashAlgorithm::Sha256,
                 key_agreement_protocol: KeyAgreementProtocol::Curve25519,

--- a/crates/ruma-common/src/events/key/verification/cancel.rs
+++ b/crates/ruma-common/src/events/key/verification/cancel.rs
@@ -5,8 +5,7 @@
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
-use super::Relation;
-use crate::{serde::StringEnum, OwnedTransactionId, PrivOwnedStr};
+use crate::{events::relation::Reference, serde::StringEnum, OwnedTransactionId, PrivOwnedStr};
 
 /// The content of a to-device `m.key.verification.cancel` event.
 ///
@@ -52,12 +51,12 @@ pub struct KeyVerificationCancelEventContent {
 
     /// Information about the related event.
     #[serde(rename = "m.relates_to")]
-    pub relates_to: Relation,
+    pub relates_to: Reference,
 }
 
 impl KeyVerificationCancelEventContent {
-    /// Creates a new `KeyVerificationCancelEventContent` with the given reason, code and relation.
-    pub fn new(reason: String, code: CancelCode, relates_to: Relation) -> Self {
+    /// Creates a new `KeyVerificationCancelEventContent` with the given reason, code and reference.
+    pub fn new(reason: String, code: CancelCode, relates_to: Reference) -> Self {
         Self { reason, code, relates_to }
     }
 }

--- a/crates/ruma-common/src/events/key/verification/done.rs
+++ b/crates/ruma-common/src/events/key/verification/done.rs
@@ -5,8 +5,7 @@
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
-use super::Relation;
-use crate::OwnedTransactionId;
+use crate::{events::relation::Reference, OwnedTransactionId};
 
 /// The content of a to-device `m.m.key.verification.done` event.
 ///
@@ -37,12 +36,12 @@ impl ToDeviceKeyVerificationDoneEventContent {
 pub struct KeyVerificationDoneEventContent {
     /// Relation signaling which verification request this event is responding to.
     #[serde(rename = "m.relates_to")]
-    pub relates_to: Relation,
+    pub relates_to: Reference,
 }
 
 impl KeyVerificationDoneEventContent {
-    /// Creates a new `KeyVerificationDoneEventContent` with the given relation.
-    pub fn new(relates_to: Relation) -> Self {
+    /// Creates a new `KeyVerificationDoneEventContent` with the given reference.
+    pub fn new(relates_to: Reference) -> Self {
         Self { relates_to }
     }
 }
@@ -52,7 +51,7 @@ mod tests {
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     use super::KeyVerificationDoneEventContent;
-    use crate::{event_id, events::key::verification::Relation};
+    use crate::{event_id, events::relation::Reference};
 
     #[test]
     fn serialization() {
@@ -65,7 +64,7 @@ mod tests {
             }
         });
 
-        let content = KeyVerificationDoneEventContent { relates_to: Relation { event_id } };
+        let content = KeyVerificationDoneEventContent { relates_to: Reference { event_id } };
 
         assert_eq!(to_json_value(&content).unwrap(), json_data);
     }

--- a/crates/ruma-common/src/events/key/verification/key.rs
+++ b/crates/ruma-common/src/events/key/verification/key.rs
@@ -5,8 +5,7 @@
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
-use super::Relation;
-use crate::{serde::Base64, OwnedTransactionId};
+use crate::{events::relation::Reference, serde::Base64, OwnedTransactionId};
 
 /// The content of a to-device `m.key.verification.key` event.
 ///
@@ -44,12 +43,12 @@ pub struct KeyVerificationKeyEventContent {
 
     /// Information about the related event.
     #[serde(rename = "m.relates_to")]
-    pub relates_to: Relation,
+    pub relates_to: Reference,
 }
 
 impl KeyVerificationKeyEventContent {
-    /// Creates a new `KeyVerificationKeyEventContent` with the given key and relation.
-    pub fn new(key: Base64, relates_to: Relation) -> Self {
+    /// Creates a new `KeyVerificationKeyEventContent` with the given key and reference.
+    pub fn new(key: Base64, relates_to: Reference) -> Self {
         Self { key, relates_to }
     }
 }

--- a/crates/ruma-common/src/events/key/verification/mac.rs
+++ b/crates/ruma-common/src/events/key/verification/mac.rs
@@ -7,8 +7,7 @@ use std::collections::BTreeMap;
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
-use super::Relation;
-use crate::{serde::Base64, OwnedTransactionId};
+use crate::{events::relation::Reference, serde::Base64, OwnedTransactionId};
 
 /// The content of a to-device `m.key.verification.` event.
 ///
@@ -62,13 +61,13 @@ pub struct KeyVerificationMacEventContent {
 
     /// Information about the related event.
     #[serde(rename = "m.relates_to")]
-    pub relates_to: Relation,
+    pub relates_to: Reference,
 }
 
 impl KeyVerificationMacEventContent {
     /// Creates a new `KeyVerificationMacEventContent` with the given key ID to MAC map, key MAC and
-    /// relation.
-    pub fn new(mac: BTreeMap<String, Base64>, keys: Base64, relates_to: Relation) -> Self {
+    /// reference.
+    pub fn new(mac: BTreeMap<String, Base64>, keys: Base64, relates_to: Reference) -> Self {
         Self { mac, keys, relates_to }
     }
 }

--- a/crates/ruma-common/src/events/key/verification/ready.rs
+++ b/crates/ruma-common/src/events/key/verification/ready.rs
@@ -5,8 +5,8 @@
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
-use super::{Relation, VerificationMethod};
-use crate::{OwnedDeviceId, OwnedTransactionId};
+use super::VerificationMethod;
+use crate::{events::relation::Reference, OwnedDeviceId, OwnedTransactionId};
 
 /// The content of a to-device `m.m.key.verification.ready` event.
 ///
@@ -57,16 +57,16 @@ pub struct KeyVerificationReadyEventContent {
     /// Relation signaling which verification request this event is responding
     /// to.
     #[serde(rename = "m.relates_to")]
-    pub relates_to: Relation,
+    pub relates_to: Reference,
 }
 
 impl KeyVerificationReadyEventContent {
     /// Creates a new `KeyVerificationReadyEventContent` with the given device ID, methods and
-    /// relation.
+    /// reference.
     pub fn new(
         from_device: OwnedDeviceId,
         methods: Vec<VerificationMethod>,
-        relates_to: Relation,
+        relates_to: Reference,
     ) -> Self {
         Self { from_device, methods, relates_to }
     }
@@ -79,7 +79,7 @@ mod tests {
     use super::{KeyVerificationReadyEventContent, ToDeviceKeyVerificationReadyEventContent};
     use crate::{
         event_id,
-        events::key::verification::{Relation, VerificationMethod},
+        events::{key::verification::VerificationMethod, relation::Reference},
         OwnedDeviceId,
     };
 
@@ -99,7 +99,7 @@ mod tests {
 
         let content = KeyVerificationReadyEventContent {
             from_device: device.clone(),
-            relates_to: Relation { event_id },
+            relates_to: Reference { event_id },
             methods: vec![VerificationMethod::SasV1],
         };
 

--- a/crates/ruma-common/src/events/key/verification/start.rs
+++ b/crates/ruma-common/src/events/key/verification/start.rs
@@ -9,10 +9,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
 use super::{
-    HashAlgorithm, KeyAgreementProtocol, MessageAuthenticationCode, Relation,
-    ShortAuthenticationString,
+    HashAlgorithm, KeyAgreementProtocol, MessageAuthenticationCode, ShortAuthenticationString,
 };
-use crate::{serde::Base64, OwnedDeviceId, OwnedTransactionId};
+use crate::{events::relation::Reference, serde::Base64, OwnedDeviceId, OwnedTransactionId};
 
 /// The content of a to-device `m.key.verification.start` event.
 ///
@@ -64,13 +63,13 @@ pub struct KeyVerificationStartEventContent {
 
     /// Information about the related event.
     #[serde(rename = "m.relates_to")]
-    pub relates_to: Relation,
+    pub relates_to: Reference,
 }
 
 impl KeyVerificationStartEventContent {
     /// Creates a new `KeyVerificationStartEventContent` with the given device ID, method and
-    /// relation.
-    pub fn new(from_device: OwnedDeviceId, method: StartMethod, relates_to: Relation) -> Self {
+    /// reference.
+    pub fn new(from_device: OwnedDeviceId, method: StartMethod, relates_to: Reference) -> Self {
         Self { from_device, method, relates_to }
     }
 }
@@ -218,7 +217,7 @@ mod tests {
     };
     use crate::{
         event_id,
-        events::{key::verification::Relation, ToDeviceEvent},
+        events::{relation::Reference, ToDeviceEvent},
         serde::Base64,
         user_id,
     };
@@ -315,7 +314,7 @@ mod tests {
 
         let key_verification_start_content = KeyVerificationStartEventContent {
             from_device: "123".into(),
-            relates_to: Relation { event_id: event_id.to_owned() },
+            relates_to: Reference { event_id: event_id.to_owned() },
             method: StartMethod::SasV1(
                 SasV1ContentInit {
                     hashes: vec![HashAlgorithm::Sha256],
@@ -346,7 +345,7 @@ mod tests {
 
         let key_verification_start_content = KeyVerificationStartEventContent {
             from_device: "123".into(),
-            relates_to: Relation { event_id: event_id.to_owned() },
+            relates_to: Reference { event_id: event_id.to_owned() },
             method: StartMethod::ReciprocateV1(ReciprocateV1Content::new(secret.clone())),
         };
 

--- a/crates/ruma-common/src/events/poll.rs
+++ b/crates/ruma-common/src/events/poll.rs
@@ -4,26 +4,6 @@
 //!
 //! [MSC3381]: https://github.com/matrix-org/matrix-spec-proposals/pull/3381
 
-use serde::{Deserialize, Serialize};
-
-use crate::OwnedEventId;
-
 pub mod end;
 pub mod response;
 pub mod start;
-
-/// An `m.reference` relation.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-#[serde(tag = "rel_type", rename = "m.reference")]
-pub struct ReferenceRelation {
-    /// The ID of the event this references.
-    pub event_id: OwnedEventId,
-}
-
-impl ReferenceRelation {
-    /// Creates a new `ReferenceRelation` that references the given event ID.
-    pub fn new(event_id: OwnedEventId) -> Self {
-        Self { event_id }
-    }
-}

--- a/crates/ruma-common/src/events/poll/end.rs
+++ b/crates/ruma-common/src/events/poll/end.rs
@@ -3,8 +3,7 @@
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
-use super::ReferenceRelation;
-use crate::OwnedEventId;
+use crate::{events::relation::Reference, OwnedEventId};
 
 /// The payload for a poll end event.
 #[derive(Clone, Debug, Serialize, Deserialize, EventContent)]
@@ -17,14 +16,14 @@ pub struct PollEndEventContent {
 
     /// Information about the poll start event this responds to.
     #[serde(rename = "m.relates_to")]
-    pub relates_to: ReferenceRelation,
+    pub relates_to: Reference,
 }
 
 impl PollEndEventContent {
     /// Creates a new `PollEndEventContent` that responds to the given poll start event ID,
     /// with the given poll end content.
     pub fn new(poll_end: PollEndContent, poll_start_id: OwnedEventId) -> Self {
-        Self { poll_end, relates_to: ReferenceRelation::new(poll_start_id) }
+        Self { poll_end, relates_to: Reference::new(poll_start_id) }
     }
 }
 

--- a/crates/ruma-common/src/events/poll/response.rs
+++ b/crates/ruma-common/src/events/poll/response.rs
@@ -3,8 +3,7 @@
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
-use super::ReferenceRelation;
-use crate::OwnedEventId;
+use crate::{events::relation::Reference, OwnedEventId};
 
 /// The payload for a poll response event.
 #[derive(Clone, Debug, Serialize, Deserialize, EventContent)]
@@ -17,14 +16,14 @@ pub struct PollResponseEventContent {
 
     /// Information about the poll start event this responds to.
     #[serde(rename = "m.relates_to")]
-    pub relates_to: ReferenceRelation,
+    pub relates_to: Reference,
 }
 
 impl PollResponseEventContent {
     /// Creates a new `PollResponseEventContent` that responds to the given poll start event ID,
     /// with the given poll response content.
     pub fn new(poll_response: PollResponseContent, poll_start_id: OwnedEventId) -> Self {
-        Self { poll_response, relates_to: ReferenceRelation::new(poll_start_id) }
+        Self { poll_response, relates_to: Reference::new(poll_start_id) }
     }
 }
 

--- a/crates/ruma-common/src/events/reaction.rs
+++ b/crates/ruma-common/src/events/reaction.rs
@@ -35,9 +35,10 @@ impl From<Annotation> for ReactionEventContent {
 #[cfg(test)]
 mod tests {
     use assert_matches::assert_matches;
-    use serde_json::{from_value as from_json_value, json};
+    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     use super::ReactionEventContent;
+    use crate::{event_id, events::relation::Annotation};
 
     #[test]
     fn deserialize() {
@@ -55,5 +56,24 @@ mod tests {
         );
         assert_eq!(relates_to.event_id, "$1598361704261elfgc:localhost");
         assert_eq!(relates_to.key, "🦛");
+    }
+
+    #[test]
+    fn serialize() {
+        let content = ReactionEventContent::new(Annotation::new(
+            event_id!("$my_reaction").to_owned(),
+            "🏠".to_owned(),
+        ));
+
+        assert_eq!(
+            to_json_value(&content).unwrap(),
+            json!({
+                "m.relates_to": {
+                    "rel_type": "m.annotation",
+                    "event_id": "$my_reaction",
+                    "key": "🏠"
+                }
+            })
+        );
     }
 }

--- a/crates/ruma-common/src/events/reaction.rs
+++ b/crates/ruma-common/src/events/reaction.rs
@@ -3,7 +3,7 @@
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
-use crate::OwnedEventId;
+use super::relation::Annotation;
 
 /// The payload for a `m.reaction` event.
 ///
@@ -14,45 +14,21 @@ use crate::OwnedEventId;
 pub struct ReactionEventContent {
     /// Information about the related event.
     #[serde(rename = "m.relates_to")]
-    pub relates_to: Relation,
+    pub relates_to: Annotation,
 }
 
 impl ReactionEventContent {
-    /// Creates a new `ReactionEventContent` from the given relation.
+    /// Creates a new `ReactionEventContent` from the given annotation.
     ///
-    /// You can also construct a `ReactionEventContent` from a relation using `From` / `Into`.
-    pub fn new(relates_to: Relation) -> Self {
+    /// You can also construct a `ReactionEventContent` from an annotation using `From` / `Into`.
+    pub fn new(relates_to: Annotation) -> Self {
         Self { relates_to }
     }
 }
 
-impl From<Relation> for ReactionEventContent {
-    fn from(relates_to: Relation) -> Self {
+impl From<Annotation> for ReactionEventContent {
+    fn from(relates_to: Annotation) -> Self {
         Self::new(relates_to)
-    }
-}
-
-/// Information about an annotation relation.
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-#[serde(tag = "rel_type", rename = "m.annotation")]
-pub struct Relation {
-    /// The event that is being annotated.
-    pub event_id: OwnedEventId,
-
-    /// A string that indicates the annotation being applied.
-    ///
-    /// When sending emoji reactions, this field should include the colourful variation-16 when
-    /// applicable.
-    ///
-    /// Clients should render reactions that have a long `key` field in a sensible manner.
-    pub key: String,
-}
-
-impl Relation {
-    /// Creates a new `Relation` with the given event ID and key.
-    pub fn new(event_id: OwnedEventId, key: String) -> Self {
-        Self { event_id, key }
     }
 }
 

--- a/crates/ruma-common/src/events/relation.rs
+++ b/crates/ruma-common/src/events/relation.rs
@@ -36,11 +36,17 @@ impl InReplyTo {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg(feature = "unstable-msc2677")]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+#[serde(tag = "rel_type", rename = "m.annotation")]
 pub struct Annotation {
     /// The event that is being annotated.
     pub event_id: OwnedEventId,
 
-    /// The annotation.
+    /// A string that indicates the annotation being applied.
+    ///
+    /// When sending emoji reactions, this field should include the colourful variation-16 when
+    /// applicable.
+    ///
+    /// Clients should render reactions that have a long `key` field in a sensible manner.
     pub key: String,
 }
 

--- a/crates/ruma-common/src/events/relation.rs
+++ b/crates/ruma-common/src/events/relation.rs
@@ -30,6 +30,28 @@ impl InReplyTo {
     }
 }
 
+/// An [annotation] for an event.
+///
+/// [annotation]: https://github.com/matrix-org/matrix-spec-proposals/pull/2677
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg(feature = "unstable-msc2677")]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+pub struct Annotation {
+    /// The event that is being annotated.
+    pub event_id: OwnedEventId,
+
+    /// The annotation.
+    pub key: String,
+}
+
+#[cfg(feature = "unstable-msc2677")]
+impl Annotation {
+    /// Creates a new `Annotation` with the given event ID and key.
+    pub fn new(event_id: OwnedEventId, key: String) -> Self {
+        Self { event_id, key }
+    }
+}
+
 /// Summary of all annotations to an event with the given key and type.
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[cfg(feature = "unstable-msc2677")]
@@ -203,6 +225,23 @@ impl BundledThread {
         current_user_participated: bool,
     ) -> Self {
         Self { latest_event, count, current_user_participated }
+    }
+}
+
+/// A [reference] to another event.
+///
+/// [reference]: https://spec.matrix.org/v1.5/client-server-api/#reference-relations
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+pub struct Reference {
+    /// The ID of the event being referenced.
+    pub event_id: OwnedEventId,
+}
+
+impl Reference {
+    /// Creates a new `Reference` with the given event ID.
+    pub fn new(event_id: OwnedEventId) -> Self {
+        Self { event_id }
     }
 }
 

--- a/crates/ruma-common/src/events/relation.rs
+++ b/crates/ruma-common/src/events/relation.rs
@@ -287,7 +287,7 @@ impl ReferenceChunk {
 /// [Bundled aggregations]: https://spec.matrix.org/v1.4/client-server-api/#aggregations
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-pub struct Relations {
+pub struct BundledRelations {
     /// Annotation relations.
     #[cfg(feature = "unstable-msc2677")]
     #[serde(rename = "m.annotation")]
@@ -306,8 +306,8 @@ pub struct Relations {
     pub reference: Option<ReferenceChunk>,
 }
 
-impl Relations {
-    /// Creates a new empty `Relations`.
+impl BundledRelations {
+    /// Creates a new empty `BundledRelations`.
     pub fn new() -> Self {
         Self::default()
     }

--- a/crates/ruma-common/src/events/relation.rs
+++ b/crates/ruma-common/src/events/relation.rs
@@ -239,6 +239,7 @@ impl BundledThread {
 /// [reference]: https://spec.matrix.org/v1.5/client-server-api/#reference-relations
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+#[serde(tag = "rel_type", rename = "m.reference")]
 pub struct Reference {
     /// The ID of the event being referenced.
     pub event_id: OwnedEventId,

--- a/crates/ruma-common/src/events/room/encrypted.rs
+++ b/crates/ruma-common/src/events/room/encrypted.rs
@@ -9,7 +9,12 @@ use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
 use super::message;
-use crate::{events::relation::InReplyTo, OwnedDeviceId, OwnedEventId};
+#[cfg(feature = "unstable-msc2677")]
+use crate::events::relation::Annotation;
+use crate::{
+    events::relation::{InReplyTo, Reference, Thread},
+    OwnedDeviceId, OwnedEventId,
+};
 
 mod relation_serde;
 
@@ -146,77 +151,6 @@ impl Replacement {
     /// Creates a new `Replacement` with the given event ID.
     pub fn new(event_id: OwnedEventId) -> Self {
         Self { event_id }
-    }
-}
-
-/// A reference to another event.
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-pub struct Reference {
-    /// The event we are referencing.
-    pub event_id: OwnedEventId,
-}
-
-impl Reference {
-    /// Creates a new `Reference` with the given event ID.
-    pub fn new(event_id: OwnedEventId) -> Self {
-        Self { event_id }
-    }
-}
-
-/// An annotation for an event.
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[cfg(feature = "unstable-msc2677")]
-#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-pub struct Annotation {
-    /// The event that is being annotated.
-    pub event_id: OwnedEventId,
-
-    /// The annotation.
-    pub key: String,
-}
-
-#[cfg(feature = "unstable-msc2677")]
-impl Annotation {
-    /// Creates a new `Annotation` with the given event ID and key.
-    pub fn new(event_id: OwnedEventId, key: String) -> Self {
-        Self { event_id, key }
-    }
-}
-
-/// A thread relation for an event.
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-pub struct Thread {
-    /// The ID of the root message in the thread.
-    pub event_id: OwnedEventId,
-
-    /// A reply relation.
-    ///
-    /// If this event is a reply and belongs to a thread, this points to the message that is being
-    /// replied to, and `is_falling_back` must be set to `false`.
-    ///
-    /// If this event is not a reply, this is used as a fallback mechanism for clients that do not
-    /// support threads. This should point to the latest message-like event in the thread and
-    /// `is_falling_back` must be set to `true`.
-    pub in_reply_to: InReplyTo,
-
-    /// Whether the `m.in_reply_to` field is a fallback for older clients or a real reply in a
-    /// thread.
-    pub is_falling_back: bool,
-}
-
-impl Thread {
-    /// Convenience method to create a regular `Thread` with the given event ID and latest
-    /// message-like event ID.
-    pub fn plain(event_id: OwnedEventId, latest_event_id: OwnedEventId) -> Self {
-        Self { event_id, in_reply_to: InReplyTo::new(latest_event_id), is_falling_back: false }
-    }
-
-    /// Convenience method to create a reply `Thread` with the given event ID and replied-to event
-    /// ID.
-    pub fn reply(event_id: OwnedEventId, reply_to_event_id: OwnedEventId) -> Self {
-        Self { event_id, in_reply_to: InReplyTo::new(reply_to_event_id), is_falling_back: true }
     }
 }
 

--- a/crates/ruma-common/src/events/room/encrypted.rs
+++ b/crates/ruma-common/src/events/room/encrypted.rs
@@ -8,8 +8,8 @@ use js_int::UInt;
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
-use super::message::{self, InReplyTo};
-use crate::{OwnedDeviceId, OwnedEventId};
+use super::message;
+use crate::{events::relation::InReplyTo, OwnedDeviceId, OwnedEventId};
 
 mod relation_serde;
 
@@ -130,9 +130,9 @@ impl<C> From<message::Relation<C>> for Relation {
 
 /// The event this relation belongs to [replaces another event].
 ///
-/// In contrast to [`message::Replacement`](super::message::Replacement), this struct doesn't
-/// store the new content, since that is part of the encrypted content of an `m.room.encrypted`
-/// events.
+/// In contrast to [`relation::Replacement`](crate::events::relation::Replacement), this struct
+/// doesn't store the new content, since that is part of the encrypted content of an
+/// `m.room.encrypted` events.
 ///
 /// [replaces another event]: https://spec.matrix.org/v1.4/client-server-api/#event-replacements
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/ruma-common/src/events/room/member.rs
+++ b/crates/ruma-common/src/events/room/member.rs
@@ -11,8 +11,8 @@ use serde_json::{from_str as from_json_str, value::RawValue as RawJsonValue};
 
 use crate::{
     events::{
-        AnyStrippedStateEvent, EventContent, RedactContent, RedactedEventContent,
-        RedactedStateEventContent, Relations, StateEventContent, StateEventType, StateUnsigned,
+        AnyStrippedStateEvent, BundledRelations, EventContent, RedactContent, RedactedEventContent,
+        RedactedStateEventContent, StateEventContent, StateEventType, StateUnsigned,
         StateUnsignedFromParts, StaticEventContent,
     },
     serde::{CanBeEmpty, Raw, StringEnum},
@@ -482,7 +482,7 @@ pub struct RoomMemberUnsigned {
     ///
     /// [Bundled aggregations]: https://spec.matrix.org/v1.4/client-server-api/#aggregations
     #[serde(rename = "m.relations", skip_serializing_if = "Option::is_none")]
-    pub relations: Option<Relations>,
+    pub relations: Option<BundledRelations>,
 }
 
 impl RoomMemberUnsigned {

--- a/crates/ruma-common/src/events/room/message.rs
+++ b/crates/ruma-common/src/events/room/message.rs
@@ -9,6 +9,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
 use crate::{
+    events::relation::{InReplyTo, Replacement, Thread},
     serde::{JsonObject, StringEnum},
     OwnedEventId, PrivOwnedStr,
 };
@@ -589,77 +590,6 @@ pub enum Relation<C> {
 
     #[doc(hidden)]
     _Custom,
-}
-
-/// Information about the event a "rich reply" is replying to.
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-pub struct InReplyTo {
-    /// The event being replied to.
-    pub event_id: OwnedEventId,
-}
-
-impl InReplyTo {
-    /// Creates a new `InReplyTo` with the given event ID.
-    pub fn new(event_id: OwnedEventId) -> Self {
-        Self { event_id }
-    }
-}
-
-/// The event this relation belongs to [replaces another event].
-///
-/// [replaces another event]: https://spec.matrix.org/v1.4/client-server-api/#event-replacements
-#[derive(Clone, Debug)]
-#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-pub struct Replacement<C> {
-    /// The ID of the event being replaced.
-    pub event_id: OwnedEventId,
-
-    /// New content.
-    pub new_content: C,
-}
-
-impl<C> Replacement<C> {
-    /// Creates a new `Replacement` with the given event ID and new content.
-    pub fn new(event_id: OwnedEventId, new_content: C) -> Self {
-        Self { event_id, new_content }
-    }
-}
-
-/// The content of a thread relation.
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-pub struct Thread {
-    /// The ID of the root message in the thread.
-    pub event_id: OwnedEventId,
-
-    /// A reply relation.
-    ///
-    /// If this event is a reply and belongs to a thread, this points to the message that is being
-    /// replied to, and `is_falling_back` must be set to `false`.
-    ///
-    /// If this event is not a reply, this is used as a fallback mechanism for clients that do not
-    /// support threads. This should point to the latest message-like event in the thread and
-    /// `is_falling_back` must be set to `true`.
-    pub in_reply_to: InReplyTo,
-
-    /// Whether the `m.in_reply_to` field is a fallback for older clients or a genuine reply in a
-    /// thread.
-    pub is_falling_back: bool,
-}
-
-impl Thread {
-    /// Convenience method to create a regular `Thread` with the given event ID and latest
-    /// message-like event ID.
-    pub fn plain(event_id: OwnedEventId, latest_event_id: OwnedEventId) -> Self {
-        Self { event_id, in_reply_to: InReplyTo::new(latest_event_id), is_falling_back: true }
-    }
-
-    /// Convenience method to create a reply `Thread` with the given event ID and replied-to event
-    /// ID.
-    pub fn reply(event_id: OwnedEventId, reply_to_event_id: OwnedEventId) -> Self {
-        Self { event_id, in_reply_to: InReplyTo::new(reply_to_event_id), is_falling_back: false }
-    }
 }
 
 /// The format for the formatted representation of a message body.

--- a/crates/ruma-common/src/events/unsigned.rs
+++ b/crates/ruma-common/src/events/unsigned.rs
@@ -2,7 +2,9 @@ use js_int::Int;
 use serde::{Deserialize, Serialize};
 use serde_json::{from_str as from_json_str, value::RawValue as RawJsonValue};
 
-use super::{relation::Relations, room::redaction::SyncRoomRedactionEvent, StateEventContent};
+use super::{
+    relation::BundledRelations, room::redaction::SyncRoomRedactionEvent, StateEventContent,
+};
 use crate::{
     serde::{CanBeEmpty, Raw},
     OwnedTransactionId,
@@ -29,7 +31,7 @@ pub struct MessageLikeUnsigned {
     ///
     /// [Bundled aggregations]: https://spec.matrix.org/v1.4/client-server-api/#aggregations
     #[serde(rename = "m.relations", skip_serializing_if = "Option::is_none")]
-    pub relations: Option<Relations>,
+    pub relations: Option<BundledRelations>,
 }
 
 impl MessageLikeUnsigned {
@@ -75,7 +77,7 @@ pub struct StateUnsigned<C: StateEventContent> {
     ///
     /// [Bundled aggregations]: https://spec.matrix.org/v1.4/client-server-api/#aggregations
     #[serde(rename = "m.relations", skip_serializing_if = "Option::is_none")]
-    pub relations: Option<Relations>,
+    pub relations: Option<BundledRelations>,
 }
 
 impl<C: StateEventContent> StateUnsigned<C> {
@@ -118,7 +120,7 @@ impl<C: StateEventContent> StateUnsignedFromParts for StateUnsigned<C> {
             transaction_id: Option<OwnedTransactionId>,
             prev_content: Option<Raw<C>>,
             #[serde(rename = "m.relations", skip_serializing_if = "Option::is_none")]
-            relations: Option<Relations>,
+            relations: Option<BundledRelations>,
         }
 
         let raw: WithRawPrevContent<C> = from_json_str(object.get())?;

--- a/crates/ruma-common/tests/events/audio.rs
+++ b/crates/ruma-common/tests/events/audio.rs
@@ -11,10 +11,9 @@ use ruma_common::{
         audio::{Amplitude, AudioContent, AudioEventContent, Waveform, WaveformError},
         file::{EncryptedContentInit, FileContent, FileContentInfo},
         message::MessageContent,
+        relation::InReplyTo,
         room::{
-            message::{
-                AudioMessageEventContent, InReplyTo, MessageType, Relation, RoomMessageEventContent,
-            },
+            message::{AudioMessageEventContent, MessageType, Relation, RoomMessageEventContent},
             JsonWebKeyInit, MediaSource,
         },
         AnyMessageLikeEvent, MessageLikeEvent, MessageLikeUnsigned, OriginalMessageLikeEvent,

--- a/crates/ruma-common/tests/events/encrypted.rs
+++ b/crates/ruma-common/tests/events/encrypted.rs
@@ -1,12 +1,12 @@
 use assert_matches::assert_matches;
 use ruma_common::{
     device_id, event_id,
-    events::room::{
-        encrypted::{
+    events::{
+        relation::InReplyTo,
+        room::encrypted::{
             EncryptedEventScheme, MegolmV1AesSha2ContentInit, Reference, Relation, Replacement,
             RoomEncryptedEventContent, Thread,
         },
-        message::InReplyTo,
     },
 };
 use serde_json::{from_value as from_json_value, json, to_value as to_json_value};

--- a/crates/ruma-common/tests/events/encrypted.rs
+++ b/crates/ruma-common/tests/events/encrypted.rs
@@ -2,10 +2,10 @@ use assert_matches::assert_matches;
 use ruma_common::{
     device_id, event_id,
     events::{
-        relation::InReplyTo,
+        relation::{InReplyTo, Reference, Thread},
         room::encrypted::{
-            EncryptedEventScheme, MegolmV1AesSha2ContentInit, Reference, Relation, Replacement,
-            RoomEncryptedEventContent, Thread,
+            EncryptedEventScheme, MegolmV1AesSha2ContentInit, Relation, Replacement,
+            RoomEncryptedEventContent,
         },
     },
 };
@@ -328,6 +328,7 @@ fn content_thread_serialization() {
             "m.relates_to": {
                 "rel_type": "m.thread",
                 "event_id": "$thread_root",
+                "is_falling_back": true,
                 "m.in_reply_to": {
                     "event_id": "$prev_event",
                 },
@@ -387,7 +388,7 @@ fn content_thread_deserialization() {
 #[test]
 #[cfg(feature = "unstable-msc2677")]
 fn content_annotation_serialization() {
-    use ruma_common::events::room::encrypted::Annotation;
+    use ruma_common::events::relation::Annotation;
 
     let content = RoomEncryptedEventContent::new(
         encrypted_scheme(),

--- a/crates/ruma-common/tests/events/file.rs
+++ b/crates/ruma-common/tests/events/file.rs
@@ -8,10 +8,9 @@ use ruma_common::{
     events::{
         file::{EncryptedContentInit, FileContentInfo, FileEventContent},
         message::MessageContent,
+        relation::InReplyTo,
         room::{
-            message::{
-                FileMessageEventContent, InReplyTo, MessageType, Relation, RoomMessageEventContent,
-            },
+            message::{FileMessageEventContent, MessageType, Relation, RoomMessageEventContent},
             EncryptedFileInit, JsonWebKeyInit, MediaSource,
         },
         AnyMessageLikeEvent, MessageLikeEvent, MessageLikeUnsigned, OriginalMessageLikeEvent,

--- a/crates/ruma-common/tests/events/image.rs
+++ b/crates/ruma-common/tests/events/image.rs
@@ -12,10 +12,9 @@ use ruma_common::{
             ThumbnailFileContentInfo,
         },
         message::MessageContent,
+        relation::InReplyTo,
         room::{
-            message::{
-                ImageMessageEventContent, InReplyTo, MessageType, Relation, RoomMessageEventContent,
-            },
+            message::{ImageMessageEventContent, MessageType, Relation, RoomMessageEventContent},
             JsonWebKeyInit, MediaSource,
         },
         AnyMessageLikeEvent, MessageLikeEvent, MessageLikeUnsigned, OriginalMessageLikeEvent,

--- a/crates/ruma-common/tests/events/location.rs
+++ b/crates/ruma-common/tests/events/location.rs
@@ -8,8 +8,9 @@ use ruma_common::{
     events::{
         location::{AssetType, LocationContent, LocationEventContent, ZoomLevel, ZoomLevelError},
         message::MessageContent,
+        relation::InReplyTo,
         room::message::{
-            InReplyTo, LocationMessageEventContent, MessageType, Relation, RoomMessageEventContent,
+            LocationMessageEventContent, MessageType, Relation, RoomMessageEventContent,
         },
         AnyMessageLikeEvent, MessageLikeEvent, MessageLikeUnsigned, OriginalMessageLikeEvent,
     },

--- a/crates/ruma-common/tests/events/message.rs
+++ b/crates/ruma-common/tests/events/message.rs
@@ -9,9 +9,8 @@ use ruma_common::{
         emote::EmoteEventContent,
         message::{MessageContent, MessageEventContent, Text},
         notice::NoticeEventContent,
-        room::message::{
-            EmoteMessageEventContent, InReplyTo, MessageType, Relation, RoomMessageEventContent,
-        },
+        relation::InReplyTo,
+        room::message::{EmoteMessageEventContent, MessageType, Relation, RoomMessageEventContent},
         AnyMessageLikeEvent, MessageLikeEvent, MessageLikeUnsigned, OriginalMessageLikeEvent,
     },
     room_id,

--- a/crates/ruma-common/tests/events/poll.rs
+++ b/crates/ruma-common/tests/events/poll.rs
@@ -14,8 +14,8 @@ use ruma_common::{
                 PollAnswer, PollAnswers, PollAnswersError, PollKind, PollStartContent,
                 PollStartEventContent,
             },
-            ReferenceRelation,
         },
+        relation::Reference,
         AnyMessageLikeEvent, MessageLikeEvent, MessageLikeUnsigned, OriginalMessageLikeEvent,
     },
     room_id, user_id, MilliSecondsSinceUnixEpoch,
@@ -318,7 +318,7 @@ fn response_event_unstable_deserialization() {
     assert_eq!(answers[0], "my-answer");
     let event_id = assert_matches!(
         message_event.content.relates_to,
-        ReferenceRelation { event_id, .. } => event_id
+        Reference { event_id, .. } => event_id
     );
     assert_eq!(event_id, "$related_event:notareal.hs");
 }
@@ -354,7 +354,7 @@ fn response_event_stable_deserialization() {
     assert_eq!(answers[1], "second-answer");
     let event_id = assert_matches!(
         message_event.content.relates_to,
-        ReferenceRelation { event_id, .. } => event_id
+        Reference { event_id, .. } => event_id
     );
     assert_eq!(event_id, "$related_event:notareal.hs");
 }
@@ -435,7 +435,7 @@ fn end_event_unstable_deserialization() {
     );
     let event_id = assert_matches!(
         message_event.content.relates_to,
-        ReferenceRelation { event_id, .. } => event_id
+        Reference { event_id, .. } => event_id
     );
     assert_eq!(event_id, "$related_event:notareal.hs");
 }
@@ -464,7 +464,7 @@ fn end_event_stable_deserialization() {
     );
     let event_id = assert_matches!(
         message_event.content.relates_to,
-        ReferenceRelation { event_id, .. } => event_id
+        Reference { event_id, .. } => event_id
     );
     assert_eq!(event_id, "$related_event:notareal.hs");
 }

--- a/crates/ruma-common/tests/events/relations.rs
+++ b/crates/ruma-common/tests/events/relations.rs
@@ -2,7 +2,10 @@ use assert_matches::assert_matches;
 use assign::assign;
 use ruma_common::{
     event_id,
-    events::room::message::{InReplyTo, MessageType, Relation, RoomMessageEventContent},
+    events::{
+        relation::{InReplyTo, Replacement, Thread},
+        room::message::{MessageType, Relation, RoomMessageEventContent},
+    },
 };
 use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
@@ -67,8 +70,6 @@ fn reply_serialize() {
 
 #[test]
 fn replacement_serialize() {
-    use ruma_common::events::room::message::Replacement;
-
     let content = assign!(
         RoomMessageEventContent::text_plain("<text msg>"),
         {
@@ -148,8 +149,6 @@ fn replacement_deserialize() {
 
 #[test]
 fn thread_plain_serialize() {
-    use ruma_common::events::room::message::Thread;
-
     let content = assign!(
         RoomMessageEventContent::text_plain("<text msg>"),
         {
@@ -200,8 +199,6 @@ fn thread_plain_serialize() {
 
 #[test]
 fn thread_reply_serialize() {
-    use ruma_common::events::room::message::Thread;
-
     let content = assign!(
         RoomMessageEventContent::text_plain("<text msg>"),
         {

--- a/crates/ruma-common/tests/events/video.rs
+++ b/crates/ruma-common/tests/events/video.rs
@@ -11,10 +11,9 @@ use ruma_common::{
         file::{EncryptedContentInit, FileContent, FileContentInfo},
         image::{ThumbnailContent, ThumbnailFileContent, ThumbnailFileContentInfo},
         message::MessageContent,
+        relation::InReplyTo,
         room::{
-            message::{
-                InReplyTo, MessageType, Relation, RoomMessageEventContent, VideoMessageEventContent,
-            },
+            message::{MessageType, Relation, RoomMessageEventContent, VideoMessageEventContent},
             JsonWebKeyInit, MediaSource,
         },
         video::{VideoContent, VideoEventContent},

--- a/crates/ruma-common/tests/events/voice.rs
+++ b/crates/ruma-common/tests/events/voice.rs
@@ -10,10 +10,9 @@ use ruma_common::{
     events::{
         audio::AudioContent,
         file::{FileContent, FileContentInfo},
+        relation::InReplyTo,
         room::{
-            message::{
-                AudioMessageEventContent, InReplyTo, MessageType, Relation, RoomMessageEventContent,
-            },
+            message::{AudioMessageEventContent, MessageType, Relation, RoomMessageEventContent},
             MediaSource,
         },
         voice::{VoiceContent, VoiceEventContent},

--- a/crates/ruma-common/tests/events/without_relation.rs
+++ b/crates/ruma-common/tests/events/without_relation.rs
@@ -1,7 +1,10 @@
 use assert_matches::assert_matches;
 use ruma_common::{
     event_id,
-    events::room::message::{InReplyTo, MessageType, Relation, RoomMessageEventContent},
+    events::{
+        relation::InReplyTo,
+        room::message::{MessageType, Relation, RoomMessageEventContent},
+    },
 };
 use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 

--- a/crates/ruma-macros/src/events/event_enum.rs
+++ b/crates/ruma-macros/src/events/event_enum.rs
@@ -595,7 +595,7 @@ fn expand_accessor_methods(
             }
 
             /// Returns this event's `relations` from inside `unsigned`, if that field exists.
-            pub fn relations(&self) -> Option<&#ruma_common::events::Relations> {
+            pub fn relations(&self) -> Option<&#ruma_common::events::BundledRelations> {
                 match self {
                     #(
                         #variants2(event) => {


### PR DESCRIPTION
Closes #1121. The title of the issue is to move `Relation` but I think it's okay to leave this enum in `room::message`, since other types might have a different list of acceptable relations (like `room::encrypted`).

By de-duplicating the code this fixes an issue that was in the `encrypted::Thread` constructors, but not in the `message::Thread` constructors.




<!-- Replace -->
----
Preview Removed
<!-- Replace -->
