### PR TITLE
events: Add utility functions for InitialStateEvent

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -11,6 +11,7 @@ Improvements:
   - To update the server-default push rules
   - To remove a user-defined push rule
 - Add `AsRef<[u8]>` implementations for identifier types
+- Add `InitialStateEvent::{new, to_raw, to_raw_any}`
 
 # 0.11.3
 


### PR DESCRIPTION
I think this is the only kind of "event" that's created client-side. If there are others, we should add the same helpers there.

<!-- Replace -->
----
Preview Removed
<!-- Replace -->
