### PR TITLE
api: Only percent-encode reserved characters in endpoint URL path

### DIFF
--- a/crates/ruma-client-api/src/state/send_state_event.rs
+++ b/crates/ruma-client-api/src/state/send_state_event.rs
@@ -229,7 +229,7 @@ pub mod v3 {
 
         assert_eq!(
             req.uri(),
-            "https://server.tld/_matrix/client/v3/rooms/%21room%3Aserver%2Etld/state/m%2Eroom%2Ename/"
+            "https://server.tld/_matrix/client/v3/rooms/!room:server.tld/state/m.room.name/"
         );
     }
 }

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -11,6 +11,7 @@ Bug fixes:
 * Fix deserialization of `StateUnsigned` when the `prev_content` is redacted
 * Allow to deserialize `PushCondition` with unknown kind
 * Allow to deserialize `push::Action` with unknown value
+* Only percent-encode reserved characters in endpoint URL path
 
 Breaking changes:
 


### PR DESCRIPTION
Fixes #1447.




<!-- Replace -->
----
Preview Removed
<!-- Replace -->
