### PR TITLE
events: Implement `sanitize` on `MessageType`

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -31,6 +31,7 @@ Improvements:
   - `user_can_send_message`
   - `user_can_send_state`
   - `user_can_trigger_room_notification`
+- Add `MessageType::sanitize` behind the `unstable-sanitize` feature
 
 # 0.11.3
 


### PR DESCRIPTION
This is needed for the SDK (we don't keep the `RoomMessageEventContent`).







<!-- Replace -->
----
Preview: https://pr-1539--ruma-docs.surge.sh
<!-- Replace -->
