### PR TITLE
events: Remove Serialize impls for all event types except ToDeviceEvent

### DIFF
--- a/crates/ruma-common/src/events/direct.rs
+++ b/crates/ruma-common/src/events/direct.rs
@@ -51,19 +51,15 @@ mod tests {
         let mut content = DirectEventContent(BTreeMap::new());
         let server_name = server_name!("ruma.io");
         let alice = UserId::new(server_name);
-        let room = vec![RoomId::new(server_name)];
+        let rooms = vec![RoomId::new(server_name)];
 
-        content.insert(alice.clone(), room.clone());
+        content.insert(alice.clone(), rooms.clone());
 
-        let event = DirectEvent { content };
         let json_data = json!({
-            "content": {
-                alice.to_string(): vec![room[0].to_string()],
-            },
-            "type": "m.direct"
+            alice.to_string(): rooms,
         });
 
-        assert_eq!(to_json_value(&event).unwrap(), json_data);
+        assert_eq!(to_json_value(&content).unwrap(), json_data);
     }
 
     #[test]

--- a/crates/ruma-common/src/events/ignored_user_list.rs
+++ b/crates/ruma-common/src/events/ignored_user_list.rs
@@ -55,29 +55,20 @@ mod tests {
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     use super::IgnoredUserListEventContent;
-    use crate::{
-        events::{AnyGlobalAccountDataEvent, GlobalAccountDataEvent},
-        user_id,
-    };
+    use crate::{events::AnyGlobalAccountDataEvent, user_id};
 
     #[test]
     fn serialization() {
-        let ignored_user_list_event = GlobalAccountDataEvent {
-            content: IgnoredUserListEventContent::users(vec![
-                user_id!("@carl:example.com").to_owned()
-            ]),
-        };
+        let ignored_user_list =
+            IgnoredUserListEventContent::users(vec![user_id!("@carl:example.com").to_owned()]);
 
         let json = json!({
-            "content": {
-                "ignored_users": {
-                    "@carl:example.com": {}
-                }
+            "ignored_users": {
+                "@carl:example.com": {}
             },
-            "type": "m.ignored_user_list"
         });
 
-        assert_eq!(to_json_value(ignored_user_list_event).unwrap(), json);
+        assert_eq!(to_json_value(ignored_user_list).unwrap(), json);
     }
 
     #[test]

--- a/crates/ruma-common/src/events/key/verification/accept.rs
+++ b/crates/ruma-common/src/events/key/verification/accept.rs
@@ -177,7 +177,6 @@ mod tests {
         event_id,
         events::{relation::Reference, ToDeviceEvent},
         serde::Base64,
-        user_id,
     };
 
     #[test]
@@ -193,37 +192,22 @@ mod tests {
             }),
         };
 
-        let sender = user_id!("@example:localhost").to_owned();
-
         let json_data = json!({
-            "content": {
-                "transaction_id": "456",
-                "method": "m.sas.v1",
-                "commitment": "aGVsbG8",
-                "key_agreement_protocol": "curve25519",
-                "hash": "sha256",
-                "message_authentication_code": "hkdf-hmac-sha256",
-                "short_authentication_string": ["decimal"]
-            },
-            "sender": sender,
-            "type": "m.key.verification.accept"
+            "transaction_id": "456",
+            "method": "m.sas.v1",
+            "commitment": "aGVsbG8",
+            "key_agreement_protocol": "curve25519",
+            "hash": "sha256",
+            "message_authentication_code": "hkdf-hmac-sha256",
+            "short_authentication_string": ["decimal"]
         });
 
-        let key_verification_accept =
-            ToDeviceEvent { sender, content: key_verification_accept_content };
-
-        assert_eq!(to_json_value(&key_verification_accept).unwrap(), json_data);
-
-        let sender = user_id!("@example:localhost").to_owned();
+        assert_eq!(to_json_value(&key_verification_accept_content).unwrap(), json_data);
 
         let json_data = json!({
-            "content": {
-                "transaction_id": "456",
-                "method": "m.sas.custom",
-                "test": "field",
-            },
-            "sender": sender,
-            "type": "m.key.verification.accept"
+            "transaction_id": "456",
+            "method": "m.sas.custom",
+            "test": "field",
         });
 
         let key_verification_accept_content = ToDeviceKeyVerificationAcceptEventContent {
@@ -236,10 +220,7 @@ mod tests {
             }),
         };
 
-        let key_verification_accept =
-            ToDeviceEvent { sender, content: key_verification_accept_content };
-
-        assert_eq!(to_json_value(&key_verification_accept).unwrap(), json_data);
+        assert_eq!(to_json_value(&key_verification_accept_content).unwrap(), json_data);
     }
 
     #[test]

--- a/crates/ruma-common/src/events/key/verification/start.rs
+++ b/crates/ruma-common/src/events/key/verification/start.rs
@@ -219,7 +219,6 @@ mod tests {
         event_id,
         events::{relation::Reference, ToDeviceEvent},
         serde::Base64,
-        user_id,
     };
 
     #[test]
@@ -238,38 +237,23 @@ mod tests {
             ),
         };
 
-        let sender = user_id!("@example:localhost").to_owned();
-
         let json_data = json!({
-            "content": {
-                "from_device": "123",
-                "transaction_id": "456",
-                "method": "m.sas.v1",
-                "key_agreement_protocols": ["curve25519"],
-                "hashes": ["sha256"],
-                "message_authentication_codes": ["hkdf-hmac-sha256"],
-                "short_authentication_string": ["decimal"]
-            },
-            "type": "m.key.verification.start",
-            "sender": sender
+            "from_device": "123",
+            "transaction_id": "456",
+            "method": "m.sas.v1",
+            "key_agreement_protocols": ["curve25519"],
+            "hashes": ["sha256"],
+            "message_authentication_codes": ["hkdf-hmac-sha256"],
+            "short_authentication_string": ["decimal"]
         });
 
-        let key_verification_start =
-            ToDeviceEvent { sender, content: key_verification_start_content };
-
-        assert_eq!(to_json_value(&key_verification_start).unwrap(), json_data);
-
-        let sender = user_id!("@example:localhost").to_owned();
+        assert_eq!(to_json_value(&key_verification_start_content).unwrap(), json_data);
 
         let json_data = json!({
-            "content": {
-                "from_device": "123",
-                "transaction_id": "456",
-                "method": "m.sas.custom",
-                "test": "field",
-            },
-            "type": "m.key.verification.start",
-            "sender": sender
+            "from_device": "123",
+            "transaction_id": "456",
+            "method": "m.sas.custom",
+            "test": "field",
         });
 
         let key_verification_start_content = ToDeviceKeyVerificationStartEventContent {
@@ -283,10 +267,7 @@ mod tests {
             }),
         };
 
-        let key_verification_start =
-            ToDeviceEvent { sender, content: key_verification_start_content };
-
-        assert_eq!(to_json_value(&key_verification_start).unwrap(), json_data);
+        assert_eq!(to_json_value(&key_verification_start_content).unwrap(), json_data);
 
         {
             let secret = Base64::new(b"This is a secret to everybody".to_vec());

--- a/crates/ruma-common/src/events/policy/rule/room.rs
+++ b/crates/ruma-common/src/events/policy/rule/room.rs
@@ -17,55 +17,29 @@ pub struct PolicyRuleRoomEventContent(pub PolicyRuleEventContent);
 
 #[cfg(test)]
 mod tests {
-    use js_int::int;
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     use super::{OriginalPolicyRuleRoomEvent, PolicyRuleRoomEventContent};
     use crate::{
-        event_id,
-        events::{
-            policy::rule::{PolicyRuleEventContent, Recommendation},
-            StateUnsigned,
-        },
-        room_id,
+        events::policy::rule::{PolicyRuleEventContent, Recommendation},
         serde::Raw,
-        user_id, MilliSecondsSinceUnixEpoch,
     };
 
     #[test]
     fn serialization() {
-        let room_event = OriginalPolicyRuleRoomEvent {
-            event_id: event_id!("$143273582443PhrSn:example.org").to_owned(),
-            sender: user_id!("@example:example.org").to_owned(),
-            origin_server_ts: MilliSecondsSinceUnixEpoch(1_432_735_824_653_u64.try_into().unwrap()),
-            room_id: room_id!("!jEsUZKDJdhlrceRyVU:example.org").to_owned(),
-            state_key: "rule:#*:example.org".into(),
-            unsigned: StateUnsigned { age: Some(int!(1234)), ..StateUnsigned::default() },
-            content: PolicyRuleRoomEventContent(PolicyRuleEventContent {
-                entity: "#*:example.org".into(),
-                reason: "undesirable content".into(),
-                recommendation: Recommendation::Ban,
-            }),
-        };
-
-        let json = json!({
-            "content": {
-                "entity": "#*:example.org",
-                "reason": "undesirable content",
-                "recommendation": "m.ban"
-            },
-            "event_id": "$143273582443PhrSn:example.org",
-            "origin_server_ts": 1_432_735_824_653_u64,
-            "room_id": "!jEsUZKDJdhlrceRyVU:example.org",
-            "sender": "@example:example.org",
-            "state_key": "rule:#*:example.org",
-            "type": "m.policy.rule.room",
-            "unsigned": {
-                "age": 1234
-            }
+        let content = PolicyRuleRoomEventContent(PolicyRuleEventContent {
+            entity: "#*:example.org".into(),
+            reason: "undesirable content".into(),
+            recommendation: Recommendation::Ban,
         });
 
-        assert_eq!(to_json_value(room_event).unwrap(), json);
+        let json = json!({
+            "entity": "#*:example.org",
+            "reason": "undesirable content",
+            "recommendation": "m.ban"
+        });
+
+        assert_eq!(to_json_value(content).unwrap(), json);
     }
 
     #[test]

--- a/crates/ruma-common/src/events/presence.rs
+++ b/crates/ruma-common/src/events/presence.rs
@@ -83,35 +83,28 @@ mod tests {
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     use super::{PresenceEvent, PresenceEventContent};
-    use crate::{mxc_uri, presence::PresenceState, user_id};
+    use crate::{mxc_uri, presence::PresenceState};
 
     #[test]
     fn serialization() {
-        let event = PresenceEvent {
-            content: PresenceEventContent {
-                avatar_url: Some(mxc_uri!("mxc://localhost/wefuiwegh8742w").to_owned()),
-                currently_active: Some(false),
-                displayname: None,
-                last_active_ago: Some(uint!(2_478_593)),
-                presence: PresenceState::Online,
-                status_msg: Some("Making cupcakes".into()),
-            },
-            sender: user_id!("@example:localhost").to_owned(),
+        let content = PresenceEventContent {
+            avatar_url: Some(mxc_uri!("mxc://localhost/wefuiwegh8742w").to_owned()),
+            currently_active: Some(false),
+            displayname: None,
+            last_active_ago: Some(uint!(2_478_593)),
+            presence: PresenceState::Online,
+            status_msg: Some("Making cupcakes".into()),
         };
 
         let json = json!({
-            "content": {
-                "avatar_url": "mxc://localhost/wefuiwegh8742w",
-                "currently_active": false,
-                "last_active_ago": 2_478_593,
-                "presence": "online",
-                "status_msg": "Making cupcakes"
-            },
-            "sender": "@example:localhost",
-            "type": "m.presence"
+            "avatar_url": "mxc://localhost/wefuiwegh8742w",
+            "currently_active": false,
+            "last_active_ago": 2_478_593,
+            "presence": "online",
+            "status_msg": "Making cupcakes"
         });
 
-        assert_eq!(to_json_value(&event).unwrap(), json);
+        assert_eq!(to_json_value(&content).unwrap(), json);
     }
 
     #[test]

--- a/crates/ruma-common/src/events/room/canonical_alias.rs
+++ b/crates/ruma-common/src/events/room/canonical_alias.rs
@@ -39,42 +39,21 @@ impl RoomCanonicalAliasEventContent {
 
 #[cfg(test)]
 mod tests {
-    use js_int::uint;
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     use super::RoomCanonicalAliasEventContent;
-    use crate::{
-        event_id,
-        events::{EmptyStateKey, OriginalStateEvent, StateUnsigned},
-        room_alias_id, room_id, user_id, MilliSecondsSinceUnixEpoch,
-    };
+    use crate::{events::OriginalStateEvent, room_alias_id};
 
     #[test]
     fn serialization_with_optional_fields_as_none() {
-        let canonical_alias_event = OriginalStateEvent {
-            content: RoomCanonicalAliasEventContent {
-                alias: Some(room_alias_id!("#somewhere:localhost").to_owned()),
-                alt_aliases: Vec::new(),
-            },
-            event_id: event_id!("$h29iv0s8:example.com").to_owned(),
-            origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(1)),
-            room_id: room_id!("!dummy:example.com").to_owned(),
-            sender: user_id!("@carl:example.com").to_owned(),
-            state_key: EmptyStateKey,
-            unsigned: StateUnsigned::default(),
+        let content = RoomCanonicalAliasEventContent {
+            alias: Some(room_alias_id!("#somewhere:localhost").to_owned()),
+            alt_aliases: Vec::new(),
         };
 
-        let actual = to_json_value(&canonical_alias_event).unwrap();
+        let actual = to_json_value(&content).unwrap();
         let expected = json!({
-            "content": {
-                "alias": "#somewhere:localhost"
-            },
-            "event_id": "$h29iv0s8:example.com",
-            "origin_server_ts": 1,
-            "room_id": "!dummy:example.com",
-            "sender": "@carl:example.com",
-            "state_key": "",
-            "type": "m.room.canonical_alias"
+            "alias": "#somewhere:localhost",
         });
 
         assert_eq!(actual, expected);

--- a/crates/ruma-common/src/events/room/name.rs
+++ b/crates/ruma-common/src/events/room/name.rs
@@ -30,41 +30,18 @@ impl RoomNameEventContent {
 #[cfg(test)]
 mod tests {
     use assert_matches::assert_matches;
-    use js_int::{int, uint};
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     use super::RoomNameEventContent;
-    use crate::{
-        event_id,
-        events::{EmptyStateKey, OriginalStateEvent, StateUnsigned},
-        room_id,
-        serde::Raw,
-        user_id, MilliSecondsSinceUnixEpoch,
-    };
+    use crate::{events::OriginalStateEvent, serde::Raw};
 
     #[test]
     fn serialization_with_optional_fields_as_none() {
-        let name_event = OriginalStateEvent {
-            content: RoomNameEventContent { name: Some("The room name".to_owned()) },
-            event_id: event_id!("$h29iv0s8:example.com").to_owned(),
-            origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(1)),
-            room_id: room_id!("!n8f893n9:example.com").to_owned(),
-            sender: user_id!("@carl:example.com").to_owned(),
-            state_key: EmptyStateKey,
-            unsigned: StateUnsigned::default(),
-        };
+        let content = RoomNameEventContent { name: Some("The room name".to_owned()) };
 
-        let actual = to_json_value(&name_event).unwrap();
+        let actual = to_json_value(&content).unwrap();
         let expected = json!({
-            "content": {
-                "name": "The room name"
-            },
-            "event_id": "$h29iv0s8:example.com",
-            "origin_server_ts": 1,
-            "room_id": "!n8f893n9:example.com",
-            "sender": "@carl:example.com",
-            "state_key": "",
-            "type": "m.room.name"
+            "name": "The room name",
         });
 
         assert_eq!(actual, expected);
@@ -72,35 +49,11 @@ mod tests {
 
     #[test]
     fn serialization_with_all_fields() {
-        let name_event = OriginalStateEvent {
-            content: RoomNameEventContent { name: Some("The room name".to_owned()) },
-            event_id: event_id!("$h29iv0s8:example.com").to_owned(),
-            origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(1)),
-            room_id: room_id!("!n8f893n9:example.com").to_owned(),
-            sender: user_id!("@carl:example.com").to_owned(),
-            state_key: EmptyStateKey,
-            unsigned: StateUnsigned {
-                age: Some(int!(100)),
-                prev_content: Some(RoomNameEventContent { name: Some("The old name".to_owned()) }),
-                ..StateUnsigned::default()
-            },
-        };
+        let content = RoomNameEventContent { name: Some("The room name".to_owned()) };
 
-        let actual = to_json_value(&name_event).unwrap();
+        let actual = to_json_value(&content).unwrap();
         let expected = json!({
-            "content": {
-                "name": "The room name"
-            },
-            "event_id": "$h29iv0s8:example.com",
-            "origin_server_ts": 1,
-            "room_id": "!n8f893n9:example.com",
-            "sender": "@carl:example.com",
-            "state_key": "",
-            "type": "m.room.name",
-            "unsigned": {
-                "age": 100,
-                "prev_content": { "name": "The old name" },
-            }
+            "name": "The room name",
         });
 
         assert_eq!(actual, expected);

--- a/crates/ruma-common/src/events/room/pinned_events.rs
+++ b/crates/ruma-common/src/events/room/pinned_events.rs
@@ -28,10 +28,7 @@ impl RoomPinnedEventsEventContent {
 #[cfg(all(test, feature = "rand"))]
 mod tests {
     use super::RoomPinnedEventsEventContent;
-    use crate::{
-        events::{EmptyStateKey, OriginalStateEvent, StateUnsigned},
-        server_name, EventId, MilliSecondsSinceUnixEpoch, RoomId, UserId,
-    };
+    use crate::{server_name, EventId};
 
     #[test]
     fn serialization_deserialization() {
@@ -42,28 +39,10 @@ mod tests {
         content.pinned.push(EventId::new(server_name));
         content.pinned.push(EventId::new(server_name));
 
-        let event = OriginalStateEvent {
-            content: content.clone(),
-            event_id: EventId::new(server_name),
-            origin_server_ts: MilliSecondsSinceUnixEpoch(1_432_804_485_886_u64.try_into().unwrap()),
-            room_id: RoomId::new(server_name),
-            sender: UserId::new(server_name),
-            state_key: EmptyStateKey,
-            unsigned: StateUnsigned::default(),
-        };
+        let serialized = serde_json::to_string(&content).unwrap();
+        let parsed_content: RoomPinnedEventsEventContent =
+            serde_json::from_str(&serialized).unwrap();
 
-        let serialized_event = serde_json::to_string(&event).unwrap();
-        let parsed_event: OriginalStateEvent<RoomPinnedEventsEventContent> =
-            serde_json::from_str(&serialized_event).unwrap();
-
-        assert_eq!(parsed_event.event_id, event.event_id);
-        assert_eq!(parsed_event.room_id, event.room_id);
-        assert_eq!(parsed_event.sender, event.sender);
-        assert_eq!(parsed_event.state_key, event.state_key);
-        assert_eq!(parsed_event.origin_server_ts, event.origin_server_ts);
-
-        assert_eq!(parsed_event.content.pinned, event.content.pinned);
-        assert_eq!(parsed_event.content.pinned[0], content.pinned[0]);
-        assert_eq!(parsed_event.content.pinned[1], content.pinned[1]);
+        assert_eq!(parsed_content.pinned, content.pinned);
     }
 }

--- a/crates/ruma-common/src/events/room/power_levels.rs
+++ b/crates/ruma-common/src/events/room/power_levels.rs
@@ -351,52 +351,32 @@ mod tests {
     use std::collections::BTreeMap;
 
     use assign::assign;
-    use js_int::{int, uint};
+    use js_int::int;
     use maplit::btreemap;
     use serde_json::{json, to_value as to_json_value};
 
     use super::{default_power_level, NotificationPowerLevels, RoomPowerLevelsEventContent};
-    use crate::{
-        event_id,
-        events::{EmptyStateKey, OriginalStateEvent, StateUnsigned},
-        room_id, user_id, MilliSecondsSinceUnixEpoch,
-    };
+    use crate::user_id;
 
     #[test]
     fn serialization_with_optional_fields_as_none() {
         let default = default_power_level();
 
-        let power_levels_event = OriginalStateEvent {
-            content: RoomPowerLevelsEventContent {
-                ban: default,
-                events: BTreeMap::new(),
-                events_default: int!(0),
-                invite: int!(0),
-                kick: default,
-                redact: default,
-                state_default: default,
-                users: BTreeMap::new(),
-                users_default: int!(0),
-                notifications: NotificationPowerLevels::default(),
-            },
-            event_id: event_id!("$h29iv0s8:example.com").to_owned(),
-            origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(1)),
-            room_id: room_id!("!n8f893n9:example.com").to_owned(),
-            unsigned: StateUnsigned::default(),
-            sender: user_id!("@carl:example.com").to_owned(),
-            state_key: EmptyStateKey,
+        let power_levels = RoomPowerLevelsEventContent {
+            ban: default,
+            events: BTreeMap::new(),
+            events_default: int!(0),
+            invite: int!(0),
+            kick: default,
+            redact: default,
+            state_default: default,
+            users: BTreeMap::new(),
+            users_default: int!(0),
+            notifications: NotificationPowerLevels::default(),
         };
 
-        let actual = to_json_value(&power_levels_event).unwrap();
-        let expected = json!({
-            "content": {},
-            "event_id": "$h29iv0s8:example.com",
-            "origin_server_ts": 1,
-            "room_id": "!n8f893n9:example.com",
-            "sender": "@carl:example.com",
-            "state_key": "",
-            "type": "m.room.power_levels"
-        });
+        let actual = to_json_value(&power_levels).unwrap();
+        let expected = json!({});
 
         assert_eq!(actual, expected);
     }
@@ -404,99 +384,41 @@ mod tests {
     #[test]
     fn serialization_with_all_fields() {
         let user = user_id!("@carl:example.com");
-        let power_levels_event = OriginalStateEvent {
-            content: RoomPowerLevelsEventContent {
-                ban: int!(23),
-                events: btreemap! {
-                    "m.dummy".into() => int!(23)
-                },
-                events_default: int!(23),
-                invite: int!(23),
-                kick: int!(23),
-                redact: int!(23),
-                state_default: int!(23),
-                users: btreemap! {
-                    user.to_owned() => int!(23)
-                },
-                users_default: int!(23),
-                notifications: assign!(NotificationPowerLevels::new(), { room: int!(23) }),
+        let power_levels_event = RoomPowerLevelsEventContent {
+            ban: int!(23),
+            events: btreemap! {
+                "m.dummy".into() => int!(23)
             },
-            event_id: event_id!("$h29iv0s8:example.com").to_owned(),
-            origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(1)),
-            room_id: room_id!("!n8f893n9:example.com").to_owned(),
-            unsigned: StateUnsigned {
-                age: Some(int!(100)),
-                prev_content: Some(RoomPowerLevelsEventContent {
-                    // Make just one field different so we at least know they're two different
-                    // objects.
-                    ban: int!(42),
-                    events: btreemap! {
-                        "m.dummy".into() => int!(42)
-                    },
-                    events_default: int!(42),
-                    invite: int!(42),
-                    kick: int!(42),
-                    redact: int!(42),
-                    state_default: int!(42),
-                    users: btreemap! {
-                        user.to_owned() => int!(42)
-                    },
-                    users_default: int!(42),
-                    notifications: assign!(NotificationPowerLevels::new(), { room: int!(42) }),
-                }),
-                ..StateUnsigned::default()
+            events_default: int!(23),
+            invite: int!(23),
+            kick: int!(23),
+            redact: int!(23),
+            state_default: int!(23),
+            users: btreemap! {
+                user.to_owned() => int!(23)
             },
-            sender: user.to_owned(),
-            state_key: EmptyStateKey,
+            users_default: int!(23),
+            notifications: assign!(NotificationPowerLevels::new(), { room: int!(23) }),
         };
 
         let actual = to_json_value(&power_levels_event).unwrap();
         let expected = json!({
-            "content": {
-                "ban": 23,
-                "events": {
-                    "m.dummy": 23
-                },
-                "events_default": 23,
-                "invite": 23,
-                "kick": 23,
-                "redact": 23,
-                "state_default": 23,
-                "users": {
-                    "@carl:example.com": 23
-                },
-                "users_default": 23,
-                "notifications": {
-                    "room": 23
-                }
+            "ban": 23,
+            "events": {
+                "m.dummy": 23
             },
-            "event_id": "$h29iv0s8:example.com",
-            "origin_server_ts": 1,
-            "room_id": "!n8f893n9:example.com",
-            "sender": "@carl:example.com",
-            "state_key": "",
-            "type": "m.room.power_levels",
-            "unsigned": {
-                "age": 100,
-                "prev_content": {
-                    "ban": 42,
-                    "events": {
-                        "m.dummy": 42
-                    },
-                    "events_default": 42,
-                    "invite": 42,
-                    "kick": 42,
-                    "redact": 42,
-                    "state_default": 42,
-                    "users": {
-                        "@carl:example.com": 42
-                    },
-                    "users_default": 42,
-                    "notifications": {
-                        "room": 42
-                    },
-                },
-            }
+            "events_default": 23,
+            "invite": 23,
+            "kick": 23,
+            "redact": 23,
+            "state_default": 23,
+            "users": {
+                "@carl:example.com": 23
+            },
+            "users_default": 23,
+            "notifications": {
+                "room": 23
+            },
         });
 
         assert_eq!(actual, expected);

--- a/crates/ruma-common/src/events/room/redaction.rs
+++ b/crates/ruma-common/src/events/room/redaction.rs
@@ -17,8 +17,7 @@ use crate::{
 
 /// A possibly-redacted redaction event.
 #[allow(clippy::exhaustive_enums)]
-#[derive(Clone, Debug, Serialize)]
-#[serde(untagged)]
+#[derive(Clone, Debug)]
 pub enum RoomRedactionEvent {
     /// Original, unredacted form of the event.
     Original(OriginalRoomRedactionEvent),
@@ -29,8 +28,7 @@ pub enum RoomRedactionEvent {
 
 /// A possibly-redacted redaction event without a `room_id`.
 #[allow(clippy::exhaustive_enums)]
-#[derive(Clone, Debug, Serialize)]
-#[serde(untagged)]
+#[derive(Clone, Debug)]
 pub enum SyncRoomRedactionEvent {
     /// Original, unredacted form of the event.
     Original(OriginalSyncRoomRedactionEvent),

--- a/crates/ruma-common/src/events/room_key.rs
+++ b/crates/ruma-common/src/events/room_key.rs
@@ -44,35 +44,27 @@ impl ToDeviceRoomKeyEventContent {
 
 #[cfg(test)]
 mod tests {
-    use crate::{room_id, user_id, EventEncryptionAlgorithm};
+    use crate::{room_id, EventEncryptionAlgorithm};
     use serde_json::{json, to_value as to_json_value};
 
     use super::ToDeviceRoomKeyEventContent;
-    use crate::events::ToDeviceEvent;
 
     #[test]
     fn serialization() {
-        let ev = ToDeviceEvent {
-            content: ToDeviceRoomKeyEventContent {
-                algorithm: EventEncryptionAlgorithm::MegolmV1AesSha2,
-                room_id: room_id!("!testroomid:example.org").to_owned(),
-                session_id: "SessId".into(),
-                session_key: "SessKey".into(),
-            },
-            sender: user_id!("@user:example.org").to_owned(),
+        let content = ToDeviceRoomKeyEventContent {
+            algorithm: EventEncryptionAlgorithm::MegolmV1AesSha2,
+            room_id: room_id!("!testroomid:example.org").to_owned(),
+            session_id: "SessId".into(),
+            session_key: "SessKey".into(),
         };
 
         assert_eq!(
-            to_json_value(ev).unwrap(),
+            to_json_value(content).unwrap(),
             json!({
-                "type": "m.room_key",
-                "content": {
-                    "algorithm": "m.megolm.v1.aes-sha2",
-                    "room_id": "!testroomid:example.org",
-                    "session_id": "SessId",
-                    "session_key": "SessKey",
-                },
-                "sender": "@user:example.org",
+                "algorithm": "m.megolm.v1.aes-sha2",
+                "room_id": "!testroomid:example.org",
+                "session_id": "SessId",
+                "session_key": "SessKey",
             })
         );
     }

--- a/crates/ruma-common/src/events/secret_storage/key.rs
+++ b/crates/ruma-common/src/events/secret_storage/key.rs
@@ -245,19 +245,15 @@ mod tests {
             },
         );
         content.name = Some("my_key".to_owned());
-        let event = GlobalAccountDataEvent { content };
 
         let json = json!({
-            "type": "m.secret_storage.key.my_key_id",
-            "content": {
-                "name": "my_key",
-                "algorithm": "m.secret_storage.v1.aes-hmac-sha2",
-                "iv": "YWJjZGVmZ2hpamtsbW5vcA",
-                "mac": "aWRvbnRrbm93d2hhdGFtYWNsb29rc2xpa2U"
-            }
+            "name": "my_key",
+            "algorithm": "m.secret_storage.v1.aes-hmac-sha2",
+            "iv": "YWJjZGVmZ2hpamtsbW5vcA",
+            "mac": "aWRvbnRrbm93d2hhdGFtYWNsb29rc2xpa2U"
         });
 
-        assert_eq!(to_json_value(&event).unwrap(), json);
+        assert_eq!(to_json_value(&content).unwrap(), json);
     }
 
     #[test]

--- a/crates/ruma-common/src/events/space/child.rs
+++ b/crates/ruma-common/src/events/space/child.rs
@@ -75,7 +75,7 @@ mod tests {
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     use super::{HierarchySpaceChildEvent, SpaceChildEventContent};
-    use crate::{server_name, user_id, MilliSecondsSinceUnixEpoch};
+    use crate::{server_name, MilliSecondsSinceUnixEpoch};
 
     #[test]
     fn space_child_serialization() {
@@ -105,29 +105,18 @@ mod tests {
 
     #[test]
     fn hierarchy_space_child_serialization() {
-        let event = HierarchySpaceChildEvent {
-            content: SpaceChildEventContent {
-                via: Some(vec![server_name!("example.com").to_owned()]),
-                order: Some("uwu".to_owned()),
-                suggested: None,
-            },
-            sender: user_id!("@example:localhost").to_owned(),
-            state_key: "!child:localhost".to_owned(),
-            origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(1_629_413_349)),
+        let content = SpaceChildEventContent {
+            via: Some(vec![server_name!("example.com").to_owned()]),
+            order: Some("uwu".to_owned()),
+            suggested: None,
         };
 
         let json = json!({
-            "content": {
-                "via": ["example.com"],
-                "order": "uwu",
-            },
-            "sender": "@example:localhost",
-            "state_key": "!child:localhost",
-            "origin_server_ts": 1_629_413_349,
-            "type": "m.space.child",
+            "via": ["example.com"],
+            "order": "uwu",
         });
 
-        assert_eq!(to_json_value(&event).unwrap(), json);
+        assert_eq!(to_json_value(&content).unwrap(), json);
     }
 
     #[test]

--- a/crates/ruma-common/src/events/unsigned.rs
+++ b/crates/ruma-common/src/events/unsigned.rs
@@ -143,7 +143,7 @@ impl<C: StateEventContent> Default for StateUnsigned<C> {
 }
 
 /// Extra information about a redacted event that is not incorporated into the event's hash.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct RedactedUnsigned {
     /// The event that redacted this event, if any.

--- a/crates/ruma-common/tests/events/audio.rs
+++ b/crates/ruma-common/tests/events/audio.rs
@@ -16,11 +16,11 @@ use ruma_common::{
             message::{AudioMessageEventContent, MessageType, Relation, RoomMessageEventContent},
             JsonWebKeyInit, MediaSource,
         },
-        AnyMessageLikeEvent, MessageLikeEvent, MessageLikeUnsigned, OriginalMessageLikeEvent,
+        AnyMessageLikeEvent, MessageLikeEvent,
     },
-    mxc_uri, room_id,
+    mxc_uri,
     serde::{Base64, CanBeEmpty},
-    user_id, MilliSecondsSinceUnixEpoch,
+    MilliSecondsSinceUnixEpoch,
 };
 use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
@@ -129,70 +129,56 @@ fn encrypted_content_serialization() {
 
 #[test]
 fn event_serialization() {
-    let event = OriginalMessageLikeEvent {
-        content: assign!(
-            AudioEventContent::with_message(
-                MessageContent::html(
-                    "Upload: my_mix.mp3",
-                    "Upload: <strong>my_mix.mp3</strong>",
-                ),
-                FileContent::plain(
-                    mxc_uri!("mxc://notareal.hs/abcdef").to_owned(),
-                    Some(Box::new(assign!(
-                        FileContentInfo::new(),
-                        {
-                            name: Some("my_mix.mp3".to_owned()),
-                            mimetype: Some("audio/mp3".to_owned()),
-                            size: Some(uint!(897_774)),
-                        }
-                    ))),
-                )
+    let content = assign!(
+        AudioEventContent::with_message(
+            MessageContent::html(
+                "Upload: my_mix.mp3",
+                "Upload: <strong>my_mix.mp3</strong>",
             ),
-            {
-                audio: assign!(
-                    AudioContent::new(),
+            FileContent::plain(
+                mxc_uri!("mxc://notareal.hs/abcdef").to_owned(),
+                Some(Box::new(assign!(
+                    FileContentInfo::new(),
                     {
-                        duration: Some(Duration::from_secs(123))
+                        name: Some("my_mix.mp3".to_owned()),
+                        mimetype: Some("audio/mp3".to_owned()),
+                        size: Some(uint!(897_774)),
                     }
-                ),
-                relates_to: Some(Relation::Reply {
-                    in_reply_to: InReplyTo::new(event_id!("$replyevent:example.com").to_owned()),
-                }),
-            }
+                ))),
+            )
         ),
-        event_id: event_id!("$event:notareal.hs").to_owned(),
-        sender: user_id!("@user:notareal.hs").to_owned(),
-        origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(134_829_848)),
-        room_id: room_id!("!roomid:notareal.hs").to_owned(),
-        unsigned: MessageLikeUnsigned::default(),
-    };
+        {
+            audio: assign!(
+                AudioContent::new(),
+                {
+                    duration: Some(Duration::from_secs(123))
+                }
+            ),
+            relates_to: Some(Relation::Reply {
+                in_reply_to: InReplyTo::new(event_id!("$replyevent:example.com").to_owned()),
+            }),
+        }
+    );
 
     assert_eq!(
-        to_json_value(&event).unwrap(),
+        to_json_value(&content).unwrap(),
         json!({
-            "content": {
-                "org.matrix.msc1767.html": "Upload: <strong>my_mix.mp3</strong>",
-                "org.matrix.msc1767.text": "Upload: my_mix.mp3",
-                "m.file": {
-                    "url": "mxc://notareal.hs/abcdef",
-                    "name": "my_mix.mp3",
-                    "mimetype": "audio/mp3",
-                    "size": 897_774,
-                },
-                "m.audio": {
-                    "duration": 123_000,
-                },
-                "m.relates_to": {
-                    "m.in_reply_to": {
-                        "event_id": "$replyevent:example.com"
-                    }
+            "org.matrix.msc1767.html": "Upload: <strong>my_mix.mp3</strong>",
+            "org.matrix.msc1767.text": "Upload: my_mix.mp3",
+            "m.file": {
+                "url": "mxc://notareal.hs/abcdef",
+                "name": "my_mix.mp3",
+                "mimetype": "audio/mp3",
+                "size": 897_774,
+            },
+            "m.audio": {
+                "duration": 123_000,
+            },
+            "m.relates_to": {
+                "m.in_reply_to": {
+                    "event_id": "$replyevent:example.com"
                 }
             },
-            "event_id": "$event:notareal.hs",
-            "origin_server_ts": 134_829_848,
-            "room_id": "!roomid:notareal.hs",
-            "sender": "@user:notareal.hs",
-            "type": "m.audio",
         })
     );
 }

--- a/crates/ruma-common/tests/events/call.rs
+++ b/crates/ruma-common/tests/events/call.rs
@@ -4,7 +4,6 @@ use assert_matches::assert_matches;
 use assign::assign;
 use js_int::uint;
 use ruma_common::{
-    event_id,
     events::{
         call::{
             answer::CallAnswerEventContent,
@@ -17,9 +16,9 @@ use ruma_common::{
             AnswerSessionDescription, CallCapabilities, OfferSessionDescription,
             SessionDescription, SessionDescriptionType,
         },
-        AnyMessageLikeEvent, MessageLikeEvent, MessageLikeUnsigned, OriginalMessageLikeEvent,
+        AnyMessageLikeEvent, MessageLikeEvent,
     },
-    room_id, user_id, MilliSecondsSinceUnixEpoch, VoipVersionId,
+    VoipVersionId,
 };
 use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
@@ -47,39 +46,25 @@ fn invite_content_serialization() {
 
 #[test]
 fn invite_event_serialization() {
-    let event = OriginalMessageLikeEvent {
-        content: CallInviteEventContent::version_1(
-            "abcdef".into(),
-            "9876".into(),
-            uint!(60000),
-            OfferSessionDescription::new("not a real sdp".to_owned()),
-            CallCapabilities::new(),
-        ),
-        event_id: event_id!("$event:notareal.hs").to_owned(),
-        sender: user_id!("@user:notareal.hs").to_owned(),
-        origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(134_829_848)),
-        room_id: room_id!("!roomid:notareal.hs").to_owned(),
-        unsigned: MessageLikeUnsigned::default(),
-    };
+    let content = CallInviteEventContent::version_1(
+        "abcdef".into(),
+        "9876".into(),
+        uint!(60000),
+        OfferSessionDescription::new("not a real sdp".to_owned()),
+        CallCapabilities::new(),
+    );
 
     assert_eq!(
-        to_json_value(&event).unwrap(),
+        to_json_value(&content).unwrap(),
         json!({
-            "content": {
-                "call_id": "abcdef",
-                "party_id": "9876",
-                "lifetime": 60000,
-                "version": "1",
-                "offer": {
-                    "type": "offer",
-                    "sdp": "not a real sdp",
-                },
+            "call_id": "abcdef",
+            "party_id": "9876",
+            "lifetime": 60000,
+            "version": "1",
+            "offer": {
+                "type": "offer",
+                "sdp": "not a real sdp",
             },
-            "event_id": "$event:notareal.hs",
-            "origin_server_ts": 134_829_848,
-            "room_id": "!roomid:notareal.hs",
-            "sender": "@user:notareal.hs",
-            "type": "m.call.invite",
         })
     );
 }
@@ -140,40 +125,26 @@ fn answer_content_serialization() {
 
 #[test]
 fn answer_event_serialization() {
-    let event = OriginalMessageLikeEvent {
-        content: CallAnswerEventContent::version_1(
-            AnswerSessionDescription::new("not a real sdp".to_owned()),
-            "abcdef".into(),
-            "9876".into(),
-            assign!(CallCapabilities::new(), { dtmf: true }),
-        ),
-        event_id: event_id!("$event:notareal.hs").to_owned(),
-        sender: user_id!("@user:notareal.hs").to_owned(),
-        origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(134_829_848)),
-        room_id: room_id!("!roomid:notareal.hs").to_owned(),
-        unsigned: MessageLikeUnsigned::default(),
-    };
+    let content = CallAnswerEventContent::version_1(
+        AnswerSessionDescription::new("not a real sdp".to_owned()),
+        "abcdef".into(),
+        "9876".into(),
+        assign!(CallCapabilities::new(), { dtmf: true }),
+    );
 
     assert_eq!(
-        to_json_value(&event).unwrap(),
+        to_json_value(&content).unwrap(),
         json!({
-            "content": {
-                "call_id": "abcdef",
-                "party_id": "9876",
-                "version": "1",
-                "answer": {
-                    "type": "answer",
-                    "sdp": "not a real sdp",
-                },
-                "capabilities": {
-                    "m.call.dtmf": true,
-                },
+            "call_id": "abcdef",
+            "party_id": "9876",
+            "version": "1",
+            "answer": {
+                "type": "answer",
+                "sdp": "not a real sdp",
             },
-            "event_id": "$event:notareal.hs",
-            "origin_server_ts": 134_829_848,
-            "room_id": "!roomid:notareal.hs",
-            "sender": "@user:notareal.hs",
-            "type": "m.call.answer",
+            "capabilities": {
+                "m.call.dtmf": true,
+            },
         })
     );
 }
@@ -238,47 +209,33 @@ fn candidates_content_serialization() {
 
 #[test]
 fn candidates_event_serialization() {
-    let event = OriginalMessageLikeEvent {
-        content: CallCandidatesEventContent::version_1(
-            "abcdef".into(),
-            "9876".into(),
-            vec![
-                Candidate::new("not a real candidate".to_owned(), "0".to_owned(), uint!(0)),
-                Candidate::new("another fake candidate".to_owned(), "0".to_owned(), uint!(1)),
-            ],
-        ),
-        event_id: event_id!("$event:notareal.hs").to_owned(),
-        sender: user_id!("@user:notareal.hs").to_owned(),
-        origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(134_829_848)),
-        room_id: room_id!("!roomid:notareal.hs").to_owned(),
-        unsigned: MessageLikeUnsigned::default(),
-    };
+    let content = CallCandidatesEventContent::version_1(
+        "abcdef".into(),
+        "9876".into(),
+        vec![
+            Candidate::new("not a real candidate".to_owned(), "0".to_owned(), uint!(0)),
+            Candidate::new("another fake candidate".to_owned(), "0".to_owned(), uint!(1)),
+        ],
+    );
 
     assert_eq!(
-        to_json_value(&event).unwrap(),
+        to_json_value(&content).unwrap(),
         json!({
-            "content": {
-                "call_id": "abcdef",
-                "party_id": "9876",
-                "version": "1",
-                "candidates": [
-                    {
-                        "candidate": "not a real candidate",
-                        "sdpMid": "0",
-                        "sdpMLineIndex": 0,
-                    },
-                    {
-                        "candidate": "another fake candidate",
-                        "sdpMid": "0",
-                        "sdpMLineIndex": 1,
-                    },
-                ],
-            },
-            "event_id": "$event:notareal.hs",
-            "origin_server_ts": 134_829_848,
-            "room_id": "!roomid:notareal.hs",
-            "sender": "@user:notareal.hs",
-            "type": "m.call.candidates",
+            "call_id": "abcdef",
+            "party_id": "9876",
+            "version": "1",
+            "candidates": [
+                {
+                    "candidate": "not a real candidate",
+                    "sdpMid": "0",
+                    "sdpMLineIndex": 0,
+                },
+                {
+                    "candidate": "another fake candidate",
+                    "sdpMid": "0",
+                    "sdpMLineIndex": 1,
+                },
+            ],
         })
     );
 }
@@ -344,33 +301,16 @@ fn hangup_content_serialization() {
 
 #[test]
 fn hangup_event_serialization() {
-    let event = OriginalMessageLikeEvent {
-        content: CallHangupEventContent::version_1(
-            "abcdef".into(),
-            "9876".into(),
-            Reason::IceFailed,
-        ),
-        event_id: event_id!("$event:notareal.hs").to_owned(),
-        sender: user_id!("@user:notareal.hs").to_owned(),
-        origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(134_829_848)),
-        room_id: room_id!("!roomid:notareal.hs").to_owned(),
-        unsigned: MessageLikeUnsigned::default(),
-    };
+    let content =
+        CallHangupEventContent::version_1("abcdef".into(), "9876".into(), Reason::IceFailed);
 
     assert_eq!(
-        to_json_value(&event).unwrap(),
+        to_json_value(&content).unwrap(),
         json!({
-            "content": {
-                "call_id": "abcdef",
-                "party_id": "9876",
-                "version": "1",
-                "reason": "ice_failed",
-            },
-            "event_id": "$event:notareal.hs",
-            "origin_server_ts": 134_829_848,
-            "room_id": "!roomid:notareal.hs",
-            "sender": "@user:notareal.hs",
-            "type": "m.call.hangup",
+            "call_id": "abcdef",
+            "party_id": "9876",
+            "version": "1",
+            "reason": "ice_failed",
         })
     );
 }
@@ -404,37 +344,23 @@ fn hangup_event_deserialization() {
 
 #[test]
 fn negotiate_event_serialization() {
-    let event = OriginalMessageLikeEvent {
-        content: CallNegotiateEventContent::new(
-            "abcdef".into(),
-            "9876".into(),
-            uint!(30000),
-            SessionDescription::new(SessionDescriptionType::Offer, "not a real sdp".to_owned()),
-        ),
-        event_id: event_id!("$event:notareal.hs").to_owned(),
-        sender: user_id!("@user:notareal.hs").to_owned(),
-        origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(134_829_848)),
-        room_id: room_id!("!roomid:notareal.hs").to_owned(),
-        unsigned: MessageLikeUnsigned::default(),
-    };
+    let content = CallNegotiateEventContent::new(
+        "abcdef".into(),
+        "9876".into(),
+        uint!(30000),
+        SessionDescription::new(SessionDescriptionType::Offer, "not a real sdp".to_owned()),
+    );
 
     assert_eq!(
-        to_json_value(&event).unwrap(),
+        to_json_value(&content).unwrap(),
         json!({
-            "content": {
-                "call_id": "abcdef",
-                "party_id": "9876",
-                "lifetime": 30000,
-                "description": {
-                    "type": "offer",
-                    "sdp": "not a real sdp",
-                }
+            "call_id": "abcdef",
+            "party_id": "9876",
+            "lifetime": 30000,
+            "description": {
+                "type": "offer",
+                "sdp": "not a real sdp",
             },
-            "event_id": "$event:notareal.hs",
-            "origin_server_ts": 134_829_848,
-            "room_id": "!roomid:notareal.hs",
-            "sender": "@user:notareal.hs",
-            "type": "m.call.negotiate",
         })
     );
 }
@@ -473,28 +399,14 @@ fn negotiate_event_deserialization() {
 
 #[test]
 fn reject_event_serialization() {
-    let event = OriginalMessageLikeEvent {
-        content: CallRejectEventContent::version_1("abcdef".into(), "9876".into()),
-        event_id: event_id!("$event:notareal.hs").to_owned(),
-        sender: user_id!("@user:notareal.hs").to_owned(),
-        origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(134_829_848)),
-        room_id: room_id!("!roomid:notareal.hs").to_owned(),
-        unsigned: MessageLikeUnsigned::default(),
-    };
+    let content = CallRejectEventContent::version_1("abcdef".into(), "9876".into());
 
     assert_eq!(
-        to_json_value(&event).unwrap(),
+        to_json_value(&content).unwrap(),
         json!({
-            "content": {
-                "call_id": "abcdef",
-                "party_id": "9876",
-                "version": "1",
-            },
-            "event_id": "$event:notareal.hs",
-            "origin_server_ts": 134_829_848,
-            "room_id": "!roomid:notareal.hs",
-            "sender": "@user:notareal.hs",
-            "type": "m.call.reject",
+            "call_id": "abcdef",
+            "party_id": "9876",
+            "version": "1",
         })
     );
 }
@@ -527,33 +439,16 @@ fn reject_event_deserialization() {
 
 #[test]
 fn select_answer_event_serialization() {
-    let event = OriginalMessageLikeEvent {
-        content: CallSelectAnswerEventContent::version_1(
-            "abcdef".into(),
-            "9876".into(),
-            "6336".into(),
-        ),
-        event_id: event_id!("$event:notareal.hs").to_owned(),
-        sender: user_id!("@user:notareal.hs").to_owned(),
-        origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(134_829_848)),
-        room_id: room_id!("!roomid:notareal.hs").to_owned(),
-        unsigned: MessageLikeUnsigned::default(),
-    };
+    let content =
+        CallSelectAnswerEventContent::version_1("abcdef".into(), "9876".into(), "6336".into());
 
     assert_eq!(
-        to_json_value(&event).unwrap(),
+        to_json_value(&content).unwrap(),
         json!({
-            "content": {
-                "call_id": "abcdef",
-                "party_id": "9876",
-                "selected_party_id": "6336",
-                "version": "1",
-            },
-            "event_id": "$event:notareal.hs",
-            "origin_server_ts": 134_829_848,
-            "room_id": "!roomid:notareal.hs",
-            "sender": "@user:notareal.hs",
-            "type": "m.call.select_answer",
+            "call_id": "abcdef",
+            "party_id": "9876",
+            "selected_party_id": "6336",
+            "version": "1",
         })
     );
 }

--- a/crates/ruma-common/tests/events/enums.rs
+++ b/crates/ruma-common/tests/events/enums.rs
@@ -1,28 +1,23 @@
 use assert_matches::assert_matches;
-use js_int::{int, uint};
+use js_int::int;
 use ruma_common::{
-    event_id,
     events::{MessageLikeEvent, StateEvent, SyncMessageLikeEvent, SyncStateEvent},
-    room_alias_id, room_id,
+    room_alias_id,
     serde::test::serde_json_eq,
-    user_id,
 };
 use serde_json::{from_value as from_json_value, json, Value as JsonValue};
 
-use ruma_common::{
-    events::{
-        room::{
-            aliases::RoomAliasesEventContent,
-            message::{MessageType, RoomMessageEventContent},
-            power_levels::RoomPowerLevelsEventContent,
-        },
-        AnyEphemeralRoomEvent, AnyMessageLikeEvent, AnyStateEvent, AnySyncMessageLikeEvent,
-        AnySyncStateEvent, AnySyncTimelineEvent, AnyTimelineEvent, EphemeralRoomEventType,
-        GlobalAccountDataEventType, MessageLikeEventType, MessageLikeUnsigned,
-        OriginalMessageLikeEvent, OriginalStateEvent, OriginalSyncMessageLikeEvent,
-        OriginalSyncStateEvent, RoomAccountDataEventType, StateEventType, ToDeviceEventType,
+use ruma_common::events::{
+    room::{
+        aliases::RoomAliasesEventContent,
+        message::{MessageType, RoomMessageEventContent},
+        power_levels::RoomPowerLevelsEventContent,
     },
-    MilliSecondsSinceUnixEpoch,
+    AnyEphemeralRoomEvent, AnyMessageLikeEvent, AnyStateEvent, AnySyncMessageLikeEvent,
+    AnySyncStateEvent, AnySyncTimelineEvent, AnyTimelineEvent, EphemeralRoomEventType,
+    GlobalAccountDataEventType, MessageLikeEventType, OriginalMessageLikeEvent, OriginalStateEvent,
+    OriginalSyncMessageLikeEvent, OriginalSyncStateEvent, RoomAccountDataEventType, StateEventType,
+    ToDeviceEventType,
 };
 
 fn message_event() -> JsonValue {
@@ -205,25 +200,18 @@ fn message_room_event_deserialization() {
 
 #[test]
 fn message_event_serialization() {
-    let event = OriginalMessageLikeEvent {
-        content: RoomMessageEventContent::text_plain("test"),
-        event_id: event_id!("$1234:example.com").to_owned(),
-        origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(0)),
-        room_id: room_id!("!roomid:example.com").to_owned(),
-        sender: user_id!("@test:example.com").to_owned(),
-        unsigned: MessageLikeUnsigned::default(),
-    };
+    let content = RoomMessageEventContent::text_plain("test");
 
     #[cfg(not(feature = "unstable-msc1767"))]
     assert_eq!(
-        serde_json::to_string(&event).expect("Failed to serialize message event"),
-        r#"{"type":"m.room.message","content":{"msgtype":"m.text","body":"test"},"event_id":"$1234:example.com","sender":"@test:example.com","origin_server_ts":0,"room_id":"!roomid:example.com"}"#
+        serde_json::to_string(&content).expect("Failed to serialize message event content"),
+        r#"{"msgtype":"m.text","body":"test"}"#
     );
 
     #[cfg(feature = "unstable-msc1767")]
     assert_eq!(
-        serde_json::to_string(&event).expect("Failed to serialize message event"),
-        r#"{"type":"m.room.message","content":{"msgtype":"m.text","body":"test","org.matrix.msc1767.text":"test"},"event_id":"$1234:example.com","sender":"@test:example.com","origin_server_ts":0,"room_id":"!roomid:example.com"}"#
+        serde_json::to_string(&content).expect("Failed to serialize message event content"),
+        r#"{"msgtype":"m.text","body":"test","org.matrix.msc1767.text":"test"}"#
     );
 }
 

--- a/crates/ruma-common/tests/events/ephemeral_event.rs
+++ b/crates/ruma-common/tests/events/ephemeral_event.rs
@@ -1,31 +1,22 @@
 use assert_matches::assert_matches;
 use js_int::uint;
 use maplit::btreemap;
-use ruma_common::{
-    event_id, events::receipt::ReceiptType, room_id, user_id, MilliSecondsSinceUnixEpoch,
-};
+use ruma_common::{event_id, events::receipt::ReceiptType, user_id, MilliSecondsSinceUnixEpoch};
 use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
 use ruma_common::events::{
     receipt::{Receipt, ReceiptEventContent},
     typing::TypingEventContent,
-    AnyEphemeralRoomEvent, EphemeralRoomEvent,
+    AnyEphemeralRoomEvent,
 };
 
 #[test]
 fn ephemeral_serialize_typing() {
-    let aliases_event = EphemeralRoomEvent {
-        content: TypingEventContent::new(vec![user_id!("@carl:example.com").to_owned()]),
-        room_id: room_id!("!roomid:room.com").to_owned(),
-    };
+    let content = TypingEventContent::new(vec![user_id!("@carl:example.com").to_owned()]);
 
-    let actual = to_json_value(&aliases_event).unwrap();
+    let actual = to_json_value(&content).unwrap();
     let expected = json!({
-        "content": {
-            "user_ids": [ "@carl:example.com" ]
-        },
-        "room_id": "!roomid:room.com",
-        "type": "m.typing",
+        "user_ids": ["@carl:example.com"],
     });
 
     assert_eq!(actual, expected);
@@ -55,28 +46,21 @@ fn ephemeral_serialize_receipt() {
     let event_id = event_id!("$h29iv0s8:example.com").to_owned();
     let user_id = user_id!("@carl:example.com").to_owned();
 
-    let aliases_event = EphemeralRoomEvent {
-        content: ReceiptEventContent(btreemap! {
-            event_id => btreemap! {
-                ReceiptType::Read => btreemap! {
-                    user_id => Receipt::new(MilliSecondsSinceUnixEpoch(uint!(1))),
-                },
+    let content = ReceiptEventContent(btreemap! {
+        event_id => btreemap! {
+            ReceiptType::Read => btreemap! {
+                user_id => Receipt::new(MilliSecondsSinceUnixEpoch(uint!(1))),
             },
-        }),
-        room_id: room_id!("!roomid:room.com").to_owned(),
-    };
-
-    let actual = to_json_value(&aliases_event).unwrap();
-    let expected = json!({
-        "content": {
-            "$h29iv0s8:example.com": {
-                "m.read": {
-                    "@carl:example.com": { "ts": 1 }
-                }
-            }
         },
-        "room_id": "!roomid:room.com",
-        "type": "m.receipt"
+    });
+
+    let actual = to_json_value(&content).unwrap();
+    let expected = json!({
+        "$h29iv0s8:example.com": {
+            "m.read": {
+                "@carl:example.com": { "ts": 1 }
+            }
+        }
     });
 
     assert_eq!(actual, expected);

--- a/crates/ruma-common/tests/events/file.rs
+++ b/crates/ruma-common/tests/events/file.rs
@@ -13,11 +13,11 @@ use ruma_common::{
             message::{FileMessageEventContent, MessageType, Relation, RoomMessageEventContent},
             EncryptedFileInit, JsonWebKeyInit, MediaSource,
         },
-        AnyMessageLikeEvent, MessageLikeEvent, MessageLikeUnsigned, OriginalMessageLikeEvent,
+        AnyMessageLikeEvent, MessageLikeEvent,
     },
-    mxc_uri, room_id,
+    mxc_uri,
     serde::{Base64, CanBeEmpty},
-    user_id, MilliSecondsSinceUnixEpoch,
+    MilliSecondsSinceUnixEpoch,
 };
 use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
@@ -91,8 +91,7 @@ fn encrypted_content_serialization() {
 
 #[test]
 fn file_event_serialization() {
-    let event = OriginalMessageLikeEvent {
-        content: assign!(
+    let content = assign!(
             FileEventContent::plain_message(
                 MessageContent::html(
                     "Upload: my_file.txt",
@@ -113,37 +112,24 @@ fn file_event_serialization() {
                     in_reply_to: InReplyTo::new(event_id!("$replyevent:example.com").to_owned()),
                 }),
             }
-        ),
-        event_id: event_id!("$event:notareal.hs").to_owned(),
-        sender: user_id!("@user:notareal.hs").to_owned(),
-        origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(134_829_848)),
-        room_id: room_id!("!roomid:notareal.hs").to_owned(),
-        unsigned: MessageLikeUnsigned::default(),
-    };
+        );
 
     assert_eq!(
-        to_json_value(&event).unwrap(),
+        to_json_value(&content).unwrap(),
         json!({
-            "content": {
-                "org.matrix.msc1767.html": "Upload: <strong>my_file.txt</strong>",
-                "org.matrix.msc1767.text": "Upload: my_file.txt",
-                "m.file": {
-                    "url": "mxc://notareal.hs/abcdef",
-                    "name": "my_file.txt",
-                    "mimetype": "text/plain",
-                    "size": 774,
-                },
-                "m.relates_to": {
-                    "m.in_reply_to": {
-                        "event_id": "$replyevent:example.com"
-                    }
+            "org.matrix.msc1767.html": "Upload: <strong>my_file.txt</strong>",
+            "org.matrix.msc1767.text": "Upload: my_file.txt",
+            "m.file": {
+                "url": "mxc://notareal.hs/abcdef",
+                "name": "my_file.txt",
+                "mimetype": "text/plain",
+                "size": 774,
+            },
+            "m.relates_to": {
+                "m.in_reply_to": {
+                    "event_id": "$replyevent:example.com"
                 }
             },
-            "event_id": "$event:notareal.hs",
-            "origin_server_ts": 134_829_848,
-            "room_id": "!roomid:notareal.hs",
-            "sender": "@user:notareal.hs",
-            "type": "m.file",
         })
     );
 }

--- a/crates/ruma-common/tests/events/image.rs
+++ b/crates/ruma-common/tests/events/image.rs
@@ -17,11 +17,11 @@ use ruma_common::{
             message::{ImageMessageEventContent, MessageType, Relation, RoomMessageEventContent},
             JsonWebKeyInit, MediaSource,
         },
-        AnyMessageLikeEvent, MessageLikeEvent, MessageLikeUnsigned, OriginalMessageLikeEvent,
+        AnyMessageLikeEvent, MessageLikeEvent,
     },
-    mxc_uri, room_id,
+    mxc_uri,
     serde::{Base64, CanBeEmpty},
-    user_id, MilliSecondsSinceUnixEpoch,
+    MilliSecondsSinceUnixEpoch,
 };
 use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
@@ -98,90 +98,76 @@ fn encrypted_content_serialization() {
 
 #[test]
 fn image_event_serialization() {
-    let event = OriginalMessageLikeEvent {
-        content: assign!(
-            ImageEventContent::with_message(
-                MessageContent::html(
-                    "Upload: my_house.jpg",
-                    "Upload: <strong>my_house.jpg</strong>",
-                ),
-                FileContent::plain(
-                    mxc_uri!("mxc://notareal.hs/abcdef").to_owned(),
-                    Some(Box::new(assign!(
-                        FileContentInfo::new(),
-                        {
-                            name: Some("my_house.jpg".to_owned()),
-                            mimetype: Some("image/jpeg".to_owned()),
-                            size: Some(uint!(897_774)),
-                        }
-                    ))),
-                )
+    let content = assign!(
+        ImageEventContent::with_message(
+            MessageContent::html(
+                "Upload: my_house.jpg",
+                "Upload: <strong>my_house.jpg</strong>",
             ),
-            {
-                image: Box::new(ImageContent::with_size(uint!(1920), uint!(1080))),
-                thumbnail: vec![ThumbnailContent::new(
-                    ThumbnailFileContent::plain(
-                        mxc_uri!("mxc://notareal.hs/thumbnail").to_owned(),
-                        Some(Box::new(assign!(ThumbnailFileContentInfo::new(), {
-                            mimetype: Some("image/jpeg".to_owned()),
-                            size: Some(uint!(334_593)),
-                        })))
-                    ),
-                    None
-                )],
-                caption: Some(MessageContent::plain("This is my house")),
-                relates_to: Some(Relation::Reply {
-                    in_reply_to: InReplyTo::new(event_id!("$replyevent:example.com").to_owned()),
-                }),
-            }
+            FileContent::plain(
+                mxc_uri!("mxc://notareal.hs/abcdef").to_owned(),
+                Some(Box::new(assign!(
+                    FileContentInfo::new(),
+                    {
+                        name: Some("my_house.jpg".to_owned()),
+                        mimetype: Some("image/jpeg".to_owned()),
+                        size: Some(uint!(897_774)),
+                    }
+                ))),
+            )
         ),
-        event_id: event_id!("$event:notareal.hs").to_owned(),
-        sender: user_id!("@user:notareal.hs").to_owned(),
-        origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(134_829_848)),
-        room_id: room_id!("!roomid:notareal.hs").to_owned(),
-        unsigned: MessageLikeUnsigned::default(),
-    };
+        {
+            image: Box::new(ImageContent::with_size(uint!(1920), uint!(1080))),
+            thumbnail: vec![ThumbnailContent::new(
+                ThumbnailFileContent::plain(
+                    mxc_uri!("mxc://notareal.hs/thumbnail").to_owned(),
+                    Some(Box::new(assign!(ThumbnailFileContentInfo::new(), {
+                        mimetype: Some("image/jpeg".to_owned()),
+                        size: Some(uint!(334_593)),
+                    })))
+                ),
+                None
+            )],
+            caption: Some(MessageContent::plain("This is my house")),
+            relates_to: Some(Relation::Reply {
+                in_reply_to: InReplyTo::new(event_id!("$replyevent:example.com").to_owned()),
+            }),
+        }
+    );
 
     assert_eq!(
-        to_json_value(&event).unwrap(),
+        to_json_value(&content).unwrap(),
         json!({
-            "content": {
-                "org.matrix.msc1767.html": "Upload: <strong>my_house.jpg</strong>",
-                "org.matrix.msc1767.text": "Upload: my_house.jpg",
-                "m.file": {
-                    "url": "mxc://notareal.hs/abcdef",
-                    "name": "my_house.jpg",
+            "org.matrix.msc1767.html": "Upload: <strong>my_house.jpg</strong>",
+            "org.matrix.msc1767.text": "Upload: my_house.jpg",
+            "m.file": {
+                "url": "mxc://notareal.hs/abcdef",
+                "name": "my_house.jpg",
+                "mimetype": "image/jpeg",
+                "size": 897_774,
+            },
+            "m.image": {
+                "width": 1920,
+                "height": 1080,
+            },
+            "m.thumbnail": [
+                {
+                    "url": "mxc://notareal.hs/thumbnail",
                     "mimetype": "image/jpeg",
-                    "size": 897_774,
-                },
-                "m.image": {
-                    "width": 1920,
-                    "height": 1080,
-                },
-                "m.thumbnail": [
-                    {
-                        "url": "mxc://notareal.hs/thumbnail",
-                        "mimetype": "image/jpeg",
-                        "size": 334_593,
-                    }
-                ],
-                "m.caption": [
-                    {
-                        "body": "This is my house",
-                        "mimetype": "text/plain",
-                    }
-                ],
-                "m.relates_to": {
-                    "m.in_reply_to": {
-                        "event_id": "$replyevent:example.com"
-                    }
+                    "size": 334_593,
+                }
+            ],
+            "m.caption": [
+                {
+                    "body": "This is my house",
+                    "mimetype": "text/plain",
+                }
+            ],
+            "m.relates_to": {
+                "m.in_reply_to": {
+                    "event_id": "$replyevent:example.com"
                 }
             },
-            "event_id": "$event:notareal.hs",
-            "origin_server_ts": 134_829_848,
-            "room_id": "!roomid:notareal.hs",
-            "sender": "@user:notareal.hs",
-            "type": "m.image",
         })
     );
 }

--- a/crates/ruma-common/tests/events/location.rs
+++ b/crates/ruma-common/tests/events/location.rs
@@ -12,7 +12,7 @@ use ruma_common::{
         room::message::{
             LocationMessageEventContent, MessageType, Relation, RoomMessageEventContent,
         },
-        AnyMessageLikeEvent, MessageLikeEvent, MessageLikeUnsigned, OriginalMessageLikeEvent,
+        AnyMessageLikeEvent, MessageLikeEvent,
     },
     room_id,
     serde::CanBeEmpty,
@@ -40,58 +40,44 @@ fn plain_content_serialization() {
 
 #[test]
 fn event_serialization() {
-    let event = OriginalMessageLikeEvent {
-        content: assign!(
-            LocationEventContent::with_message(
-                MessageContent::html(
-                    "Alice was at geo:51.5008,0.1247;u=35 as of Sat Nov 13 18:50:58 2021",
-                    "Alice was at <strong>geo:51.5008,0.1247;u=35</strong> as of <em>Sat Nov 13 18:50:58 2021</em>",
-                ),
-                assign!(
-                    LocationContent::new("geo:51.5008,0.1247;u=35".to_owned()),
-                    {
-                        description: Some("Alice's whereabouts".into()),
-                        zoom_level: Some(ZoomLevel::new(4).unwrap())
-                    }
-                )
+    let content = assign!(
+        LocationEventContent::with_message(
+            MessageContent::html(
+                "Alice was at geo:51.5008,0.1247;u=35 as of Sat Nov 13 18:50:58 2021",
+                "Alice was at <strong>geo:51.5008,0.1247;u=35</strong> as of <em>Sat Nov 13 18:50:58 2021</em>",
             ),
-            {
-                ts: Some(MilliSecondsSinceUnixEpoch(uint!(1_636_829_458))),
-                relates_to: Some(Relation::Reply {
-                    in_reply_to: InReplyTo::new(event_id!("$replyevent:example.com").to_owned()),
-                }),
-            }
+            assign!(
+                LocationContent::new("geo:51.5008,0.1247;u=35".to_owned()),
+                {
+                    description: Some("Alice's whereabouts".into()),
+                    zoom_level: Some(ZoomLevel::new(4).unwrap())
+                }
+            )
         ),
-        event_id: event_id!("$event:notareal.hs").to_owned(),
-        sender: user_id!("@user:notareal.hs").to_owned(),
-        origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(134_829_848)),
-        room_id: room_id!("!roomid:notareal.hs").to_owned(),
-        unsigned: MessageLikeUnsigned::default(),
-    };
+        {
+            ts: Some(MilliSecondsSinceUnixEpoch(uint!(1_636_829_458))),
+            relates_to: Some(Relation::Reply {
+                in_reply_to: InReplyTo::new(event_id!("$replyevent:example.com").to_owned()),
+            }),
+        }
+    );
 
     assert_eq!(
-        to_json_value(&event).unwrap(),
+        to_json_value(&content).unwrap(),
         json!({
-            "content": {
-                "org.matrix.msc1767.html": "Alice was at <strong>geo:51.5008,0.1247;u=35</strong> as of <em>Sat Nov 13 18:50:58 2021</em>",
-                "org.matrix.msc1767.text": "Alice was at geo:51.5008,0.1247;u=35 as of Sat Nov 13 18:50:58 2021",
-                "m.location": {
-                    "uri": "geo:51.5008,0.1247;u=35",
-                    "description": "Alice's whereabouts",
-                    "zoom_level": 4,
-                },
-                "m.ts": 1_636_829_458,
-                "m.relates_to": {
-                    "m.in_reply_to": {
-                        "event_id": "$replyevent:example.com",
-                    },
+            "org.matrix.msc1767.html": "Alice was at <strong>geo:51.5008,0.1247;u=35</strong> as of <em>Sat Nov 13 18:50:58 2021</em>",
+            "org.matrix.msc1767.text": "Alice was at geo:51.5008,0.1247;u=35 as of Sat Nov 13 18:50:58 2021",
+            "m.location": {
+                "uri": "geo:51.5008,0.1247;u=35",
+                "description": "Alice's whereabouts",
+                "zoom_level": 4,
+            },
+            "m.ts": 1_636_829_458,
+            "m.relates_to": {
+                "m.in_reply_to": {
+                    "event_id": "$replyevent:example.com",
                 },
             },
-            "event_id": "$event:notareal.hs",
-            "origin_server_ts": 134_829_848,
-            "room_id": "!roomid:notareal.hs",
-            "sender": "@user:notareal.hs",
-            "type": "m.location",
         })
     );
 }

--- a/crates/ruma-common/tests/events/message.rs
+++ b/crates/ruma-common/tests/events/message.rs
@@ -11,11 +11,10 @@ use ruma_common::{
         notice::NoticeEventContent,
         relation::InReplyTo,
         room::message::{EmoteMessageEventContent, MessageType, Relation, RoomMessageEventContent},
-        AnyMessageLikeEvent, MessageLikeEvent, MessageLikeUnsigned, OriginalMessageLikeEvent,
+        AnyMessageLikeEvent, MessageLikeEvent,
     },
-    room_id,
     serde::CanBeEmpty,
-    user_id, MilliSecondsSinceUnixEpoch,
+    MilliSecondsSinceUnixEpoch,
 };
 use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
@@ -146,27 +145,10 @@ fn relates_to_content_serialization() {
 
 #[test]
 fn message_event_serialization() {
-    let event = OriginalMessageLikeEvent {
-        content: MessageEventContent::plain("Hello, World!"),
-        event_id: event_id!("$event:notareal.hs").to_owned(),
-        sender: user_id!("@user:notareal.hs").to_owned(),
-        origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(134_829_848)),
-        room_id: room_id!("!roomid:notareal.hs").to_owned(),
-        unsigned: MessageLikeUnsigned::default(),
-    };
-
+    let content = MessageEventContent::plain("Hello, World!");
     assert_eq!(
-        to_json_value(&event).unwrap(),
-        json!({
-            "content": {
-                "org.matrix.msc1767.text": "Hello, World!",
-            },
-            "event_id": "$event:notareal.hs",
-            "origin_server_ts": 134_829_848,
-            "room_id": "!roomid:notareal.hs",
-            "sender": "@user:notareal.hs",
-            "type": "m.message",
-        })
+        to_json_value(&content).unwrap(),
+        json!({ "org.matrix.msc1767.text": "Hello, World!" })
     );
 }
 
@@ -469,27 +451,10 @@ fn room_message_message_unstable_deserialization() {
 
 #[test]
 fn notice_event_serialization() {
-    let event = OriginalMessageLikeEvent {
-        content: NoticeEventContent::plain("Hello, I'm a robot!"),
-        event_id: event_id!("$event:notareal.hs").to_owned(),
-        sender: user_id!("@user:notareal.hs").to_owned(),
-        origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(134_829_848)),
-        room_id: room_id!("!roomid:notareal.hs").to_owned(),
-        unsigned: MessageLikeUnsigned::default(),
-    };
-
+    let content = NoticeEventContent::plain("Hello, I'm a robot!");
     assert_eq!(
-        to_json_value(&event).unwrap(),
-        json!({
-            "content": {
-                "org.matrix.msc1767.text": "Hello, I'm a robot!",
-            },
-            "event_id": "$event:notareal.hs",
-            "origin_server_ts": 134_829_848,
-            "room_id": "!roomid:notareal.hs",
-            "sender": "@user:notareal.hs",
-            "type": "m.notice",
-        })
+        to_json_value(&content).unwrap(),
+        json!({ "org.matrix.msc1767.text": "Hello, I'm a robot!" })
     );
 }
 
@@ -616,30 +581,14 @@ fn room_message_notice_unstable_deserialization() {
 
 #[test]
 fn emote_event_serialization() {
-    let event = OriginalMessageLikeEvent {
-        content: EmoteEventContent::html(
-            "is testing some code…",
-            "is testing some <code>code</code>…",
-        ),
-        event_id: event_id!("$event:notareal.hs").to_owned(),
-        sender: user_id!("@user:notareal.hs").to_owned(),
-        origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(134_829_848)),
-        room_id: room_id!("!roomid:notareal.hs").to_owned(),
-        unsigned: MessageLikeUnsigned::default(),
-    };
+    let content =
+        EmoteEventContent::html("is testing some code…", "is testing some <code>code</code>…");
 
     assert_eq!(
-        to_json_value(&event).unwrap(),
+        to_json_value(&content).unwrap(),
         json!({
-            "content": {
-                "org.matrix.msc1767.html": "is testing some <code>code</code>…",
-                "org.matrix.msc1767.text": "is testing some code…",
-            },
-            "event_id": "$event:notareal.hs",
-            "origin_server_ts": 134_829_848,
-            "room_id": "!roomid:notareal.hs",
-            "sender": "@user:notareal.hs",
-            "type": "m.emote",
+            "org.matrix.msc1767.html": "is testing some <code>code</code>…",
+            "org.matrix.msc1767.text": "is testing some code…",
         })
     );
 }

--- a/crates/ruma-common/tests/events/message_event.rs
+++ b/crates/ruma-common/tests/events/message_event.rs
@@ -2,117 +2,95 @@ use assert_matches::assert_matches;
 use assign::assign;
 use js_int::{uint, UInt};
 use ruma_common::{
-    event_id,
     events::{
         room::{ImageInfo, MediaSource, ThumbnailInfo},
         sticker::StickerEventContent,
         AnyMessageLikeEvent, AnyMessageLikeEventContent, AnySyncMessageLikeEvent, MessageLikeEvent,
-        MessageLikeEventType, MessageLikeUnsigned, OriginalMessageLikeEvent,
+        MessageLikeEventType,
     },
     mxc_uri, room_id,
     serde::{CanBeEmpty, Raw},
-    user_id, MilliSecondsSinceUnixEpoch, VoipVersionId,
+    MilliSecondsSinceUnixEpoch, VoipVersionId,
 };
 use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
 #[test]
 fn message_serialize_sticker() {
-    let aliases_event = OriginalMessageLikeEvent {
-        content: StickerEventContent::new(
-            "Hello".into(),
-            assign!(ImageInfo::new(), {
-                height: UInt::new(423),
-                width: UInt::new(1011),
+    let content = StickerEventContent::new(
+        "Hello".into(),
+        assign!(ImageInfo::new(), {
+            height: UInt::new(423),
+            width: UInt::new(1011),
+            mimetype: Some("image/png".into()),
+            size: UInt::new(84242),
+            thumbnail_info: Some(Box::new(assign!(ThumbnailInfo::new(), {
+                width: UInt::new(800),
+                height: UInt::new(334),
                 mimetype: Some("image/png".into()),
-                size: UInt::new(84242),
-                thumbnail_info: Some(Box::new(assign!(ThumbnailInfo::new(), {
-                    width: UInt::new(800),
-                    height: UInt::new(334),
-                    mimetype: Some("image/png".into()),
-                    size: UInt::new(82595),
-                }))),
-                thumbnail_source: Some(MediaSource::Plain(mxc_uri!("mxc://matrix.org/irsns989Rrsn").to_owned())),
-            }),
-            mxc_uri!("mxc://matrix.org/rnsldl8srs98IRrs").to_owned(),
-        ),
-        event_id: event_id!("$h29iv0s8:example.com").to_owned(),
-        origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(1)),
-        room_id: room_id!("!roomid:room.com").to_owned(),
-        sender: user_id!("@carl:example.com").to_owned(),
-        unsigned: MessageLikeUnsigned::default(),
-    };
+                size: UInt::new(82595),
+            }))),
+            thumbnail_source: Some(MediaSource::Plain(mxc_uri!("mxc://matrix.org/irsns989Rrsn").to_owned())),
+        }),
+        mxc_uri!("mxc://matrix.org/rnsldl8srs98IRrs").to_owned(),
+    );
 
-    let actual = to_json_value(&aliases_event).unwrap();
+    let actual = to_json_value(&content).unwrap();
 
     #[cfg(not(feature = "unstable-msc3552"))]
     let expected = json!({
-        "content": {
-            "body": "Hello",
-            "info": {
-                "h": 423,
+        "body": "Hello",
+        "info": {
+            "h": 423,
+            "mimetype": "image/png",
+            "size": 84242,
+            "thumbnail_info": {
+                "h": 334,
                 "mimetype": "image/png",
-                "size": 84242,
-                "thumbnail_info": {
-                  "h": 334,
-                  "mimetype": "image/png",
-                  "size": 82595,
-                  "w": 800
-                },
-                "thumbnail_url": "mxc://matrix.org/irsns989Rrsn",
-                "w": 1011
-              },
-            "url": "mxc://matrix.org/rnsldl8srs98IRrs"
-        },
-        "event_id": "$h29iv0s8:example.com",
-        "origin_server_ts": 1,
-        "room_id": "!roomid:room.com",
-        "sender": "@carl:example.com",
-        "type": "m.sticker",
+                "size": 82595,
+                "w": 800
+            },
+            "thumbnail_url": "mxc://matrix.org/irsns989Rrsn",
+            "w": 1011
+            },
+        "url": "mxc://matrix.org/rnsldl8srs98IRrs",
     });
 
     #[cfg(feature = "unstable-msc3552")]
     let expected = json!({
-        "content": {
-            "body": "Hello",
-            "info": {
-                "h": 423,
+        "body": "Hello",
+        "info": {
+            "h": 423,
+            "mimetype": "image/png",
+            "size": 84242,
+            "thumbnail_info": {
+                "h": 334,
                 "mimetype": "image/png",
-                "size": 84242,
-                "thumbnail_info": {
-                  "h": 334,
-                  "mimetype": "image/png",
-                  "size": 82595,
-                  "w": 800
-                },
-                "thumbnail_url": "mxc://matrix.org/irsns989Rrsn",
-                "w": 1011
-              },
+                "size": 82595,
+                "w": 800
+            },
+            "thumbnail_url": "mxc://matrix.org/irsns989Rrsn",
+            "w": 1011
+            },
+        "url": "mxc://matrix.org/rnsldl8srs98IRrs",
+        "org.matrix.msc1767.text": "Hello",
+        "org.matrix.msc1767.file": {
             "url": "mxc://matrix.org/rnsldl8srs98IRrs",
-            "org.matrix.msc1767.text": "Hello",
-            "org.matrix.msc1767.file": {
-                "url": "mxc://matrix.org/rnsldl8srs98IRrs",
-                "mimetype": "image/png",
-                "size": 84242,
-            },
-            "org.matrix.msc1767.image": {
-                "height": 423,
-                "width": 1011,
-            },
-            "org.matrix.msc1767.thumbnail": [
-                {
-                    "url": "mxc://matrix.org/irsns989Rrsn",
-                    "mimetype": "image/png",
-                    "size": 82595,
-                    "height": 334,
-                    "width": 800,
-                }
-            ],
+            "mimetype": "image/png",
+            "size": 84242,
         },
-        "event_id": "$h29iv0s8:example.com",
-        "origin_server_ts": 1,
-        "room_id": "!roomid:room.com",
-        "sender": "@carl:example.com",
-        "type": "m.sticker",
+        "org.matrix.msc1767.image": {
+            "height": 423,
+            "width": 1011,
+        },
+        "org.matrix.msc1767.thumbnail": [
+            {
+                "url": "mxc://matrix.org/irsns989Rrsn",
+                "mimetype": "image/png",
+                "size": 82595,
+                "height": 334,
+                "width": 800,
+            }
+        ],
     });
 
     assert_eq!(actual, expected);

--- a/crates/ruma-common/tests/events/poll.rs
+++ b/crates/ruma-common/tests/events/poll.rs
@@ -16,9 +16,8 @@ use ruma_common::{
             },
         },
         relation::Reference,
-        AnyMessageLikeEvent, MessageLikeEvent, MessageLikeUnsigned, OriginalMessageLikeEvent,
+        AnyMessageLikeEvent, MessageLikeEvent,
     },
-    room_id, user_id, MilliSecondsSinceUnixEpoch,
 };
 use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
@@ -105,48 +104,34 @@ fn start_content_serialization() {
 
 #[test]
 fn start_event_serialization() {
-    let event = OriginalMessageLikeEvent {
-        content: PollStartEventContent::new(assign!(
-            PollStartContent::new(
-                MessageContent::plain("How's the weather?"),
-                PollKind::Disclosed,
-                vec![
-                    PollAnswer::new("not-bad".to_owned(), MessageContent::plain("Not bad…")),
-                    PollAnswer::new("fine".to_owned(), MessageContent::plain("Fine.")),
-                    PollAnswer::new("amazing".to_owned(), MessageContent::plain("Amazing!")),
-                ]
-                .try_into()
-                .unwrap(),
-            ),
-            { max_selections: uint!(2) }
-        )),
-        event_id: event_id!("$event:notareal.hs").to_owned(),
-        sender: user_id!("@user:notareal.hs").to_owned(),
-        origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(134_829_848)),
-        room_id: room_id!("!roomid:notareal.hs").to_owned(),
-        unsigned: MessageLikeUnsigned::default(),
-    };
+    let content = PollStartEventContent::new(assign!(
+        PollStartContent::new(
+            MessageContent::plain("How's the weather?"),
+            PollKind::Disclosed,
+            vec![
+                PollAnswer::new("not-bad".to_owned(), MessageContent::plain("Not bad…")),
+                PollAnswer::new("fine".to_owned(), MessageContent::plain("Fine.")),
+                PollAnswer::new("amazing".to_owned(), MessageContent::plain("Amazing!")),
+            ]
+            .try_into()
+            .unwrap(),
+        ),
+        { max_selections: uint!(2) }
+    ));
 
     assert_eq!(
-        to_json_value(&event).unwrap(),
+        to_json_value(&content).unwrap(),
         json!({
-            "content": {
-                "org.matrix.msc3381.poll.start": {
-                    "question": { "org.matrix.msc1767.text": "How's the weather?" },
-                    "kind": "org.matrix.msc3381.poll.disclosed",
-                    "max_selections": 2,
-                    "answers": [
-                        { "id": "not-bad", "org.matrix.msc1767.text": "Not bad…"},
-                        { "id": "fine", "org.matrix.msc1767.text": "Fine."},
-                        { "id": "amazing", "org.matrix.msc1767.text": "Amazing!"},
-                    ]
-                },
+            "org.matrix.msc3381.poll.start": {
+                "question": { "org.matrix.msc1767.text": "How's the weather?" },
+                "kind": "org.matrix.msc3381.poll.disclosed",
+                "max_selections": 2,
+                "answers": [
+                    { "id": "not-bad", "org.matrix.msc1767.text": "Not bad…"},
+                    { "id": "fine", "org.matrix.msc1767.text": "Fine."},
+                    { "id": "amazing", "org.matrix.msc1767.text": "Amazing!"},
+                ]
             },
-            "event_id": "$event:notareal.hs",
-            "origin_server_ts": 134_829_848,
-            "room_id": "!roomid:notareal.hs",
-            "sender": "@user:notareal.hs",
-            "type": "org.matrix.msc3381.poll.start",
         })
     );
 }
@@ -255,35 +240,21 @@ fn response_content_serialization() {
 
 #[test]
 fn response_event_serialization() {
-    let event = OriginalMessageLikeEvent {
-        content: PollResponseEventContent::new(
-            PollResponseContent::new(vec!["first-answer".to_owned(), "second-answer".to_owned()]),
-            event_id!("$related_event:notareal.hs").to_owned(),
-        ),
-        event_id: event_id!("$event:notareal.hs").to_owned(),
-        sender: user_id!("@user:notareal.hs").to_owned(),
-        origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(134_829_848)),
-        room_id: room_id!("!roomid:notareal.hs").to_owned(),
-        unsigned: MessageLikeUnsigned::default(),
-    };
+    let content = PollResponseEventContent::new(
+        PollResponseContent::new(vec!["first-answer".to_owned(), "second-answer".to_owned()]),
+        event_id!("$related_event:notareal.hs").to_owned(),
+    );
 
     assert_eq!(
-        to_json_value(&event).unwrap(),
+        to_json_value(&content).unwrap(),
         json!({
-            "content": {
-                "org.matrix.msc3381.poll.response": {
-                    "answers": ["first-answer", "second-answer"],
-                },
-                "m.relates_to": {
-                    "rel_type": "m.reference",
-                    "event_id": "$related_event:notareal.hs",
-                }
+            "org.matrix.msc3381.poll.response": {
+                "answers": ["first-answer", "second-answer"],
             },
-            "event_id": "$event:notareal.hs",
-            "origin_server_ts": 134_829_848,
-            "room_id": "!roomid:notareal.hs",
-            "sender": "@user:notareal.hs",
-            "type": "org.matrix.msc3381.poll.response",
+            "m.relates_to": {
+                "rel_type": "m.reference",
+                "event_id": "$related_event:notareal.hs",
+            },
         })
     );
 }
@@ -380,33 +351,19 @@ fn end_content_serialization() {
 
 #[test]
 fn end_event_serialization() {
-    let event = OriginalMessageLikeEvent {
-        content: PollEndEventContent::new(
-            PollEndContent::new(),
-            event_id!("$related_event:notareal.hs").to_owned(),
-        ),
-        event_id: event_id!("$event:notareal.hs").to_owned(),
-        sender: user_id!("@user:notareal.hs").to_owned(),
-        origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(134_829_848)),
-        room_id: room_id!("!roomid:notareal.hs").to_owned(),
-        unsigned: MessageLikeUnsigned::default(),
-    };
+    let content = PollEndEventContent::new(
+        PollEndContent::new(),
+        event_id!("$related_event:notareal.hs").to_owned(),
+    );
 
     assert_eq!(
-        to_json_value(&event).unwrap(),
+        to_json_value(&content).unwrap(),
         json!({
-            "content": {
-                "org.matrix.msc3381.poll.end": {},
-                "m.relates_to": {
-                    "rel_type": "m.reference",
-                    "event_id": "$related_event:notareal.hs",
-                }
+            "org.matrix.msc3381.poll.end": {},
+            "m.relates_to": {
+                "rel_type": "m.reference",
+                "event_id": "$related_event:notareal.hs",
             },
-            "event_id": "$event:notareal.hs",
-            "origin_server_ts": 134_829_848,
-            "room_id": "!roomid:notareal.hs",
-            "sender": "@user:notareal.hs",
-            "type": "org.matrix.msc3381.poll.end",
         })
     );
 }

--- a/crates/ruma-common/tests/events/redaction.rs
+++ b/crates/ruma-common/tests/events/redaction.rs
@@ -1,25 +1,32 @@
 use assert_matches::assert_matches;
 use js_int::uint;
 use ruma_common::{
-    event_id,
     events::{
-        room::redaction::{
-            OriginalRoomRedactionEvent, RoomRedactionEvent, RoomRedactionEventContent,
-        },
-        AnyMessageLikeEvent, MessageLikeUnsigned,
+        room::redaction::{RoomRedactionEvent, RoomRedactionEventContent},
+        AnyMessageLikeEvent,
     },
-    room_id,
     serde::CanBeEmpty,
-    user_id, MilliSecondsSinceUnixEpoch,
+    MilliSecondsSinceUnixEpoch,
 };
-use serde_json::{
-    from_value as from_json_value, json, to_value as to_json_value, Value as JsonValue,
-};
+use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
-fn redaction() -> JsonValue {
-    json!({
+#[test]
+fn serialize_redaction_content() {
+    let content = RoomRedactionEventContent::with_reason("being very unfriendly".into());
+
+    let actual = to_json_value(content).unwrap();
+    let expected = json!({
+        "reason": "being very unfriendly"
+    });
+
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn deserialize_redaction() {
+    let json_data = json!({
         "content": {
-            "reason": "being a turd"
+            "reason": "being very unfriendly"
         },
         "redacts": "$nomore:example.com",
         "event_id": "$h29iv0s8:example.com",
@@ -27,36 +34,13 @@ fn redaction() -> JsonValue {
         "origin_server_ts": 1,
         "room_id": "!roomid:room.com",
         "type": "m.room.redaction"
-    })
-}
-
-#[test]
-fn serialize_redaction() {
-    let aliases_event = OriginalRoomRedactionEvent {
-        content: RoomRedactionEventContent::with_reason("being a turd".into()),
-        redacts: event_id!("$nomore:example.com").to_owned(),
-        event_id: event_id!("$h29iv0s8:example.com").to_owned(),
-        origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(1)),
-        room_id: room_id!("!roomid:room.com").to_owned(),
-        sender: user_id!("@carl:example.com").to_owned(),
-        unsigned: MessageLikeUnsigned::default(),
-    };
-
-    let actual = to_json_value(&aliases_event).unwrap();
-    let expected = redaction();
-
-    assert_eq!(actual, expected);
-}
-
-#[test]
-fn deserialize_redaction() {
-    let json_data = redaction();
+    });
 
     let ev = assert_matches!(
         from_json_value::<AnyMessageLikeEvent>(json_data),
         Ok(AnyMessageLikeEvent::RoomRedaction(RoomRedactionEvent::Original(ev))) => ev
     );
-    assert_eq!(ev.content.reason.as_deref(), Some("being a turd"));
+    assert_eq!(ev.content.reason.as_deref(), Some("being very unfriendly"));
     assert_eq!(ev.event_id, "$h29iv0s8:example.com");
     assert_eq!(ev.redacts, "$nomore:example.com");
     assert_eq!(ev.origin_server_ts, MilliSecondsSinceUnixEpoch(uint!(1)));

--- a/crates/ruma-common/tests/events/room_message.rs
+++ b/crates/ruma-common/tests/events/room_message.rs
@@ -34,55 +34,35 @@ macro_rules! json_object {
 
 #[test]
 fn serialization() {
-    let ev = OriginalRoomMessageEvent {
-        content: RoomMessageEventContent::new(MessageType::Audio(AudioMessageEventContent::plain(
+    let content =
+        RoomMessageEventContent::new(MessageType::Audio(AudioMessageEventContent::plain(
             "test".into(),
             mxc_uri!("mxc://example.org/ffed755USFFxlgbQYZGtryd").to_owned(),
             None,
-        ))),
-        event_id: event_id!("$143273582443PhrSn:example.org").to_owned(),
-        origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(10_000)),
-        room_id: room_id!("!testroomid:example.org").to_owned(),
-        sender: user_id!("@user:example.org").to_owned(),
-        unsigned: MessageLikeUnsigned::default(),
-    };
+        )));
 
     #[cfg(not(feature = "unstable-msc3246"))]
     assert_eq!(
-        to_json_value(ev).unwrap(),
+        to_json_value(content).unwrap(),
         json!({
-            "type": "m.room.message",
-            "event_id": "$143273582443PhrSn:example.org",
-            "origin_server_ts": 10_000,
-            "room_id": "!testroomid:example.org",
-            "sender": "@user:example.org",
-            "content": {
-                "body": "test",
-                "msgtype": "m.audio",
-                "url": "mxc://example.org/ffed755USFFxlgbQYZGtryd",
-            }
+            "body": "test",
+            "msgtype": "m.audio",
+            "url": "mxc://example.org/ffed755USFFxlgbQYZGtryd",
         })
     );
 
     #[cfg(feature = "unstable-msc3246")]
     assert_eq!(
-        to_json_value(ev).unwrap(),
+        to_json_value(content).unwrap(),
         json!({
-            "type": "m.room.message",
-            "event_id": "$143273582443PhrSn:example.org",
-            "origin_server_ts": 10_000,
-            "room_id": "!testroomid:example.org",
-            "sender": "@user:example.org",
-            "content": {
-                "body": "test",
-                "msgtype": "m.audio",
+            "body": "test",
+            "msgtype": "m.audio",
+            "url": "mxc://example.org/ffed755USFFxlgbQYZGtryd",
+            "org.matrix.msc1767.text": "test",
+            "org.matrix.msc1767.file": {
                 "url": "mxc://example.org/ffed755USFFxlgbQYZGtryd",
-                "org.matrix.msc1767.text": "test",
-                "org.matrix.msc1767.file": {
-                    "url": "mxc://example.org/ffed755USFFxlgbQYZGtryd",
-                },
-                "org.matrix.msc1767.audio": {},
-            }
+            },
+            "org.matrix.msc1767.audio": {},
         })
     );
 }

--- a/crates/ruma-common/tests/events/state_event.rs
+++ b/crates/ruma-common/tests/events/state_event.rs
@@ -1,20 +1,15 @@
 use assert_matches::assert_matches;
-use assign::assign;
 use js_int::uint;
 use ruma_common::{
-    event_id,
     events::{
-        room::aliases::RoomAliasesEventContent, AnyStateEvent, AnyStateEventContent,
-        AnySyncStateEvent, AnyTimelineEvent, OriginalStateEvent, StateEvent, StateEventType,
-        StateUnsigned, SyncStateEvent,
+        AnyStateEvent, AnyStateEventContent, AnySyncStateEvent, AnyTimelineEvent, StateEvent,
+        StateEventType, SyncStateEvent,
     },
-    mxc_uri, room_alias_id, room_id,
+    mxc_uri, room_alias_id,
     serde::{CanBeEmpty, Raw},
-    server_name, user_id, MilliSecondsSinceUnixEpoch,
+    MilliSecondsSinceUnixEpoch,
 };
-use serde_json::{
-    from_value as from_json_value, json, to_value as to_json_value, Value as JsonValue,
-};
+use serde_json::{from_value as from_json_value, json, Value as JsonValue};
 
 fn aliases_event_with_prev_content() -> JsonValue {
     json!({
@@ -36,64 +31,9 @@ fn aliases_event_with_prev_content() -> JsonValue {
 }
 
 #[test]
-fn serialize_aliases_with_prev_content() {
-    let aliases_event = OriginalStateEvent {
-        content: RoomAliasesEventContent::new(vec![
-            room_alias_id!("#somewhere:localhost").to_owned()
-        ]),
-        event_id: event_id!("$h29iv0s8:example.com").to_owned(),
-        origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(1)),
-        room_id: room_id!("!roomid:room.com").to_owned(),
-        sender: user_id!("@carl:example.com").to_owned(),
-        state_key: server_name!("room.com").to_owned(),
-        unsigned: assign!(StateUnsigned::default(), {
-            prev_content: Some(RoomAliasesEventContent::new(vec![room_alias_id!(
-                "#inner:localhost"
-            )
-            .to_owned()])),
-        }),
-    };
-
-    let actual = to_json_value(&aliases_event).unwrap();
-    let expected = aliases_event_with_prev_content();
-
-    assert_eq!(actual, expected);
-}
-
-#[test]
-fn serialize_aliases_without_prev_content() {
-    let aliases_event = OriginalStateEvent {
-        content: RoomAliasesEventContent::new(vec![
-            room_alias_id!("#somewhere:localhost").to_owned()
-        ]),
-        event_id: event_id!("$h29iv0s8:example.com").to_owned(),
-        origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(1)),
-        room_id: room_id!("!roomid:room.com").to_owned(),
-        sender: user_id!("@carl:example.com").to_owned(),
-        state_key: server_name!("example.com").to_owned(),
-        unsigned: StateUnsigned::default(),
-    };
-
-    let actual = to_json_value(&aliases_event).unwrap();
-    let expected = json!({
-        "content": {
-            "aliases": [ "#somewhere:localhost" ]
-        },
-        "event_id": "$h29iv0s8:example.com",
-        "origin_server_ts": 1,
-        "room_id": "!roomid:room.com",
-        "sender": "@carl:example.com",
-        "state_key": "example.com",
-        "type": "m.room.aliases",
-    });
-
-    assert_eq!(actual, expected);
-}
-
-#[test]
 fn deserialize_aliases_content() {
     let json_data = json!({
-        "aliases": [ "#somewhere:localhost" ]
+        "aliases": ["#somewhere:localhost"],
     });
 
     let content = assert_matches!(

--- a/crates/ruma-common/tests/events/stripped.rs
+++ b/crates/ruma-common/tests/events/stripped.rs
@@ -3,30 +3,18 @@ use js_int::uint;
 use ruma_common::{
     events::{
         room::{join_rules::JoinRule, topic::RoomTopicEventContent},
-        AnyStrippedStateEvent, EmptyStateKey, StrippedStateEvent,
+        AnyStrippedStateEvent,
     },
-    mxc_uri, user_id,
+    mxc_uri,
 };
 use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
 #[test]
 fn serialize_stripped_state_event_any_content() {
-    let event = StrippedStateEvent {
-        content: RoomTopicEventContent::new("Testing room".into()),
-        state_key: EmptyStateKey,
-        sender: user_id!("@example:localhost").to_owned(),
-    };
-
-    let json_data = json!({
-        "content": {
-            "topic": "Testing room"
-        },
-        "type": "m.room.topic",
-        "state_key": "",
-        "sender": "@example:localhost"
-    });
-
-    assert_eq!(to_json_value(&event).unwrap(), json_data);
+    assert_eq!(
+        to_json_value(RoomTopicEventContent::new("Testing room".into())).unwrap(),
+        json!({ "topic": "Testing room" })
+    );
 }
 
 #[test]

--- a/crates/ruma-common/tests/events/to_device.rs
+++ b/crates/ruma-common/tests/events/to_device.rs
@@ -1,32 +1,24 @@
 use ruma_common::{
-    events::{room_key::ToDeviceRoomKeyEventContent, ToDeviceEvent},
-    room_id, user_id, EventEncryptionAlgorithm,
+    events::room_key::ToDeviceRoomKeyEventContent, room_id, EventEncryptionAlgorithm,
 };
 use serde_json::{json, to_value as to_json_value};
 
 #[test]
 fn serialization() {
-    let ev = ToDeviceEvent {
-        sender: user_id!("@example:example.org").to_owned(),
-        content: ToDeviceRoomKeyEventContent::new(
-            EventEncryptionAlgorithm::MegolmV1AesSha2,
-            room_id!("!testroomid:example.org").to_owned(),
-            "SessId".into(),
-            "SessKey".into(),
-        ),
-    };
+    let content = ToDeviceRoomKeyEventContent::new(
+        EventEncryptionAlgorithm::MegolmV1AesSha2,
+        room_id!("!testroomid:example.org").to_owned(),
+        "SessId".into(),
+        "SessKey".into(),
+    );
 
     assert_eq!(
-        to_json_value(&ev).unwrap(),
+        to_json_value(&content).unwrap(),
         json!({
-            "type": "m.room_key",
-            "sender": "@example:example.org",
-            "content": {
-                "algorithm": "m.megolm.v1.aes-sha2",
-                "room_id": "!testroomid:example.org",
-                "session_id": "SessId",
-                "session_key": "SessKey",
-            },
+            "algorithm": "m.megolm.v1.aes-sha2",
+            "room_id": "!testroomid:example.org",
+            "session_id": "SessId",
+            "session_key": "SessKey",
         })
     );
 }

--- a/crates/ruma-common/tests/events/video.rs
+++ b/crates/ruma-common/tests/events/video.rs
@@ -17,11 +17,11 @@ use ruma_common::{
             JsonWebKeyInit, MediaSource,
         },
         video::{VideoContent, VideoEventContent},
-        AnyMessageLikeEvent, MessageLikeEvent, MessageLikeUnsigned, OriginalMessageLikeEvent,
+        AnyMessageLikeEvent, MessageLikeEvent,
     },
-    mxc_uri, room_id,
+    mxc_uri,
     serde::{Base64, CanBeEmpty},
-    user_id, MilliSecondsSinceUnixEpoch,
+    MilliSecondsSinceUnixEpoch,
 };
 use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
@@ -98,98 +98,84 @@ fn encrypted_content_serialization() {
 
 #[test]
 fn event_serialization() {
-    let event = OriginalMessageLikeEvent {
-        content: assign!(
-            VideoEventContent::with_message(
-                MessageContent::html(
-                    "Upload: my_lava_lamp.webm",
-                    "Upload: <strong>my_lava_lamp.webm</strong>",
-                ),
-                FileContent::plain(
-                    mxc_uri!("mxc://notareal.hs/abcdef").to_owned(),
-                    Some(Box::new(assign!(
-                        FileContentInfo::new(),
-                        {
-                            name: Some("my_lava_lamp.webm".to_owned()),
-                            mimetype: Some("video/webm".to_owned()),
-                            size: Some(uint!(1_897_774)),
-                        }
-                    ))),
-                )
+    let content = assign!(
+        VideoEventContent::with_message(
+            MessageContent::html(
+                "Upload: my_lava_lamp.webm",
+                "Upload: <strong>my_lava_lamp.webm</strong>",
             ),
-            {
-                video: Box::new(assign!(
-                    VideoContent::new(),
+            FileContent::plain(
+                mxc_uri!("mxc://notareal.hs/abcdef").to_owned(),
+                Some(Box::new(assign!(
+                    FileContentInfo::new(),
                     {
-                        width: Some(uint!(1920)),
-                        height: Some(uint!(1080)),
-                        duration: Some(Duration::from_secs(15)),
+                        name: Some("my_lava_lamp.webm".to_owned()),
+                        mimetype: Some("video/webm".to_owned()),
+                        size: Some(uint!(1_897_774)),
                     }
-                )),
-                thumbnail: vec![ThumbnailContent::new(
-                    ThumbnailFileContent::plain(
-                        mxc_uri!("mxc://notareal.hs/thumbnail").to_owned(),
-                        Some(Box::new(assign!(ThumbnailFileContentInfo::new(), {
-                            mimetype: Some("image/jpeg".to_owned()),
-                            size: Some(uint!(334_593)),
-                        })))
-                    ),
-                    None
-                )],
-                caption: Some(MessageContent::plain("This is my awesome vintage lava lamp")),
-                relates_to: Some(Relation::Reply {
-                    in_reply_to: InReplyTo::new(event_id!("$replyevent:example.com").to_owned()),
-                }),
-            }
+                ))),
+            )
         ),
-        event_id: event_id!("$event:notareal.hs").to_owned(),
-        sender: user_id!("@user:notareal.hs").to_owned(),
-        origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(134_829_848)),
-        room_id: room_id!("!roomid:notareal.hs").to_owned(),
-        unsigned: MessageLikeUnsigned::default(),
-    };
+        {
+            video: Box::new(assign!(
+                VideoContent::new(),
+                {
+                    width: Some(uint!(1920)),
+                    height: Some(uint!(1080)),
+                    duration: Some(Duration::from_secs(15)),
+                }
+            )),
+            thumbnail: vec![ThumbnailContent::new(
+                ThumbnailFileContent::plain(
+                    mxc_uri!("mxc://notareal.hs/thumbnail").to_owned(),
+                    Some(Box::new(assign!(ThumbnailFileContentInfo::new(), {
+                        mimetype: Some("image/jpeg".to_owned()),
+                        size: Some(uint!(334_593)),
+                    })))
+                ),
+                None
+            )],
+            caption: Some(MessageContent::plain("This is my awesome vintage lava lamp")),
+            relates_to: Some(Relation::Reply {
+                in_reply_to: InReplyTo::new(event_id!("$replyevent:example.com").to_owned()),
+            }),
+        }
+    );
 
     assert_eq!(
-        to_json_value(&event).unwrap(),
+        to_json_value(&content).unwrap(),
         json!({
-            "content": {
-                "org.matrix.msc1767.html": "Upload: <strong>my_lava_lamp.webm</strong>",
-                "org.matrix.msc1767.text": "Upload: my_lava_lamp.webm",
-                "m.file": {
-                    "url": "mxc://notareal.hs/abcdef",
-                    "name": "my_lava_lamp.webm",
-                    "mimetype": "video/webm",
-                    "size": 1_897_774,
-                },
-                "m.video": {
-                    "width": 1920,
-                    "height": 1080,
-                    "duration": 15_000,
-                },
-                "m.thumbnail": [
-                    {
-                        "url": "mxc://notareal.hs/thumbnail",
-                        "mimetype": "image/jpeg",
-                        "size": 334_593,
-                    }
-                ],
-                "m.caption": [
-                    {
-                        "body": "This is my awesome vintage lava lamp",
-                        "mimetype": "text/plain",
-                    }
-                ],
-                "m.relates_to": {
-                    "m.in_reply_to": {
-                        "event_id": "$replyevent:example.com"
-                    }
-                }
+            "org.matrix.msc1767.html": "Upload: <strong>my_lava_lamp.webm</strong>",
+            "org.matrix.msc1767.text": "Upload: my_lava_lamp.webm",
+            "m.file": {
+                "url": "mxc://notareal.hs/abcdef",
+                "name": "my_lava_lamp.webm",
+                "mimetype": "video/webm",
+                "size": 1_897_774,
             },
-            "event_id": "$event:notareal.hs",
-            "origin_server_ts": 134_829_848,
-            "room_id": "!roomid:notareal.hs",
-            "sender": "@user:notareal.hs",
-            "type": "m.video",
+            "m.video": {
+                "width": 1920,
+                "height": 1080,
+                "duration": 15_000,
+            },
+            "m.thumbnail": [
+                {
+                    "url": "mxc://notareal.hs/thumbnail",
+                    "mimetype": "image/jpeg",
+                    "size": 334_593,
+                }
+            ],
+            "m.caption": [
+                {
+                    "body": "This is my awesome vintage lava lamp",
+                    "mimetype": "text/plain",
+                }
+            ],
+            "m.relates_to": {
+                "m.in_reply_to": {
+                    "event_id": "$replyevent:example.com"
+                }
+            }
         })
     );
 }

--- a/crates/ruma-common/tests/events/voice.rs
+++ b/crates/ruma-common/tests/events/voice.rs
@@ -16,77 +16,63 @@ use ruma_common::{
             MediaSource,
         },
         voice::{VoiceContent, VoiceEventContent},
-        AnyMessageLikeEvent, MessageLikeEvent, MessageLikeUnsigned, OriginalMessageLikeEvent,
+        AnyMessageLikeEvent, MessageLikeEvent,
     },
-    mxc_uri, room_id,
+    mxc_uri,
     serde::CanBeEmpty,
-    user_id, MilliSecondsSinceUnixEpoch,
+    MilliSecondsSinceUnixEpoch,
 };
 use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
 #[test]
 fn event_serialization() {
-    let event = OriginalMessageLikeEvent {
-        content: assign!(
-            VoiceEventContent::plain(
-                "Voice message",
-                FileContent::plain(
-                    mxc_uri!("mxc://notareal.hs/abcdef").to_owned(),
-                    Some(Box::new(assign!(
-                        FileContentInfo::new(),
-                        {
-                            name: Some("voice_message.ogg".to_owned()),
-                            mimetype: Some("audio/opus".to_owned()),
-                            size: Some(uint!(897_774)),
-                        }
-                    ))),
-                )
-            ),
-            {
-                audio: assign!(
-                    AudioContent::new(),
+    let content = assign!(
+        VoiceEventContent::plain(
+            "Voice message",
+            FileContent::plain(
+                mxc_uri!("mxc://notareal.hs/abcdef").to_owned(),
+                Some(Box::new(assign!(
+                    FileContentInfo::new(),
                     {
-                        duration: Some(Duration::from_secs(23))
+                        name: Some("voice_message.ogg".to_owned()),
+                        mimetype: Some("audio/opus".to_owned()),
+                        size: Some(uint!(897_774)),
                     }
-                ),
-                relates_to: Some(Relation::Reply {
-                    in_reply_to: InReplyTo::new(event_id!("$replyevent:example.com").to_owned()),
-                }),
-            }
+                ))),
+            )
         ),
-        event_id: event_id!("$event:notareal.hs").to_owned(),
-        sender: user_id!("@user:notareal.hs").to_owned(),
-        origin_server_ts: MilliSecondsSinceUnixEpoch(uint!(134_829_848)),
-        room_id: room_id!("!roomid:notareal.hs").to_owned(),
-        unsigned: MessageLikeUnsigned::default(),
-    };
+        {
+            audio: assign!(
+                AudioContent::new(),
+                {
+                    duration: Some(Duration::from_secs(23))
+                }
+            ),
+            relates_to: Some(Relation::Reply {
+                in_reply_to: InReplyTo::new(event_id!("$replyevent:example.com").to_owned()),
+            }),
+        }
+    );
 
     assert_eq!(
-        to_json_value(&event).unwrap(),
+        to_json_value(&content).unwrap(),
         json!({
-            "content": {
-                "org.matrix.msc1767.text": "Voice message",
-                "m.file": {
-                    "url": "mxc://notareal.hs/abcdef",
-                    "name": "voice_message.ogg",
-                    "mimetype": "audio/opus",
-                    "size": 897_774,
-                },
-                "m.audio": {
-                    "duration": 23_000,
-                },
-                "m.voice": {},
-                "m.relates_to": {
-                    "m.in_reply_to": {
-                        "event_id": "$replyevent:example.com"
-                    }
+            "org.matrix.msc1767.text": "Voice message",
+            "m.file": {
+                "url": "mxc://notareal.hs/abcdef",
+                "name": "voice_message.ogg",
+                "mimetype": "audio/opus",
+                "size": 897_774,
+            },
+            "m.audio": {
+                "duration": 23_000,
+            },
+            "m.voice": {},
+            "m.relates_to": {
+                "m.in_reply_to": {
+                    "event_id": "$replyevent:example.com"
                 }
             },
-            "event_id": "$event:notareal.hs",
-            "origin_server_ts": 134_829_848,
-            "room_id": "!roomid:notareal.hs",
-            "sender": "@user:notareal.hs",
-            "type": "m.voice",
         })
     );
 }


### PR DESCRIPTION
This requires some changes before it works in matrix-rust-sdk, but otherwise it's ready.

The reason for doing this is that it is a feature encourages doing serde roundtrips of events, which is not a good idea. There are very few to no "proper" uses of it:

- Clients only need to serialize event content types, not full events
- Servers need event types with raw content, so they don't fall into the same trap of first fully deserializing user content before embedding it in events and thus loosing unknown fields




<!-- Replace -->
----
Preview Removed
<!-- Replace -->
