### PR TITLE
ci: Bump clap and unpin Rust nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          # FIXME: Remove pinning when clippy lint with clap issue is solved
-          # See https://github.com/clap-rs/clap/issues/4733
-          toolchain: nightly-2023-02-25
+          toolchain: nightly
           override: true
 
       - uses: Swatinem/rust-cache@v1
@@ -210,9 +208,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          # FIXME: Remove pinning when clippy lint with clap issue is solved
-          # See https://github.com/clap-rs/clap/issues/4733
-          toolchain: nightly-2023-02-25
+          toolchain: nightly
           override: true
           components: ${{ matrix.components }}
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 default = ["dep:semver", "dep:toml_edit"]
 
 [dependencies]
-clap = { version = "4.0.18", features = ["derive"] }
+clap = { version = "4.1.8", features = ["derive"] }
 html5gum = "0.5.2"
 isahc = { version = "1.7.0", features = ["json"] }
 semver = { version = "1.0.6", features = ["serde"], optional = true }

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -10,9 +10,7 @@ mod spec_links;
 use spec_links::check_spec_links;
 
 const MSRV: &str = "1.64";
-// FIXME: Remove pinning when clippy lint with clap issue is solved
-// See https://github.com/clap-rs/clap/issues/4733
-const NIGHTLY: &str = "nightly-2023-02-25";
+const NIGHTLY: &str = "nightly";
 
 #[derive(Args)]
 pub struct CiArgs {


### PR DESCRIPTION
The issue has been fixed and released.

The reason that `allow` wasn't working was because the derive macro was adding a `deny` in the generated code…




<!-- Replace -->
----
Preview Removed
<!-- Replace -->
