### PR TITLE
events: Add methods to compute poll results

### DIFF
--- a/crates/ruma-common/src/events/poll.rs
+++ b/crates/ruma-common/src/events/poll.rs
@@ -4,6 +4,71 @@
 //!
 //! [MSC3381]: https://github.com/matrix-org/matrix-spec-proposals/pull/3381
 
+use std::collections::{BTreeMap, BTreeSet};
+
+use indexmap::IndexMap;
+use js_int::uint;
+
+use crate::{MilliSecondsSinceUnixEpoch, UserId};
+
+use self::{response::OriginalSyncPollResponseEvent, start::PollContentBlock};
+
 pub mod end;
 pub mod response;
 pub mod start;
+
+/// Generate the current results with the given poll and responses.
+///
+/// If the `end_timestamp` is provided, any response with an `origin_server_ts` after that timestamp
+/// is ignored. If it is not provided, `MilliSecondsSinceUnixEpoch::now()` will be used instead.
+///
+/// This method will handle invalid responses, or several response from the same user so all
+/// responses to the poll should be provided.
+///
+/// Returns a map of answer ID to a set of user IDs that voted for them. When using `.iter()` or
+/// `.into_iter()` on the map, the results are sorted from the highest number of votes to the
+/// lowest.
+pub fn compile_poll_results<'a>(
+    poll: &'a PollContentBlock,
+    responses: impl IntoIterator<Item = &'a OriginalSyncPollResponseEvent>,
+    end_timestamp: Option<MilliSecondsSinceUnixEpoch>,
+) -> IndexMap<&'a str, BTreeSet<&'a UserId>> {
+    let end_ts = end_timestamp.unwrap_or_else(MilliSecondsSinceUnixEpoch::now);
+
+    let users_selections = responses
+        .into_iter()
+        .filter(|ev| {
+            // Filter out responses after the end_timestamp.
+            ev.origin_server_ts <= end_ts
+        })
+        .fold(BTreeMap::new(), |mut acc, ev| {
+            let response =
+                acc.entry(&*ev.sender).or_insert((MilliSecondsSinceUnixEpoch(uint!(0)), None));
+
+            // Only keep the latest selections for each user.
+            if response.0 < ev.origin_server_ts {
+                *response = (ev.origin_server_ts, ev.content.selections.validate(poll));
+            }
+
+            acc
+        });
+
+    // Aggregate the selections by answer.
+    let mut results =
+        IndexMap::from_iter(poll.answers.iter().map(|a| (a.id.as_str(), BTreeSet::new())));
+
+    for (user, (_, selections)) in users_selections {
+        if let Some(selections) = selections {
+            for selection in selections {
+                results
+                    .get_mut(selection)
+                    .expect("validated selections should only match possible answers")
+                    .insert(user);
+            }
+        }
+    }
+
+    results.sort_by(|_, a, _, b| b.len().cmp(&a.len()));
+
+    results
+}

--- a/crates/ruma-common/src/events/poll/end.rs
+++ b/crates/ruma-common/src/events/poll/end.rs
@@ -15,6 +15,11 @@ use crate::{
 };
 
 /// The payload for a poll end event.
+///
+/// This type can be generated from the poll start and poll response events with
+/// [`OriginalSyncPollStartEvent::compile_results()`].
+///
+/// [`OriginalSyncPollStartEvent::compile_results()`]: super::start::OriginalSyncPollStartEvent::compile_results
 #[derive(Clone, Debug, Serialize, Deserialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[ruma_event(type = "org.matrix.msc3381.v2.poll.end", alias = "m.poll.end", kind = MessageLike)]
@@ -76,6 +81,17 @@ impl PollEndEventContent {
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct PollResultsContentBlock(BTreeMap<String, UInt>);
+
+impl PollResultsContentBlock {
+    /// Get these results sorted from the highest number of votes to the lowest.
+    ///
+    /// Returns a list of `(answer ID, number of votes)`.
+    pub fn sorted(&self) -> Vec<(&str, UInt)> {
+        let mut sorted = self.0.iter().map(|(id, count)| (id.as_str(), *count)).collect::<Vec<_>>();
+        sorted.sort_by(|(_, a), (_, b)| b.cmp(a));
+        sorted
+    }
+}
 
 impl From<BTreeMap<String, UInt>> for PollResultsContentBlock {
     fn from(value: BTreeMap<String, UInt>) -> Self {

--- a/crates/ruma-common/tests/events/message.rs
+++ b/crates/ruma-common/tests/events/message.rs
@@ -3,9 +3,10 @@
 use assert_matches2::assert_matches;
 use assign::assign;
 use js_int::uint;
+#[cfg(feature = "unstable-msc3954")]
+use ruma_common::events::emote::EmoteEventContent;
 use ruma_common::{
     events::{
-        emote::EmoteEventContent,
         message::{MessageEventContent, TextContentBlock, TextRepresentation},
         relation::InReplyTo,
         room::message::Relation,


### PR DESCRIPTION
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->














<!-- Replace -->
----
Preview Removed
<!-- Replace -->
