### PR TITLE
events: Add custom PossiblyRedactedRoomTombstoneEventContent

### DIFF
--- a/crates/ruma-common/src/events/room/tombstone.rs
+++ b/crates/ruma-common/src/events/room/tombstone.rs
@@ -5,14 +5,25 @@
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
-use crate::{events::EmptyStateKey, OwnedRoomId};
+use crate::{
+    events::{
+        EmptyStateKey, EventContent, PossiblyRedactedStateEventContent, StateEventType,
+        StaticEventContent,
+    },
+    OwnedRoomId,
+};
 
 /// The content of an `m.room.tombstone` event.
 ///
 /// A state event signifying that a room has been upgraded to a different room version, and that
 /// clients should go there.
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
-#[ruma_event(type = "m.room.tombstone", kind = State, state_key_type = EmptyStateKey)]
+#[ruma_event(
+    type = "m.room.tombstone",
+    kind = State,
+    state_key_type = EmptyStateKey,
+    custom_possibly_redacted,
+)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct RoomTombstoneEventContent {
     /// A server-defined message.
@@ -31,4 +42,33 @@ impl RoomTombstoneEventContent {
     pub fn new(body: String, replacement_room: OwnedRoomId) -> Self {
         Self { body, replacement_room }
     }
+}
+
+/// The possibly redacted form of [`RoomTombstoneEventContent`].
+///
+/// This type is used when it's not obvious whether the content is redacted or not.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+pub struct PossiblyRedactedRoomTombstoneEventContent {
+    /// A server-defined message.
+    pub body: Option<String>,
+
+    /// The new room the client should be visiting.
+    pub replacement_room: Option<OwnedRoomId>,
+}
+
+impl EventContent for PossiblyRedactedRoomTombstoneEventContent {
+    type EventType = StateEventType;
+
+    fn event_type(&self) -> Self::EventType {
+        StateEventType::RoomTombstone
+    }
+}
+
+impl PossiblyRedactedStateEventContent for PossiblyRedactedRoomTombstoneEventContent {
+    type StateKey = EmptyStateKey;
+}
+
+impl StaticEventContent for PossiblyRedactedRoomTombstoneEventContent {
+    const TYPE: &'static str = "m.room.tombstone";
 }


### PR DESCRIPTION
The auto-generated type would look different based on whether the compat feature is active or not previously.




<!-- Replace -->
----
Preview Removed
<!-- Replace -->
