### PR TITLE
events: Remove the serde alias for the `blurhash` field in events

### DIFF
--- a/crates/ruma-common/src/events/room.rs
+++ b/crates/ruma-common/src/events/room.rs
@@ -106,11 +106,7 @@ pub struct ImageInfo {
     /// This uses the unstable prefix in
     /// [MSC2448](https://github.com/matrix-org/matrix-spec-proposals/pull/2448).
     #[cfg(feature = "unstable-msc2448")]
-    #[serde(
-        rename = "xyz.amorgan.blurhash",
-        alias = "blurhash",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(rename = "xyz.amorgan.blurhash", skip_serializing_if = "Option::is_none")]
     pub blurhash: Option<String>,
 }
 

--- a/crates/ruma-common/src/events/room/avatar.rs
+++ b/crates/ruma-common/src/events/room/avatar.rs
@@ -66,11 +66,7 @@ pub struct ImageInfo {
     /// This uses the unstable prefix in
     /// [MSC2448](https://github.com/matrix-org/matrix-spec-proposals/pull/2448).
     #[cfg(feature = "unstable-msc2448")]
-    #[serde(
-        rename = "xyz.amorgan.blurhash",
-        alias = "blurhash",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(rename = "xyz.amorgan.blurhash", skip_serializing_if = "Option::is_none")]
     pub blurhash: Option<String>,
 }
 

--- a/crates/ruma-common/src/events/room/member.rs
+++ b/crates/ruma-common/src/events/room/member.rs
@@ -89,11 +89,7 @@ pub struct RoomMemberEventContent {
     /// This uses the unstable prefix in
     /// [MSC2448](https://github.com/matrix-org/matrix-spec-proposals/pull/2448).
     #[cfg(feature = "unstable-msc2448")]
-    #[serde(
-        rename = "xyz.amorgan.blurhash",
-        alias = "blurhash",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(rename = "xyz.amorgan.blurhash", skip_serializing_if = "Option::is_none")]
     pub blurhash: Option<String>,
 
     /// User-supplied text for why their membership has changed.


### PR DESCRIPTION
Some clients send both the stable and unstable version so deserialization fails:

```
Error deserializing event Error("duplicate field `xyz.amorgan.blurhash`", line: 1, column: 258)
```

Related to #1266.




<!-- Replace -->
----
Preview Removed
<!-- Replace -->
