### PR TITLE
feat(client-api): Support `bump_event_types` in `sync::sync_events::v4::Request`

### DIFF
--- a/crates/ruma-client-api/src/sync/sync_events/v4.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v4.rs
@@ -13,7 +13,7 @@ use ruma_common::{
     events::{
         receipt::SyncReceiptEvent, typing::SyncTypingEvent, AnyGlobalAccountDataEvent,
         AnyRoomAccountDataEvent, AnyStrippedStateEvent, AnySyncStateEvent, AnySyncTimelineEvent,
-        AnyToDeviceEvent, StateEventType,
+        AnyToDeviceEvent, StateEventType, TimelineEventType,
     },
     metadata,
     serde::{duration::opt_ms, Raw},
@@ -75,6 +75,16 @@ pub struct Request {
     /// name.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub lists: BTreeMap<String, SyncRequestList>,
+
+    /// An allow-list of event types which should be considered recent activity when sorting
+    /// `by_recency`. By omitting event types from this field, clients can ensure that
+    /// uninteresting events (e.g. a profil rename) do not cause a room to jump to the top of its
+    /// list(s). Empty or omitted `bump_event_types` have no effect; all events in a room will be
+    /// considered recent activity.
+    ///
+    /// This is currently per-connection, not per-list. Sticky.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub bump_event_types: Vec<TimelineEventType>,
 
     /// Specific rooms and event types that we want to receive events from.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]

--- a/crates/ruma-state-res/src/lib.rs
+++ b/crates/ruma-state-res/src/lib.rs
@@ -1149,7 +1149,7 @@ mod tests {
         .map(|ev| (ev.event_type().with_state_key(ev.state_key().unwrap()), ev.event_id.clone()))
         .collect::<StateMap<_>>();
 
-        let ev_map = store.0.clone();
+        let ev_map = &store.0;
         let state_sets = [state_set_a, state_set_b];
         let resolved = match crate::resolve(
             &RoomVersionId::V6,


### PR DESCRIPTION
This patch updates `sync::sync_events::v4::Request` to add the new `bump_event_types` field, as described in [MSC3575] (more precisely in this [diff]).

That's the first step to address https://github.com/matrix-org/matrix-rust-sdk/issues/1728.

[MSC3575]: https://github.com/matrix-org/matrix-spec-proposals/blob/kegan/sync-v3/proposals/3575-sync.md
[diff]: https://github.com/matrix-org/matrix-spec-proposals/compare/35b79f6ebe80f9a36c0ccd1ddc47ab0ef3f4d78f...5bd13e66df73cfcf4a635094758ed86906b84a73#diff-1f7276cbbee4eeaaca06b07d2fe58312eab735259f2490e28e04710dde77fdccL78

<!-- Replace -->
----
Preview Removed
<!-- Replace -->
