### PR TITLE
events: Use accessors on events for Message-like event enums accessors

### DIFF
--- a/crates/ruma-common/src/events/content.rs
+++ b/crates/ruma-common/src/events/content.rs
@@ -3,7 +3,10 @@ use std::fmt;
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::{from_str as from_json_str, value::RawValue as RawJsonValue};
 
-use crate::serde::{CanBeEmpty, Raw};
+use crate::{
+    serde::{CanBeEmpty, Raw},
+    TransactionId,
+};
 
 use super::{
     EphemeralRoomEventType, GlobalAccountDataEventType, MessageLikeEventType,
@@ -70,7 +73,12 @@ pub trait StaticStateEventContent: StateEventContent {
     type PossiblyRedacted: PossiblyRedactedStateEventContent;
 
     /// The type of the event's `unsigned` field.
-    type Unsigned: Clone + fmt::Debug + Default + CanBeEmpty + DeserializeOwned;
+    type Unsigned: Clone
+        + fmt::Debug
+        + Default
+        + CanBeEmpty
+        + DeserializeOwned
+        + OriginalStateUnsigned;
 }
 
 /// Content of a redacted state event.
@@ -102,4 +110,10 @@ where
     fn from_parts(_event_type: &str, content: &RawJsonValue) -> serde_json::Result<Self> {
         from_json_str(content.get())
     }
+}
+
+/// Unsigned data of an unredacted event.
+pub trait OriginalStateUnsigned {
+    /// The transaction ID if this event was sent from this session.
+    fn transaction_id(&self) -> Option<&TransactionId>;
 }

--- a/crates/ruma-common/src/events/kinds.rs
+++ b/crates/ruma-common/src/events/kinds.rs
@@ -5,17 +5,17 @@ use serde::{ser::SerializeStruct, Deserialize, Deserializer, Serialize};
 use serde_json::value::RawValue as RawJsonValue;
 
 use super::{
-    AnyInitialStateEvent, EmptyStateKey, EphemeralRoomEventContent, EventContent,
-    EventContentFromType, GlobalAccountDataEventContent, MessageLikeEventContent,
-    MessageLikeEventType, MessageLikeUnsigned, PossiblyRedactedStateEventContent, RedactContent,
-    RedactedMessageLikeEventContent, RedactedStateEventContent, RedactedUnsigned,
-    RedactionDeHelper, RoomAccountDataEventContent, StateEventType, StaticStateEventContent,
-    ToDeviceEventContent,
+    AnyInitialStateEvent, BundledMessageLikeRelations, EmptyStateKey, EphemeralRoomEventContent,
+    EventContent, EventContentFromType, GlobalAccountDataEventContent, MessageLikeEventContent,
+    MessageLikeEventType, MessageLikeUnsigned, OriginalStateUnsigned,
+    PossiblyRedactedStateEventContent, RedactContent, RedactedMessageLikeEventContent,
+    RedactedStateEventContent, RedactedUnsigned, RedactionDeHelper, RoomAccountDataEventContent,
+    StateEventType, StaticStateEventContent, ToDeviceEventContent,
 };
 use crate::{
     serde::{from_raw_json_value, Raw},
     EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedUserId, RoomId,
-    RoomVersionId, UserId,
+    RoomVersionId, TransactionId, UserId,
 };
 
 /// A global account data event.
@@ -668,6 +668,27 @@ impl_possibly_redacted_event!(
                 _ => None,
             }
         }
+
+        /// Get the inner content if this is an unredacted event.
+        pub fn original_content(&self) -> Option<&C> {
+            self.as_original().map(|ev| &ev.content)
+        }
+
+        /// Get the `TransactionId` from the unsigned data of this event.
+        pub fn transaction_id(&self) -> Option<&TransactionId> {
+            match self {
+                Self::Original(ev) => ev.unsigned.transaction_id.as_deref(),
+                _ => None,
+            }
+        }
+
+        /// Get the `BundledMessageLikeRelations` from the unsigned data of this event.
+        pub fn relations(&self) -> Option<&BundledMessageLikeRelations<OriginalSyncMessageLikeEvent<C>>> {
+            match self {
+                Self::Original(ev) => Some(&ev.unsigned.relations),
+                _ => None,
+            }
+        }
     }
 );
 
@@ -679,6 +700,27 @@ impl_possibly_redacted_event!(
         pub fn as_original(&self) -> Option<&OriginalSyncMessageLikeEvent<C>> {
             match self {
                 Self::Original(v) => Some(v),
+                _ => None,
+            }
+        }
+
+        /// Get the inner content if this is an unredacted event.
+        pub fn original_content(&self) -> Option<&C> {
+            self.as_original().map(|ev| &ev.content)
+        }
+
+        /// Get the `TransactionId` from the unsigned data of this event.
+        pub fn transaction_id(&self) -> Option<&TransactionId> {
+            match self {
+                Self::Original(ev) => ev.unsigned.transaction_id.as_deref(),
+                _ => None,
+            }
+        }
+
+        /// Get the `BundledMessageLikeRelations` from the unsigned data of this event.
+        pub fn relations(&self) -> Option<&BundledMessageLikeRelations<OriginalSyncMessageLikeEvent<C>>> {
+            match self {
+                Self::Original(ev) => Some(&ev.unsigned.relations),
                 _ => None,
             }
         }
@@ -721,6 +763,19 @@ impl_possibly_redacted_event!(
                 _ => None,
             }
         }
+
+        /// Get the inner content if this is an unredacted event.
+        pub fn original_content(&self) -> Option<&C> {
+            self.as_original().map(|ev| &ev.content)
+        }
+
+        /// Get the `TransactionId` from the unsigned data of this event.
+        pub fn transaction_id(&self) -> Option<&TransactionId> {
+            match self {
+                Self::Original(ev) => ev.unsigned.transaction_id(),
+                _ => None,
+            }
+        }
     }
 );
 
@@ -741,6 +796,19 @@ impl_possibly_redacted_event!(
         pub fn as_original(&self) -> Option<&OriginalSyncStateEvent<C>> {
             match self {
                 Self::Original(v) => Some(v),
+                _ => None,
+            }
+        }
+
+        /// Get the inner content if this is an unredacted event.
+        pub fn original_content(&self) -> Option<&C> {
+            self.as_original().map(|ev| &ev.content)
+        }
+
+        /// Get the `TransactionId` from the unsigned data of this event.
+        pub fn transaction_id(&self) -> Option<&TransactionId> {
+            match self {
+                Self::Original(ev) => ev.unsigned.transaction_id(),
                 _ => None,
             }
         }

--- a/crates/ruma-common/src/events/room/member.rs
+++ b/crates/ruma-common/src/events/room/member.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     events::{
-        AnyStrippedStateEvent, BundledStateRelations, EventContent,
+        AnyStrippedStateEvent, BundledStateRelations, EventContent, OriginalStateUnsigned,
         PossiblyRedactedStateEventContent, RedactContent, RedactedStateEventContent,
         StateEventType,
     },
@@ -530,6 +530,12 @@ impl CanBeEmpty for RoomMemberUnsigned {
             && self.prev_content.is_none()
             && self.invite_room_state.is_empty()
             && self.relations.is_empty()
+    }
+}
+
+impl OriginalStateUnsigned for RoomMemberUnsigned {
+    fn transaction_id(&self) -> Option<&crate::TransactionId> {
+        self.transaction_id.as_deref()
     }
 }
 

--- a/crates/ruma-common/src/events/room/redaction.rs
+++ b/crates/ruma-common/src/events/room/redaction.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     serde::{from_raw_json_value, CanBeEmpty},
     EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedTransactionId,
-    OwnedUserId, RoomId, UserId,
+    OwnedUserId, RoomId, TransactionId, UserId,
 };
 
 /// A possibly-redacted redaction event.
@@ -207,6 +207,29 @@ impl RoomRedactionEvent {
             _ => None,
         }
     }
+
+    /// Get the inner content if this is an unredacted event.
+    pub fn original_content(&self) -> Option<&RoomRedactionEventContent> {
+        self.as_original().map(|ev| &ev.content)
+    }
+
+    /// Get the `TransactionId` from the unsigned data of this event.
+    pub fn transaction_id(&self) -> Option<&TransactionId> {
+        match self {
+            Self::Original(ev) => ev.unsigned.transaction_id.as_deref(),
+            _ => None,
+        }
+    }
+
+    /// Get the `BundledMessageLikeRelations` from the unsigned data of this event.
+    pub fn relations(
+        &self,
+    ) -> Option<&BundledMessageLikeRelations<OriginalSyncRoomRedactionEvent>> {
+        match self {
+            Self::Original(ev) => Some(&ev.unsigned.relations),
+            _ => None,
+        }
+    }
 }
 
 impl<'de> Deserialize<'de> for RoomRedactionEvent {
@@ -262,6 +285,29 @@ impl SyncRoomRedactionEvent {
     pub fn as_original(&self) -> Option<&OriginalSyncRoomRedactionEvent> {
         match self {
             Self::Original(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Get the inner content if this is an unredacted event.
+    pub fn original_content(&self) -> Option<&RoomRedactionEventContent> {
+        self.as_original().map(|ev| &ev.content)
+    }
+
+    /// Get the `TransactionId` from the unsigned data of this event.
+    pub fn transaction_id(&self) -> Option<&TransactionId> {
+        match self {
+            Self::Original(ev) => ev.unsigned.transaction_id.as_deref(),
+            _ => None,
+        }
+    }
+
+    /// Get the `BundledMessageLikeRelations` from the unsigned data of this event.
+    pub fn relations(
+        &self,
+    ) -> Option<&BundledMessageLikeRelations<OriginalSyncRoomRedactionEvent>> {
+        match self {
+            Self::Original(ev) => Some(&ev.unsigned.relations),
             _ => None,
         }
     }

--- a/crates/ruma-common/src/events/unsigned.rs
+++ b/crates/ruma-common/src/events/unsigned.rs
@@ -4,7 +4,8 @@ use serde::{de::DeserializeOwned, Deserialize};
 use super::{
     relation::{BundledMessageLikeRelations, BundledStateRelations},
     room::redaction::RoomRedactionEventContent,
-    MessageLikeEventContent, OriginalSyncMessageLikeEvent, PossiblyRedactedStateEventContent,
+    MessageLikeEventContent, OriginalStateUnsigned, OriginalSyncMessageLikeEvent,
+    PossiblyRedactedStateEventContent,
 };
 use crate::{
     serde::CanBeEmpty, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, OwnedUserId,
@@ -57,6 +58,12 @@ impl<C: MessageLikeEventContent> CanBeEmpty for MessageLikeUnsigned<C> {
     }
 }
 
+impl<C: MessageLikeEventContent> OriginalStateUnsigned for MessageLikeUnsigned<C> {
+    fn transaction_id(&self) -> Option<&crate::TransactionId> {
+        self.transaction_id.as_deref()
+    }
+}
+
 /// Extra information about a state event that is not incorporated into the event's hash.
 #[derive(Clone, Debug, Deserialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
@@ -106,6 +113,12 @@ impl<C: PossiblyRedactedStateEventContent> CanBeEmpty for StateUnsigned<C> {
 impl<C: PossiblyRedactedStateEventContent> Default for StateUnsigned<C> {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl<C: PossiblyRedactedStateEventContent> OriginalStateUnsigned for StateUnsigned<C> {
+    fn transaction_id(&self) -> Option<&crate::TransactionId> {
+        self.transaction_id.as_deref()
     }
 }
 

--- a/crates/ruma-macros/src/events/event_enum.rs
+++ b/crates/ruma-macros/src/events/event_enum.rs
@@ -450,16 +450,16 @@ fn expand_accessor_methods(
                 match self {
                     #(
                         #self_variants(event) => {
-                            event.as_original().map(|ev| #content_variants(ev.content.clone()))
+                            event.original_content().cloned().map(#content_variants)
                         }
                     )*
-                    Self::_Custom(event) => event.as_original().map(|ev| {
+                    Self::_Custom(event) => event.original_content().map(|content| {
                         #content_enum::_Custom {
                             event_type: crate::PrivOwnedStr(
                                 ::std::convert::From::from(
                                     ::std::string::ToString::to_string(
                                         &#ruma_common::events::EventContent::event_type(
-                                            &ev.content,
+                                            content,
                                         ),
                                     ),
                                 ),
@@ -597,16 +597,16 @@ fn expand_accessor_methods(
             ) -> #ruma_common::events::BundledMessageLikeRelations<AnySyncMessageLikeEvent> {
                 match self {
                     #(
-                        #variants(event) => event.as_original().map_or_else(
+                        #variants(event) => event.relations().cloned().map_or_else(
                             ::std::default::Default::default,
-                            |ev| ev.unsigned.relations.clone().map_replace(|r| {
+                            |rel| rel.map_replace(|r| {
                                 ::std::convert::From::from(r.into_maybe_redacted())
                             }),
                         ),
                     )*
-                    Self::_Custom(event) => event.as_original().map_or_else(
+                    Self::_Custom(event) => event.relations().cloned().map_or_else(
                         ::std::default::Default::default,
-                        |ev| ev.unsigned.relations.clone().map_replace(|r| {
+                        |rel| rel.map_replace(|r| {
                             AnySyncMessageLikeEvent::_Custom(r.into_maybe_redacted())
                         }),
                     ),
@@ -624,7 +624,7 @@ fn expand_accessor_methods(
                 match self {
                     #(
                         #variants(event) => {
-                            event.as_original().and_then(|ev| ev.unsigned.transaction_id.as_deref())
+                            event.transaction_id()
                         }
                     )*
                     Self::_Custom(event) => {


### PR DESCRIPTION
Allows for Message-like events to be enums instead of structs. Pre-requisite for #42.

I only did it for `MessageLike` events but we could do it for `State` events too, it should only require to add more accessors to the `OriginalStateUnsigned` trait.

Edit: A simpler alternative is #1616.





<!-- Replace -->
----
Preview Removed
<!-- Replace -->
