### PR TITLE
client-api: Clarify that get_context always returns 'event' even if limit is zero

### DIFF
--- a/crates/ruma-client-api/src/context/get_context.rs
+++ b/crates/ruma-client-api/src/context/get_context.rs
@@ -39,7 +39,10 @@ pub mod v3 {
         #[ruma_api(path)]
         pub event_id: OwnedEventId,
 
-        /// The maximum number of events to return.
+        /// The maximum number of context events to return.
+        ///
+        /// This limit applies to the sum of the `events_before` and `events_after` arrays. The
+        /// requested event ID is always returned in `event` even if the limit is `0`.
         ///
         /// Defaults to 10.
         #[ruma_api(query)]


### PR DESCRIPTION
[Spec PR](https://github.com/matrix-org/matrix-spec/pull/1239).

Part of #1400.




<!-- Replace -->
----
Preview: https://pr-1402--ruma-docs.surge.sh
<!-- Replace -->
