### PR TITLE
client-api: Don't serialize `None` as `null` in `report_content`

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [unreleased]
 
+Bug fixes:
+
+- Don't serialize `None` as `null` in `report_content::v3::Request`
+
 # 0.16.1
 
 Improvements:

--- a/crates/ruma-client-api/src/room/report_content.rs
+++ b/crates/ruma-client-api/src/room/report_content.rs
@@ -35,11 +35,13 @@ pub mod v3 {
         pub event_id: OwnedEventId,
 
         /// Integer between -100 and 0 rating offensivness.
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub score: Option<Int>,
 
         /// Reason to report content.
         ///
         /// May be blank.
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub reason: Option<String>,
     }
 


### PR DESCRIPTION








<!-- Replace -->
----
Preview Removed
<!-- Replace -->
