### PR TITLE
sliding-sync receipts: use the right EDU type in the map

### DIFF
--- a/crates/ruma-client-api/src/sync/sync_events/v4.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v4.rs
@@ -11,8 +11,8 @@ use js_int::UInt;
 use ruma_common::{
     api::{request, response, Metadata},
     events::{
-        AnyEphemeralRoomEvent, AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent,
-        AnyStrippedStateEvent, AnySyncEphemeralRoomEvent, AnySyncStateEvent, AnySyncTimelineEvent,
+        receipt::SyncReceiptEvent, typing::SyncTypingEvent, AnyGlobalAccountDataEvent,
+        AnyRoomAccountDataEvent, AnyStrippedStateEvent, AnySyncStateEvent, AnySyncTimelineEvent,
         AnyToDeviceEvent, StateEventType,
     },
     metadata,
@@ -644,7 +644,7 @@ pub struct ReceiptsConfig {
 pub struct Receipts {
     /// The ephemeral receipt room event for each room
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub rooms: BTreeMap<OwnedRoomId, Raw<AnySyncEphemeralRoomEvent>>,
+    pub rooms: BTreeMap<OwnedRoomId, Raw<SyncReceiptEvent>>,
 }
 
 /// Typing extension configuration.
@@ -668,5 +668,5 @@ pub struct TypingConfig {
 pub struct Typing {
     /// The empheral typing event for each room
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub rooms: BTreeMap<OwnedRoomId, Raw<AnyEphemeralRoomEvent>>,
+    pub rooms: BTreeMap<OwnedRoomId, Raw<SyncTypingEvent>>,
 }

--- a/crates/ruma-client-api/src/sync/sync_events/v4.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v4.rs
@@ -12,8 +12,8 @@ use ruma_common::{
     api::{request, response, Metadata},
     events::{
         AnyEphemeralRoomEvent, AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent,
-        AnyStrippedStateEvent, AnySyncStateEvent, AnySyncTimelineEvent, AnyToDeviceEvent,
-        StateEventType,
+        AnyStrippedStateEvent, AnySyncEphemeralRoomEvent, AnySyncStateEvent, AnySyncTimelineEvent,
+        AnyToDeviceEvent, StateEventType,
     },
     metadata,
     serde::{duration::opt_ms, Raw},

--- a/crates/ruma-client-api/src/sync/sync_events/v4.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v4.rs
@@ -642,9 +642,9 @@ pub struct ReceiptsConfig {
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct Receipts {
-    /// The empheral receipt room event for each room
+    /// The ephemeral receipt room event for each room
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub rooms: BTreeMap<OwnedRoomId, Raw<AnyEphemeralRoomEvent>>,
+    pub rooms: BTreeMap<OwnedRoomId, Raw<AnySyncEphemeralRoomEvent>>,
 }
 
 /// Typing extension configuration.


### PR DESCRIPTION
As these objects do not have a `room_id` field.

<!-- Replace -->
----
Preview Removed
<!-- Replace -->
