### PR TITLE
events: Add support for redacts key into content of RoomRedactionEvent (simpler alternative)

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -24,6 +24,11 @@ Breaking changes:
   (MSC2746 / Matrix 1.7)
 - The `Replacement` relation for `RoomMessageEventContent` now takes a
   `RoomMessageEventContentWithoutRelation` instead of a `MessageType`
+- Make the `redacts` field of `Original(Sync)RoomRedactionEvent` optional to handle the format
+  where the `redacts` key is moved inside the `content`, as introduced in room version 11,
+  according to MSC2174 / MSC3820
+    - `RoomRedactionEventContent::new()` was renamed to `new_v1()`, and `with_reason()` is no
+      longer a constructor but a builder-type method
 
 Improvements:
 

--- a/crates/ruma-common/src/events/room/redaction/event_serde.rs
+++ b/crates/ruma-common/src/events/room/redaction/event_serde.rs
@@ -1,0 +1,105 @@
+use serde::{de, Deserialize, Deserializer};
+use serde_json::value::RawValue as RawJsonValue;
+
+use super::{
+    OriginalRoomRedactionEvent, OriginalSyncRoomRedactionEvent, RoomRedactionEvent,
+    RoomRedactionEventContent, RoomRedactionUnsigned, SyncRoomRedactionEvent,
+};
+use crate::{
+    events::RedactionDeHelper, serde::from_raw_json_value, MilliSecondsSinceUnixEpoch,
+    OwnedEventId, OwnedRoomId, OwnedUserId,
+};
+
+impl<'de> Deserialize<'de> for RoomRedactionEvent {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let json = Box::<RawJsonValue>::deserialize(deserializer)?;
+        let RedactionDeHelper { unsigned } = from_raw_json_value(&json)?;
+
+        if unsigned.and_then(|u| u.redacted_because).is_some() {
+            Ok(Self::Redacted(from_raw_json_value(&json)?))
+        } else {
+            Ok(Self::Original(from_raw_json_value(&json)?))
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for SyncRoomRedactionEvent {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let json = Box::<RawJsonValue>::deserialize(deserializer)?;
+        let RedactionDeHelper { unsigned } = from_raw_json_value(&json)?;
+
+        if unsigned.and_then(|u| u.redacted_because).is_some() {
+            Ok(Self::Redacted(from_raw_json_value(&json)?))
+        } else {
+            Ok(Self::Original(from_raw_json_value(&json)?))
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct OriginalRoomRedactionEventDeHelper {
+    content: RoomRedactionEventContent,
+    redacts: Option<OwnedEventId>,
+    event_id: OwnedEventId,
+    sender: OwnedUserId,
+    origin_server_ts: MilliSecondsSinceUnixEpoch,
+    room_id: Option<OwnedRoomId>,
+    #[serde(default)]
+    unsigned: RoomRedactionUnsigned,
+}
+
+impl<'de> Deserialize<'de> for OriginalRoomRedactionEvent {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let json = Box::<RawJsonValue>::deserialize(deserializer)?;
+        let OriginalRoomRedactionEventDeHelper {
+            content,
+            redacts,
+            event_id,
+            sender,
+            origin_server_ts,
+            room_id,
+            unsigned,
+        } = from_raw_json_value(&json)?;
+
+        let Some(room_id) = room_id else { return Err(de::Error::missing_field("room_id")) };
+
+        if redacts.is_none() && content.redacts.is_none() {
+            return Err(de::Error::missing_field("redacts"));
+        }
+
+        Ok(Self { content, redacts, event_id, sender, origin_server_ts, room_id, unsigned })
+    }
+}
+
+impl<'de> Deserialize<'de> for OriginalSyncRoomRedactionEvent {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let json = Box::<RawJsonValue>::deserialize(deserializer)?;
+        let OriginalRoomRedactionEventDeHelper {
+            content,
+            redacts,
+            event_id,
+            sender,
+            origin_server_ts,
+            unsigned,
+            ..
+        } = from_raw_json_value(&json)?;
+
+        if redacts.is_none() && content.redacts.is_none() {
+            return Err(de::Error::missing_field("redacts"));
+        }
+
+        Ok(Self { content, redacts, event_id, sender, origin_server_ts, unsigned })
+    }
+}

--- a/crates/ruma-common/tests/events/redacted.rs
+++ b/crates/ruma-common/tests/events/redacted.rs
@@ -22,7 +22,7 @@ fn unsigned() -> JsonValue {
     json!({
         "redacted_because": {
             "type": "m.room.redaction",
-            "content": RoomRedactionEventContent::with_reason("redacted because".into()),
+            "content": RoomRedactionEventContent::new_v1().with_reason("redacted because".into()),
             "redacts": "$h29iv0s8:example.com",
             "event_id": "$h29iv0s8:example.com",
             "origin_server_ts": 1,

--- a/crates/ruma-common/tests/events/redaction.rs
+++ b/crates/ruma-common/tests/events/redaction.rs
@@ -5,14 +5,15 @@ use ruma_common::{
         room::redaction::{RoomRedactionEvent, RoomRedactionEventContent},
         AnyMessageLikeEvent,
     },
+    owned_event_id,
     serde::CanBeEmpty,
-    MilliSecondsSinceUnixEpoch,
+    MilliSecondsSinceUnixEpoch, RoomVersionId,
 };
 use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
 #[test]
 fn serialize_redaction_content() {
-    let content = RoomRedactionEventContent::with_reason("being very unfriendly".into());
+    let content = RoomRedactionEventContent::new_v1().with_reason("being very unfriendly".into());
 
     let actual = to_json_value(content).unwrap();
     let expected = json!({
@@ -23,12 +24,28 @@ fn serialize_redaction_content() {
 }
 
 #[test]
+fn serialize_redaction_content_v11() {
+    let redacts = owned_event_id!("$abcdef");
+    let content = RoomRedactionEventContent::new_v11(redacts.clone())
+        .with_reason("being very unfriendly".into());
+
+    let actual = to_json_value(content).unwrap();
+    let expected = json!({
+        "redacts": redacts,
+        "reason": "being very unfriendly"
+    });
+
+    assert_eq!(actual, expected);
+}
+
+#[test]
 fn deserialize_redaction() {
     let json_data = json!({
         "content": {
+            "redacts": "$nomorev11:example.com",
             "reason": "being very unfriendly"
         },
-        "redacts": "$nomore:example.com",
+        "redacts": "$nomorev1:example.com",
         "event_id": "$h29iv0s8:example.com",
         "sender": "@carl:example.com",
         "origin_server_ts": 1,
@@ -40,11 +57,32 @@ fn deserialize_redaction() {
         from_json_value::<AnyMessageLikeEvent>(json_data),
         Ok(AnyMessageLikeEvent::RoomRedaction(RoomRedactionEvent::Original(ev)))
     );
+
+    assert_eq!(ev.redacts(&RoomVersionId::V1), "$nomorev1:example.com");
+    assert_eq!(ev.redacts(&RoomVersionId::V11), "$nomorev11:example.com");
+
+    assert_eq!(ev.content.redacts.unwrap(), "$nomorev11:example.com");
     assert_eq!(ev.content.reason.as_deref(), Some("being very unfriendly"));
     assert_eq!(ev.event_id, "$h29iv0s8:example.com");
-    assert_eq!(ev.redacts, "$nomore:example.com");
+    assert_eq!(ev.redacts.unwrap(), "$nomorev1:example.com");
     assert_eq!(ev.origin_server_ts, MilliSecondsSinceUnixEpoch(uint!(1)));
     assert_eq!(ev.room_id, "!roomid:room.com");
     assert_eq!(ev.sender, "@carl:example.com");
     assert!(ev.unsigned.is_empty());
+}
+
+#[test]
+fn deserialize_redaction_missing_redacts() {
+    let json_data = json!({
+        "content": {
+            "reason": "being very unfriendly"
+        },
+        "event_id": "$h29iv0s8:example.com",
+        "sender": "@carl:example.com",
+        "origin_server_ts": 1,
+        "room_id": "!roomid:room.com",
+        "type": "m.room.redaction"
+    });
+
+    from_json_value::<AnyMessageLikeEvent>(json_data).unwrap_err();
 }


### PR DESCRIPTION
Simpler alternative to #1612 & #1615.

Instead of creating an enum, we mark the fields as optional.

According to [MSC2174](https://github.com/matrix-org/matrix-spec-proposals/pull/2174) (part of [MSC3820](https://github.com/matrix-org/matrix-spec-proposals/issues/3820) - Room version 11) / [Spec PR](https://github.com/matrix-org/matrix-spec/pull/1604).

Note that the MSC was accepted, but the spec PR is still in review.

Closes #42.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->























<!-- Replace -->
----
Preview: https://pr-1616--ruma-docs.surge.sh
<!-- Replace -->
