### PR TITLE
events: Update redacted types according to changes in room version 11

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -33,6 +33,11 @@ Breaking changes:
   in room version 11, according to MSC2175 / MSC3820
     - `RoomCreateEventContent::new()` was renamed to `new_v1()`
     - `RedactedRoomCreateEventContent` is now a typedef over `RoomCreateEventContent`
+- Add preserved fields to match the new redaction algorithm in room version 11, according to
+  MSC2176 / MSC3821 / MSC3820, for the following types:
+  - `RedactedRoomRedactionEventContent`,
+  - `RedactedRoomPowerLevelsEventContent`,
+  - `RedactedRoomMemberEventContent` 
 
 Improvements:
 


### PR DESCRIPTION
[MSC2176](https://github.com/matrix-org/matrix-spec-proposals/pull/2176) / [MSC3821](https://github.com/matrix-org/matrix-spec-proposals/pull/3821) (parts of [MSC3820](https://github.com/matrix-org/matrix-spec-proposals/pull/3820)) / [Spec PR](https://github.com/matrix-org/matrix-spec/pull/1604)

This changes just the types and the algorithms in the `RedactContent` implementations. A follow up PR will change the algorithm for the `canonical_json` module.

Note that `RedactedRoomRedactionEventContent` and  `RedactedRoomCreateEventContent` and their redaction algorithms are already updated in #1616 and #1617, respectively.










<!-- Replace -->
----
Preview Removed
<!-- Replace -->
