### PR TITLE
signatures: Prevent accepting events without at least one valid signature

### DIFF
--- a/crates/ruma-signatures/CHANGELOG.md
+++ b/crates/ruma-signatures/CHANGELOG.md
@@ -1,8 +1,8 @@
 # [unreleased]
 
-Improvements:
+Bug fixes:
 
-* Ignore keys with unknown algorithms in `verify_events`
+- Ignore keys with unknown algorithms in `verify_events`
 
 # 0.13.1
 

--- a/crates/ruma-signatures/CHANGELOG.md
+++ b/crates/ruma-signatures/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [unreleased]
 
+Improvements:
+
+* Ignore keys with unknown algorithms in `verify_events`
+
 # 0.13.1
 
 No changes for this version

--- a/crates/ruma-signatures/src/functions.rs
+++ b/crates/ruma-signatures/src/functions.rs
@@ -1158,7 +1158,7 @@ mod tests {
     }
 
     fn add_key_to_map(public_key_map: &mut PublicKeyMap, name: &str, pair: &Ed25519KeyPair) {
-        let sender_key_map = public_key_map.entry(name.to_string()).or_default();
+        let sender_key_map = public_key_map.entry(name.to_owned()).or_default();
         let encoded_public_key = Base64::new(pair.public_key().to_owned());
         let version = ServerSigningKeyId::from_parts(
             SigningKeyAlgorithm::Ed25519,
@@ -1173,7 +1173,7 @@ mod tests {
         name: &str,
         pair: &Ed25519KeyPair,
     ) {
-        let sender_key_map = public_key_map.entry(name.to_string()).or_default();
+        let sender_key_map = public_key_map.entry(name.to_owned()).or_default();
         let encoded_public_key = Base64::new(pair.public_key().to_owned());
         let version = ServerSigningKeyId::from_parts(
             SigningKeyAlgorithm::from("an-unknown-algorithm"),


### PR DESCRIPTION
`verify_event` has been [recently changed](https://github.com/ruma/ruma/pull/1496) to be more aligned with the spec. In the previous algorithm, it returned an error if the event was not signed by at least one of the required entities.

The new algorithm is iterating over all the signatures for the required entities *and* skipping unknown algorithms. If an event is signed only by unknown algorithms, the event would be accepted and not verifications will happen. In order to prevent that, we check that, at least, a single key was used to verify the event. Specifically, this covers the 2nd point in: https://spec.matrix.org/v1.6/appendices/#checking-for-a-signature

A few more test cases were added:

- The event is properly signed, but key map contains a key with an unknown algorithm. Under this circumstances, the event should be allowed.
- An event signed by multiple keys for an entity, should verify all those signatures
- An event signed by a single key with an unkown algorithm by the required entity, should fail

<!-- Replace -->
----
Preview Removed
<!-- Replace -->
