### PR TITLE
events: Fix outdated docs

### DIFF
--- a/crates/ruma-common/src/events/room/message.rs
+++ b/crates/ruma-common/src/events/room/message.rs
@@ -60,9 +60,9 @@ pub struct RoomMessageEventContent {
     #[serde(flatten)]
     pub msgtype: MessageType,
 
-    /// Information about related messages for [rich replies].
+    /// Information about [related messages].
     ///
-    /// [rich replies]: https://spec.matrix.org/latest/client-server-api/#rich-replies
+    /// [related messages]: https://spec.matrix.org/latest/client-server-api/#forming-relationships-between-events
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
     pub relates_to: Option<Relation<MessageType>>,
 }


### PR DESCRIPTION
There are now a bunch of other relations.

I'm not super happy about the description of `msgtype`, it looks complicated compared to how easy it is to use. "The content of the message" would be enough, imo.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->





<!-- Replace -->
----
Preview Removed
<!-- Replace -->
