### PR TITLE
Add support for media download redirects

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -10,6 +10,7 @@ Improvements:
 
 - Add convenience constructors for enabling lazy-loading in filters 
 - Add support for using an existing session to log in another (MSC3882 / Matrix 1.7)
+- Add support for media download redirects (MSC3860 / Matrix 1.7)
 
 # 0.16.2
 

--- a/crates/ruma-client-api/src/media/get_content.rs
+++ b/crates/ruma-client-api/src/media/get_content.rs
@@ -65,6 +65,14 @@ pub mod v3 {
             rename = "fi.mau.msc2246.max_stall_ms"
         )]
         pub timeout_ms: Duration,
+
+        /// Whether the server may return a 307 or 308 redirect response that points at the
+        /// relevant media content.
+        ///
+        /// Unless explicitly set to `true`, the server must return the media content itself.
+        #[ruma_api(query)]
+        #[serde(default, skip_serializing_if = "ruma_common::serde::is_default")]
+        pub allow_redirect: bool,
     }
 
     /// Response type for the `get_media_content` endpoint.
@@ -105,6 +113,7 @@ pub mod v3 {
                 allow_remote: true,
                 #[cfg(feature = "unstable-msc2246")]
                 timeout_ms: crate::media::default_download_timeout(),
+                allow_redirect: false,
             }
         }
 

--- a/crates/ruma-client-api/src/media/get_content_as_filename.rs
+++ b/crates/ruma-client-api/src/media/get_content_as_filename.rs
@@ -69,6 +69,14 @@ pub mod v3 {
             rename = "fi.mau.msc2246.max_stall_ms"
         )]
         pub timeout_ms: Duration,
+
+        /// Whether the server may return a 307 or 308 redirect response that points at the
+        /// relevant media content.
+        ///
+        /// Unless explicitly set to `true`, the server must return the media content itself.
+        #[ruma_api(query)]
+        #[serde(default, skip_serializing_if = "ruma_common::serde::is_default")]
+        pub allow_redirect: bool,
     }
 
     /// Response type for the `get_media_content_as_filename` endpoint.
@@ -110,6 +118,7 @@ pub mod v3 {
                 allow_remote: true,
                 #[cfg(feature = "unstable-msc2246")]
                 timeout_ms: crate::media::default_download_timeout(),
+                allow_redirect: false,
             }
         }
 

--- a/crates/ruma-client-api/src/media/get_content_thumbnail.rs
+++ b/crates/ruma-client-api/src/media/get_content_thumbnail.rs
@@ -85,6 +85,14 @@ pub mod v3 {
             rename = "fi.mau.msc2246.max_stall_ms"
         )]
         pub timeout_ms: Duration,
+
+        /// Whether the server may return a 307 or 308 redirect response that points at the
+        /// relevant media content.
+        ///
+        /// Unless explicitly set to `true`, the server must return the media content itself.
+        #[ruma_api(query)]
+        #[serde(default, skip_serializing_if = "ruma_common::serde::is_default")]
+        pub allow_redirect: bool,
     }
 
     /// Response type for the `get_content_thumbnail` endpoint.
@@ -125,6 +133,7 @@ pub mod v3 {
                 allow_remote: true,
                 #[cfg(feature = "unstable-msc2246")]
                 timeout_ms: crate::media::default_download_timeout(),
+                allow_redirect: false,
             }
         }
 


### PR DESCRIPTION
According to [MSC3860](https://github.com/matrix-org/matrix-spec-proposals/pull/3860), [spec PR](https://github.com/matrix-org/matrix-spec/pull/1529).

This doesn't use the unstable prefix and should be merged after the release of Matrix 1.7.







<!-- Replace -->
----
Preview Removed
<!-- Replace -->
