### PR TITLE
events: Remove the Redact trait

### DIFF
--- a/crates/ruma-common/src/events.rs
+++ b/crates/ruma-common/src/events.rs
@@ -104,7 +104,6 @@
 
 use serde::{de::IgnoredAny, Deserialize, Serializer};
 
-use self::room::redaction::SyncRoomRedactionEvent;
 use crate::{EventEncryptionAlgorithm, RoomVersionId};
 
 // Needs to be public for trybuild tests
@@ -177,18 +176,6 @@ pub use self::{
     unsigned::{MessageLikeUnsigned, RedactedUnsigned, StateUnsigned, StateUnsignedFromParts},
 };
 
-/// Trait to define the behavior of redacting an event.
-pub trait Redact {
-    /// The redacted form of the event.
-    type Redacted;
-
-    /// Transforms `self` into a redacted form (removing most fields) according to the spec.
-    ///
-    /// A small number of events have room-version specific redaction behavior, so a version has to
-    /// be specified.
-    fn redact(self, redaction: SyncRoomRedactionEvent, version: &RoomVersionId) -> Self::Redacted;
-}
-
 /// Trait to define the behavior of redact an event's content object.
 pub trait RedactContent {
     /// The redacted form of the event's content.
@@ -198,8 +185,6 @@ pub trait RedactContent {
     ///
     /// A small number of events have room-version specific redaction behavior, so a version has to
     /// be specified.
-    ///
-    /// Where applicable, it is preferred to use [`Redact::redact`] on the outer event.
     fn redact(self, version: &RoomVersionId) -> Self::Redacted;
 }
 

--- a/crates/ruma-common/src/events/enums.rs
+++ b/crates/ruma-common/src/events/enums.rs
@@ -2,13 +2,10 @@ use ruma_macros::{event_enum, EventEnumFromEvent};
 use serde::{de, Deserialize};
 use serde_json::value::RawValue as RawJsonValue;
 
-use super::{
-    room::{encrypted, redaction::SyncRoomRedactionEvent},
-    BundledRelations, Redact,
-};
+use super::{room::encrypted, BundledRelations};
 use crate::{
     serde::from_raw_json_value, EventId, MilliSecondsSinceUnixEpoch, OwnedRoomId, RoomId,
-    RoomVersionId, TransactionId, UserId,
+    TransactionId, UserId,
 };
 
 event_enum! {
@@ -268,34 +265,6 @@ impl<'de> Deserialize<'de> for AnySyncTimelineEvent {
             Ok(AnySyncTimelineEvent::State(from_raw_json_value(&json)?))
         } else {
             Ok(AnySyncTimelineEvent::MessageLike(from_raw_json_value(&json)?))
-        }
-    }
-}
-
-impl Redact for AnyTimelineEvent {
-    type Redacted = Self;
-
-    /// Redacts `self`, referencing the given event in `unsigned.redacted_because`.
-    ///
-    /// Does nothing for events that are already redacted.
-    fn redact(self, redaction: SyncRoomRedactionEvent, version: &RoomVersionId) -> Self {
-        match self {
-            Self::MessageLike(ev) => Self::MessageLike(ev.redact(redaction, version)),
-            Self::State(ev) => Self::State(ev.redact(redaction, version)),
-        }
-    }
-}
-
-impl Redact for AnySyncTimelineEvent {
-    type Redacted = Self;
-
-    /// Redacts `self`, referencing the given event in `unsigned.redacted_because`.
-    ///
-    /// Does nothing for events that are already redacted.
-    fn redact(self, redaction: SyncRoomRedactionEvent, version: &RoomVersionId) -> Self {
-        match self {
-            Self::MessageLike(ev) => Self::MessageLike(ev.redact(redaction, version)),
-            Self::State(ev) => Self::State(ev.redact(redaction, version)),
         }
     }
 }

--- a/crates/ruma-common/src/events/kinds.rs
+++ b/crates/ruma-common/src/events/kinds.rs
@@ -5,15 +5,15 @@ use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::value::RawValue as RawJsonValue;
 
 use super::{
-    room::redaction::SyncRoomRedactionEvent, EphemeralRoomEventContent, EventContent,
-    GlobalAccountDataEventContent, MessageLikeEventContent, MessageLikeEventType,
-    MessageLikeUnsigned, Redact, RedactContent, RedactedMessageLikeEventContent,
-    RedactedStateEventContent, RedactedUnsigned, RedactionDeHelper, RoomAccountDataEventContent,
-    StateEventContent, StateEventType, ToDeviceEventContent,
+    EphemeralRoomEventContent, EventContent, GlobalAccountDataEventContent,
+    MessageLikeEventContent, MessageLikeEventType, MessageLikeUnsigned, RedactContent,
+    RedactedMessageLikeEventContent, RedactedStateEventContent, RedactedUnsigned,
+    RedactionDeHelper, RoomAccountDataEventContent, StateEventContent, StateEventType,
+    ToDeviceEventContent,
 };
 use crate::{
     serde::from_raw_json_value, EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId,
-    OwnedUserId, RoomId, RoomVersionId, UserId,
+    OwnedUserId, RoomId, UserId,
 };
 
 /// A global account data event.
@@ -454,22 +454,6 @@ macro_rules! impl_possibly_redacted_event {
 
             // So the room_id method can be in the same impl block, in rustdoc
             $($extra)*
-        }
-
-        impl<C> Redact for $ty<C>
-        where
-            C: $content_trait + RedactContent,
-            C::Redacted: $redacted_content_trait,
-            $( C::Redacted: $trait<StateKey = C::StateKey>, )?
-        {
-            type Redacted = Self;
-
-            fn redact(self, redaction: SyncRoomRedactionEvent, version: &RoomVersionId) -> Self {
-                match self {
-                    Self::Original(ev) => Self::Redacted(ev.redact(redaction, version)),
-                    Self::Redacted(ev) => Self::Redacted(ev),
-                }
-            }
         }
 
         impl<'de, C> Deserialize<'de> for $ty<C>

--- a/crates/ruma-macros/src/events/event_parse.rs
+++ b/crates/ruma-macros/src/events/event_parse.rs
@@ -55,14 +55,6 @@ impl EventKindVariation {
         matches!(self, Self::OriginalSync | Self::RedactedSync)
     }
 
-    pub fn to_redacted(self) -> Self {
-        match self {
-            EventKindVariation::Original => EventKindVariation::Redacted,
-            EventKindVariation::OriginalSync => EventKindVariation::RedactedSync,
-            _ => panic!("No redacted form of {self:?}"),
-        }
-    }
-
     pub fn to_full(self) -> Self {
         match self {
             EventKindVariation::OriginalSync => EventKindVariation::Original,


### PR DESCRIPTION
It has not proven to be useful, being used by no downstream project.




<!-- Replace -->
----
Preview: https://pr-1401--ruma-docs.surge.sh
<!-- Replace -->
