### PR TITLE
client-api: Add convenience constructors for enabling lazy-loading in filters

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [unreleased]
 
+Improvements:
+
+- Add convenience constructors for enabling lazy-loading in filters 
+
 # 0.16.2
 
 Bug fixes:

--- a/crates/ruma-client-api/src/filter.rs
+++ b/crates/ruma-client-api/src/filter.rs
@@ -117,6 +117,18 @@ impl RoomEventFilter {
         Self { types: Some(vec![]), ..Default::default() }
     }
 
+    /// Creates a new `RoomEventFilter` with [room member lazy-loading] enabled.
+    ///
+    /// Redundant membership events are disabled.
+    ///
+    /// [room member lazy-loading]: https://spec.matrix.org/latest/client-server-api/#lazy-loading-room-members
+    pub fn with_lazy_loading() -> Self {
+        Self {
+            lazy_load_options: LazyLoadOptions::Enabled { include_redundant_members: false },
+            ..Default::default()
+        }
+    }
+
     /// Returns `true` if all fields are empty.
     pub fn is_empty(&self) -> bool {
         self.not_types.is_empty()
@@ -186,6 +198,15 @@ impl RoomFilter {
     /// Creates a new `RoomFilter` that can be used to ignore all room events (of any type).
     pub fn ignore_all() -> Self {
         Self { rooms: Some(vec![]), ..Default::default() }
+    }
+
+    /// Creates a new `RoomFilter` with [room member lazy-loading] enabled.
+    ///
+    /// Redundant membership events are disabled.
+    ///
+    /// [room member lazy-loading]: https://spec.matrix.org/latest/client-server-api/#lazy-loading-room-members
+    pub fn with_lazy_loading() -> Self {
+        Self { state: RoomEventFilter::with_lazy_loading(), ..Default::default() }
     }
 
     /// Returns `true` if all fields are empty.
@@ -309,6 +330,15 @@ impl FilterDefinition {
             presence: Filter::ignore_all(),
             ..Default::default()
         }
+    }
+
+    /// Creates a new `FilterDefinition` with [room member lazy-loading] enabled.
+    ///
+    /// Redundant membership events are disabled.
+    ///
+    /// [room member lazy-loading]: https://spec.matrix.org/latest/client-server-api/#lazy-loading-room-members
+    pub fn with_lazy_loading() -> Self {
+        Self { room: RoomFilter::with_lazy_loading(), ..Default::default() }
     }
 
     /// Returns `true` if all fields are empty.


### PR DESCRIPTION
Since it's a well-defined and common feature (even required for faster joins).







<!-- Replace -->
----
Preview: https://pr-1493--ruma-docs.surge.sh
<!-- Replace -->
