### PR TITLE
Temporarily add back Serialize implementations for non-DAG events

### DIFF
--- a/crates/ruma-common/src/events/kinds.rs
+++ b/crates/ruma-common/src/events/kinds.rs
@@ -23,11 +23,35 @@ pub struct GlobalAccountDataEvent<C: GlobalAccountDataEventContent> {
     pub content: C,
 }
 
+impl<C: GlobalAccountDataEventContent> Serialize for GlobalAccountDataEvent<C> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("GlobalAccountDataEvent", 2)?;
+        state.serialize_field("type", &self.content.event_type())?;
+        state.serialize_field("content", &self.content)?;
+        state.end()
+    }
+}
+
 /// A room account data event.
 #[derive(Clone, Debug, Event)]
 pub struct RoomAccountDataEvent<C: RoomAccountDataEventContent> {
     /// Data specific to the event type.
     pub content: C,
+}
+
+impl<C: RoomAccountDataEventContent> Serialize for RoomAccountDataEvent<C> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("RoomAccountDataEvent", 2)?;
+        state.serialize_field("type", &self.content.event_type())?;
+        state.serialize_field("content", &self.content)?;
+        state.end()
+    }
 }
 
 /// An ephemeral room event.
@@ -40,11 +64,36 @@ pub struct EphemeralRoomEvent<C: EphemeralRoomEventContent> {
     pub room_id: OwnedRoomId,
 }
 
+impl<C: EphemeralRoomEventContent> Serialize for EphemeralRoomEvent<C> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("EphemeralRoomEvent", 2)?;
+        state.serialize_field("type", &self.content.event_type())?;
+        state.serialize_field("content", &self.content)?;
+        state.serialize_field("room_id", &self.room_id)?;
+        state.end()
+    }
+}
+
 /// An ephemeral room event without a `room_id`.
 #[derive(Clone, Debug, Event)]
 pub struct SyncEphemeralRoomEvent<C: EphemeralRoomEventContent> {
     /// Data specific to the event type.
     pub content: C,
+}
+
+impl<C: EphemeralRoomEventContent> Serialize for SyncEphemeralRoomEvent<C> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("SyncEphemeralRoomEvent", 2)?;
+        state.serialize_field("type", &self.content.event_type())?;
+        state.serialize_field("content", &self.content)?;
+        state.end()
+    }
 }
 
 /// An unredacted message-like event.

--- a/crates/ruma-common/src/events/presence.rs
+++ b/crates/ruma-common/src/events/presence.rs
@@ -4,9 +4,9 @@
 
 use js_int::UInt;
 use ruma_macros::{Event, EventContent};
-use serde::{Deserialize, Serialize};
+use serde::{ser::SerializeStruct, Deserialize, Serialize};
 
-use super::{EventKind, StaticEventContent};
+use super::{EventContent, EventKind, StaticEventContent};
 use crate::{presence::PresenceState, OwnedMxcUri, OwnedUserId};
 
 /// Presence event.
@@ -18,6 +18,19 @@ pub struct PresenceEvent {
 
     /// Contains the fully-qualified ID of the user who sent this event.
     pub sender: OwnedUserId,
+}
+
+impl Serialize for PresenceEvent {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("PresenceEvent", 3)?;
+        state.serialize_field("type", &self.content.event_type())?;
+        state.serialize_field("content", &self.content)?;
+        state.serialize_field("sender", &self.sender)?;
+        state.end()
+    }
 }
 
 /// Informs the room of members presence.


### PR DESCRIPTION
… since they are being used by Conduit.




<!-- Replace -->
----
Preview Removed
<!-- Replace -->
