### PR TITLE
feat(ruma-client-api): Add missing `sync::sync_events::v4::Response::txn_id` field

### DIFF
--- a/crates/ruma-client-api/src/sync/sync_events/v4.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v4.rs
@@ -97,6 +97,10 @@ pub struct Response {
     #[serde(default, skip_serializing_if = "ruma_common::serde::is_default")]
     pub initial: bool,
 
+    /// Matches the `txn_id` sent by the request. Please see [`Request::txn_id`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub txn_id: Option<String>,
+
     /// The token to supply in the `pos` param of the next `/sync` request.
     pub pos: String,
 
@@ -142,6 +146,7 @@ impl Response {
     pub fn new(pos: String) -> Self {
         Self {
             initial: Default::default(),
+            txn_id: None,
             pos,
             delta_token: Default::default(),
             lists: Default::default(),


### PR DESCRIPTION
In the [specification], if the request contains a `txn_id` value, the response must echo the same `txn_id`. Unfortunately, this field is missing from `sync::sync_events::v4::Response::txn_id`. This patch addresses that problem by adding the missing field.

[specification]: https://github.com/matrix-org/matrix-spec-proposals/blob/89cf0341b5fac4311839bed4b90070faae14de91/proposals/3575-sync.md

<!-- Replace -->
----
Preview Removed
<!-- Replace -->
