### PR TITLE
push: Add support for intentional mentions push rules 

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -42,6 +42,7 @@ Improvements:
 - Add `MessageType::sanitize` behind the `unstable-sanitize` feature
 - Add `MatrixVersion::V1_7`
 - Stabilize support for annotations and reactions (MSC2677 / Matrix 1.7)
+- Add support for intentional mentions push rules (MSC3952 / Matrix 1.7)
 
 # 0.11.3
 


### PR DESCRIPTION
This is the simplest part of intentional mentions.

[Spec PR](https://github.com/matrix-org/matrix-spec/pull/1508)\
[MSC3952](https://github.com/matrix-org/matrix-spec-proposals/pull/3952)

I didn't use the unstable prefixes because we are very close to the release. We can just merge this when the release is out.
















<!-- Replace -->
----
Preview: https://pr-1550--ruma-docs.surge.sh
<!-- Replace -->
