### PR TITLE
sync v4: add `lists` and `rooms` to most extensions' request configurations

### DIFF
--- a/crates/ruma-client-api/src/sync/sync_events/v4.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v4.rs
@@ -569,6 +569,24 @@ pub struct ToDeviceConfig {
     /// Give messages since this token only.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub since: Option<String>,
+
+    /// List of list names for which to-device events should be enabled.
+    ///
+    /// If not defined, will be enabled for *all* the lists appearing in the request.
+    /// If defined and empty, will be disabled for all the lists.
+    ///
+    /// Sticky.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lists: Option<Vec<String>>,
+
+    /// List of room names for which to-device events should be enabled.
+    ///
+    /// If not defined, will be enabled for *all* the rooms appearing in the `room_subscriptions`.
+    /// If defined and empty, will be disabled for all the rooms.
+    ///
+    /// Sticky.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rooms: Option<Vec<OwnedRoomId>>,
 }
 
 impl ToDeviceConfig {
@@ -655,6 +673,28 @@ pub struct AccountDataConfig {
     /// Activate or deactivate this extension. Sticky.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
+
+    /// List of list names for which account data should be enabled.
+    ///
+    /// This is specific to room account data (e.g. user-defined room tags).
+    ///
+    /// If not defined, will be enabled for *all* the lists appearing in the request.
+    /// If defined and empty, will be disabled for all the lists.
+    ///
+    /// Sticky.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lists: Option<Vec<String>>,
+
+    /// List of room names for which account data should be enabled.
+    ///
+    /// This is specific to room account data (e.g. user-defined room tags).
+    ///
+    /// If not defined, will be enabled for *all* the rooms appearing in the `room_subscriptions`.
+    /// If defined and empty, will be disabled for all the rooms.
+    ///
+    /// Sticky.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rooms: Option<Vec<OwnedRoomId>>,
 }
 
 impl AccountDataConfig {
@@ -696,6 +736,24 @@ pub struct ReceiptsConfig {
     /// Activate or deactivate this extension. Sticky.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
+
+    /// List of list names for which receipts should be enabled.
+    ///
+    /// If not defined, will be enabled for *all* the lists appearing in the request.
+    /// If defined and empty, will be disabled for all the lists.
+    ///
+    /// Sticky.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lists: Option<Vec<String>>,
+
+    /// List of room names for which receipts should be enabled.
+    ///
+    /// If not defined, will be enabled for *all* the rooms appearing in the `room_subscriptions`.
+    /// If defined and empty, will be disabled for all the rooms.
+    ///
+    /// Sticky.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rooms: Option<Vec<OwnedRoomId>>,
 }
 
 impl ReceiptsConfig {
@@ -733,6 +791,24 @@ pub struct TypingConfig {
     /// Activate or deactivate this extension. Sticky.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
+
+    /// List of list names for which typing notifications should be enabled.
+    ///
+    /// If not defined, will be enabled for *all* the lists appearing in the request.
+    /// If defined and empty, will be disabled for all the lists.
+    ///
+    /// Sticky.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lists: Option<Vec<String>>,
+
+    /// List of room names for which typing notifications should be enabled.
+    ///
+    /// If not defined, will be enabled for *all* the rooms appearing in the `room_subscriptions`.
+    /// If defined and empty, will be disabled for all the rooms.
+    ///
+    /// Sticky.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rooms: Option<Vec<OwnedRoomId>>,
 }
 
 impl TypingConfig {


### PR DESCRIPTION
Following [a clarification from the spec](https://github.com/matrix-org/matrix-spec-proposals/commit/30e31c8c50c1e69c7794540ba4090814087a06dc), it turns out that most extensions can enable the `lists` / `rooms` parameters to only enable the extensions for a subset of the entire request.

An implementation alternative would have been to add a `CommonExtensionConfig` field that contained `enabled: bool, lists: ..., rooms :...` and then use it as a field in most extensions, with a `#[serde(flatten)]` annotation. It's a bit less direct to manipulate, as a API user, so I've not done that, but no strong opinions here.

<!-- Replace -->
----
Preview Removed
<!-- Replace -->
