### PR TITLE
fix: parse `TagInfo::order` as a f64 or a stringified f64

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -4,6 +4,8 @@ Bug fixes:
 
 - Set the predefined server-default `.m.rule.tombstone` push rule as enabled by default, as defined
   in the spec.
+- Parse `m.tag` `order` as a f64 value or a stringified f64 value, if the `compat-tag-info` feature
+  is enabled.
 
 Breaking changes:
 

--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -69,6 +69,9 @@ compat-null = []
 # mandatory. Deserialization will yield a default value like an empty string.
 compat-optional = []
 
+# Allow TagInfo to contain a stringified floating-point value for the `order` field.
+compat-tag-info = []
+
 [dependencies]
 base64 = { workspace = true }
 bytes = "1.0.1"

--- a/crates/ruma-common/src/events/tag.rs
+++ b/crates/ruma-common/src/events/tag.rs
@@ -236,11 +236,20 @@ mod tests {
         let json = json!({ "order": 0.42 });
         assert_eq!(from_json_value::<TagInfo>(json).unwrap(), TagInfo { order: Some(0.42) });
 
-        let json = json!({ "order": "0.5" });
-        assert_eq!(from_json_value::<TagInfo>(json).unwrap(), TagInfo { order: Some(0.5) });
+        #[cfg(feature = "compat-tag-info")]
+        {
+            let json = json!({ "order": "0.5" });
+            assert_eq!(from_json_value::<TagInfo>(json).unwrap(), TagInfo { order: Some(0.5) });
 
-        let json = json!({ "order": ".5" });
-        assert_eq!(from_json_value::<TagInfo>(json).unwrap(), TagInfo { order: Some(0.5) });
+            let json = json!({ "order": ".5" });
+            assert_eq!(from_json_value::<TagInfo>(json).unwrap(), TagInfo { order: Some(0.5) });
+        }
+
+        #[cfg(not(feature = "compat-tag-info"))]
+        {
+            let json = json!({ "order": "0.5" });
+            assert!(from_json_value::<TagInfo>(json).is_err());
+        }
     }
 
     #[test]

--- a/crates/ruma-common/src/events/tag.rs
+++ b/crates/ruma-common/src/events/tag.rs
@@ -7,7 +7,10 @@ use std::{collections::BTreeMap, error::Error, fmt, str::FromStr};
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
-use crate::{serde::deserialize_cow_str, PrivOwnedStr};
+use crate::{
+    serde::{deserialize_as_optional_f64_or_string, deserialize_cow_str},
+    PrivOwnedStr,
+};
 
 /// Map of tag names to tag info.
 pub type Tags = BTreeMap<TagName, TagInfo>;
@@ -167,11 +170,18 @@ impl Serialize for TagName {
 }
 
 /// Information about a tag.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct TagInfo {
     /// Value to use for lexicographically ordering rooms with this tag.
+    ///
+    /// If you activate the `compat-tag-info` feature, this field can be decoded as a stringified
+    /// floating-point value, instead of a number as it should be according to the specification.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(
+        feature = "compat-tag-info",
+        serde(default, deserialize_with = "deserialize_as_optional_f64_or_string")
+    )]
     pub order: Option<f64>,
 }
 
@@ -185,7 +195,7 @@ impl TagInfo {
 #[cfg(test)]
 mod tests {
     use maplit::btreemap;
-    use serde_json::{json, to_value as to_json_value};
+    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     use super::{TagEventContent, TagInfo, TagName};
 
@@ -213,6 +223,24 @@ mod tests {
                 },
             })
         );
+    }
+
+    #[test]
+    fn deserialize_tag_info() {
+        let json = json!({});
+        assert_eq!(from_json_value::<TagInfo>(json).unwrap(), TagInfo::default());
+
+        let json = json!({ "order": null });
+        assert_eq!(from_json_value::<TagInfo>(json).unwrap(), TagInfo::default());
+
+        let json = json!({ "order": 0.42 });
+        assert_eq!(from_json_value::<TagInfo>(json).unwrap(), TagInfo { order: Some(0.42) });
+
+        let json = json!({ "order": "0.5" });
+        assert_eq!(from_json_value::<TagInfo>(json).unwrap(), TagInfo { order: Some(0.5) });
+
+        let json = json!({ "order": ".5" });
+        assert_eq!(from_json_value::<TagInfo>(json).unwrap(), TagInfo { order: Some(0.5) });
     }
 
     #[test]

--- a/crates/ruma-common/src/events/tag.rs
+++ b/crates/ruma-common/src/events/tag.rs
@@ -7,10 +7,10 @@ use std::{collections::BTreeMap, error::Error, fmt, str::FromStr};
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    serde::{deserialize_as_optional_f64_or_string, deserialize_cow_str},
-    PrivOwnedStr,
-};
+use crate::{serde::deserialize_cow_str, PrivOwnedStr};
+
+#[cfg(feature = "compat-tag-info")]
+use crate::serde::deserialize_as_optional_f64_or_string;
 
 /// Map of tag names to tag info.
 pub type Tags = BTreeMap<TagName, TagInfo>;

--- a/crates/ruma-common/src/serde.rs
+++ b/crates/ruma-common/src/serde.rs
@@ -26,7 +26,8 @@ pub use self::{
     cow::deserialize_cow_str,
     raw::Raw,
     strings::{
-        btreemap_deserialize_v1_powerlevel_values, deserialize_v1_powerlevel, empty_string_as_none,
+        btreemap_deserialize_v1_powerlevel_values, deserialize_as_f64_or_string,
+        deserialize_as_optional_f64_or_string, deserialize_v1_powerlevel, empty_string_as_none,
         none_as_empty_string,
     },
 };

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -98,6 +98,7 @@ compat = [
     "compat-unset-avatar",
     "compat-get-3pids",
     "compat-signature-id",
+    "compat-tag-info",
 ]
 # Don't validate the version part in `KeyId`.
 compat-key-id = ["ruma-common/compat-key-id"]
@@ -125,6 +126,8 @@ compat-unset-avatar = ["ruma-client-api?/compat-unset-avatar"]
 compat-get-3pids = ["ruma-client-api?/compat-get-3pids"]
 # Allow extra characters in signature IDs not allowed in the specification.
 compat-signature-id = ["ruma-signatures?/compat-signature-id"]
+# Allow TagInfo to contain a stringified floating-point value for the `order` field.
+compat-tag-info = ["ruma-common/compat-tag-info"]
 
 # Specific compatibility for past ring public/private key documents.
 ring-compat = ["dep:ruma-signatures", "ruma-signatures?/ring-compat"]

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -211,7 +211,7 @@ impl CiTask {
     fn test_common(&self) -> Result<()> {
         cmd!(
             "rustup run stable cargo test -p ruma-common
-                --features events,compat-empty-string-null,compat-user-id compat"
+                --features events,compat-empty-string-null,compat-user-id,compat-tag-info compat"
         )
         .run()
         .map_err(Into::into)


### PR DESCRIPTION
Some servers are returning a stringified value for the `TagInfo::order` field; this PR allows parsing this field as either a f64 or a stringified f64, if present.

<!-- Replace -->
----
Preview Removed
<!-- Replace -->
