### PR TITLE
BundledRelations improvements

### DIFF
--- a/crates/ruma-common/src/events/enums.rs
+++ b/crates/ruma-common/src/events/enums.rs
@@ -177,8 +177,8 @@ impl AnyTimelineEvent {
         /// Returns this event's `transaction_id` from inside `unsigned`, if there is one.
         pub fn transaction_id(&self) -> Option<&TransactionId>;
 
-        /// Returns this event's `relations` from inside `unsigned`, if that field exists.
-        pub fn relations(&self) -> Option<&BundledRelations>;
+        /// Returns this event's `relations` from inside `unsigned`.
+        pub fn relations(&self) -> &BundledRelations;
     }
 }
 
@@ -210,7 +210,7 @@ impl AnySyncTimelineEvent {
         pub fn transaction_id(&self) -> Option<&TransactionId>;
 
         /// Returns this event's `relations` from inside `unsigned`, if that field exists.
-        pub fn relations(&self) -> Option<&BundledRelations>;
+        pub fn relations(&self) -> &BundledRelations;
     }
 
     /// Converts `self` to an `AnyTimelineEvent` by adding the given a room ID.

--- a/crates/ruma-common/src/events/relation.rs
+++ b/crates/ruma-common/src/events/relation.rs
@@ -291,19 +291,19 @@ pub struct BundledRelations {
     /// Annotation relations.
     #[cfg(feature = "unstable-msc2677")]
     #[serde(rename = "m.annotation", skip_serializing_if = "Option::is_none")]
-    pub annotation: Option<AnnotationChunk>,
+    pub annotation: Option<Box<AnnotationChunk>>,
 
     /// Replacement relation.
     #[serde(rename = "m.replace", skip_serializing_if = "Option::is_none")]
-    pub replace: Option<BundledReplacement>,
+    pub replace: Option<Box<BundledReplacement>>,
 
     /// Thread relation.
     #[serde(rename = "m.thread", skip_serializing_if = "Option::is_none")]
-    pub thread: Option<BundledThread>,
+    pub thread: Option<Box<BundledThread>>,
 
     /// Reference relations.
     #[serde(rename = "m.reference", skip_serializing_if = "Option::is_none")]
-    pub reference: Option<ReferenceChunk>,
+    pub reference: Option<Box<ReferenceChunk>>,
 }
 
 impl BundledRelations {

--- a/crates/ruma-common/src/events/relation.rs
+++ b/crates/ruma-common/src/events/relation.rs
@@ -308,8 +308,26 @@ pub struct BundledRelations {
 
 impl BundledRelations {
     /// Creates a new empty `BundledRelations`.
-    pub fn new() -> Self {
-        Self::default()
+    pub const fn new() -> Self {
+        Self {
+            #[cfg(feature = "unstable-msc2677")]
+            annotation: None,
+            replace: None,
+            thread: None,
+            reference: None,
+        }
+    }
+
+    /// Returns `true` if all fields are empty.
+    pub fn is_empty(&self) -> bool {
+        #[cfg(not(feature = "unstable-msc2677"))]
+        return self.replace.is_none() && self.thread.is_none() && self.reference.is_none();
+
+        #[cfg(feature = "unstable-msc2677")]
+        return self.annotation.is_none()
+            && self.replace.is_none()
+            && self.thread.is_none()
+            && self.reference.is_none();
     }
 }
 

--- a/crates/ruma-common/src/events/relation.rs
+++ b/crates/ruma-common/src/events/relation.rs
@@ -214,7 +214,7 @@ impl Thread {
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct BundledThread {
     /// The latest event in the thread.
-    pub latest_event: Box<Raw<AnyMessageLikeEvent>>,
+    pub latest_event: Raw<AnyMessageLikeEvent>,
 
     /// The number of events in the thread.
     pub count: UInt,
@@ -226,7 +226,7 @@ pub struct BundledThread {
 impl BundledThread {
     /// Creates a new `BundledThread` with the given event, count and user participated flag.
     pub fn new(
-        latest_event: Box<Raw<AnyMessageLikeEvent>>,
+        latest_event: Raw<AnyMessageLikeEvent>,
         count: UInt,
         current_user_participated: bool,
     ) -> Self {

--- a/crates/ruma-common/src/events/relation.rs
+++ b/crates/ruma-common/src/events/relation.rs
@@ -290,19 +290,19 @@ impl ReferenceChunk {
 pub struct BundledRelations {
     /// Annotation relations.
     #[cfg(feature = "unstable-msc2677")]
-    #[serde(rename = "m.annotation")]
+    #[serde(rename = "m.annotation", skip_serializing_if = "Option::is_none")]
     pub annotation: Option<AnnotationChunk>,
 
     /// Replacement relation.
-    #[serde(rename = "m.replace")]
+    #[serde(rename = "m.replace", skip_serializing_if = "Option::is_none")]
     pub replace: Option<BundledReplacement>,
 
     /// Thread relation.
-    #[serde(rename = "m.thread")]
+    #[serde(rename = "m.thread", skip_serializing_if = "Option::is_none")]
     pub thread: Option<BundledThread>,
 
     /// Reference relations.
-    #[serde(rename = "m.reference")]
+    #[serde(rename = "m.reference", skip_serializing_if = "Option::is_none")]
     pub reference: Option<ReferenceChunk>,
 }
 

--- a/crates/ruma-common/src/events/room/member.rs
+++ b/crates/ruma-common/src/events/room/member.rs
@@ -480,8 +480,8 @@ pub struct RoomMemberUnsigned {
     /// [Bundled aggregations] of related child events.
     ///
     /// [Bundled aggregations]: https://spec.matrix.org/v1.4/client-server-api/#aggregations
-    #[serde(rename = "m.relations", skip_serializing_if = "Option::is_none")]
-    pub relations: Option<BundledRelations>,
+    #[serde(rename = "m.relations", default, skip_serializing_if = "BundledRelations::is_empty")]
+    pub relations: BundledRelations,
 }
 
 impl RoomMemberUnsigned {
@@ -502,7 +502,7 @@ impl CanBeEmpty for RoomMemberUnsigned {
             && self.transaction_id.is_none()
             && self.prev_content.is_none()
             && self.invite_room_state.is_empty()
-            && self.relations.is_none()
+            && self.relations.is_empty()
     }
 }
 

--- a/crates/ruma-common/src/events/unsigned.rs
+++ b/crates/ruma-common/src/events/unsigned.rs
@@ -30,8 +30,8 @@ pub struct MessageLikeUnsigned {
     /// [Bundled aggregations] of related child events.
     ///
     /// [Bundled aggregations]: https://spec.matrix.org/v1.4/client-server-api/#aggregations
-    #[serde(rename = "m.relations", skip_serializing_if = "Option::is_none")]
-    pub relations: Option<BundledRelations>,
+    #[serde(rename = "m.relations", default, skip_serializing_if = "BundledRelations::is_empty")]
+    pub relations: BundledRelations,
 }
 
 impl MessageLikeUnsigned {
@@ -48,7 +48,7 @@ impl CanBeEmpty for MessageLikeUnsigned {
     /// events. Do not use it to determine whether an incoming `unsigned` field was present - it
     /// could still have been present but contained none of the known fields.
     fn is_empty(&self) -> bool {
-        self.age.is_none() && self.transaction_id.is_none() && self.relations.is_none()
+        self.age.is_none() && self.transaction_id.is_none() && self.relations.is_empty()
     }
 }
 
@@ -76,14 +76,14 @@ pub struct StateUnsigned<C: StateEventContent> {
     /// [Bundled aggregations] of related child events.
     ///
     /// [Bundled aggregations]: https://spec.matrix.org/v1.4/client-server-api/#aggregations
-    #[serde(rename = "m.relations", skip_serializing_if = "Option::is_none")]
-    pub relations: Option<BundledRelations>,
+    #[serde(rename = "m.relations", default, skip_serializing_if = "BundledRelations::is_empty")]
+    pub relations: BundledRelations,
 }
 
 impl<C: StateEventContent> StateUnsigned<C> {
     /// Create a new `Unsigned` with fields set to `None`.
     pub fn new() -> Self {
-        Self { age: None, transaction_id: None, prev_content: None, relations: None }
+        Self { age: None, transaction_id: None, prev_content: None, relations: Default::default() }
     }
 }
 
@@ -97,7 +97,7 @@ impl<C: StateEventContent> CanBeEmpty for StateUnsigned<C> {
         self.age.is_none()
             && self.transaction_id.is_none()
             && self.prev_content.is_none()
-            && self.relations.is_none()
+            && self.relations.is_empty()
     }
 }
 
@@ -119,8 +119,12 @@ impl<C: StateEventContent> StateUnsignedFromParts for StateUnsigned<C> {
             #[serde(skip_serializing_if = "Option::is_none")]
             transaction_id: Option<OwnedTransactionId>,
             prev_content: Option<Raw<C>>,
-            #[serde(rename = "m.relations", skip_serializing_if = "Option::is_none")]
-            relations: Option<BundledRelations>,
+            #[serde(
+                rename = "m.relations",
+                default,
+                skip_serializing_if = "BundledRelations::is_empty"
+            )]
+            relations: BundledRelations,
         }
 
         let raw: WithRawPrevContent<C> = from_json_str(object.get())?;

--- a/crates/ruma-macros/src/events/event_enum.rs
+++ b/crates/ruma-macros/src/events/event_enum.rs
@@ -550,16 +550,24 @@ fn expand_accessor_methods(
                 }
             }
 
-            /// Returns this event's `relations` from inside `unsigned`, if that field exists.
-            pub fn relations(&self) -> Option<&#ruma_common::events::BundledRelations> {
+            /// Returns this event's `relations` from inside `unsigned`.
+            pub fn relations(&self) -> &#ruma_common::events::BundledRelations {
+                static DEFAULT_BUNDLED_RELATIONS: #ruma_common::events::BundledRelations =
+                    #ruma_common::events::BundledRelations::new();
                 match self {
                     #(
                         #variants2(event) => {
-                            event.as_original().and_then(|ev| ev.unsigned.relations.as_ref())
+                            event.as_original().map_or_else(
+                                || &DEFAULT_BUNDLED_RELATIONS,
+                                |ev| &ev.unsigned.relations,
+                            )
                         }
                     )*
                     Self::_Custom(event) => {
-                        event.as_original().and_then(|ev| ev.unsigned.relations.as_ref())
+                        event.as_original().map_or_else(
+                            || &DEFAULT_BUNDLED_RELATIONS,
+                            |ev| &ev.unsigned.relations,
+                        )
                     }
                 }
             }


### PR DESCRIPTION
We should probably do the same boxing thing for the `relates_to` field, but I think that will make some pattern matching code more complicated (the same goes here, but I think there's much less code out there working with bundled relations than code working with `relates_to`.




<!-- Replace -->
----
Preview Removed
<!-- Replace -->
