### PR TITLE
docs: Migrate spec links to v1.6

### DIFF
--- a/crates/ruma-client-api/src/membership/invite_user.rs
+++ b/crates/ruma-client-api/src/membership/invite_user.rs
@@ -9,8 +9,8 @@ pub mod v3 {
     //! [by their Matrix identifier][spec-mxid], and one to invite a user
     //! [by their third party identifier][spec-3pid].
     //!
-    //! [spec-mxid]: https://spec.matrix.org/v1.5/client-server-api/#post_matrixclientv3roomsroomidinvite
-    //! [spec-3pid]: https://spec.matrix.org/v1.5/client-server-api/#post_matrixclientv3roomsroomidinvite-1
+    //! [spec-mxid]: https://spec.matrix.org/v1.6/client-server-api/#post_matrixclientv3roomsroomidinvite
+    //! [spec-3pid]: https://spec.matrix.org/v1.6/client-server-api/#post_matrixclientv3roomsroomidinvite-1
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-common/src/push/condition.rs
+++ b/crates/ruma-common/src/push/condition.rs
@@ -590,7 +590,7 @@ mod tests {
         assert!(!"m".matches_word("[[:alpha:]]?"));
         assert!("[[:alpha:]]!".matches_word("[[:alpha:]]?"));
 
-        // From the spec: <https://spec.matrix.org/v1.5/client-server-api/#conditions-1>
+        // From the spec: <https://spec.matrix.org/v1.6/client-server-api/#conditions-1>
         assert!("An example event.".matches_word("ex*ple"));
         assert!("exple".matches_word("ex*ple"));
         assert!("An exciting triple-whammy".matches_word("ex*ple"));
@@ -639,7 +639,7 @@ mod tests {
         assert!("".matches_pattern("*", false));
         assert!(!"foo".matches_pattern("", false));
 
-        // From the spec: <https://spec.matrix.org/v1.5/client-server-api/#conditions-1>
+        // From the spec: <https://spec.matrix.org/v1.6/client-server-api/#conditions-1>
         assert!("Lunch plans".matches_pattern("lunc?*", false));
         assert!("LUNCH".matches_pattern("lunc?*", false));
         assert!(!" lunch".matches_pattern("lunc?*", false));

--- a/crates/ruma-identifiers-validation/src/error.rs
+++ b/crates/ruma-identifiers-validation/src/error.rs
@@ -77,7 +77,7 @@ pub enum MxcUriError {
     /// Media identifier malformed due to invalid characters detected.
     ///
     /// Valid characters are (in regex notation) `[A-Za-z0-9_-]+`.
-    /// See [here](https://spec.matrix.org/v1.5/client-server-api/#security-considerations-5) for more details.
+    /// See [here](https://spec.matrix.org/v1.6/client-server-api/#security-considerations-5) for more details.
     #[error("Media Identifier malformed, invalid characters")]
     MediaIdMalformed,
 

--- a/crates/ruma-identifiers-validation/src/mxc_uri.rs
+++ b/crates/ruma-identifiers-validation/src/mxc_uri.rs
@@ -17,7 +17,7 @@ pub fn validate(uri: &str) -> Result<NonZeroU8, MxcUriError> {
 
     let server_name = &uri[..index];
     let media_id = &uri[index + 1..];
-    // See: https://spec.matrix.org/v1.5/client-server-api/#security-considerations-5
+    // See: https://spec.matrix.org/v1.6/client-server-api/#security-considerations-5
     let media_id_is_valid =
         media_id.bytes().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'z' | b'A'..=b'Z' | b'-' ));
 


### PR DESCRIPTION
It's easier when there are only a few links to check manually :smile: 




<!-- Replace -->
----
Preview Removed
<!-- Replace -->
