### PR TITLE
events: Move `EventContent::from_parts` to a separate trait

### DIFF
--- a/crates/ruma-client-api/src/config/get_global_account_data.rs
+++ b/crates/ruma-client-api/src/config/get_global_account_data.rs
@@ -42,7 +42,12 @@ pub mod v3 {
     pub struct Response {
         /// Account data content for the given type.
         ///
-        /// Use [`Raw::deserialize_content`] for deserialization.
+        /// Since the inner type of the `Raw` does not implement `Deserialize`, you need to use
+        /// `.deserialize_as::<T>()` or `.cast_ref::<T>().deserialize_with_type()` for event
+        /// types with a variable suffix (like [`SecretStorageKeyEventContent`]) to
+        /// deserialize it.
+        ///
+        /// [`SecretStorageKeyEventContent`]: ruma_common::events::secret_storage::key::SecretStorageKeyEventContent
         #[ruma_api(body)]
         pub account_data: Raw<AnyGlobalAccountDataEventContent>,
     }

--- a/crates/ruma-client-api/src/config/get_room_account_data.rs
+++ b/crates/ruma-client-api/src/config/get_room_account_data.rs
@@ -46,7 +46,8 @@ pub mod v3 {
     pub struct Response {
         /// Account data content for the given type.
         ///
-        /// Use [`Raw::deserialize_content`] for deserialization.
+        /// Since the inner type of the `Raw` does not implement `Deserialize`, you need to use
+        /// [`Raw::deserialize_as`] to deserialize it.
         #[ruma_api(body)]
         pub account_data: Raw<AnyRoomAccountDataEventContent>,
     }

--- a/crates/ruma-client-api/src/state/get_state_events_for_key.rs
+++ b/crates/ruma-client-api/src/state/get_state_events_for_key.rs
@@ -52,7 +52,7 @@ pub mod v3 {
         /// The content of the state event.
         ///
         /// Since the inner type of the `Raw` does not implement `Deserialize`, you need to use
-        /// [`Raw::deserialize_content`] to deserialize it.
+        /// [`Raw::deserialize_as`] to deserialize it.
         #[ruma_api(body)]
         pub content: Raw<AnyStateEventContent>,
     }

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -53,6 +53,8 @@ Breaking changes:
   * Use `EventContentFromType::from_parts` instead
 * Remove `StateUnsignedFromParts`
   * Replace it with a bound on `DeserializeOwned`
+* Remove `Raw::deserialize_content`
+  * Instead, use `.deserialize_as::<T>()` or `.cast_ref::<T>().deserialize_with_type()`
 
 Improvements:
 

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -49,6 +49,8 @@ Breaking changes:
 * Remove the `serde::urlencoded` module
   * Query string (de)serialization is now done by the `serde_html_form` crate
 * Rename `RoomEventType` to `TimelineEventType`
+* Remove `SecretStorageKeyEventContent`'s implementation of `Deserialize`
+  * Use `EventContentFromType::from_parts` instead
 
 Improvements:
 

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -55,6 +55,8 @@ Breaking changes:
   * Replace it with a bound on `DeserializeOwned`
 * Remove `Raw::deserialize_content`
   * Instead, use `.deserialize_as::<T>()` or `.cast_ref::<T>().deserialize_with_type()`
+* Remove `EventContent::from_parts`
+  * Replace it with `EventContentFromType::from_parts`
 
 Improvements:
 

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -51,6 +51,8 @@ Breaking changes:
 * Rename `RoomEventType` to `TimelineEventType`
 * Remove `SecretStorageKeyEventContent`'s implementation of `Deserialize`
   * Use `EventContentFromType::from_parts` instead
+* Remove `StateUnsignedFromParts`
+  * Replace it with a bound on `DeserializeOwned`
 
 Improvements:
 

--- a/crates/ruma-common/src/events.rs
+++ b/crates/ruma-common/src/events.rs
@@ -173,10 +173,7 @@ pub use self::{
     kinds::*,
     relation::BundledRelations,
     state_key::EmptyStateKey,
-    unsigned::{
-        MessageLikeUnsigned, RedactedUnsigned, StateUnsigned, StateUnsignedFromParts,
-        UnsignedRoomRedactionEvent,
-    },
+    unsigned::{MessageLikeUnsigned, RedactedUnsigned, StateUnsigned, UnsignedRoomRedactionEvent},
 };
 
 /// Trait to define the behavior of redact an event's content object.

--- a/crates/ruma-common/src/events/_custom.rs
+++ b/crates/ruma-common/src/events/_custom.rs
@@ -4,9 +4,9 @@ use serde_json::value::RawValue as RawJsonValue;
 use super::{
     EphemeralRoomEventContent, EphemeralRoomEventType, EventContent, EventContentFromType,
     GlobalAccountDataEventContent, GlobalAccountDataEventType, MessageLikeEventContent,
-    MessageLikeEventType, OriginalStateEventContent, RedactContent, RedactedEventContent,
-    RedactedMessageLikeEventContent, RedactedStateEventContent, RoomAccountDataEventContent,
-    RoomAccountDataEventType, StateEventContent, StateEventType, StateUnsigned,
+    MessageLikeEventType, MessageLikeUnsigned, OriginalStateEventContent, RedactContent,
+    RedactedEventContent, RedactedMessageLikeEventContent, RedactedStateEventContent,
+    RoomAccountDataEventContent, RoomAccountDataEventType, StateEventContent, StateEventType,
     ToDeviceEventContent, ToDeviceEventType,
 };
 use crate::RoomVersionId;
@@ -77,7 +77,10 @@ impl StateEventContent for CustomStateEventContent {
     type StateKey = String;
 }
 impl OriginalStateEventContent for CustomStateEventContent {
-    type Unsigned = StateUnsigned<Self>;
+    // Like `StateUnsigned`, but without `prev_content`.
+    // We don't care about `prev_content` since we'd only store the event type that is the same
+    // as in the content.
+    type Unsigned = MessageLikeUnsigned;
     type PossiblyRedacted = Self;
 }
 impl RedactedStateEventContent for CustomStateEventContent {}

--- a/crates/ruma-common/src/events/_custom.rs
+++ b/crates/ruma-common/src/events/_custom.rs
@@ -2,9 +2,9 @@ use serde::Serialize;
 use serde_json::value::RawValue as RawJsonValue;
 
 use super::{
-    EphemeralRoomEventContent, EphemeralRoomEventType, EventContent, GlobalAccountDataEventContent,
-    GlobalAccountDataEventType, MessageLikeEventContent, MessageLikeEventType,
-    OriginalStateEventContent, RedactContent, RedactedEventContent,
+    EphemeralRoomEventContent, EphemeralRoomEventType, EventContent, EventContentFromType,
+    GlobalAccountDataEventContent, GlobalAccountDataEventType, MessageLikeEventContent,
+    MessageLikeEventType, OriginalStateEventContent, RedactContent, RedactedEventContent,
     RedactedMessageLikeEventContent, RedactedStateEventContent, RoomAccountDataEventContent,
     RoomAccountDataEventType, StateEventContent, StateEventType, StateUnsigned,
     ToDeviceEventContent, ToDeviceEventType,
@@ -30,6 +30,12 @@ macro_rules! custom_event_content {
                 self.event_type[..].into()
             }
 
+            fn from_parts(event_type: &str, _content: &RawJsonValue) -> serde_json::Result<Self> {
+                Ok(Self { event_type: event_type.into() })
+            }
+        }
+
+        impl EventContentFromType for $i {
             fn from_parts(event_type: &str, _content: &RawJsonValue) -> serde_json::Result<Self> {
                 Ok(Self { event_type: event_type.into() })
             }

--- a/crates/ruma-common/src/events/_custom.rs
+++ b/crates/ruma-common/src/events/_custom.rs
@@ -29,10 +29,6 @@ macro_rules! custom_event_content {
             fn event_type(&self) -> Self::EventType {
                 self.event_type[..].into()
             }
-
-            fn from_parts(event_type: &str, _content: &RawJsonValue) -> serde_json::Result<Self> {
-                Ok(Self { event_type: event_type.into() })
-            }
         }
 
         impl EventContentFromType for $i {

--- a/crates/ruma-common/src/events/content.rs
+++ b/crates/ruma-common/src/events/content.rs
@@ -21,10 +21,6 @@ pub trait EventContent: Sized + Serialize {
 
     /// Get the event's type, like `m.room.message`.
     fn event_type(&self) -> Self::EventType;
-
-    /// Constructs the given event content.
-    #[doc(hidden)]
-    fn from_parts(event_type: &str, content: &RawJsonValue) -> serde_json::Result<Self>;
 }
 
 impl<T> Raw<T>
@@ -34,7 +30,7 @@ where
 {
     /// Try to deserialize the JSON as an event's content with the given event type.
     pub fn deserialize_with_type(&self, event_type: T::EventType) -> serde_json::Result<T> {
-        <T as EventContentFromType>::from_parts(&event_type.to_string(), self.json())
+        T::from_parts(&event_type.to_string(), self.json())
     }
 }
 

--- a/crates/ruma-common/src/events/content.rs
+++ b/crates/ruma-common/src/events/content.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use serde::{de::DeserializeOwned, Serialize};
-use serde_json::value::RawValue as RawJsonValue;
+use serde_json::{from_str as from_json_str, value::RawValue as RawJsonValue};
 
 use crate::serde::{CanBeEmpty, Raw};
 
@@ -140,3 +140,19 @@ pub trait RedactedStateEventContent: StateEventContent + RedactedEventContent {}
 
 /// Content of a to-device event.
 pub trait ToDeviceEventContent: EventContent<EventType = ToDeviceEventType> {}
+
+/// Event content that can be deserialized with its event type.
+pub trait EventContentFromType: EventContent {
+    /// Constructs this event content from the given event type and JSON.
+    #[doc(hidden)]
+    fn from_parts(event_type: &str, content: &RawJsonValue) -> serde_json::Result<Self>;
+}
+
+impl<T> EventContentFromType for T
+where
+    T: EventContent + DeserializeOwned,
+{
+    fn from_parts(_event_type: &str, content: &RawJsonValue) -> serde_json::Result<Self> {
+        from_json_str(content.get())
+    }
+}

--- a/crates/ruma-common/src/events/content.rs
+++ b/crates/ruma-common/src/events/content.rs
@@ -7,7 +7,7 @@ use crate::serde::{CanBeEmpty, Raw};
 
 use super::{
     EphemeralRoomEventType, GlobalAccountDataEventType, MessageLikeEventType, RedactContent,
-    RoomAccountDataEventType, StateEventType, StateUnsignedFromParts, ToDeviceEventType,
+    RoomAccountDataEventType, StateEventType, ToDeviceEventType,
 };
 
 /// The base trait that all event content types implement.
@@ -129,7 +129,7 @@ pub trait StateEventContent: EventContent<EventType = StateEventType> {
 /// Content of a non-redacted state event.
 pub trait OriginalStateEventContent: StateEventContent + RedactContent {
     /// The type of the event's `unsigned` field.
-    type Unsigned: Clone + fmt::Debug + Default + CanBeEmpty + StateUnsignedFromParts;
+    type Unsigned: Clone + fmt::Debug + Default + CanBeEmpty + DeserializeOwned;
 
     /// The possibly redacted form of the event's content.
     type PossiblyRedacted: StateEventContent;

--- a/crates/ruma-common/src/events/content.rs
+++ b/crates/ruma-common/src/events/content.rs
@@ -29,12 +29,12 @@ pub trait EventContent: Sized + Serialize {
 
 impl<T> Raw<T>
 where
-    T: EventContent,
+    T: EventContentFromType,
     T::EventType: fmt::Display,
 {
-    /// Try to deserialize the JSON as an event's content.
-    pub fn deserialize_content(&self, event_type: T::EventType) -> serde_json::Result<T> {
-        T::from_parts(&event_type.to_string(), self.json())
+    /// Try to deserialize the JSON as an event's content with the given event type.
+    pub fn deserialize_with_type(&self, event_type: T::EventType) -> serde_json::Result<T> {
+        <T as EventContentFromType>::from_parts(&event_type.to_string(), self.json())
     }
 }
 

--- a/crates/ruma-common/src/events/kinds.rs
+++ b/crates/ruma-common/src/events/kinds.rs
@@ -5,7 +5,7 @@ use serde::{ser::SerializeStruct, Deserialize, Deserializer, Serialize};
 use serde_json::value::RawValue as RawJsonValue;
 
 use super::{
-    EphemeralRoomEventContent, EventContent, GlobalAccountDataEventContent,
+    EphemeralRoomEventContent, EventContent, EventContentFromType, GlobalAccountDataEventContent,
     MessageLikeEventContent, MessageLikeEventType, MessageLikeUnsigned, OriginalStateEventContent,
     RedactContent, RedactedMessageLikeEventContent, RedactedStateEventContent, RedactedUnsigned,
     RedactionDeHelper, RoomAccountDataEventContent, StateEventContent, StateEventType,
@@ -551,8 +551,8 @@ macro_rules! impl_possibly_redacted_event {
 
         impl<'de, C> Deserialize<'de> for $ty<C>
         where
-            C: $content_trait + RedactContent,
-            C::Redacted: $redacted_content_trait,
+            C: $content_trait + EventContentFromType + RedactContent,
+            C::Redacted: $redacted_content_trait + EventContentFromType,
             $( C::Redacted: $trait<StateKey = C::StateKey>, )?
         {
             fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>

--- a/crates/ruma-common/src/events/policy/rule/room.rs
+++ b/crates/ruma-common/src/events/policy/rule/room.rs
@@ -4,7 +4,6 @@
 
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
-use serde_json::value::RawValue as RawJsonValue;
 
 use super::{PolicyRuleEventContent, PossiblyRedactedPolicyRuleEventContent};
 use crate::events::{EventContent, StateEventContent, StateEventType};
@@ -29,16 +28,6 @@ impl EventContent for PossiblyRedactedPolicyRuleRoomEventContent {
 
     fn event_type(&self) -> Self::EventType {
         StateEventType::PolicyRuleRoom
-    }
-
-    fn from_parts(event_type: &str, content: &RawJsonValue) -> serde_json::Result<Self> {
-        if event_type != "m.policy.rule.room" {
-            return Err(::serde::de::Error::custom(format!(
-                "expected event type `m.policy.rule.room`, found `{event_type}`",
-            )));
-        }
-
-        serde_json::from_str(content.get())
     }
 }
 

--- a/crates/ruma-common/src/events/policy/rule/server.rs
+++ b/crates/ruma-common/src/events/policy/rule/server.rs
@@ -4,7 +4,6 @@
 
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
-use serde_json::value::RawValue as RawJsonValue;
 
 use super::{PolicyRuleEventContent, PossiblyRedactedPolicyRuleEventContent};
 use crate::events::{EventContent, StateEventContent, StateEventType};
@@ -29,16 +28,6 @@ impl EventContent for PossiblyRedactedPolicyRuleServerEventContent {
 
     fn event_type(&self) -> Self::EventType {
         StateEventType::PolicyRuleServer
-    }
-
-    fn from_parts(event_type: &str, content: &RawJsonValue) -> serde_json::Result<Self> {
-        if event_type != "m.policy.rule.server" {
-            return Err(::serde::de::Error::custom(format!(
-                "expected event type `m.policy.rule.server`, found `{event_type}`",
-            )));
-        }
-
-        serde_json::from_str(content.get())
     }
 }
 

--- a/crates/ruma-common/src/events/policy/rule/user.rs
+++ b/crates/ruma-common/src/events/policy/rule/user.rs
@@ -4,7 +4,6 @@
 
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
-use serde_json::value::RawValue as RawJsonValue;
 
 use super::{PolicyRuleEventContent, PossiblyRedactedPolicyRuleEventContent};
 use crate::events::{EventContent, StateEventContent, StateEventType};
@@ -29,16 +28,6 @@ impl EventContent for PossiblyRedactedPolicyRuleUserEventContent {
 
     fn event_type(&self) -> Self::EventType {
         StateEventType::PolicyRuleUser
-    }
-
-    fn from_parts(event_type: &str, content: &RawJsonValue) -> serde_json::Result<Self> {
-        if event_type != "m.policy.rule.user" {
-            return Err(::serde::de::Error::custom(format!(
-                "expected event type `m.policy.rule.user`, found `{event_type}`",
-            )));
-        }
-
-        serde_json::from_str(content.get())
     }
 }
 

--- a/crates/ruma-common/src/events/room/aliases.rs
+++ b/crates/ruma-common/src/events/room/aliases.rs
@@ -2,7 +2,6 @@
 
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
-use serde_json::value::RawValue as RawJsonValue;
 
 use crate::{
     events::{
@@ -82,16 +81,6 @@ impl EventContent for RedactedRoomAliasesEventContent {
 
     fn event_type(&self) -> StateEventType {
         StateEventType::RoomAliases
-    }
-
-    fn from_parts(event_type: &str, content: &RawJsonValue) -> serde_json::Result<Self> {
-        if event_type != "m.room.aliases" {
-            return Err(::serde::de::Error::custom(format!(
-                "expected event type `m.room.aliases`, found `{event_type}`",
-            )));
-        }
-
-        serde_json::from_str(content.get())
     }
 }
 

--- a/crates/ruma-common/src/events/room/member.rs
+++ b/crates/ruma-common/src/events/room/member.rs
@@ -7,7 +7,6 @@ use std::collections::BTreeMap;
 use js_int::Int;
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
-use serde_json::value::RawValue as RawJsonValue;
 
 use crate::{
     events::{
@@ -242,16 +241,6 @@ impl EventContent for RedactedRoomMemberEventContent {
 
     fn event_type(&self) -> StateEventType {
         StateEventType::RoomMember
-    }
-
-    fn from_parts(event_type: &str, content: &RawJsonValue) -> serde_json::Result<Self> {
-        if event_type != "m.room.member" {
-            return Err(::serde::de::Error::custom(format!(
-                "expected event type `m.room.member`, found `{event_type}`",
-            )));
-        }
-
-        serde_json::from_str(content.get())
     }
 }
 

--- a/crates/ruma-common/src/events/room/member.rs
+++ b/crates/ruma-common/src/events/room/member.rs
@@ -7,13 +7,12 @@ use std::collections::BTreeMap;
 use js_int::Int;
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
-use serde_json::{from_str as from_json_str, value::RawValue as RawJsonValue};
+use serde_json::value::RawValue as RawJsonValue;
 
 use crate::{
     events::{
         AnyStrippedStateEvent, BundledRelations, EventContent, RedactContent, RedactedEventContent,
-        RedactedStateEventContent, StateEventContent, StateEventType, StateUnsignedFromParts,
-        StaticEventContent,
+        RedactedStateEventContent, StateEventContent, StateEventType,
     },
     serde::{CanBeEmpty, Raw, StringEnum},
     OwnedMxcUri, OwnedServerName, OwnedServerSigningKeyId, OwnedTransactionId, OwnedUserId,
@@ -547,20 +546,6 @@ impl CanBeEmpty for RoomMemberUnsigned {
             && self.prev_content.is_none()
             && self.invite_room_state.is_empty()
             && self.relations.is_empty()
-    }
-}
-
-impl StateUnsignedFromParts for RoomMemberUnsigned {
-    fn _from_parts(event_type: &str, object: &RawJsonValue) -> serde_json::Result<Self> {
-        const EVENT_TYPE: &str = <RoomMemberEventContent as StaticEventContent>::TYPE;
-
-        if event_type != EVENT_TYPE {
-            return Err(serde::de::Error::custom(format!(
-                "expected event type of `{EVENT_TYPE}`, found `{event_type}`",
-            )));
-        }
-
-        from_json_str(object.get())
     }
 }
 

--- a/crates/ruma-common/src/events/secret_storage/key.rs
+++ b/crates/ruma-common/src/events/secret_storage/key.rs
@@ -141,11 +141,8 @@ mod tests {
         }))
         .unwrap();
 
-        let content = <SecretStorageKeyEventContent as EventContentFromType>::from_parts(
-            "m.secret_storage.key.test",
-            &json,
-        )
-        .unwrap();
+        let content =
+            SecretStorageKeyEventContent::from_parts("m.secret_storage.key.test", &json).unwrap();
         assert_eq!(content.name.unwrap(), "my_key");
         assert_matches!(content.passphrase, None);
 
@@ -169,11 +166,8 @@ mod tests {
         }))
         .unwrap();
 
-        let content = <SecretStorageKeyEventContent as EventContentFromType>::from_parts(
-            "m.secret_storage.key.test",
-            &json,
-        )
-        .unwrap();
+        let content =
+            SecretStorageKeyEventContent::from_parts("m.secret_storage.key.test", &json).unwrap();
         assert!(content.name.is_none());
         assert_matches!(content.passphrase, None);
 
@@ -233,11 +227,8 @@ mod tests {
         }))
         .unwrap();
 
-        let content = <SecretStorageKeyEventContent as EventContentFromType>::from_parts(
-            "m.secret_storage.key.test",
-            &json,
-        )
-        .unwrap();
+        let content =
+            SecretStorageKeyEventContent::from_parts("m.secret_storage.key.test", &json).unwrap();
         assert_eq!(content.name.unwrap(), "my_key");
 
         let passphrase = content.passphrase.unwrap();

--- a/crates/ruma-common/src/events/unsigned.rs
+++ b/crates/ruma-common/src/events/unsigned.rs
@@ -1,13 +1,11 @@
 use js_int::Int;
 use serde::Deserialize;
-use serde_json::{from_str as from_json_str, value::RawValue as RawJsonValue};
 
 use super::{
     relation::BundledRelations, room::redaction::RoomRedactionEventContent, StateEventContent,
 };
 use crate::{
-    serde::{CanBeEmpty, Raw},
-    MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, OwnedUserId,
+    serde::CanBeEmpty, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, OwnedUserId,
 };
 
 /// Extra information about a message event that is not incorporated into the event's hash.
@@ -93,45 +91,6 @@ impl<C: StateEventContent> CanBeEmpty for StateUnsigned<C> {
             && self.transaction_id.is_none()
             && self.prev_content.is_none()
             && self.relations.is_empty()
-    }
-}
-
-/// Helper functions for proc-macro code.
-///
-/// Needs to be public for state events defined outside ruma-common.
-#[doc(hidden)]
-pub trait StateUnsignedFromParts: Sized {
-    fn _from_parts(event_type: &str, object: &RawJsonValue) -> serde_json::Result<Self>;
-}
-
-impl<C: StateEventContent> StateUnsignedFromParts for StateUnsigned<C> {
-    fn _from_parts(event_type: &str, object: &RawJsonValue) -> serde_json::Result<Self> {
-        #[derive(Deserialize)]
-        #[serde(bound = "")] // Disable default C: Deserialize bound
-        struct WithRawPrevContent<C> {
-            #[serde(skip_serializing_if = "Option::is_none")]
-            age: Option<Int>,
-            #[serde(skip_serializing_if = "Option::is_none")]
-            transaction_id: Option<OwnedTransactionId>,
-            prev_content: Option<Raw<C>>,
-            #[serde(
-                rename = "m.relations",
-                default,
-                skip_serializing_if = "BundledRelations::is_empty"
-            )]
-            relations: BundledRelations,
-        }
-
-        let raw: WithRawPrevContent<C> = from_json_str(object.get())?;
-        let prev_content =
-            raw.prev_content.map(|r| r.deserialize_content(event_type.into())).transpose()?;
-
-        Ok(Self {
-            age: raw.age,
-            transaction_id: raw.transaction_id,
-            relations: raw.relations,
-            prev_content,
-        })
     }
 }
 

--- a/crates/ruma-common/tests/events/message_event.rs
+++ b/crates/ruma-common/tests/events/message_event.rs
@@ -3,13 +3,13 @@ use assign::assign;
 use js_int::{uint, UInt};
 use ruma_common::{
     events::{
+        call::answer::CallAnswerEventContent,
         room::{ImageInfo, MediaSource, ThumbnailInfo},
         sticker::StickerEventContent,
-        AnyMessageLikeEvent, AnyMessageLikeEventContent, AnySyncMessageLikeEvent, MessageLikeEvent,
-        MessageLikeEventType,
+        AnyMessageLikeEvent, AnySyncMessageLikeEvent, MessageLikeEvent,
     },
     mxc_uri, room_id,
-    serde::{CanBeEmpty, Raw},
+    serde::CanBeEmpty,
     MilliSecondsSinceUnixEpoch, VoipVersionId,
 };
 use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
@@ -107,13 +107,7 @@ fn deserialize_message_call_answer_content() {
         "version": 0
     });
 
-    let content = assert_matches!(
-        from_json_value::<Raw<AnyMessageLikeEventContent>>(json_data)
-            .unwrap()
-            .deserialize_content(MessageLikeEventType::CallAnswer)
-            .unwrap(),
-        AnyMessageLikeEventContent::CallAnswer(content) => content
-    );
+    let content = from_json_value::<CallAnswerEventContent>(json_data).unwrap();
 
     assert_eq!(content.answer.sdp, "Hello");
     assert_eq!(content.call_id, "foofoo");

--- a/crates/ruma-common/tests/events/redacted.rs
+++ b/crates/ruma-common/tests/events/redacted.rs
@@ -8,8 +8,8 @@ use ruma_common::{
             redaction::RoomRedactionEventContent,
         },
         AnyMessageLikeEvent, AnySyncMessageLikeEvent, AnySyncStateEvent, AnySyncTimelineEvent,
-        AnyTimelineEvent, EventContent, MessageLikeEvent, RedactContent, SyncMessageLikeEvent,
-        SyncStateEvent,
+        AnyTimelineEvent, EventContentFromType, MessageLikeEvent, RedactContent,
+        SyncMessageLikeEvent, SyncStateEvent,
     },
     RoomVersionId,
 };

--- a/crates/ruma-common/tests/events/state_event.rs
+++ b/crates/ruma-common/tests/events/state_event.rs
@@ -2,11 +2,11 @@ use assert_matches::assert_matches;
 use js_int::uint;
 use ruma_common::{
     events::{
-        AnyStateEvent, AnyStateEventContent, AnySyncStateEvent, AnyTimelineEvent, StateEvent,
-        StateEventType, SyncStateEvent,
+        room::aliases::RoomAliasesEventContent, AnyStateEvent, AnySyncStateEvent, AnyTimelineEvent,
+        StateEvent, SyncStateEvent,
     },
     mxc_uri, room_alias_id,
-    serde::{CanBeEmpty, Raw},
+    serde::CanBeEmpty,
     MilliSecondsSinceUnixEpoch,
 };
 use serde_json::{from_value as from_json_value, json, Value as JsonValue};
@@ -36,12 +36,7 @@ fn deserialize_aliases_content() {
         "aliases": ["#somewhere:localhost"],
     });
 
-    let content = assert_matches!(
-        from_json_value::<Raw<AnyStateEventContent>>(json_data)
-            .unwrap()
-            .deserialize_content(StateEventType::RoomAliases),
-        Ok(AnyStateEventContent::RoomAliases(content)) => content
-    );
+    let content = from_json_value::<RoomAliasesEventContent>(json_data).unwrap();
     assert_eq!(content.aliases, vec![room_alias_id!("#somewhere:localhost")]);
 }
 

--- a/crates/ruma-common/tests/events/ui/04-event-sanity-check.rs
+++ b/crates/ruma-common/tests/events/ui/04-event-sanity-check.rs
@@ -1,17 +1,13 @@
-// Required, probably until Rust 1.57
-// https://github.com/rust-lang/rust/issues/55779
-#[allow(unused_extern_crates)]
-extern crate serde;
-
 use ruma_common::{
     events::{StateEventContent, StateUnsigned},
     MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedUserId,
 };
 use ruma_macros::Event;
+use serde::de::DeserializeOwned;
 
 /// State event.
 #[derive(Clone, Debug, Event)]
-pub struct OriginalStateEvent<C: StateEventContent> {
+pub struct OriginalStateEvent<C: StateEventContent + DeserializeOwned> {
     pub content: C,
     pub event_id: OwnedEventId,
     pub sender: OwnedUserId,

--- a/crates/ruma-common/tests/events/ui/10-content-wildcard.rs
+++ b/crates/ruma-common/tests/events/ui/10-content-wildcard.rs
@@ -1,7 +1,7 @@
 use ruma_macros::EventContent;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
-#[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
+#[derive(Clone, Debug, Serialize, EventContent)]
 #[ruma_event(type = "m.macro.test.*", kind = GlobalAccountData)]
 pub struct MacroTestContent {
     #[ruma_event(type_fragment)]

--- a/crates/ruma-macros/src/events/event_content.rs
+++ b/crates/ruma-macros/src/events/event_content.rs
@@ -894,27 +894,6 @@ fn generate_event_content_impl<'a>(
 
     let event_types = aliases.iter().chain([event_type]);
 
-    let from_parts_fn_impl = if type_suffix_data.is_some() {
-        quote! {
-            <Self as #ruma_common::events::EventContentFromType>::from_parts(ev_type, content)
-        }
-    } else {
-        let event_types = event_types.clone();
-        let event_types = quote! {
-            [#(#event_types,)*]
-        };
-
-        quote! {
-            if !#event_types.contains(&ev_type) {
-                return ::std::result::Result::Err(#serde::de::Error::custom(
-                    ::std::format!("expected event type as one of `{:?}`, found `{}`", #event_types, ev_type)
-                ));
-            }
-
-            #serde_json::from_str(content.get())
-        }
-    };
-
     let event_content_from_type_impl = type_suffix_data.map(|(_, type_fragment_field)| {
         let type_prefixes = event_types.map(|ev_type| {
             ev_type
@@ -970,13 +949,6 @@ fn generate_event_content_impl<'a>(
 
             fn event_type(&self) -> Self::EventType {
                 #event_type_fn_impl
-            }
-
-            fn from_parts(
-                ev_type: &::std::primitive::str,
-                content: &#serde_json::value::RawValue,
-            ) -> #serde_json::Result<Self> {
-                #from_parts_fn_impl
             }
         }
 

--- a/crates/ruma-macros/src/events/util.rs
+++ b/crates/ruma-macros/src/events/util.rs
@@ -10,8 +10,3 @@ pub(crate) fn is_non_stripped_room_event(kind: EventKind, var: EventKindVariatio
                 | EventKindVariation::RedactedSync
         )
 }
-
-pub(crate) fn has_prev_content(kind: EventKind, var: EventKindVariation) -> bool {
-    matches!(kind, EventKind::State)
-        && matches!(var, EventKindVariation::Original | EventKindVariation::OriginalSync)
-}


### PR DESCRIPTION
Simplify some implementations in the process.










<!-- Replace -->
----
Preview: https://pr-1443--ruma-docs.surge.sh
<!-- Replace -->
