### PR TITLE
events: Add support for `m.mentions` (intentional mentions) event property

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -20,8 +20,10 @@ Breaking changes:
   - Remove `SessionDescriptionType`, use a `String` instead. A clarification in MSC2746 / Matrix 1.7
     explains that the `type` field should not be validated but passed as-is to the WebRTC API. It
     also avoids an unnecessary conversion between the WebRTC API and the Ruma type.
-- The `reason` field in `CallHangupEventContent` is now required an defaults to `Reason::UserHangup`
+- The `reason` field in `CallHangupEventContent` is now required and defaults to `Reason::UserHangup`
   (MSC2746 / Matrix 1.7)
+- The `Replacement` relation for `RoomMessageEventContent` now takes a
+  `RoomMessageEventContentWithoutRelation` instead of a `MessageType`
 
 Improvements:
 
@@ -50,6 +52,7 @@ Improvements:
 - Stabilize support for VoIP signalling improvements (MSC2746 / Matrix 1.7)
 - Make the generated and stripped plain text reply fallback behavior more compatible with most
   of the Matrix ecosystem.
+- Add support for intentional mentions according to MSC3952 / Matrix 1.7
 
 # 0.11.3
 

--- a/crates/ruma-common/src/events.rs
+++ b/crates/ruma-common/src/events.rs
@@ -102,9 +102,9 @@
 //! ));
 //! ```
 
-use serde::{de::IgnoredAny, Deserialize, Serializer};
+use serde::{de::IgnoredAny, Deserialize, Serialize, Serializer};
 
-use crate::{EventEncryptionAlgorithm, RoomVersionId};
+use crate::{EventEncryptionAlgorithm, OwnedUserId, RoomVersionId};
 
 // Needs to be public for trybuild tests
 #[doc(hidden)]
@@ -223,4 +223,38 @@ pub fn serialize_custom_event_error<T, S: Serializer>(_: &T, _: S) -> Result<S::
          To send custom events, turn them into `Raw<EnumType>` by going through
          `serde_json::value::to_raw_value` and `Raw::from_json`.",
     ))
+}
+
+/// Describes whether the event mentions other users or the room.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct Mentions {
+    /// The list of mentioned users.
+    ///
+    /// Defaults to an empty `Vec`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub user_ids: Vec<OwnedUserId>,
+
+    /// Whether the whole room is mentioned.
+    ///
+    /// Defaults to `false`.
+    #[serde(default, skip_serializing_if = "crate::serde::is_default")]
+    pub room: bool,
+}
+
+impl Mentions {
+    /// Create a `Mentions` with the default values.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create a `Mentions` for the given user IDs.
+    pub fn with_user_ids(user_ids: Vec<OwnedUserId>) -> Self {
+        Self { user_ids, ..Default::default() }
+    }
+
+    /// Create a `Mentions` for a room mention.
+    pub fn with_room_mention() -> Self {
+        Self { room: true, ..Default::default() }
+    }
 }

--- a/crates/ruma-common/tests/events/relations.rs
+++ b/crates/ruma-common/tests/events/relations.rs
@@ -107,7 +107,7 @@ fn replacement_deserialize() {
         })
     );
     assert_eq!(replacement.event_id, "$1598361704261elfgc");
-    assert_matches!(replacement.new_content, MessageType::Text(text));
+    assert_matches!(replacement.new_content.msgtype, MessageType::Text(text));
     assert_eq!(text.body, "Hello! My name is bar");
 }
 


### PR DESCRIPTION
According to [MSC3952](https://github.com/matrix-org/matrix-spec-proposals/pull/3952), [Spec PR](https://github.com/matrix-org/matrix-spec/pull/1508).

It doesn't use the unstable prefixes and should be merged after the release of Matrix 1.7.










<!-- Replace -->
----
Preview: https://pr-1551--ruma-docs.surge.sh
<!-- Replace -->
