### PR TITLE
events: Improve compatibility of generated and stripped plain reply fallback

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -46,6 +46,8 @@ Improvements:
 - Stabilize support for annotations and reactions (MSC2677 / Matrix 1.7)
 - Add support for intentional mentions push rules (MSC3952 / Matrix 1.7)
 - Stabilize support for VoIP signalling improvements (MSC2746 / Matrix 1.7)
+- Make the generated and stripped plain text reply fallback behavior more compatible with most
+  of the Matrix ecosystem.
 
 # 0.11.3
 

--- a/crates/ruma-common/src/events/room/message/reply.rs
+++ b/crates/ruma-common/src/events/room/message/reply.rs
@@ -113,7 +113,7 @@ pub fn plain_and_formatted_reply_body(
 ) -> (String, String) {
     let (quoted, quoted_html) = get_message_quote_fallbacks(original_message);
 
-    let plain = format!("{quoted}\n{body}");
+    let plain = format!("{quoted}\n\n{body}");
     let html = match formatted {
         Some(formatted) => format!("{quoted_html}{formatted}"),
         None => format!("{quoted_html}{}", EscapeHtmlEntities(body)),

--- a/crates/ruma-common/tests/events/room_message.rs
+++ b/crates/ruma-common/tests/events/room_message.rs
@@ -282,6 +282,7 @@ fn escape_tags_in_plain_reply_body() {
         body,
         "\
         > <@user:example.org> Usage: cp <source> <destination>\n\
+        \n\
         Usage: rm <path>\
         "
     );
@@ -352,6 +353,7 @@ fn reply_sanitize() {
         body,
         "\
         > <@user:example.org> # This is the first message\n\
+        \n\
         This is the _second_ message\
         "
     );
@@ -379,6 +381,7 @@ fn reply_sanitize() {
         body,
         "\
         > <@user:example.org> This is the _second_ message\n\
+        \n\
         This is **my** reply\
         "
     );
@@ -448,6 +451,7 @@ fn make_replacement_with_reply() {
         body,
         "\
         > <@user:example.org> # This is the first message\n\
+        \n\
         * This is _an edited_ reply.\
         "
     );


### PR DESCRIPTION
Now what we send looks like what the spec shows and most clients send and expect, and stripping the fallback is more compatible with those clients.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->





<!-- Replace -->
----
Preview Removed
<!-- Replace -->
