### PR TITLE
events: Make polls events compatible with v1 of MSC3381

### DIFF
--- a/crates/ruma-common/src/events/enums.rs
+++ b/crates/ruma-common/src/events/enums.rs
@@ -68,14 +68,11 @@ event_enum! {
         #[ruma_enum(alias = "m.message")]
         "org.matrix.msc1767.message" => super::message,
         #[cfg(feature = "unstable-msc3381")]
-        #[ruma_enum(alias = "m.poll.start")]
-        "org.matrix.msc3381.v2.poll.start" => super::poll::start,
+        "m.poll.start" => super::poll::start,
         #[cfg(feature = "unstable-msc3381")]
-        #[ruma_enum(alias = "m.poll.response")]
-        "org.matrix.msc3381.v2.poll.response" => super::poll::response,
+        "m.poll.response" => super::poll::response,
         #[cfg(feature = "unstable-msc3381")]
-        #[ruma_enum(alias = "m.poll.end")]
-        "org.matrix.msc3381.v2.poll.end" => super::poll::end,
+        "m.poll.end" => super::poll::end,
         "m.reaction" => super::reaction,
         "m.room.encrypted" => super::room::encrypted,
         "m.room.message" => super::room::message,

--- a/crates/ruma-common/src/events/enums.rs
+++ b/crates/ruma-common/src/events/enums.rs
@@ -70,9 +70,18 @@ event_enum! {
         #[cfg(feature = "unstable-msc3381")]
         "m.poll.start" => super::poll::start,
         #[cfg(feature = "unstable-msc3381")]
+        #[ruma_enum(ident = UnstablePollStart)]
+        "org.matrix.msc3381.poll.start" => super::poll::unstable_start,
+        #[cfg(feature = "unstable-msc3381")]
         "m.poll.response" => super::poll::response,
         #[cfg(feature = "unstable-msc3381")]
+        #[ruma_enum(ident = UnstablePollResponse)]
+        "org.matrix.msc3381.poll.response" => super::poll::unstable_response,
+        #[cfg(feature = "unstable-msc3381")]
         "m.poll.end" => super::poll::end,
+        #[cfg(feature = "unstable-msc3381")]
+        #[ruma_enum(ident = UnstablePollEnd)]
+        "org.matrix.msc3381.poll.end" => super::poll::unstable_end,
         "m.reaction" => super::reaction,
         "m.room.encrypted" => super::room::encrypted,
         "m.room.message" => super::room::message,
@@ -293,7 +302,11 @@ impl AnyMessageLikeEventContent {
             start::KeyVerificationStartEventContent,
         };
         #[cfg(feature = "unstable-msc3381")]
-        use super::poll::{end::PollEndEventContent, response::PollResponseEventContent};
+        use super::poll::{
+            end::PollEndEventContent, response::PollResponseEventContent,
+            unstable_end::UnstablePollEndEventContent,
+            unstable_response::UnstablePollResponseEventContent,
+        };
 
         match self {
             #[rustfmt::skip]
@@ -329,11 +342,13 @@ impl AnyMessageLikeEventContent {
             Self::Video(ev) => ev.relates_to.clone().map(Into::into),
             #[cfg(feature = "unstable-msc3381")]
             Self::PollResponse(PollResponseEventContent { relates_to, .. })
-            | Self::PollEnd(PollEndEventContent { relates_to, .. }) => {
+            | Self::UnstablePollResponse(UnstablePollResponseEventContent { relates_to, .. })
+            | Self::PollEnd(PollEndEventContent { relates_to, .. })
+            | Self::UnstablePollEnd(UnstablePollEndEventContent { relates_to, .. }) => {
                 Some(encrypted::Relation::Reference(relates_to.clone()))
             }
             #[cfg(feature = "unstable-msc3381")]
-            Self::PollStart(_) => None,
+            Self::PollStart(_) | Self::UnstablePollStart(_) => None,
             Self::CallNegotiate(_)
             | Self::CallReject(_)
             | Self::CallSelectAnswer(_)

--- a/crates/ruma-common/src/events/poll.rs
+++ b/crates/ruma-common/src/events/poll.rs
@@ -11,11 +11,18 @@ use js_int::uint;
 
 use crate::{MilliSecondsSinceUnixEpoch, UserId};
 
-use self::{response::OriginalSyncPollResponseEvent, start::PollContentBlock};
+use self::{
+    response::OriginalSyncPollResponseEvent, start::PollContentBlock,
+    unstable_response::OriginalSyncUnstablePollResponseEvent,
+    unstable_start::UnstablePollStartContentBlock,
+};
 
 pub mod end;
 pub mod response;
 pub mod start;
+pub mod unstable_end;
+pub mod unstable_response;
+pub mod unstable_start;
 
 /// Generate the current results with the given poll and responses.
 ///
@@ -53,9 +60,57 @@ pub fn compile_poll_results<'a>(
             acc
         });
 
-    // Aggregate the selections by answer.
-    let mut results =
-        IndexMap::from_iter(poll.answers.iter().map(|a| (a.id.as_str(), BTreeSet::new())));
+    aggregate_results(poll.answers.iter().map(|a| a.id.as_str()), users_selections)
+}
+
+/// Generate the current results with the given unstable poll and responses.
+///
+/// If the `end_timestamp` is provided, any response with an `origin_server_ts` after that timestamp
+/// is ignored. If it is not provided, `MilliSecondsSinceUnixEpoch::now()` will be used instead.
+///
+/// This method will handle invalid responses, or several response from the same user so all
+/// responses to the poll should be provided.
+///
+/// Returns a map of answer ID to a set of user IDs that voted for them. When using `.iter()` or
+/// `.into_iter()` on the map, the results are sorted from the highest number of votes to the
+/// lowest.
+pub fn compile_unstable_poll_results<'a>(
+    poll: &'a UnstablePollStartContentBlock,
+    responses: impl IntoIterator<Item = &'a OriginalSyncUnstablePollResponseEvent>,
+    end_timestamp: Option<MilliSecondsSinceUnixEpoch>,
+) -> IndexMap<&'a str, BTreeSet<&'a UserId>> {
+    let end_ts = end_timestamp.unwrap_or_else(MilliSecondsSinceUnixEpoch::now);
+
+    let users_selections = responses
+        .into_iter()
+        .filter(|ev| {
+            // Filter out responses after the end_timestamp.
+            ev.origin_server_ts <= end_ts
+        })
+        .fold(BTreeMap::new(), |mut acc, ev| {
+            let response =
+                acc.entry(&*ev.sender).or_insert((MilliSecondsSinceUnixEpoch(uint!(0)), None));
+
+            // Only keep the latest selections for each user.
+            if response.0 < ev.origin_server_ts {
+                *response = (ev.origin_server_ts, ev.content.poll_response.validate(poll));
+            }
+
+            acc
+        });
+
+    aggregate_results(poll.answers.iter().map(|a| a.id.as_str()), users_selections)
+}
+
+// Aggregate the given selections by answer.
+fn aggregate_results<'a>(
+    answers: impl Iterator<Item = &'a str>,
+    users_selections: BTreeMap<
+        &'a UserId,
+        (MilliSecondsSinceUnixEpoch, Option<impl Iterator<Item = &'a str>>),
+    >,
+) -> IndexMap<&'a str, BTreeSet<&'a UserId>> {
+    let mut results = IndexMap::from_iter(answers.into_iter().map(|a| (a, BTreeSet::new())));
 
     for (user, (_, selections)) in users_selections {
         if let Some(selections) = selections {
@@ -71,4 +126,52 @@ pub fn compile_poll_results<'a>(
     results.sort_by(|_, a, _, b| b.len().cmp(&a.len()));
 
     results
+}
+
+/// Generate the fallback text representation of a poll end event.
+///
+/// This is a sentence that lists the top answers for the given results, in english. It is used to
+/// generate a valid poll end event when using
+/// `OriginalSync(Unstable)PollStartEvent::compile_results()`.
+///
+/// `answers` is an iterator of `(answer ID, answer plain text representation)` and `results` is an
+/// iterator of `(answer ID, count)` ordered in descending order.
+fn generate_poll_end_fallback_text<'a>(
+    answers: &[(&'a str, &'a str)],
+    results: impl Iterator<Item = (&'a str, usize)>,
+) -> String {
+    let mut top_answers = Vec::new();
+    let mut top_count = 0;
+
+    for (id, count) in results {
+        if count >= top_count {
+            top_answers.push(id);
+            top_count = count;
+        } else {
+            break;
+        }
+    }
+
+    let top_answers_text = top_answers
+        .into_iter()
+        .map(|id| {
+            answers
+                .iter()
+                .find(|(a_id, _)| *a_id == id)
+                .expect("top answer ID should be a valid answer ID")
+                .1
+        })
+        .collect::<Vec<_>>();
+
+    // Construct the plain text representation.
+    match top_answers_text.len() {
+        l if l > 1 => {
+            let answers = top_answers_text.join(", ");
+            format!("The poll has closed. Top answers: {answers}")
+        }
+        l if l == 1 => {
+            format!("The poll has closed. Top answer: {}", top_answers_text[0])
+        }
+        _ => "The poll has closed with no top answer".to_owned(),
+    }
 }

--- a/crates/ruma-common/src/events/poll/end.rs
+++ b/crates/ruma-common/src/events/poll/end.rs
@@ -19,7 +19,14 @@ use crate::{
 /// This type can be generated from the poll start and poll response events with
 /// [`OriginalSyncPollStartEvent::compile_results()`].
 ///
+/// This is the event content that should be sent for room versions that support extensible events.
+/// As of Matrix 1.7, none of the stable room versions (1 through 10) support extensible events.
+///
+/// To send a poll end event for a room version that does not support extensible events, use
+/// [`UnstablePollEndEventContent`].
+///
 /// [`OriginalSyncPollStartEvent::compile_results()`]: super::start::OriginalSyncPollStartEvent::compile_results
+/// [`UnstablePollEndEventContent`]: super::unstable_end::UnstablePollEndEventContent
 #[derive(Clone, Debug, Serialize, Deserialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[ruma_event(type = "m.poll.end", kind = MessageLike)]

--- a/crates/ruma-common/src/events/poll/end.rs
+++ b/crates/ruma-common/src/events/poll/end.rs
@@ -1,4 +1,4 @@
-//! Types for the [`m.poll.end`] event.
+//! Types for the `m.poll.end` event.
 
 use std::{
     collections::{btree_map, BTreeMap},
@@ -22,17 +22,14 @@ use crate::{
 /// [`OriginalSyncPollStartEvent::compile_results()`]: super::start::OriginalSyncPollStartEvent::compile_results
 #[derive(Clone, Debug, Serialize, Deserialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-#[ruma_event(type = "org.matrix.msc3381.v2.poll.end", alias = "m.poll.end", kind = MessageLike)]
+#[ruma_event(type = "m.poll.end", kind = MessageLike)]
 pub struct PollEndEventContent {
     /// The text representation of the results.
-    #[serde(rename = "org.matrix.msc1767.text")]
+    #[serde(rename = "m.text")]
     pub text: TextContentBlock,
 
     /// The sender's perspective of the results.
-    #[serde(
-        rename = "org.matrix.msc3381.v2.poll.results",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(rename = "m.poll.results", skip_serializing_if = "Option::is_none")]
     pub poll_results: Option<PollResultsContentBlock>,
 
     /// Whether this message is automated.

--- a/crates/ruma-common/src/events/poll/response.rs
+++ b/crates/ruma-common/src/events/poll/response.rs
@@ -10,6 +10,14 @@ use crate::{events::relation::Reference, OwnedEventId};
 use super::start::PollContentBlock;
 
 /// The payload for a poll response event.
+///
+/// This is the event content that should be sent for room versions that support extensible events.
+/// As of Matrix 1.7, none of the stable room versions (1 through 10) support extensible events.
+///
+/// To send a poll response event for a room version that does not support extensible events, use
+/// [`UnstablePollResponseEventContent`].
+///
+/// [`UnstablePollResponseEventContent`]: super::unstable_response::UnstablePollResponseEventContent
 #[derive(Clone, Debug, Serialize, Deserialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[ruma_event(type = "m.poll.response", kind = MessageLike)]

--- a/crates/ruma-common/src/events/poll/response.rs
+++ b/crates/ruma-common/src/events/poll/response.rs
@@ -1,4 +1,4 @@
-//! Types for the [`m.poll.response`] event.
+//! Types for the `m.poll.response` event.
 
 use std::{ops::Deref, vec};
 
@@ -12,10 +12,10 @@ use super::start::PollContentBlock;
 /// The payload for a poll response event.
 #[derive(Clone, Debug, Serialize, Deserialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-#[ruma_event(type = "org.matrix.msc3381.v2.poll.response", alias = "m.poll.response", kind = MessageLike)]
+#[ruma_event(type = "m.poll.response", kind = MessageLike)]
 pub struct PollResponseEventContent {
     /// The user's selection.
-    #[serde(rename = "org.matrix.msc3381.v2.selections")]
+    #[serde(rename = "m.selections")]
     pub selections: SelectionsContentBlock,
 
     /// Whether this message is automated.

--- a/crates/ruma-common/src/events/poll/start.rs
+++ b/crates/ruma-common/src/events/poll/start.rs
@@ -1,4 +1,4 @@
-//! Types for the [`m.poll.start`] event.
+//! Types for the `m.poll.start` event.
 
 use std::ops::Deref;
 
@@ -21,14 +21,14 @@ use super::{
 /// The payload for a poll start event.
 #[derive(Clone, Debug, Serialize, Deserialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-#[ruma_event(type = "org.matrix.msc3381.v2.poll.start", alias = "m.poll.start", kind = MessageLike)]
+#[ruma_event(type = "m.poll.start", kind = MessageLike)]
 pub struct PollStartEventContent {
     /// The poll content of the message.
-    #[serde(rename = "org.matrix.msc3381.v2.poll")]
+    #[serde(rename = "m.poll")]
     pub poll: PollContentBlock,
 
     /// Text representation of the message, for clients that don't support polls.
-    #[serde(rename = "org.matrix.msc1767.text")]
+    #[serde(rename = "m.text")]
     pub text: TextContentBlock,
 
     /// Whether this message is automated.
@@ -184,7 +184,7 @@ impl PollContentBlock {
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct PollQuestion {
     /// The text representation of the question.
-    #[serde(rename = "org.matrix.msc1767.text")]
+    #[serde(rename = "m.text")]
     pub text: TextContentBlock,
 }
 
@@ -201,11 +201,11 @@ impl From<TextContentBlock> for PollQuestion {
 pub enum PollKind {
     /// The results are revealed once the poll is closed.
     #[default]
-    #[ruma_enum(rename = "org.matrix.msc3381.v2.undisclosed")]
+    #[ruma_enum(rename = "m.undisclosed")]
     Undisclosed,
 
     /// The votes are visible up until and including when the poll is closed.
-    #[ruma_enum(rename = "org.matrix.msc3381.v2.disclosed")]
+    #[ruma_enum(rename = "m.disclosed")]
     Disclosed,
 
     #[doc(hidden)]
@@ -278,11 +278,11 @@ pub struct PollAnswer {
     /// The ID of the answer.
     ///
     /// This must be unique among the answers of a poll.
-    #[serde(rename = "org.matrix.msc3381.v2.id")]
+    #[serde(rename = "m.id")]
     pub id: String,
 
     /// The text representation of the answer.
-    #[serde(rename = "org.matrix.msc1767.text")]
+    #[serde(rename = "m.text")]
     pub text: TextContentBlock,
 }
 

--- a/crates/ruma-common/src/events/poll/unstable_end.rs
+++ b/crates/ruma-common/src/events/poll/unstable_end.rs
@@ -1,0 +1,56 @@
+//! Types for the `org.matrix.msc3381.poll.end` event, the unstable version of `m.poll.end`.
+
+use ruma_macros::EventContent;
+use serde::{Deserialize, Serialize};
+
+use crate::{events::relation::Reference, OwnedEventId};
+
+/// The payload for an unstable poll end event.
+///
+/// This type can be generated from the unstable poll start and poll response events with
+/// [`OriginalSyncUnstablePollStartEvent::compile_results()`].
+///
+/// This is the event content that should be sent for room versions that don't support extensible
+/// events. As of Matrix 1.7, none of the stable room versions (1 through 10) support extensible
+/// events.
+///
+/// To send a poll end event for a room version that supports extensible events, use
+/// [`PollEndEventContent`].
+///
+/// [`OriginalSyncUnstablePollStartEvent::compile_results()`]: super::unstable_start::OriginalSyncUnstablePollStartEvent::compile_results
+/// [`PollEndEventContent`]: super::end::PollEndEventContent
+#[derive(Clone, Debug, Serialize, Deserialize, EventContent)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+#[ruma_event(type = "org.matrix.msc3381.poll.end", kind = MessageLike)]
+pub struct UnstablePollEndEventContent {
+    /// The text representation of the results.
+    #[serde(rename = "org.matrix.msc1767.text")]
+    pub text: String,
+
+    /// The poll end content.
+    #[serde(default, rename = "org.matrix.msc3381.poll.end")]
+    pub poll_end: UnstablePollEndContentBlock,
+
+    /// Information about the poll start event this responds to.
+    #[serde(rename = "m.relates_to")]
+    pub relates_to: Reference,
+}
+
+impl UnstablePollEndEventContent {
+    /// Creates a new `PollEndEventContent` with the given fallback representation and
+    /// that responds to the given poll start event ID.
+    pub fn new(text: impl Into<String>, poll_start_id: OwnedEventId) -> Self {
+        Self {
+            text: text.into(),
+            poll_end: UnstablePollEndContentBlock {},
+            relates_to: Reference::new(poll_start_id),
+        }
+    }
+}
+
+/// A block for the results of a poll.
+///
+/// This is currently an empty struct.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+pub struct UnstablePollEndContentBlock {}

--- a/crates/ruma-common/src/events/poll/unstable_response.rs
+++ b/crates/ruma-common/src/events/poll/unstable_response.rs
@@ -1,0 +1,86 @@
+//! Types for the `org.matrix.msc3381.poll.response` event, the unstable version of
+//! `m.poll.response`.
+
+use std::ops::Deref;
+
+use ruma_macros::EventContent;
+use serde::{Deserialize, Serialize};
+
+use crate::{events::relation::Reference, OwnedEventId};
+
+use super::unstable_start::UnstablePollStartContentBlock;
+
+/// The payload for an unstable poll response event.
+///
+/// This is the event content that should be sent for room versions that don't support extensible
+/// events. As of Matrix 1.7, none of the stable room versions (1 through 10) support extensible
+/// events.
+///
+/// To send a poll response event for a room version that supports extensible events, use
+/// [`PollResponseEventContent`].
+///
+/// [`PollResponseEventContent`]: super::response::PollResponseEventContent
+#[derive(Clone, Debug, Serialize, Deserialize, EventContent)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+#[ruma_event(type = "org.matrix.msc3381.poll.response", kind = MessageLike)]
+pub struct UnstablePollResponseEventContent {
+    /// The response's content.
+    #[serde(rename = "org.matrix.msc3381.poll.response")]
+    pub poll_response: UnstablePollResponseContentBlock,
+
+    /// Information about the poll start event this responds to.
+    #[serde(rename = "m.relates_to")]
+    pub relates_to: Reference,
+}
+
+impl UnstablePollResponseEventContent {
+    /// Creates a new `UnstablePollResponseEventContent` that responds to the given poll start event
+    /// ID, with the given answers.
+    pub fn new(answers: Vec<String>, poll_start_id: OwnedEventId) -> Self {
+        Self {
+            poll_response: UnstablePollResponseContentBlock::new(answers),
+            relates_to: Reference::new(poll_start_id),
+        }
+    }
+}
+
+/// An unstable block for poll response content.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+pub struct UnstablePollResponseContentBlock {
+    /// The selected answers for the response.
+    pub answers: Vec<String>,
+}
+
+impl UnstablePollResponseContentBlock {
+    /// Creates a new `UnstablePollResponseContentBlock` with the given answers.
+    pub fn new(answers: Vec<String>) -> Self {
+        Self { answers }
+    }
+
+    /// Validate these selections against the given `UnstablePollStartContentBlock`.
+    ///
+    /// Returns the list of valid selections in this `UnstablePollResponseContentBlock`, or `None`
+    /// if there is no valid selection.
+    pub fn validate(
+        &self,
+        poll: &UnstablePollStartContentBlock,
+    ) -> Option<impl Iterator<Item = &str>> {
+        // Vote is spoiled if any answer is unknown.
+        if self.answers.iter().any(|s| !poll.answers.iter().any(|a| a.id == *s)) {
+            return None;
+        }
+
+        // Fallback to the maximum value for usize because we can't have more selections than that
+        // in memory.
+        let max_selections: usize = poll.max_selections.try_into().unwrap_or(usize::MAX);
+
+        Some(self.answers.iter().take(max_selections).map(Deref::deref))
+    }
+}
+
+impl From<Vec<String>> for UnstablePollResponseContentBlock {
+    fn from(value: Vec<String>) -> Self {
+        Self::new(value)
+    }
+}

--- a/crates/ruma-common/src/events/poll/unstable_start.rs
+++ b/crates/ruma-common/src/events/poll/unstable_start.rs
@@ -1,0 +1,194 @@
+//! Types for the `org.matrix.msc3381.poll.start` event, the unstable version of `m.poll.start`.
+
+use std::ops::Deref;
+
+use js_int::UInt;
+use ruma_macros::EventContent;
+use serde::{Deserialize, Serialize};
+
+mod unstable_poll_answers_serde;
+mod unstable_poll_kind_serde;
+
+use self::unstable_poll_answers_serde::UnstablePollAnswersDeHelper;
+use super::{
+    compile_unstable_poll_results, generate_poll_end_fallback_text,
+    start::{PollAnswers, PollAnswersError, PollContentBlock, PollKind},
+    unstable_end::UnstablePollEndEventContent,
+    unstable_response::OriginalSyncUnstablePollResponseEvent,
+};
+
+/// The payload for an unstable poll start event.
+///
+/// This is the event content that should be sent for room versions that don't support extensible
+/// events. As of Matrix 1.7, none of the stable room versions (1 through 10) support extensible
+/// events.
+///
+/// To send a poll start event for a room version that supports extensible events, use
+/// [`PollStartEventContent`].
+///
+/// [`PollStartEventContent`]: super::start::PollStartEventContent
+#[derive(Clone, Debug, Serialize, Deserialize, EventContent)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+#[ruma_event(type = "org.matrix.msc3381.poll.start", kind = MessageLike)]
+pub struct UnstablePollStartEventContent {
+    /// The poll content of the message.
+    #[serde(rename = "org.matrix.msc3381.poll.start")]
+    pub poll_start: UnstablePollStartContentBlock,
+
+    /// Text representation of the message, for clients that don't support polls.
+    #[serde(rename = "org.matrix.msc1767.text")]
+    pub text: Option<String>,
+}
+
+impl UnstablePollStartEventContent {
+    /// Creates a new `PollStartEventContent` with the given poll content.
+    pub fn new(poll_start: UnstablePollStartContentBlock) -> Self {
+        Self { poll_start, text: None }
+    }
+
+    /// Creates a new `PollStartEventContent` with the given plain text fallback
+    /// representation and poll content.
+    pub fn plain_text(text: impl Into<String>, poll_start: UnstablePollStartContentBlock) -> Self {
+        Self { poll_start, text: Some(text.into()) }
+    }
+}
+
+impl OriginalSyncUnstablePollStartEvent {
+    /// Compile the results for this poll with the given response into an
+    /// `UnstablePollEndEventContent`.
+    ///
+    /// It generates a default text representation of the results in English.
+    ///
+    /// This uses [`compile_unstable_poll_results()`] internally.
+    pub fn compile_results<'a>(
+        &'a self,
+        responses: impl IntoIterator<Item = &'a OriginalSyncUnstablePollResponseEvent>,
+    ) -> UnstablePollEndEventContent {
+        let full_results = compile_unstable_poll_results(&self.content.poll_start, responses, None);
+        let results =
+            full_results.into_iter().map(|(id, users)| (id, users.len())).collect::<Vec<_>>();
+
+        // Get the text representation of the best answers.
+        let answers = self
+            .content
+            .poll_start
+            .answers
+            .iter()
+            .map(|a| (a.id.as_str(), a.text.as_str()))
+            .collect::<Vec<_>>();
+        let plain_text = generate_poll_end_fallback_text(&answers, results.into_iter());
+
+        UnstablePollEndEventContent::new(plain_text, self.event_id.clone())
+    }
+}
+
+/// An unstable block for poll start content.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+pub struct UnstablePollStartContentBlock {
+    /// The question of the poll.
+    pub question: UnstablePollQuestion,
+
+    /// The kind of the poll.
+    #[serde(default, with = "unstable_poll_kind_serde")]
+    pub kind: PollKind,
+
+    /// The maximum number of responses a user is able to select.
+    ///
+    /// Must be greater or equal to `1`.
+    ///
+    /// Defaults to `1`.
+    #[serde(default = "PollContentBlock::default_max_selections")]
+    pub max_selections: UInt,
+
+    /// The possible answers to the poll.
+    pub answers: UnstablePollAnswers,
+}
+
+impl UnstablePollStartContentBlock {
+    /// Creates a new `PollStartContent` with the given question and answers.
+    pub fn new(question: impl Into<String>, answers: UnstablePollAnswers) -> Self {
+        Self {
+            question: UnstablePollQuestion::new(question),
+            kind: Default::default(),
+            max_selections: PollContentBlock::default_max_selections(),
+            answers,
+        }
+    }
+}
+
+/// An unstable poll question.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+pub struct UnstablePollQuestion {
+    /// The text representation of the question.
+    #[serde(rename = "org.matrix.msc1767.text")]
+    pub text: String,
+}
+
+impl UnstablePollQuestion {
+    /// Creates a new `UnstablePollQuestion` with the given plain text.
+    pub fn new(text: impl Into<String>) -> Self {
+        Self { text: text.into() }
+    }
+}
+
+/// The unstable answers to a poll.
+///
+/// Must include between 1 and 20 `UnstablePollAnswer`s.
+///
+/// To build this, use one of the `TryFrom` implementations.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(try_from = "UnstablePollAnswersDeHelper")]
+pub struct UnstablePollAnswers(Vec<UnstablePollAnswer>);
+
+impl TryFrom<Vec<UnstablePollAnswer>> for UnstablePollAnswers {
+    type Error = PollAnswersError;
+
+    fn try_from(value: Vec<UnstablePollAnswer>) -> Result<Self, Self::Error> {
+        if value.len() < PollAnswers::MIN_LENGTH {
+            Err(PollAnswersError::NotEnoughValues)
+        } else if value.len() > PollAnswers::MAX_LENGTH {
+            Err(PollAnswersError::TooManyValues)
+        } else {
+            Ok(Self(value))
+        }
+    }
+}
+
+impl TryFrom<&[UnstablePollAnswer]> for UnstablePollAnswers {
+    type Error = PollAnswersError;
+
+    fn try_from(value: &[UnstablePollAnswer]) -> Result<Self, Self::Error> {
+        Self::try_from(value.to_owned())
+    }
+}
+
+impl Deref for UnstablePollAnswers {
+    type Target = [UnstablePollAnswer];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// Unstable poll answer.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+pub struct UnstablePollAnswer {
+    /// The ID of the answer.
+    ///
+    /// This must be unique among the answers of a poll.
+    pub id: String,
+
+    /// The text representation of the answer.
+    #[serde(rename = "org.matrix.msc1767.text")]
+    pub text: String,
+}
+
+impl UnstablePollAnswer {
+    /// Creates a new `PollAnswer` with the given id and text representation.
+    pub fn new(id: impl Into<String>, text: impl Into<String>) -> Self {
+        Self { id: id.into(), text: text.into() }
+    }
+}

--- a/crates/ruma-common/src/events/poll/unstable_start/unstable_poll_answers_serde.rs
+++ b/crates/ruma-common/src/events/poll/unstable_start/unstable_poll_answers_serde.rs
@@ -1,0 +1,20 @@
+//! `Deserialize` helpers for unstable poll answers (MSC3381).
+
+use serde::Deserialize;
+
+use crate::events::poll::start::{PollAnswers, PollAnswersError};
+
+use super::{UnstablePollAnswer, UnstablePollAnswers};
+
+#[derive(Debug, Default, Deserialize)]
+pub(crate) struct UnstablePollAnswersDeHelper(Vec<UnstablePollAnswer>);
+
+impl TryFrom<UnstablePollAnswersDeHelper> for UnstablePollAnswers {
+    type Error = PollAnswersError;
+
+    fn try_from(helper: UnstablePollAnswersDeHelper) -> Result<Self, Self::Error> {
+        let mut answers = helper.0;
+        answers.truncate(PollAnswers::MAX_LENGTH);
+        UnstablePollAnswers::try_from(answers)
+    }
+}

--- a/crates/ruma-common/src/events/poll/unstable_start/unstable_poll_kind_serde.rs
+++ b/crates/ruma-common/src/events/poll/unstable_start/unstable_poll_kind_serde.rs
@@ -1,0 +1,37 @@
+//! `Serialize` and `Deserialize` helpers for unstable poll kind (MSC3381).
+
+use std::borrow::Cow;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::{events::poll::start::PollKind, PrivOwnedStr};
+
+/// Serializes a PollKind using the unstable prefixes.
+pub(super) fn serialize<S>(kind: &PollKind, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let s = match kind {
+        PollKind::Undisclosed => "org.matrix.msc3381.poll.undisclosed",
+        PollKind::Disclosed => "org.matrix.msc3381.poll.disclosed",
+        PollKind::_Custom(s) => &s.0,
+    };
+
+    s.serialize(serializer)
+}
+
+/// Deserializes a PollKind using the unstable prefixes.
+pub(super) fn deserialize<'de, D>(deserializer: D) -> Result<PollKind, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s = Cow::<'_, str>::deserialize(deserializer)?;
+
+    let kind = match &*s {
+        "org.matrix.msc3381.poll.undisclosed" => PollKind::Undisclosed,
+        "org.matrix.msc3381.poll.disclosed" => PollKind::Disclosed,
+        _ => PollKind::_Custom(PrivOwnedStr(s.into())),
+    };
+
+    Ok(kind)
+}

--- a/crates/ruma-common/src/events/room/message/content_serde.rs
+++ b/crates/ruma-common/src/events/room/message/content_serde.rs
@@ -57,7 +57,7 @@ pub(in super::super) mod msc3488 {
     use crate::{
         events::{
             location::{AssetContent, LocationContent},
-            message::historical_serde::MessageContentBlockSerDeHelper,
+            message::historical_serde::MessageContentBlock,
             room::message::{LocationInfo, LocationMessageEventContent},
         },
         MilliSecondsSinceUnixEpoch,
@@ -75,7 +75,7 @@ pub(in super::super) mod msc3488 {
         pub info: Option<Box<LocationInfo>>,
 
         #[serde(flatten)]
-        pub message: MessageContentBlockSerDeHelper,
+        pub message: Option<MessageContentBlock>,
 
         #[serde(rename = "org.matrix.msc3488.location", skip_serializing_if = "Option::is_none")]
         pub location: Option<LocationContent>,
@@ -92,15 +92,7 @@ pub(in super::super) mod msc3488 {
             let LocationMessageEventContent { body, geo_uri, info, message, location, asset, ts } =
                 value;
 
-            Self {
-                body,
-                geo_uri,
-                info,
-                message: message.map(Into::into).unwrap_or_default(),
-                location,
-                asset,
-                ts,
-            }
+            Self { body, geo_uri, info, message: message.map(Into::into), location, asset, ts }
         }
     }
 
@@ -120,7 +112,7 @@ pub(in super::super) mod msc3488 {
                 body,
                 geo_uri,
                 info,
-                message: message.try_into().ok(),
+                message: message.map(Into::into),
                 location,
                 asset,
                 ts,

--- a/crates/ruma-common/tests/events/poll.rs
+++ b/crates/ruma-common/tests/events/poll.rs
@@ -25,6 +25,7 @@ use ruma_common::{
             },
         },
         relation::Reference,
+        room::message::Relation,
         AnyMessageLikeEvent, MessageLikeEvent,
     },
     owned_event_id, MilliSecondsSinceUnixEpoch,
@@ -176,6 +177,33 @@ fn start_event_deserialization() {
                     },
                 ]
             },
+            "m.new_content": {
+                "m.text": [
+                    { "body": "How's the weather?\n1. Not bad…\n2. Fine.\n3. Amazing!" }
+                ],
+                "m.poll": {
+                    "question": { "m.text": [{ "body": "How's the weather?" }] },
+                    "max_selections": 2,
+                    "answers": [
+                        {
+                            "m.id": "not-bad",
+                            "m.text": [{ "body": "Not bad…" }],
+                        },
+                        {
+                            "m.id": "fine",
+                            "m.text": [{ "body": "Fine." }],
+                        },
+                        {
+                            "m.id": "amazing",
+                            "m.text": [{ "body": "Amazing!" }],
+                        },
+                    ]
+                },
+            },
+            "m.relates_to": {
+                "rel_type": "m.replace",
+                "event_id": "$previous_event_id",
+            },
         },
         "event_id": "$event:notareal.hs",
         "origin_server_ts": 134_829_848,
@@ -205,6 +233,7 @@ fn start_event_deserialization() {
     assert_eq!(answers[1].text[0].body, "Fine.");
     assert_eq!(answers[2].id, "amazing");
     assert_eq!(answers[2].text[0].body, "Amazing!");
+    assert_matches!(message_event.content.relates_to, Some(Relation::Replacement(_)));
 }
 
 #[test]
@@ -413,6 +442,31 @@ fn unstable_start_event_deserialization() {
                     },
                 ]
             },
+            "m.new_content": {
+                "org.matrix.msc1767.text": "How's the weather?\n1. Not bad…\n2. Fine.\n3. Amazing!",
+                "org.matrix.msc3381.poll.start": {
+                    "question": { "org.matrix.msc1767.text": "How's the weather?" },
+                    "max_selections": 2,
+                    "answers": [
+                        {
+                            "id": "not-bad",
+                            "org.matrix.msc1767.text": "Not bad…",
+                        },
+                        {
+                            "id": "fine",
+                            "org.matrix.msc1767.text": "Fine.",
+                        },
+                        {
+                            "id": "amazing",
+                            "org.matrix.msc1767.text": "Amazing!",
+                        },
+                    ]
+                },
+            },
+            "m.relates_to": {
+                "rel_type": "m.replace",
+                "event_id": "$previous_event_id",
+            },
         },
         "event_id": "$event:notareal.hs",
         "origin_server_ts": 134_829_848,
@@ -442,6 +496,7 @@ fn unstable_start_event_deserialization() {
     assert_eq!(answers[1].text, "Fine.");
     assert_eq!(answers[2].id, "amazing");
     assert_eq!(answers[2].text, "Amazing!");
+    assert_matches!(message_event.content.relates_to, Some(Relation::Replacement(_)));
 }
 
 #[test]

--- a/crates/ruma-common/tests/events/poll.rs
+++ b/crates/ruma-common/tests/events/poll.rs
@@ -26,8 +26,8 @@ use serde_json::{from_value as from_json_value, json, to_value as to_json_value}
 #[test]
 fn poll_answers_deserialization_valid() {
     let json_data = json!([
-        { "org.matrix.msc3381.v2.id": "aaa", "org.matrix.msc1767.text": [{ "body": "First answer" }] },
-        { "org.matrix.msc3381.v2.id": "bbb", "org.matrix.msc1767.text": [{ "body": "Second answer" }] },
+        { "m.id": "aaa", "m.text": [{ "body": "First answer" }] },
+        { "m.id": "bbb", "m.text": [{ "body": "Second answer" }] },
     ]);
 
     let answers = from_json_value::<PollAnswers>(json_data).unwrap();
@@ -37,28 +37,28 @@ fn poll_answers_deserialization_valid() {
 #[test]
 fn poll_answers_deserialization_truncate() {
     let json_data = json!([
-        { "org.matrix.msc3381.v2.id": "aaa", "org.matrix.msc1767.text": [{ "body": "1st answer" }] },
-        { "org.matrix.msc3381.v2.id": "bbb", "org.matrix.msc1767.text": [{ "body": "2nd answer" }] },
-        { "org.matrix.msc3381.v2.id": "ccc", "org.matrix.msc1767.text": [{ "body": "3rd answer" }] },
-        { "org.matrix.msc3381.v2.id": "ddd", "org.matrix.msc1767.text": [{ "body": "4th answer" }] },
-        { "org.matrix.msc3381.v2.id": "eee", "org.matrix.msc1767.text": [{ "body": "5th answer" }] },
-        { "org.matrix.msc3381.v2.id": "fff", "org.matrix.msc1767.text": [{ "body": "6th answer" }] },
-        { "org.matrix.msc3381.v2.id": "ggg", "org.matrix.msc1767.text": [{ "body": "7th answer" }] },
-        { "org.matrix.msc3381.v2.id": "hhh", "org.matrix.msc1767.text": [{ "body": "8th answer" }] },
-        { "org.matrix.msc3381.v2.id": "iii", "org.matrix.msc1767.text": [{ "body": "9th answer" }] },
-        { "org.matrix.msc3381.v2.id": "jjj", "org.matrix.msc1767.text": [{ "body": "10th answer" }] },
-        { "org.matrix.msc3381.v2.id": "kkk", "org.matrix.msc1767.text": [{ "body": "11th answer" }] },
-        { "org.matrix.msc3381.v2.id": "lll", "org.matrix.msc1767.text": [{ "body": "12th answer" }] },
-        { "org.matrix.msc3381.v2.id": "mmm", "org.matrix.msc1767.text": [{ "body": "13th answer" }] },
-        { "org.matrix.msc3381.v2.id": "nnn", "org.matrix.msc1767.text": [{ "body": "14th answer" }] },
-        { "org.matrix.msc3381.v2.id": "ooo", "org.matrix.msc1767.text": [{ "body": "15th answer" }] },
-        { "org.matrix.msc3381.v2.id": "ppp", "org.matrix.msc1767.text": [{ "body": "16th answer" }] },
-        { "org.matrix.msc3381.v2.id": "qqq", "org.matrix.msc1767.text": [{ "body": "17th answer" }] },
-        { "org.matrix.msc3381.v2.id": "rrr", "org.matrix.msc1767.text": [{ "body": "18th answer" }] },
-        { "org.matrix.msc3381.v2.id": "sss", "org.matrix.msc1767.text": [{ "body": "19th answer" }] },
-        { "org.matrix.msc3381.v2.id": "ttt", "org.matrix.msc1767.text": [{ "body": "20th answer" }] },
-        { "org.matrix.msc3381.v2.id": "uuu", "org.matrix.msc1767.text": [{ "body": "21th answer" }] },
-        { "org.matrix.msc3381.v2.id": "vvv", "org.matrix.msc1767.text": [{ "body": "22th answer" }] },
+        { "m.id": "aaa", "m.text": [{ "body": "1st answer" }] },
+        { "m.id": "bbb", "m.text": [{ "body": "2nd answer" }] },
+        { "m.id": "ccc", "m.text": [{ "body": "3rd answer" }] },
+        { "m.id": "ddd", "m.text": [{ "body": "4th answer" }] },
+        { "m.id": "eee", "m.text": [{ "body": "5th answer" }] },
+        { "m.id": "fff", "m.text": [{ "body": "6th answer" }] },
+        { "m.id": "ggg", "m.text": [{ "body": "7th answer" }] },
+        { "m.id": "hhh", "m.text": [{ "body": "8th answer" }] },
+        { "m.id": "iii", "m.text": [{ "body": "9th answer" }] },
+        { "m.id": "jjj", "m.text": [{ "body": "10th answer" }] },
+        { "m.id": "kkk", "m.text": [{ "body": "11th answer" }] },
+        { "m.id": "lll", "m.text": [{ "body": "12th answer" }] },
+        { "m.id": "mmm", "m.text": [{ "body": "13th answer" }] },
+        { "m.id": "nnn", "m.text": [{ "body": "14th answer" }] },
+        { "m.id": "ooo", "m.text": [{ "body": "15th answer" }] },
+        { "m.id": "ppp", "m.text": [{ "body": "16th answer" }] },
+        { "m.id": "qqq", "m.text": [{ "body": "17th answer" }] },
+        { "m.id": "rrr", "m.text": [{ "body": "18th answer" }] },
+        { "m.id": "sss", "m.text": [{ "body": "19th answer" }] },
+        { "m.id": "ttt", "m.text": [{ "body": "20th answer" }] },
+        { "m.id": "uuu", "m.text": [{ "body": "21th answer" }] },
+        { "m.id": "vvv", "m.text": [{ "body": "22th answer" }] },
     ]);
 
     let answers = from_json_value::<PollAnswers>(json_data).unwrap();
@@ -93,15 +93,13 @@ fn start_content_serialization() {
     assert_eq!(
         to_json_value(&event_content).unwrap(),
         json!({
-            "org.matrix.msc1767.text": [
-                { "body": "How's the weather?\n1. Not bad…\n2. Fine.\n3. Amazing!" }
-            ],
-            "org.matrix.msc3381.v2.poll": {
-                "question": { "org.matrix.msc1767.text": [{ "body": "How's the weather?" }] },
+            "m.text": [{ "body": "How's the weather?\n1. Not bad…\n2. Fine.\n3. Amazing!" }],
+            "m.poll": {
+                "question": { "m.text": [{ "body": "How's the weather?" }] },
                 "answers": [
-                    { "org.matrix.msc3381.v2.id": "not-bad", "org.matrix.msc1767.text": [{ "body": "Not bad…" }] },
-                    { "org.matrix.msc3381.v2.id": "fine", "org.matrix.msc1767.text": [{ "body": "Fine." }] },
-                    { "org.matrix.msc3381.v2.id": "amazing", "org.matrix.msc1767.text": [{ "body": "Amazing!" }] },
+                    { "m.id": "not-bad", "m.text": [{ "body": "Not bad…" }] },
+                    { "m.id": "fine", "m.text":  [{ "body": "Fine." }] },
+                    { "m.id": "amazing", "m.text":  [{ "body": "Amazing!" }] },
                 ],
             },
         })
@@ -109,7 +107,7 @@ fn start_content_serialization() {
 }
 
 #[test]
-fn start_event_serialization() {
+fn start_content_other_serialization() {
     let mut poll = PollContentBlock::new(
         TextContentBlock::plain("How's the weather?"),
         vec![
@@ -130,17 +128,15 @@ fn start_event_serialization() {
     assert_eq!(
         to_json_value(&content).unwrap(),
         json!({
-            "org.matrix.msc1767.text": [
-                { "body": "How's the weather?\n1. Not bad…\n2. Fine.\n3. Amazing!" }
-            ],
-            "org.matrix.msc3381.v2.poll": {
-                "question": { "org.matrix.msc1767.text": [{ "body": "How's the weather?" }] },
-                "kind": "org.matrix.msc3381.v2.disclosed",
+            "m.text": [{ "body": "How's the weather?\n1. Not bad…\n2. Fine.\n3. Amazing!" }],
+            "m.poll": {
+                "question": { "m.text": [{ "body": "How's the weather?" }] },
+                "kind": "m.disclosed",
                 "max_selections": 2,
                 "answers": [
-                    { "org.matrix.msc3381.v2.id": "not-bad", "org.matrix.msc1767.text": [{ "body": "Not bad…" }] },
-                    { "org.matrix.msc3381.v2.id": "fine", "org.matrix.msc1767.text": [{ "body": "Fine." }] },
-                    { "org.matrix.msc3381.v2.id": "amazing", "org.matrix.msc1767.text": [{ "body": "Amazing!" }] },
+                    { "m.id": "not-bad", "m.text":  [{ "body": "Not bad…" }] },
+                    { "m.id": "fine", "m.text":  [{ "body": "Fine." }] },
+                    { "m.id": "amazing", "m.text":  [{ "body": "Amazing!" }] },
                 ]
             },
         })
@@ -151,16 +147,25 @@ fn start_event_serialization() {
 fn start_event_deserialization() {
     let json_data = json!({
         "content": {
-            "org.matrix.msc1767.text": [
+            "m.text": [
                 { "body": "How's the weather?\n1. Not bad…\n2. Fine.\n3. Amazing!" }
             ],
-            "org.matrix.msc3381.v2.poll": {
-                "question": { "org.matrix.msc1767.text": [{ "body": "How's the weather?" }] },
+            "m.poll": {
+                "question": { "m.text": [{ "body": "How's the weather?" }] },
                 "max_selections": 2,
                 "answers": [
-                    { "org.matrix.msc3381.v2.id": "not-bad", "org.matrix.msc1767.text": [{ "body": "Not bad…" }] },
-                    { "org.matrix.msc3381.v2.id": "fine", "org.matrix.msc1767.text": [{ "body": "Fine." }] },
-                    { "org.matrix.msc3381.v2.id": "amazing", "org.matrix.msc1767.text": [{ "body": "Amazing!" }] },
+                    {
+                        "m.id": "not-bad",
+                        "m.text": [{ "body": "Not bad…" }],
+                    },
+                    {
+                        "m.id": "fine",
+                        "m.text": [{ "body": "Fine." }],
+                    },
+                    {
+                        "m.id": "amazing",
+                        "m.text": [{ "body": "Amazing!" }],
+                    },
                 ]
             },
         },
@@ -168,7 +173,7 @@ fn start_event_deserialization() {
         "origin_server_ts": 134_829_848,
         "room_id": "!roomid:notareal.hs",
         "sender": "@user:notareal.hs",
-        "type": "org.matrix.msc3381.v2.poll.start",
+        "type": "m.poll.start",
     });
 
     let event = from_json_value::<AnyMessageLikeEvent>(json_data).unwrap();
@@ -204,7 +209,7 @@ fn response_content_serialization() {
     assert_eq!(
         to_json_value(&event_content).unwrap(),
         json!({
-            "org.matrix.msc3381.v2.selections": ["my-answer"],
+            "m.selections": ["my-answer"],
             "m.relates_to": {
                 "rel_type": "m.reference",
                 "event_id": "$related_event:notareal.hs",
@@ -214,7 +219,7 @@ fn response_content_serialization() {
 }
 
 #[test]
-fn response_event_serialization() {
+fn response_content_other_serialization() {
     let content = PollResponseEventContent::new(
         vec!["first-answer".to_owned(), "second-answer".to_owned()].into(),
         owned_event_id!("$related_event:notareal.hs"),
@@ -223,7 +228,7 @@ fn response_event_serialization() {
     assert_eq!(
         to_json_value(&content).unwrap(),
         json!({
-            "org.matrix.msc3381.v2.selections": ["first-answer", "second-answer"],
+            "m.selections": ["first-answer", "second-answer"],
             "m.relates_to": {
                 "rel_type": "m.reference",
                 "event_id": "$related_event:notareal.hs",
@@ -236,7 +241,7 @@ fn response_event_serialization() {
 fn response_event_deserialization() {
     let json_data = json!({
         "content": {
-            "org.matrix.msc3381.v2.selections": ["my-answer"],
+            "m.selections": ["my-answer"],
             "m.relates_to": {
                 "rel_type": "m.reference",
                 "event_id": "$related_event:notareal.hs",
@@ -246,7 +251,7 @@ fn response_event_deserialization() {
         "origin_server_ts": 134_829_848,
         "room_id": "!roomid:notareal.hs",
         "sender": "@user:notareal.hs",
-        "type": "org.matrix.msc3381.v2.poll.response",
+        "type": "m.poll.response",
     });
 
     let event = from_json_value::<AnyMessageLikeEvent>(json_data).unwrap();
@@ -271,9 +276,7 @@ fn end_content_serialization() {
     assert_eq!(
         to_json_value(&event_content).unwrap(),
         json!({
-            "org.matrix.msc1767.text": [
-                { "body": "The poll has closed. Top answer: Amazing!" }
-            ],
+            "m.text":  [{ "body": "The poll has closed. Top answer: Amazing!" }],
             "m.relates_to": {
                 "rel_type": "m.reference",
                 "event_id": "$related_event:notareal.hs",
@@ -283,7 +286,7 @@ fn end_content_serialization() {
 }
 
 #[test]
-fn end_event_serialization() {
+fn end_content_with_results_serialization() {
     let mut content = PollEndEventContent::with_plain_text(
         "The poll has closed. Top answer: Amazing!",
         owned_event_id!("$related_event:notareal.hs"),
@@ -300,10 +303,8 @@ fn end_event_serialization() {
     assert_eq!(
         to_json_value(&content).unwrap(),
         json!({
-            "org.matrix.msc1767.text": [
-                { "body": "The poll has closed. Top answer: Amazing!" },
-            ],
-            "org.matrix.msc3381.v2.poll.results": {
+            "m.text":  [{ "body": "The poll has closed. Top answer: Amazing!" }],
+            "m.poll.results": {
                 "not-bad": 1,
                 "fine": 5,
                 "amazing": 14,
@@ -320,9 +321,14 @@ fn end_event_serialization() {
 fn end_event_deserialization() {
     let json_data = json!({
         "content": {
-            "org.matrix.msc1767.text": [
+            "m.text": [
                 { "body": "The poll has closed. Top answer: Amazing!" },
             ],
+            "m.poll.results": {
+                "not-bad": 1,
+                "fine": 5,
+                "amazing": 14,
+            },
             "m.relates_to": {
                 "rel_type": "m.reference",
                 "event_id": "$related_event:notareal.hs",
@@ -332,7 +338,7 @@ fn end_event_deserialization() {
         "origin_server_ts": 134_829_848,
         "room_id": "!roomid:notareal.hs",
         "sender": "@user:notareal.hs",
-        "type": "org.matrix.msc3381.v2.poll.end",
+        "type": "m.poll.end",
     });
 
     let event = from_json_value::<AnyMessageLikeEvent>(json_data).unwrap();
@@ -349,7 +355,7 @@ fn new_poll_response(
     selections: &[&str],
 ) -> OriginalSyncPollResponseEvent {
     from_json_value(json!({
-      "type": "org.matrix.msc3381.v2.poll.response",
+      "type": "m.poll.response",
       "sender": user_id,
       "origin_server_ts": ts,
       "event_id": event_id,
@@ -358,7 +364,7 @@ fn new_poll_response(
           "rel_type": "m.reference",
           "event_id": "$poll_start_event_id"
         },
-        "org.matrix.msc3381.v2.selections": selections,
+        "m.selections": selections,
       }
     }))
     .unwrap()
@@ -384,30 +390,27 @@ fn generate_poll_responses(
 #[test]
 fn compute_results() {
     let poll: OriginalSyncPollStartEvent = from_json_value(json!({
-        "type": "org.matrix.msc3381.v2.poll.start",
+        "type": "m.poll.start",
         "sender": "@alice:localhost",
         "event_id": "$poll_start_event_id",
         "origin_server_ts": 1,
         "content": {
-          "org.matrix.msc1767.text": [
-            {
-              "mimetype": "text/plain",
-              "body": "What should we order for the party?\n1. Pizza 🍕\n2. Poutine 🍟\n3. Italian 🍝\n4. Wings 🔥"
-            }
+          "m.text": [
+            { "body": "What should we order for the party?\n1. Pizza 🍕\n2. Poutine 🍟\n3. Italian 🍝\n4. Wings 🔥" },
           ],
-          "org.matrix.msc3381.v2.poll": {
+          "m.poll": {
             "kind": "m.disclosed",
             "max_selections": 2,
             "question": {
-              "org.matrix.msc1767.text": [{"body": "What should we order for the party?"}]
+              "m.text": [{ "body": "What should we order for the party?" }],
             },
             "answers": [
-              {"org.matrix.msc3381.v2.id": "pizza", "org.matrix.msc1767.text": [{"body": "Pizza 🍕"}]},
-              {"org.matrix.msc3381.v2.id": "poutine", "org.matrix.msc1767.text": [{"body": "Poutine 🍟"}]},
-              {"org.matrix.msc3381.v2.id": "italian", "org.matrix.msc1767.text": [{"body": "Italian 🍝"}]},
-              {"org.matrix.msc3381.v2.id": "wings", "org.matrix.msc1767.text": [{"body": "Wings 🔥"}]},
+              { "m.id": "pizza", "m.text":  [{ "body": "Pizza 🍕" }] },
+              { "m.id": "poutine", "m.text":  [{ "body": "Poutine 🍟" }] },
+              { "m.id": "italian", "m.text":  [{ "body": "Italian 🍝" }] },
+              { "m.id": "wings", "m.text":  [{ "body": "Wings 🔥" }] },
             ]
-          }
+          },
         }
       })).unwrap();
 

--- a/crates/ruma-macros/src/events/event_type.rs
+++ b/crates/ruma-macros/src/events/event_type.rs
@@ -40,6 +40,7 @@ pub fn expand_event_type_enum(
         aliases: vec![],
         ev_type: LitStr::new("m.presence", Span::call_site()),
         ev_path: parse_quote! { #ruma_common::events::presence },
+        ident: None,
     }];
     let mut all = input.enums.iter().map(|e| &e.events).collect::<Vec<_>>();
     all.push(&presence);


### PR DESCRIPTION
Necessary for Element X to implement polls. v2 should not be necessary because the MSC is in PFCP, and it is just an update to the latest extensible events type format, so I removed it.

~~I decided to hide the v1 type as a serde helper instead of exposing it. That will also allow to keep recognizing unstable polls after the MSC is merged.~~

















<!-- Replace -->
----
Preview Removed
<!-- Replace -->
