### PR TITLE
events: Add type accessors to `Any{Sync}TimelineEvent`

### DIFF
--- a/crates/ruma-client-api/src/relations/get_relating_events_with_rel_type_and_event_type.rs
+++ b/crates/ruma-client-api/src/relations/get_relating_events_with_rel_type_and_event_type.rs
@@ -11,7 +11,7 @@ pub mod v1 {
     use js_int::UInt;
     use ruma_common::{
         api::{request, response, Metadata},
-        events::{relation::RelationType, AnyMessageLikeEvent, RoomEventType},
+        events::{relation::RelationType, AnyMessageLikeEvent, TimelineEventType},
         metadata,
         serde::Raw,
         OwnedEventId, OwnedRoomId,
@@ -47,7 +47,7 @@ pub mod v1 {
         /// Note that in encrypted rooms this will typically always be `m.room.encrypted`
         /// regardless of the event type contained within the encrypted payload.
         #[ruma_api(path)]
-        pub event_type: RoomEventType,
+        pub event_type: TimelineEventType,
 
         /// The pagination token to start returning results from.
         ///
@@ -118,7 +118,7 @@ pub mod v1 {
             room_id: OwnedRoomId,
             event_id: OwnedEventId,
             rel_type: RelationType,
-            event_type: RoomEventType,
+            event_type: TimelineEventType,
         ) -> Self {
             Self { room_id, event_id, rel_type, event_type, from: None, to: None, limit: None }
         }

--- a/crates/ruma-client-api/src/sync/sync_events/v4.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v4.rs
@@ -12,7 +12,7 @@ use ruma_common::{
     api::{request, response, Metadata},
     events::{
         AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnyStrippedStateEvent,
-        AnySyncStateEvent, AnySyncTimelineEvent, AnyToDeviceEvent, RoomEventType,
+        AnySyncStateEvent, AnySyncTimelineEvent, AnyToDeviceEvent, TimelineEventType,
     },
     metadata,
     serde::{duration::opt_ms, Raw},
@@ -236,7 +236,7 @@ pub struct SyncRequestList {
     /// Note that elements of this array are NOT sticky so they must be specified in full when they
     /// are changed. Sticky.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub required_state: Vec<(RoomEventType, String)>,
+    pub required_state: Vec<(TimelineEventType, String)>,
 
     /// The maximum number of timeline events to return per room. Sticky.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -257,7 +257,7 @@ pub struct RoomSubscription {
     /// are changed. Sticky.
 
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub required_state: Vec<(RoomEventType, String)>,
+    pub required_state: Vec<(TimelineEventType, String)>,
 
     /// The maximum number of timeline events to return per room. Sticky.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -46,6 +46,7 @@ Breaking changes:
   * `Redacted*EventContent`s don't have an `unsigned` type anymore
 * Remove the `serde::urlencoded` module
   * Query string (de)serialization is now done by the `serde_html_form` crate
+* Rename `RoomEventType` to `TimelineEventType`
 
 Improvements:
 

--- a/crates/ruma-common/src/events/enums.rs
+++ b/crates/ruma-common/src/events/enums.rs
@@ -180,6 +180,14 @@ impl AnyTimelineEvent {
         /// Returns this event's `relations` from inside `unsigned`.
         pub fn relations(&self) -> &BundledRelations;
     }
+
+    /// Returns this event's `type`.
+    pub fn event_type(&self) -> TimelineEventType {
+        match self {
+            Self::MessageLike(e) => e.event_type().into(),
+            Self::State(e) => e.event_type().into(),
+        }
+    }
 }
 
 /// Any sync room event.
@@ -211,6 +219,14 @@ impl AnySyncTimelineEvent {
 
         /// Returns this event's `relations` from inside `unsigned`, if that field exists.
         pub fn relations(&self) -> &BundledRelations;
+    }
+
+    /// Returns this event's `type`.
+    pub fn event_type(&self) -> TimelineEventType {
+        match self {
+            Self::MessageLike(e) => e.event_type().into(),
+            Self::State(e) => e.event_type().into(),
+        }
     }
 
     /// Converts `self` to an `AnyTimelineEvent` by adding the given a room ID.

--- a/crates/ruma-common/src/events/pdu.rs
+++ b/crates/ruma-common/src/events/pdu.rs
@@ -14,7 +14,7 @@ use serde::{
 };
 use serde_json::{from_str as from_json_str, value::RawValue as RawJsonValue};
 
-use super::RoomEventType;
+use super::TimelineEventType;
 use crate::{
     MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedServerName,
     OwnedServerSigningKeyId, OwnedUserId,
@@ -52,7 +52,7 @@ pub struct RoomV1Pdu {
     // TODO: Encode event type as content enum variant, like event enums do
     /// The event's type.
     #[serde(rename = "type")]
-    pub kind: RoomEventType,
+    pub kind: TimelineEventType,
 
     /// The event's content.
     pub content: Box<RawJsonValue>,
@@ -107,7 +107,7 @@ pub struct RoomV3Pdu {
     // TODO: Encode event type as content enum variant, like event enums do
     /// The event's type.
     #[serde(rename = "type")]
-    pub kind: RoomEventType,
+    pub kind: TimelineEventType,
 
     /// The event's content.
     pub content: Box<RawJsonValue>,

--- a/crates/ruma-common/src/events/room/power_levels.rs
+++ b/crates/ruma-common/src/events/room/power_levels.rs
@@ -9,7 +9,7 @@ use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    events::{EmptyStateKey, MessageLikeEventType, RoomEventType, StateEventType},
+    events::{EmptyStateKey, MessageLikeEventType, StateEventType, TimelineEventType},
     power_levels::{default_power_level, NotificationPowerLevels},
     OwnedUserId, UserId,
 };
@@ -39,7 +39,7 @@ pub struct RoomPowerLevelsEventContent {
         deserialize_with = "crate::serde::btreemap_deserialize_v1_powerlevel_values"
     )]
     #[ruma_event(skip_redaction)]
-    pub events: BTreeMap<RoomEventType, Int>,
+    pub events: BTreeMap<TimelineEventType, Int>,
 
     /// The default level required to send message events.
     #[serde(
@@ -187,7 +187,7 @@ pub struct RoomPowerLevels {
     /// The level required to send specific event types.
     ///
     /// This is a mapping from event type to power level required.
-    pub events: BTreeMap<RoomEventType, Int>,
+    pub events: BTreeMap<TimelineEventType, Int>,
 
     /// The default level required to send message events.
     pub events_default: Int,

--- a/crates/ruma-common/tests/events/pdu.rs
+++ b/crates/ruma-common/tests/events/pdu.rs
@@ -7,7 +7,7 @@ use ruma_common::{
     event_id,
     events::{
         pdu::{EventHash, Pdu, RoomV1Pdu, RoomV3Pdu},
-        RoomEventType,
+        TimelineEventType,
     },
     room_id, server_name, server_signing_key_id, user_id, MilliSecondsSinceUnixEpoch,
 };
@@ -34,7 +34,7 @@ fn serialize_pdu_as_v1() {
         event_id: event_id!("$somejoinevent:matrix.org").to_owned(),
         sender: user_id!("@sender:example.com").to_owned(),
         origin_server_ts: MilliSecondsSinceUnixEpoch(1_592_050_773_658_u64.try_into().unwrap()),
-        kind: RoomEventType::RoomPowerLevels,
+        kind: TimelineEventType::RoomPowerLevels,
         content: to_raw_json_value(&json!({ "testing": 123 })).unwrap(),
         state_key: Some("state".into()),
         prev_events: vec![(
@@ -98,7 +98,7 @@ fn serialize_pdu_as_v3() {
         room_id: room_id!("!n8f893n9:example.com").to_owned(),
         sender: user_id!("@sender:example.com").to_owned(),
         origin_server_ts: MilliSecondsSinceUnixEpoch(1_592_050_773_658_u64.try_into().unwrap()),
-        kind: RoomEventType::RoomPowerLevels,
+        kind: TimelineEventType::RoomPowerLevels,
         content: to_raw_json_value(&json!({ "testing": 123 })).unwrap(),
         state_key: Some("state".into()),
         prev_events: vec![event_id!("$previousevent:matrix.org").to_owned()],

--- a/crates/ruma-push-gateway-api/src/send_event_notification.rs
+++ b/crates/ruma-push-gateway-api/src/send_event_notification.rs
@@ -10,7 +10,7 @@ pub mod v1 {
     use js_int::{uint, UInt};
     use ruma_common::{
         api::{request, response, Metadata},
-        events::RoomEventType,
+        events::TimelineEventType,
         metadata,
         push::{PushFormat, Tweak},
         serde::StringEnum,
@@ -87,7 +87,7 @@ pub mod v1 {
 
         /// The type of the event as in the event's `type` field.
         #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
-        pub event_type: Option<RoomEventType>,
+        pub event_type: Option<TimelineEventType>,
 
         /// The sender of the event as in the corresponding event field.
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -376,7 +376,8 @@ pub mod v1 {
     mod tests {
         use js_int::uint;
         use ruma_common::{
-            event_id, events::RoomEventType, room_alias_id, room_id, user_id, SecondsSinceUnixEpoch,
+            event_id, events::TimelineEventType, room_alias_id, room_id, user_id,
+            SecondsSinceUnixEpoch,
         };
         use serde_json::{
             from_value as from_json_value, json, to_value as to_json_value, Value as JsonValue,
@@ -439,7 +440,7 @@ pub mod v1 {
             let notice = Notification {
                 event_id: Some(eid),
                 room_id: Some(rid),
-                event_type: Some(RoomEventType::RoomMessage),
+                event_type: Some(TimelineEventType::RoomMessage),
                 sender: Some(uid),
                 sender_display_name: Some("Major Tom".to_owned()),
                 room_alias: Some(alias),

--- a/crates/ruma-state-res/benches/state_res_bench.rs
+++ b/crates/ruma-state-res/benches/state_res_bench.rs
@@ -27,7 +27,7 @@ use ruma_common::{
             join_rules::{JoinRule, RoomJoinRulesEventContent},
             member::{MembershipState, RoomMemberEventContent},
         },
-        RoomEventType, StateEventType,
+        StateEventType, TimelineEventType,
     },
     room_id, user_id, EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, RoomId, RoomVersionId,
     UserId,
@@ -234,7 +234,7 @@ impl TestStore<PduEvent> {
         let create_event = to_pdu_event::<&EventId>(
             "CREATE",
             alice(),
-            RoomEventType::RoomCreate,
+            TimelineEventType::RoomCreate,
             Some(""),
             to_raw_json_value(&json!({ "creator": alice() })).unwrap(),
             &[],
@@ -246,7 +246,7 @@ impl TestStore<PduEvent> {
         let alice_mem = to_pdu_event(
             "IMA",
             alice(),
-            RoomEventType::RoomMember,
+            TimelineEventType::RoomMember,
             Some(alice().to_string().as_str()),
             member_content_join(),
             &[cre.clone()],
@@ -257,7 +257,7 @@ impl TestStore<PduEvent> {
         let join_rules = to_pdu_event(
             "IJR",
             alice(),
-            RoomEventType::RoomJoinRules,
+            TimelineEventType::RoomJoinRules,
             Some(""),
             to_raw_json_value(&RoomJoinRulesEventContent::new(JoinRule::Public)).unwrap(),
             &[cre.clone(), alice_mem.event_id().to_owned()],
@@ -270,7 +270,7 @@ impl TestStore<PduEvent> {
         let bob_mem = to_pdu_event(
             "IMB",
             bob(),
-            RoomEventType::RoomMember,
+            TimelineEventType::RoomMember,
             Some(bob().to_string().as_str()),
             member_content_join(),
             &[cre.clone(), join_rules.event_id().to_owned()],
@@ -281,7 +281,7 @@ impl TestStore<PduEvent> {
         let charlie_mem = to_pdu_event(
             "IMC",
             charlie(),
-            RoomEventType::RoomMember,
+            TimelineEventType::RoomMember,
             Some(charlie().to_string().as_str()),
             member_content_join(),
             &[cre, join_rules.event_id().to_owned()],
@@ -352,7 +352,7 @@ fn member_content_join() -> Box<RawJsonValue> {
 fn to_pdu_event<S>(
     id: &str,
     sender: &UserId,
-    ev_type: RoomEventType,
+    ev_type: TimelineEventType,
     state_key: Option<&str>,
     content: Box<RawJsonValue>,
     auth_events: &[S],
@@ -396,7 +396,7 @@ fn INITIAL_EVENTS() -> HashMap<OwnedEventId, Arc<PduEvent>> {
         to_pdu_event::<&EventId>(
             "CREATE",
             alice(),
-            RoomEventType::RoomCreate,
+            TimelineEventType::RoomCreate,
             Some(""),
             to_raw_json_value(&json!({ "creator": alice() })).unwrap(),
             &[],
@@ -405,7 +405,7 @@ fn INITIAL_EVENTS() -> HashMap<OwnedEventId, Arc<PduEvent>> {
         to_pdu_event(
             "IMA",
             alice(),
-            RoomEventType::RoomMember,
+            TimelineEventType::RoomMember,
             Some(alice().as_str()),
             member_content_join(),
             &["CREATE"],
@@ -414,7 +414,7 @@ fn INITIAL_EVENTS() -> HashMap<OwnedEventId, Arc<PduEvent>> {
         to_pdu_event(
             "IPOWER",
             alice(),
-            RoomEventType::RoomPowerLevels,
+            TimelineEventType::RoomPowerLevels,
             Some(""),
             to_raw_json_value(&json!({ "users": { alice(): 100 } })).unwrap(),
             &["CREATE", "IMA"],
@@ -423,7 +423,7 @@ fn INITIAL_EVENTS() -> HashMap<OwnedEventId, Arc<PduEvent>> {
         to_pdu_event(
             "IJR",
             alice(),
-            RoomEventType::RoomJoinRules,
+            TimelineEventType::RoomJoinRules,
             Some(""),
             to_raw_json_value(&RoomJoinRulesEventContent::new(JoinRule::Public)).unwrap(),
             &["CREATE", "IMA", "IPOWER"],
@@ -432,7 +432,7 @@ fn INITIAL_EVENTS() -> HashMap<OwnedEventId, Arc<PduEvent>> {
         to_pdu_event(
             "IMB",
             bob(),
-            RoomEventType::RoomMember,
+            TimelineEventType::RoomMember,
             Some(bob().to_string().as_str()),
             member_content_join(),
             &["CREATE", "IJR", "IPOWER"],
@@ -441,7 +441,7 @@ fn INITIAL_EVENTS() -> HashMap<OwnedEventId, Arc<PduEvent>> {
         to_pdu_event(
             "IMC",
             charlie(),
-            RoomEventType::RoomMember,
+            TimelineEventType::RoomMember,
             Some(charlie().to_string().as_str()),
             member_content_join(),
             &["CREATE", "IJR", "IPOWER"],
@@ -450,7 +450,7 @@ fn INITIAL_EVENTS() -> HashMap<OwnedEventId, Arc<PduEvent>> {
         to_pdu_event::<&EventId>(
             "START",
             charlie(),
-            RoomEventType::RoomTopic,
+            TimelineEventType::RoomTopic,
             Some(""),
             to_raw_json_value(&json!({})).unwrap(),
             &[],
@@ -459,7 +459,7 @@ fn INITIAL_EVENTS() -> HashMap<OwnedEventId, Arc<PduEvent>> {
         to_pdu_event::<&EventId>(
             "END",
             charlie(),
-            RoomEventType::RoomTopic,
+            TimelineEventType::RoomTopic,
             Some(""),
             to_raw_json_value(&json!({})).unwrap(),
             &[],
@@ -478,7 +478,7 @@ fn BAN_STATE_SET() -> HashMap<OwnedEventId, Arc<PduEvent>> {
         to_pdu_event(
             "PA",
             alice(),
-            RoomEventType::RoomPowerLevels,
+            TimelineEventType::RoomPowerLevels,
             Some(""),
             to_raw_json_value(&json!({ "users": { alice(): 100, bob(): 50 } })).unwrap(),
             &["CREATE", "IMA", "IPOWER"], // auth_events
@@ -487,7 +487,7 @@ fn BAN_STATE_SET() -> HashMap<OwnedEventId, Arc<PduEvent>> {
         to_pdu_event(
             "PB",
             alice(),
-            RoomEventType::RoomPowerLevels,
+            TimelineEventType::RoomPowerLevels,
             Some(""),
             to_raw_json_value(&json!({ "users": { alice(): 100, bob(): 50 } })).unwrap(),
             &["CREATE", "IMA", "IPOWER"],
@@ -496,7 +496,7 @@ fn BAN_STATE_SET() -> HashMap<OwnedEventId, Arc<PduEvent>> {
         to_pdu_event(
             "MB",
             alice(),
-            RoomEventType::RoomMember,
+            TimelineEventType::RoomMember,
             Some(ella().as_str()),
             member_content_ban(),
             &["CREATE", "IMA", "PB"],
@@ -505,7 +505,7 @@ fn BAN_STATE_SET() -> HashMap<OwnedEventId, Arc<PduEvent>> {
         to_pdu_event(
             "IME",
             ella(),
-            RoomEventType::RoomMember,
+            TimelineEventType::RoomMember,
             Some(ella().as_str()),
             member_content_join(),
             &["CREATE", "IJR", "PA"],
@@ -522,7 +522,7 @@ trait EventTypeExt {
     fn with_state_key(self, state_key: impl Into<String>) -> (StateEventType, String);
 }
 
-impl EventTypeExt for &RoomEventType {
+impl EventTypeExt for &TimelineEventType {
     fn with_state_key(self, state_key: impl Into<String>) -> (StateEventType, String) {
         (self.to_string().into(), state_key.into())
     }
@@ -530,7 +530,7 @@ impl EventTypeExt for &RoomEventType {
 
 mod event {
     use ruma_common::{
-        events::{pdu::Pdu, RoomEventType},
+        events::{pdu::Pdu, TimelineEventType},
         MilliSecondsSinceUnixEpoch, OwnedEventId, RoomId, UserId,
     };
     use ruma_state_res::Event;
@@ -562,7 +562,7 @@ mod event {
             }
         }
 
-        fn event_type(&self) -> &RoomEventType {
+        fn event_type(&self) -> &TimelineEventType {
             match &self.rest {
                 Pdu::RoomV1Pdu(ev) => &ev.kind,
                 Pdu::RoomV3Pdu(ev) => &ev.kind,

--- a/crates/ruma-state-res/src/power_levels.rs
+++ b/crates/ruma-state-res/src/power_levels.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use js_int::Int;
 use ruma_common::{
-    events::{room::power_levels::RoomPowerLevelsEventContent, RoomEventType},
+    events::{room::power_levels::RoomPowerLevelsEventContent, TimelineEventType},
     power_levels::{default_power_level, NotificationPowerLevels},
     serde::{btreemap_deserialize_v1_powerlevel_values, deserialize_v1_powerlevel},
     OwnedUserId,
@@ -19,7 +19,7 @@ struct IntRoomPowerLevelsEventContent {
     pub ban: Int,
 
     #[serde(default)]
-    pub events: BTreeMap<RoomEventType, Int>,
+    pub events: BTreeMap<TimelineEventType, Int>,
 
     #[serde(default)]
     pub events_default: Int,

--- a/crates/ruma-state-res/src/state_event.rs
+++ b/crates/ruma-state-res/src/state_event.rs
@@ -5,7 +5,7 @@ use std::{
     sync::Arc,
 };
 
-use ruma_common::{events::RoomEventType, EventId, MilliSecondsSinceUnixEpoch, RoomId, UserId};
+use ruma_common::{events::TimelineEventType, EventId, MilliSecondsSinceUnixEpoch, RoomId, UserId};
 use serde_json::value::RawValue as RawJsonValue;
 
 /// Abstraction of a PDU so users can have their own PDU types.
@@ -25,7 +25,7 @@ pub trait Event {
     fn origin_server_ts(&self) -> MilliSecondsSinceUnixEpoch;
 
     /// The event type.
-    fn event_type(&self) -> &RoomEventType;
+    fn event_type(&self) -> &TimelineEventType;
 
     /// The event's content.
     fn content(&self) -> &RawJsonValue;
@@ -64,7 +64,7 @@ impl<T: Event> Event for &T {
         (*self).origin_server_ts()
     }
 
-    fn event_type(&self) -> &RoomEventType {
+    fn event_type(&self) -> &TimelineEventType {
         (*self).event_type()
     }
 
@@ -108,7 +108,7 @@ impl<T: Event> Event for Arc<T> {
         (**self).origin_server_ts()
     }
 
-    fn event_type(&self) -> &RoomEventType {
+    fn event_type(&self) -> &TimelineEventType {
         (**self).event_type()
     }
 

--- a/crates/ruma-state-res/src/test_utils.rs
+++ b/crates/ruma-state-res/src/test_utils.rs
@@ -16,7 +16,7 @@ use ruma_common::{
             join_rules::{JoinRule, RoomJoinRulesEventContent},
             member::{MembershipState, RoomMemberEventContent},
         },
-        RoomEventType,
+        TimelineEventType,
     },
     room_id, user_id, EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, RoomId, RoomVersionId,
     UserId,
@@ -251,7 +251,7 @@ impl TestStore<PduEvent> {
         let create_event = to_pdu_event::<&EventId>(
             "CREATE",
             alice(),
-            RoomEventType::RoomCreate,
+            TimelineEventType::RoomCreate,
             Some(""),
             to_raw_json_value(&json!({ "creator": alice() })).unwrap(),
             &[],
@@ -263,7 +263,7 @@ impl TestStore<PduEvent> {
         let alice_mem = to_pdu_event(
             "IMA",
             alice(),
-            RoomEventType::RoomMember,
+            TimelineEventType::RoomMember,
             Some(alice().as_str()),
             member_content_join(),
             &[cre.clone()],
@@ -274,7 +274,7 @@ impl TestStore<PduEvent> {
         let join_rules = to_pdu_event(
             "IJR",
             alice(),
-            RoomEventType::RoomJoinRules,
+            TimelineEventType::RoomJoinRules,
             Some(""),
             to_raw_json_value(&RoomJoinRulesEventContent::new(JoinRule::Public)).unwrap(),
             &[cre.clone(), alice_mem.event_id().to_owned()],
@@ -287,7 +287,7 @@ impl TestStore<PduEvent> {
         let bob_mem = to_pdu_event(
             "IMB",
             bob(),
-            RoomEventType::RoomMember,
+            TimelineEventType::RoomMember,
             Some(bob().as_str()),
             member_content_join(),
             &[cre.clone(), join_rules.event_id().to_owned()],
@@ -298,7 +298,7 @@ impl TestStore<PduEvent> {
         let charlie_mem = to_pdu_event(
             "IMC",
             charlie(),
-            RoomEventType::RoomMember,
+            TimelineEventType::RoomMember,
             Some(charlie().as_str()),
             member_content_join(),
             &[cre, join_rules.event_id().to_owned()],
@@ -374,7 +374,7 @@ pub fn member_content_join() -> Box<RawJsonValue> {
 pub fn to_init_pdu_event(
     id: &str,
     sender: &UserId,
-    ev_type: RoomEventType,
+    ev_type: TimelineEventType,
     state_key: Option<&str>,
     content: Box<RawJsonValue>,
 ) -> Arc<PduEvent> {
@@ -405,7 +405,7 @@ pub fn to_init_pdu_event(
 pub fn to_pdu_event<S>(
     id: &str,
     sender: &UserId,
-    ev_type: RoomEventType,
+    ev_type: TimelineEventType,
     state_key: Option<&str>,
     content: Box<RawJsonValue>,
     auth_events: &[S],
@@ -447,7 +447,7 @@ pub fn INITIAL_EVENTS() -> HashMap<OwnedEventId, Arc<PduEvent>> {
         to_pdu_event::<&EventId>(
             "CREATE",
             alice(),
-            RoomEventType::RoomCreate,
+            TimelineEventType::RoomCreate,
             Some(""),
             to_raw_json_value(&json!({ "creator": alice() })).unwrap(),
             &[],
@@ -456,7 +456,7 @@ pub fn INITIAL_EVENTS() -> HashMap<OwnedEventId, Arc<PduEvent>> {
         to_pdu_event(
             "IMA",
             alice(),
-            RoomEventType::RoomMember,
+            TimelineEventType::RoomMember,
             Some(alice().as_str()),
             member_content_join(),
             &["CREATE"],
@@ -465,7 +465,7 @@ pub fn INITIAL_EVENTS() -> HashMap<OwnedEventId, Arc<PduEvent>> {
         to_pdu_event(
             "IPOWER",
             alice(),
-            RoomEventType::RoomPowerLevels,
+            TimelineEventType::RoomPowerLevels,
             Some(""),
             to_raw_json_value(&json!({ "users": { alice(): 100 } })).unwrap(),
             &["CREATE", "IMA"],
@@ -474,7 +474,7 @@ pub fn INITIAL_EVENTS() -> HashMap<OwnedEventId, Arc<PduEvent>> {
         to_pdu_event(
             "IJR",
             alice(),
-            RoomEventType::RoomJoinRules,
+            TimelineEventType::RoomJoinRules,
             Some(""),
             to_raw_json_value(&RoomJoinRulesEventContent::new(JoinRule::Public)).unwrap(),
             &["CREATE", "IMA", "IPOWER"],
@@ -483,7 +483,7 @@ pub fn INITIAL_EVENTS() -> HashMap<OwnedEventId, Arc<PduEvent>> {
         to_pdu_event(
             "IMB",
             bob(),
-            RoomEventType::RoomMember,
+            TimelineEventType::RoomMember,
             Some(bob().as_str()),
             member_content_join(),
             &["CREATE", "IJR", "IPOWER"],
@@ -492,7 +492,7 @@ pub fn INITIAL_EVENTS() -> HashMap<OwnedEventId, Arc<PduEvent>> {
         to_pdu_event(
             "IMC",
             charlie(),
-            RoomEventType::RoomMember,
+            TimelineEventType::RoomMember,
             Some(charlie().as_str()),
             member_content_join(),
             &["CREATE", "IJR", "IPOWER"],
@@ -501,7 +501,7 @@ pub fn INITIAL_EVENTS() -> HashMap<OwnedEventId, Arc<PduEvent>> {
         to_pdu_event::<&EventId>(
             "START",
             charlie(),
-            RoomEventType::RoomMessage,
+            TimelineEventType::RoomMessage,
             Some("dummy"),
             to_raw_json_value(&json!({})).unwrap(),
             &[],
@@ -510,7 +510,7 @@ pub fn INITIAL_EVENTS() -> HashMap<OwnedEventId, Arc<PduEvent>> {
         to_pdu_event::<&EventId>(
             "END",
             charlie(),
-            RoomEventType::RoomMessage,
+            TimelineEventType::RoomMessage,
             Some("dummy"),
             to_raw_json_value(&json!({})).unwrap(),
             &[],
@@ -528,7 +528,7 @@ pub fn INITIAL_EVENTS_CREATE_ROOM() -> HashMap<OwnedEventId, Arc<PduEvent>> {
     vec![to_pdu_event::<&EventId>(
         "CREATE",
         alice(),
-        RoomEventType::RoomCreate,
+        TimelineEventType::RoomCreate,
         Some(""),
         to_raw_json_value(&json!({ "creator": alice() })).unwrap(),
         &[],
@@ -549,7 +549,7 @@ pub fn INITIAL_EDGES() -> Vec<OwnedEventId> {
 
 pub mod event {
     use ruma_common::{
-        events::{pdu::Pdu, RoomEventType},
+        events::{pdu::Pdu, TimelineEventType},
         MilliSecondsSinceUnixEpoch, OwnedEventId, RoomId, UserId,
     };
     use serde::{Deserialize, Serialize};
@@ -582,7 +582,7 @@ pub mod event {
             }
         }
 
-        fn event_type(&self) -> &RoomEventType {
+        fn event_type(&self) -> &TimelineEventType {
             match &self.rest {
                 Pdu::RoomV1Pdu(ev) => &ev.kind,
                 Pdu::RoomV3Pdu(ev) => &ev.kind,


### PR DESCRIPTION
The first commit is for consistency with the previous renaming of `Any[Sync]RoomEvent` to `Any[Sync]TimelineEvent` in ruma-common 0.10.0.

Closes #1424.







<!-- Replace -->
----
Preview: https://pr-1428--ruma-docs.surge.sh
<!-- Replace -->
