### PR TITLE
Some cleanup

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,6 +6,7 @@ crates-io = "https://docs.rs/"
 
 [target.'cfg(all())']
 rustflags = [
+    "-Wprivate_in_public",
     "-Wrust_2018_idioms",
     "-Wsemicolon_in_expressions_from_macros",
     "-Wunused_import_braces",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Check spelling
-        uses: crate-ci/typos@v1.14.8
+        uses: crate-ci/typos@v1.15.0
 
       - name: Install cargo-sort
         uses: taiki-e/cache-cargo-install-action@v1

--- a/crates/ruma-client-api/src/backup/get_backup_info.rs
+++ b/crates/ruma-client-api/src/backup/get_backup_info.rs
@@ -64,7 +64,7 @@ pub mod v3 {
     }
 
     impl Response {
-        /// Creates a new `Response` with the gien algorithm, key count, etag and version.
+        /// Creates a new `Response` with the given algorithm, key count, etag and version.
         pub fn new(
             algorithm: Raw<BackupAlgorithm>,
             count: UInt,

--- a/crates/ruma-common/src/events/room/encrypted/relation_serde.rs
+++ b/crates/ruma-common/src/events/room/encrypted/relation_serde.rs
@@ -104,19 +104,19 @@ impl RelatesToJsonRepr {
 #[derive(Clone, Deserialize, Serialize)]
 struct ThreadStableJsonRepr {
     /// The ID of the root message in the thread.
-    pub event_id: OwnedEventId,
+    event_id: OwnedEventId,
 
     /// Whether the `m.in_reply_to` field is a fallback for older clients or a real reply in a
     /// thread.
     #[serde(default, skip_serializing_if = "ruma_common::serde::is_default")]
-    pub is_falling_back: bool,
+    is_falling_back: bool,
 }
 
 /// A thread relation without the reply fallback, with unstable names.
 #[derive(Clone, Deserialize, Serialize)]
 struct ThreadUnstableJsonRepr {
     /// The ID of the root message in the thread.
-    pub event_id: OwnedEventId,
+    event_id: OwnedEventId,
 
     /// Whether the `m.in_reply_to` field is a fallback for older clients or a real reply in a
     /// thread.
@@ -125,7 +125,7 @@ struct ThreadUnstableJsonRepr {
         default,
         skip_serializing_if = "ruma_common::serde::is_default"
     )]
-    pub is_falling_back: bool,
+    is_falling_back: bool,
 }
 
 /// A relation, which associates new information to an existing event.

--- a/crates/ruma-common/src/events/room/message/sanitize/html_fragment.rs
+++ b/crates/ruma-common/src/events/room/message/sanitize/html_fragment.rs
@@ -13,7 +13,7 @@ use tracing::debug;
 ///
 /// To get the serialized HTML, use its `Display` implementation.
 #[derive(Debug)]
-pub struct Fragment {
+pub(crate) struct Fragment {
     pub nodes: Vec<Node>,
 }
 
@@ -265,7 +265,7 @@ impl fmt::Display for Fragment {
 
 /// An HTML node.
 #[derive(Debug)]
-pub struct Node {
+pub(crate) struct Node {
     pub parent: Option<usize>,
     pub prev_sibling: Option<usize>,
     pub next_sibling: Option<usize>,
@@ -353,7 +353,7 @@ impl Node {
 
 /// The data of a `Node`.
 #[derive(Debug)]
-pub enum NodeData {
+pub(crate) enum NodeData {
     /// The root node of the `Fragment`.
     Document,
 
@@ -369,7 +369,7 @@ pub enum NodeData {
 
 /// The data of an HTML element.
 #[derive(Debug)]
-pub struct ElementData {
+pub(crate) struct ElementData {
     /// The qualified name of the element.
     pub name: QualName,
 

--- a/crates/ruma-common/src/events/room/message/sanitize/html_sanitizer.rs
+++ b/crates/ruma-common/src/events/room/message/sanitize/html_sanitizer.rs
@@ -11,7 +11,7 @@ use super::{
 ///
 /// [HTML tags and attributes]: https://spec.matrix.org/latest/client-server-api/#mroommessage-msgtypes
 #[derive(Debug, Clone)]
-pub struct HtmlSanitizer {
+pub(crate) struct HtmlSanitizer {
     /// The mode of the HTML sanitizer.
     mode: HtmlSanitizerMode,
 

--- a/crates/ruma-common/src/serde/base64.rs
+++ b/crates/ruma-common/src/serde/base64.rs
@@ -63,7 +63,7 @@ impl<C: Base64Config, B> Base64<C, B> {
 }
 
 impl<C: Base64Config, B: AsRef<[u8]>> Base64<C, B> {
-    /// Create a `Base64` instance from raw bytes, to be base64-encoded in serialialization.
+    /// Create a `Base64` instance from raw bytes, to be base64-encoded in serialization.
     pub fn new(bytes: B) -> Self {
         Self { bytes, _phantom_conf: PhantomData }
     }

--- a/crates/ruma-identity-service-api/src/association/bind_3pid.rs
+++ b/crates/ruma-identity-service-api/src/association/bind_3pid.rs
@@ -58,7 +58,7 @@ pub mod v2 {
         /// The UNIX timestamp at which the association was verified.
         pub ts: MilliSecondsSinceUnixEpoch,
 
-        /// The signatures of the verifiying identity servers which show that the
+        /// The signatures of the verifying identity servers which show that the
         /// association should be trusted, if you trust the verifying identity services.
         pub signatures: ServerSignatures,
     }


### PR DESCRIPTION
The second and third commit were done based on `unreachable_pub` lint warnings, however [that lint is very noisy right now](https://github.com/rust-lang/rust/issues/112615) and not activated permanently because of that.





<!-- Replace -->
----
Preview Removed
<!-- Replace -->
