### PR TITLE
events: Use input visibility for generated types in EventContent derive

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -3,6 +3,9 @@
 Improvements:
 
 - Derive `Hash` for `ReceiptType` and `ReceiptThread`
+- Update `EventContent` derive macro to emit new type definitions and type
+  aliases under the same visibility as the input type (this fixes a future-
+  compatibility warning when deriving `EventContent` on a non-`pub` type)
 
 # 0.11.1
 

--- a/crates/ruma-common/tests/events/event_content.rs
+++ b/crates/ruma-common/tests/events/event_content.rs
@@ -7,4 +7,5 @@ fn ui() {
     t.pass("tests/events/ui/10-content-wildcard.rs");
     t.pass("tests/events/ui/11-content-without-relation-sanity-check.rs");
     t.compile_fail("tests/events/ui/12-no-relates_to.rs");
+    t.pass("tests/events/ui/13-private-event-content-type.rs");
 }

--- a/crates/ruma-common/tests/events/ui/13-private-event-content-type.rs
+++ b/crates/ruma-common/tests/events/ui/13-private-event-content-type.rs
@@ -1,0 +1,12 @@
+#![deny(private_in_public)]
+
+use ruma_macros::EventContent;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
+#[ruma_event(type = "m.macro.test", kind = State, state_key_type = String)]
+struct MacroTestContent {
+    url: String,
+}
+
+fn main() {}


### PR DESCRIPTION
Fixes #1423.




<!-- Replace -->
----
Preview Removed
<!-- Replace -->
