### PR TITLE
events: Implement Deserialize for encrypted::Relation

### DIFF
--- a/crates/ruma-common/src/events/encrypted.rs
+++ b/crates/ruma-common/src/events/encrypted.rs
@@ -23,11 +23,7 @@ pub struct EncryptedEventContent {
     pub encrypted: EncryptedContentBlock,
 
     /// Information about related events.
-    #[serde(
-        flatten,
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "super::room::encrypted::relation_serde::deserialize_relation"
-    )]
+    #[serde(rename = "m.relates_to", skip_serializing_if = "Option::is_none")]
     pub relates_to: Option<Relation>,
 }
 

--- a/crates/ruma-common/src/events/room/encrypted.rs
+++ b/crates/ruma-common/src/events/room/encrypted.rs
@@ -26,11 +26,7 @@ pub struct RoomEncryptedEventContent {
     pub scheme: EncryptedEventScheme,
 
     /// Information about related events.
-    #[serde(
-        flatten,
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "relation_serde::deserialize_relation"
-    )]
+    #[serde(rename = "m.relates_to", skip_serializing_if = "Option::is_none")]
     pub relates_to: Option<Relation>,
 }
 


### PR DESCRIPTION
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->





<!-- Replace -->
----
Preview Removed
<!-- Replace -->
