### PR TITLE
Remove methods that depend on `EventContent::from_parts`

### DIFF
--- a/crates/ruma-client-api/src/config/get_global_account_data.rs
+++ b/crates/ruma-client-api/src/config/get_global_account_data.rs
@@ -42,7 +42,7 @@ pub mod v3 {
     pub struct Response {
         /// Account data content for the given type.
         ///
-        /// Use [`Raw::deserialize_content`] for deserialization.
+        /// Use [`Raw::deserialize_as`] for deserialization.
         #[ruma_api(body)]
         pub account_data: Raw<AnyGlobalAccountDataEventContent>,
     }

--- a/crates/ruma-client-api/src/config/get_room_account_data.rs
+++ b/crates/ruma-client-api/src/config/get_room_account_data.rs
@@ -46,7 +46,7 @@ pub mod v3 {
     pub struct Response {
         /// Account data content for the given type.
         ///
-        /// Use [`Raw::deserialize_content`] for deserialization.
+        /// Use [`Raw::deserialize_as`] for deserialization.
         #[ruma_api(body)]
         pub account_data: Raw<AnyRoomAccountDataEventContent>,
     }

--- a/crates/ruma-client-api/src/state/get_state_events_for_key.rs
+++ b/crates/ruma-client-api/src/state/get_state_events_for_key.rs
@@ -52,7 +52,7 @@ pub mod v3 {
         /// The content of the state event.
         ///
         /// Since the inner type of the `Raw` does not implement `Deserialize`, you need to use
-        /// [`Raw::deserialize_content`] to deserialize it.
+        /// [`Raw::deserialize_as`] to deserialize it.
         #[ruma_api(body)]
         pub content: Raw<AnyStateEventContent>,
     }

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -49,6 +49,7 @@ Breaking changes:
 * Rename `RoomEventType` to `TimelineEventType`
 * Remove `Raw::deserialize_content`
   * `Raw::deserialize_as` can be used instead
+* Remove `StateUnsignedFromParts` and replace it in trait bounds with `DeserializeOwned`
 
 Improvements:
 

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -47,6 +47,8 @@ Breaking changes:
 * Remove the `serde::urlencoded` module
   * Query string (de)serialization is now done by the `serde_html_form` crate
 * Rename `RoomEventType` to `TimelineEventType`
+* Remove `Raw::deserialize_content`
+  * `Raw::deserialize_as` can be used instead
 
 Improvements:
 

--- a/crates/ruma-common/src/events.rs
+++ b/crates/ruma-common/src/events.rs
@@ -173,10 +173,7 @@ pub use self::{
     kinds::*,
     relation::BundledRelations,
     state_key::EmptyStateKey,
-    unsigned::{
-        MessageLikeUnsigned, RedactedUnsigned, StateUnsigned, StateUnsignedFromParts,
-        UnsignedRoomRedactionEvent,
-    },
+    unsigned::{MessageLikeUnsigned, RedactedUnsigned, StateUnsigned, UnsignedRoomRedactionEvent},
 };
 
 /// Trait to define the behavior of redact an event's content object.

--- a/crates/ruma-common/src/events/_custom.rs
+++ b/crates/ruma-common/src/events/_custom.rs
@@ -1,4 +1,4 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue as RawJsonValue;
 
 use super::{
@@ -16,7 +16,7 @@ macro_rules! custom_event_content {
         /// A custom event's type. Used for event enum `_Custom` variants.
         // FIXME: Serialize shouldn't be required here, but it's currently a supertrait of
         // EventContent
-        #[derive(Clone, Debug, Serialize)]
+        #[derive(Clone, Debug, Serialize, Deserialize)]
         #[allow(clippy::exhaustive_structs)]
         pub struct $i {
             #[serde(skip)]

--- a/crates/ruma-common/src/events/content.rs
+++ b/crates/ruma-common/src/events/content.rs
@@ -7,7 +7,7 @@ use crate::serde::CanBeEmpty;
 
 use super::{
     EphemeralRoomEventType, GlobalAccountDataEventType, MessageLikeEventType, RedactContent,
-    RoomAccountDataEventType, StateEventType, StateUnsignedFromParts, ToDeviceEventType,
+    RoomAccountDataEventType, StateEventType, ToDeviceEventType,
 };
 
 /// The base trait that all event content types implement.
@@ -118,7 +118,7 @@ pub trait StateEventContent: EventContent<EventType = StateEventType> {
 /// Content of a non-redacted state event.
 pub trait OriginalStateEventContent: StateEventContent + RedactContent {
     /// The type of the event's `unsigned` field.
-    type Unsigned: Clone + fmt::Debug + Default + CanBeEmpty + StateUnsignedFromParts;
+    type Unsigned: Clone + fmt::Debug + Default + CanBeEmpty + DeserializeOwned;
 
     /// The possibly redacted form of the event's content.
     type PossiblyRedacted: StateEventContent + DeserializeOwned;

--- a/crates/ruma-common/src/events/content.rs
+++ b/crates/ruma-common/src/events/content.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::value::RawValue as RawJsonValue;
 
-use crate::serde::{CanBeEmpty, Raw};
+use crate::serde::CanBeEmpty;
 
 use super::{
     EphemeralRoomEventType, GlobalAccountDataEventType, MessageLikeEventType, RedactContent,
@@ -25,17 +25,6 @@ pub trait EventContent: Sized + Serialize {
     /// Constructs the given event content.
     #[doc(hidden)]
     fn from_parts(event_type: &str, content: &RawJsonValue) -> serde_json::Result<Self>;
-}
-
-impl<T> Raw<T>
-where
-    T: EventContent,
-    T::EventType: fmt::Display,
-{
-    /// Try to deserialize the JSON as an event's content.
-    pub fn deserialize_content(&self, event_type: T::EventType) -> serde_json::Result<T> {
-        T::from_parts(&event_type.to_string(), self.json())
-    }
 }
 
 /// The base trait that all redacted event content types implement.
@@ -132,7 +121,7 @@ pub trait OriginalStateEventContent: StateEventContent + RedactContent {
     type Unsigned: Clone + fmt::Debug + Default + CanBeEmpty + StateUnsignedFromParts;
 
     /// The possibly redacted form of the event's content.
-    type PossiblyRedacted: StateEventContent;
+    type PossiblyRedacted: StateEventContent + DeserializeOwned;
 }
 
 /// Content of a redacted state event.

--- a/crates/ruma-common/src/events/room/member.rs
+++ b/crates/ruma-common/src/events/room/member.rs
@@ -7,13 +7,12 @@ use std::collections::BTreeMap;
 use js_int::Int;
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
-use serde_json::{from_str as from_json_str, value::RawValue as RawJsonValue};
+use serde_json::value::RawValue as RawJsonValue;
 
 use crate::{
     events::{
         AnyStrippedStateEvent, BundledRelations, EventContent, RedactContent, RedactedEventContent,
-        RedactedStateEventContent, StateEventContent, StateEventType, StateUnsignedFromParts,
-        StaticEventContent,
+        RedactedStateEventContent, StateEventContent, StateEventType,
     },
     serde::{CanBeEmpty, Raw, StringEnum},
     OwnedMxcUri, OwnedServerName, OwnedServerSigningKeyId, OwnedTransactionId, OwnedUserId,
@@ -547,20 +546,6 @@ impl CanBeEmpty for RoomMemberUnsigned {
             && self.prev_content.is_none()
             && self.invite_room_state.is_empty()
             && self.relations.is_empty()
-    }
-}
-
-impl StateUnsignedFromParts for RoomMemberUnsigned {
-    fn _from_parts(event_type: &str, object: &RawJsonValue) -> serde_json::Result<Self> {
-        const EVENT_TYPE: &str = <RoomMemberEventContent as StaticEventContent>::TYPE;
-
-        if event_type != EVENT_TYPE {
-            return Err(serde::de::Error::custom(format!(
-                "expected event type of `{EVENT_TYPE}`, found `{event_type}`",
-            )));
-        }
-
-        from_json_str(object.get())
     }
 }
 

--- a/crates/ruma-common/tests/events/message_event.rs
+++ b/crates/ruma-common/tests/events/message_event.rs
@@ -3,10 +3,10 @@ use assign::assign;
 use js_int::{uint, UInt};
 use ruma_common::{
     events::{
+        call::answer::CallAnswerEventContent,
         room::{ImageInfo, MediaSource, ThumbnailInfo},
         sticker::StickerEventContent,
-        AnyMessageLikeEvent, AnyMessageLikeEventContent, AnySyncMessageLikeEvent, MessageLikeEvent,
-        MessageLikeEventType,
+        AnyMessageLikeEvent, AnySyncMessageLikeEvent, MessageLikeEvent,
     },
     mxc_uri, room_id,
     serde::{CanBeEmpty, Raw},
@@ -107,13 +107,8 @@ fn deserialize_message_call_answer_content() {
         "version": 0
     });
 
-    let content = assert_matches!(
-        from_json_value::<Raw<AnyMessageLikeEventContent>>(json_data)
-            .unwrap()
-            .deserialize_content(MessageLikeEventType::CallAnswer)
-            .unwrap(),
-        AnyMessageLikeEventContent::CallAnswer(content) => content
-    );
+    let content =
+        from_json_value::<Raw<CallAnswerEventContent>>(json_data).unwrap().deserialize().unwrap();
 
     assert_eq!(content.answer.sdp, "Hello");
     assert_eq!(content.call_id, "foofoo");

--- a/crates/ruma-common/tests/events/state_event.rs
+++ b/crates/ruma-common/tests/events/state_event.rs
@@ -2,8 +2,8 @@ use assert_matches::assert_matches;
 use js_int::uint;
 use ruma_common::{
     events::{
-        AnyStateEvent, AnyStateEventContent, AnySyncStateEvent, AnyTimelineEvent, StateEvent,
-        StateEventType, SyncStateEvent,
+        room::aliases::RoomAliasesEventContent, AnyStateEvent, AnySyncStateEvent, AnyTimelineEvent,
+        StateEvent, SyncStateEvent,
     },
     mxc_uri, room_alias_id,
     serde::{CanBeEmpty, Raw},
@@ -36,12 +36,8 @@ fn deserialize_aliases_content() {
         "aliases": ["#somewhere:localhost"],
     });
 
-    let content = assert_matches!(
-        from_json_value::<Raw<AnyStateEventContent>>(json_data)
-            .unwrap()
-            .deserialize_content(StateEventType::RoomAliases),
-        Ok(AnyStateEventContent::RoomAliases(content)) => content
-    );
+    let content =
+        from_json_value::<Raw<RoomAliasesEventContent>>(json_data).unwrap().deserialize().unwrap();
     assert_eq!(content.aliases, vec![room_alias_id!("#somewhere:localhost")]);
 }
 

--- a/crates/ruma-common/tests/events/ui/04-event-sanity-check.rs
+++ b/crates/ruma-common/tests/events/ui/04-event-sanity-check.rs
@@ -4,21 +4,21 @@
 extern crate serde;
 
 use ruma_common::{
-    events::{StateEventContent, StateUnsigned},
+    events::{OriginalStateEventContent, StateUnsigned},
     MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedUserId,
 };
 use ruma_macros::Event;
 
 /// State event.
 #[derive(Clone, Debug, Event)]
-pub struct OriginalStateEvent<C: StateEventContent> {
+pub struct OriginalStateEvent<C: OriginalStateEventContent> {
     pub content: C,
     pub event_id: OwnedEventId,
     pub sender: OwnedUserId,
     pub origin_server_ts: MilliSecondsSinceUnixEpoch,
     pub room_id: OwnedRoomId,
     pub state_key: C::StateKey,
-    pub unsigned: StateUnsigned<C>,
+    pub unsigned: StateUnsigned<C::PossiblyRedacted>,
 }
 
 fn main() {}

--- a/crates/ruma-macros/src/events/util.rs
+++ b/crates/ruma-macros/src/events/util.rs
@@ -10,8 +10,3 @@ pub(crate) fn is_non_stripped_room_event(kind: EventKind, var: EventKindVariatio
                 | EventKindVariation::RedactedSync
         )
 }
-
-pub(crate) fn has_prev_content(kind: EventKind, var: EventKindVariation) -> bool {
-    matches!(kind, EventKind::State)
-        && matches!(var, EventKindVariation::Original | EventKindVariation::OriginalSync)
-}


### PR DESCRIPTION
Even if we can't remove `from_parts`, they can depend on the type implementing `Deserialize` instead.




<!-- Replace -->
----
Preview Removed
<!-- Replace -->
