### PR TITLE
events: Add accessor for AnyFullStateEventContent's event type

### DIFF
--- a/crates/ruma-common/src/events/kinds.rs
+++ b/crates/ruma-common/src/events/kinds.rs
@@ -439,6 +439,19 @@ where
     Redacted(C::Redacted),
 }
 
+impl<C: StateEventContent + RedactContent> FullStateEventContent<C>
+where
+    C::Redacted: RedactedStateEventContent,
+{
+    /// Get the event’s type, like `m.room.create`.
+    pub fn event_type(&self) -> StateEventType {
+        match self {
+            Self::Original { content, .. } => content.event_type(),
+            Self::Redacted(content) => content.event_type(),
+        }
+    }
+}
+
 macro_rules! impl_possibly_redacted_event {
     (
         $ty:ident ( $content_trait:ident, $redacted_content_trait:ident, $event_type:ident )


### PR DESCRIPTION
The main use case for that is to be able to access the event type of a custom event.

Usually this would be available by implementing `EventContent` but it doesn't make sense to implement `Serialize` for this type.




<!-- Replace -->
----
Preview Removed
<!-- Replace -->
