### PR TITLE
Add unstable support for discovering a sliding sync proxy (MSC3575)

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -31,6 +31,7 @@ Improvements:
 * Send CORP headers by default for media responses (MSC3828 / Matrix 1.4)
 * Add support for read receipts for threads (MSC3771 / Matrix 1.4)
 * Add unstable support to get an event by timestamp (MSC3030)
+* Add unstable support for discovering a sliding sync proxy (MSC3575)
 
 # 0.15.3
 

--- a/crates/ruma-client-api/src/discovery/discover_homeserver.rs
+++ b/crates/ruma-client-api/src/discovery/discover_homeserver.rs
@@ -52,6 +52,11 @@ pub struct Response {
         skip_serializing_if = "Option::is_none"
     )]
     pub authentication: Option<AuthenticationServerInfo>,
+
+    /// Information about the homeserver's trusted proxy to use for sliding sync development.
+    #[cfg(feature = "unstable-msc3575")]
+    #[serde(rename = "org.matrix.msc3575.proxy", skip_serializing_if = "Option::is_none")]
+    pub sliding_sync_proxy: Option<SlidingSyncProxyInfo>,
 }
 
 impl Request {
@@ -71,6 +76,8 @@ impl Response {
             tile_server: None,
             #[cfg(feature = "unstable-msc2965")]
             authentication: None,
+            #[cfg(feature = "unstable-msc3575")]
+            sliding_sync_proxy: None,
         }
     }
 }
@@ -140,8 +147,25 @@ pub struct AuthenticationServerInfo {
 
 #[cfg(feature = "unstable-msc2965")]
 impl AuthenticationServerInfo {
-    /// Creates an `AuthenticationServerInfo` with the given `issuer` and an optional `account.
+    /// Creates an `AuthenticationServerInfo` with the given `issuer` and an optional `account`.
     pub fn new(issuer: String, account: Option<String>) -> Self {
         Self { issuer, account }
+    }
+}
+
+/// Information about a discovered sliding sync proxy.
+#[cfg(feature = "unstable-msc3575")]
+#[derive(Clone, Debug, Deserialize, Hash, Serialize)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+pub struct SlidingSyncProxyInfo {
+    /// The URL of a sliding sync proxy that is trusted by the homeserver.
+    pub url: String,
+}
+
+#[cfg(feature = "unstable-msc3575")]
+impl SlidingSyncProxyInfo {
+    /// Creates a `SlidingSyncProxyInfo` with the given proxy URL.
+    pub fn new(url: String) -> Self {
+        Self { url }
     }
 }


### PR DESCRIPTION
As part of https://github.com/vector-im/element-x-ios/issues/410 we will need to discover the sliding sync proxy from the homeserver's .well-known file. This PR adds support for that.

<!-- Replace -->
----
Preview Removed
<!-- Replace -->
