### PR TITLE
chore: Work around new rustfmt bug

### DIFF
--- a/crates/ruma-common/src/api/metadata.rs
+++ b/crates/ruma-common/src/api/metadata.rs
@@ -651,7 +651,7 @@ impl MatrixVersion {
     /// Get the default [`RoomVersionId`] for this `MatrixVersion`.
     pub fn default_room_version(&self) -> RoomVersionId {
         match self {
-            // <https://matrix.org/docs/spec/index.html#complete-list-of-room-versions>
+            // <https://spec.matrix.org/historical/index.html#complete-list-of-room-versions>
             MatrixVersion::V1_0
             // <https://spec.matrix.org/v1.1/rooms/#complete-list-of-room-versions>
             | MatrixVersion::V1_1

--- a/crates/ruma-common/tests/events/message.rs
+++ b/crates/ruma-common/tests/events/message.rs
@@ -129,6 +129,7 @@ fn markdown_content_serialization() {
 
 #[test]
 fn relates_to_content_serialization() {
+    #[rustfmt::skip] // rustfmt wants to merge the next two lines
     let message_event_content =
         assign!(MessageEventContent::plain("> <@test:example.com> test\n\ntest reply"), {
             relates_to: Some(Relation::Reply {

--- a/xtask/src/ci/spec_links.rs
+++ b/xtask/src/ci/spec_links.rs
@@ -123,7 +123,7 @@ fn check_whitelist(links: &[SpecLink]) -> Result<()> {
     for link in links {
         let url_without_prefix = &link.url[URL_PREFIX.len()..];
 
-        if url_without_prefix.starts_with(OLD_VERSION) {
+        if url_without_prefix.starts_with(&format!("{OLD_VERSION}/")) {
             // Only old spec links in the whitelist are allowed.
             if !OLD_URL_WHITELIST.contains(&link.url.as_str()) {
                 err_nb += 1;
@@ -131,7 +131,7 @@ fn check_whitelist(links: &[SpecLink]) -> Result<()> {
             }
         } else if !NEW_VERSION_WHITELIST
             .iter()
-            .any(|version| url_without_prefix.starts_with(version))
+            .any(|version| url_without_prefix.starts_with(&format!("{version}/")))
         {
             err_nb += 1;
             print_link_err("New spec link with wrong version", link);


### PR DESCRIPTION
Apparently it wants to merge the two lines (see CI in #1542).

This is the same workaround that was applied in the SDK.








<!-- Replace -->
----
Preview: https://pr-1543--ruma-docs.surge.sh
<!-- Replace -->
