### PR TITLE
chore: Bump MSRV to 1.65

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         run: target/debug/xtask ci lint
 
   msrv:
-    name: Rust 1.64 / ${{ matrix.name }}
+    name: Rust 1.65 / ${{ matrix.name }}
     needs: xtask
     runs-on: ubuntu-latest
     strategy:
@@ -90,17 +90,17 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Install rust 1.64 toolchain
+      - name: Install rust 1.65 toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.64
+          toolchain: 1.65
 
       - uses: Swatinem/rust-cache@v2
         with:
           # A stable compiler update should automatically not reuse old caches.
           # Add the MSRV as a stable cache key too so bumping it also gets us a
           # fresh cache.
-          sharedKey: msrv1.64
+          sharedKey: msrv1.65
 
       - name: Get xtask
         uses: actions/cache@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,9 @@ members = ["crates/*", "examples/*", "xtask"]
 default-members = ["crates/*"]
 resolver = "2"
 
+[workspace.package]
+rust-version = "1.64"
+
 [workspace.dependencies]
 assert_matches2 = "0.1.0"
 assign = "1.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-rust-version = "1.64"
+rust-version = "1.65"
 
 [workspace.dependencies]
 assert_matches2 = "0.1.0"

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Minimum Rust version
 
-Ruma currently requires Rust 1.64. In general, we will never require beta or
+Ruma currently requires Rust 1.65. In general, we will never require beta or
 nightly for crates.io releases of our crates, and we will try to avoid releasing
 crates that depend on features that were only just stabilized.
 

--- a/crates/ruma-appservice-api/Cargo.toml
+++ b/crates/ruma-appservice-api/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 repository = "https://github.com/ruma/ruma"
 version = "0.8.1"
 edition = "2021"
-rust-version = "1.64"
+rust-version = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/ruma-client-api/Cargo.toml
+++ b/crates/ruma-client-api/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 repository = "https://github.com/ruma/ruma"
 version = "0.16.2"
 edition = "2021"
-rust-version = "1.64"
+rust-version = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/ruma-client/Cargo.toml
+++ b/crates/ruma-client/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 repository = "https://github.com/ruma/ruma"
 version = "0.11.0"
 edition = "2021"
-rust-version = "1.64"
+rust-version = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/ruma/ruma"
 edition = "2021"
-rust-version = "1.64"
+rust-version = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/ruma-federation-api/Cargo.toml
+++ b/crates/ruma-federation-api/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 repository = "https://github.com/ruma/ruma"
 version = "0.7.1"
 edition = "2021"
-rust-version = "1.64"
+rust-version = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/ruma-identifiers-validation/Cargo.toml
+++ b/crates/ruma-identifiers-validation/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/ruma/ruma"
 license = "MIT"
 version = "0.9.1"
 edition = "2021"
-rust-version = "1.64"
+rust-version = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/ruma-identity-service-api/Cargo.toml
+++ b/crates/ruma-identity-service-api/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/ruma/ruma"
 edition = "2021"
-rust-version = "1.64"
+rust-version = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/ruma-macros/Cargo.toml
+++ b/crates/ruma-macros/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 repository = "https://github.com/ruma/ruma"
 version = "0.11.3"
 edition = "2021"
-rust-version = "1.64"
+rust-version = { workspace = true }
 
 [lib]
 proc-macro = true

--- a/crates/ruma-push-gateway-api/Cargo.toml
+++ b/crates/ruma-push-gateway-api/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/ruma/ruma"
 edition = "2021"
-rust-version = "1.64"
+rust-version = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/ruma-server-util/Cargo.toml
+++ b/crates/ruma-server-util/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 repository = "https://github.com/ruma/ruma"
 version = "0.1.1"
 edition = "2021"
-rust-version = "1.64"
+rust-version = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/ruma-state-res/Cargo.toml
+++ b/crates/ruma-state-res/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 license = "MIT"
 version = "0.9.1"
 edition = "2021"
-rust-version = "1.64"
+rust-version = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 license = "MIT"
 version = "0.8.2"
 edition = "2021"
-rust-version = "1.64"
+rust-version = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -12,7 +12,7 @@ mod spec_links;
 
 use spec_links::check_spec_links;
 
-const MSRV: &str = "1.64";
+const MSRV: &str = "1.65";
 const NIGHTLY: &str = "nightly-2023-07-03";
 
 #[derive(Args)]


### PR DESCRIPTION
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->





<!-- Replace -->
----
Preview Removed
<!-- Replace -->
