### PR TITLE
chore: Make all applicable spec links use the latest spec instead of a specific version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Here is a list of helpful resources you can consult:
 
 ## Documentation
 
-- [Matrix spec Documentation](https://spec.matrix.org/v1.4/)
+- [Matrix spec Documentation](https://spec.matrix.org/latest/)
 
 ## Chat Rooms
 
@@ -154,7 +154,7 @@ the latest minor version of the Matrix specification.
 
 ### Endpoint Module Structure
 
-Matrix uses [versioned endpoints](https://spec.matrix.org/v1.4/#endpoint-versioning) (with a few small exceptions),
+Matrix uses [versioned endpoints](https://spec.matrix.org/latest/#endpoint-versioning) (with a few small exceptions),
 we follow this versioning approach in modules as well.
 
 We structure endpoints and their versions like the following;
@@ -192,7 +192,7 @@ Then, in the subsequent version module, embed the version and specification link
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3sync
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3sync
 }
 ```
 

--- a/crates/ruma-appservice-api/src/event/push_events.rs
+++ b/crates/ruma-appservice-api/src/event/push_events.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/application-service-api/#put_matrixappv1transactionstxnid
+    //! [spec]: https://spec.matrix.org/latest/application-service-api/#put_matrixappv1transactionstxnid
 
     #[cfg(any(feature = "unstable-msc2409", feature = "unstable-msc3202"))]
     use std::collections::BTreeMap;

--- a/crates/ruma-appservice-api/src/lib.rs
+++ b/crates/ruma-appservice-api/src/lib.rs
@@ -3,7 +3,7 @@
 //! (De)serializable types for the [Matrix Application Service API][appservice-api].
 //! These types can be shared by application service and server code.
 //!
-//! [appservice-api]: https://spec.matrix.org/v1.4/application-service-api/
+//! [appservice-api]: https://spec.matrix.org/latest/application-service-api/
 
 #![warn(missing_docs)]
 
@@ -15,7 +15,7 @@ pub mod thirdparty;
 
 /// A namespace defined by an application service.
 ///
-/// Used for [appservice registration](https://spec.matrix.org/v1.4/application-service-api/#registration).
+/// Used for [appservice registration](https://spec.matrix.org/latest/application-service-api/#registration).
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct Namespace {
@@ -35,7 +35,7 @@ impl Namespace {
 
 /// Namespaces defined by an application service.
 ///
-/// Used for [appservice registration](https://spec.matrix.org/v1.4/application-service-api/#registration).
+/// Used for [appservice registration](https://spec.matrix.org/latest/application-service-api/#registration).
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct Namespaces {
@@ -65,7 +65,7 @@ impl Namespaces {
 /// To create an instance of this type, first create a `RegistrationInit` and convert it via
 /// `Registration::from` / `.into()`.
 ///
-/// Used for [appservice registration](https://spec.matrix.org/v1.4/application-service-api/#registration).
+/// Used for [appservice registration](https://spec.matrix.org/latest/application-service-api/#registration).
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct Registration {
@@ -103,7 +103,7 @@ pub struct Registration {
 /// This struct will not be updated even if additional fields are added to `Registration` in a new
 /// (non-breaking) release of the Matrix specification.
 ///
-/// Used for [appservice registration](https://spec.matrix.org/v1.4/application-service-api/#registration).
+/// Used for [appservice registration](https://spec.matrix.org/latest/application-service-api/#registration).
 #[derive(Debug)]
 #[allow(clippy::exhaustive_structs)]
 pub struct RegistrationInit {

--- a/crates/ruma-appservice-api/src/query/query_room_alias.rs
+++ b/crates/ruma-appservice-api/src/query/query_room_alias.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/application-service-api/#get_matrixappv1roomsroomalias
+    //! [spec]: https://spec.matrix.org/latest/application-service-api/#get_matrixappv1roomsroomalias
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-appservice-api/src/query/query_user_id.rs
+++ b/crates/ruma-appservice-api/src/query/query_user_id.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/application-service-api/#get_matrixappv1usersuserid
+    //! [spec]: https://spec.matrix.org/latest/application-service-api/#get_matrixappv1usersuserid
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-appservice-api/src/thirdparty/get_location_for_protocol.rs
+++ b/crates/ruma-appservice-api/src/thirdparty/get_location_for_protocol.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/application-service-api/#get_matrixappv1thirdpartylocationprotocol
+    //! [spec]: https://spec.matrix.org/latest/application-service-api/#get_matrixappv1thirdpartylocationprotocol
 
     use std::collections::BTreeMap;
 

--- a/crates/ruma-appservice-api/src/thirdparty/get_location_for_room_alias.rs
+++ b/crates/ruma-appservice-api/src/thirdparty/get_location_for_room_alias.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/application-service-api/#get_matrixappv1thirdpartylocation
+    //! [spec]: https://spec.matrix.org/latest/application-service-api/#get_matrixappv1thirdpartylocation
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-appservice-api/src/thirdparty/get_protocol.rs
+++ b/crates/ruma-appservice-api/src/thirdparty/get_protocol.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/application-service-api/#get_matrixappv1thirdpartyprotocolprotocol
+    //! [spec]: https://spec.matrix.org/latest/application-service-api/#get_matrixappv1thirdpartyprotocolprotocol
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-appservice-api/src/thirdparty/get_user_for_protocol.rs
+++ b/crates/ruma-appservice-api/src/thirdparty/get_user_for_protocol.rs
@@ -6,7 +6,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/application-service-api/#get_matrixappv1thirdpartyuserprotocol
+    //! [spec]: https://spec.matrix.org/latest/application-service-api/#get_matrixappv1thirdpartyuserprotocol
 
     use std::collections::BTreeMap;
 

--- a/crates/ruma-appservice-api/src/thirdparty/get_user_for_user_id.rs
+++ b/crates/ruma-appservice-api/src/thirdparty/get_user_for_user_id.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/application-service-api/#get_matrixappv1thirdpartyuser
+    //! [spec]: https://spec.matrix.org/latest/application-service-api/#get_matrixappv1thirdpartyuser
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/account/add_3pid.rs
+++ b/crates/ruma-client-api/src/account/add_3pid.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3account3pidadd
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3account3pidadd
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/account/bind_3pid.rs
+++ b/crates/ruma-client-api/src/account/bind_3pid.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3account3pidbind
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3account3pidbind
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/account/change_password.rs
+++ b/crates/ruma-client-api/src/account/change_password.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3accountpassword
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3accountpassword
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/account/check_registration_token_validity.rs
+++ b/crates/ruma-client-api/src/account/check_registration_token_validity.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv1registermloginregistration_tokenvalidity
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv1registermloginregistration_tokenvalidity
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/account/deactivate.rs
+++ b/crates/ruma-client-api/src/account/deactivate.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3accountdeactivate
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3accountdeactivate
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/account/delete_3pid.rs
+++ b/crates/ruma-client-api/src/account/delete_3pid.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3account3piddelete
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3account3piddelete
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/account/get_3pids.rs
+++ b/crates/ruma-client-api/src/account/get_3pids.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3account3pid
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3account3pid
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/account/get_username_availability.rs
+++ b/crates/ruma-client-api/src/account/get_username_availability.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3registeravailable
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3registeravailable
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/account/register.rs
+++ b/crates/ruma-client-api/src/account/register.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3register
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3register
 
     use std::time::Duration;
 
@@ -85,13 +85,13 @@ pub mod v3 {
         /// Appservices can [bypass the registration flows][admin] entirely by providing their
         /// token in the header and setting this login `type` to `m.login.application_service`.
         ///
-        /// [admin]: https://spec.matrix.org/v1.4/application-service-api/#server-admin-style-permissions
+        /// [admin]: https://spec.matrix.org/latest/application-service-api/#server-admin-style-permissions
         #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
         pub login_type: Option<LoginType>,
 
         /// If set to `true`, the client supports [refresh tokens].
         ///
-        /// [refresh tokens]: https://spec.matrix.org/v1.4/client-server-api/#refreshing-access-tokens
+        /// [refresh tokens]: https://spec.matrix.org/latest/client-server-api/#refreshing-access-tokens
         #[serde(default, skip_serializing_if = "ruma_common::serde::is_default")]
         pub refresh_token: bool,
     }
@@ -124,7 +124,7 @@ pub mod v3 {
         ///
         /// Omitted if the request's `inhibit_login` was set to `true`.
         ///
-        /// [refresh token]: https://spec.matrix.org/v1.4/client-server-api/#refreshing-access-tokens
+        /// [refresh token]: https://spec.matrix.org/latest/client-server-api/#refreshing-access-tokens
         /// [`refresh_token`]: crate::session::refresh_token
         #[serde(skip_serializing_if = "Option::is_none")]
         pub refresh_token: Option<String>,

--- a/crates/ruma-client-api/src/account/request_3pid_management_token_via_email.rs
+++ b/crates/ruma-client-api/src/account/request_3pid_management_token_via_email.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3account3pidemailrequesttoken
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3account3pidemailrequesttoken
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-client-api/src/account/request_3pid_management_token_via_msisdn.rs
+++ b/crates/ruma-client-api/src/account/request_3pid_management_token_via_msisdn.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3account3pidmsisdnrequesttoken
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3account3pidmsisdnrequesttoken
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-client-api/src/account/request_openid_token.rs
+++ b/crates/ruma-client-api/src/account/request_openid_token.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3useruseridopenidrequest_token
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3useruseridopenidrequest_token
 
     use std::time::Duration;
 

--- a/crates/ruma-client-api/src/account/request_password_change_token_via_email.rs
+++ b/crates/ruma-client-api/src/account/request_password_change_token_via_email.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3accountpasswordemailrequesttoken
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3accountpasswordemailrequesttoken
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-client-api/src/account/request_password_change_token_via_msisdn.rs
+++ b/crates/ruma-client-api/src/account/request_password_change_token_via_msisdn.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3accountpasswordmsisdnrequesttoken
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3accountpasswordmsisdnrequesttoken
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-client-api/src/account/request_registration_token_via_email.rs
+++ b/crates/ruma-client-api/src/account/request_registration_token_via_email.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3registeremailrequesttoken
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3registeremailrequesttoken
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-client-api/src/account/request_registration_token_via_msisdn.rs
+++ b/crates/ruma-client-api/src/account/request_registration_token_via_msisdn.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3registermsisdnrequesttoken
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3registermsisdnrequesttoken
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-client-api/src/account/unbind_3pid.rs
+++ b/crates/ruma-client-api/src/account/unbind_3pid.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3account3pidunbind
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3account3pidunbind
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/account/whoami.rs
+++ b/crates/ruma-client-api/src/account/whoami.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3accountwhoami
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3accountwhoami
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/alias/create_alias.rs
+++ b/crates/ruma-client-api/src/alias/create_alias.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#put_matrixclientv3directoryroomroomalias
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3directoryroomroomalias
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/alias/delete_alias.rs
+++ b/crates/ruma-client-api/src/alias/delete_alias.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#delete_matrixclientv3directoryroomroomalias
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#delete_matrixclientv3directoryroomroomalias
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/alias/get_alias.rs
+++ b/crates/ruma-client-api/src/alias/get_alias.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3directoryroomroomalias
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3directoryroomroomalias
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/appservice/set_room_visibility.rs
+++ b/crates/ruma-client-api/src/appservice/set_room_visibility.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/application-service-api/#put_matrixclientv3directorylistappservicenetworkidroomid
+    //! [spec]: https://spec.matrix.org/latest/application-service-api/#put_matrixclientv3directorylistappservicenetworkidroomid
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/backup/add_backup_keys.rs
+++ b/crates/ruma-client-api/src/backup/add_backup_keys.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#put_matrixclientv3room_keyskeys
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3room_keyskeys
 
     use std::collections::BTreeMap;
 

--- a/crates/ruma-client-api/src/backup/add_backup_keys_for_room.rs
+++ b/crates/ruma-client-api/src/backup/add_backup_keys_for_room.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#put_matrixclientv3room_keyskeysroomid
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3room_keyskeysroomid
 
     use std::collections::BTreeMap;
 

--- a/crates/ruma-client-api/src/backup/add_backup_keys_for_session.rs
+++ b/crates/ruma-client-api/src/backup/add_backup_keys_for_session.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#put_matrixclientv3room_keyskeysroomidsessionid
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3room_keyskeysroomidsessionid
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-client-api/src/backup/create_backup_version.rs
+++ b/crates/ruma-client-api/src/backup/create_backup_version.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3room_keysversion
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3room_keysversion
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/backup/delete_backup_keys.rs
+++ b/crates/ruma-client-api/src/backup/delete_backup_keys.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#delete_matrixclientv3room_keyskeys
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#delete_matrixclientv3room_keyskeys
     //!
     //! This deletes keys from a backup version, but not the version itself.
 

--- a/crates/ruma-client-api/src/backup/delete_backup_keys_for_room.rs
+++ b/crates/ruma-client-api/src/backup/delete_backup_keys_for_room.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#delete_matrixclientv3room_keyskeysroomid
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#delete_matrixclientv3room_keyskeysroomid
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-client-api/src/backup/delete_backup_keys_for_session.rs
+++ b/crates/ruma-client-api/src/backup/delete_backup_keys_for_session.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#delete_matrixclientv3room_keyskeysroomidsessionid
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#delete_matrixclientv3room_keyskeysroomidsessionid
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-client-api/src/backup/delete_backup_version.rs
+++ b/crates/ruma-client-api/src/backup/delete_backup_version.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#delete_matrixclientv3room_keysversionversion
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#delete_matrixclientv3room_keysversionversion
     //!
     //! This deletes a backup version and its room keys.
 

--- a/crates/ruma-client-api/src/backup/get_backup_info.rs
+++ b/crates/ruma-client-api/src/backup/get_backup_info.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3room_keysversionversion
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3room_keysversionversion
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-client-api/src/backup/get_backup_keys.rs
+++ b/crates/ruma-client-api/src/backup/get_backup_keys.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3room_keyskeys
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3room_keyskeys
 
     use std::collections::BTreeMap;
 

--- a/crates/ruma-client-api/src/backup/get_backup_keys_for_room.rs
+++ b/crates/ruma-client-api/src/backup/get_backup_keys_for_room.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3room_keyskeysroomid
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3room_keyskeysroomid
 
     use std::collections::BTreeMap;
 

--- a/crates/ruma-client-api/src/backup/get_backup_keys_for_session.rs
+++ b/crates/ruma-client-api/src/backup/get_backup_keys_for_session.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3room_keyskeysroomidsessionid
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3room_keyskeysroomidsessionid
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/backup/get_latest_backup_info.rs
+++ b/crates/ruma-client-api/src/backup/get_latest_backup_info.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3room_keysversion
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3room_keysversion
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-client-api/src/backup/update_backup_version.rs
+++ b/crates/ruma-client-api/src/backup/update_backup_version.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#put_matrixclientv3room_keysversionversion
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3room_keysversionversion
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/config/get_global_account_data.rs
+++ b/crates/ruma-client-api/src/config/get_global_account_data.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3useruseridaccount_datatype
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3useruseridaccount_datatype
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/config/get_room_account_data.rs
+++ b/crates/ruma-client-api/src/config/get_room_account_data.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3useruseridroomsroomidaccount_datatype
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3useruseridroomsroomidaccount_datatype
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/config/set_global_account_data.rs
+++ b/crates/ruma-client-api/src/config/set_global_account_data.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#put_matrixclientv3useruseridaccount_datatype
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3useruseridaccount_datatype
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/config/set_room_account_data.rs
+++ b/crates/ruma-client-api/src/config/set_room_account_data.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#put_matrixclientv3useruseridroomsroomidaccount_datatype
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3useruseridroomsroomidaccount_datatype
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/context/get_context.rs
+++ b/crates/ruma-client-api/src/context/get_context.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3roomsroomidcontexteventid
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3roomsroomidcontexteventid
 
     use js_int::{uint, UInt};
     use ruma_common::{

--- a/crates/ruma-client-api/src/device/delete_device.rs
+++ b/crates/ruma-client-api/src/device/delete_device.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#delete_matrixclientv3devicesdeviceid
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#delete_matrixclientv3devicesdeviceid
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/device/delete_devices.rs
+++ b/crates/ruma-client-api/src/device/delete_devices.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3delete_devices
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3delete_devices
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/device/get_device.rs
+++ b/crates/ruma-client-api/src/device/get_device.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3devicesdeviceid
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3devicesdeviceid
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/device/get_devices.rs
+++ b/crates/ruma-client-api/src/device/get_devices.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3devices
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3devices
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/device/update_device.rs
+++ b/crates/ruma-client-api/src/device/update_device.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#put_matrixclientv3devicesdeviceid
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3devicesdeviceid
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/directory/get_public_rooms.rs
+++ b/crates/ruma-client-api/src/directory/get_public_rooms.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3publicrooms
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3publicrooms
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-client-api/src/directory/get_public_rooms_filtered.rs
+++ b/crates/ruma-client-api/src/directory/get_public_rooms_filtered.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3publicrooms
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3publicrooms
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-client-api/src/directory/get_room_visibility.rs
+++ b/crates/ruma-client-api/src/directory/get_room_visibility.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3directorylistroomroomid
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3directorylistroomroomid
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/directory/set_room_visibility.rs
+++ b/crates/ruma-client-api/src/directory/set_room_visibility.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#put_matrixclientv3directorylistroomroomid
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3directorylistroomroomid
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/discovery/discover_homeserver.rs
+++ b/crates/ruma-client-api/src/discovery/discover_homeserver.rs
@@ -1,6 +1,6 @@
 //! `GET /.well-known/matrix/client` ([spec])
 //!
-//! [spec]: https://spec.matrix.org/v1.4/client-server-api/#getwell-knownmatrixclient
+//! [spec]: https://spec.matrix.org/latest/client-server-api/#getwell-knownmatrixclient
 //!
 //! Get discovery information about the domain.
 

--- a/crates/ruma-client-api/src/discovery/get_capabilities.rs
+++ b/crates/ruma-client-api/src/discovery/get_capabilities.rs
@@ -3,7 +3,7 @@
 //! Get information about the server's supported feature set and other relevant capabilities
 //! ([spec]).
 //!
-//! [spec]: https://spec.matrix.org/unstable/client-server-api/#capabilities-negotiation
+//! [spec]: https://spec.matrix.org/latest/client-server-api/#capabilities-negotiation
 
 use std::{borrow::Cow, collections::BTreeMap};
 

--- a/crates/ruma-client-api/src/discovery/get_capabilities/v3.rs
+++ b/crates/ruma-client-api/src/discovery/get_capabilities/v3.rs
@@ -1,6 +1,6 @@
 //! `/v3/` ([spec])
 //!
-//! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3capabilities
+//! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3capabilities
 
 use ruma_common::{
     api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/discovery/get_supported_versions.rs
+++ b/crates/ruma-client-api/src/discovery/get_supported_versions.rs
@@ -2,7 +2,7 @@
 //!
 //! Get the versions of the client-server API supported by this homeserver.
 //!
-//! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientversions
+//! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientversions
 
 use std::collections::BTreeMap;
 

--- a/crates/ruma-client-api/src/error.rs
+++ b/crates/ruma-client-api/src/error.rs
@@ -35,7 +35,7 @@ pub enum ErrorKind {
         ///
         /// For more information, see [the spec].
         ///
-        /// [the spec]: https://spec.matrix.org/v1.4/client-server-api/#soft-logout
+        /// [the spec]: https://spec.matrix.org/latest/client-server-api/#soft-logout
         soft_logout: bool,
     },
 

--- a/crates/ruma-client-api/src/filter.rs
+++ b/crates/ruma-client-api/src/filter.rs
@@ -98,7 +98,7 @@ pub struct RoomEventFilter {
     ///
     /// Only applies to the [`sync_events`] endpoint.
     ///
-    /// [per-thread notification counts]: https://spec.matrix.org/v1.4/client-server-api/#receiving-notifications
+    /// [per-thread notification counts]: https://spec.matrix.org/latest/client-server-api/#receiving-notifications
     /// [`sync_events`]: crate::sync::sync_events
     #[serde(default, skip_serializing_if = "ruma_common::serde::is_default")]
     pub unread_thread_notifications: bool,

--- a/crates/ruma-client-api/src/filter/create_filter.rs
+++ b/crates/ruma-client-api/src/filter/create_filter.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3useruseridfilter
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3useruseridfilter
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/filter/get_filter.rs
+++ b/crates/ruma-client-api/src/filter/get_filter.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3useruseridfilterfilterid
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3useruseridfilterfilterid
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/filter/lazy_load.rs
+++ b/crates/ruma-client-api/src/filter/lazy_load.rs
@@ -3,7 +3,7 @@ use serde::{ser::SerializeStruct as _, Deserialize, Serialize, Serializer};
 /// Specifies options for [lazy-loading membership events][lazy-loading] on
 /// supported endpoints
 ///
-/// [lazy-loading]: https://spec.matrix.org/v1.4/client-server-api/#lazy-loading-room-members
+/// [lazy-loading]: https://spec.matrix.org/latest/client-server-api/#lazy-loading-room-members
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Deserialize)]
 #[serde(from = "LazyLoadJsonRepr")]
 #[allow(clippy::exhaustive_enums)]

--- a/crates/ruma-client-api/src/keys/claim_keys.rs
+++ b/crates/ruma-client-api/src/keys/claim_keys.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3keysclaim
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3keysclaim
 
     use std::{collections::BTreeMap, time::Duration};
 

--- a/crates/ruma-client-api/src/keys/get_key_changes.rs
+++ b/crates/ruma-client-api/src/keys/get_key_changes.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3keyschanges
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3keyschanges
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/keys/get_keys.rs
+++ b/crates/ruma-client-api/src/keys/get_keys.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3keysquery
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3keysquery
 
     use std::{collections::BTreeMap, time::Duration};
 

--- a/crates/ruma-client-api/src/keys/upload_keys.rs
+++ b/crates/ruma-client-api/src/keys/upload_keys.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3keysupload
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3keysupload
 
     use std::collections::BTreeMap;
 

--- a/crates/ruma-client-api/src/keys/upload_signatures.rs
+++ b/crates/ruma-client-api/src/keys/upload_signatures.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3keyssignaturesupload
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3keyssignaturesupload
 
     use std::collections::BTreeMap;
 

--- a/crates/ruma-client-api/src/keys/upload_signing_keys.rs
+++ b/crates/ruma-client-api/src/keys/upload_signing_keys.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3keysdevice_signingupload
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3keysdevice_signingupload
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/knock/knock_room.rs
+++ b/crates/ruma-client-api/src/knock/knock_room.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3knockroomidoralias
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3knockroomidoralias
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/lib.rs
+++ b/crates/ruma-client-api/src/lib.rs
@@ -3,7 +3,7 @@
 //! (De)serializable types for the [Matrix Client-Server API][client-api].
 //! These types can be shared by client and server code.
 //!
-//! [client-api]: https://spec.matrix.org/v1.4/client-server-api/
+//! [client-api]: https://spec.matrix.org/latest/client-server-api/
 
 #![cfg(any(feature = "client", feature = "server"))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]

--- a/crates/ruma-client-api/src/media/create_content.rs
+++ b/crates/ruma-client-api/src/media/create_content.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixmediav3upload
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixmediav3upload
 
     use http::header::CONTENT_TYPE;
     use ruma_common::{

--- a/crates/ruma-client-api/src/media/get_content.rs
+++ b/crates/ruma-client-api/src/media/get_content.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixmediav3downloadservernamemediaid
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixmediav3downloadservernamemediaid
 
     use http::header::{CONTENT_DISPOSITION, CONTENT_TYPE};
     #[cfg(feature = "unstable-msc2246")]

--- a/crates/ruma-client-api/src/media/get_content_as_filename.rs
+++ b/crates/ruma-client-api/src/media/get_content_as_filename.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixmediav3downloadservernamemediaidfilename
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixmediav3downloadservernamemediaidfilename
 
     use http::header::{CONTENT_DISPOSITION, CONTENT_TYPE};
     use ruma_common::{

--- a/crates/ruma-client-api/src/media/get_content_thumbnail.rs
+++ b/crates/ruma-client-api/src/media/get_content_thumbnail.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixmediav3thumbnailservernamemediaid
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixmediav3thumbnailservernamemediaid
 
     use http::header::CONTENT_TYPE;
     use js_int::UInt;

--- a/crates/ruma-client-api/src/media/get_media_config.rs
+++ b/crates/ruma-client-api/src/media/get_media_config.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixmediav3config
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixmediav3config
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-client-api/src/media/get_media_preview.rs
+++ b/crates/ruma-client-api/src/media/get_media_preview.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixmediav3preview_url
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixmediav3preview_url
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/membership/ban_user.rs
+++ b/crates/ruma-client-api/src/membership/ban_user.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3roomsroomidban
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidban
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/membership/forget_room.rs
+++ b/crates/ruma-client-api/src/membership/forget_room.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3roomsroomidforget
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidforget
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/membership/get_member_events.rs
+++ b/crates/ruma-client-api/src/membership/get_member_events.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3roomsroomidmembers
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3roomsroomidmembers
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/membership/invite_user.rs
+++ b/crates/ruma-client-api/src/membership/invite_user.rs
@@ -9,8 +9,8 @@ pub mod v3 {
     //! [by their Matrix identifier][spec-mxid], and one to invite a user
     //! [by their third party identifier][spec-3pid].
     //!
-    //! [spec-mxid]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidinvite
-    //! [spec-3pid]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidinvite-1
+    //! [spec-mxid]: https://spec.matrix.org/v1.5/client-server-api/#post_matrixclientv3roomsroomidinvite
+    //! [spec-3pid]: https://spec.matrix.org/v1.5/client-server-api/#post_matrixclientv3roomsroomidinvite-1
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/membership/invite_user.rs
+++ b/crates/ruma-client-api/src/membership/invite_user.rs
@@ -9,8 +9,8 @@ pub mod v3 {
     //! [by their Matrix identifier][spec-mxid], and one to invite a user
     //! [by their third party identifier][spec-3pid].
     //!
-    //! [spec-mxid]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3roomsroomidinvite
-    //! [spec-3pid]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3roomsroomidinvite-1
+    //! [spec-mxid]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidinvite
+    //! [spec-3pid]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidinvite-1
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/membership/join_room_by_id.rs
+++ b/crates/ruma-client-api/src/membership/join_room_by_id.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3roomsroomidjoin
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidjoin
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
+++ b/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3joinroomidoralias
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3joinroomidoralias
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/membership/joined_members.rs
+++ b/crates/ruma-client-api/src/membership/joined_members.rs
@@ -6,7 +6,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3roomsroomidjoined_members
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3roomsroomidjoined_members
 
     use std::collections::BTreeMap;
 

--- a/crates/ruma-client-api/src/membership/joined_rooms.rs
+++ b/crates/ruma-client-api/src/membership/joined_rooms.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3joined_rooms
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3joined_rooms
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/membership/kick_user.rs
+++ b/crates/ruma-client-api/src/membership/kick_user.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3roomsroomidkick
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidkick
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/membership/leave_room.rs
+++ b/crates/ruma-client-api/src/membership/leave_room.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3roomsroomidleave
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidleave
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/membership/unban_user.rs
+++ b/crates/ruma-client-api/src/membership/unban_user.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3roomsroomidunban
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidunban
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/message/get_message_events.rs
+++ b/crates/ruma-client-api/src/message/get_message_events.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3roomsroomidmessages
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3roomsroomidmessages
 
     use js_int::{uint, UInt};
     use ruma_common::{

--- a/crates/ruma-client-api/src/message/send_message_event.rs
+++ b/crates/ruma-client-api/src/message/send_message_event.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#put_matrixclientv3roomsroomidsendeventtypetxnid
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3roomsroomidsendeventtypetxnid
 
     use ruma_common::{
         api::{request, response, Metadata},
@@ -45,7 +45,7 @@ pub mod v3 {
         ///
         /// It will be used by the server to ensure idempotency of requests.
         ///
-        /// [access token is refreshed]: https://spec.matrix.org/v1.4/client-server-api/#refreshing-access-tokens
+        /// [access token is refreshed]: https://spec.matrix.org/latest/client-server-api/#refreshing-access-tokens
         #[ruma_api(path)]
         pub txn_id: OwnedTransactionId,
 
@@ -59,7 +59,7 @@ pub mod v3 {
         ///
         /// Note that this does not change the position of the event in the timeline.
         ///
-        /// [timestamp massaging]: https://spec.matrix.org/v1.4/application-service-api/#timestamp-massaging
+        /// [timestamp massaging]: https://spec.matrix.org/latest/application-service-api/#timestamp-massaging
         #[ruma_api(query)]
         #[serde(skip_serializing_if = "Option::is_none", rename = "ts")]
         pub timestamp: Option<MilliSecondsSinceUnixEpoch>,

--- a/crates/ruma-client-api/src/presence/get_presence.rs
+++ b/crates/ruma-client-api/src/presence/get_presence.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3presenceuseridstatus
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3presenceuseridstatus
 
     use std::time::Duration;
 

--- a/crates/ruma-client-api/src/presence/set_presence.rs
+++ b/crates/ruma-client-api/src/presence/set_presence.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#put_matrixclientv3presenceuseridstatus
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3presenceuseridstatus
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/profile/get_avatar_url.rs
+++ b/crates/ruma-client-api/src/profile/get_avatar_url.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3profileuseridavatar_url
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3profileuseridavatar_url
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/profile/get_display_name.rs
+++ b/crates/ruma-client-api/src/profile/get_display_name.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3profileuseriddisplayname
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3profileuseriddisplayname
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/profile/get_profile.rs
+++ b/crates/ruma-client-api/src/profile/get_profile.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3profileuserid
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3profileuserid
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/profile/set_avatar_url.rs
+++ b/crates/ruma-client-api/src/profile/set_avatar_url.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#put_matrixclientv3profileuseridavatar_url
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3profileuseridavatar_url
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/profile/set_display_name.rs
+++ b/crates/ruma-client-api/src/profile/set_display_name.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#put_matrixclientv3profileuseriddisplayname
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3profileuseriddisplayname
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/push/delete_pushrule.rs
+++ b/crates/ruma-client-api/src/push/delete_pushrule.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#delete_matrixclientv3pushrulesscopekindruleid
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#delete_matrixclientv3pushrulesscopekindruleid
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/push/get_notifications.rs
+++ b/crates/ruma-client-api/src/push/get_notifications.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3notifications
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3notifications
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-client-api/src/push/get_pushers.rs
+++ b/crates/ruma-client-api/src/push/get_pushers.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3pushers
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3pushers
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/push/get_pushrule.rs
+++ b/crates/ruma-client-api/src/push/get_pushrule.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3pushrulesscopekindruleid
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3pushrulesscopekindruleid
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/push/get_pushrule_actions.rs
+++ b/crates/ruma-client-api/src/push/get_pushrule_actions.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3pushrulesscopekindruleidactions
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3pushrulesscopekindruleidactions
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/push/get_pushrule_enabled.rs
+++ b/crates/ruma-client-api/src/push/get_pushrule_enabled.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3pushrulesscopekindruleidenabled
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3pushrulesscopekindruleidenabled
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/push/get_pushrules_all.rs
+++ b/crates/ruma-client-api/src/push/get_pushrules_all.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3pushrules
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3pushrules
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/push/get_pushrules_global_scope.rs
+++ b/crates/ruma-client-api/src/push/get_pushrules_global_scope.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3pushrules
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3pushrules
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/push/set_pusher.rs
+++ b/crates/ruma-client-api/src/push/set_pusher.rs
@@ -7,7 +7,7 @@ mod set_pusher_serde;
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3pushersset
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3pushersset
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/push/set_pushrule.rs
+++ b/crates/ruma-client-api/src/push/set_pushrule.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#put_matrixclientv3pushrulesscopekindruleid
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3pushrulesscopekindruleid
 
     use ruma_common::{
         api::{response, Metadata},

--- a/crates/ruma-client-api/src/push/set_pushrule_actions.rs
+++ b/crates/ruma-client-api/src/push/set_pushrule_actions.rs
@@ -6,7 +6,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#put_matrixclientv3pushrulesscopekindruleidactions
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3pushrulesscopekindruleidactions
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/push/set_pushrule_enabled.rs
+++ b/crates/ruma-client-api/src/push/set_pushrule_enabled.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#put_matrixclientv3pushrulesscopekindruleidenabled
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3pushrulesscopekindruleidenabled
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/read_marker/set_read_marker.rs
+++ b/crates/ruma-client-api/src/read_marker/set_read_marker.rs
@@ -9,7 +9,7 @@ pub mod v3 {
     //! This endpoint is equivalent to calling the [`create_receipt`] endpoint,
     //! but is provided as a way to update several read markers with a single call.
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3roomsroomidread_markers
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidread_markers
     //! [`create_receipt`]: crate::receipt::create_receipt
 
     use ruma_common::{

--- a/crates/ruma-client-api/src/receipt/create_receipt.rs
+++ b/crates/ruma-client-api/src/receipt/create_receipt.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3roomsroomidreceiptreceipttypeeventid
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidreceiptreceipttypeeventid
 
     use ruma_common::{
         api::{request, response, Metadata},
@@ -90,7 +90,7 @@ pub mod v3 {
         ///
         /// This receipt is federated to other users.
         ///
-        /// [public read receipt]: https://spec.matrix.org/v1.4/client-server-api/#receipts
+        /// [public read receipt]: https://spec.matrix.org/latest/client-server-api/#receipts
         #[ruma_enum(rename = "m.read")]
         Read,
 
@@ -101,7 +101,7 @@ pub mod v3 {
         /// This read receipt is not federated so only the user and their homeserver
         /// are aware of it.
         ///
-        /// [private read receipt]: https://spec.matrix.org/v1.4/client-server-api/#private-read-receipts
+        /// [private read receipt]: https://spec.matrix.org/latest/client-server-api/#private-read-receipts
         #[ruma_enum(rename = "m.read.private")]
         ReadPrivate,
 
@@ -112,7 +112,7 @@ pub mod v3 {
         /// This is actually not a receipt, but a piece of room account data. It is
         /// provided here for convenience.
         ///
-        /// [fully read marker]: https://spec.matrix.org/v1.4/client-server-api/#fully-read-markers
+        /// [fully read marker]: https://spec.matrix.org/latest/client-server-api/#fully-read-markers
         #[ruma_enum(rename = "m.fully_read")]
         FullyRead,
 

--- a/crates/ruma-client-api/src/redact/redact_event.rs
+++ b/crates/ruma-client-api/src/redact/redact_event.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#put_matrixclientv3roomsroomidredacteventidtxnid
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3roomsroomidredacteventidtxnid
 
     use ruma_common::{
         api::{request, response, Metadata},
@@ -41,7 +41,7 @@ pub mod v3 {
         ///
         /// It will be used by the server to ensure idempotency of requests.
         ///
-        /// [access token is refreshed]: https://spec.matrix.org/v1.4/client-server-api/#refreshing-access-tokens
+        /// [access token is refreshed]: https://spec.matrix.org/latest/client-server-api/#refreshing-access-tokens
         #[ruma_api(path)]
         pub txn_id: OwnedTransactionId,
 

--- a/crates/ruma-client-api/src/relations/get_relating_events.rs
+++ b/crates/ruma-client-api/src/relations/get_relating_events.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv1roomsroomidrelationseventid
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv1roomsroomidrelationseventid
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-client-api/src/relations/get_relating_events_with_rel_type.rs
+++ b/crates/ruma-client-api/src/relations/get_relating_events_with_rel_type.rs
@@ -6,7 +6,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv1roomsroomidrelationseventidreltype
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv1roomsroomidrelationseventidreltype
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-client-api/src/relations/get_relating_events_with_rel_type_and_event_type.rs
+++ b/crates/ruma-client-api/src/relations/get_relating_events_with_rel_type_and_event_type.rs
@@ -6,7 +6,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv1roomsroomidrelationseventidreltypeeventtype
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv1roomsroomidrelationseventidreltypeeventtype
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-client-api/src/room/aliases.rs
+++ b/crates/ruma-client-api/src/room/aliases.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3roomsroomidaliases
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3roomsroomidaliases
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/room/create_room.rs
+++ b/crates/ruma-client-api/src/room/create_room.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3createroom
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3createroom
 
     use assign::assign;
     use ruma_common::{

--- a/crates/ruma-client-api/src/room/get_room_event.rs
+++ b/crates/ruma-client-api/src/room/get_room_event.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3roomsroomideventeventid
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3roomsroomideventeventid
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/room/report_content.rs
+++ b/crates/ruma-client-api/src/room/report_content.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3roomsroomidreporteventid
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidreporteventid
 
     use js_int::Int;
     use ruma_common::{

--- a/crates/ruma-client-api/src/room/upgrade_room.rs
+++ b/crates/ruma-client-api/src/room/upgrade_room.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3roomsroomidupgrade
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidupgrade
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/search/search_events.rs
+++ b/crates/ruma-client-api/src/search/search_events.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3search
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3search
 
     use std::collections::BTreeMap;
 

--- a/crates/ruma-client-api/src/server/get_user_info.rs
+++ b/crates/ruma-client-api/src/server/get_user_info.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3adminwhoisuserid
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3adminwhoisuserid
 
     use std::collections::BTreeMap;
 

--- a/crates/ruma-client-api/src/session/get_login_types.rs
+++ b/crates/ruma-client-api/src/session/get_login_types.rs
@@ -6,7 +6,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3login
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3login
 
     use std::borrow::Cow;
 

--- a/crates/ruma-client-api/src/session/login.rs
+++ b/crates/ruma-client-api/src/session/login.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3login
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3login
 
     use std::{fmt, time::Duration};
 
@@ -52,7 +52,7 @@ pub mod v3 {
 
         /// If set to `true`, the client supports [refresh tokens].
         ///
-        /// [refresh tokens]: https://spec.matrix.org/v1.4/client-server-api/#refreshing-access-tokens
+        /// [refresh tokens]: https://spec.matrix.org/latest/client-server-api/#refreshing-access-tokens
         #[serde(default, skip_serializing_if = "ruma_common::serde::is_default")]
         pub refresh_token: bool,
     }
@@ -90,7 +90,7 @@ pub mod v3 {
         /// This token can be used to obtain a new access token when it expires by calling the
         /// [`refresh_token`] endpoint.
         ///
-        /// [refresh token]: https://spec.matrix.org/v1.4/client-server-api/#refreshing-access-tokens
+        /// [refresh token]: https://spec.matrix.org/latest/client-server-api/#refreshing-access-tokens
         /// [`refresh_token`]: crate::session::refresh_token
         #[serde(skip_serializing_if = "Option::is_none")]
         pub refresh_token: Option<String>,

--- a/crates/ruma-client-api/src/session/login_fallback.rs
+++ b/crates/ruma-client-api/src/session/login_fallback.rs
@@ -2,7 +2,7 @@
 //!
 //! Get login fallback web page.
 //!
-//! [spec]: https://spec.matrix.org/v1.4/client-server-api/#login-fallback
+//! [spec]: https://spec.matrix.org/latest/client-server-api/#login-fallback
 
 use ruma_common::{
     api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/session/logout.rs
+++ b/crates/ruma-client-api/src/session/logout.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3logout
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3logout
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/session/logout_all.rs
+++ b/crates/ruma-client-api/src/session/logout_all.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3logoutall
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3logoutall
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/session/refresh_token.rs
+++ b/crates/ruma-client-api/src/session/refresh_token.rs
@@ -23,7 +23,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3refresh
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3refresh
 
     use std::time::Duration;
 

--- a/crates/ruma-client-api/src/session/sso_login.rs
+++ b/crates/ruma-client-api/src/session/sso_login.rs
@@ -3,7 +3,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3loginssoredirect
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3loginssoredirect
 
     use http::header::LOCATION;
     use ruma_common::{

--- a/crates/ruma-client-api/src/session/sso_login_with_provider.rs
+++ b/crates/ruma-client-api/src/session/sso_login_with_provider.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3loginssoredirectidpid
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3loginssoredirectidpid
 
     use http::header::LOCATION;
     use ruma_common::{

--- a/crates/ruma-client-api/src/space.rs
+++ b/crates/ruma-client-api/src/space.rs
@@ -2,7 +2,7 @@
 //!
 //! See the [Matrix specification][spec] for more details about spaces.
 //!
-//! [spec]: https://spec.matrix.org/v1.4/client-server-api/#spaces
+//! [spec]: https://spec.matrix.org/latest/client-server-api/#spaces
 
 use js_int::UInt;
 use ruma_common::{

--- a/crates/ruma-client-api/src/space/get_hierarchy.rs
+++ b/crates/ruma-client-api/src/space/get_hierarchy.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv1roomsroomidhierarchy
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv1roomsroomidhierarchy
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-client-api/src/state/get_state_events.rs
+++ b/crates/ruma-client-api/src/state/get_state_events.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3roomsroomidstate
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3roomsroomidstate
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/state/get_state_events_for_key.rs
+++ b/crates/ruma-client-api/src/state/get_state_events_for_key.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3roomsroomidstateeventtypestatekey
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3roomsroomidstateeventtypestatekey
 
     use ruma_common::{
         api::{response, Metadata},

--- a/crates/ruma-client-api/src/state/send_state_event.rs
+++ b/crates/ruma-client-api/src/state/send_state_event.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#put_matrixclientv3roomsroomidstateeventtypestatekey
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3roomsroomidstateeventtypestatekey
 
     use std::borrow::Borrow;
 
@@ -50,7 +50,7 @@ pub mod v3 {
         ///
         /// Note that this does not change the position of the event in the timeline.
         ///
-        /// [timestamp massaging]: https://spec.matrix.org/v1.4/application-service-api/#timestamp-massaging
+        /// [timestamp massaging]: https://spec.matrix.org/latest/application-service-api/#timestamp-massaging
         pub timestamp: Option<MilliSecondsSinceUnixEpoch>,
     }
 

--- a/crates/ruma-client-api/src/sync/sync_events/v3.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v3.rs
@@ -1,6 +1,6 @@
 //! `/v3/` ([spec])
 //!
-//! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3sync
+//! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3sync
 
 use std::{collections::BTreeMap, time::Duration};
 
@@ -248,7 +248,7 @@ pub struct JoinedRoom {
     /// If `unread_thread_notifications` was set to `true` in the [`RoomEventFilter`], these
     /// include only the unread notifications for the main timeline.
     ///
-    /// [unread notifications]: https://spec.matrix.org/v1.4/client-server-api/#receiving-notifications
+    /// [unread notifications]: https://spec.matrix.org/latest/client-server-api/#receiving-notifications
     /// [`RoomEventFilter`]: crate::filter::RoomEventFilter
     #[serde(default, skip_serializing_if = "UnreadNotificationsCount::is_empty")]
     pub unread_notifications: UnreadNotificationsCount,
@@ -259,7 +259,7 @@ pub struct JoinedRoom {
     ///
     /// Only set if `unread_thread_notifications` was set to `true` in the [`RoomEventFilter`].
     ///
-    /// [unread notifications]: https://spec.matrix.org/v1.4/client-server-api/#receiving-notifications
+    /// [unread notifications]: https://spec.matrix.org/latest/client-server-api/#receiving-notifications
     /// [`RoomEventFilter`]: crate::filter::RoomEventFilter
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub unread_thread_notifications: BTreeMap<OwnedEventId, UnreadNotificationsCount>,

--- a/crates/ruma-client-api/src/tag/create_tag.rs
+++ b/crates/ruma-client-api/src/tag/create_tag.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#put_matrixclientv3useruseridroomsroomidtagstag
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3useruseridroomsroomidtagstag
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/tag/delete_tag.rs
+++ b/crates/ruma-client-api/src/tag/delete_tag.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#put_matrixclientv3useruseridroomsroomidtagstag
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3useruseridroomsroomidtagstag
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/tag/get_tags.rs
+++ b/crates/ruma-client-api/src/tag/get_tags.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3useruseridroomsroomidtags
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3useruseridroomsroomidtags
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/thirdparty/get_location_for_protocol.rs
+++ b/crates/ruma-client-api/src/thirdparty/get_location_for_protocol.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3thirdpartylocationprotocol
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3thirdpartylocationprotocol
 
     use std::collections::BTreeMap;
 

--- a/crates/ruma-client-api/src/thirdparty/get_location_for_room_alias.rs
+++ b/crates/ruma-client-api/src/thirdparty/get_location_for_room_alias.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3thirdpartylocation
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3thirdpartylocation
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/thirdparty/get_protocol.rs
+++ b/crates/ruma-client-api/src/thirdparty/get_protocol.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3thirdpartyprotocolprotocol
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3thirdpartyprotocolprotocol
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/thirdparty/get_protocols.rs
+++ b/crates/ruma-client-api/src/thirdparty/get_protocols.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3thirdpartyprotocols
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3thirdpartyprotocols
 
     use std::collections::BTreeMap;
 

--- a/crates/ruma-client-api/src/thirdparty/get_user_for_protocol.rs
+++ b/crates/ruma-client-api/src/thirdparty/get_user_for_protocol.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3thirdpartyuserprotocol
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3thirdpartyuserprotocol
 
     use std::collections::BTreeMap;
 

--- a/crates/ruma-client-api/src/thirdparty/get_user_for_user_id.rs
+++ b/crates/ruma-client-api/src/thirdparty/get_user_for_user_id.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3thirdpartyuser
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3thirdpartyuser
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/threads/get_threads.rs
+++ b/crates/ruma-client-api/src/threads/get_threads.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv1roomsroomidthreads
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv1roomsroomidthreads
 
     use js_int::UInt;
     use ruma_common::{
@@ -104,7 +104,7 @@ pub mod v1 {
         ///
         /// Only include thread roots for threads where [`current_user_participated`] is `true`.
         ///
-        /// [`current_user_participated`]: https://spec.matrix.org/v1.4/client-server-api/#server-side-aggregation-of-mthread-relationships
+        /// [`current_user_participated`]: https://spec.matrix.org/latest/client-server-api/#server-side-aggregation-of-mthread-relationships
         Participated,
 
         #[doc(hidden)]

--- a/crates/ruma-client-api/src/to_device/send_event_to_device.rs
+++ b/crates/ruma-client-api/src/to_device/send_event_to_device.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#put_matrixclientv3sendtodeviceeventtypetxnid
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3sendtodeviceeventtypetxnid
 
     use std::collections::BTreeMap;
 
@@ -43,7 +43,7 @@ pub mod v3 {
         ///
         /// It will be used by the server to ensure idempotency of requests.
         ///
-        /// [access token is refreshed]: https://spec.matrix.org/v1.4/client-server-api/#refreshing-access-tokens
+        /// [access token is refreshed]: https://spec.matrix.org/latest/client-server-api/#refreshing-access-tokens
         #[ruma_api(path)]
         pub txn_id: OwnedTransactionId,
 

--- a/crates/ruma-client-api/src/typing/create_typing_event.rs
+++ b/crates/ruma-client-api/src/typing/create_typing_event.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#put_matrixclientv3roomsroomidtypinguserid
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3roomsroomidtypinguserid
 
     use std::time::Duration;
 

--- a/crates/ruma-client-api/src/uiaa.rs
+++ b/crates/ruma-client-api/src/uiaa.rs
@@ -1,6 +1,6 @@
 //! Module for [User-Interactive Authentication API][uiaa] types.
 //!
-//! [uiaa]: https://spec.matrix.org/v1.4/client-server-api/#user-interactive-authentication-api
+//! [uiaa]: https://spec.matrix.org/latest/client-server-api/#user-interactive-authentication-api
 
 use std::{borrow::Cow, fmt};
 
@@ -260,7 +260,7 @@ pub enum AuthType {
 ///
 /// See [the spec] for how to use this.
 ///
-/// [the spec]: https://spec.matrix.org/v1.4/client-server-api/#password-based
+/// [the spec]: https://spec.matrix.org/latest/client-server-api/#password-based
 #[derive(Clone, Deserialize, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[serde(tag = "type", rename = "m.login.password")]
@@ -296,7 +296,7 @@ impl fmt::Debug for Password {
 ///
 /// See [the spec] for how to use this.
 ///
-/// [the spec]: https://spec.matrix.org/v1.4/client-server-api/#google-recaptcha
+/// [the spec]: https://spec.matrix.org/latest/client-server-api/#google-recaptcha
 #[derive(Clone, Deserialize, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[serde(tag = "type", rename = "m.login.recaptcha")]
@@ -326,7 +326,7 @@ impl fmt::Debug for ReCaptcha {
 ///
 /// See [the spec] for how to use this.
 ///
-/// [the spec]: https://spec.matrix.org/v1.4/client-server-api/#email-based-identity--homeserver
+/// [the spec]: https://spec.matrix.org/latest/client-server-api/#email-based-identity--homeserver
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[serde(tag = "type", rename = "m.login.email.identity")]
@@ -343,7 +343,7 @@ pub struct EmailIdentity {
 ///
 /// See [the spec] for how to use this.
 ///
-/// [the spec]: https://spec.matrix.org/v1.4/client-server-api/#phone-numbermsisdn-based-identity--homeserver
+/// [the spec]: https://spec.matrix.org/latest/client-server-api/#phone-numbermsisdn-based-identity--homeserver
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[serde(tag = "type", rename = "m.login.msisdn")]
@@ -360,7 +360,7 @@ pub struct Msisdn {
 ///
 /// See [the spec] for how to use this.
 ///
-/// [the spec]: https://spec.matrix.org/v1.4/client-server-api/#dummy-auth
+/// [the spec]: https://spec.matrix.org/latest/client-server-api/#dummy-auth
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[serde(tag = "type", rename = "m.login.dummy")]
@@ -380,7 +380,7 @@ impl Dummy {
 ///
 /// See [the spec] for how to use this.
 ///
-/// [the spec]: https://spec.matrix.org/v1.4/client-server-api/#token-authenticated-registration
+/// [the spec]: https://spec.matrix.org/latest/client-server-api/#token-authenticated-registration
 #[derive(Clone, Deserialize, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[serde(tag = "type", rename = "m.login.registration_token")]
@@ -410,7 +410,7 @@ impl fmt::Debug for RegistrationToken {
 ///
 /// See [the spec] for how to use this.
 ///
-/// [the spec]: https://spec.matrix.org/v1.4/client-server-api/#fallback
+/// [the spec]: https://spec.matrix.org/latest/client-server-api/#fallback
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct FallbackAcknowledgement {

--- a/crates/ruma-client-api/src/uiaa/get_uiaa_fallback_page.rs
+++ b/crates/ruma-client-api/src/uiaa/get_uiaa_fallback_page.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#fallback
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#fallback
 
     use http::header::LOCATION;
     use ruma_common::{

--- a/crates/ruma-client-api/src/user_directory/search_users.rs
+++ b/crates/ruma-client-api/src/user_directory/search_users.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#post_matrixclientv3user_directorysearch
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3user_directorysearch
 
     use http::header::ACCEPT_LANGUAGE;
     use js_int::{uint, UInt};

--- a/crates/ruma-client-api/src/voip/get_turn_server_info.rs
+++ b/crates/ruma-client-api/src/voip/get_turn_server_info.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/client-server-api/#get_matrixclientv3voipturnserver
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3voipturnserver
 
     use std::time::Duration;
 

--- a/crates/ruma-common/src/api.rs
+++ b/crates/ruma-common/src/api.rs
@@ -10,7 +10,7 @@
 //! successful response. Such types can then be used by client code to make requests, and by server
 //! code to fulfill those requests.
 //!
-//! [apis]: https://spec.matrix.org/v1.4/#matrix-apis
+//! [apis]: https://spec.matrix.org/latest/#matrix-apis
 
 use std::{convert::TryInto as _, error::Error as StdError};
 
@@ -326,7 +326,7 @@ pub trait OutgoingRequestAppserviceExt: OutgoingRequest {
     /// Tries to convert this request into an `http::Request` and appends a virtual `user_id` to
     /// [assert Appservice identity][id_assert].
     ///
-    /// [id_assert]: https://spec.matrix.org/v1.4/application-service-api/#identity-assertion
+    /// [id_assert]: https://spec.matrix.org/latest/application-service-api/#identity-assertion
     fn try_into_http_request_with_user_id<T: Default + BufMut>(
         self,
         base_url: &str,

--- a/crates/ruma-common/src/api/metadata.rs
+++ b/crates/ruma-common/src/api/metadata.rs
@@ -467,7 +467,7 @@ pub enum VersioningDecision {
 /// Every new minor version denotes stable support for endpoints in a *relatively*
 /// backwards-compatible manner.
 ///
-/// Matrix has a deprecation policy, read more about it here: <https://spec.matrix.org/v1.4/#deprecation-policy>.
+/// Matrix has a deprecation policy, read more about it here: <https://spec.matrix.org/latest/#deprecation-policy>.
 ///
 /// Ruma keeps track of when endpoints are added, deprecated, and removed. It'll automatically
 /// select the right endpoint stability variation to use depending on which Matrix versions you
@@ -478,7 +478,7 @@ pub enum VersioningDecision {
 pub enum MatrixVersion {
     /// Version 1.0 of the Matrix specification.
     ///
-    /// Retroactively defined as <https://spec.matrix.org/v1.4/#legacy-versioning>.
+    /// Retroactively defined as <https://spec.matrix.org/latest/#legacy-versioning>.
     V1_0,
 
     /// Version 1.1 of the Matrix specification, released in Q4 2021.
@@ -516,7 +516,7 @@ impl TryFrom<&str> for MatrixVersion {
         Ok(match value {
             // FIXME: these are likely not entirely correct; https://github.com/ruma/ruma/issues/852
             "v1.0" |
-            // Additional definitions according to https://spec.matrix.org/v1.4/#legacy-versioning
+            // Additional definitions according to https://spec.matrix.org/latest/#legacy-versioning
             "r0.5.0" | "r0.6.0" | "r0.6.1" => V1_0,
             "v1.1" => V1_1,
             "v1.2" => V1_2,

--- a/crates/ruma-common/src/doc/rich_reply.md
+++ b/crates/ruma-common/src/doc/rich_reply.md
@@ -11,4 +11,4 @@ It is recommended to enable the `unstable-sanitize` feature when using this meth
 clean up nested [rich reply fallbacks] in chains of replies. This uses [`sanitize_html()`]
 internally, with [`RemoveReplyFallback::Yes`].
 
-[rich reply fallbacks]: https://spec.matrix.org/v1.4/client-server-api/#fallbacks-for-rich-replies
+[rich reply fallbacks]: https://spec.matrix.org/latest/client-server-api/#fallbacks-for-rich-replies

--- a/crates/ruma-common/src/encryption.rs
+++ b/crates/ruma-common/src/encryption.rs
@@ -1,6 +1,6 @@
 //! Common types for [encryption] related tasks.
 //!
-//! [encryption]: https://spec.matrix.org/v1.4/client-server-api/#end-to-end-encryption
+//! [encryption]: https://spec.matrix.org/latest/client-server-api/#end-to-end-encryption
 
 use std::collections::BTreeMap;
 

--- a/crates/ruma-common/src/events/call/answer.rs
+++ b/crates/ruma-common/src/events/call/answer.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.call.answer`] event.
 //!
-//! [`m.call.answer`]: https://spec.matrix.org/v1.4/client-server-api/#mcallanswer
+//! [`m.call.answer`]: https://spec.matrix.org/latest/client-server-api/#mcallanswer
 
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-common/src/events/call/candidates.rs
+++ b/crates/ruma-common/src/events/call/candidates.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.call.candidates`] event.
 //!
-//! [`m.call.candidates`]: https://spec.matrix.org/v1.4/client-server-api/#mcallcandidates
+//! [`m.call.candidates`]: https://spec.matrix.org/latest/client-server-api/#mcallcandidates
 
 use js_int::UInt;
 use ruma_macros::EventContent;

--- a/crates/ruma-common/src/events/call/hangup.rs
+++ b/crates/ruma-common/src/events/call/hangup.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.call.hangup`] event.
 //!
-//! [`m.call.hangup`]: https://spec.matrix.org/v1.4/client-server-api/#mcallhangup
+//! [`m.call.hangup`]: https://spec.matrix.org/latest/client-server-api/#mcallhangup
 
 use ruma_macros::EventContent;
 #[cfg(feature = "unstable-msc2746")]

--- a/crates/ruma-common/src/events/call/invite.rs
+++ b/crates/ruma-common/src/events/call/invite.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.call.invite`] event.
 //!
-//! [`m.call.invite`]: https://spec.matrix.org/v1.4/client-server-api/#mcallinvite
+//! [`m.call.invite`]: https://spec.matrix.org/latest/client-server-api/#mcallinvite
 
 use js_int::UInt;
 use ruma_macros::EventContent;

--- a/crates/ruma-common/src/events/direct.rs
+++ b/crates/ruma-common/src/events/direct.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.direct`] event.
 //!
-//! [`m.direct`]: https://spec.matrix.org/v1.4/client-server-api/#mdirect
+//! [`m.direct`]: https://spec.matrix.org/latest/client-server-api/#mdirect
 
 use std::{
     collections::BTreeMap,

--- a/crates/ruma-common/src/events/dummy.rs
+++ b/crates/ruma-common/src/events/dummy.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.dummy`] event.
 //!
-//! [`m.dummy`]: https://spec.matrix.org/v1.4/client-server-api/#mdummy
+//! [`m.dummy`]: https://spec.matrix.org/latest/client-server-api/#mdummy
 
 use std::fmt;
 

--- a/crates/ruma-common/src/events/forwarded_room_key.rs
+++ b/crates/ruma-common/src/events/forwarded_room_key.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.forwarded_room_key`] event.
 //!
-//! [`m.forwarded_room_key`]: https://spec.matrix.org/v1.4/client-server-api/#mforwarded_room_key
+//! [`m.forwarded_room_key`]: https://spec.matrix.org/latest/client-server-api/#mforwarded_room_key
 
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-common/src/events/fully_read.rs
+++ b/crates/ruma-common/src/events/fully_read.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.fully_read`] event.
 //!
-//! [`m.fully_read`]: https://spec.matrix.org/v1.4/client-server-api/#mfully_read
+//! [`m.fully_read`]: https://spec.matrix.org/latest/client-server-api/#mfully_read
 
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-common/src/events/identity_server.rs
+++ b/crates/ruma-common/src/events/identity_server.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.identity_server`] event.
 //!
-//! [`m.identity_server`]: https://spec.matrix.org/v1.4/client-server-api/#mdirect
+//! [`m.identity_server`]: https://spec.matrix.org/latest/client-server-api/#mdirect
 
 use js_option::JsOption;
 use ruma_macros::EventContent;

--- a/crates/ruma-common/src/events/ignored_user_list.rs
+++ b/crates/ruma-common/src/events/ignored_user_list.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.ignored_user_list`] event.
 //!
-//! [`m.ignored_user_list`]: https://spec.matrix.org/v1.4/client-server-api/#mignored_user_list
+//! [`m.ignored_user_list`]: https://spec.matrix.org/latest/client-server-api/#mignored_user_list
 
 use std::collections::BTreeMap;
 

--- a/crates/ruma-common/src/events/key/verification/accept.rs
+++ b/crates/ruma-common/src/events/key/verification/accept.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.key.verification.accept`] event.
 //!
-//! [`m.key.verification.accept`]: https://spec.matrix.org/v1.4/client-server-api/#mkeyverificationaccept
+//! [`m.key.verification.accept`]: https://spec.matrix.org/latest/client-server-api/#mkeyverificationaccept
 
 use std::collections::BTreeMap;
 

--- a/crates/ruma-common/src/events/key/verification/cancel.rs
+++ b/crates/ruma-common/src/events/key/verification/cancel.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.key.verification.cancel`] event.
 //!
-//! [`m.key.verification.cancel`]: https://spec.matrix.org/v1.4/client-server-api/#mkeyverificationcancel
+//! [`m.key.verification.cancel`]: https://spec.matrix.org/latest/client-server-api/#mkeyverificationcancel
 
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-common/src/events/key/verification/done.rs
+++ b/crates/ruma-common/src/events/key/verification/done.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.key.verification.done`] event.
 //!
-//! [`m.key.verification.done`]: https://spec.matrix.org/v1.4/client-server-api/#mkeyverificationdone
+//! [`m.key.verification.done`]: https://spec.matrix.org/latest/client-server-api/#mkeyverificationdone
 
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-common/src/events/key/verification/key.rs
+++ b/crates/ruma-common/src/events/key/verification/key.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.key.verification.key`] event.
 //!
-//! [`m.key.verification.key`]: https://spec.matrix.org/v1.4/client-server-api/#mkeyverificationkey
+//! [`m.key.verification.key`]: https://spec.matrix.org/latest/client-server-api/#mkeyverificationkey
 
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-common/src/events/key/verification/mac.rs
+++ b/crates/ruma-common/src/events/key/verification/mac.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.key.verification.mac`] event.
 //!
-//! [`m.key.verification.mac`]: https://spec.matrix.org/v1.4/client-server-api/#mkeyverificationmac
+//! [`m.key.verification.mac`]: https://spec.matrix.org/latest/client-server-api/#mkeyverificationmac
 
 use std::collections::BTreeMap;
 

--- a/crates/ruma-common/src/events/key/verification/ready.rs
+++ b/crates/ruma-common/src/events/key/verification/ready.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.key.verification.ready`] event.
 //!
-//! [`m.key.verification.ready`]: https://spec.matrix.org/v1.4/client-server-api/#mkeyverificationready
+//! [`m.key.verification.ready`]: https://spec.matrix.org/latest/client-server-api/#mkeyverificationready
 
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-common/src/events/key/verification/request.rs
+++ b/crates/ruma-common/src/events/key/verification/request.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.key.verification.request`] event.
 //!
-//! [`m.key.verification.request`]: https://spec.matrix.org/v1.4/client-server-api/#mkeyverificationrequest
+//! [`m.key.verification.request`]: https://spec.matrix.org/latest/client-server-api/#mkeyverificationrequest
 
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-common/src/events/key/verification/start.rs
+++ b/crates/ruma-common/src/events/key/verification/start.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.key.verification.start`] event.
 //!
-//! [`m.key.verification.start`]: https://spec.matrix.org/v1.4/client-server-api/#mkeyverificationstart
+//! [`m.key.verification.start`]: https://spec.matrix.org/latest/client-server-api/#mkeyverificationstart
 
 use std::{collections::BTreeMap, fmt};
 
@@ -86,7 +86,7 @@ pub enum StartMethod {
     ///
     /// The spec entry for this method can be found [here].
     ///
-    /// [here]: https://spec.matrix.org/v1.4/client-server-api/#mkeyverificationstartmreciprocatev1
+    /// [here]: https://spec.matrix.org/latest/client-server-api/#mkeyverificationstartmreciprocatev1
     ReciprocateV1(ReciprocateV1Content),
 
     /// Any unknown start method.

--- a/crates/ruma-common/src/events/policy/rule/room.rs
+++ b/crates/ruma-common/src/events/policy/rule/room.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.policy.rule.room`] event.
 //!
-//! [`m.policy.rule.room`]: https://spec.matrix.org/v1.4/client-server-api/#mpolicyruleroom
+//! [`m.policy.rule.room`]: https://spec.matrix.org/latest/client-server-api/#mpolicyruleroom
 
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-common/src/events/policy/rule/server.rs
+++ b/crates/ruma-common/src/events/policy/rule/server.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.policy.rule.server`] event.
 //!
-//! [`m.policy.rule.server`]: https://spec.matrix.org/v1.4/client-server-api/#mpolicyruleserver
+//! [`m.policy.rule.server`]: https://spec.matrix.org/latest/client-server-api/#mpolicyruleserver
 
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-common/src/events/policy/rule/user.rs
+++ b/crates/ruma-common/src/events/policy/rule/user.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.policy.rule.user`] event.
 //!
-//! [`m.policy.rule.user`]: https://spec.matrix.org/v1.4/client-server-api/#mpolicyruleuser
+//! [`m.policy.rule.user`]: https://spec.matrix.org/latest/client-server-api/#mpolicyruleuser
 
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-common/src/events/push_rules.rs
+++ b/crates/ruma-common/src/events/push_rules.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.push_rules`] event.
 //!
-//! [`m.push_rules`]: https://spec.matrix.org/v1.4/client-server-api/#mpush_rules
+//! [`m.push_rules`]: https://spec.matrix.org/latest/client-server-api/#mpush_rules
 
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-common/src/events/receipt.rs
+++ b/crates/ruma-common/src/events/receipt.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.receipt`] event.
 //!
-//! [`m.receipt`]: https://spec.matrix.org/v1.4/client-server-api/#mreceipt
+//! [`m.receipt`]: https://spec.matrix.org/latest/client-server-api/#mreceipt
 
 mod receipt_thread_serde;
 
@@ -72,7 +72,7 @@ pub enum ReceiptType {
     /// If both `Read` and `ReadPrivate` are present, the one that references
     /// the most recent event is used to get the latest read receipt.
     ///
-    /// [public read receipt]: https://spec.matrix.org/v1.4/client-server-api/#receipts
+    /// [public read receipt]: https://spec.matrix.org/latest/client-server-api/#receipts
     #[ruma_enum(rename = "m.read")]
     Read,
 
@@ -87,7 +87,7 @@ pub enum ReceiptType {
     /// If both `Read` and `ReadPrivate` are present, the one that references
     /// the most recent event is used to get the latest read receipt.
     ///
-    /// [private read receipt]: https://spec.matrix.org/v1.4/client-server-api/#private-read-receipts
+    /// [private read receipt]: https://spec.matrix.org/latest/client-server-api/#private-read-receipts
     #[ruma_enum(rename = "m.read.private")]
     ReadPrivate,
 
@@ -131,7 +131,7 @@ impl Receipt {
 /// To check for values that are not available as a documented variant here, use its string
 /// representation, obtained through [`.as_str()`](Self::as_str()).
 ///
-/// [thread a receipt applies to]: https://spec.matrix.org/v1.4/client-server-api/#threaded-read-receipts
+/// [thread a receipt applies to]: https://spec.matrix.org/latest/client-server-api/#threaded-read-receipts
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum ReceiptThread {

--- a/crates/ruma-common/src/events/relation.rs
+++ b/crates/ruma-common/src/events/relation.rs
@@ -1,6 +1,6 @@
 //! Types describing [relationships between events].
 //!
-//! [relationships between events]: https://spec.matrix.org/v1.4/client-server-api/#forming-relationships-between-events
+//! [relationships between events]: https://spec.matrix.org/latest/client-server-api/#forming-relationships-between-events
 
 use std::fmt::Debug;
 
@@ -15,7 +15,7 @@ use crate::{
 
 /// Information about the event a [rich reply] is replying to.
 ///
-/// [rich reply]: https://spec.matrix.org/v1.5/client-server-api/#rich-replies
+/// [rich reply]: https://spec.matrix.org/latest/client-server-api/#rich-replies
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct InReplyTo {
@@ -153,7 +153,7 @@ impl BundledReplacement {
 
 /// The content of a [replacement] relation.
 ///
-/// [replacement]: https://spec.matrix.org/v1.5/client-server-api/#event-replacements
+/// [replacement]: https://spec.matrix.org/latest/client-server-api/#event-replacements
 #[derive(Clone, Debug)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct Replacement<C> {
@@ -173,7 +173,7 @@ impl<C> Replacement<C> {
 
 /// The content of a [thread] relation.
 ///
-/// [thread]: https://spec.matrix.org/v1.5/client-server-api/#threading
+/// [thread]: https://spec.matrix.org/latest/client-server-api/#threading
 #[derive(Clone, Debug)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct Thread {
@@ -236,7 +236,7 @@ impl BundledThread {
 
 /// A [reference] to another event.
 ///
-/// [reference]: https://spec.matrix.org/v1.5/client-server-api/#reference-relations
+/// [reference]: https://spec.matrix.org/latest/client-server-api/#reference-relations
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[serde(tag = "rel_type", rename = "m.reference")]
@@ -284,7 +284,7 @@ impl ReferenceChunk {
 
 /// [Bundled aggregations] of related child events.
 ///
-/// [Bundled aggregations]: https://spec.matrix.org/v1.4/client-server-api/#aggregations
+/// [Bundled aggregations]: https://spec.matrix.org/latest/client-server-api/#aggregations
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct BundledRelations {

--- a/crates/ruma-common/src/events/room/avatar.rs
+++ b/crates/ruma-common/src/events/room/avatar.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.room.avatar`] event.
 //!
-//! [`m.room.avatar`]: https://spec.matrix.org/v1.4/client-server-api/#mroomavatar
+//! [`m.room.avatar`]: https://spec.matrix.org/latest/client-server-api/#mroomavatar
 
 use js_int::UInt;
 use ruma_macros::EventContent;

--- a/crates/ruma-common/src/events/room/canonical_alias.rs
+++ b/crates/ruma-common/src/events/room/canonical_alias.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.room.canonical_alias`] event.
 //!
-//! [`m.room.canonical_alias`]: https://spec.matrix.org/v1.4/client-server-api/#mroomcanonical_alias
+//! [`m.room.canonical_alias`]: https://spec.matrix.org/latest/client-server-api/#mroomcanonical_alias
 
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-common/src/events/room/create.rs
+++ b/crates/ruma-common/src/events/room/create.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.room.create`] event.
 //!
-//! [`m.room.create`]: https://spec.matrix.org/v1.4/client-server-api/#mroomcreate
+//! [`m.room.create`]: https://spec.matrix.org/latest/client-server-api/#mroomcreate
 
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-common/src/events/room/encrypted.rs
+++ b/crates/ruma-common/src/events/room/encrypted.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.room.encrypted`] event.
 //!
-//! [`m.room.encrypted`]: https://spec.matrix.org/v1.4/client-server-api/#mroomencrypted
+//! [`m.room.encrypted`]: https://spec.matrix.org/latest/client-server-api/#mroomencrypted
 
 use std::collections::BTreeMap;
 
@@ -139,7 +139,7 @@ impl<C> From<message::Relation<C>> for Relation {
 /// doesn't store the new content, since that is part of the encrypted content of an
 /// `m.room.encrypted` events.
 ///
-/// [replaces another event]: https://spec.matrix.org/v1.4/client-server-api/#event-replacements
+/// [replaces another event]: https://spec.matrix.org/latest/client-server-api/#event-replacements
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct Replacement {

--- a/crates/ruma-common/src/events/room/encryption.rs
+++ b/crates/ruma-common/src/events/room/encryption.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.room.encryption`] event.
 //!
-//! [`m.room.encryption`]: https://spec.matrix.org/v1.4/client-server-api/#mroomencryption
+//! [`m.room.encryption`]: https://spec.matrix.org/latest/client-server-api/#mroomencryption
 
 use js_int::UInt;
 use ruma_macros::EventContent;

--- a/crates/ruma-common/src/events/room/guest_access.rs
+++ b/crates/ruma-common/src/events/room/guest_access.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.room.guest_access`] event.
 //!
-//! [`m.room.guest_access`]: https://spec.matrix.org/v1.4/client-server-api/#mroomguest_access
+//! [`m.room.guest_access`]: https://spec.matrix.org/latest/client-server-api/#mroomguest_access
 
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-common/src/events/room/history_visibility.rs
+++ b/crates/ruma-common/src/events/room/history_visibility.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.room.history_visibility`] event.
 //!
-//! [`m.room.history_visibility`]: https://spec.matrix.org/v1.4/client-server-api/#mroomhistory_visibility
+//! [`m.room.history_visibility`]: https://spec.matrix.org/latest/client-server-api/#mroomhistory_visibility
 
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-common/src/events/room/join_rules.rs
+++ b/crates/ruma-common/src/events/room/join_rules.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.room.join_rules`] event.
 //!
-//! [`m.room.join_rules`]: https://spec.matrix.org/v1.4/client-server-api/#mroomjoin_rules
+//! [`m.room.join_rules`]: https://spec.matrix.org/latest/client-server-api/#mroomjoin_rules
 
 use std::{borrow::Cow, collections::BTreeMap};
 

--- a/crates/ruma-common/src/events/room/member.rs
+++ b/crates/ruma-common/src/events/room/member.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.room.member`] event.
 //!
-//! [`m.room.member`]: https://spec.matrix.org/v1.4/client-server-api/#mroommember
+//! [`m.room.member`]: https://spec.matrix.org/latest/client-server-api/#mroommember
 
 use std::collections::BTreeMap;
 
@@ -153,7 +153,7 @@ impl RoomMemberEventContent {
     ///
     /// Check [the specification][spec] for details.
     ///
-    /// [spec]: https://spec.matrix.org/v1.4/client-server-api/#mroommember
+    /// [spec]: https://spec.matrix.org/latest/client-server-api/#mroommember
     pub fn membership_change<'a>(
         &'a self,
         prev_details: Option<MembershipDetails<'a>>,
@@ -229,7 +229,7 @@ impl RedactedRoomMemberEventContent {
     ///
     /// Check [the specification][spec] for details.
     ///
-    /// [spec]: https://spec.matrix.org/v1.4/client-server-api/#mroommember
+    /// [spec]: https://spec.matrix.org/latest/client-server-api/#mroommember
     pub fn membership_change<'a>(
         &'a self,
         prev_details: Option<MembershipDetails<'a>>,
@@ -371,7 +371,7 @@ impl OriginalRoomMemberEvent {
     ///
     /// Check [the specification][spec] for details.
     ///
-    /// [spec]: https://spec.matrix.org/v1.4/client-server-api/#mroommember
+    /// [spec]: https://spec.matrix.org/latest/client-server-api/#mroommember
     pub fn membership_change(&self) -> MembershipChange<'_> {
         membership_change(self.details(), self.prev_details(), &self.sender, &self.state_key)
     }
@@ -394,7 +394,7 @@ impl RedactedRoomMemberEvent {
     ///
     /// Check [the specification][spec] for details.
     ///
-    /// [spec]: https://spec.matrix.org/v1.4/client-server-api/#mroommember
+    /// [spec]: https://spec.matrix.org/latest/client-server-api/#mroommember
     pub fn membership_change<'a>(
         &'a self,
         prev_details: Option<MembershipDetails<'a>>,
@@ -427,7 +427,7 @@ impl OriginalSyncRoomMemberEvent {
     ///
     /// Check [the specification][spec] for details.
     ///
-    /// [spec]: https://spec.matrix.org/v1.4/client-server-api/#mroommember
+    /// [spec]: https://spec.matrix.org/latest/client-server-api/#mroommember
     pub fn membership_change(&self) -> MembershipChange<'_> {
         membership_change(self.details(), self.prev_details(), &self.sender, &self.state_key)
     }
@@ -450,7 +450,7 @@ impl RedactedSyncRoomMemberEvent {
     ///
     /// Check [the specification][spec] for details.
     ///
-    /// [spec]: https://spec.matrix.org/v1.4/client-server-api/#mroommember
+    /// [spec]: https://spec.matrix.org/latest/client-server-api/#mroommember
     pub fn membership_change<'a>(
         &'a self,
         prev_details: Option<MembershipDetails<'a>>,
@@ -476,7 +476,7 @@ impl StrippedRoomMemberEvent {
     ///
     /// Check [the specification][spec] for details.
     ///
-    /// [spec]: https://spec.matrix.org/v1.4/client-server-api/#mroommember
+    /// [spec]: https://spec.matrix.org/latest/client-server-api/#mroommember
     pub fn membership_change<'a>(
         &'a self,
         prev_details: Option<MembershipDetails<'a>>,
@@ -509,7 +509,7 @@ pub struct RoomMemberUnsigned {
 
     /// [Bundled aggregations] of related child events.
     ///
-    /// [Bundled aggregations]: https://spec.matrix.org/v1.4/client-server-api/#aggregations
+    /// [Bundled aggregations]: https://spec.matrix.org/latest/client-server-api/#aggregations
     #[serde(rename = "m.relations", default)]
     pub relations: BundledRelations,
 }

--- a/crates/ruma-common/src/events/room/member/change.rs
+++ b/crates/ruma-common/src/events/room/member/change.rs
@@ -100,7 +100,7 @@ impl<T: PartialEq> Change<T> {
 ///
 /// This must match the table for [`m.room.member`] in the spec.
 ///
-/// [`m.room.member`]: https://spec.matrix.org/v1.4/client-server-api/#mroommember
+/// [`m.room.member`]: https://spec.matrix.org/latest/client-server-api/#mroommember
 pub(super) fn membership_change<'a>(
     details: MembershipDetails<'a>,
     prev_details: Option<MembershipDetails<'a>>,

--- a/crates/ruma-common/src/events/room/message.rs
+++ b/crates/ruma-common/src/events/room/message.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.room.message`] event.
 //!
-//! [`m.room.message`]: https://spec.matrix.org/v1.4/client-server-api/#mroommessage
+//! [`m.room.message`]: https://spec.matrix.org/latest/client-server-api/#mroommessage
 
 use std::borrow::Cow;
 
@@ -62,7 +62,7 @@ pub struct RoomMessageEventContent {
 
     /// Information about related messages for [rich replies].
     ///
-    /// [rich replies]: https://spec.matrix.org/v1.4/client-server-api/#rich-replies
+    /// [rich replies]: https://spec.matrix.org/latest/client-server-api/#rich-replies
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
     pub relates_to: Option<Relation<MessageType>>,
 }
@@ -235,7 +235,7 @@ impl RoomMessageEventContent {
     ///
     /// Panics if `self` has a `formatted_body` with a format other than HTML.
     ///
-    /// [replacement]: https://spec.matrix.org/v1.4/client-server-api/#event-replacements
+    /// [replacement]: https://spec.matrix.org/latest/client-server-api/#event-replacements
     #[track_caller]
     pub fn make_replacement(
         mut self,
@@ -318,8 +318,8 @@ impl RoomMessageEventContent {
     ///
     /// This method is only effective on text, notice and emote messages.
     ///
-    /// [tags and attributes]: https://spec.matrix.org/v1.4/client-server-api/#mroommessage-msgtypes
-    /// [rich reply fallback]: https://spec.matrix.org/v1.4/client-server-api/#fallbacks-for-rich-replies
+    /// [tags and attributes]: https://spec.matrix.org/latest/client-server-api/#mroommessage-msgtypes
+    /// [rich reply fallback]: https://spec.matrix.org/latest/client-server-api/#fallbacks-for-rich-replies
     #[cfg(feature = "unstable-sanitize")]
     pub fn sanitize(
         &mut self,
@@ -351,7 +351,7 @@ pub enum ForwardThread {
     /// This should be set if your client doesn't render threads (see the [info
     /// box for clients which are acutely aware of threads]).
     ///
-    /// [info box for clients which are acutely aware of threads]: https://spec.matrix.org/v1.4/client-server-api/#fallback-for-unthreaded-clients
+    /// [info box for clients which are acutely aware of threads]: https://spec.matrix.org/latest/client-server-api/#fallback-for-unthreaded-clients
     Yes,
 
     /// Create a reply in the main conversation even if the original message is in a thread.
@@ -368,14 +368,14 @@ pub enum ReplyWithinThread {
     ///
     /// Create a [reply within the thread].
     ///
-    /// [reply within the thread]: https://spec.matrix.org/v1.4/client-server-api/#replies-within-threads
+    /// [reply within the thread]: https://spec.matrix.org/latest/client-server-api/#replies-within-threads
     Yes,
 
     /// This is not a reply.
     ///
     /// Create a regular message in the thread, with a [fallback for unthreaded clients].
     ///
-    /// [fallback for unthreaded clients]: https://spec.matrix.org/v1.4/client-server-api/#fallback-for-unthreaded-clients
+    /// [fallback for unthreaded clients]: https://spec.matrix.org/latest/client-server-api/#fallback-for-unthreaded-clients
     No,
 }
 
@@ -422,7 +422,7 @@ pub enum MessageType {
 impl MessageType {
     /// Creates a new `MessageType`.
     ///
-    /// The `msgtype` and `body` are required fields as defined by [the `m.room.message` spec](https://spec.matrix.org/v1.4/client-server-api/#mroommessage).
+    /// The `msgtype` and `body` are required fields as defined by [the `m.room.message` spec](https://spec.matrix.org/latest/client-server-api/#mroommessage).
     /// Additionally it's possible to add arbitrary key/value pairs to the event content for custom
     /// events through the `data` map.
     ///
@@ -641,8 +641,8 @@ impl FormattedBody {
     ///
     /// Returns the sanitized HTML if the format is `MessageFormat::Html`.
     ///
-    /// [tags and attributes]: https://spec.matrix.org/v1.4/client-server-api/#mroommessage-msgtypes
-    /// [rich reply fallback]: https://spec.matrix.org/v1.4/client-server-api/#fallbacks-for-rich-replies
+    /// [tags and attributes]: https://spec.matrix.org/latest/client-server-api/#mroommessage-msgtypes
+    /// [rich reply fallback]: https://spec.matrix.org/latest/client-server-api/#fallbacks-for-rich-replies
     #[cfg(feature = "unstable-sanitize")]
     pub fn sanitize_html(
         &mut self,

--- a/crates/ruma-common/src/events/room/message/reply.rs
+++ b/crates/ruma-common/src/events/room/message/reply.rs
@@ -104,8 +104,8 @@ impl fmt::Display for FormattedOrPlainBody<'_> {
 /// spec and previous [rich reply fallbacks] are removed from the previous message in the new rich
 /// reply fallback.
 ///
-/// [HTML tags and attributes]: https://spec.matrix.org/v1.4/client-server-api/#mroommessage-msgtypes
-/// [rich reply fallbacks]: https://spec.matrix.org/v1.4/client-server-api/#fallbacks-for-rich-replies
+/// [HTML tags and attributes]: https://spec.matrix.org/latest/client-server-api/#mroommessage-msgtypes
+/// [rich reply fallbacks]: https://spec.matrix.org/latest/client-server-api/#fallbacks-for-rich-replies
 pub fn plain_and_formatted_reply_body(
     body: &str,
     formatted: Option<impl fmt::Display>,

--- a/crates/ruma-common/src/events/room/message/sanitize.rs
+++ b/crates/ruma-common/src/events/room/message/sanitize.rs
@@ -14,8 +14,8 @@ pub(super) use html_sanitizer::HtmlSanitizer;
 ///
 /// It can also optionally remove the [rich reply fallback].
 ///
-/// [tags and attributes]: https://spec.matrix.org/v1.4/client-server-api/#mroommessage-msgtypes
-/// [rich reply fallback]: https://spec.matrix.org/v1.4/client-server-api/#fallbacks-for-rich-replies
+/// [tags and attributes]: https://spec.matrix.org/latest/client-server-api/#mroommessage-msgtypes
+/// [rich reply fallback]: https://spec.matrix.org/latest/client-server-api/#fallbacks-for-rich-replies
 #[cfg(feature = "unstable-sanitize")]
 pub fn sanitize_html(
     s: &str,
@@ -28,7 +28,7 @@ pub fn sanitize_html(
 
 /// What HTML [tags and attributes] should be kept by the sanitizer.
 ///
-/// [tags and attributes]: https://spec.matrix.org/v1.4/client-server-api/#mroommessage-msgtypes
+/// [tags and attributes]: https://spec.matrix.org/latest/client-server-api/#mroommessage-msgtypes
 #[cfg(feature = "unstable-sanitize")]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[allow(clippy::exhaustive_enums)]
@@ -43,7 +43,7 @@ pub enum HtmlSanitizerMode {
 
 /// Whether to remove the [rich reply fallback] while sanitizing.
 ///
-/// [rich reply fallback]: https://spec.matrix.org/v1.4/client-server-api/#fallbacks-for-rich-replies
+/// [rich reply fallback]: https://spec.matrix.org/latest/client-server-api/#fallbacks-for-rich-replies
 #[cfg(feature = "unstable-sanitize")]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[allow(clippy::exhaustive_enums)]
@@ -60,7 +60,7 @@ pub enum RemoveReplyFallback {
 /// Due to the fact that the HTML is parsed, note that malformed HTML and comments will be stripped
 /// from the output.
 ///
-/// [rich reply fallback]: https://spec.matrix.org/v1.4/client-server-api/#fallbacks-for-rich-replies
+/// [rich reply fallback]: https://spec.matrix.org/latest/client-server-api/#fallbacks-for-rich-replies
 #[cfg(feature = "unstable-sanitize")]
 pub fn remove_html_reply_fallback(s: &str) -> String {
     let sanitizer = HtmlSanitizer::reply_fallback_remover();
@@ -69,7 +69,7 @@ pub fn remove_html_reply_fallback(s: &str) -> String {
 
 /// Remove the [rich reply fallback] of the given plain text string.
 ///
-/// [rich reply fallback]: https://spec.matrix.org/v1.4/client-server-api/#fallbacks-for-rich-replies
+/// [rich reply fallback]: https://spec.matrix.org/latest/client-server-api/#fallbacks-for-rich-replies
 pub fn remove_plain_reply_fallback(mut s: &str) -> &str {
     while s.starts_with("> ") {
         if let Some((_line, rest)) = s.split_once('\n') {

--- a/crates/ruma-common/src/events/room/message/sanitize/html_sanitizer.rs
+++ b/crates/ruma-common/src/events/room/message/sanitize/html_sanitizer.rs
@@ -9,7 +9,7 @@ use super::{
 
 /// A sanitizer to filter [HTML tags and attributes] according to the Matrix specification.
 ///
-/// [HTML tags and attributes]: https://spec.matrix.org/v1.4/client-server-api/#mroommessage-msgtypes
+/// [HTML tags and attributes]: https://spec.matrix.org/latest/client-server-api/#mroommessage-msgtypes
 #[derive(Debug, Clone)]
 pub struct HtmlSanitizer {
     /// The mode of the HTML sanitizer.
@@ -37,7 +37,7 @@ impl HtmlSanitizer {
     ///
     /// It can also optionally remove the [rich reply fallback].
     ///
-    /// [rich reply fallback]: https://spec.matrix.org/v1.4/client-server-api/#fallbacks-for-rich-replies
+    /// [rich reply fallback]: https://spec.matrix.org/latest/client-server-api/#fallbacks-for-rich-replies
     pub fn new(mode: HtmlSanitizerMode, remove_reply_fallback: RemoveReplyFallback) -> Self {
         Self {
             mode,
@@ -48,7 +48,7 @@ impl HtmlSanitizer {
 
     /// Constructs a `HTMLSanitizer` instance that only removes the [rich reply fallback].
     ///
-    /// [rich reply fallback]: https://spec.matrix.org/v1.4/client-server-api/#fallbacks-for-rich-replies
+    /// [rich reply fallback]: https://spec.matrix.org/latest/client-server-api/#fallbacks-for-rich-replies
     pub fn reply_fallback_remover() -> Self {
         Self {
             mode: HtmlSanitizerMode::Strict,

--- a/crates/ruma-common/src/events/room/name.rs
+++ b/crates/ruma-common/src/events/room/name.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.room.name`] event.
 //!
-//! [`m.room.name`]: https://spec.matrix.org/v1.4/client-server-api/#mroomname
+//! [`m.room.name`]: https://spec.matrix.org/latest/client-server-api/#mroomname
 
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-common/src/events/room/pinned_events.rs
+++ b/crates/ruma-common/src/events/room/pinned_events.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.room.pinned_events`] event.
 //!
-//! [`m.room.pinned_events`]: https://spec.matrix.org/v1.4/client-server-api/#mroompinned_events
+//! [`m.room.pinned_events`]: https://spec.matrix.org/latest/client-server-api/#mroompinned_events
 
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-common/src/events/room/power_levels.rs
+++ b/crates/ruma-common/src/events/room/power_levels.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.room.power_levels`] event.
 //!
-//! [`m.room.power_levels`]: https://spec.matrix.org/v1.4/client-server-api/#mroompower_levels
+//! [`m.room.power_levels`]: https://spec.matrix.org/latest/client-server-api/#mroompower_levels
 
 use std::{cmp::max, collections::BTreeMap};
 

--- a/crates/ruma-common/src/events/room/redaction.rs
+++ b/crates/ruma-common/src/events/room/redaction.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.room.redaction`] event.
 //!
-//! [`m.room.redaction`]: https://spec.matrix.org/v1.4/client-server-api/#mroomredaction
+//! [`m.room.redaction`]: https://spec.matrix.org/latest/client-server-api/#mroomredaction
 
 use ruma_macros::{Event, EventContent};
 use serde::{Deserialize, Deserializer, Serialize};

--- a/crates/ruma-common/src/events/room/server_acl.rs
+++ b/crates/ruma-common/src/events/room/server_acl.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.room.server_acl`] event.
 //!
-//! [`m.room.server_acl`]: https://spec.matrix.org/v1.4/client-server-api/#mroomserver_acl
+//! [`m.room.server_acl`]: https://spec.matrix.org/latest/client-server-api/#mroomserver_acl
 
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-common/src/events/room/third_party_invite.rs
+++ b/crates/ruma-common/src/events/room/third_party_invite.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.room.third_party_invite`] event.
 //!
-//! [`m.room.third_party_invite`]: https://spec.matrix.org/v1.4/client-server-api/#mroomthird_party_invite
+//! [`m.room.third_party_invite`]: https://spec.matrix.org/latest/client-server-api/#mroomthird_party_invite
 
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-common/src/events/room/tombstone.rs
+++ b/crates/ruma-common/src/events/room/tombstone.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.room.tombstone`] event.
 //!
-//! [`m.room.tombstone`]: https://spec.matrix.org/v1.4/client-server-api/#mroomtombstone
+//! [`m.room.tombstone`]: https://spec.matrix.org/latest/client-server-api/#mroomtombstone
 
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-common/src/events/room/topic.rs
+++ b/crates/ruma-common/src/events/room/topic.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.room.topic`] event.
 //!
-//! [`m.room.topic`]: https://spec.matrix.org/v1.4/client-server-api/#mroomtopic
+//! [`m.room.topic`]: https://spec.matrix.org/latest/client-server-api/#mroomtopic
 
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-common/src/events/room_key.rs
+++ b/crates/ruma-common/src/events/room_key.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.room_key`] event.
 //!
-//! [`m.room_key`]: https://spec.matrix.org/v1.4/client-server-api/#mroom_key
+//! [`m.room_key`]: https://spec.matrix.org/latest/client-server-api/#mroom_key
 
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-common/src/events/room_key_request.rs
+++ b/crates/ruma-common/src/events/room_key_request.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.room_key_request`] event.
 //!
-//! [`m.room_key_request`]: https://spec.matrix.org/v1.4/client-server-api/#mroom_key_request
+//! [`m.room_key_request`]: https://spec.matrix.org/latest/client-server-api/#mroom_key_request
 
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-common/src/events/secret/request.rs
+++ b/crates/ruma-common/src/events/secret/request.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.secret.request`] event.
 //!
-//! [`m.secret.request`]: https://spec.matrix.org/v1.4/client-server-api/#msecretrequest
+//! [`m.secret.request`]: https://spec.matrix.org/latest/client-server-api/#msecretrequest
 
 use ruma_macros::EventContent;
 use serde::{ser::SerializeStruct, Deserialize, Serialize};

--- a/crates/ruma-common/src/events/secret/send.rs
+++ b/crates/ruma-common/src/events/secret/send.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.secret.send`] event.
 //!
-//! [`m.secret.send`]: https://spec.matrix.org/v1.4/client-server-api/#msecretsend
+//! [`m.secret.send`]: https://spec.matrix.org/latest/client-server-api/#msecretsend
 
 use std::fmt;
 

--- a/crates/ruma-common/src/events/secret_storage/default_key.rs
+++ b/crates/ruma-common/src/events/secret_storage/default_key.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.secret_storage.default_key`] event.
 //!
-//! [`m.secret_storage.default_key`]: https://spec.matrix.org/v1.4/client-server-api/#key-storage
+//! [`m.secret_storage.default_key`]: https://spec.matrix.org/latest/client-server-api/#key-storage
 
 use ruma_common::events::macros::EventContent;
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-common/src/events/secret_storage/key.rs
+++ b/crates/ruma-common/src/events/secret_storage/key.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.secret_storage.key.*`] event.
 //!
-//! [`m.secret_storage.key.*`]: https://spec.matrix.org/v1.4/client-server-api/#key-storage
+//! [`m.secret_storage.key.*`]: https://spec.matrix.org/latest/client-server-api/#key-storage
 
 use js_int::{uint, UInt};
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-common/src/events/space.rs
+++ b/crates/ruma-common/src/events/space.rs
@@ -1,6 +1,6 @@
 //! Types for the `m.space` events.
 //!
-//! See [the specification](https://spec.matrix.org/v1.4/client-server-api/#spaces).
+//! See [the specification](https://spec.matrix.org/latest/client-server-api/#spaces).
 
 pub mod child;
 pub mod parent;

--- a/crates/ruma-common/src/events/space/child.rs
+++ b/crates/ruma-common/src/events/space/child.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.space.child`] event.
 //!
-//! [`m.space.child`]: https://spec.matrix.org/v1.4/client-server-api/#mspacechild
+//! [`m.space.child`]: https://spec.matrix.org/latest/client-server-api/#mspacechild
 
 use ruma_macros::{Event, EventContent};
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-common/src/events/space/parent.rs
+++ b/crates/ruma-common/src/events/space/parent.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.space.parent`] event.
 //!
-//! [`m.space.parent`]: https://spec.matrix.org/v1.4/client-server-api/#mspaceparent
+//! [`m.space.parent`]: https://spec.matrix.org/latest/client-server-api/#mspaceparent
 
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-common/src/events/sticker.rs
+++ b/crates/ruma-common/src/events/sticker.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.sticker`] event.
 //!
-//! [`m.sticker`]: https://spec.matrix.org/v1.4/client-server-api/#msticker
+//! [`m.sticker`]: https://spec.matrix.org/latest/client-server-api/#msticker
 
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-common/src/events/tag.rs
+++ b/crates/ruma-common/src/events/tag.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.tag`] event.
 //!
-//! [`m.tag`]: https://spec.matrix.org/v1.4/client-server-api/#mtag
+//! [`m.tag`]: https://spec.matrix.org/latest/client-server-api/#mtag
 
 use std::{collections::BTreeMap, error::Error, fmt, str::FromStr};
 
@@ -87,7 +87,7 @@ pub enum TagName {
     LowPriority,
 
     /// `m.server_notice`: Used to identify
-    /// [Server Notice Rooms](https://spec.matrix.org/v1.4/client-server-api/#server-notices).
+    /// [Server Notice Rooms](https://spec.matrix.org/latest/client-server-api/#server-notices).
     ServerNotice,
 
     /// `u.*`: User-defined tag

--- a/crates/ruma-common/src/events/typing.rs
+++ b/crates/ruma-common/src/events/typing.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.typing`] event.
 //!
-//! [`m.typing`]: https://spec.matrix.org/v1.4/client-server-api/#mtyping
+//! [`m.typing`]: https://spec.matrix.org/latest/client-server-api/#mtyping
 
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-common/src/events/unsigned.rs
+++ b/crates/ruma-common/src/events/unsigned.rs
@@ -26,7 +26,7 @@ pub struct MessageLikeUnsigned {
 
     /// [Bundled aggregations] of related child events.
     ///
-    /// [Bundled aggregations]: https://spec.matrix.org/v1.4/client-server-api/#aggregations
+    /// [Bundled aggregations]: https://spec.matrix.org/latest/client-server-api/#aggregations
     #[serde(rename = "m.relations", default)]
     pub relations: BundledRelations,
 }
@@ -69,7 +69,7 @@ pub struct StateUnsigned<C: PossiblyRedactedStateEventContent> {
 
     /// [Bundled aggregations] of related child events.
     ///
-    /// [Bundled aggregations]: https://spec.matrix.org/v1.4/client-server-api/#aggregations
+    /// [Bundled aggregations]: https://spec.matrix.org/latest/client-server-api/#aggregations
     #[serde(rename = "m.relations", default)]
     pub relations: BundledRelations,
 }

--- a/crates/ruma-common/src/identifiers/event_id.rs
+++ b/crates/ruma-common/src/identifiers/event_id.rs
@@ -33,8 +33,8 @@ use super::ServerName;
 /// );
 /// ```
 ///
-/// [event ID]: https://spec.matrix.org/v1.4/appendices/#room-ids-and-event-ids
-/// [room versions]: https://spec.matrix.org/v1.4/rooms/#complete-list-of-room-versions
+/// [event ID]: https://spec.matrix.org/latest/appendices/#room-ids-and-event-ids
+/// [room versions]: https://spec.matrix.org/latest/rooms/#complete-list-of-room-versions
 #[repr(transparent)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdZst)]
 #[ruma_id(validate = ruma_identifiers_validation::event_id::validate)]

--- a/crates/ruma-common/src/identifiers/matrix_uri.rs
+++ b/crates/ruma-common/src/identifiers/matrix_uri.rs
@@ -258,7 +258,7 @@ impl From<(&RoomAliasId, &EventId)> for MatrixId {
 /// Get the URI through its `Display` implementation (i.e. by interpolating it
 /// in a formatting macro or via `.to_string()`).
 ///
-/// [`matrix.to` URI]: https://spec.matrix.org/v1.4/appendices/#matrixto-navigation
+/// [`matrix.to` URI]: https://spec.matrix.org/latest/appendices/#matrixto-navigation
 #[derive(Debug, PartialEq, Eq)]
 pub struct MatrixToUri {
     id: MatrixId,
@@ -442,7 +442,7 @@ impl From<Box<str>> for UriAction {
 /// Get the URI through its `Display` implementation (i.e. by interpolating it
 /// in a formatting macro or via `.to_string()`).
 ///
-/// [`matrix:` URI]: https://spec.matrix.org/v1.4/appendices/#matrix-uri-scheme
+/// [`matrix:` URI]: https://spec.matrix.org/latest/appendices/#matrix-uri-scheme
 #[derive(Debug, PartialEq, Eq)]
 pub struct MatrixUri {
     id: MatrixId,

--- a/crates/ruma-common/src/identifiers/mxc_uri.rs
+++ b/crates/ruma-common/src/identifiers/mxc_uri.rs
@@ -1,6 +1,6 @@
 //! A URI that should be a Matrix-spec compliant [MXC URI].
 //!
-//! [MXC URI]: https://spec.matrix.org/v1.4/client-server-api/#matrix-content-mxc-uris
+//! [MXC URI]: https://spec.matrix.org/latest/client-server-api/#matrix-content-mxc-uris
 
 use std::num::NonZeroU8;
 
@@ -13,7 +13,7 @@ type Result<T, E = MxcUriError> = std::result::Result<T, E>;
 
 /// A URI that should be a Matrix-spec compliant [MXC URI].
 ///
-/// [MXC URI]: https://spec.matrix.org/v1.4/client-server-api/#matrix-content-mxc-uris
+/// [MXC URI]: https://spec.matrix.org/latest/client-server-api/#matrix-content-mxc-uris
 
 #[repr(transparent)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdZst)]

--- a/crates/ruma-common/src/identifiers/room_alias_id.rs
+++ b/crates/ruma-common/src/identifiers/room_alias_id.rs
@@ -14,7 +14,7 @@ use super::{matrix_uri::UriAction, server_name::ServerName, MatrixToUri, MatrixU
 /// assert_eq!(<&RoomAliasId>::try_from("#ruma:example.com").unwrap(), "#ruma:example.com");
 /// ```
 ///
-/// [room alias ID]: https://spec.matrix.org/v1.4/appendices/#room-aliases
+/// [room alias ID]: https://spec.matrix.org/latest/appendices/#room-aliases
 #[repr(transparent)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdZst)]
 #[ruma_id(validate = ruma_identifiers_validation::room_alias_id::validate)]

--- a/crates/ruma-common/src/identifiers/room_id.rs
+++ b/crates/ruma-common/src/identifiers/room_id.rs
@@ -16,7 +16,7 @@ use super::{
 /// assert_eq!(<&RoomId>::try_from("!n8f893n9:example.com").unwrap(), "!n8f893n9:example.com");
 /// ```
 ///
-/// [room ID]: https://spec.matrix.org/v1.4/appendices/#room-ids-and-event-ids
+/// [room ID]: https://spec.matrix.org/latest/appendices/#room-ids-and-event-ids
 #[repr(transparent)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdZst)]
 #[ruma_id(validate = ruma_identifiers_validation::room_id::validate)]
@@ -81,7 +81,7 @@ impl RoomId {
     /// );
     /// ```
     ///
-    /// [routing algorithm]: https://spec.matrix.org/v1.4/appendices/#routing
+    /// [routing algorithm]: https://spec.matrix.org/latest/appendices/#routing
     pub fn matrix_to_uri_via<T>(&self, via: T) -> MatrixToUri
     where
         T: IntoIterator,
@@ -105,7 +105,7 @@ impl RoomId {
     ///
     /// If you don't have a list of servers, you can use [`RoomId::matrix_to_event_uri()`] instead.
     ///
-    /// [routing algorithm]: https://spec.matrix.org/v1.4/appendices/#routing
+    /// [routing algorithm]: https://spec.matrix.org/latest/appendices/#routing
     pub fn matrix_to_event_uri_via<T>(&self, ev_id: impl Into<OwnedEventId>, via: T) -> MatrixToUri
     where
         T: IntoIterator,
@@ -162,7 +162,7 @@ impl RoomId {
     /// );
     /// ```
     ///
-    /// [routing algorithm]: https://spec.matrix.org/v1.4/appendices/#routing
+    /// [routing algorithm]: https://spec.matrix.org/latest/appendices/#routing
     pub fn matrix_uri_via<T>(&self, via: T, join: bool) -> MatrixUri
     where
         T: IntoIterator,
@@ -190,7 +190,7 @@ impl RoomId {
     ///
     /// If you don't have a list of servers, you can use [`RoomId::matrix_event_uri()`] instead.
     ///
-    /// [routing algorithm]: https://spec.matrix.org/v1.4/appendices/#routing
+    /// [routing algorithm]: https://spec.matrix.org/latest/appendices/#routing
     pub fn matrix_event_uri_via<T>(&self, ev_id: impl Into<OwnedEventId>, via: T) -> MatrixUri
     where
         T: IntoIterator,

--- a/crates/ruma-common/src/identifiers/room_or_room_alias_id.rs
+++ b/crates/ruma-common/src/identifiers/room_or_room_alias_id.rs
@@ -22,8 +22,8 @@ use super::{server_name::ServerName, OwnedRoomAliasId, OwnedRoomId, RoomAliasId,
 /// );
 /// ```
 ///
-/// [room ID]: https://spec.matrix.org/v1.4/appendices/#room-ids-and-event-ids
-/// [room alias ID]: https://spec.matrix.org/v1.4/appendices/#room-aliases
+/// [room ID]: https://spec.matrix.org/latest/appendices/#room-ids-and-event-ids
+/// [room alias ID]: https://spec.matrix.org/latest/appendices/#room-aliases
 #[repr(transparent)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdZst)]
 #[ruma_id(validate = ruma_identifiers_validation::room_id_or_alias_id::validate)]

--- a/crates/ruma-common/src/identifiers/room_version_id.rs
+++ b/crates/ruma-common/src/identifiers/room_version_id.rs
@@ -22,7 +22,7 @@ use super::IdParseError;
 /// written are represented by a hidden enum variant. You can still construct them the same, and
 /// check for them using one of `RoomVersionId`s `PartialEq` implementations or through `.as_str()`.
 ///
-/// [room version]: https://spec.matrix.org/v1.4/rooms/
+/// [room version]: https://spec.matrix.org/latest/rooms/
 #[derive(Clone, Debug, PartialEq, Eq, Hash, DisplayAsRefStr)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub enum RoomVersionId {

--- a/crates/ruma-common/src/identifiers/server_name.rs
+++ b/crates/ruma-common/src/identifiers/server_name.rs
@@ -8,7 +8,7 @@ use ruma_macros::IdZst;
 ///
 /// It consists of a host and an optional port (separated by a colon if present).
 ///
-/// [server name]: https://spec.matrix.org/v1.4/appendices/#server-name
+/// [server name]: https://spec.matrix.org/latest/appendices/#server-name
 #[repr(transparent)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdZst)]
 #[ruma_id(validate = ruma_identifiers_validation::server_name::validate)]

--- a/crates/ruma-common/src/identifiers/user_id.rs
+++ b/crates/ruma-common/src/identifiers/user_id.rs
@@ -14,7 +14,7 @@ use super::{matrix_uri::UriAction, IdParseError, MatrixToUri, MatrixUri, ServerN
 /// assert_eq!(<&UserId>::try_from("@carl:example.com").unwrap(), "@carl:example.com");
 /// ```
 ///
-/// [user ID]: https://spec.matrix.org/v1.4/appendices/#user-identifiers
+/// [user ID]: https://spec.matrix.org/latest/appendices/#user-identifiers
 #[repr(transparent)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdZst)]
 #[ruma_id(validate = ruma_identifiers_validation::user_id::validate)]

--- a/crates/ruma-common/src/power_levels.rs
+++ b/crates/ruma-common/src/power_levels.rs
@@ -1,6 +1,6 @@
 //! Common types for the [`m.room.power_levels` event][power_levels].
 //!
-//! [power_levels]: https://spec.matrix.org/v1.4/client-server-api/#mroompower_levels
+//! [power_levels]: https://spec.matrix.org/latest/client-server-api/#mroompower_levels
 
 use js_int::{int, Int};
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-common/src/presence.rs
+++ b/crates/ruma-common/src/presence.rs
@@ -1,6 +1,6 @@
 //! Common types for the [presence module][presence].
 //!
-//! [presence]: https://spec.matrix.org/v1.4/client-server-api/#presence
+//! [presence]: https://spec.matrix.org/latest/client-server-api/#presence
 
 use crate::{serde::StringEnum, PrivOwnedStr};
 

--- a/crates/ruma-common/src/push.rs
+++ b/crates/ruma-common/src/push.rs
@@ -1,6 +1,6 @@
 //! Common types for the [push notifications module][push].
 //!
-//! [push]: https://spec.matrix.org/v1.4/client-server-api/#push-notifications
+//! [push]: https://spec.matrix.org/latest/client-server-api/#push-notifications
 //!
 //! ## Understanding the types of this module
 //!
@@ -661,7 +661,7 @@ impl HttpPusherData {
 /// A special format that the homeserver should use when sending notifications to a Push Gateway.
 /// Currently, only `event_id_only` is supported, see the [Push Gateway API][spec].
 ///
-/// [spec]: https://spec.matrix.org/v1.4/push-gateway-api/#homeserver-behaviour
+/// [spec]: https://spec.matrix.org/latest/push-gateway-api/#homeserver-behaviour
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
 #[derive(Clone, PartialEq, Eq, StringEnum)]
 #[ruma_enum(rename_all = "snake_case")]

--- a/crates/ruma-common/src/push/action.rs
+++ b/crates/ruma-common/src/push/action.rs
@@ -8,7 +8,7 @@ use crate::serde::from_raw_json_value;
 /// This represents the different actions that should be taken when a rule is matched, and
 /// controls how notifications are delivered to the client.
 ///
-/// See [the spec](https://spec.matrix.org/v1.4/client-server-api/#actions) for details.
+/// See [the spec](https://spec.matrix.org/latest/client-server-api/#actions) for details.
 #[derive(Clone, Debug)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub enum Action {

--- a/crates/ruma-common/src/push/condition.rs
+++ b/crates/ruma-common/src/push/condition.rs
@@ -590,7 +590,7 @@ mod tests {
         assert!(!"m".matches_word("[[:alpha:]]?"));
         assert!("[[:alpha:]]!".matches_word("[[:alpha:]]?"));
 
-        // From the spec: <https://spec.matrix.org/latest/client-server-api/#conditions-1>
+        // From the spec: <https://spec.matrix.org/v1.5/client-server-api/#conditions-1>
         assert!("An example event.".matches_word("ex*ple"));
         assert!("exple".matches_word("ex*ple"));
         assert!("An exciting triple-whammy".matches_word("ex*ple"));
@@ -639,7 +639,7 @@ mod tests {
         assert!("".matches_pattern("*", false));
         assert!(!"foo".matches_pattern("", false));
 
-        // From the spec: <https://spec.matrix.org/latest/client-server-api/#conditions-1>
+        // From the spec: <https://spec.matrix.org/v1.5/client-server-api/#conditions-1>
         assert!("Lunch plans".matches_pattern("lunc?*", false));
         assert!("LUNCH".matches_pattern("lunc?*", false));
         assert!(!" lunch".matches_pattern("lunc?*", false));

--- a/crates/ruma-common/src/push/condition.rs
+++ b/crates/ruma-common/src/push/condition.rs
@@ -590,7 +590,7 @@ mod tests {
         assert!(!"m".matches_word("[[:alpha:]]?"));
         assert!("[[:alpha:]]!".matches_word("[[:alpha:]]?"));
 
-        // From the spec: <https://spec.matrix.org/v1.4/client-server-api/#conditions-1>
+        // From the spec: <https://spec.matrix.org/latest/client-server-api/#conditions-1>
         assert!("An example event.".matches_word("ex*ple"));
         assert!("exple".matches_word("ex*ple"));
         assert!("An exciting triple-whammy".matches_word("ex*ple"));
@@ -639,7 +639,7 @@ mod tests {
         assert!("".matches_pattern("*", false));
         assert!(!"foo".matches_pattern("", false));
 
-        // From the spec: <https://spec.matrix.org/v1.4/client-server-api/#conditions-1>
+        // From the spec: <https://spec.matrix.org/latest/client-server-api/#conditions-1>
         assert!("Lunch plans".matches_pattern("lunc?*", false));
         assert!("LUNCH".matches_pattern("lunc?*", false));
         assert!(!" lunch".matches_pattern("lunc?*", false));

--- a/crates/ruma-common/src/push/predefined.rs
+++ b/crates/ruma-common/src/push/predefined.rs
@@ -2,7 +2,7 @@ use ruma_macros::StringEnum;
 
 ///! Constructors for [predefined push rules].
 ///!
-///! [predefined push rules]: https://spec.matrix.org/v1.4/client-server-api/#predefined-rules
+///! [predefined push rules]: https://spec.matrix.org/latest/client-server-api/#predefined-rules
 use super::{
     Action::*, ConditionalPushRule, PatternedPushRule, PushCondition::*, RoomMemberCountIs,
     Ruleset, Tweak,
@@ -12,7 +12,7 @@ use crate::{PrivOwnedStr, UserId};
 impl Ruleset {
     /// The list of all [predefined push rules].
     ///
-    /// [predefined push rules]: https://spec.matrix.org/v1.4/client-server-api/#predefined-rules
+    /// [predefined push rules]: https://spec.matrix.org/latest/client-server-api/#predefined-rules
     ///
     /// # Parameters
     ///
@@ -175,7 +175,7 @@ impl ConditionalPushRule {
 
     /// Matches [room server ACLs].
     ///
-    /// [room server ACLs]: https://spec.matrix.org/v1.4/client-server-api/#server-access-control-lists-acls-for-rooms
+    /// [room server ACLs]: https://spec.matrix.org/latest/client-server-api/#server-access-control-lists-acls-for-rooms
     pub fn server_acl() -> Self {
         Self {
             actions: vec![],

--- a/crates/ruma-common/src/thirdparty.rs
+++ b/crates/ruma-common/src/thirdparty.rs
@@ -1,6 +1,6 @@
 //! Common types for the [third party networks module][thirdparty].
 //!
-//! [thirdparty]: https://spec.matrix.org/v1.4/client-server-api/#third-party-networks
+//! [thirdparty]: https://spec.matrix.org/latest/client-server-api/#third-party-networks
 
 use std::collections::BTreeMap;
 

--- a/crates/ruma-common/src/to_device.rs
+++ b/crates/ruma-common/src/to_device.rs
@@ -1,6 +1,6 @@
 //! Common types for the Send-To-Device Messaging
 //!
-//! [send-to-device]: https://spec.matrix.org/v1.4/client-server-api/#send-to-device-messaging
+//! [send-to-device]: https://spec.matrix.org/latest/client-server-api/#send-to-device-messaging
 
 use std::fmt::{Display, Formatter, Result as FmtResult};
 

--- a/crates/ruma-federation-api/src/authorization/get_event_authorization.rs
+++ b/crates/ruma-federation-api/src/authorization/get_event_authorization.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/server-server-api/#get_matrixfederationv1event_authroomideventid
+    //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1event_authroomideventid
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-federation-api/src/backfill/get_backfill.rs
+++ b/crates/ruma-federation-api/src/backfill/get_backfill.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/server-server-api/#get_matrixfederationv1backfillroomid
+    //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1backfillroomid
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-federation-api/src/device/get_devices.rs
+++ b/crates/ruma-federation-api/src/device/get_devices.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/server-server-api/#get_matrixfederationv1userdevicesuserid
+    //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1userdevicesuserid
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-federation-api/src/directory/get_public_rooms.rs
+++ b/crates/ruma-federation-api/src/directory/get_public_rooms.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/server-server-api/#post_matrixfederationv1publicrooms
+    //! [spec]: https://spec.matrix.org/latest/server-server-api/#post_matrixfederationv1publicrooms
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-federation-api/src/directory/get_public_rooms_filtered.rs
+++ b/crates/ruma-federation-api/src/directory/get_public_rooms_filtered.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/server-server-api/#post_matrixfederationv1publicrooms
+    //! [spec]: https://spec.matrix.org/latest/server-server-api/#post_matrixfederationv1publicrooms
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-federation-api/src/discovery/discover_homeserver.rs
+++ b/crates/ruma-federation-api/src/discovery/discover_homeserver.rs
@@ -2,7 +2,7 @@
 //!
 //! Get discovery information about the domain.
 //!
-//! [spec]: https://spec.matrix.org/v1.4/server-server-api/#getwell-knownmatrixserver
+//! [spec]: https://spec.matrix.org/latest/server-server-api/#getwell-knownmatrixserver
 
 use ruma_common::{
     api::{request, response, Metadata},

--- a/crates/ruma-federation-api/src/discovery/get_remote_server_keys.rs
+++ b/crates/ruma-federation-api/src/discovery/get_remote_server_keys.rs
@@ -6,7 +6,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/server-server-api/#get_matrixkeyv2queryservernamekeyid
+    //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixkeyv2queryservernamekeyid
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-federation-api/src/discovery/get_remote_server_keys_batch.rs
+++ b/crates/ruma-federation-api/src/discovery/get_remote_server_keys_batch.rs
@@ -6,7 +6,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/server-server-api/#post_matrixkeyv2query
+    //! [spec]: https://spec.matrix.org/latest/server-server-api/#post_matrixkeyv2query
 
     use std::collections::BTreeMap;
 

--- a/crates/ruma-federation-api/src/discovery/get_server_keys.rs
+++ b/crates/ruma-federation-api/src/discovery/get_server_keys.rs
@@ -5,7 +5,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/server-server-api/#get_matrixkeyv2serverkeyid
+    //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixkeyv2serverkeyid
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-federation-api/src/discovery/get_server_version.rs
+++ b/crates/ruma-federation-api/src/discovery/get_server_version.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/server-server-api/#get_matrixfederationv1version
+    //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1version
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-federation-api/src/event/get_event.rs
+++ b/crates/ruma-federation-api/src/event/get_event.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/server-server-api/#get_matrixfederationv1eventeventid
+    //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1eventeventid
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-federation-api/src/event/get_missing_events.rs
+++ b/crates/ruma-federation-api/src/event/get_missing_events.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/server-server-api/#post_matrixfederationv1get_missing_eventsroomid
+    //! [spec]: https://spec.matrix.org/latest/server-server-api/#post_matrixfederationv1get_missing_eventsroomid
 
     use js_int::{uint, UInt};
     use ruma_common::{

--- a/crates/ruma-federation-api/src/event/get_room_state.rs
+++ b/crates/ruma-federation-api/src/event/get_room_state.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/server-server-api/#get_matrixfederationv1stateroomid
+    //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1stateroomid
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-federation-api/src/event/get_room_state_ids.rs
+++ b/crates/ruma-federation-api/src/event/get_room_state_ids.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/server-server-api/#get_matrixfederationv1state_idsroomid
+    //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1state_idsroomid
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-federation-api/src/keys/claim_keys.rs
+++ b/crates/ruma-federation-api/src/keys/claim_keys.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/server-server-api/#post_matrixfederationv1userkeysclaim
+    //! [spec]: https://spec.matrix.org/latest/server-server-api/#post_matrixfederationv1userkeysclaim
 
     use std::collections::BTreeMap;
 

--- a/crates/ruma-federation-api/src/keys/get_keys.rs
+++ b/crates/ruma-federation-api/src/keys/get_keys.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/server-server-api/#post_matrixfederationv1userkeysquery
+    //! [spec]: https://spec.matrix.org/latest/server-server-api/#post_matrixfederationv1userkeysquery
 
     use std::collections::BTreeMap;
 

--- a/crates/ruma-federation-api/src/knock/create_knock_event_template.rs
+++ b/crates/ruma-federation-api/src/knock/create_knock_event_template.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/server-server-api/#get_matrixfederationv1make_knockroomiduserid
+    //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1make_knockroomiduserid
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-federation-api/src/knock/send_knock.rs
+++ b/crates/ruma-federation-api/src/knock/send_knock.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/server-server-api/#put_matrixfederationv1send_knockroomideventid
+    //! [spec]: https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv1send_knockroomideventid
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-federation-api/src/lib.rs
+++ b/crates/ruma-federation-api/src/lib.rs
@@ -3,7 +3,7 @@
 //! (De)serializable types for the [Matrix Server-Server API][federation-api].
 //! These types are used by server code.
 //!
-//! [federation-api]: https://spec.matrix.org/v1.4/server-server-api/
+//! [federation-api]: https://spec.matrix.org/latest/server-server-api/
 
 #![warn(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]

--- a/crates/ruma-federation-api/src/membership/create_invite/v1.rs
+++ b/crates/ruma-federation-api/src/membership/create_invite/v1.rs
@@ -1,6 +1,6 @@
 //! `/v1/` ([spec])
 //!
-//! [spec]: https://spec.matrix.org/v1.4/server-server-api/#put_matrixfederationv1inviteroomideventid
+//! [spec]: https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv1inviteroomideventid
 
 use ruma_common::{
     api::{request, response, Metadata},

--- a/crates/ruma-federation-api/src/membership/create_invite/v2.rs
+++ b/crates/ruma-federation-api/src/membership/create_invite/v2.rs
@@ -1,6 +1,6 @@
 //! `/v2/` ([spec])
 //!
-//! [spec]: https://spec.matrix.org/v1.4/server-server-api/#put_matrixfederationv2inviteroomideventid
+//! [spec]: https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv2inviteroomideventid
 
 use ruma_common::{
     api::{request, response, Metadata},

--- a/crates/ruma-federation-api/src/membership/create_join_event/v1.rs
+++ b/crates/ruma-federation-api/src/membership/create_join_event/v1.rs
@@ -1,6 +1,6 @@
 //! `/v1/` ([spec])
 //!
-//! [spec]: https://spec.matrix.org/v1.4/server-server-api/#put_matrixfederationv1send_joinroomideventid
+//! [spec]: https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv1send_joinroomideventid
 
 use ruma_common::{
     api::{request, response, Metadata},

--- a/crates/ruma-federation-api/src/membership/create_join_event/v2.rs
+++ b/crates/ruma-federation-api/src/membership/create_join_event/v2.rs
@@ -1,6 +1,6 @@
 //! `/v2/` ([spec])
 //!
-//! [spec]: https://spec.matrix.org/v1.4/server-server-api/#put_matrixfederationv2send_joinroomideventid
+//! [spec]: https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv2send_joinroomideventid
 
 use ruma_common::{
     api::{request, response, Metadata},

--- a/crates/ruma-federation-api/src/membership/create_leave_event/v1.rs
+++ b/crates/ruma-federation-api/src/membership/create_leave_event/v1.rs
@@ -1,6 +1,6 @@
 //! `/v1/` ([spec])
 //!
-//! [spec]: https://spec.matrix.org/v1.4/server-server-api/#put_matrixfederationv1send_leaveroomideventid
+//! [spec]: https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv1send_leaveroomideventid
 
 use js_int::UInt;
 use ruma_common::{

--- a/crates/ruma-federation-api/src/membership/create_leave_event/v2.rs
+++ b/crates/ruma-federation-api/src/membership/create_leave_event/v2.rs
@@ -1,6 +1,6 @@
 //! `/v2/` ([spec])
 //!
-//! [spec]: https://spec.matrix.org/v1.4/server-server-api/#put_matrixfederationv2send_leaveroomideventid
+//! [spec]: https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv2send_leaveroomideventid
 
 use ruma_common::{
     api::{request, response, Metadata},

--- a/crates/ruma-federation-api/src/membership/prepare_join_event.rs
+++ b/crates/ruma-federation-api/src/membership/prepare_join_event.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/server-server-api/#get_matrixfederationv1make_joinroomiduserid
+    //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1make_joinroomiduserid
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-federation-api/src/membership/prepare_leave_event.rs
+++ b/crates/ruma-federation-api/src/membership/prepare_leave_event.rs
@@ -6,7 +6,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/server-server-api/#get_matrixfederationv1make_leaveroomiduserid
+    //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1make_leaveroomiduserid
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-federation-api/src/openid/get_openid_userinfo.rs
+++ b/crates/ruma-federation-api/src/openid/get_openid_userinfo.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/server-server-api/#get_matrixfederationv1openiduserinfo
+    //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1openiduserinfo
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-federation-api/src/query/get_custom_information.rs
+++ b/crates/ruma-federation-api/src/query/get_custom_information.rs
@@ -6,7 +6,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/server-server-api/#get_matrixfederationv1queryquerytype
+    //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1queryquerytype
 
     use std::collections::BTreeMap;
 

--- a/crates/ruma-federation-api/src/query/get_profile_information.rs
+++ b/crates/ruma-federation-api/src/query/get_profile_information.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/server-server-api/#get_matrixfederationv1queryprofile
+    //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1queryprofile
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-federation-api/src/query/get_room_information.rs
+++ b/crates/ruma-federation-api/src/query/get_room_information.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/server-server-api/#get_matrixfederationv1querydirectory
+    //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1querydirectory
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-federation-api/src/serde/v1_pdu.rs
+++ b/crates/ruma-federation-api/src/serde/v1_pdu.rs
@@ -1,8 +1,8 @@
 //! A module to deserialize a response from incorrectly specified endpoint:
 //!
-//! - [PUT /_matrix/federation/v1/send_join/{roomId}/{eventId}](https://spec.matrix.org/v1.4/server-server-api/#put_matrixfederationv1send_joinroomideventid)
-//! - [PUT /_matrix/federation/v1/invite/{roomId}/{eventId}](https://spec.matrix.org/v1.4/server-server-api/#put_matrixfederationv1inviteroomideventid)
-//! - [PUT /_matrix/federation/v1/send_leave/{roomId}/{eventId}](https://spec.matrix.org/v1.4/server-server-api/#put_matrixfederationv1send_leaveroomideventid)
+//! - [PUT /_matrix/federation/v1/send_join/{roomId}/{eventId}](https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv1send_joinroomideventid)
+//! - [PUT /_matrix/federation/v1/invite/{roomId}/{eventId}](https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv1inviteroomideventid)
+//! - [PUT /_matrix/federation/v1/send_leave/{roomId}/{eventId}](https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv1send_leaveroomideventid)
 //!
 //! For more information, see this [GitHub issue][issue].
 //!

--- a/crates/ruma-federation-api/src/space/get_hierarchy.rs
+++ b/crates/ruma-federation-api/src/space/get_hierarchy.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/server-server-api/#get_matrixfederationv1hierarchyroomid
+    //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1hierarchyroomid
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-federation-api/src/thirdparty/bind_callback.rs
+++ b/crates/ruma-federation-api/src/thirdparty/bind_callback.rs
@@ -7,7 +7,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/server-server-api/#put_matrixfederationv13pidonbind
+    //! [spec]: https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv13pidonbind
 
     use std::collections::BTreeMap;
 

--- a/crates/ruma-federation-api/src/thirdparty/exchange_invite.rs
+++ b/crates/ruma-federation-api/src/thirdparty/exchange_invite.rs
@@ -4,12 +4,12 @@
 //! If valid, the receiving server will issue an invite as per the [Inviting to a room] section
 //! before returning a response to this request.
 //!
-//! [Inviting to a room]: https://spec.matrix.org/v1.4/server-server-api/#inviting-to-a-room
+//! [Inviting to a room]: https://spec.matrix.org/latest/server-server-api/#inviting-to-a-room
 
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/server-server-api/#put_matrixfederationv1exchange_third_party_inviteroomid
+    //! [spec]: https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv1exchange_third_party_inviteroomid
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-federation-api/src/transactions/send_transaction_message.rs
+++ b/crates/ruma-federation-api/src/transactions/send_transaction_message.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/server-server-api/#put_matrixfederationv1sendtxnid
+    //! [spec]: https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv1sendtxnid
 
     use std::collections::BTreeMap;
 

--- a/crates/ruma-identifiers-validation/src/error.rs
+++ b/crates/ruma-identifiers-validation/src/error.rs
@@ -77,7 +77,7 @@ pub enum MxcUriError {
     /// Media identifier malformed due to invalid characters detected.
     ///
     /// Valid characters are (in regex notation) `[A-Za-z0-9_-]+`.
-    /// See [here](https://spec.matrix.org/v1.4/client-server-api/#security-considerations-5) for more details.
+    /// See [here](https://spec.matrix.org/latest/client-server-api/#security-considerations-5) for more details.
     #[error("Media Identifier malformed, invalid characters")]
     MediaIdMalformed,
 

--- a/crates/ruma-identifiers-validation/src/error.rs
+++ b/crates/ruma-identifiers-validation/src/error.rs
@@ -77,7 +77,7 @@ pub enum MxcUriError {
     /// Media identifier malformed due to invalid characters detected.
     ///
     /// Valid characters are (in regex notation) `[A-Za-z0-9_-]+`.
-    /// See [here](https://spec.matrix.org/latest/client-server-api/#security-considerations-5) for more details.
+    /// See [here](https://spec.matrix.org/v1.5/client-server-api/#security-considerations-5) for more details.
     #[error("Media Identifier malformed, invalid characters")]
     MediaIdMalformed,
 

--- a/crates/ruma-identifiers-validation/src/mxc_uri.rs
+++ b/crates/ruma-identifiers-validation/src/mxc_uri.rs
@@ -17,7 +17,7 @@ pub fn validate(uri: &str) -> Result<NonZeroU8, MxcUriError> {
 
     let server_name = &uri[..index];
     let media_id = &uri[index + 1..];
-    // See: https://spec.matrix.org/latest/client-server-api/#security-considerations-5
+    // See: https://spec.matrix.org/v1.5/client-server-api/#security-considerations-5
     let media_id_is_valid =
         media_id.bytes().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'z' | b'A'..=b'Z' | b'-' ));
 

--- a/crates/ruma-identifiers-validation/src/mxc_uri.rs
+++ b/crates/ruma-identifiers-validation/src/mxc_uri.rs
@@ -17,7 +17,7 @@ pub fn validate(uri: &str) -> Result<NonZeroU8, MxcUriError> {
 
     let server_name = &uri[..index];
     let media_id = &uri[index + 1..];
-    // See: https://spec.matrix.org/v1.4/client-server-api/#security-considerations-5
+    // See: https://spec.matrix.org/latest/client-server-api/#security-considerations-5
     let media_id_is_valid =
         media_id.bytes().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'z' | b'A'..=b'Z' | b'-' ));
 

--- a/crates/ruma-identifiers-validation/src/user_id.rs
+++ b/crates/ruma-identifiers-validation/src/user_id.rs
@@ -18,7 +18,7 @@ pub fn validate(s: &str) -> Result<(), Error> {
 /// due to Synapse allowing them over federation. This will likely be fixed in an upcoming room
 /// version; see [MSC2828](https://github.com/matrix-org/matrix-spec-proposals/pull/2828).
 pub fn localpart_is_fully_conforming(localpart: &str) -> Result<bool, Error> {
-    // See https://spec.matrix.org/v1.4/appendices/#user-identifiers
+    // See https://spec.matrix.org/latest/appendices/#user-identifiers
     let is_fully_conforming = localpart
         .bytes()
         .all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'z' | b'-' | b'.' | b'=' | b'_' | b'/'));
@@ -26,7 +26,7 @@ pub fn localpart_is_fully_conforming(localpart: &str) -> Result<bool, Error> {
     if !is_fully_conforming {
         // If it's not fully conforming, check if it contains characters that are also disallowed
         // for historical user IDs. If there are, return an error.
-        // See https://spec.matrix.org/v1.4/appendices/#historical-user-ids
+        // See https://spec.matrix.org/latest/appendices/#historical-user-ids
         #[cfg(not(feature = "compat"))]
         let is_invalid = localpart.bytes().any(|b| b < 0x21 || b == b':' || b > 0x7E);
 

--- a/crates/ruma-identity-service-api/src/association/bind_3pid.rs
+++ b/crates/ruma-identity-service-api/src/association/bind_3pid.rs
@@ -5,7 +5,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/identity-service-api/#post_matrixidentityv23pidbind
+    //! [spec]: https://spec.matrix.org/latest/identity-service-api/#post_matrixidentityv23pidbind
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-identity-service-api/src/association/check_3pid_validity.rs
+++ b/crates/ruma-identity-service-api/src/association/check_3pid_validity.rs
@@ -5,7 +5,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/identity-service-api/#get_matrixidentityv23pidgetvalidated3pid
+    //! [spec]: https://spec.matrix.org/latest/identity-service-api/#get_matrixidentityv23pidgetvalidated3pid
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-identity-service-api/src/association/email/create_email_validation_session.rs
+++ b/crates/ruma-identity-service-api/src/association/email/create_email_validation_session.rs
@@ -5,7 +5,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/identity-service-api/#post_matrixidentityv2validateemailrequesttoken
+    //! [spec]: https://spec.matrix.org/latest/identity-service-api/#post_matrixidentityv2validateemailrequesttoken
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-identity-service-api/src/association/email/validate_email.rs
+++ b/crates/ruma-identity-service-api/src/association/email/validate_email.rs
@@ -5,7 +5,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/identity-service-api/#post_matrixidentityv2validateemailsubmittoken
+    //! [spec]: https://spec.matrix.org/latest/identity-service-api/#post_matrixidentityv2validateemailsubmittoken
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-identity-service-api/src/association/email/validate_email_by_end_user.rs
+++ b/crates/ruma-identity-service-api/src/association/email/validate_email_by_end_user.rs
@@ -5,7 +5,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/identity-service-api/#get_matrixidentityv2validateemailsubmittoken
+    //! [spec]: https://spec.matrix.org/latest/identity-service-api/#get_matrixidentityv2validateemailsubmittoken
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-identity-service-api/src/association/msisdn/create_msisdn_validation_session.rs
+++ b/crates/ruma-identity-service-api/src/association/msisdn/create_msisdn_validation_session.rs
@@ -5,7 +5,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/identity-service-api/#post_matrixidentityv2validatemsisdnrequesttoken
+    //! [spec]: https://spec.matrix.org/latest/identity-service-api/#post_matrixidentityv2validatemsisdnrequesttoken
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-identity-service-api/src/association/msisdn/validate_msisdn.rs
+++ b/crates/ruma-identity-service-api/src/association/msisdn/validate_msisdn.rs
@@ -5,7 +5,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/identity-service-api/#post_matrixidentityv2validatemsisdnsubmittoken
+    //! [spec]: https://spec.matrix.org/latest/identity-service-api/#post_matrixidentityv2validatemsisdnsubmittoken
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-identity-service-api/src/association/msisdn/validate_msisdn_by_phone_number.rs
+++ b/crates/ruma-identity-service-api/src/association/msisdn/validate_msisdn_by_phone_number.rs
@@ -5,7 +5,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/identity-service-api/#get_matrixidentityv2validatemsisdnsubmittoken
+    //! [spec]: https://spec.matrix.org/latest/identity-service-api/#get_matrixidentityv2validatemsisdnsubmittoken
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-identity-service-api/src/association/unbind_3pid.rs
+++ b/crates/ruma-identity-service-api/src/association/unbind_3pid.rs
@@ -5,7 +5,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/identity-service-api/#post_matrixidentityv23pidunbind
+    //! [spec]: https://spec.matrix.org/latest/identity-service-api/#post_matrixidentityv23pidunbind
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-identity-service-api/src/authentication/get_account_information.rs
+++ b/crates/ruma-identity-service-api/src/authentication/get_account_information.rs
@@ -5,7 +5,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/identity-service-api/#get_matrixidentityv2account
+    //! [spec]: https://spec.matrix.org/latest/identity-service-api/#get_matrixidentityv2account
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-identity-service-api/src/authentication/logout.rs
+++ b/crates/ruma-identity-service-api/src/authentication/logout.rs
@@ -6,7 +6,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/identity-service-api/#post_matrixidentityv2accountlogout
+    //! [spec]: https://spec.matrix.org/latest/identity-service-api/#post_matrixidentityv2accountlogout
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-identity-service-api/src/authentication/register.rs
+++ b/crates/ruma-identity-service-api/src/authentication/register.rs
@@ -5,7 +5,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/identity-service-api/#post_matrixidentityv2accountregister
+    //! [spec]: https://spec.matrix.org/latest/identity-service-api/#post_matrixidentityv2accountregister
 
     use std::time::Duration;
 

--- a/crates/ruma-identity-service-api/src/discovery/get_server_status.rs
+++ b/crates/ruma-identity-service-api/src/discovery/get_server_status.rs
@@ -5,7 +5,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/identity-service-api/#get_matrixidentityv2
+    //! [spec]: https://spec.matrix.org/latest/identity-service-api/#get_matrixidentityv2
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-identity-service-api/src/discovery/get_supported_versions.rs
+++ b/crates/ruma-identity-service-api/src/discovery/get_supported_versions.rs
@@ -8,7 +8,7 @@
 //!
 //! Note: This endpoint does not contain an unstable variant for 1.0.
 //!
-//! [spec]: https://spec.matrix.org/v1.4/identity-service-api/#get_matrixidentityversions
+//! [spec]: https://spec.matrix.org/latest/identity-service-api/#get_matrixidentityversions
 
 use std::collections::BTreeMap;
 

--- a/crates/ruma-identity-service-api/src/invitation/sign_invitation_ed25519.rs
+++ b/crates/ruma-identity-service-api/src/invitation/sign_invitation_ed25519.rs
@@ -5,7 +5,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/identity-service-api/#post_matrixidentityv2sign-ed25519
+    //! [spec]: https://spec.matrix.org/latest/identity-service-api/#post_matrixidentityv2sign-ed25519
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-identity-service-api/src/invitation/store_invitation.rs
+++ b/crates/ruma-identity-service-api/src/invitation/store_invitation.rs
@@ -5,7 +5,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/identity-service-api/#post_matrixidentityv2store-invite
+    //! [spec]: https://spec.matrix.org/latest/identity-service-api/#post_matrixidentityv2store-invite
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-identity-service-api/src/keys/check_public_key_validity.rs
+++ b/crates/ruma-identity-service-api/src/keys/check_public_key_validity.rs
@@ -6,7 +6,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/identity-service-api/#get_matrixidentityv2pubkeyisvalid
+    //! [spec]: https://spec.matrix.org/latest/identity-service-api/#get_matrixidentityv2pubkeyisvalid
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-identity-service-api/src/keys/get_public_key.rs
+++ b/crates/ruma-identity-service-api/src/keys/get_public_key.rs
@@ -5,7 +5,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/identity-service-api/#get_matrixidentityv2pubkeykeyid
+    //! [spec]: https://spec.matrix.org/latest/identity-service-api/#get_matrixidentityv2pubkeykeyid
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-identity-service-api/src/keys/validate_ephemeral_key.rs
+++ b/crates/ruma-identity-service-api/src/keys/validate_ephemeral_key.rs
@@ -5,7 +5,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/identity-service-api/#get_matrixidentityv2pubkeyephemeralisvalid
+    //! [spec]: https://spec.matrix.org/latest/identity-service-api/#get_matrixidentityv2pubkeyephemeralisvalid
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-identity-service-api/src/lib.rs
+++ b/crates/ruma-identity-service-api/src/lib.rs
@@ -3,7 +3,7 @@
 //! (De)serializable types for the [Matrix Identity Service API][identity-api].
 //! These types can be shared by client and identity service code.
 //!
-//! [identity-api]: https://spec.matrix.org/v1.4/identity-service-api/
+//! [identity-api]: https://spec.matrix.org/latest/identity-service-api/
 
 #![warn(missing_docs)]
 

--- a/crates/ruma-identity-service-api/src/lookup/get_hash_parameters.rs
+++ b/crates/ruma-identity-service-api/src/lookup/get_hash_parameters.rs
@@ -6,7 +6,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/identity-service-api/#get_matrixidentityv2hash_details
+    //! [spec]: https://spec.matrix.org/latest/identity-service-api/#get_matrixidentityv2hash_details
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-identity-service-api/src/lookup/lookup_3pid.rs
+++ b/crates/ruma-identity-service-api/src/lookup/lookup_3pid.rs
@@ -5,7 +5,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/identity-service-api/#post_matrixidentityv2lookup
+    //! [spec]: https://spec.matrix.org/latest/identity-service-api/#post_matrixidentityv2lookup
 
     use std::collections::BTreeMap;
 

--- a/crates/ruma-identity-service-api/src/tos/accept_terms_of_service.rs
+++ b/crates/ruma-identity-service-api/src/tos/accept_terms_of_service.rs
@@ -5,7 +5,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/identity-service-api/#post_matrixidentityv2terms
+    //! [spec]: https://spec.matrix.org/latest/identity-service-api/#post_matrixidentityv2terms
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-identity-service-api/src/tos/get_terms_of_service.rs
+++ b/crates/ruma-identity-service-api/src/tos/get_terms_of_service.rs
@@ -5,7 +5,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/identity-service-api/#get_matrixidentityv2terms
+    //! [spec]: https://spec.matrix.org/latest/identity-service-api/#get_matrixidentityv2terms
 
     use std::collections::BTreeMap;
 

--- a/crates/ruma-push-gateway-api/src/lib.rs
+++ b/crates/ruma-push-gateway-api/src/lib.rs
@@ -3,7 +3,7 @@
 //! (De)serializable types for the [Matrix Push Gateway API][push-api].
 //! These types can be shared by push gateway and server code.
 //!
-//! [push-api]: https://spec.matrix.org/v1.4/push-gateway-api/
+//! [push-api]: https://spec.matrix.org/latest/push-gateway-api/
 
 #![warn(missing_docs)]
 

--- a/crates/ruma-push-gateway-api/src/send_event_notification.rs
+++ b/crates/ruma-push-gateway-api/src/send_event_notification.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.4/push-gateway-api/#post_matrixpushv1notify
+    //! [spec]: https://spec.matrix.org/latest/push-gateway-api/#post_matrixpushv1notify
 
     use js_int::{uint, UInt};
     use ruma_common::{

--- a/crates/ruma-server-util/src/authorization.rs
+++ b/crates/ruma-server-util/src/authorization.rs
@@ -11,7 +11,7 @@ use yap::{IntoTokens, TokenLocation, Tokens};
 /// [`headers::authorization::Credentials`] for automatically handling the encoding and decoding
 /// when using a web framework that supports typed headers.
 ///
-/// [spec]: https://spec.matrix.org/v1.4/server-server-api/#request-authentication
+/// [spec]: https://spec.matrix.org/latest/server-server-api/#request-authentication
 #[non_exhaustive]
 pub struct XMatrix {
     /// The server name of the sending server.

--- a/crates/ruma-signatures/src/functions.rs
+++ b/crates/ruma-signatures/src/functions.rs
@@ -135,7 +135,7 @@ where
 
 /// Converts an event into the [canonical] string form.
 ///
-/// [canonical]: https://spec.matrix.org/v1.4/appendices/#canonical-json
+/// [canonical]: https://spec.matrix.org/latest/appendices/#canonical-json
 ///
 /// # Parameters
 ///

--- a/crates/ruma-state-res/src/event_auth.rs
+++ b/crates/ruma-state-res/src/event_auth.rs
@@ -143,7 +143,7 @@ pub fn auth_check<E: Event>(
 
     let sender = incoming_event.sender();
 
-    // Implementation of https://spec.matrix.org/v1.4/rooms/v1/#authorization-rules
+    // Implementation of https://spec.matrix.org/latest/rooms/v1/#authorization-rules
     //
     // 1. If type is m.room.create:
     if *incoming_event.event_type() == TimelineEventType::RoomCreate {

--- a/crates/ruma-state-res/src/room_version.rs
+++ b/crates/ruma-state-res/src/room_version.rs
@@ -60,7 +60,7 @@ pub struct RoomVersion {
     pub extra_redaction_checks: bool,
     /// Allow knocking in event authentication.
     ///
-    /// See [room v7 specification](https://spec.matrix.org/v1.4/rooms/v7/) for more information.
+    /// See [room v7 specification](https://spec.matrix.org/latest/rooms/v7/) for more information.
     pub allow_knocking: bool,
     /// Adds support for the restricted join rule.
     ///

--- a/crates/ruma/src/lib.rs
+++ b/crates/ruma/src/lib.rs
@@ -95,7 +95,7 @@ pub use ruma_state_res as state_res;
 /// (De)serializable types for various [Matrix APIs][apis] requests and responses and abstractions
 /// for them.
 ///
-/// [apis]: https://spec.matrix.org/v1.4/#matrix-apis
+/// [apis]: https://spec.matrix.org/latest/#matrix-apis
 #[cfg(feature = "api")]
 pub mod api {
     // The metadata macro is also exported at the crate root because `#[macro_export]` always

--- a/xtask/src/ci/spec_links.rs
+++ b/xtask/src/ci/spec_links.rs
@@ -27,8 +27,12 @@ impl Spec {
         &["https://matrix.org/docs/spec/index.html#complete-list-of-room-versions"];
 
     /// Authorized versions in URLs pointing to the new specs.
-    const NEW_VERSION_WHITELIST: &'static [&'static str] =
-        &["v1.1", "v1.2", "v1.3", "v1.4", "v1.5", "latest", "unstable"];
+    const NEW_VERSION_WHITELIST: &'static [&'static str] = &[
+        "v1.1", "v1.2", "v1.3", "v1.4", "v1.5",
+        "latest",
+        // This should only be enabled if a legitimate use case is found.
+        // "unstable",
+    ];
 
     /// Get the start of the URLs pointing to this `Spec`.
     const fn url_prefix(&self) -> &'static str {

--- a/xtask/src/ci/spec_links.rs
+++ b/xtask/src/ci/spec_links.rs
@@ -28,7 +28,7 @@ impl Spec {
 
     /// Authorized versions in URLs pointing to the new specs.
     const NEW_VERSION_WHITELIST: &'static [&'static str] =
-        &["v1.1", "v1.2", "v1.3", "v1.4", "v1.5", "unstable"];
+        &["v1.1", "v1.2", "v1.3", "v1.4", "v1.5", "latest", "unstable"];
 
     /// Get the start of the URLs pointing to this `Spec`.
     const fn url_prefix(&self) -> &'static str {


### PR DESCRIPTION
Will avoid having to update the Matrix version in the spec links after each release.













<!-- Replace -->
----
Preview: https://pr-1473--ruma-docs.surge.sh
<!-- Replace -->
