### PR TITLE
events: Keep data of unknown relations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ ruma-push-gateway-api = { version = "0.7.1", path = "crates/ruma-push-gateway-ap
 ruma-signatures = { version = "0.13.1", path = "crates/ruma-signatures" }
 ruma-server-util = { version = "0.1.1", path = "crates/ruma-server-util" }
 ruma-state-res = { version = "0.9.1", path = "crates/ruma-state-res" }
-serde = { version = "1.0.147", features = ["derive"] }
+serde = { version = "1.0.164", features = ["derive"] }
 serde_html_form = "0.2.0"
 serde_json = "1.0.87"
 thiserror = "1.0.37"

--- a/crates/ruma-common/src/events/room/encrypted/relation_serde.rs
+++ b/crates/ruma-common/src/events/room/encrypted/relation_serde.rs
@@ -1,151 +1,101 @@
-use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use serde::{de, ser::SerializeStruct, Deserialize, Deserializer, Serialize};
+use serde_json::{value::RawValue as RawJsonValue, Value as JsonValue};
 
-use super::{Annotation, InReplyTo, Reference, Relation, Replacement, Thread};
-use crate::OwnedEventId;
+use super::{InReplyTo, Relation, Thread};
+use crate::{
+    serde::{from_raw_json_value, JsonObject},
+    OwnedEventId,
+};
 
 impl<'de> Deserialize<'de> for Relation {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
-        let relates_to = RelatesToJsonRepr::deserialize(deserializer)?;
+        let json = Box::<RawJsonValue>::deserialize(deserializer)?;
 
-        if let Some(
-            RelationJsonRepr::ThreadStable(ThreadStableJsonRepr { event_id, is_falling_back })
-            | RelationJsonRepr::ThreadUnstable(ThreadUnstableJsonRepr { event_id, is_falling_back }),
-        ) = relates_to.relation
-        {
-            let in_reply_to = relates_to.in_reply_to;
-            return Ok(Relation::Thread(Thread { event_id, in_reply_to, is_falling_back }));
-        }
-        let rel = if let Some(in_reply_to) = relates_to.in_reply_to {
-            Relation::Reply { in_reply_to }
-        } else if let Some(relation) = relates_to.relation {
-            match relation {
-                RelationJsonRepr::Annotation(a) => Relation::Annotation(a),
-                RelationJsonRepr::Reference(r) => Relation::Reference(r),
-                RelationJsonRepr::Replacement(Replacement { event_id }) => {
-                    Relation::Replacement(Replacement { event_id })
-                }
-                RelationJsonRepr::ThreadStable(_) | RelationJsonRepr::ThreadUnstable(_) => {
-                    unreachable!()
-                }
-                // FIXME: Maybe we should log this, though at this point we don't even have
-                // access to the rel_type of the unknown relation.
-                RelationJsonRepr::Unknown => Relation::_Custom,
+        let RelationDeHelper { in_reply_to, rel_type } = from_raw_json_value(&json)?;
+
+        let rel = match (in_reply_to, rel_type.as_deref()) {
+            (None, None) => return Err(de::Error::missing_field("m.in_reply_to or rel_type")),
+            (_, Some("m.thread")) => Relation::Thread(from_raw_json_value(&json)?),
+            (in_reply_to, Some("io.element.thread")) => {
+                let ThreadUnstableDeHelper { event_id, is_falling_back } =
+                    from_raw_json_value(&json)?;
+                Relation::Thread(Thread { event_id, in_reply_to, is_falling_back })
             }
-        } else {
-            return Err(de::Error::missing_field("m.in_reply_to or rel_type"));
+            (_, Some("m.annotation")) => Relation::Annotation(from_raw_json_value(&json)?),
+            (_, Some("m.reference")) => Relation::Reference(from_raw_json_value(&json)?),
+            (_, Some("m.replace")) => Relation::Replacement(from_raw_json_value(&json)?),
+            (Some(in_reply_to), _) => Relation::Reply { in_reply_to },
+            _ => Relation::_Custom(from_raw_json_value(&json)?),
         };
 
         Ok(rel)
     }
 }
 
-impl Serialize for Relation {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let relates_to = match self {
-            Relation::Annotation(r) => RelatesToJsonRepr {
-                relation: Some(RelationJsonRepr::Annotation(r.clone())),
-                ..Default::default()
-            },
-            Relation::Reference(r) => RelatesToJsonRepr {
-                relation: Some(RelationJsonRepr::Reference(r.clone())),
-                ..Default::default()
-            },
-            Relation::Replacement(r) => RelatesToJsonRepr {
-                relation: Some(RelationJsonRepr::Replacement(r.clone())),
-                ..Default::default()
-            },
-            Relation::Reply { in_reply_to } => {
-                RelatesToJsonRepr { in_reply_to: Some(in_reply_to.clone()), ..Default::default() }
-            }
-            Relation::Thread(Thread { event_id, in_reply_to, is_falling_back }) => {
-                RelatesToJsonRepr {
-                    in_reply_to: in_reply_to.clone(),
-                    relation: Some(RelationJsonRepr::ThreadStable(ThreadStableJsonRepr {
-                        event_id: event_id.clone(),
-                        is_falling_back: *is_falling_back,
-                    })),
-                }
-            }
-            Relation::_Custom => RelatesToJsonRepr::default(),
-        };
-
-        relates_to.serialize(serializer)
-    }
-}
-
-/// Struct modeling the different ways relationships can be expressed in a `m.relates_to` field of
-/// an event.
-#[derive(Default, Deserialize, Serialize)]
-struct RelatesToJsonRepr {
-    #[serde(rename = "m.in_reply_to", skip_serializing_if = "Option::is_none")]
+#[derive(Default, Deserialize)]
+struct RelationDeHelper {
+    #[serde(rename = "m.in_reply_to")]
     in_reply_to: Option<InReplyTo>,
 
-    #[serde(flatten, skip_serializing_if = "Option::is_none")]
-    relation: Option<RelationJsonRepr>,
-}
-
-/// A thread relation without the reply fallback, with stable names.
-#[derive(Clone, Deserialize, Serialize)]
-struct ThreadStableJsonRepr {
-    /// The ID of the root message in the thread.
-    event_id: OwnedEventId,
-
-    /// Whether the `m.in_reply_to` field is a fallback for older clients or a real reply in a
-    /// thread.
-    #[serde(default, skip_serializing_if = "ruma_common::serde::is_default")]
-    is_falling_back: bool,
+    rel_type: Option<String>,
 }
 
 /// A thread relation without the reply fallback, with unstable names.
-#[derive(Clone, Deserialize, Serialize)]
-struct ThreadUnstableJsonRepr {
-    /// The ID of the root message in the thread.
+#[derive(Clone, Deserialize)]
+struct ThreadUnstableDeHelper {
     event_id: OwnedEventId,
 
-    /// Whether the `m.in_reply_to` field is a fallback for older clients or a real reply in a
-    /// thread.
-    #[serde(
-        rename = "io.element.show_reply",
-        default,
-        skip_serializing_if = "ruma_common::serde::is_default"
-    )]
+    #[serde(rename = "io.element.show_reply", default)]
     is_falling_back: bool,
 }
 
-/// A relation, which associates new information to an existing event.
-#[derive(Clone, Deserialize, Serialize)]
-#[serde(tag = "rel_type")]
-enum RelationJsonRepr {
-    /// An annotation to an event.
-    #[serde(rename = "m.annotation")]
-    Annotation(Annotation),
+impl Relation {
+    pub(super) fn serialize_data(&self) -> JsonObject {
+        match serde_json::to_value(self).expect("relation serialization to succeed") {
+            JsonValue::Object(mut obj) => {
+                obj.remove("rel_type");
+                obj
+            }
+            _ => panic!("all relations must serialize to objects"),
+        }
+    }
+}
 
-    /// A reference to another event.
-    #[serde(rename = "m.reference")]
-    Reference(Reference),
+impl Serialize for Relation {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Relation::Reply { in_reply_to } => {
+                let mut st = serializer.serialize_struct("Relation", 1)?;
+                st.serialize_field("m.in_reply_to", in_reply_to)?;
+                st.end()
+            }
+            Relation::Replacement(data) => {
+                RelationSerHelper { rel_type: "m.replace", data }.serialize(serializer)
+            }
+            Relation::Reference(data) => {
+                RelationSerHelper { rel_type: "m.reference", data }.serialize(serializer)
+            }
+            Relation::Annotation(data) => {
+                RelationSerHelper { rel_type: "m.annotation", data }.serialize(serializer)
+            }
+            Relation::Thread(data) => {
+                RelationSerHelper { rel_type: "m.thread", data }.serialize(serializer)
+            }
+            Relation::_Custom(c) => c.serialize(serializer),
+        }
+    }
+}
 
-    /// An event that replaces another event.
-    #[serde(rename = "m.replace")]
-    Replacement(Replacement),
+#[derive(Serialize)]
+struct RelationSerHelper<'a, T> {
+    rel_type: &'a str,
 
-    /// An event that belongs to a thread, with stable names.
-    #[serde(rename = "m.thread")]
-    ThreadStable(ThreadStableJsonRepr),
-
-    /// An event that belongs to a thread, with unstable names.
-    #[serde(rename = "io.element.thread")]
-    ThreadUnstable(ThreadUnstableJsonRepr),
-
-    /// An unknown relation type.
-    ///
-    /// Not available in the public API, but exists here so deserialization
-    /// doesn't fail with new / custom `rel_type`s.
-    #[serde(other)]
-    Unknown,
+    #[serde(flatten)]
+    data: &'a T,
 }

--- a/crates/ruma-common/src/events/room/message.rs
+++ b/crates/ruma-common/src/events/room/message.rs
@@ -9,9 +9,9 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
 use crate::{
-    events::relation::{InReplyTo, Replacement, Thread},
+    events::relation::{CustomRelation, InReplyTo, RelationType, Replacement, Thread},
     serde::{JsonObject, StringEnum},
-    OwnedEventId, PrivOwnedStr,
+    EventId, OwnedEventId, PrivOwnedStr,
 };
 
 mod audio;
@@ -648,7 +648,53 @@ pub enum Relation<C> {
     Thread(Thread),
 
     #[doc(hidden)]
-    _Custom,
+    _Custom(CustomRelation),
+}
+
+impl<C> Relation<C> {
+    /// The type of this `Relation`.
+    ///
+    /// Returns an `Option` because the `Reply` relation does not have a`rel_type` field.
+    pub fn rel_type(&self) -> Option<RelationType> {
+        match self {
+            Relation::Reply { .. } => None,
+            Relation::Replacement(_) => Some(RelationType::Replacement),
+            Relation::Thread(_) => Some(RelationType::Thread),
+            Relation::_Custom(c) => Some(c.rel_type.as_str().into()),
+        }
+    }
+
+    /// The ID of the event this relates to.
+    ///
+    /// This is the `event_id` field at the root of an `m.relates_to` object, except in the case of
+    /// a reply relation where it's the `event_id` field in the `m.in_reply_to` object.
+    pub fn event_id(&self) -> &EventId {
+        match self {
+            Relation::Reply { in_reply_to } => &in_reply_to.event_id,
+            Relation::Replacement(r) => &r.event_id,
+            Relation::Thread(t) => &t.event_id,
+            Relation::_Custom(c) => &c.event_id,
+        }
+    }
+
+    /// The associated data.
+    ///
+    /// The returned JSON object won't contain the `rel_type` field, use
+    /// [`.rel_type()`][Self::rel_type] to access it. It also won't contain data
+    /// outside of `m.relates_to` (e.g. `m.new_content` for `m.replace` relations).
+    ///
+    /// Prefer to use the public variants of `Relation` where possible; this method is meant to
+    /// be used for custom relations only.
+    pub fn data(&self) -> Cow<'_, JsonObject>
+    where
+        C: Clone,
+    {
+        if let Relation::_Custom(c) = self {
+            Cow::Borrowed(&c.data)
+        } else {
+            Cow::Owned(self.serialize_data())
+        }
+    }
 }
 
 /// The format for the formatted representation of a message body.

--- a/crates/ruma-common/src/events/room/message/relation_serde.rs
+++ b/crates/ruma-common/src/events/room/message/relation_serde.rs
@@ -1,7 +1,8 @@
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{de, Deserialize, Deserializer, Serialize};
+use serde_json::Value as JsonValue;
 
 use super::{InReplyTo, Relation, Replacement, Thread};
-use crate::OwnedEventId;
+use crate::{events::relation::CustomRelation, serde::JsonObject, OwnedEventId};
 
 /// Deserialize an event's `relates_to` field.
 ///
@@ -25,39 +26,39 @@ where
     D: Deserializer<'de>,
     C: Deserialize<'de>,
 {
-    let ev = EventWithRelatesToJsonRepr::deserialize(deserializer)?;
-
-    if let Some(
-        RelationJsonRepr::ThreadStable(ThreadStableJsonRepr { event_id, is_falling_back })
-        | RelationJsonRepr::ThreadUnstable(ThreadUnstableJsonRepr { event_id, is_falling_back }),
-    ) = ev.relates_to.relation
-    {
-        let in_reply_to = ev.relates_to.in_reply_to;
-        return Ok(Some(Relation::Thread(Thread { event_id, in_reply_to, is_falling_back })));
-    }
-
-    let rel = if let Some(in_reply_to) = ev.relates_to.in_reply_to {
-        Some(Relation::Reply { in_reply_to })
-    } else if let Some(relation) = ev.relates_to.relation {
-        match relation {
-            RelationJsonRepr::Replacement(ReplacementJsonRepr { event_id }) => {
-                let new_content = ev
-                    .new_content
-                    .ok_or_else(|| serde::de::Error::missing_field("m.new_content"))?;
-                Some(Relation::Replacement(Replacement { event_id, new_content }))
-            }
-            // FIXME: Maybe we should log this, though at this point we don't even have
-            // access to the rel_type of the unknown relation.
-            RelationJsonRepr::Unknown => Some(Relation::_Custom),
-            RelationJsonRepr::ThreadStable(_) | RelationJsonRepr::ThreadUnstable(_) => {
-                unreachable!()
-            }
-        }
-    } else {
-        None
+    let EventWithRelatesToDeHelper { relates_to, new_content } =
+        EventWithRelatesToDeHelper::deserialize(deserializer)?;
+    let Some(relates_to) = relates_to else {
+        return Ok(None);
     };
 
-    Ok(rel)
+    let RelatesToDeHelper { in_reply_to, relation } = relates_to;
+
+    let rel = if let Some(RelationDeHelper::Known(relation)) = relation {
+        match relation {
+            KnownRelationDeHelper::Replacement(ReplacementJsonRepr { event_id }) => {
+                match new_content {
+                    Some(new_content) => {
+                        Relation::Replacement(Replacement { event_id, new_content })
+                    }
+                    None => return Err(de::Error::missing_field("m.new_content")),
+                }
+            }
+            KnownRelationDeHelper::Thread(ThreadDeHelper { event_id, is_falling_back })
+            | KnownRelationDeHelper::ThreadUnstable(ThreadUnstableDeHelper {
+                event_id,
+                is_falling_back,
+            }) => Relation::Thread(Thread { event_id, in_reply_to, is_falling_back }),
+        }
+    } else if let Some(in_reply_to) = in_reply_to {
+        Relation::Reply { in_reply_to }
+    } else if let Some(RelationDeHelper::Unknown(c)) = relation {
+        Relation::_Custom(c)
+    } else {
+        return Err(de::Error::missing_field("m.in_reply_to or rel_type"));
+    };
+
+    Ok(Some(rel))
 }
 
 impl<C> Serialize for Relation<C>
@@ -66,133 +67,157 @@ where
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: Serializer,
+        S: serde::Serializer,
     {
-        let json_repr = match self {
-            Relation::Reply { in_reply_to } => {
-                EventWithRelatesToJsonRepr::<C>::new(RelatesToJsonRepr {
-                    in_reply_to: Some(in_reply_to.clone()),
-                    ..Default::default()
-                })
-            }
-            Relation::Replacement(Replacement { event_id, new_content }) => {
-                EventWithRelatesToJsonRepr {
-                    relates_to: RelatesToJsonRepr {
-                        relation: Some(RelationJsonRepr::Replacement(ReplacementJsonRepr {
-                            event_id: event_id.clone(),
-                        })),
-                        ..Default::default()
-                    },
-                    new_content: Some(new_content.clone()),
-                }
-            }
-            Relation::Thread(Thread { event_id, in_reply_to, is_falling_back }) => {
-                EventWithRelatesToJsonRepr::new(RelatesToJsonRepr {
-                    in_reply_to: in_reply_to.clone(),
-                    relation: Some(RelationJsonRepr::ThreadStable(ThreadStableJsonRepr {
-                        event_id: event_id.clone(),
-                        is_falling_back: *is_falling_back,
-                    })),
-                })
-            }
-            Relation::_Custom => EventWithRelatesToJsonRepr::<C>::default(),
-        };
+        let (relates_to, new_content) = self.clone().into_parts();
 
-        json_repr.serialize(serializer)
+        EventWithRelatesToSerHelper { relates_to, new_content }.serialize(serializer)
     }
 }
 
+#[derive(Deserialize)]
+struct EventWithRelatesToDeHelper<C> {
+    #[serde(rename = "m.relates_to")]
+    relates_to: Option<RelatesToDeHelper>,
+
+    #[serde(rename = "m.new_content")]
+    new_content: Option<C>,
+}
+
+#[derive(Deserialize)]
+struct RelatesToDeHelper {
+    #[serde(rename = "m.in_reply_to")]
+    in_reply_to: Option<InReplyTo>,
+
+    #[serde(flatten)]
+    relation: Option<RelationDeHelper>,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum RelationDeHelper {
+    Known(KnownRelationDeHelper),
+    Unknown(CustomRelation),
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "rel_type")]
+enum KnownRelationDeHelper {
+    #[serde(rename = "m.replace")]
+    Replacement(ReplacementJsonRepr),
+
+    #[serde(rename = "m.thread")]
+    Thread(ThreadDeHelper),
+
+    #[serde(rename = "io.element.thread")]
+    ThreadUnstable(ThreadUnstableDeHelper),
+}
+
+/// A replacement relation without `m.new_content`.
 #[derive(Deserialize, Serialize)]
-struct EventWithRelatesToJsonRepr<C> {
-    #[serde(rename = "m.relates_to", default, skip_serializing_if = "RelatesToJsonRepr::is_empty")]
-    relates_to: RelatesToJsonRepr,
+pub(super) struct ReplacementJsonRepr {
+    event_id: OwnedEventId,
+}
+
+/// A thread relation without the reply fallback, with stable names.
+#[derive(Deserialize)]
+struct ThreadDeHelper {
+    event_id: OwnedEventId,
+
+    #[serde(default)]
+    is_falling_back: bool,
+}
+
+/// A thread relation without the reply fallback, with unstable names.
+#[derive(Deserialize)]
+struct ThreadUnstableDeHelper {
+    event_id: OwnedEventId,
+
+    #[serde(rename = "io.element.show_reply", default)]
+    is_falling_back: bool,
+}
+
+#[derive(Serialize)]
+pub(super) struct EventWithRelatesToSerHelper<C> {
+    #[serde(rename = "m.relates_to")]
+    relates_to: RelationSerHelper,
 
     #[serde(rename = "m.new_content", skip_serializing_if = "Option::is_none")]
     new_content: Option<C>,
 }
 
-impl<C> EventWithRelatesToJsonRepr<C> {
-    fn new(relates_to: RelatesToJsonRepr) -> Self {
-        Self { relates_to, new_content: None }
-    }
-}
-
-impl<C> Default for EventWithRelatesToJsonRepr<C> {
-    fn default() -> Self {
-        Self { relates_to: RelatesToJsonRepr::default(), new_content: None }
-    }
-}
-
-/// Struct modeling the different ways relationships can be expressed in a `m.relates_to` field of
-/// an event.
-#[derive(Default, Deserialize, Serialize)]
-struct RelatesToJsonRepr {
-    #[serde(rename = "m.in_reply_to", skip_serializing_if = "Option::is_none")]
-    in_reply_to: Option<InReplyTo>,
-
-    #[serde(flatten, skip_serializing_if = "Option::is_none")]
-    relation: Option<RelationJsonRepr>,
-}
-
-impl RelatesToJsonRepr {
-    fn is_empty(&self) -> bool {
-        self.in_reply_to.is_none() && self.relation.is_none()
-    }
-}
-
 /// A relation, which associates new information to an existing event.
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Serialize)]
 #[serde(tag = "rel_type")]
-enum RelationJsonRepr {
+pub(super) enum RelationSerHelper {
     /// An event that replaces another event.
     #[serde(rename = "m.replace")]
     Replacement(ReplacementJsonRepr),
 
     /// An event that belongs to a thread, with stable names.
     #[serde(rename = "m.thread")]
-    ThreadStable(ThreadStableJsonRepr),
-
-    /// An event that belongs to a thread, with unstable names.
-    #[serde(rename = "io.element.thread")]
-    ThreadUnstable(ThreadUnstableJsonRepr),
+    Thread(Thread),
 
     /// An unknown relation type.
-    ///
-    /// Not available in the public API, but exists here so deserialization
-    /// doesn't fail with new / custom `rel_type`s.
-    #[serde(other)]
-    Unknown,
+    #[serde(untagged)]
+    Custom(CustomSerHelper),
 }
 
-#[derive(Clone, Deserialize, Serialize)]
-struct ReplacementJsonRepr {
-    event_id: OwnedEventId,
+impl<C> Relation<C> {
+    fn into_parts(self) -> (RelationSerHelper, Option<C>) {
+        match self {
+            Relation::Replacement(Replacement { event_id, new_content }) => (
+                RelationSerHelper::Replacement(ReplacementJsonRepr { event_id }),
+                Some(new_content),
+            ),
+            Relation::Reply { in_reply_to } => {
+                (RelationSerHelper::Custom(in_reply_to.into()), None)
+            }
+            Relation::Thread(t) => (RelationSerHelper::Thread(t), None),
+            Relation::_Custom(c) => (RelationSerHelper::Custom(c.into()), None),
+        }
+    }
+
+    pub(super) fn serialize_data(&self) -> JsonObject
+    where
+        C: Clone,
+    {
+        let (relates_to, _) = self.clone().into_parts();
+
+        match serde_json::to_value(relates_to).expect("relation serialization to succeed") {
+            JsonValue::Object(mut obj) => {
+                obj.remove("rel_type");
+                obj
+            }
+            _ => panic!("all relations must serialize to objects"),
+        }
+    }
 }
 
-/// A thread relation without the reply fallback, with stable names.
-#[derive(Clone, Deserialize, Serialize)]
-struct ThreadStableJsonRepr {
-    /// The ID of the root message in the thread.
-    event_id: OwnedEventId,
+#[derive(Default, Serialize)]
+pub(super) struct CustomSerHelper {
+    #[serde(rename = "m.in_reply_to", skip_serializing_if = "Option::is_none")]
+    in_reply_to: Option<InReplyTo>,
 
-    /// Whether the `m.in_reply_to` field is a fallback for older clients or a real reply in a
-    /// thread.
-    #[serde(default, skip_serializing_if = "ruma_common::serde::is_default")]
-    is_falling_back: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rel_type: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    event_id: Option<OwnedEventId>,
+
+    #[serde(flatten, skip_serializing_if = "JsonObject::is_empty")]
+    data: JsonObject,
 }
 
-/// A thread relation without the reply fallback, with unstable names.
-#[derive(Clone, Deserialize, Serialize)]
-struct ThreadUnstableJsonRepr {
-    /// The ID of the root message in the thread.
-    event_id: OwnedEventId,
+impl From<InReplyTo> for CustomSerHelper {
+    fn from(value: InReplyTo) -> Self {
+        Self { in_reply_to: Some(value), ..Default::default() }
+    }
+}
 
-    /// Whether the `m.in_reply_to` field is a fallback for older clients or a real reply in a
-    /// thread.
-    #[serde(
-        rename = "io.element.show_reply",
-        default,
-        skip_serializing_if = "ruma_common::serde::is_default"
-    )]
-    is_falling_back: bool,
+impl From<CustomRelation> for CustomSerHelper {
+    fn from(value: CustomRelation) -> Self {
+        let CustomRelation { rel_type, event_id, data } = value;
+        Self { rel_type: Some(rel_type), event_id: Some(event_id), data, ..Default::default() }
+    }
 }

--- a/crates/ruma-common/tests/events/message.rs
+++ b/crates/ruma-common/tests/events/message.rs
@@ -129,7 +129,7 @@ fn markdown_content_serialization() {
 }
 
 #[test]
-fn relates_to_content_serialization() {
+fn reply_content_serialization() {
     #[rustfmt::skip] // rustfmt wants to merge the next two lines
     let message_event_content =
         assign!(MessageEventContent::plain("> <@test:example.com> test\n\ntest reply"), {
@@ -214,7 +214,7 @@ fn html_and_text_content_deserialization() {
 }
 
 #[test]
-fn relates_to_content_deserialization() {
+fn reply_content_deserialization() {
     let json_data = json!({
         "org.matrix.msc1767.text": [
             { "body": "> <@test:example.com> test\n\ntest reply" },
@@ -235,6 +235,26 @@ fn relates_to_content_deserialization() {
         Some(Relation::Reply { in_reply_to: InReplyTo { event_id, .. } })
     );
     assert_eq!(event_id, "$15827405538098VGFWH:example.com");
+}
+
+#[test]
+fn thread_content_deserialization() {
+    let json_data = json!({
+        "org.matrix.msc1767.text": [
+            { "body": "Test in thread" },
+        ],
+        "m.relates_to": {
+            "rel_type": "m.thread",
+            "event_id": "$15827405538098VGFWH:example.com",
+        }
+    });
+
+    let content = from_json_value::<MessageEventContent>(json_data).unwrap();
+    assert_eq!(content.text.find_plain(), Some("Test in thread"));
+    assert_eq!(content.text.find_html(), None);
+
+    assert_matches!(content.relates_to, Some(Relation::Thread(thread)));
+    assert_eq!(thread.event_id, "$15827405538098VGFWH:example.com");
 }
 
 #[test]


### PR DESCRIPTION
So I thought that being able to catch the data of unknown relations would be as simple as adding an `untagged` variant, thanks to the [latest release](https://github.com/serde-rs/serde/releases/tag/v1.0.164), but it seems like it doesn't work.

For some reason the `relation` field of `RelatesToJsonRepr` is `None` with an unknown `rel_type` (see tests)… I'm putting the code here to make sure this is a serde issue rather than me not seeing something with our code. Maybe it's an issue with having a `flatten` above…






















<!-- Replace -->
----
Preview: https://pr-1581--ruma-docs.surge.sh
<!-- Replace -->
