### PR TITLE
push: Move `.m.rule.roomnotif` push rule before `.m.rule.tombstone`

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [unreleased]
 
+Bug fixes:
+
+- Move `.m.rule.roomnotif` push rule before `.m.rule.tombstone` in the server default push rules,
+  according to a spec clarification in Matrix 1.6
+
 Improvements:
 
 * Add `MatrixVersion::V1_6`

--- a/crates/ruma-common/src/push/predefined.rs
+++ b/crates/ruma-common/src/push/predefined.rs
@@ -27,9 +27,9 @@ impl Ruleset {
                 ConditionalPushRule::invite_for_me(user_id),
                 ConditionalPushRule::member_event(),
                 ConditionalPushRule::contains_display_name(),
+                ConditionalPushRule::roomnotif(),
                 ConditionalPushRule::tombstone(),
                 ConditionalPushRule::server_acl(),
-                ConditionalPushRule::roomnotif(),
                 #[cfg(feature = "unstable-msc2677")]
                 ConditionalPushRule::reaction(),
             ]
@@ -390,16 +390,16 @@ pub enum PredefinedOverrideRuleId {
     /// `.m.rule.contains_display_name`
     ContainsDisplayName,
 
+    /// `.m.rule.roomnotif`
+    #[ruma_enum(rename = ".m.rule.roomnotif")]
+    RoomNotif,
+
     /// `.m.rule.tombstone`
     Tombstone,
 
     /// `.m.rule.room.server_acl`
     #[ruma_enum(rename = ".m.rule.room.server_acl")]
     RoomServerAcl,
-
-    /// `.m.rule.roomnotif`
-    #[ruma_enum(rename = ".m.rule.roomnotif")]
-    RoomNotif,
 
     /// `.m.rule.reaction`
     #[cfg(feature = "unstable-msc2677")]


### PR DESCRIPTION
According to a [spec clarification](https://github.com/matrix-org/matrix-spec/pull/1421) in Matrix 1.6.

Part of #1400.




<!-- Replace -->
----
Preview Removed
<!-- Replace -->
