### PR TITLE
signatures: Relax key version string character constraints.

### DIFF
--- a/crates/ruma-signatures/src/lib.rs
+++ b/crates/ruma-signatures/src/lib.rs
@@ -83,12 +83,6 @@ fn split_id(id: &str) -> Result<(Algorithm, String), Error> {
         return Err(Error::InvalidLength(signature_id_length));
     }
 
-    let version = signature_id[1];
-
-    if !version.bytes().all(|ch| ch.is_ascii_alphanumeric() || ch == b'_') {
-        return Err(Error::InvalidVersion(version.into()));
-    }
-
     let algorithm_input = signature_id[0];
 
     let algorithm = match algorithm_input {


### PR DESCRIPTION
The specification offers no such constraint for the characters permitted in the key version identifier.