### PR TITLE
federation-api: Remove mentions of `keyId` in the keys query endpoints

### DIFF
--- a/crates/ruma-federation-api/src/discovery/get_remote_server_keys.rs
+++ b/crates/ruma-federation-api/src/discovery/get_remote_server_keys.rs
@@ -1,4 +1,4 @@
-//! `GET /_matrix/key/*/query/{serverName}/{keyId}`
+//! `GET /_matrix/key/*/query/{serverName}`
 //!
 //! Query for another server's keys. The receiving (notary) server must sign the keys returned by
 //! the queried server.
@@ -22,8 +22,6 @@ pub mod v2 {
         rate_limited: false,
         authentication: None,
         history: {
-            // Note: The spec has an additional, deprecated path parameter on this. We may want to
-            // support an additional parameter at the end, even if it is ignored.
             1.0 => "/_matrix/key/v2/query/:server_name",
         }
     };

--- a/crates/ruma-federation-api/src/discovery/get_server_keys.rs
+++ b/crates/ruma-federation-api/src/discovery/get_server_keys.rs
@@ -5,9 +5,6 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! Note: The specification includes `/{keyID}`, but this is deprecated, and the trailing slash
-    //! then made optional.
-    //!
     //! [spec]: https://spec.matrix.org/v1.4/server-server-api/#get_matrixkeyv2serverkeyid
 
     use ruma_common::{


### PR DESCRIPTION
According to [MSC3938](https://github.com/matrix-org/matrix-spec-proposals/pull/3938).

I reckon it's not necessary to wait for the change to become stable as the types are already compatible and the docs are not consistent about it.

Closes #1435.




<!-- Replace -->
----
Preview: https://pr-1436--ruma-docs.surge.sh
<!-- Replace -->
