### PR TITLE
push: Use bytes Regex to allow to match invalid UTF-8

### DIFF
--- a/crates/ruma-common/src/push/condition.rs
+++ b/crates/ruma-common/src/push/condition.rs
@@ -1,7 +1,7 @@
 use std::{collections::BTreeMap, ops::RangeBounds, str::FromStr};
 
 use js_int::{Int, UInt};
-use regex::Regex;
+use regex::bytes::Regex;
 #[cfg(feature = "unstable-msc3931")]
 use ruma_macros::StringEnum;
 use serde::{Deserialize, Serialize};
@@ -392,7 +392,7 @@ impl StrExt for str {
             // The word characters in ASCII compatible mode (with the `-u` flag) match the
             // definition in the spec: any character not in the set `[A-Za-z0-9_]`.
             let regex = format!(r"(?-u:^|\W|\b){}(?-u:\b|\W|$)", chunks.concat());
-            Regex::new(&regex).ok().filter(|re| re.is_match(self)).is_some()
+            Regex::new(&regex).ok().filter(|re| re.is_match(self.as_bytes())).is_some()
         } else {
             match self.find(pattern) {
                 Some(start) => {

--- a/crates/ruma-common/src/push/condition.rs
+++ b/crates/ruma-common/src/push/condition.rs
@@ -392,7 +392,8 @@ impl StrExt for str {
             // The word characters in ASCII compatible mode (with the `-u` flag) match the
             // definition in the spec: any character not in the set `[A-Za-z0-9_]`.
             let regex = format!(r"(?-u:^|\W|\b){}(?-u:\b|\W|$)", chunks.concat());
-            Regex::new(&regex).ok().filter(|re| re.is_match(self.as_bytes())).is_some()
+            let re = Regex::new(&regex).expect("regex construction should succeed");
+            re.is_match(self.as_bytes())
         } else {
             match self.find(pattern) {
                 Some(start) => {


### PR DESCRIPTION
Due to a new error detected in the regex crate.

The matrix spec definition only cares about ASCII characters so we have to enforce it as well.







<!-- Replace -->
----
Preview Removed
<!-- Replace -->
