### PR TITLE
Clippy fixes

### DIFF
--- a/crates/ruma-common/src/events/room.rs
+++ b/crates/ruma-common/src/events/room.rs
@@ -2,9 +2,6 @@
 //!
 //! This module also contains types shared by events in its child namespaces.
 
-// https://github.com/rust-lang/rust-clippy/issues/9111
-#![allow(clippy::needless_borrow)]
-
 use std::collections::BTreeMap;
 
 use js_int::UInt;

--- a/crates/ruma-common/src/events/room/encrypted/relation_serde.rs
+++ b/crates/ruma-common/src/events/room/encrypted/relation_serde.rs
@@ -43,7 +43,6 @@ impl Serialize for Relation {
     where
         S: Serializer,
     {
-        #[allow(clippy::needless_update)]
         let relates_to = match self {
             Relation::Annotation(r) => RelatesToJsonRepr {
                 relation: Some(RelationJsonRepr::Annotation(r.clone())),
@@ -67,7 +66,6 @@ impl Serialize for Relation {
                         event_id: event_id.clone(),
                         is_falling_back: *is_falling_back,
                     })),
-                    ..Default::default()
                 }
             }
             Relation::_Custom => RelatesToJsonRepr::default(),

--- a/crates/ruma-common/src/events/room/message/relation_serde.rs
+++ b/crates/ruma-common/src/events/room/message/relation_serde.rs
@@ -68,7 +68,6 @@ where
     where
         S: Serializer,
     {
-        #[allow(clippy::needless_update)]
         let json_repr = match self {
             Relation::Reply { in_reply_to } => {
                 EventWithRelatesToJsonRepr::<C>::new(RelatesToJsonRepr {
@@ -94,7 +93,6 @@ where
                         event_id: event_id.clone(),
                         is_falling_back: *is_falling_back,
                     })),
-                    ..Default::default()
                 })
             }
             Relation::_Custom => EventWithRelatesToJsonRepr::<C>::default(),

--- a/crates/ruma-common/src/events/room/name.rs
+++ b/crates/ruma-common/src/events/room/name.rs
@@ -39,7 +39,7 @@ mod tests {
     fn serialization_with_optional_fields_as_none() {
         let content = RoomNameEventContent { name: Some("The room name".to_owned()) };
 
-        let actual = to_json_value(&content).unwrap();
+        let actual = to_json_value(content).unwrap();
         let expected = json!({
             "name": "The room name",
         });
@@ -51,7 +51,7 @@ mod tests {
     fn serialization_with_all_fields() {
         let content = RoomNameEventContent { name: Some("The room name".to_owned()) };
 
-        let actual = to_json_value(&content).unwrap();
+        let actual = to_json_value(content).unwrap();
         let expected = json!({
             "name": "The room name",
         });


### PR DESCRIPTION
The issue for the first commit was closed : https://github.com/rust-lang/rust-clippy/issues/9111, and removing the `allow` only triggers sane linting errors now.

For the second commit, I'm not sure if it was a false positive before because there is no link to an issue, but it doesn't look like the code at the time of commit https://github.com/ruma/ruma/commit/401c0b07b34b336ff13c04dfb855f47e2bf655d9 should have triggered the lint. Now it seems to only trigger rightfully.




<!-- Replace -->
----
Preview Removed
<!-- Replace -->
