### PR TITLE
events: Derive `Hash` for `ReceiptType` and `ReceiptThread`

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [unreleased]
 
+Improvements:
+
+- Derive `Hash` for `ReceiptType` and `ReceiptThread`
+
 # 0.11.1
 
 Improvements:

--- a/crates/ruma-common/src/events/receipt.rs
+++ b/crates/ruma-common/src/events/receipt.rs
@@ -59,7 +59,7 @@ pub type Receipts = BTreeMap<ReceiptType, UserReceipts>;
 
 /// The type of receipt.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, PartialOrdAsRefStr, OrdAsRefStr, PartialEqAsRefStr, Eq, StringEnum)]
+#[derive(Clone, PartialOrdAsRefStr, OrdAsRefStr, PartialEqAsRefStr, Eq, StringEnum, Hash)]
 #[non_exhaustive]
 pub enum ReceiptType {
     /// A [public read receipt].
@@ -132,7 +132,7 @@ impl Receipt {
 /// representation, obtained through [`.as_str()`](Self::as_str()).
 ///
 /// [thread a receipt applies to]: https://spec.matrix.org/v1.4/client-server-api/#threaded-read-receipts
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum ReceiptThread {
     /// The receipt applies to the timeline, regardless of threads.

--- a/crates/ruma-common/src/push/condition.rs
+++ b/crates/ruma-common/src/push/condition.rs
@@ -469,7 +469,7 @@ mod tests {
             "pattern": "m.notice"
         });
         assert_eq!(
-            to_json_value(&PushCondition::EventMatch {
+            to_json_value(PushCondition::EventMatch {
                 key: "content.msgtype".into(),
                 pattern: "m.notice".into(),
             })
@@ -481,7 +481,7 @@ mod tests {
     #[test]
     fn serialize_contains_display_name_condition() {
         assert_eq!(
-            to_json_value(&PushCondition::ContainsDisplayName).unwrap(),
+            to_json_value(PushCondition::ContainsDisplayName).unwrap(),
             json!({ "kind": "contains_display_name" })
         );
     }
@@ -493,10 +493,8 @@ mod tests {
             "kind": "room_member_count"
         });
         assert_eq!(
-            to_json_value(&PushCondition::RoomMemberCount {
-                is: RoomMemberCountIs::from(uint!(2))
-            })
-            .unwrap(),
+            to_json_value(PushCondition::RoomMemberCount { is: RoomMemberCountIs::from(uint!(2)) })
+                .unwrap(),
             json_data
         );
     }
@@ -509,7 +507,7 @@ mod tests {
         });
         assert_eq!(
             json_data,
-            to_json_value(&PushCondition::SenderNotificationPermission { key: "room".into() })
+            to_json_value(PushCondition::SenderNotificationPermission { key: "room".into() })
                 .unwrap()
         );
     }

--- a/crates/ruma-common/src/serde/duration/opt_ms.rs
+++ b/crates/ruma-common/src/serde/duration/opt_ms.rs
@@ -86,12 +86,12 @@ mod tests {
     #[test]
     fn serialize_some() {
         let request = DurationTest { timeout: Some(Duration::new(2, 0)) };
-        assert_eq!(serde_json::to_value(&request).unwrap(), json!({ "timeout": 2000 }));
+        assert_eq!(serde_json::to_value(request).unwrap(), json!({ "timeout": 2000 }));
     }
 
     #[test]
     fn serialize_none() {
         let request = DurationTest { timeout: None };
-        assert_eq!(serde_json::to_value(&request).unwrap(), json!({}));
+        assert_eq!(serde_json::to_value(request).unwrap(), json!({}));
     }
 }

--- a/crates/ruma-common/src/time.rs
+++ b/crates/ruma-common/src/time.rs
@@ -137,6 +137,6 @@ mod tests {
             secs: SecondsSinceUnixEpoch(uint!(0)),
         };
 
-        assert_eq!(serde_json::to_value(&request).unwrap(), json!({ "millis": 2000, "secs": 0 }));
+        assert_eq!(serde_json::to_value(request).unwrap(), json!({ "millis": 2000, "secs": 0 }));
     }
 }

--- a/crates/ruma-common/tests/events/redacted.rs
+++ b/crates/ruma-common/tests/events/redacted.rs
@@ -60,10 +60,8 @@ fn deserialize_redacted_aliases() {
         "type": "m.room.aliases",
     });
 
-    let actual = to_json_value(&redacted).unwrap();
-
     let redacted = assert_matches!(
-        from_json_value::<AnySyncTimelineEvent>(actual),
+        from_json_value::<AnySyncTimelineEvent>(redacted),
         Ok(AnySyncTimelineEvent::State(AnySyncStateEvent::RoomAliases(
             SyncStateEvent::Redacted(redacted),
         ))) => redacted
@@ -84,10 +82,8 @@ fn deserialize_redacted_any_room() {
         "type": "m.room.message",
     });
 
-    let actual = to_json_value(&redacted).unwrap();
-
     let redacted = assert_matches!(
-        from_json_value::<AnyTimelineEvent>(actual),
+        from_json_value::<AnyTimelineEvent>(redacted),
         Ok(AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::RoomMessage(
             MessageLikeEvent::Redacted(redacted),
         ))) => redacted
@@ -107,10 +103,8 @@ fn deserialize_redacted_any_room_sync() {
         "type": "m.room.message",
     });
 
-    let actual = to_json_value(&redacted).unwrap();
-
     let redacted = assert_matches!(
-        from_json_value::<AnySyncTimelineEvent>(actual),
+        from_json_value::<AnySyncTimelineEvent>(redacted),
         Ok(AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::RoomMessage(
             SyncMessageLikeEvent::Redacted(redacted),
         ))) => redacted

--- a/crates/ruma-federation-api/src/serde/v1_pdu.rs
+++ b/crates/ruma-federation-api/src/serde/v1_pdu.rs
@@ -71,7 +71,7 @@ where
 #[cfg(test)]
 mod tests {
     use assert_matches::assert_matches;
-    use serde_json::{json, to_value as to_json_value};
+    use serde_json::json;
 
     use super::{deserialize, serialize};
     use crate::membership::create_join_event::v1::RoomState;
@@ -104,7 +104,7 @@ mod tests {
         };
 
         let serialized = serialize(&room_state, serde_json::value::Serializer).unwrap();
-        let expected = to_json_value(&json!(
+        let expected = json!(
             [
                 200,
                 {
@@ -113,8 +113,7 @@ mod tests {
                     "state": []
                 }
             ]
-        ))
-        .unwrap();
+        );
 
         assert_eq!(serialized, expected);
     }


### PR DESCRIPTION
Since uniqueness of receipts is determined per type and per thread it's common to use them as keys of a map.




<!-- Replace -->
----
Preview Removed
<!-- Replace -->
