### PR TITLE
federation-api: Use SpaceRoomJoinRule for SpaceHierarchy(Parent/Child)Summary(Init)

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -5,6 +5,7 @@ Breaking changes:
 - Define `rank` as an `Option<f64>` instead of an `Option<UInt>` in
   `search::search_events::v3::SearchResult`
 - Remove the `token` field from `keys::get_keys::Request`, according to a spec clarification.
+- `SpaceRoomJoinRule` has been moved to the `space` module of the ruma-common crate
 
 Improvements:
 

--- a/crates/ruma-client-api/src/space.rs
+++ b/crates/ruma-client-api/src/space.rs
@@ -6,14 +6,10 @@
 
 use js_int::UInt;
 use ruma_common::{
-    events::space::child::HierarchySpaceChildEvent,
-    room::RoomType,
-    serde::{Raw, StringEnum},
-    OwnedMxcUri, OwnedRoomAliasId, OwnedRoomId,
+    events::space::child::HierarchySpaceChildEvent, room::RoomType, serde::Raw,
+    space::SpaceRoomJoinRule, OwnedMxcUri, OwnedRoomAliasId, OwnedRoomId,
 };
 use serde::{Deserialize, Serialize};
-
-use crate::PrivOwnedStr;
 
 pub mod get_hierarchy;
 
@@ -134,46 +130,4 @@ impl From<SpaceHierarchyRoomsChunkInit> for SpaceHierarchyRoomsChunk {
             children_state,
         }
     }
-}
-
-/// The rule used for users wishing to join a room.
-///
-/// In contrast to the regular [`JoinRule`](ruma_common::events::room::join_rules::JoinRule), this
-/// enum does not hold the conditions for joining restricted rooms. Instead, the server is assumed
-/// to only return rooms the user is allowed to join in a space hierarchy listing response.
-#[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, Default, PartialEq, Eq, StringEnum)]
-#[ruma_enum(rename_all = "snake_case")]
-#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-pub enum SpaceRoomJoinRule {
-    /// A user who wishes to join the room must first receive an invite to the room from someone
-    /// already inside of the room.
-    Invite,
-
-    /// Users can join the room if they are invited, or they can request an invite to the room.
-    ///
-    /// They can be allowed (invited) or denied (kicked/banned) access.
-    Knock,
-
-    /// Reserved but not yet implemented by the Matrix specification.
-    Private,
-
-    /// Users can join the room if they are invited, or if they meet any of the conditions
-    /// described in a set of [`AllowRule`](ruma_common::events::room::join_rules::AllowRule)s.
-    ///
-    /// These rules are not made available as part of a space hierarchy listing response and can
-    /// only be seen by users inside the room.
-    Restricted,
-
-    /// Users can join the room if they are invited, or if they meet any of the conditions
-    /// described in a set of [`AllowRule`](ruma_common::events::room::join_rules::AllowRule)s, or
-    /// they can request an invite to the room.
-    KnockRestricted,
-
-    /// Anyone can join the room without any prior action.
-    #[default]
-    Public,
-
-    #[doc(hidden)]
-    _Custom(PrivOwnedStr),
 }

--- a/crates/ruma-common/src/lib.rs
+++ b/crates/ruma-common/src/lib.rs
@@ -33,6 +33,7 @@ pub mod presence;
 pub mod push;
 pub mod room;
 pub mod serde;
+pub mod space;
 pub mod thirdparty;
 mod time;
 pub mod to_device;

--- a/crates/ruma-common/src/space.rs
+++ b/crates/ruma-common/src/space.rs
@@ -1,0 +1,49 @@
+//! Common types for [spaces].
+//!
+//! [spaces]: https://spec.matrix.org/latest/client-server-api/#spaces
+
+use ruma_macros::StringEnum;
+
+use crate::PrivOwnedStr;
+
+/// The rule used for users wishing to join a room.
+///
+/// In contrast to the regular [`JoinRule`](crate::events::room::join_rules::JoinRule), this
+/// enum does not hold the conditions for joining restricted rooms. Instead, the server is assumed
+/// to only return rooms the user is allowed to join in a space hierarchy listing response.
+#[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
+#[derive(Clone, Default, PartialEq, Eq, StringEnum)]
+#[ruma_enum(rename_all = "snake_case")]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+pub enum SpaceRoomJoinRule {
+    /// A user who wishes to join the room must first receive an invite to the room from someone
+    /// already inside of the room.
+    Invite,
+
+    /// Users can join the room if they are invited, or they can request an invite to the room.
+    ///
+    /// They can be allowed (invited) or denied (kicked/banned) access.
+    Knock,
+
+    /// Reserved but not yet implemented by the Matrix specification.
+    Private,
+
+    /// Users can join the room if they are invited, or if they meet any of the conditions
+    /// described in a set of [`AllowRule`](crate::events::room::join_rules::AllowRule)s.
+    ///
+    /// These rules are not made available as part of a space hierarchy listing response and can
+    /// only be seen by users inside the room.
+    Restricted,
+
+    /// Users can join the room if they are invited, or if they meet any of the conditions
+    /// described in a set of [`AllowRule`](crate::events::room::join_rules::AllowRule)s, or
+    /// they can request an invite to the room.
+    KnockRestricted,
+
+    /// Anyone can join the room without any prior action.
+    #[default]
+    Public,
+
+    #[doc(hidden)]
+    _Custom(PrivOwnedStr),
+}

--- a/crates/ruma-federation-api/CHANGELOG.md
+++ b/crates/ruma-federation-api/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [unreleased]
 
+Bug fixes:
+
+* Use `SpaceRoomJoinRule` for `SpaceHierarchy(Parent/Child)Summary(Init)`. Even if
+  (de)serialization worked before, it is more correct to expect any join rule, like in the CS API
+
 Improvements:
 
 * Deprecate the `v1/send_join` and `v1/send_leave` endpoints according to a spec clarification

--- a/crates/ruma-federation-api/src/space.rs
+++ b/crates/ruma-federation-api/src/space.rs
@@ -2,8 +2,8 @@
 
 use js_int::UInt;
 use ruma_common::{
-    directory::PublicRoomJoinRule, events::space::child::HierarchySpaceChildEvent, room::RoomType,
-    serde::Raw, OwnedMxcUri, OwnedRoomAliasId, OwnedRoomId,
+    events::space::child::HierarchySpaceChildEvent, room::RoomType, serde::Raw,
+    space::SpaceRoomJoinRule, OwnedMxcUri, OwnedRoomAliasId, OwnedRoomId,
 };
 use serde::{Deserialize, Serialize};
 
@@ -62,7 +62,7 @@ pub struct SpaceHierarchyParentSummary {
 
     /// The join rule of the room.
     #[serde(default, skip_serializing_if = "ruma_common::serde::is_default")]
-    pub join_rule: PublicRoomJoinRule,
+    pub join_rule: SpaceRoomJoinRule,
 
     /// The type of room from `m.room.create`, if any.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -101,7 +101,7 @@ pub struct SpaceHierarchyParentSummaryInit {
     pub guest_can_join: bool,
 
     /// The join rule of the room.
-    pub join_rule: PublicRoomJoinRule,
+    pub join_rule: SpaceRoomJoinRule,
 
     /// The stripped `m.space.child` events of the space-room.
     ///
@@ -195,7 +195,7 @@ pub struct SpaceHierarchyChildSummary {
 
     /// The join rule of the room.
     #[serde(default, skip_serializing_if = "ruma_common::serde::is_default")]
-    pub join_rule: PublicRoomJoinRule,
+    pub join_rule: SpaceRoomJoinRule,
 
     /// The type of room from `m.room.create`, if any.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -229,7 +229,7 @@ pub struct SpaceHierarchyChildSummaryInit {
     pub guest_can_join: bool,
 
     /// The join rule of the room.
-    pub join_rule: PublicRoomJoinRule,
+    pub join_rule: SpaceRoomJoinRule,
 
     /// If the room is a restricted room, these are the room IDs which are specified by the join
     /// rules.


### PR DESCRIPTION
It is more correct to expect any join rule, like the endpoint of the CS API, rather than only the join rules of the public rooms directory.




<!-- Replace -->
----
Preview Removed
<!-- Replace -->
