### PR TITLE
Add optional redacted_because insertion to redaction

### DIFF
--- a/crates/ruma-common/src/canonical_json.rs
+++ b/crates/ruma-common/src/canonical_json.rs
@@ -138,12 +138,11 @@ pub fn to_canonical_value<T: Serialize>(
 /// * `object` contains a field called `signatures` that is not a JSON object.
 /// * `object` is missing the `type` field or the field is not a JSON string.
 pub fn redact(
-    object: &CanonicalJsonObject,
+    mut object: CanonicalJsonObject,
     version: &RoomVersionId,
 ) -> Result<CanonicalJsonObject, RedactionError> {
-    let mut val = object.clone();
-    redact_in_place(&mut val, version)?;
-    Ok(val)
+    redact_in_place(&mut object, version)?;
+    Ok(object)
 }
 
 /// Redacts an event using the rules specified in the Matrix client-server specification.

--- a/crates/ruma-common/src/canonical_json/value.rs
+++ b/crates/ruma-common/src/canonical_json/value.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeMap, fmt};
 
-use js_int::Int;
+use js_int::{Int, UInt};
 use serde::{de::Deserializer, ser::Serializer, Deserialize, Serialize};
 use serde_json::{to_string as to_json_string, Value as JsonValue};
 
@@ -236,7 +236,7 @@ macro_rules! variant_impls {
     ($variant:ident($ty:ty)) => {
         impl From<$ty> for CanonicalJsonValue {
             fn from(val: $ty) -> Self {
-                Self::$variant(val)
+                Self::$variant(val.into())
             }
         }
 
@@ -263,8 +263,15 @@ macro_rules! variant_impls {
 variant_impls!(Bool(bool));
 variant_impls!(Integer(Int));
 variant_impls!(String(String));
+variant_impls!(String(&str));
 variant_impls!(Array(Vec<CanonicalJsonValue>));
 variant_impls!(Object(CanonicalJsonObject));
+
+impl From<UInt> for CanonicalJsonValue {
+    fn from(value: UInt) -> Self {
+        Self::Integer(value.into())
+    }
+}
 
 impl Serialize for CanonicalJsonValue {
     #[inline]

--- a/crates/ruma-common/src/events.rs
+++ b/crates/ruma-common/src/events.rs
@@ -173,7 +173,10 @@ pub use self::{
     kinds::*,
     relation::BundledRelations,
     state_key::EmptyStateKey,
-    unsigned::{MessageLikeUnsigned, RedactedUnsigned, StateUnsigned, StateUnsignedFromParts},
+    unsigned::{
+        MessageLikeUnsigned, RedactedUnsigned, StateUnsigned, StateUnsignedFromParts,
+        UnsignedRoomRedactionEvent,
+    },
 };
 
 /// Trait to define the behavior of redact an event's content object.

--- a/crates/ruma-signatures/src/functions.rs
+++ b/crates/ruma-signatures/src/functions.rs
@@ -321,7 +321,7 @@ pub fn reference_hash(
     value: &CanonicalJsonObject,
     version: &RoomVersionId,
 ) -> Result<String, Error> {
-    let redacted_value = redact(value, version)?;
+    let redacted_value = redact(value.clone(), version)?;
 
     let json =
         canonical_json_with_fields_to_remove(&redacted_value, REFERENCE_HASH_FIELDS_TO_REMOVE)?;
@@ -458,7 +458,7 @@ where
         _ => return Err(JsonError::not_of_type("hashes", JsonType::Object)),
     };
 
-    let mut redacted = redact(object, version)?;
+    let mut redacted = redact(object.clone(), version)?;
 
     sign_json(entity_id, key_pair, &mut redacted)?;
 
@@ -539,7 +539,7 @@ pub fn verify_event(
     object: &CanonicalJsonObject,
     version: &RoomVersionId,
 ) -> Result<Verified, Error> {
-    let redacted = redact(object, version)?;
+    let redacted = redact(object.clone(), version)?;
 
     let hash = match object.get("hashes") {
         Some(hashes_value) => match hashes_value {

--- a/crates/ruma-signatures/src/functions.rs
+++ b/crates/ruma-signatures/src/functions.rs
@@ -321,7 +321,7 @@ pub fn reference_hash(
     value: &CanonicalJsonObject,
     version: &RoomVersionId,
 ) -> Result<String, Error> {
-    let redacted_value = redact(value.clone(), version)?;
+    let redacted_value = redact(value.clone(), version, None)?;
 
     let json =
         canonical_json_with_fields_to_remove(&redacted_value, REFERENCE_HASH_FIELDS_TO_REMOVE)?;
@@ -458,7 +458,7 @@ where
         _ => return Err(JsonError::not_of_type("hashes", JsonType::Object)),
     };
 
-    let mut redacted = redact(object.clone(), version)?;
+    let mut redacted = redact(object.clone(), version, None)?;
 
     sign_json(entity_id, key_pair, &mut redacted)?;
 
@@ -539,7 +539,7 @@ pub fn verify_event(
     object: &CanonicalJsonObject,
     version: &RoomVersionId,
 ) -> Result<Verified, Error> {
-    let redacted = redact(object.clone(), version)?;
+    let redacted = redact(object.clone(), version, None)?;
 
     let hash = match object.get("hashes") {
         Some(hashes_value) => match hashes_value {


### PR DESCRIPTION
We made redaction deserialization require `redacted_because`, and this exposed a bug in matrix-rust-sdk, which currently doesn't add `redacted_because` to events in the store. That logic seems more reasonable to add here rather than in matrix-rust-sdk.



















<!-- Replace -->
----
Preview Removed
<!-- Replace -->
