### PR TITLE
Use escaped dotted-paths

### DIFF
--- a/crates/ruma-client-api/src/filter.rs
+++ b/crates/ruma-client-api/src/filter.rs
@@ -289,8 +289,8 @@ pub struct FilterDefinition {
     ///
     /// If this list is absent then all fields are included. The entries may include '.' characters
     /// to indicate sub-fields. So ['content.body'] will include the 'body' field of the 'content'
-    /// object. A literal '.' character in a field name may be escaped using a '\'. A server may
-    /// include more fields than were requested.
+    /// object. A literal '.' or '\' character in a field name may be escaped using a '\'. A server
+    /// may include more fields than were requested.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub event_fields: Option<Vec<String>>,
 

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -18,6 +18,7 @@ Improvements:
 - Add `AsRef<[u8]>` implementations for identifier types
 - Add `InitialStateEvent::{new, to_raw, to_raw_any}`
 - Add a convenience method to construct `RoomEncryptionEventContent` with the recommended defaults.
+- `PushCondition::EventMatch` and `FlattenedJson` now use escaped dotted paths, according to MSC3873
 
 # 0.11.3
 


### PR DESCRIPTION
According to [MSC3873](https://github.com/matrix-org/matrix-spec-proposals/pull/3873), [MSC3980](https://github.com/matrix-org/matrix-spec-proposals/pull/3980) and [Spec PR](https://github.com/matrix-org/matrix-spec/pull/1464).

I'm not placing it behind a feature flag because it's an improvement that shouldn't break much things in principle (it breaks nothing from the spec) and it has already been merged to the spec.




<!-- Replace -->
----
Preview Removed
<!-- Replace -->
