### PR TITLE
signatures: Remove `age_ts` from reference hash calculation

### DIFF
--- a/crates/ruma-signatures/CHANGELOG.md
+++ b/crates/ruma-signatures/CHANGELOG.md
@@ -4,6 +4,10 @@ Bug fixes:
 
 - Ignore keys with unknown algorithms in `verify_events`
 
+Improvements:
+
+- Remove `age_ts` from `REFERENCE_HASH_FIELDS_TO_REMOVE` according to a spec clarification
+
 # 0.13.1
 
 No changes for this version

--- a/crates/ruma-signatures/src/functions.rs
+++ b/crates/ruma-signatures/src/functions.rs
@@ -31,7 +31,7 @@ static CANONICAL_JSON_FIELDS_TO_REMOVE: &[&str] = &["signatures", "unsigned"];
 static CONTENT_HASH_FIELDS_TO_REMOVE: &[&str] = &["hashes", "signatures", "unsigned"];
 
 /// The fields to remove from a JSON object when creating a reference hash of an event.
-static REFERENCE_HASH_FIELDS_TO_REMOVE: &[&str] = &["age_ts", "signatures", "unsigned"];
+static REFERENCE_HASH_FIELDS_TO_REMOVE: &[&str] = &["signatures", "unsigned"];
 
 /// Signs an arbitrary JSON object and adds the signature to an object under the key `signatures`.
 ///


### PR DESCRIPTION
According to a [spec clarification](https://github.com/matrix-org/matrix-spec/pull/1536).

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->





<!-- Replace -->
----
Preview Removed
<!-- Replace -->
