### PR TITLE
events: Add method to construct `RoomEncryptionEventContent` with the recommended defaults

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -12,6 +12,7 @@ Improvements:
   - To remove a user-defined push rule
 - Add `AsRef<[u8]>` implementations for identifier types
 - Add `InitialStateEvent::{new, to_raw, to_raw_any}`
+- Add a convenience method to construct `RoomEncryptionEventContent` with the recommended defaults.
 
 # 0.11.3
 

--- a/crates/ruma-common/src/events/room/encryption.rs
+++ b/crates/ruma-common/src/events/room/encryption.rs
@@ -2,7 +2,7 @@
 //!
 //! [`m.room.encryption`]: https://spec.matrix.org/latest/client-server-api/#mroomencryption
 
-use js_int::UInt;
+use js_int::{uint, UInt};
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
@@ -37,5 +37,18 @@ impl RoomEncryptionEventContent {
     /// Creates a new `RoomEncryptionEventContent` with the given algorithm.
     pub fn new(algorithm: EventEncryptionAlgorithm) -> Self {
         Self { algorithm, rotation_period_ms: None, rotation_period_msgs: None }
+    }
+
+    /// Creates a new `RoomEncryptionEventContent` with the mandatory algorithm and the recommended
+    /// defaults.
+    ///
+    /// Note that changing the values of the fields is not a breaking change and you shouldn't rely
+    /// on those specific values.
+    pub fn with_recommended_defaults() -> Self {
+        Self {
+            algorithm: EventEncryptionAlgorithm::MegolmV1AesSha2,
+            rotation_period_ms: Some(uint!(604_800_000)),
+            rotation_period_msgs: Some(uint!(100)),
+        }
     }
 }


### PR DESCRIPTION
As a convenience for clients.







<!-- Replace -->
----
Preview: https://pr-1497--ruma-docs.surge.sh
<!-- Replace -->
