### PR TITLE
docs: Don't use `since` with the `deprecated` attribute

### DIFF
--- a/crates/ruma-client-api/src/account/request_3pid_management_token_via_email.rs
+++ b/crates/ruma-client-api/src/account/request_3pid_management_token_via_email.rs
@@ -43,7 +43,7 @@ pub mod v3 {
 
         /// Optional identity server hostname and access token.
         #[serde(flatten, skip_serializing_if = "Option::is_none")]
-        #[deprecated(since = "0.6.0")]
+        #[deprecated = "Since Matrix Client-Server API r0.6.0."]
         pub identity_server_info: Option<IdentityServerInfo>,
     }
 

--- a/crates/ruma-client-api/src/account/request_3pid_management_token_via_msisdn.rs
+++ b/crates/ruma-client-api/src/account/request_3pid_management_token_via_msisdn.rs
@@ -46,7 +46,7 @@ pub mod v3 {
 
         /// Optional identity server hostname and access token.
         #[serde(flatten, skip_serializing_if = "Option::is_none")]
-        #[deprecated(since = "0.6.0")]
+        #[deprecated = "Since Matrix Client-Server API r0.6.0."]
         pub identity_server_info: Option<IdentityServerInfo>,
     }
 

--- a/crates/ruma-client-api/src/account/request_password_change_token_via_email.rs
+++ b/crates/ruma-client-api/src/account/request_password_change_token_via_email.rs
@@ -43,7 +43,7 @@ pub mod v3 {
 
         /// Optional identity server hostname and access token.
         #[serde(flatten, skip_serializing_if = "Option::is_none")]
-        #[deprecated(since = "0.6.0")]
+        #[deprecated = "Since Matrix Client-Server API r0.6.0."]
         pub identity_server_info: Option<IdentityServerInfo>,
     }
 

--- a/crates/ruma-client-api/src/account/request_registration_token_via_email.rs
+++ b/crates/ruma-client-api/src/account/request_registration_token_via_email.rs
@@ -43,7 +43,7 @@ pub mod v3 {
 
         /// Optional identity server hostname and access token.
         #[serde(flatten, skip_serializing_if = "Option::is_none")]
-        #[deprecated(since = "0.6.0")]
+        #[deprecated = "Since Matrix Client-Server API r0.6.0."]
         pub identity_server_info: Option<IdentityServerInfo>,
     }
 

--- a/crates/ruma-client-api/src/account/request_registration_token_via_msisdn.rs
+++ b/crates/ruma-client-api/src/account/request_registration_token_via_msisdn.rs
@@ -46,7 +46,7 @@ pub mod v3 {
 
         /// Optional identity server hostname and access token.
         #[serde(flatten, skip_serializing_if = "Option::is_none")]
-        #[deprecated(since = "0.6.0")]
+        #[deprecated = "Since Matrix Client-Server API r0.6.0."]
         pub identity_server_info: Option<IdentityServerInfo>,
     }
 

--- a/crates/ruma-client-api/src/session/login.rs
+++ b/crates/ruma-client-api/src/session/login.rs
@@ -68,7 +68,10 @@ pub mod v3 {
 
         /// The hostname of the homeserver on which the account has been registered.
         #[serde(skip_serializing_if = "Option::is_none")]
-        #[deprecated = "Clients should instead use the `user_id.server_name()` method if they require it."]
+        #[deprecated = "\
+            Since Matrix Client-Server API r0.4.0. Clients should instead use the \
+            `user_id.server_name()` method if they require it.\
+        "]
         pub home_server: Option<OwnedServerName>,
 
         /// ID of the logged-in device.


### PR DESCRIPTION
It can be confusing as this is usually used for the crate version, while it is used here for the Matrix spec version. Also by default clippy expects a version that respects semver, which is not compatible with the Matrix spec.







<!-- Replace -->
----
Preview Removed
<!-- Replace -->
