### PR TITLE
client-api: Remove `token` from `keys::get_keys::Request`

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -4,6 +4,7 @@ Breaking changes:
 
 - Define `rank` as an `Option<f64>` instead of an `Option<UInt>` in
   `search::search_events::v3::SearchResult`
+- Remove the `token` field from `keys::get_keys::Request`, according to a spec clarification.
 
 Improvements:
 

--- a/crates/ruma-client-api/src/keys/get_keys.rs
+++ b/crates/ruma-client-api/src/keys/get_keys.rs
@@ -46,15 +46,6 @@ pub mod v3 {
         ///
         /// An empty list indicates all devices for the corresponding user.
         pub device_keys: BTreeMap<OwnedUserId, Vec<OwnedDeviceId>>,
-
-        /// If the client is fetching keys as a result of a device update received in a sync
-        /// request, this should be the 'since' token of that sync request, or any later sync
-        /// token.
-        ///
-        /// This allows the server to ensure its response contains the keys advertised by the
-        /// notification in that sync.
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub token: Option<String>,
     }
 
     /// Response type for the `get_keys` endpoint.


### PR DESCRIPTION
According to a spec clarification: [spec PR](https://github.com/matrix-org/matrix-spec/pull/1485).




<!-- Replace -->
----
Preview Removed
<!-- Replace -->
