### PR TITLE
signatures: Skip keys which don't split so other keys can be used

### DIFF
--- a/crates/ruma-signatures/src/functions.rs
+++ b/crates/ruma-signatures/src/functions.rs
@@ -588,7 +588,7 @@ pub fn verify_event(
             // Since only ed25519 is supported right now, we don't actually need to check what the
             // algorithm is. If it split successfully, it's ed25519.
             if split_id(key_id).is_err() {
-                break;
+                continue;
             }
 
             if let Some(signature) = signature_set.get(key_id) {


### PR DESCRIPTION
Rejected keys must not terminate the loop to preclude other keys which would not be rejected.