### PR TITLE
ci: Pin rust nightly for clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,9 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          # FIXME: Remove pinning when clippy lint with clap issue is solved
+          # See https://github.com/clap-rs/clap/issues/4733
+          toolchain: nightly-2023-02-25
           override: true
 
       - uses: Swatinem/rust-cache@v1
@@ -208,7 +210,9 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          # FIXME: Remove pinning when clippy lint with clap issue is solved
+          # See https://github.com/clap-rs/clap/issues/4733
+          toolchain: nightly-2023-02-25
           override: true
           components: ${{ matrix.components }}
 

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -10,7 +10,9 @@ mod spec_links;
 use spec_links::check_spec_links;
 
 const MSRV: &str = "1.64";
-const NIGHTLY: &str = "nightly";
+// FIXME: Remove pinning when clippy lint with clap issue is solved
+// See https://github.com/clap-rs/clap/issues/4733
+const NIGHTLY: &str = "nightly-2023-02-25";
 
 #[derive(Args)]
 pub struct CiArgs {


### PR DESCRIPTION
To work around lint issue with clap




<!-- Replace -->
----
Preview: https://pr-1499--ruma-docs.surge.sh
<!-- Replace -->
