### PR TITLE
events: Move `Unsigned` type to new `OriginalStateEventContent` trait

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -41,6 +41,8 @@ Breaking changes:
 * Make the `redacted_because` field in `UnsignedRedacted` non-optional and replace parameterless
   `new` constructor by one that takes a redaction event (like `new_because` previously, which is
   now removed)
+* Move the `Unsigned` associated type from `StateEventContent` to `OriginalStateEventContent`
+  * `Redacted*EventContent`s don't have an `unsigned` type anymore
 
 Improvements:
 

--- a/crates/ruma-common/src/events/_custom.rs
+++ b/crates/ruma-common/src/events/_custom.rs
@@ -3,10 +3,11 @@ use serde_json::value::RawValue as RawJsonValue;
 
 use super::{
     EphemeralRoomEventContent, EphemeralRoomEventType, EventContent, GlobalAccountDataEventContent,
-    GlobalAccountDataEventType, MessageLikeEventContent, MessageLikeEventType, RedactContent,
-    RedactedEventContent, RedactedMessageLikeEventContent, RedactedStateEventContent,
-    RoomAccountDataEventContent, RoomAccountDataEventType, StateEventContent, StateEventType,
-    StateUnsigned, ToDeviceEventContent, ToDeviceEventType,
+    GlobalAccountDataEventType, MessageLikeEventContent, MessageLikeEventType,
+    OriginalStateEventContent, RedactContent, RedactedEventContent,
+    RedactedMessageLikeEventContent, RedactedStateEventContent, RoomAccountDataEventContent,
+    RoomAccountDataEventType, StateEventContent, StateEventType, StateUnsigned,
+    ToDeviceEventContent, ToDeviceEventType,
 };
 use crate::RoomVersionId;
 
@@ -68,6 +69,8 @@ impl RedactedMessageLikeEventContent for CustomMessageLikeEventContent {}
 custom_room_event_content!(CustomStateEventContent, StateEventType);
 impl StateEventContent for CustomStateEventContent {
     type StateKey = String;
+}
+impl OriginalStateEventContent for CustomStateEventContent {
     type Unsigned = StateUnsigned<Self>;
 }
 impl RedactedStateEventContent for CustomStateEventContent {}

--- a/crates/ruma-common/src/events/content.rs
+++ b/crates/ruma-common/src/events/content.rs
@@ -6,7 +6,7 @@ use serde_json::value::RawValue as RawJsonValue;
 use crate::serde::{CanBeEmpty, Raw};
 
 use super::{
-    EphemeralRoomEventType, GlobalAccountDataEventType, MessageLikeEventType,
+    EphemeralRoomEventType, GlobalAccountDataEventType, MessageLikeEventType, RedactContent,
     RoomAccountDataEventType, StateEventType, StateUnsignedFromParts, ToDeviceEventType,
 };
 
@@ -124,7 +124,10 @@ pub trait RedactedMessageLikeEventContent: MessageLikeEventContent + RedactedEve
 pub trait StateEventContent: EventContent<EventType = StateEventType> {
     /// The type of the event's `state_key` field.
     type StateKey: AsRef<str> + Clone + fmt::Debug + DeserializeOwned + Serialize;
+}
 
+/// Content of a non-redacted state event.
+pub trait OriginalStateEventContent: StateEventContent + RedactContent {
     /// The type of the event's `unsigned` field.
     type Unsigned: Clone + fmt::Debug + Default + CanBeEmpty + StateUnsignedFromParts;
 }

--- a/crates/ruma-common/src/events/kinds.rs
+++ b/crates/ruma-common/src/events/kinds.rs
@@ -6,8 +6,8 @@ use serde_json::value::RawValue as RawJsonValue;
 
 use super::{
     EphemeralRoomEventContent, EventContent, GlobalAccountDataEventContent,
-    MessageLikeEventContent, MessageLikeEventType, MessageLikeUnsigned, RedactContent,
-    RedactedMessageLikeEventContent, RedactedStateEventContent, RedactedUnsigned,
+    MessageLikeEventContent, MessageLikeEventType, MessageLikeUnsigned, OriginalStateEventContent,
+    RedactContent, RedactedMessageLikeEventContent, RedactedStateEventContent, RedactedUnsigned,
     RedactionDeHelper, RoomAccountDataEventContent, StateEventContent, StateEventType,
     ToDeviceEventContent,
 };
@@ -229,7 +229,7 @@ where
 /// `OriginalStateEvent` implements the comparison traits using only the `event_id` field, a sorted
 /// list would be sorted lexicographically based on the event's `EventId`.
 #[derive(Clone, Debug, Event)]
-pub struct OriginalStateEvent<C: StateEventContent> {
+pub struct OriginalStateEvent<C: OriginalStateEventContent> {
     /// Data specific to the event type.
     pub content: C,
 
@@ -260,7 +260,7 @@ pub struct OriginalStateEvent<C: StateEventContent> {
 /// `OriginalSyncStateEvent` implements the comparison traits using only the `event_id` field, a
 /// sorted list would be sorted lexicographically based on the event's `EventId`.
 #[derive(Clone, Debug, Event)]
-pub struct OriginalSyncStateEvent<C: StateEventContent> {
+pub struct OriginalSyncStateEvent<C: OriginalStateEventContent> {
     /// Data specific to the event type.
     pub content: C,
 
@@ -379,7 +379,7 @@ pub struct RedactedSyncStateEvent<C: RedactedStateEventContent> {
 /// would be sorted lexicographically based on the event's `EventId`.
 #[allow(clippy::exhaustive_enums)]
 #[derive(Clone, Debug)]
-pub enum StateEvent<C: StateEventContent + RedactContent>
+pub enum StateEvent<C: OriginalStateEventContent>
 where
     C::Redacted: RedactedStateEventContent,
 {
@@ -396,7 +396,7 @@ where
 /// would be sorted lexicographically based on the event's `EventId`.
 #[allow(clippy::exhaustive_enums)]
 #[derive(Clone, Debug)]
-pub enum SyncStateEvent<C: StateEventContent + RedactContent>
+pub enum SyncStateEvent<C: OriginalStateEventContent>
 where
     C::Redacted: RedactedStateEventContent,
 {
@@ -617,7 +617,7 @@ impl_possibly_redacted_event!(
 );
 
 impl_possibly_redacted_event!(
-    StateEvent(StateEventContent, RedactedStateEventContent, StateEventType)
+    StateEvent(OriginalStateEventContent, RedactedStateEventContent, StateEventType)
     where
         C::Redacted: StateEventContent<StateKey = C::StateKey>,
     {
@@ -648,7 +648,7 @@ impl_possibly_redacted_event!(
 );
 
 impl_possibly_redacted_event!(
-    SyncStateEvent(StateEventContent, RedactedStateEventContent, StateEventType)
+    SyncStateEvent(OriginalStateEventContent, RedactedStateEventContent, StateEventType)
     where
         C::Redacted: StateEventContent<StateKey = C::StateKey>,
     {
@@ -701,4 +701,9 @@ impl_sync_from_full!(
     MessageLikeEventContent,
     RedactedMessageLikeEventContent
 );
-impl_sync_from_full!(SyncStateEvent, StateEvent, StateEventContent, RedactedStateEventContent);
+impl_sync_from_full!(
+    SyncStateEvent,
+    StateEvent,
+    OriginalStateEventContent,
+    RedactedStateEventContent
+);

--- a/crates/ruma-common/src/events/room/aliases.rs
+++ b/crates/ruma-common/src/events/room/aliases.rs
@@ -7,7 +7,7 @@ use serde_json::value::RawValue as RawJsonValue;
 use crate::{
     events::{
         EventContent, RedactContent, RedactedEventContent, RedactedStateEventContent,
-        StateEventContent, StateEventType, StateUnsigned,
+        StateEventContent, StateEventType,
     },
     OwnedRoomAliasId, OwnedServerName, RoomVersionId,
 };
@@ -97,8 +97,6 @@ impl EventContent for RedactedRoomAliasesEventContent {
 
 impl StateEventContent for RedactedRoomAliasesEventContent {
     type StateKey = OwnedServerName;
-    // FIXME: Not actually used
-    type Unsigned = StateUnsigned<Self>;
 }
 
 impl RedactedStateEventContent for RedactedRoomAliasesEventContent {}

--- a/crates/ruma-common/src/events/room/member.rs
+++ b/crates/ruma-common/src/events/room/member.rs
@@ -12,8 +12,8 @@ use serde_json::{from_str as from_json_str, value::RawValue as RawJsonValue};
 use crate::{
     events::{
         AnyStrippedStateEvent, BundledRelations, EventContent, RedactContent, RedactedEventContent,
-        RedactedStateEventContent, StateEventContent, StateEventType, StateUnsigned,
-        StateUnsignedFromParts, StaticEventContent,
+        RedactedStateEventContent, StateEventContent, StateEventType, StateUnsignedFromParts,
+        StaticEventContent,
     },
     serde::{CanBeEmpty, Raw, StringEnum},
     OwnedMxcUri, OwnedServerName, OwnedServerSigningKeyId, OwnedTransactionId, OwnedUserId,
@@ -252,8 +252,6 @@ impl EventContent for RedactedRoomMemberEventContent {
 
 impl StateEventContent for RedactedRoomMemberEventContent {
     type StateKey = OwnedUserId;
-    // FIXME: Not actually used
-    type Unsigned = StateUnsigned<Self>;
 }
 
 impl RedactedStateEventContent for RedactedRoomMemberEventContent {}

--- a/crates/ruma-macros/src/events/event_enum.rs
+++ b/crates/ruma-macros/src/events/event_enum.rs
@@ -358,8 +358,6 @@ fn expand_content_enum(
     let state_event_content_impl = (kind == EventKind::State).then(|| {
         quote! {
             type StateKey = String;
-            // FIXME: Not actually used
-            type Unsigned = #ruma_common::events::StateUnsigned<Self>;
         }
     });
 


### PR DESCRIPTION
Only original events require it.

This removes a few FIXMEs and will simplify work on #1422.




<!-- Replace -->
----
Preview Removed
<!-- Replace -->
