### PR TITLE
identifiers: Add initial support for room version 11

### DIFF
--- a/crates/ruma-common/src/identifiers/room_version_id.rs
+++ b/crates/ruma-common/src/identifiers/room_version_id.rs
@@ -56,6 +56,9 @@ pub enum RoomVersionId {
     /// A version 10 room.
     V10,
 
+    /// A version 11 room.
+    V11,
+
     #[doc(hidden)]
     _Custom(CustomRoomVersion),
 }
@@ -76,6 +79,7 @@ impl RoomVersionId {
             Self::V8 => "8",
             Self::V9 => "9",
             Self::V10 => "10",
+            Self::V11 => "11",
             Self::_Custom(version) => version.as_str(),
         }
     }
@@ -99,6 +103,7 @@ impl From<RoomVersionId> for String {
             RoomVersionId::V8 => "8".to_owned(),
             RoomVersionId::V9 => "9".to_owned(),
             RoomVersionId::V10 => "10".to_owned(),
+            RoomVersionId::V11 => "11".to_owned(),
             RoomVersionId::_Custom(version) => version.into(),
         }
     }
@@ -172,6 +177,7 @@ where
         "8" => RoomVersionId::V8,
         "9" => RoomVersionId::V9,
         "10" => RoomVersionId::V10,
+        "11" => RoomVersionId::V11,
         custom => {
             ruma_identifiers_validation::room_version_id::validate(custom)?;
             RoomVersionId::_Custom(CustomRoomVersion(room_version_id.into()))

--- a/crates/ruma-common/src/push/condition.rs
+++ b/crates/ruma-common/src/push/condition.rs
@@ -55,6 +55,7 @@ impl RoomVersionFeature {
             | RoomVersionId::V8
             | RoomVersionId::V9
             | RoomVersionId::V10
+            | RoomVersionId::V11
             | RoomVersionId::_Custom(_) => vec![],
         }
     }


### PR DESCRIPTION
This doesn't do anything except for adding the variant. But since there will be unrelated large-ish PRs to implement this fully, I thought it would be nicer to start with this separately.

Note that this room version will only be made stable in Matrix 1.8 that should come out in a few weeks, so we might want to wait for it to be released to merge this (or not).

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->





<!-- Replace -->
----
Preview Removed
<!-- Replace -->
