### PR TITLE
events: Make creator field of RoomCreateEventContent optional

### DIFF
--- a/crates/ruma-client-api/src/room/create_room.rs
+++ b/crates/ruma-client-api/src/room/create_room.rs
@@ -162,7 +162,7 @@ pub mod v3 {
             creator: OwnedUserId,
             room_version: RoomVersionId,
         ) -> RoomCreateEventContent {
-            assign!(RoomCreateEventContent::new(creator), {
+            assign!(RoomCreateEventContent::new_v1(creator), {
                 federate: self.federate,
                 room_version: room_version,
                 predecessor: self.predecessor,

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -29,6 +29,10 @@ Breaking changes:
   according to MSC2174 / MSC3820
     - `RoomRedactionEventContent::new()` was renamed to `new_v1()`, and `with_reason()` is no
       longer a constructor but a builder-type method
+- Make the `creator` field of `RoomCreateEventContent` optional and deprecate it, as it was removed
+  in room version 11, according to MSC2175 / MSC3820
+    - `RoomCreateEventContent::new()` was renamed to `new_v1()`
+    - `RedactedRoomCreateEventContent` is now a typedef over `RoomCreateEventContent`
 
 Improvements:
 

--- a/crates/ruma-common/tests/events/redacted.rs
+++ b/crates/ruma-common/tests/events/redacted.rs
@@ -113,6 +113,7 @@ fn deserialize_redacted_any_room_sync() {
 }
 
 #[test]
+#[allow(deprecated)]
 fn deserialize_redacted_state_event() {
     let redacted = json!({
         "content": {
@@ -133,7 +134,7 @@ fn deserialize_redacted_state_event() {
         ),)))
     );
     assert_eq!(redacted.event_id, "$h29iv0s8:example.com");
-    assert_eq!(redacted.content.creator, "@carl:example.com");
+    assert_eq!(redacted.content.creator.unwrap(), "@carl:example.com");
 }
 
 #[test]
@@ -213,6 +214,7 @@ fn redact_message_content() {
 }
 
 #[test]
+#[allow(deprecated)]
 fn redact_state_content() {
     let json = json!({
         "creator": "@carl:example.com",
@@ -227,5 +229,5 @@ fn redact_state_content() {
         content.redact(&RoomVersionId::V6),
         RedactedRoomCreateEventContent { creator, .. }
     );
-    assert_eq!(creator, "@carl:example.com");
+    assert_eq!(creator.unwrap(), "@carl:example.com");
 }

--- a/crates/ruma-state-res/src/event_auth.rs
+++ b/crates/ruma-state-res/src/event_auth.rs
@@ -343,9 +343,10 @@ pub fn auth_check<E: Event>(
         }
     } else {
         // If no power level event found the creator gets 100 everyone else gets 0
+        #[allow(deprecated)]
         from_json_str::<RoomCreateEventContent>(room_create_event.content().get())
             .ok()
-            .and_then(|create| (create.creator == *sender).then(|| int!(100)))
+            .and_then(|create| (create.creator.unwrap() == *sender).then(|| int!(100)))
             .unwrap_or_default()
     };
 
@@ -533,7 +534,9 @@ fn valid_membership_change(
                 let create_content =
                     from_json_str::<RoomCreateEventContent>(create_room.content().get())?;
 
-                if create_content.creator == sender && create_content.creator == target_user {
+                #[allow(deprecated)]
+                let creator = create_content.creator.unwrap();
+                if creator == sender && creator == target_user {
                     return Ok(true);
                 }
             }


### PR DESCRIPTION
According to [MSC2175](https://github.com/matrix-org/matrix-spec-proposals/pull/2175) (Part of [MSC3820](https://github.com/matrix-org/matrix-spec-proposals/pull/3820) / [Spec PR](https://github.com/matrix-org/matrix-spec/pull/1604)

Note that the few changes in state res are only to reflect the changes of the type and make it still only valid up to room version 10. An upcoming PR will change it for room version 11.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->

















<!-- Replace -->
----
Preview Removed
<!-- Replace -->
