### PR TITLE
ci: Check that links to the spec are valid

### DIFF
--- a/crates/ruma-common/src/identifiers/event_id.rs
+++ b/crates/ruma-common/src/identifiers/event_id.rs
@@ -11,12 +11,11 @@ use super::ServerName;
 ///
 /// # Room versions
 ///
-/// Matrix specifies multiple [room versions](https://spec.matrix.org/v1.4/#room-versions) and the
-/// format of event identifiers differ between them. The original format used by room versions 1 and
-/// 2 uses a short pseudorandom "localpart" followed by the hostname and port of the originating
-/// homeserver. Later room versions change event identifiers to be a hash of the event encoded with
-/// Base64. Some of the methods provided by `EventId` are only relevant to the original event
-/// format.
+/// Matrix specifies multiple [room versions] and the format of event identifiers differ between
+/// them. The original format used by room versions 1 and 2 uses a short pseudorandom "localpart"
+/// followed by the hostname and port of the originating homeserver. Later room versions change
+/// event identifiers to be a hash of the event encoded with Base64. Some of the methods provided by
+/// `EventId` are only relevant to the original event format.
 ///
 /// ```
 /// # use ruma_common::EventId;
@@ -35,6 +34,7 @@ use super::ServerName;
 /// ```
 ///
 /// [event ID]: https://spec.matrix.org/v1.4/appendices/#room-ids-and-event-ids
+/// [room versions]: https://spec.matrix.org/v1.4/rooms/#complete-list-of-room-versions
 #[repr(transparent)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdZst)]
 #[ruma_id(validate = ruma_identifiers_validation::event_id::validate)]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -5,11 +5,12 @@ edition = "2021"
 publish = false
 
 [features]
-default = ["dep:isahc", "dep:semver", "dep:toml_edit"]
+default = ["dep:semver", "dep:toml_edit"]
 
 [dependencies]
 clap = { version = "4.0.18", features = ["derive"] }
-isahc = { version = "1.7.0", features = ["json"], optional = true }
+html5gum = "0.5.2"
+isahc = { version = "1.7.0", features = ["json"] }
 semver = { version = "1.0.6", features = ["serde"], optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
... and even found one that was not!

Sadly the IDs in the spec are not unique in the HTML source, so they are modified with JS. That means we need to make the same transformation locally to be sure that we can match them. Hopefully this wont break.

Closes #871.







<!-- Replace -->
----
Preview: https://pr-1474--ruma-docs.surge.sh
<!-- Replace -->
