### PR TITLE
Update tracing-subscriber dependency

### DIFF
--- a/crates/ruma-server-util/Cargo.toml
+++ b/crates/ruma-server-util/Cargo.toml
@@ -22,4 +22,4 @@ tracing = { workspace = true }
 yap = "0.8.0"
 
 [dev-dependencies]
-tracing-subscriber = "0.3.3"
+tracing-subscriber = "0.3.16"

--- a/crates/ruma-state-res/Cargo.toml
+++ b/crates/ruma-state-res/Cargo.toml
@@ -33,7 +33,7 @@ criterion = { workspace = true, optional = true }
 maplit = { workspace = true }
 rand = "0.8.3"
 ruma-common = { version = "0.10.5", path = "../ruma-common", features = ["unstable-pdu"] }
-tracing-subscriber = "0.3.3"
+tracing-subscriber = "0.3.16"
 
 [[bench]]
 name = "state_res_bench"


### PR DESCRIPTION
Removes dependency to ansi_term which is unmaintained.

Closes #1267.




<!-- Replace -->
----
Preview Removed
<!-- Replace -->
