### PR TITLE
feat: Make deserialize_relation public

### DIFF
--- a/crates/ruma-common/src/events/room/message.rs
+++ b/crates/ruma-common/src/events/room/message.rs
@@ -36,6 +36,7 @@ pub use image::ImageMessageEventContent;
 pub use key_verification_request::KeyVerificationRequestEventContent;
 pub use location::{LocationInfo, LocationMessageEventContent};
 pub use notice::NoticeMessageEventContent;
+pub use relation_serde::deserialize_relation;
 #[cfg(feature = "unstable-sanitize")]
 use sanitize::{
     remove_plain_reply_fallback, sanitize_html, HtmlSanitizerMode, RemoveReplyFallback,

--- a/crates/ruma-common/src/events/room/message/relation_serde.rs
+++ b/crates/ruma-common/src/events/room/message/relation_serde.rs
@@ -8,7 +8,7 @@ use crate::OwnedEventId;
 /// Use it like this:
 /// ```
 /// # use serde::{Deserialize, Serialize};
-/// use ruma_common::events::room::message::{MessageType, Relation};
+/// use ruma_common::events::room::message::{deserialize_relation, MessageType, Relation};
 ///
 /// #[derive(Deserialize, Serialize)]
 /// struct MyEventContent {

--- a/crates/ruma-common/src/events/room/message/relation_serde.rs
+++ b/crates/ruma-common/src/events/room/message/relation_serde.rs
@@ -3,9 +3,20 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use super::{InReplyTo, Relation, Replacement, Thread};
 use crate::OwnedEventId;
 
-pub(crate) fn deserialize_relation<'de, D, C>(
-    deserializer: D,
-) -> Result<Option<Relation<C>>, D::Error>
+/// Deserialize an event's `relates_to` field.
+///
+/// The full use looks like this:
+/// ```
+/// struct MyEventContent {
+///     #[serde(
+///         flatten,
+///         skip_serializing_if = "Option::is_none",
+///         deserialize_with = "deserialize_relation"
+///     )]
+///     relates_to: Option<Relation<MessageType>>,
+/// }
+/// ```
+pub fn deserialize_relation<'de, D, C>(deserializer: D) -> Result<Option<Relation<C>>, D::Error>
 where
     D: Deserializer<'de>,
     C: Deserialize<'de>,

--- a/crates/ruma-common/src/events/room/message/relation_serde.rs
+++ b/crates/ruma-common/src/events/room/message/relation_serde.rs
@@ -5,8 +5,12 @@ use crate::OwnedEventId;
 
 /// Deserialize an event's `relates_to` field.
 ///
-/// The full use looks like this:
+/// Use it like this:
 /// ```
+/// # use serde::{Deserialize, Serialize};
+/// use ruma_common::events::room::message::{MessageType, Relation};
+///
+/// #[derive(Deserialize, Serialize)]
 /// struct MyEventContent {
 ///     #[serde(
 ///         flatten,


### PR DESCRIPTION
This allows to create custom EventContent implementations with relates_to again.

<!-- Replace -->
----
Preview Removed
<!-- Replace -->
