### PR TITLE
events: Add support for redacts key into content of RoomRedactionEvent 

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -24,6 +24,8 @@ Breaking changes:
   (MSC2746 / Matrix 1.7)
 - The `Replacement` relation for `RoomMessageEventContent` now takes a
   `RoomMessageEventContentWithoutRelation` instead of a `MessageType`
+- Make `RoomRedactionEvent` and associated types enums to handle the format where the `redacts` key
+  is moved inside the `content`, as introduced in room version 11, according to MSC2174 / MSC3820
 
 Improvements:
 

--- a/crates/ruma-common/src/events/content.rs
+++ b/crates/ruma-common/src/events/content.rs
@@ -3,7 +3,10 @@ use std::fmt;
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::{from_str as from_json_str, value::RawValue as RawJsonValue};
 
-use crate::serde::{CanBeEmpty, Raw};
+use crate::{
+    serde::{CanBeEmpty, Raw},
+    TransactionId,
+};
 
 use super::{
     EphemeralRoomEventType, GlobalAccountDataEventType, MessageLikeEventType,
@@ -70,7 +73,12 @@ pub trait StaticStateEventContent: StateEventContent {
     type PossiblyRedacted: PossiblyRedactedStateEventContent;
 
     /// The type of the event's `unsigned` field.
-    type Unsigned: Clone + fmt::Debug + Default + CanBeEmpty + DeserializeOwned;
+    type Unsigned: Clone
+        + fmt::Debug
+        + Default
+        + CanBeEmpty
+        + DeserializeOwned
+        + OriginalStateUnsigned;
 }
 
 /// Content of a redacted state event.
@@ -102,4 +110,10 @@ where
     fn from_parts(_event_type: &str, content: &RawJsonValue) -> serde_json::Result<Self> {
         from_json_str(content.get())
     }
+}
+
+/// Unsigned data of an unredacted event.
+pub trait OriginalStateUnsigned {
+    /// The transaction ID if this event was sent from this session.
+    fn transaction_id(&self) -> Option<&TransactionId>;
 }

--- a/crates/ruma-common/src/events/kinds.rs
+++ b/crates/ruma-common/src/events/kinds.rs
@@ -5,17 +5,17 @@ use serde::{ser::SerializeStruct, Deserialize, Deserializer, Serialize};
 use serde_json::value::RawValue as RawJsonValue;
 
 use super::{
-    AnyInitialStateEvent, EmptyStateKey, EphemeralRoomEventContent, EventContent,
-    EventContentFromType, GlobalAccountDataEventContent, MessageLikeEventContent,
-    MessageLikeEventType, MessageLikeUnsigned, PossiblyRedactedStateEventContent, RedactContent,
-    RedactedMessageLikeEventContent, RedactedStateEventContent, RedactedUnsigned,
-    RedactionDeHelper, RoomAccountDataEventContent, StateEventType, StaticStateEventContent,
-    ToDeviceEventContent,
+    AnyInitialStateEvent, BundledMessageLikeRelations, EmptyStateKey, EphemeralRoomEventContent,
+    EventContent, EventContentFromType, GlobalAccountDataEventContent, MessageLikeEventContent,
+    MessageLikeEventType, MessageLikeUnsigned, OriginalStateUnsigned,
+    PossiblyRedactedStateEventContent, RedactContent, RedactedMessageLikeEventContent,
+    RedactedStateEventContent, RedactedUnsigned, RedactionDeHelper, RoomAccountDataEventContent,
+    StateEventType, StaticStateEventContent, ToDeviceEventContent,
 };
 use crate::{
     serde::{from_raw_json_value, Raw},
     EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedUserId, RoomId,
-    RoomVersionId, UserId,
+    RoomVersionId, TransactionId, UserId,
 };
 
 /// A global account data event.
@@ -668,6 +668,27 @@ impl_possibly_redacted_event!(
                 _ => None,
             }
         }
+
+        /// Get the inner content if this is an unredacted event.
+        pub fn original_content(&self) -> Option<&C> {
+            self.as_original().map(|ev| &ev.content)
+        }
+
+        /// Get the `TransactionId` from the unsigned data of this event.
+        pub fn transaction_id(&self) -> Option<&TransactionId> {
+            match self {
+                Self::Original(ev) => ev.unsigned.transaction_id.as_deref(),
+                _ => None,
+            }
+        }
+
+        /// Get the `BundledMessageLikeRelations` from the unsigned data of this event.
+        pub fn relations(&self) -> Option<&BundledMessageLikeRelations<OriginalSyncMessageLikeEvent<C>>> {
+            match self {
+                Self::Original(ev) => Some(&ev.unsigned.relations),
+                _ => None,
+            }
+        }
     }
 );
 
@@ -679,6 +700,27 @@ impl_possibly_redacted_event!(
         pub fn as_original(&self) -> Option<&OriginalSyncMessageLikeEvent<C>> {
             match self {
                 Self::Original(v) => Some(v),
+                _ => None,
+            }
+        }
+
+        /// Get the inner content if this is an unredacted event.
+        pub fn original_content(&self) -> Option<&C> {
+            self.as_original().map(|ev| &ev.content)
+        }
+
+        /// Get the `TransactionId` from the unsigned data of this event.
+        pub fn transaction_id(&self) -> Option<&TransactionId> {
+            match self {
+                Self::Original(ev) => ev.unsigned.transaction_id.as_deref(),
+                _ => None,
+            }
+        }
+
+        /// Get the `BundledMessageLikeRelations` from the unsigned data of this event.
+        pub fn relations(&self) -> Option<&BundledMessageLikeRelations<OriginalSyncMessageLikeEvent<C>>> {
+            match self {
+                Self::Original(ev) => Some(&ev.unsigned.relations),
                 _ => None,
             }
         }
@@ -721,6 +763,19 @@ impl_possibly_redacted_event!(
                 _ => None,
             }
         }
+
+        /// Get the inner content if this is an unredacted event.
+        pub fn original_content(&self) -> Option<&C> {
+            self.as_original().map(|ev| &ev.content)
+        }
+
+        /// Get the `TransactionId` from the unsigned data of this event.
+        pub fn transaction_id(&self) -> Option<&TransactionId> {
+            match self {
+                Self::Original(ev) => ev.unsigned.transaction_id(),
+                _ => None,
+            }
+        }
     }
 );
 
@@ -741,6 +796,19 @@ impl_possibly_redacted_event!(
         pub fn as_original(&self) -> Option<&OriginalSyncStateEvent<C>> {
             match self {
                 Self::Original(v) => Some(v),
+                _ => None,
+            }
+        }
+
+        /// Get the inner content if this is an unredacted event.
+        pub fn original_content(&self) -> Option<&C> {
+            self.as_original().map(|ev| &ev.content)
+        }
+
+        /// Get the `TransactionId` from the unsigned data of this event.
+        pub fn transaction_id(&self) -> Option<&TransactionId> {
+            match self {
+                Self::Original(ev) => ev.unsigned.transaction_id(),
                 _ => None,
             }
         }

--- a/crates/ruma-common/src/events/room/member.rs
+++ b/crates/ruma-common/src/events/room/member.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     events::{
-        AnyStrippedStateEvent, BundledStateRelations, EventContent,
+        AnyStrippedStateEvent, BundledStateRelations, EventContent, OriginalStateUnsigned,
         PossiblyRedactedStateEventContent, RedactContent, RedactedStateEventContent,
         StateEventType,
     },
@@ -530,6 +530,12 @@ impl CanBeEmpty for RoomMemberUnsigned {
             && self.prev_content.is_none()
             && self.invite_room_state.is_empty()
             && self.relations.is_empty()
+    }
+}
+
+impl OriginalStateUnsigned for RoomMemberUnsigned {
+    fn transaction_id(&self) -> Option<&crate::TransactionId> {
+        self.transaction_id.as_deref()
     }
 }
 

--- a/crates/ruma-common/src/events/room/redaction.rs
+++ b/crates/ruma-common/src/events/room/redaction.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     serde::{from_raw_json_value, CanBeEmpty},
     EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedTransactionId,
-    OwnedUserId, RoomId, UserId,
+    OwnedUserId, RoomId, TransactionId, UserId,
 };
 
 /// A possibly-redacted redaction event.
@@ -207,6 +207,29 @@ impl RoomRedactionEvent {
             _ => None,
         }
     }
+
+    /// Get the inner content if this is an unredacted event.
+    pub fn original_content(&self) -> Option<&RoomRedactionEventContent> {
+        self.as_original().map(|ev| &ev.content)
+    }
+
+    /// Get the `TransactionId` from the unsigned data of this event.
+    pub fn transaction_id(&self) -> Option<&TransactionId> {
+        match self {
+            Self::Original(ev) => ev.unsigned.transaction_id.as_deref(),
+            _ => None,
+        }
+    }
+
+    /// Get the `BundledMessageLikeRelations` from the unsigned data of this event.
+    pub fn relations(
+        &self,
+    ) -> Option<&BundledMessageLikeRelations<OriginalSyncRoomRedactionEvent>> {
+        match self {
+            Self::Original(ev) => Some(&ev.unsigned.relations),
+            _ => None,
+        }
+    }
 }
 
 impl<'de> Deserialize<'de> for RoomRedactionEvent {
@@ -262,6 +285,29 @@ impl SyncRoomRedactionEvent {
     pub fn as_original(&self) -> Option<&OriginalSyncRoomRedactionEvent> {
         match self {
             Self::Original(v) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Get the inner content if this is an unredacted event.
+    pub fn original_content(&self) -> Option<&RoomRedactionEventContent> {
+        self.as_original().map(|ev| &ev.content)
+    }
+
+    /// Get the `TransactionId` from the unsigned data of this event.
+    pub fn transaction_id(&self) -> Option<&TransactionId> {
+        match self {
+            Self::Original(ev) => ev.unsigned.transaction_id.as_deref(),
+            _ => None,
+        }
+    }
+
+    /// Get the `BundledMessageLikeRelations` from the unsigned data of this event.
+    pub fn relations(
+        &self,
+    ) -> Option<&BundledMessageLikeRelations<OriginalSyncRoomRedactionEvent>> {
+        match self {
+            Self::Original(ev) => Some(&ev.unsigned.relations),
             _ => None,
         }
     }

--- a/crates/ruma-common/src/events/room/redaction/event_serde.rs
+++ b/crates/ruma-common/src/events/room/redaction/event_serde.rs
@@ -1,0 +1,85 @@
+use serde::{de, Deserialize, Deserializer};
+use serde_json::value::RawValue as RawJsonValue;
+
+use super::{
+    OriginalRoomRedactionEvent, OriginalSyncRoomRedactionEvent, RoomRedactionEvent,
+    SyncRoomRedactionEvent,
+};
+use crate::{events::RedactionDeHelper, serde::from_raw_json_value};
+
+impl<'de> Deserialize<'de> for RoomRedactionEvent {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let json = Box::<RawJsonValue>::deserialize(deserializer)?;
+        let RedactionDeHelper { unsigned } = from_raw_json_value(&json)?;
+
+        if unsigned.and_then(|u| u.redacted_because).is_some() {
+            Ok(Self::Redacted(from_raw_json_value(&json)?))
+        } else {
+            Ok(Self::Original(from_raw_json_value(&json)?))
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for SyncRoomRedactionEvent {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let json = Box::<RawJsonValue>::deserialize(deserializer)?;
+        let RedactionDeHelper { unsigned } = from_raw_json_value(&json)?;
+
+        if unsigned.and_then(|u| u.redacted_because).is_some() {
+            Ok(Self::Redacted(from_raw_json_value(&json)?))
+        } else {
+            Ok(Self::Original(from_raw_json_value(&json)?))
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct RoomRedactionDeHelper {
+    content: RoomRedactionContentDeHelper,
+    redacts: Option<de::IgnoredAny>,
+}
+
+#[derive(Deserialize)]
+struct RoomRedactionContentDeHelper {
+    redacts: Option<de::IgnoredAny>,
+}
+
+impl<'de> Deserialize<'de> for OriginalRoomRedactionEvent {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let json = Box::<RawJsonValue>::deserialize(deserializer)?;
+        let RoomRedactionDeHelper { content, redacts } = from_raw_json_value(&json)?;
+
+        match (redacts, content.redacts) {
+            (Some(_), Some(_)) => Ok(Self::V1V11Compat(from_raw_json_value(&json)?)),
+            (Some(_), None) => Ok(Self::V1(from_raw_json_value(&json)?)),
+            (None, Some(_)) => Ok(Self::V11(from_raw_json_value(&json)?)),
+            (None, None) => Err(de::Error::missing_field("redacts")),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for OriginalSyncRoomRedactionEvent {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let json = Box::<RawJsonValue>::deserialize(deserializer)?;
+        let RoomRedactionDeHelper { content, redacts } = from_raw_json_value(&json)?;
+
+        match (redacts, content.redacts) {
+            (Some(_), Some(_)) => Ok(Self::V1V11Compat(from_raw_json_value(&json)?)),
+            (Some(_), None) => Ok(Self::V1(from_raw_json_value(&json)?)),
+            (None, Some(_)) => Ok(Self::V11(from_raw_json_value(&json)?)),
+            (None, None) => Err(de::Error::missing_field("redacts")),
+        }
+    }
+}

--- a/crates/ruma-common/src/events/room/redaction/v1.rs
+++ b/crates/ruma-common/src/events/room/redaction/v1.rs
@@ -1,0 +1,120 @@
+//! Types for the `m.room.redaction` event as defined in room versions 1 through 10.
+
+use ruma_macros::{Event, EventContent};
+use serde::{Deserialize, Serialize};
+use tracing::warn;
+
+use crate::{
+    events::RedactContent, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedUserId,
+    RoomVersionId,
+};
+
+use super::{RedactedRoomRedactionEventContent, RedactionEventContent, RoomRedactionUnsigned};
+
+/// Redaction event as defined in room versions 1 through 10.
+pub type OriginalRoomRedactionV1Event = OriginalRedactionV1Event<RoomRedactionV1EventContent>;
+
+/// Redaction event as defined in room versions 1 through 10.
+pub type OriginalSyncRoomRedactionV1Event =
+    OriginalSyncRedactionV1Event<RoomRedactionV1EventContent>;
+
+/// Redaction event as defined in room versions 1 through 10.
+#[derive(Clone, Debug, Event)]
+#[allow(clippy::exhaustive_structs)]
+pub struct OriginalRedactionV1Event<C>
+where
+    C: RedactionEventContent,
+{
+    /// Data specific to the event type.
+    pub content: C,
+
+    /// The ID of the event that was redacted.
+    pub redacts: OwnedEventId,
+
+    /// The globally unique event identifier for the user who sent the event.
+    pub event_id: OwnedEventId,
+
+    /// The fully-qualified ID of the user who sent this event.
+    pub sender: OwnedUserId,
+
+    /// Timestamp in milliseconds on originating homeserver when this event was sent.
+    pub origin_server_ts: MilliSecondsSinceUnixEpoch,
+
+    /// The ID of the room associated with this event.
+    pub room_id: OwnedRoomId,
+
+    /// Additional key-value pairs not signed by the homeserver.
+    pub unsigned: RoomRedactionUnsigned<OriginalSyncRedactionV1Event<C>>,
+}
+
+/// Redaction event without a `room_id` as defined in room versions 1 through 10.
+#[derive(Clone, Debug, Event)]
+#[allow(clippy::exhaustive_structs)]
+pub struct OriginalSyncRedactionV1Event<C>
+where
+    C: RedactionEventContent,
+{
+    /// Data specific to the event type.
+    pub content: C,
+
+    /// The ID of the event that was redacted.
+    pub redacts: OwnedEventId,
+
+    /// The globally unique event identifier for the user who sent the event.
+    pub event_id: OwnedEventId,
+
+    /// The fully-qualified ID of the user who sent this event.
+    pub sender: OwnedUserId,
+
+    /// Timestamp in milliseconds on originating homeserver when this event was sent.
+    pub origin_server_ts: MilliSecondsSinceUnixEpoch,
+
+    /// Additional key-value pairs not signed by the homeserver.
+    pub unsigned: RoomRedactionUnsigned<OriginalSyncRedactionV1Event<C>>,
+}
+
+/// A redaction of an event as defined in room versions 1 through 10.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, EventContent)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+#[ruma_event(type = "m.room.redaction", kind = MessageLike, custom_redacted)]
+pub struct RoomRedactionV1EventContent {
+    /// The reason for the redaction, if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+impl RoomRedactionV1EventContent {
+    /// Creates an empty `RoomRedactionV1EventContent`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Creates a new `RoomRedactionV1EventContent` with the given reason.
+    pub fn with_reason(reason: String) -> Self {
+        Self { reason: Some(reason) }
+    }
+}
+
+impl RedactionEventContent for RoomRedactionV1EventContent {}
+
+impl RedactContent for RoomRedactionV1EventContent {
+    type Redacted = RedactedRoomRedactionEventContent;
+
+    fn redact(self, version: &RoomVersionId) -> Self::Redacted {
+        match version {
+            RoomVersionId::V1
+            | RoomVersionId::V2
+            | RoomVersionId::V3
+            | RoomVersionId::V4
+            | RoomVersionId::V5
+            | RoomVersionId::V6
+            | RoomVersionId::V7
+            | RoomVersionId::V8
+            | RoomVersionId::V9
+            | RoomVersionId::V10 => {}
+            _ => warn!("Trying to apply {version:?} redaction algorithm to pre-v11 RoomRedactionV1EventContent"),
+        }
+
+        RedactedRoomRedactionEventContent::default()
+    }
+}

--- a/crates/ruma-common/src/events/room/redaction/v11.rs
+++ b/crates/ruma-common/src/events/room/redaction/v11.rs
@@ -1,0 +1,115 @@
+//! Types for the `m.room.redaction` event as introduced in room version 11.
+
+use ruma_macros::{Event, EventContent};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    events::RedactContent, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedUserId,
+    RoomVersionId,
+};
+
+use super::{
+    v1::{OriginalRedactionV1Event, OriginalSyncRedactionV1Event},
+    RedactedRoomRedactionEventContent, RedactionEventContent, RoomRedactionUnsigned,
+};
+
+/// Redaction event as introduced in room version 11.
+#[derive(Clone, Debug, Event)]
+#[allow(clippy::exhaustive_structs)]
+pub struct OriginalRoomRedactionV11Event {
+    /// Data specific to the event type.
+    pub content: RoomRedactionV11EventContent,
+
+    /// The globally unique event identifier for the user who sent the event.
+    pub event_id: OwnedEventId,
+
+    /// The fully-qualified ID of the user who sent this event.
+    pub sender: OwnedUserId,
+
+    /// Timestamp in milliseconds on originating homeserver when this event was sent.
+    pub origin_server_ts: MilliSecondsSinceUnixEpoch,
+
+    /// The ID of the room associated with this event.
+    pub room_id: OwnedRoomId,
+
+    /// Additional key-value pairs not signed by the homeserver.
+    pub unsigned: RoomRedactionUnsigned<OriginalSyncRoomRedactionV11Event>,
+}
+
+/// Redaction event compatible with v1 and v11.
+pub type OriginalRoomRedactionV1V11CompatEvent =
+    OriginalRedactionV1Event<RoomRedactionV11EventContent>;
+
+/// Redaction event without a `room_id`, as introduced in room version 11.
+#[derive(Clone, Debug, Event)]
+#[allow(clippy::exhaustive_structs)]
+pub struct OriginalSyncRoomRedactionV11Event {
+    /// Data specific to the event type.
+    pub content: RoomRedactionV11EventContent,
+
+    /// The globally unique event identifier for the user who sent the event.
+    pub event_id: OwnedEventId,
+
+    /// The fully-qualified ID of the user who sent this event.
+    pub sender: OwnedUserId,
+
+    /// Timestamp in milliseconds on originating homeserver when this event was sent.
+    pub origin_server_ts: MilliSecondsSinceUnixEpoch,
+
+    /// Additional key-value pairs not signed by the homeserver.
+    pub unsigned: RoomRedactionUnsigned<OriginalSyncRoomRedactionV11Event>,
+}
+
+/// Redaction event compatible with v1 and v11.
+pub type OriginalSyncRoomRedactionV1V11CompatEvent =
+    OriginalSyncRedactionV1Event<RoomRedactionV11EventContent>;
+
+/// A redaction of an event as introduced in room version 11.
+#[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+#[ruma_event(type = "m.room.redaction", kind = MessageLike, custom_redacted)]
+pub struct RoomRedactionV11EventContent {
+    /// The ID of the event that was redacted.
+    pub redacts: OwnedEventId,
+
+    /// The reason for the redaction, if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+impl RoomRedactionV11EventContent {
+    /// Creates a new `RoomRedactionV1EventContent` which redacts the event with the given ID.
+    pub fn new(redacts: OwnedEventId) -> Self {
+        Self { redacts, reason: None }
+    }
+
+    /// Creates a new `RoomRedactionV1EventContent` which redacts the event with the given ID for
+    /// the given reason.
+    pub fn with_reason(redacts: OwnedEventId, reason: String) -> Self {
+        Self { redacts, reason: Some(reason) }
+    }
+}
+
+impl RedactionEventContent for RoomRedactionV11EventContent {}
+
+impl RedactContent for RoomRedactionV11EventContent {
+    type Redacted = RedactedRoomRedactionEventContent;
+
+    fn redact(self, version: &RoomVersionId) -> Self::Redacted {
+        let redacts = match version {
+            RoomVersionId::V1
+            | RoomVersionId::V2
+            | RoomVersionId::V3
+            | RoomVersionId::V4
+            | RoomVersionId::V5
+            | RoomVersionId::V6
+            | RoomVersionId::V7
+            | RoomVersionId::V8
+            | RoomVersionId::V9
+            | RoomVersionId::V10 => None,
+            _ => Some(self.redacts),
+        };
+
+        RedactedRoomRedactionEventContent { redacts }
+    }
+}

--- a/crates/ruma-common/src/events/unsigned.rs
+++ b/crates/ruma-common/src/events/unsigned.rs
@@ -3,7 +3,7 @@ use serde::{de::DeserializeOwned, Deserialize};
 
 use super::{
     relation::{BundledMessageLikeRelations, BundledStateRelations},
-    room::redaction::RoomRedactionEventContent,
+    room::redaction::v1::RoomRedactionV1EventContent,
     MessageLikeEventContent, OriginalStateUnsigned, OriginalSyncMessageLikeEvent,
     PossiblyRedactedStateEventContent,
 };
@@ -149,7 +149,7 @@ impl RedactedUnsigned {
 #[non_exhaustive]
 pub struct UnsignedRoomRedactionEvent {
     /// Data specific to the event type.
-    pub content: RoomRedactionEventContent,
+    pub content: RoomRedactionV1EventContent,
 
     /// The globally unique event identifier for the user who sent the event.
     pub event_id: OwnedEventId,
@@ -162,5 +162,5 @@ pub struct UnsignedRoomRedactionEvent {
 
     /// Additional key-value pairs not signed by the homeserver.
     #[serde(default)]
-    pub unsigned: MessageLikeUnsigned<RoomRedactionEventContent>,
+    pub unsigned: MessageLikeUnsigned<RoomRedactionV1EventContent>,
 }

--- a/crates/ruma-common/src/events/unsigned.rs
+++ b/crates/ruma-common/src/events/unsigned.rs
@@ -4,7 +4,8 @@ use serde::{de::DeserializeOwned, Deserialize};
 use super::{
     relation::{BundledMessageLikeRelations, BundledStateRelations},
     room::redaction::RoomRedactionEventContent,
-    MessageLikeEventContent, OriginalSyncMessageLikeEvent, PossiblyRedactedStateEventContent,
+    MessageLikeEventContent, OriginalStateUnsigned, OriginalSyncMessageLikeEvent,
+    PossiblyRedactedStateEventContent,
 };
 use crate::{
     serde::CanBeEmpty, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, OwnedUserId,
@@ -57,6 +58,12 @@ impl<C: MessageLikeEventContent> CanBeEmpty for MessageLikeUnsigned<C> {
     }
 }
 
+impl<C: MessageLikeEventContent> OriginalStateUnsigned for MessageLikeUnsigned<C> {
+    fn transaction_id(&self) -> Option<&crate::TransactionId> {
+        self.transaction_id.as_deref()
+    }
+}
+
 /// Extra information about a state event that is not incorporated into the event's hash.
 #[derive(Clone, Debug, Deserialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
@@ -106,6 +113,12 @@ impl<C: PossiblyRedactedStateEventContent> CanBeEmpty for StateUnsigned<C> {
 impl<C: PossiblyRedactedStateEventContent> Default for StateUnsigned<C> {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl<C: PossiblyRedactedStateEventContent> OriginalStateUnsigned for StateUnsigned<C> {
+    fn transaction_id(&self) -> Option<&crate::TransactionId> {
+        self.transaction_id.as_deref()
     }
 }
 

--- a/crates/ruma-common/tests/events/redacted.rs
+++ b/crates/ruma-common/tests/events/redacted.rs
@@ -5,7 +5,7 @@ use ruma_common::{
             aliases::RedactedRoomAliasesEventContent,
             create::{RedactedRoomCreateEventContent, RoomCreateEventContent},
             message::{RedactedRoomMessageEventContent, RoomMessageEventContent},
-            redaction::RoomRedactionEventContent,
+            redaction::v1::RoomRedactionV1EventContent,
         },
         AnyMessageLikeEvent, AnySyncMessageLikeEvent, AnySyncStateEvent, AnySyncTimelineEvent,
         AnyTimelineEvent, EventContentFromType, MessageLikeEvent, RedactContent,
@@ -22,7 +22,7 @@ fn unsigned() -> JsonValue {
     json!({
         "redacted_because": {
             "type": "m.room.redaction",
-            "content": RoomRedactionEventContent::with_reason("redacted because".into()),
+            "content": RoomRedactionV1EventContent::with_reason("redacted because".into()),
             "redacts": "$h29iv0s8:example.com",
             "event_id": "$h29iv0s8:example.com",
             "origin_server_ts": 1,

--- a/crates/ruma-common/tests/events/redaction.rs
+++ b/crates/ruma-common/tests/events/redaction.rs
@@ -2,17 +2,21 @@ use assert_matches2::assert_matches;
 use js_int::uint;
 use ruma_common::{
     events::{
-        room::redaction::{RoomRedactionEvent, RoomRedactionEventContent},
+        room::redaction::{
+            v1::RoomRedactionV1EventContent, v11::RoomRedactionV11EventContent,
+            OriginalRoomRedactionEvent, RoomRedactionEvent,
+        },
         AnyMessageLikeEvent,
     },
+    owned_event_id,
     serde::CanBeEmpty,
-    MilliSecondsSinceUnixEpoch,
+    MilliSecondsSinceUnixEpoch, RoomVersionId,
 };
 use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
 #[test]
-fn serialize_redaction_content() {
-    let content = RoomRedactionEventContent::with_reason("being very unfriendly".into());
+fn serialize_redaction_v1_content() {
+    let content = RoomRedactionV1EventContent::with_reason("being very unfriendly".into());
 
     let actual = to_json_value(content).unwrap();
     let expected = json!({
@@ -23,7 +27,7 @@ fn serialize_redaction_content() {
 }
 
 #[test]
-fn deserialize_redaction() {
+fn deserialize_redaction_v1() {
     let json_data = json!({
         "content": {
             "reason": "being very unfriendly"
@@ -38,13 +42,99 @@ fn deserialize_redaction() {
 
     assert_matches!(
         from_json_value::<AnyMessageLikeEvent>(json_data),
-        Ok(AnyMessageLikeEvent::RoomRedaction(RoomRedactionEvent::Original(ev)))
+        Ok(AnyMessageLikeEvent::RoomRedaction(ev))
     );
-    assert_eq!(ev.content.reason.as_deref(), Some("being very unfriendly"));
-    assert_eq!(ev.event_id, "$h29iv0s8:example.com");
-    assert_eq!(ev.redacts, "$nomore:example.com");
-    assert_eq!(ev.origin_server_ts, MilliSecondsSinceUnixEpoch(uint!(1)));
-    assert_eq!(ev.room_id, "!roomid:room.com");
-    assert_eq!(ev.sender, "@carl:example.com");
-    assert!(ev.unsigned.is_empty());
+    assert_eq!(ev.redacts(RoomVersionId::V1).unwrap(), "$nomore:example.com");
+    assert_eq!(ev.redacts(RoomVersionId::V11), None);
+
+    assert_matches!(ev, RoomRedactionEvent::Original(OriginalRoomRedactionEvent::V1(v1_ev)));
+    assert_eq!(v1_ev.content.reason.as_deref(), Some("being very unfriendly"));
+    assert_eq!(v1_ev.redacts, "$nomore:example.com");
+    assert_eq!(v1_ev.event_id, "$h29iv0s8:example.com");
+    assert_eq!(v1_ev.origin_server_ts, MilliSecondsSinceUnixEpoch(uint!(1)));
+    assert_eq!(v1_ev.room_id, "!roomid:room.com");
+    assert_eq!(v1_ev.sender, "@carl:example.com");
+    assert!(v1_ev.unsigned.is_empty());
+}
+
+#[test]
+fn serialize_redaction_v11_content() {
+    let redacts = owned_event_id!("$abcdef");
+    let content =
+        RoomRedactionV11EventContent::with_reason(redacts.clone(), "being very unfriendly".into());
+
+    let actual = to_json_value(content).unwrap();
+    let expected = json!({
+        "redacts": redacts,
+        "reason": "being very unfriendly"
+    });
+
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn deserialize_redaction_v11() {
+    let json_data = json!({
+        "content": {
+            "redacts": "$nomore:example.com",
+            "reason": "being very unfriendly",
+        },
+        "event_id": "$h29iv0s8:example.com",
+        "sender": "@carl:example.com",
+        "origin_server_ts": 1,
+        "room_id": "!roomid:room.com",
+        "type": "m.room.redaction",
+    });
+
+    assert_matches!(
+        from_json_value::<AnyMessageLikeEvent>(json_data),
+        Ok(AnyMessageLikeEvent::RoomRedaction(ev))
+    );
+    assert_eq!(ev.redacts(RoomVersionId::V1), None);
+    assert_eq!(ev.redacts(RoomVersionId::V11).unwrap(), "$nomore:example.com");
+
+    assert_matches!(ev, RoomRedactionEvent::Original(OriginalRoomRedactionEvent::V11(v11_ev)));
+    assert_eq!(v11_ev.content.redacts, "$nomore:example.com");
+    assert_eq!(v11_ev.content.reason.as_deref(), Some("being very unfriendly"));
+    assert_eq!(v11_ev.event_id, "$h29iv0s8:example.com");
+    assert_eq!(v11_ev.origin_server_ts, MilliSecondsSinceUnixEpoch(uint!(1)));
+    assert_eq!(v11_ev.room_id, "!roomid:room.com");
+    assert_eq!(v11_ev.sender, "@carl:example.com");
+    assert!(v11_ev.unsigned.is_empty());
+}
+
+#[test]
+fn deserialize_redaction_v1_v11_compat() {
+    let json_data = json!({
+        "content": {
+            "redacts": "$nomorev11:example.com",
+            "reason": "being very unfriendly",
+        },
+        "redacts": "$nomorev1:example.com",
+        "event_id": "$h29iv0s8:example.com",
+        "sender": "@carl:example.com",
+        "origin_server_ts": 1,
+        "room_id": "!roomid:room.com",
+        "type": "m.room.redaction",
+    });
+
+    assert_matches!(
+        from_json_value::<AnyMessageLikeEvent>(json_data),
+        Ok(AnyMessageLikeEvent::RoomRedaction(ev))
+    );
+    assert_eq!(ev.redacts(RoomVersionId::V1).unwrap(), "$nomorev1:example.com");
+    assert_eq!(ev.redacts(RoomVersionId::V11).unwrap(), "$nomorev11:example.com");
+
+    assert_matches!(
+        ev,
+        RoomRedactionEvent::Original(OriginalRoomRedactionEvent::V1V11Compat(compat_ev))
+    );
+    assert_eq!(compat_ev.content.redacts, "$nomorev11:example.com");
+    assert_eq!(compat_ev.content.reason.as_deref(), Some("being very unfriendly"));
+    assert_eq!(compat_ev.redacts, "$nomorev1:example.com");
+    assert_eq!(compat_ev.event_id, "$h29iv0s8:example.com");
+    assert_eq!(compat_ev.origin_server_ts, MilliSecondsSinceUnixEpoch(uint!(1)));
+    assert_eq!(compat_ev.room_id, "!roomid:room.com");
+    assert_eq!(compat_ev.sender, "@carl:example.com");
+    assert!(compat_ev.unsigned.is_empty());
 }

--- a/crates/ruma-macros/src/events/event_content.rs
+++ b/crates/ruma-macros/src/events/event_content.rs
@@ -711,7 +711,7 @@ fn generate_event_type_aliases(
     ruma_common: &TokenStream,
 ) -> syn::Result<TokenStream> {
     // The redaction module has its own event types.
-    if ident == "RoomRedactionEventContent" {
+    if ident.to_string().starts_with("RoomRedaction") {
         return Ok(quote! {});
     }
 

--- a/crates/ruma-macros/src/events/event_enum.rs
+++ b/crates/ruma-macros/src/events/event_enum.rs
@@ -450,16 +450,16 @@ fn expand_accessor_methods(
                 match self {
                     #(
                         #self_variants(event) => {
-                            event.as_original().map(|ev| #content_variants(ev.content.clone()))
+                            event.original_content().cloned().map(#content_variants)
                         }
                     )*
-                    Self::_Custom(event) => event.as_original().map(|ev| {
+                    Self::_Custom(event) => event.original_content().map(|content| {
                         #content_enum::_Custom {
                             event_type: crate::PrivOwnedStr(
                                 ::std::convert::From::from(
                                     ::std::string::ToString::to_string(
                                         &#ruma_common::events::EventContent::event_type(
-                                            &ev.content,
+                                            content,
                                         ),
                                     ),
                                 ),
@@ -597,16 +597,16 @@ fn expand_accessor_methods(
             ) -> #ruma_common::events::BundledMessageLikeRelations<AnySyncMessageLikeEvent> {
                 match self {
                     #(
-                        #variants(event) => event.as_original().map_or_else(
+                        #variants(event) => event.relations().cloned().map_or_else(
                             ::std::default::Default::default,
-                            |ev| ev.unsigned.relations.clone().map_replace(|r| {
+                            |rel| rel.map_replace(|r| {
                                 ::std::convert::From::from(r.into_maybe_redacted())
                             }),
                         ),
                     )*
-                    Self::_Custom(event) => event.as_original().map_or_else(
+                    Self::_Custom(event) => event.relations().cloned().map_or_else(
                         ::std::default::Default::default,
-                        |ev| ev.unsigned.relations.clone().map_replace(|r| {
+                        |rel| rel.map_replace(|r| {
                             AnySyncMessageLikeEvent::_Custom(r.into_maybe_redacted())
                         }),
                     ),
@@ -624,7 +624,7 @@ fn expand_accessor_methods(
                 match self {
                     #(
                         #variants(event) => {
-                            event.as_original().and_then(|ev| ev.unsigned.transaction_id.as_deref())
+                            event.transaction_id()
                         }
                     )*
                     Self::_Custom(event) => {

--- a/crates/ruma-macros/src/events/event_enum.rs
+++ b/crates/ruma-macros/src/events/event_enum.rs
@@ -450,7 +450,7 @@ fn expand_accessor_methods(
                 match self {
                     #(
                         #self_variants(event) => {
-                            event.original_content().cloned().map(#content_variants)
+                            event.original_content().map(|c| #content_variants(c.clone()))
                         }
                     )*
                     Self::_Custom(event) => event.original_content().map(|content| {
@@ -597,9 +597,9 @@ fn expand_accessor_methods(
             ) -> #ruma_common::events::BundledMessageLikeRelations<AnySyncMessageLikeEvent> {
                 match self {
                     #(
-                        #variants(event) => event.relations().cloned().map_or_else(
+                        #variants(event) => event.relations().map_or_else(
                             ::std::default::Default::default,
-                            |rel| rel.map_replace(|r| {
+                            |rel| rel.clone().map_replace(|r| {
                                 ::std::convert::From::from(r.into_maybe_redacted())
                             }),
                         ),

--- a/crates/ruma-macros/src/events/event_parse.rs
+++ b/crates/ruma-macros/src/events/event_parse.rs
@@ -75,6 +75,8 @@ pub enum EventKind {
     State,
     ToDevice,
     RoomRedaction,
+    RoomRedactionV1,
+    RoomRedactionV11,
     Presence,
     HierarchySpaceChild,
     Decrypted,
@@ -89,7 +91,9 @@ impl fmt::Display for EventKind {
             EventKind::MessageLike => write!(f, "MessageLikeEvent"),
             EventKind::State => write!(f, "StateEvent"),
             EventKind::ToDevice => write!(f, "ToDeviceEvent"),
-            EventKind::RoomRedaction => write!(f, "RoomRedactionEvent"),
+            EventKind::RoomRedaction => write!(f, "RedactionEvent"),
+            EventKind::RoomRedactionV1 => write!(f, "RedactionV1Event"),
+            EventKind::RoomRedactionV11 => write!(f, "RoomRedactionV11Event"),
             EventKind::Presence => write!(f, "PresenceEvent"),
             EventKind::HierarchySpaceChild => write!(f, "HierarchySpaceChildEvent"),
             EventKind::Decrypted => unreachable!(),
@@ -125,7 +129,11 @@ impl EventKind {
             (_, V::None)
             | (Self::Ephemeral | Self::MessageLike | Self::State, V::Sync)
             | (
-                Self::MessageLike | Self::RoomRedaction | Self::State,
+                Self::MessageLike
+                | Self::RoomRedaction
+                | Self::RoomRedactionV1
+                | Self::RoomRedactionV11
+                | Self::State,
                 V::Original | V::OriginalSync | V::Redacted | V::RedactedSync,
             )
             | (Self::State, V::Stripped | V::Initial) => Ok(format_ident!("{var}{self}")),
@@ -207,14 +215,18 @@ pub fn to_kind_variation(ident: &Ident) -> Option<(EventKind, EventKindVariation
         "HierarchySpaceChildEvent" => {
             Some((EventKind::HierarchySpaceChild, EventKindVariation::Stripped))
         }
-        "OriginalRoomRedactionEvent" => Some((EventKind::RoomRedaction, EventKindVariation::None)),
-        "OriginalSyncRoomRedactionEvent" => {
-            Some((EventKind::RoomRedaction, EventKindVariation::OriginalSync))
+        "OriginalRedactionV1Event" => Some((EventKind::RoomRedactionV1, EventKindVariation::None)),
+        "OriginalRoomRedactionV11Event" => {
+            Some((EventKind::RoomRedactionV11, EventKindVariation::None))
         }
-        "RedactedRoomRedactionEvent" => {
-            Some((EventKind::RoomRedaction, EventKindVariation::Redacted))
+        "OriginalSyncRedactionV1Event" => {
+            Some((EventKind::RoomRedactionV1, EventKindVariation::OriginalSync))
         }
-        "RedactedSyncRoomRedactionEvent" => {
+        "OriginalSyncRoomRedactionV11Event" => {
+            Some((EventKind::RoomRedactionV11, EventKindVariation::OriginalSync))
+        }
+        "RedactedRedactionEvent" => Some((EventKind::RoomRedaction, EventKindVariation::Redacted)),
+        "RedactedSyncRedactionEvent" => {
             Some((EventKind::RoomRedaction, EventKindVariation::RedactedSync))
         }
         "DecryptedOlmV1Event" | "DecryptedMegolmV1Event" => {

--- a/crates/ruma-macros/src/events/event_type.rs
+++ b/crates/ruma-macros/src/events/event_type.rs
@@ -30,6 +30,8 @@ pub fn expand_event_type_enum(
             }
             EventKind::ToDevice => to_device.push(&event.events),
             EventKind::RoomRedaction
+            | EventKind::RoomRedactionV1
+            | EventKind::RoomRedactionV11
             | EventKind::Presence
             | EventKind::Decrypted
             | EventKind::HierarchySpaceChild => {}


### PR DESCRIPTION
Based on #1612.

According to [MSC2174](https://github.com/matrix-org/matrix-spec-proposals/pull/2174) (part of [MSC3820](https://github.com/matrix-org/matrix-spec-proposals/issues/3820) - Room version 11) / [Spec PR](https://github.com/matrix-org/matrix-spec/pull/1604).

Note that the MSC was accepted, but the spec PR is still in review.

Closes #42.

Edit: A simpler alternative is #1616.






<!-- Replace -->
----
Preview Removed
<!-- Replace -->
