### PR TITLE
client-api: Fix type of `rank` in `search::search_events::v3::SearchResult`

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [unreleased]
 
+Breaking changes:
+
+- Define `rank` as an `Option<f64>` instead of an `Option<UInt>` in
+  `search::search_events::v3::SearchResult`
+
 Improvements:
 
 - Add convenience constructors for enabling lazy-loading in filters 

--- a/crates/ruma-client-api/src/search/search_events.rs
+++ b/crates/ruma-client-api/src/search/search_events.rs
@@ -435,7 +435,7 @@ pub mod v3 {
         ///
         /// Higher is closer.
         #[serde(skip_serializing_if = "Option::is_none")]
-        pub rank: Option<UInt>,
+        pub rank: Option<f64>,
 
         /// The event that matched.
         #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
It is [defined in the spec](https://spec.matrix.org/v1.6/client-server-api/#_matrixclientv3search_result) as a number, not an integer.




<!-- Replace -->
----
Preview: https://pr-1509--ruma-docs.surge.sh
<!-- Replace -->
