### PR TITLE
Enable unreachable_pub lint

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -9,6 +9,7 @@ rustflags = [
     "-Wprivate_in_public",
     "-Wrust_2018_idioms",
     "-Wsemicolon_in_expressions_from_macros",
+    "-Wunreachable_pub",
     "-Wunused_import_braces",
     "-Wunused_qualifications",
     "-Wclippy::branches_sharing_code",

--- a/crates/ruma-client-api/src/backup/get_backup_info.rs
+++ b/crates/ruma-client-api/src/backup/get_backup_info.rs
@@ -2,6 +2,7 @@
 //!
 //! Get information about a specific backup.
 
+#[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/112615
 pub mod v3 {
     //! `/v3/` ([spec])
     //!

--- a/crates/ruma-client-api/src/session/get_login_types.rs
+++ b/crates/ruma-client-api/src/session/get_login_types.rs
@@ -329,7 +329,7 @@ pub mod v3 {
 
         #[derive(Debug, Deserialize, Serialize)]
         struct Wrapper {
-            pub flows: Vec<LoginType>,
+            flows: Vec<LoginType>,
         }
 
         #[test]

--- a/crates/ruma-client-api/src/state/send_state_event.rs
+++ b/crates/ruma-client-api/src/state/send_state_event.rs
@@ -201,7 +201,7 @@ pub mod v3 {
     struct RequestQuery {
         /// Timestamp to use for the `origin_server_ts` of the event.
         #[serde(rename = "ts", skip_serializing_if = "Option::is_none")]
-        pub timestamp: Option<MilliSecondsSinceUnixEpoch>,
+        timestamp: Option<MilliSecondsSinceUnixEpoch>,
     }
 
     #[cfg(feature = "client")]

--- a/crates/ruma-common/src/events/enums.rs
+++ b/crates/ruma-common/src/events/enums.rs
@@ -248,7 +248,7 @@ impl From<AnyTimelineEvent> for AnySyncTimelineEvent {
 #[derive(Deserialize)]
 #[allow(clippy::exhaustive_structs)]
 struct EventDeHelper {
-    pub state_key: Option<de::IgnoredAny>,
+    state_key: Option<de::IgnoredAny>,
 }
 
 impl<'de> Deserialize<'de> for AnyTimelineEvent {

--- a/crates/ruma-common/src/events/room.rs
+++ b/crates/ruma-common/src/events/room.rs
@@ -56,7 +56,7 @@ impl<'de> Deserialize<'de> for MediaSource {
         D: serde::Deserializer<'de>,
     {
         #[derive(Deserialize)]
-        pub struct MediaSourceJsonRepr {
+        struct MediaSourceJsonRepr {
             url: Option<OwnedMxcUri>,
             file: Option<Box<EncryptedFile>>,
         }

--- a/crates/ruma-common/src/events/room/message/content_serde.rs
+++ b/crates/ruma-common/src/events/room/message/content_serde.rs
@@ -75,6 +75,7 @@ impl<'de> Deserialize<'de> for MessageType {
     }
 }
 
+#[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/112615
 #[cfg(feature = "unstable-msc3488")]
 pub(in super::super) mod msc3488 {
     use serde::{Deserialize, Serialize};

--- a/crates/ruma-common/src/events/room/message/reply.rs
+++ b/crates/ruma-common/src/events/room/message/reply.rs
@@ -106,7 +106,7 @@ impl fmt::Display for FormattedOrPlainBody<'_> {
 ///
 /// [HTML tags and attributes]: https://spec.matrix.org/latest/client-server-api/#mroommessage-msgtypes
 /// [rich reply fallbacks]: https://spec.matrix.org/latest/client-server-api/#fallbacks-for-rich-replies
-pub fn plain_and_formatted_reply_body(
+pub(crate) fn plain_and_formatted_reply_body(
     body: &str,
     formatted: Option<impl fmt::Display>,
     original_message: &OriginalRoomMessageEvent,

--- a/crates/ruma-common/src/events/room/message/sanitize.rs
+++ b/crates/ruma-common/src/events/room/message/sanitize.rs
@@ -1,5 +1,7 @@
 //! Convenience methods and types to sanitize text messages.
 
+#![allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/112615
+
 #[cfg(feature = "unstable-sanitize")]
 mod html_fragment;
 #[cfg(feature = "unstable-sanitize")]

--- a/crates/ruma-common/src/events/room/thumbnail_source_serde.rs
+++ b/crates/ruma-common/src/events/room/thumbnail_source_serde.rs
@@ -10,7 +10,7 @@ use crate::OwnedMxcUri;
 use super::{EncryptedFile, MediaSource};
 
 /// Serializes a MediaSource to a thumbnail source.
-pub fn serialize<S>(source: &Option<MediaSource>, serializer: S) -> Result<S::Ok, S::Error>
+pub(crate) fn serialize<S>(source: &Option<MediaSource>, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
@@ -27,12 +27,12 @@ where
 }
 
 /// Deserializes a thumbnail source to a MediaSource.
-pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<MediaSource>, D::Error>
+pub(crate) fn deserialize<'de, D>(deserializer: D) -> Result<Option<MediaSource>, D::Error>
 where
     D: Deserializer<'de>,
 {
     #[derive(Deserialize)]
-    pub struct ThumbnailSourceJsonRepr {
+    struct ThumbnailSourceJsonRepr {
         thumbnail_url: Option<OwnedMxcUri>,
         thumbnail_file: Option<Box<EncryptedFile>>,
     }

--- a/crates/ruma-common/src/push.rs
+++ b/crates/ruma-common/src/push.rs
@@ -39,7 +39,7 @@ pub use self::{
     action::{Action, Tweak},
     condition::{
         ComparisonOperator, FlattenedJson, FlattenedJsonValue, PushCondition, PushConditionRoomCtx,
-        RoomMemberCountIs, _CustomPushCondition,
+        RoomMemberCountIs, ScalarJsonValue, _CustomPushCondition,
     },
     iter::{AnyPushRule, AnyPushRuleRef, RulesetIntoIter, RulesetIter},
     predefined::{

--- a/crates/ruma-common/tests/api/mod.rs
+++ b/crates/ruma-common/tests/api/mod.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "api")]
+#![allow(unreachable_pub)]
 
 mod conversions;
 mod header_override;

--- a/crates/ruma-federation-api/src/serde.rs
+++ b/crates/ruma-federation-api/src/serde.rs
@@ -1,4 +1,4 @@
 //! Modules for custom serde de/-serialization implementations.
 
-pub mod pdu_process_response;
-pub mod v1_pdu;
+pub(crate) mod pdu_process_response;
+pub(crate) mod v1_pdu;

--- a/crates/ruma-federation-api/src/serde/pdu_process_response.rs
+++ b/crates/ruma-federation-api/src/serde/pdu_process_response.rs
@@ -13,7 +13,7 @@ struct WrappedError {
     error: Option<String>,
 }
 
-pub fn serialize<S>(
+pub(crate) fn serialize<S>(
     response: &BTreeMap<OwnedEventId, Result<(), String>>,
     serializer: S,
 ) -> Result<S::Ok, S::Error>
@@ -34,7 +34,7 @@ where
 }
 
 #[allow(clippy::type_complexity)]
-pub fn deserialize<'de, D>(
+pub(crate) fn deserialize<'de, D>(
     deserializer: D,
 ) -> Result<BTreeMap<OwnedEventId, Result<(), String>>, D::Error>
 where

--- a/crates/ruma-federation-api/src/serde/v1_pdu.rs
+++ b/crates/ruma-federation-api/src/serde/v1_pdu.rs
@@ -15,7 +15,7 @@ use serde::{
     ser::{Serialize, SerializeSeq, Serializer},
 };
 
-pub fn serialize<T, S>(val: &T, serializer: S) -> Result<S::Ok, S::Error>
+pub(crate) fn serialize<T, S>(val: &T, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
     T: Serialize,
@@ -26,7 +26,7 @@ where
     seq.end()
 }
 
-pub fn deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+pub(crate) fn deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>
 where
     D: Deserializer<'de>,
     T: Deserialize<'de>,

--- a/crates/ruma-macros/src/api/response.rs
+++ b/crates/ruma-macros/src/api/response.rs
@@ -13,7 +13,7 @@ use super::{
     attribute::{DeriveResponseMeta, ResponseMeta},
     ensure_feature_presence,
 };
-use crate::util::import_ruma_common;
+use crate::util::{import_ruma_common, PrivateField};
 
 mod incoming;
 mod outgoing;
@@ -132,7 +132,8 @@ impl Response {
             });
 
             let serde_attr = self.has_newtype_body().then(|| quote! { #[serde(transparent)] });
-            let fields = self.fields.iter().filter_map(ResponseField::as_body_field);
+            let fields =
+                self.fields.iter().filter_map(ResponseField::as_body_field).map(PrivateField);
 
             quote! {
                 /// Data in the response body.

--- a/crates/ruma-macros/src/events/event_content.rs
+++ b/crates/ruma-macros/src/events/event_content.rs
@@ -12,7 +12,7 @@ use syn::{
     DeriveInput, Field, Ident, LitStr, Meta, Token, Type,
 };
 
-use crate::util::m_prefix_name_to_type_name;
+use crate::util::{m_prefix_name_to_type_name, PrivateField};
 
 use super::event_parse::{EventKind, EventKindVariation};
 
@@ -930,9 +930,10 @@ fn generate_event_content_impl<'a>(
                         && matches!(a.parse_args(), Ok(EventFieldMeta::TypeFragment))
                 })
             })
+            .map(PrivateField)
             .collect::<Vec<_>>();
         let fields_ident_without_type_fragment =
-            fields_without_type_fragment.iter().filter_map(|f| f.ident.as_ref());
+            fields_without_type_fragment.iter().filter_map(|f| f.0.ident.as_ref());
 
         quote! {
             impl #ruma_common::events::EventContentFromType for #ident {

--- a/crates/ruma-macros/src/events/event_content.rs
+++ b/crates/ruma-macros/src/events/event_content.rs
@@ -941,16 +941,24 @@ fn generate_event_content_impl<'a>(
                         #( #fields_without_type_fragment, )*
                     }
 
-                    if let ::std::option::Option::Some(type_fragment) = #type_prefixes.iter().find_map(|prefix| ev_type.strip_prefix(prefix)) {
+                    if let ::std::option::Option::Some(type_fragment) =
+                        #type_prefixes.iter().find_map(|prefix| ev_type.strip_prefix(prefix))
+                    {
                         let c: WithoutTypeFragment = #serde_json::from_str(content.get())?;
 
                         ::std::result::Result::Ok(Self {
-                            #( #fields_ident_without_type_fragment: c.#fields_ident_without_type_fragment, )*
+                            #(
+                                #fields_ident_without_type_fragment:
+                                    c.#fields_ident_without_type_fragment,
+                            )*
                             #type_fragment_field: type_fragment.to_owned(),
                         })
                     } else {
                         ::std::result::Result::Err(#serde::de::Error::custom(
-                            ::std::format!("expected event type starting with one of `{:?}`, found `{}`", #type_prefixes, ev_type)
+                            ::std::format!(
+                                "expected event type starting with one of `{:?}`, found `{}`",
+                                #type_prefixes, ev_type,
+                            )
                         ))
                     }
                 }

--- a/crates/ruma-macros/src/events/event_content.rs
+++ b/crates/ruma-macros/src/events/event_content.rs
@@ -923,12 +923,16 @@ fn generate_event_content_impl<'a>(
         let type_prefixes = quote! {
             [#(#type_prefixes,)*]
         };
-        let fields_without_type_fragment = fields.filter(|f| {
-            !f.attrs.iter().any(|a| {
-                a.path().is_ident("ruma_event") && matches!(a.parse_args(), Ok(EventFieldMeta::TypeFragment))
+        let fields_without_type_fragment = fields
+            .filter(|f| {
+                !f.attrs.iter().any(|a| {
+                    a.path().is_ident("ruma_event")
+                        && matches!(a.parse_args(), Ok(EventFieldMeta::TypeFragment))
+                })
             })
-        }).collect::<Vec<_>>();
-        let fields_ident_without_type_fragment = fields_without_type_fragment.iter().filter_map(|f| f.ident.as_ref());
+            .collect::<Vec<_>>();
+        let fields_ident_without_type_fragment =
+            fields_without_type_fragment.iter().filter_map(|f| f.ident.as_ref());
 
         quote! {
             impl #ruma_common::events::EventContentFromType for #ident {

--- a/crates/ruma-macros/src/lib.rs
+++ b/crates/ruma-macros/src/lib.rs
@@ -5,6 +5,7 @@
 //! See the documentation for the individual macros for usage details.
 
 #![warn(missing_docs)]
+#![allow(unreachable_pub)]
 // https://github.com/rust-lang/rust-clippy/issues/9029
 #![allow(clippy::derive_partial_eq_without_eq)]
 

--- a/crates/ruma-push-gateway-api/src/send_event_notification.rs
+++ b/crates/ruma-push-gateway-api/src/send_event_notification.rs
@@ -305,7 +305,7 @@ pub mod v1 {
             Deserializer, Serializer,
         };
 
-        pub fn serialize<S>(tweak: &[Tweak], serializer: S) -> Result<S::Ok, S::Error>
+        pub(super) fn serialize<S>(tweak: &[Tweak], serializer: S) -> Result<S::Ok, S::Error>
         where
             S: Serializer,
         {
@@ -364,7 +364,7 @@ pub mod v1 {
             }
         }
 
-        pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<Tweak>, D::Error>
+        pub(super) fn deserialize<'de, D>(deserializer: D) -> Result<Vec<Tweak>, D::Error>
         where
             D: Deserializer<'de>,
         {

--- a/crates/ruma-signatures/src/keys.rs
+++ b/crates/ruma-signatures/src/keys.rs
@@ -24,7 +24,7 @@ pub trait KeyPair: Sized {
     fn sign(&self, message: &[u8]) -> Signature;
 }
 
-pub const ED25519_OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.101.112");
+const ED25519_OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.101.112");
 
 /// An Ed25519 key pair.
 pub struct Ed25519KeyPair {

--- a/crates/ruma-signatures/src/verification.rs
+++ b/crates/ruma-signatures/src/verification.rs
@@ -5,7 +5,7 @@ use ed25519_dalek::{PublicKey, Verifier as _};
 use crate::{Error, ParseError, VerificationError};
 
 /// A digital signature verifier.
-pub trait Verifier {
+pub(crate) trait Verifier {
     /// Use a public key to verify a signature against the JSON object that was signed.
     ///
     /// # Parameters
@@ -23,7 +23,7 @@ pub trait Verifier {
 
 /// A verifier for Ed25519 digital signatures.
 #[derive(Debug, Default)]
-pub struct Ed25519Verifier;
+pub(crate) struct Ed25519Verifier;
 
 impl Verifier for Ed25519Verifier {
     fn verify_json(

--- a/crates/ruma-state-res/src/power_levels.rs
+++ b/crates/ruma-state-res/src/power_levels.rs
@@ -16,34 +16,34 @@ use crate::RoomVersion;
 #[derive(Deserialize)]
 struct IntRoomPowerLevelsEventContent {
     #[serde(default = "default_power_level")]
-    pub ban: Int,
+    ban: Int,
 
     #[serde(default)]
-    pub events: BTreeMap<TimelineEventType, Int>,
+    events: BTreeMap<TimelineEventType, Int>,
 
     #[serde(default)]
-    pub events_default: Int,
+    events_default: Int,
 
     #[serde(default)]
-    pub invite: Int,
+    invite: Int,
 
     #[serde(default = "default_power_level")]
-    pub kick: Int,
+    kick: Int,
 
     #[serde(default = "default_power_level")]
-    pub redact: Int,
+    redact: Int,
 
     #[serde(default = "default_power_level")]
-    pub state_default: Int,
+    state_default: Int,
 
     #[serde(default)]
-    pub users: BTreeMap<OwnedUserId, Int>,
+    users: BTreeMap<OwnedUserId, Int>,
 
     #[serde(default)]
-    pub users_default: Int,
+    users_default: Int,
 
     #[serde(default)]
-    pub notifications: IntNotificationPowerLevels,
+    notifications: IntNotificationPowerLevels,
 }
 
 impl From<IntRoomPowerLevelsEventContent> for RoomPowerLevelsEventContent {
@@ -80,7 +80,7 @@ impl From<IntRoomPowerLevelsEventContent> for RoomPowerLevelsEventContent {
 #[derive(Deserialize)]
 struct IntNotificationPowerLevels {
     #[serde(default = "default_power_level")]
-    pub room: Int,
+    room: Int,
 }
 
 impl Default for IntNotificationPowerLevels {

--- a/crates/ruma-state-res/src/test_utils.rs
+++ b/crates/ruma-state-res/src/test_utils.rs
@@ -29,11 +29,11 @@ use tracing::info;
 
 use crate::{auth_types_for_event, Error, Event, EventTypeExt, Result, StateMap};
 
-pub use event::PduEvent;
+pub(crate) use event::PduEvent;
 
 static SERVER_TIMESTAMP: AtomicU64 = AtomicU64::new(0);
 
-pub fn do_check(
+pub(crate) fn do_check(
     events: &[Arc<PduEvent>],
     edges: Vec<Vec<OwnedEventId>>,
     expected_state_ids: Vec<OwnedEventId>,
@@ -206,10 +206,10 @@ pub fn do_check(
 }
 
 #[allow(clippy::exhaustive_structs)]
-pub struct TestStore<E: Event>(pub HashMap<OwnedEventId, Arc<E>>);
+pub(crate) struct TestStore<E: Event>(pub(crate) HashMap<OwnedEventId, Arc<E>>);
 
 impl<E: Event> TestStore<E> {
-    pub fn get_event(&self, _: &RoomId, event_id: &EventId) -> Result<Arc<E>> {
+    pub(crate) fn get_event(&self, _: &RoomId, event_id: &EventId) -> Result<Arc<E>> {
         self.0
             .get(event_id)
             .map(Arc::clone)
@@ -217,7 +217,7 @@ impl<E: Event> TestStore<E> {
     }
 
     /// Returns a Vec of the related auth events to the given `event`.
-    pub fn auth_event_ids(
+    pub(crate) fn auth_event_ids(
         &self,
         room_id: &RoomId,
         event_ids: Vec<E::Id>,
@@ -245,7 +245,7 @@ impl<E: Event> TestStore<E> {
 // A StateStore implementation for testing
 #[allow(clippy::type_complexity)]
 impl TestStore<PduEvent> {
-    pub fn set_up(
+    pub(crate) fn set_up(
         &mut self,
     ) -> (StateMap<OwnedEventId>, StateMap<OwnedEventId>, StateMap<OwnedEventId>) {
         let create_event = to_pdu_event::<&EventId>(
@@ -331,7 +331,7 @@ impl TestStore<PduEvent> {
     }
 }
 
-pub fn event_id(id: &str) -> OwnedEventId {
+pub(crate) fn event_id(id: &str) -> OwnedEventId {
     if id.contains('$') {
         return id.try_into().unwrap();
     }
@@ -339,39 +339,39 @@ pub fn event_id(id: &str) -> OwnedEventId {
     format!("${id}:foo").try_into().unwrap()
 }
 
-pub fn alice() -> &'static UserId {
+pub(crate) fn alice() -> &'static UserId {
     user_id!("@alice:foo")
 }
 
-pub fn bob() -> &'static UserId {
+pub(crate) fn bob() -> &'static UserId {
     user_id!("@bob:foo")
 }
 
-pub fn charlie() -> &'static UserId {
+pub(crate) fn charlie() -> &'static UserId {
     user_id!("@charlie:foo")
 }
 
-pub fn ella() -> &'static UserId {
+pub(crate) fn ella() -> &'static UserId {
     user_id!("@ella:foo")
 }
 
-pub fn zara() -> &'static UserId {
+pub(crate) fn zara() -> &'static UserId {
     user_id!("@zara:foo")
 }
 
-pub fn room_id() -> &'static RoomId {
+pub(crate) fn room_id() -> &'static RoomId {
     room_id!("!test:foo")
 }
 
-pub fn member_content_ban() -> Box<RawJsonValue> {
+pub(crate) fn member_content_ban() -> Box<RawJsonValue> {
     to_raw_json_value(&RoomMemberEventContent::new(MembershipState::Ban)).unwrap()
 }
 
-pub fn member_content_join() -> Box<RawJsonValue> {
+pub(crate) fn member_content_join() -> Box<RawJsonValue> {
     to_raw_json_value(&RoomMemberEventContent::new(MembershipState::Join)).unwrap()
 }
 
-pub fn to_init_pdu_event(
+pub(crate) fn to_init_pdu_event(
     id: &str,
     sender: &UserId,
     ev_type: TimelineEventType,
@@ -402,7 +402,7 @@ pub fn to_init_pdu_event(
     })
 }
 
-pub fn to_pdu_event<S>(
+pub(crate) fn to_pdu_event<S>(
     id: &str,
     sender: &UserId,
     ev_type: TimelineEventType,
@@ -442,7 +442,7 @@ where
 
 // all graphs start with these input events
 #[allow(non_snake_case)]
-pub fn INITIAL_EVENTS() -> HashMap<OwnedEventId, Arc<PduEvent>> {
+pub(crate) fn INITIAL_EVENTS() -> HashMap<OwnedEventId, Arc<PduEvent>> {
     vec![
         to_pdu_event::<&EventId>(
             "CREATE",
@@ -524,7 +524,7 @@ pub fn INITIAL_EVENTS() -> HashMap<OwnedEventId, Arc<PduEvent>> {
 
 // all graphs start with these input events
 #[allow(non_snake_case)]
-pub fn INITIAL_EVENTS_CREATE_ROOM() -> HashMap<OwnedEventId, Arc<PduEvent>> {
+pub(crate) fn INITIAL_EVENTS_CREATE_ROOM() -> HashMap<OwnedEventId, Arc<PduEvent>> {
     vec![to_pdu_event::<&EventId>(
         "CREATE",
         alice(),
@@ -540,14 +540,14 @@ pub fn INITIAL_EVENTS_CREATE_ROOM() -> HashMap<OwnedEventId, Arc<PduEvent>> {
 }
 
 #[allow(non_snake_case)]
-pub fn INITIAL_EDGES() -> Vec<OwnedEventId> {
+pub(crate) fn INITIAL_EDGES() -> Vec<OwnedEventId> {
     vec!["START", "IMC", "IMB", "IJR", "IPOWER", "IMA", "CREATE"]
         .into_iter()
         .map(event_id)
         .collect::<Vec<_>>()
 }
 
-pub mod event {
+pub(crate) mod event {
     use ruma_common::{
         events::{pdu::Pdu, TimelineEventType},
         MilliSecondsSinceUnixEpoch, OwnedEventId, RoomId, UserId,
@@ -648,9 +648,9 @@ pub mod event {
 
     #[derive(Clone, Debug, Deserialize, Serialize)]
     #[allow(clippy::exhaustive_structs)]
-    pub struct PduEvent {
-        pub event_id: OwnedEventId,
+    pub(crate) struct PduEvent {
+        pub(crate) event_id: OwnedEventId,
         #[serde(flatten)]
-        pub rest: Pdu,
+        pub(crate) rest: Pdu,
     }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -3,6 +3,7 @@
 //! This binary is integrated into the `cargo` command line by using an alias in
 //! `.cargo/config`. Run commands as `cargo xtask [command]`.
 
+#![allow(unreachable_pub)]
 #![allow(clippy::exhaustive_structs)]
 // https://github.com/rust-lang/rust-clippy/issues/9029
 #![allow(clippy::derive_partial_eq_without_eq)]


### PR DESCRIPTION
Been wanting to activate this lint for a while since it makes sure that new public items are actually reachable in case the module they're defined in or a parent module isn't public.




<!-- Replace -->
----
Preview Removed
<!-- Replace -->
