### PR TITLE
push: Enable by default `.m.rule.tombstone` push rule

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [unreleased]
 
+Bug fixes:
+
+- Set the predefined server-default `.m.rule.tombstone` push rule as enabled by default, as defined
+  in the spec.
+
 Breaking changes:
 
 - Make `in_reply_to` field of `Thread` optional

--- a/crates/ruma-common/src/push/predefined.rs
+++ b/crates/ruma-common/src/push/predefined.rs
@@ -202,7 +202,7 @@ impl ConditionalPushRule {
         Self {
             actions: vec![Notify, SetTweak(Tweak::Highlight(true))],
             default: true,
-            enabled: false,
+            enabled: true,
             rule_id: PredefinedOverrideRuleId::Tombstone.to_string(),
             conditions: vec![
                 EventMatch { key: "type".into(), pattern: "m.room.tombstone".into() },


### PR DESCRIPTION
As defined in the spec.




<!-- Replace -->
----
Preview: https://pr-1516--ruma-docs.surge.sh
<!-- Replace -->
