### PR TITLE
xtask: Don't wait after ruma-macros release

### DIFF
--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -161,22 +161,19 @@ impl Package {
     }
 
     /// Publish this package on crates.io.
-    pub fn publish(&self, client: &HttpClient, dry_run: bool) -> Result<bool> {
+    pub fn publish(&self, client: &HttpClient, dry_run: bool) -> Result<()> {
         println!("Publishing {} {} on crates.io…", self.name, self.version);
         let _dir = pushd(self.manifest_path.parent().unwrap())?;
 
         if self.is_published(client)? {
-            if ask_yes_no("This version is already published. Skip this step and continue?")? {
-                Ok(false)
-            } else {
-                Err("Release interrupted by user.".into())
+            if !ask_yes_no("This version is already published. Skip this step and continue?")? {
+                return Err("Release interrupted by user.".into());
             }
-        } else {
-            if !dry_run {
-                cmd!("cargo publish").run()?;
-            }
-            Ok(true)
+        } else if !dry_run {
+            cmd!("cargo publish").run()?;
         }
+
+        Ok(())
     }
 }
 

--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -1,8 +1,4 @@
-use std::{
-    io::{stdin, stdout, BufRead, Write},
-    thread::sleep,
-    time::Duration,
-};
+use std::io::{stdin, stdout, BufRead, Write};
 
 use clap::Args;
 use isahc::{
@@ -152,14 +148,7 @@ impl ReleaseTask {
         }
 
         if let Some(m) = macros {
-            let published = m.publish(&self.http_client, self.dry_run)?;
-
-            if published && !self.dry_run {
-                // Crate was published, instead of publishing skipped (because release already
-                // existed).
-                println!("Waiting 20 seconds for the release to make it into the crates.io index…");
-                sleep(Duration::from_secs(20));
-            }
+            m.publish(&self.http_client, self.dry_run)?;
         }
 
         self.package.publish(&self.http_client, self.dry_run)?;


### PR DESCRIPTION
Current versions of Cargo do this as part of `cargo publish`.




<!-- Replace -->
----
Preview Removed
<!-- Replace -->
