### PR TITLE
support -Z build-std

### DIFF
--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -54,7 +54,7 @@ form_urlencoded = "1.0.0"
 getrandom = { version = "0.2.6", optional = true }
 html5ever = { version = "0.25.2", optional = true }
 http = { workspace = true, optional = true }
-indexmap = { version = "1.9.1", features = ["serde"] }
+indexmap = { version = "1.9.1", features = ["serde", "std"] }
 itoa = "1.0.1"
 js_int = { workspace = true, features = ["serde"] }
 js_option = "0.1.0"


### PR DESCRIPTION
To build on rust toolchains without a prebuilt std library (e.g. Mac Catalyst), you have to pass `-Z build-std` to rustc.
However, this breaks ruma-common as it depends on indexmap, which chokes if there's no std... unless you activate the `std` feature. I doubt this has much impact in the common case, but unbreaks `-Z build-std`.

(See the end of https://gist.github.com/ara4n/320a53ea768aba51afad4c9ed2168536 for more details)