### PR TITLE
federation-api: Deprecate `v1/send_join` and `v1/send_leave`

### DIFF
--- a/crates/ruma-federation-api/CHANGELOG.md
+++ b/crates/ruma-federation-api/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [unreleased]
 
+Improvements:
+
+* Deprecate the `v1/send_join` and `v1/send_leave` endpoints according to a spec clarification
+
 # 0.7.1
 
 Improvements:

--- a/crates/ruma-federation-api/src/membership/create_join_event.rs
+++ b/crates/ruma-federation-api/src/membership/create_join_event.rs
@@ -2,5 +2,6 @@
 //!
 //! Send a join event to a resident server.
 
+#[deprecated = "Since Matrix Server-Server API r0.1.4. Use the v2 endpoint instead."]
 pub mod v1;
 pub mod v2;

--- a/crates/ruma-federation-api/src/membership/create_join_event/v1.rs
+++ b/crates/ruma-federation-api/src/membership/create_join_event/v1.rs
@@ -15,6 +15,7 @@ const METADATA: Metadata = metadata! {
     authentication: ServerSignatures,
     history: {
         1.0 => "/_matrix/federation/v1/send_join/:room_id/:event_id",
+        1.0 => deprecated,
     }
 };
 
@@ -109,6 +110,7 @@ impl RoomState {
     }
 }
 
+#[allow(deprecated)]
 #[cfg(all(test, feature = "server", not(feature = "unstable-unspecified")))]
 mod tests {
     use ruma_common::api::OutgoingResponse;

--- a/crates/ruma-federation-api/src/membership/create_join_event/v1.rs
+++ b/crates/ruma-federation-api/src/membership/create_join_event/v1.rs
@@ -109,24 +109,3 @@ impl RoomState {
         Self { auth_chain: Vec::new(), state: Vec::new(), event: None }
     }
 }
-
-#[allow(deprecated)]
-#[cfg(all(test, feature = "server", not(feature = "unstable-unspecified")))]
-mod tests {
-    use ruma_common::api::OutgoingResponse;
-    use serde_json::{from_slice as from_json_slice, json, Value as JsonValue};
-
-    use super::{Response, RoomState};
-
-    #[test]
-    fn response_body() {
-        let res = Response::new(RoomState::new("ORIGIN".to_owned()))
-            .try_into_http_response::<Vec<u8>>()
-            .unwrap();
-
-        assert_eq!(
-            from_json_slice::<JsonValue>(res.body()).unwrap(),
-            json!([200, { "auth_chain": [], "origin": "ORIGIN", "state": [] }])
-        );
-    }
-}

--- a/crates/ruma-federation-api/src/membership/create_leave_event.rs
+++ b/crates/ruma-federation-api/src/membership/create_leave_event.rs
@@ -2,5 +2,6 @@
 //!
 //! Submit a signed leave event to the receiving server for it to accept it into the room's graph.
 
+#[deprecated = "Since Matrix Server-Server API r0.1.4. Use the v2 endpoint instead."]
 pub mod v1;
 pub mod v2;

--- a/crates/ruma-federation-api/src/membership/create_leave_event/v1.rs
+++ b/crates/ruma-federation-api/src/membership/create_leave_event/v1.rs
@@ -18,6 +18,7 @@ const METADATA: Metadata = metadata! {
     authentication: ServerSignatures,
     history: {
         1.0 => "/_matrix/federation/v1/send_leave/:room_id/:event_id",
+        1.0 => deprecated,
     }
 };
 

--- a/crates/ruma-federation-api/src/serde/v1_pdu.rs
+++ b/crates/ruma-federation-api/src/serde/v1_pdu.rs
@@ -74,6 +74,7 @@ mod tests {
     use serde_json::json;
 
     use super::{deserialize, serialize};
+    #[allow(deprecated)]
     use crate::membership::create_join_event::v1::RoomState;
 
     #[test]
@@ -87,6 +88,7 @@ mod tests {
             }
         ]);
 
+        #[allow(deprecated)]
         let RoomState { origin, auth_chain, state, event } = deserialize(response).unwrap();
         assert_eq!(origin, "example.com");
         assert_matches!(auth_chain.as_slice(), []);
@@ -96,6 +98,7 @@ mod tests {
 
     #[test]
     fn serialize_response() {
+        #[allow(deprecated)]
         let room_state = RoomState {
             origin: "matrix.org".into(),
             auth_chain: Vec::new(),
@@ -121,6 +124,7 @@ mod tests {
     #[test]
     fn too_short_array() {
         let json = json!([200]);
+        #[allow(deprecated)]
         let failed_room_state = deserialize::<RoomState, _>(json);
         assert_eq!(
             failed_room_state.unwrap_err().to_string(),
@@ -135,6 +139,7 @@ mod tests {
             "auth_chain": [],
             "state": []
         });
+        #[allow(deprecated)]
         let failed_room_state = deserialize::<RoomState, _>(json);
 
         assert_eq!(
@@ -146,6 +151,7 @@ mod tests {
     #[test]
     fn too_long_array() {
         let json = json!([200, { "origin": "", "auth_chain": [], "state": [] }, 200]);
+        #[allow(deprecated)]
         let RoomState { origin, auth_chain, state, event } = deserialize(json).unwrap();
         assert_eq!(origin, "");
         assert_matches!(auth_chain.as_slice(), []);

--- a/crates/ruma-federation-api/tests/membership/create_join_event.rs
+++ b/crates/ruma-federation-api/tests/membership/create_join_event.rs
@@ -1,0 +1,19 @@
+#[allow(deprecated)]
+#[cfg(all(feature = "server", not(feature = "unstable-unspecified")))]
+mod v1 {
+    use ruma_common::api::OutgoingResponse;
+    use ruma_federation_api::membership::create_join_event::v1::{Response, RoomState};
+    use serde_json::{from_slice as from_json_slice, json, Value as JsonValue};
+
+    #[test]
+    fn response_body() {
+        let res = Response::new(RoomState::new("ORIGIN".to_owned()))
+            .try_into_http_response::<Vec<u8>>()
+            .unwrap();
+
+        assert_eq!(
+            from_json_slice::<JsonValue>(res.body()).unwrap(),
+            json!([200, { "auth_chain": [], "origin": "ORIGIN", "state": [] }])
+        );
+    }
+}

--- a/crates/ruma-federation-api/tests/membership/mod.rs
+++ b/crates/ruma-federation-api/tests/membership/mod.rs
@@ -1,0 +1,1 @@
+mod create_join_event;

--- a/crates/ruma-federation-api/tests/tests.rs
+++ b/crates/ruma-federation-api/tests/tests.rs
@@ -1,0 +1,1 @@
+mod membership;


### PR DESCRIPTION
According to a [spec clarification](https://github.com/matrix-org/matrix-spec/pull/1518).

This required to allow to declare an endpoint as both stable and deprecated in Matrix 1.0.








<!-- Replace -->
----
Preview: https://pr-1556--ruma-docs.surge.sh
<!-- Replace -->
