### PR TITLE
client-api: Stabilize async media uploads

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -11,6 +11,7 @@ Improvements:
 - Add convenience constructors for enabling lazy-loading in filters 
 - Add support for using an existing session to log in another (MSC3882 / Matrix 1.7)
 - Add support for media download redirects (MSC3860 / Matrix 1.7)
+- Stabilize support for asynchronous media uploads (MSC2246 / Matrix 1.7)
 
 # 0.16.2
 

--- a/crates/ruma-client-api/Cargo.toml
+++ b/crates/ruma-client-api/Cargo.toml
@@ -34,7 +34,6 @@ compat-unset-avatar = []
 compat-get-3pids = []
 
 unstable-exhaustive-types = ["ruma-common/unstable-exhaustive-types"]
-unstable-msc2246 = []
 unstable-msc2666 = []
 unstable-msc2448 = []
 unstable-msc2654 = []

--- a/crates/ruma-client-api/src/error.rs
+++ b/crates/ruma-client-api/src/error.rs
@@ -154,12 +154,10 @@ pub enum ErrorKind {
     #[cfg(feature = "unstable-msc2677")]
     DuplicateAnnotation,
 
-    /// FI.MAU.MSC2246_NOT_YET_UPLOADED
-    #[cfg(feature = "unstable-msc2246")]
+    /// M_NOT_YET_UPLOADED
     NotYetUploaded,
 
-    /// FI.MAU.MSC2246_CANNOT_OVERWRITE_MEDIA
-    #[cfg(feature = "unstable-msc2246")]
+    /// M_CANNOT_OVERWRITE_MEDIA
     CannotOverwriteMedia,
 
     /// M_UNKNOWN_POS for sliding sync
@@ -215,10 +213,8 @@ impl AsRef<str> for ErrorKind {
             Self::BadAlias => "M_BAD_ALIAS",
             #[cfg(feature = "unstable-msc2677")]
             Self::DuplicateAnnotation => "M_DUPLICATE_ANNOTATION",
-            #[cfg(feature = "unstable-msc2246")]
-            Self::NotYetUploaded => "FI.MAU.MSC2246_NOT_YET_UPLOADED",
-            #[cfg(feature = "unstable-msc2246")]
-            Self::CannotOverwriteMedia => "FI.MAU.MSC2246_CANNOT_OVERWRITE_MEDIA",
+            Self::NotYetUploaded => "M_NOT_YET_UPLOADED",
+            Self::CannotOverwriteMedia => "M_CANNOT_OVERWRITE_MEDIA",
             #[cfg(feature = "unstable-msc3575")]
             Self::UnknownPos => "M_UNKNOWN_POS",
             Self::_Custom { errcode, .. } => &errcode.0,

--- a/crates/ruma-client-api/src/error/kind_serde.rs
+++ b/crates/ruma-client-api/src/error/kind_serde.rs
@@ -208,9 +208,7 @@ impl<'de> Visitor<'de> for ErrorKindVisitor {
             ErrCode::WeakPassword => ErrorKind::WeakPassword,
             #[cfg(feature = "unstable-msc2677")]
             ErrCode::DuplicateAnnotation => ErrorKind::DuplicateAnnotation,
-            #[cfg(feature = "unstable-msc2246")]
             ErrCode::NotYetUploaded => ErrorKind::NotYetUploaded,
-            #[cfg(feature = "unstable-msc2246")]
             ErrCode::CannotOverwriteMedia => ErrorKind::CannotOverwriteMedia,
             #[cfg(feature = "unstable-msc3575")]
             ErrCode::UnknownPos => ErrorKind::UnknownPos,
@@ -257,14 +255,9 @@ enum ErrCode {
     WeakPassword,
     #[cfg(feature = "unstable-msc2677")]
     DuplicateAnnotation,
-    #[cfg(feature = "unstable-msc2246")]
-    #[ruma_enum(rename = "FI.MAU.MSC2246_NOT_YET_UPLOADED", alias = "M_NOT_YET_UPLOADED")]
+    #[ruma_enum(alias = "FI.MAU.MSC2246_NOT_YET_UPLOADED")]
     NotYetUploaded,
-    #[cfg(feature = "unstable-msc2246")]
-    #[ruma_enum(
-        rename = "FI.MAU.MSC2246_CANNOT_OVERWRITE_MEDIA",
-        alias = "M_CANNOT_OVERWRITE_MEDIA"
-    )]
+    #[ruma_enum(alias = "FI.MAU.MSC2246_CANNOT_OVERWRITE_MEDIA")]
     CannotOverwriteMedia,
     #[cfg(feature = "unstable-msc3575")]
     UnknownPos,

--- a/crates/ruma-client-api/src/media.rs
+++ b/crates/ruma-client-api/src/media.rs
@@ -1,12 +1,9 @@
 //! Endpoints for the media repository.
 
-#[cfg(feature = "unstable-msc2246")]
 use std::time::Duration;
 
 pub mod create_content;
-#[cfg(feature = "unstable-msc2246")]
 pub mod create_content_async;
-#[cfg(feature = "unstable-msc2246")]
 pub mod create_mxc_uri;
 pub mod get_content;
 pub mod get_content_as_filename;
@@ -15,14 +12,12 @@ pub mod get_media_config;
 pub mod get_media_preview;
 
 /// The default duration that the client should be willing to wait to start receiving data.
-#[cfg(feature = "unstable-msc2246")]
 fn default_download_timeout() -> Duration {
     Duration::from_secs(20)
 }
 
 /// Whether the given duration is the default duration that the client should be willing to wait to
 /// start receiving data.
-#[cfg(feature = "unstable-msc2246")]
 fn is_default_download_timeout(timeout: &Duration) -> bool {
     timeout.as_secs() == 20
 }

--- a/crates/ruma-client-api/src/media/create_content_async.rs
+++ b/crates/ruma-client-api/src/media/create_content_async.rs
@@ -2,10 +2,10 @@
 //!
 //! Upload media to an MXC URI that was created with create_mxc_uri.
 
-pub mod unstable {
-    //! `/unstable/` ([spec])
+pub mod v3 {
+    //! `/v3/` ([spec])
     //!
-    //! [spec]: https://github.com/tulir/matrix-doc/blob/asynchronous_uploads/proposals/2246-asynchronous-uploads.md
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixmediav3uploadservernamemediaid
 
     use http::header::CONTENT_TYPE;
     use ruma_common::{
@@ -19,6 +19,7 @@ pub mod unstable {
         authentication: AccessToken,
         history: {
             unstable => "/_matrix/media/unstable/fi.mau.msc2246/upload/:server_name/:media_id",
+            1.7 => "/_matrix/media/v3/upload/:server_name/:media_id",
         }
     };
 

--- a/crates/ruma-client-api/src/media/create_mxc_uri.rs
+++ b/crates/ruma-client-api/src/media/create_mxc_uri.rs
@@ -2,10 +2,10 @@
 //!
 //! Create an MXC URI without content.
 
-pub mod unstable {
-    //! `/unstable/` ([spec])
+pub mod v1 {
+    //! `/v1/` ([spec])
     //!
-    //! [spec]: https://github.com/tulir/matrix-doc/blob/asynchronous_uploads/proposals/2246-asynchronous-uploads.md
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixmediav1create
 
     use ruma_common::{
         api::{request, response, Metadata},
@@ -18,6 +18,7 @@ pub mod unstable {
         authentication: AccessToken,
         history: {
             unstable => "/_matrix/media/unstable/fi.mau.msc2246/create",
+            1.7 => "/_matrix/media/v1/create",
         }
     };
 

--- a/crates/ruma-client-api/src/media/get_content.rs
+++ b/crates/ruma-client-api/src/media/get_content.rs
@@ -7,7 +7,6 @@ pub mod v3 {
     //!
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixmediav3downloadservernamemediaid
 
-    #[cfg(feature = "unstable-msc2246")]
     use std::time::Duration;
 
     use http::header::{CONTENT_DISPOSITION, CONTENT_TYPE};
@@ -53,16 +52,11 @@ pub mod v3 {
         /// case that the content has not yet been uploaded.
         ///
         /// The default value is 20 seconds.
-        ///
-        /// This uses the unstable prefix in
-        /// [MSC2246](https://github.com/matrix-org/matrix-spec-proposals/pull/2246).
         #[ruma_api(query)]
-        #[cfg(feature = "unstable-msc2246")]
         #[serde(
             with = "ruma_common::serde::duration::ms",
             default = "crate::media::default_download_timeout",
-            skip_serializing_if = "crate::media::is_default_download_timeout",
-            rename = "fi.mau.msc2246.max_stall_ms"
+            skip_serializing_if = "crate::media::is_default_download_timeout"
         )]
         pub timeout_ms: Duration,
 
@@ -111,7 +105,6 @@ pub mod v3 {
                 media_id,
                 server_name,
                 allow_remote: true,
-                #[cfg(feature = "unstable-msc2246")]
                 timeout_ms: crate::media::default_download_timeout(),
                 allow_redirect: false,
             }

--- a/crates/ruma-client-api/src/media/get_content_as_filename.rs
+++ b/crates/ruma-client-api/src/media/get_content_as_filename.rs
@@ -7,7 +7,6 @@ pub mod v3 {
     //!
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixmediav3downloadservernamemediaidfilename
 
-    #[cfg(feature = "unstable-msc2246")]
     use std::time::Duration;
 
     use http::header::{CONTENT_DISPOSITION, CONTENT_TYPE};
@@ -57,16 +56,11 @@ pub mod v3 {
         /// case that the content has not yet been uploaded.
         ///
         /// The default value is 20 seconds.
-        ///
-        /// This uses the unstable prefix in
-        /// [MSC2246](https://github.com/matrix-org/matrix-spec-proposals/pull/2246).
         #[ruma_api(query)]
-        #[cfg(feature = "unstable-msc2246")]
         #[serde(
             with = "ruma_common::serde::duration::ms",
             default = "crate::media::default_download_timeout",
-            skip_serializing_if = "crate::media::is_default_download_timeout",
-            rename = "fi.mau.msc2246.max_stall_ms"
+            skip_serializing_if = "crate::media::is_default_download_timeout"
         )]
         pub timeout_ms: Duration,
 
@@ -116,7 +110,6 @@ pub mod v3 {
                 server_name,
                 filename,
                 allow_remote: true,
-                #[cfg(feature = "unstable-msc2246")]
                 timeout_ms: crate::media::default_download_timeout(),
                 allow_redirect: false,
             }

--- a/crates/ruma-client-api/src/media/get_content_thumbnail.rs
+++ b/crates/ruma-client-api/src/media/get_content_thumbnail.rs
@@ -7,7 +7,6 @@ pub mod v3 {
     //!
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixmediav3thumbnailservernamemediaid
 
-    #[cfg(feature = "unstable-msc2246")]
     use std::time::Duration;
 
     use http::header::CONTENT_TYPE;
@@ -73,16 +72,11 @@ pub mod v3 {
         /// case that the content has not yet been uploaded.
         ///
         /// The default value is 20 seconds.
-        ///
-        /// This uses the unstable prefix in
-        /// [MSC2246](https://github.com/matrix-org/matrix-spec-proposals/pull/2246).
         #[ruma_api(query)]
-        #[cfg(feature = "unstable-msc2246")]
         #[serde(
             with = "ruma_common::serde::duration::ms",
             default = "crate::media::default_download_timeout",
-            skip_serializing_if = "crate::media::is_default_download_timeout",
-            rename = "fi.mau.msc2246.max_stall_ms"
+            skip_serializing_if = "crate::media::is_default_download_timeout"
         )]
         pub timeout_ms: Duration,
 
@@ -131,7 +125,6 @@ pub mod v3 {
                 width,
                 height,
                 allow_remote: true,
-                #[cfg(feature = "unstable-msc2246")]
                 timeout_ms: crate::media::default_download_timeout(),
                 allow_redirect: false,
             }

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -148,7 +148,6 @@ unstable-extensible-events = [
     "unstable-msc3955",
 ]
 unstable-msc1767 = ["ruma-common/unstable-msc1767"]
-unstable-msc2246 = ["ruma-client-api?/unstable-msc2246"]
 unstable-msc2409 = ["ruma-appservice-api?/unstable-msc2409"]
 unstable-msc2448 = [
     "ruma-client-api?/unstable-msc2448",
@@ -203,7 +202,6 @@ __ci = [
     "unstable-unspecified",
     "unstable-sanitize",
     "unstable-msc1767",
-    "unstable-msc2246",
     "unstable-msc2409",
     "unstable-msc2448",
     "unstable-msc2654",


### PR DESCRIPTION
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->





<!-- Replace -->
----
Preview Removed
<!-- Replace -->
