### PR TITLE
chore: Bump MSRV to 1.70

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         run: target/debug/xtask ci lint
 
   msrv:
-    name: Rust 1.65 / ${{ matrix.name }}
+    name: Rust 1.70 / ${{ matrix.name }}
     needs: xtask
     runs-on: ubuntu-latest
     strategy:
@@ -92,17 +92,17 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Install rust 1.65 toolchain
+      - name: Install rust 1.70 toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.65
+          toolchain: "1.70"
 
       - uses: Swatinem/rust-cache@v2
         with:
           # A stable compiler update should automatically not reuse old caches.
           # Add the MSRV as a stable cache key too so bumping it also gets us a
           # fresh cache.
-          sharedKey: msrv1.65
+          sharedKey: msrv1.70
 
       - name: Get xtask
         uses: actions/cache@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-rust-version = "1.65"
+rust-version = "1.70"
 
 [workspace.dependencies]
 assert_matches2 = "0.1.0"

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Minimum Rust version
 
-Ruma currently requires Rust 1.65. In general, we will never require beta or
+Ruma currently requires Rust 1.70. In general, we will never require beta or
 nightly for crates.io releases of our crates, and we will try to avoid releasing
 crates that depend on features that were only just stabilized.
 

--- a/crates/ruma-common/src/api/metadata.rs
+++ b/crates/ruma-common/src/api/metadata.rs
@@ -358,19 +358,18 @@ impl VersionHistory {
             |version: MatrixVersion| versions.iter().all(|v| v.is_superset_of(version));
 
         // Check if all versions removed this endpoint.
-        if self.removed.map_or(false, greater_or_equal_all) {
+        if self.removed.is_some_and(greater_or_equal_all) {
             return VersioningDecision::Removed;
         }
 
         // Check if *any* version marks this endpoint as stable.
-        if self.added_in().map_or(false, greater_or_equal_any) {
-            let all_deprecated = self.deprecated.map_or(false, greater_or_equal_all);
+        if self.added_in().is_some_and(greater_or_equal_any) {
+            let all_deprecated = self.deprecated.is_some_and(greater_or_equal_all);
 
             return VersioningDecision::Stable {
-                any_deprecated: all_deprecated
-                    || self.deprecated.map_or(false, greater_or_equal_any),
+                any_deprecated: all_deprecated || self.deprecated.is_some_and(greater_or_equal_any),
                 all_deprecated,
-                any_removed: self.removed.map_or(false, greater_or_equal_any),
+                any_removed: self.removed.is_some_and(greater_or_equal_any),
             };
         }
 

--- a/crates/ruma-common/src/push.rs
+++ b/crates/ruma-common/src/push.rs
@@ -115,10 +115,10 @@ impl Ruleset {
         if rule_id.contains('\\') {
             return Err(InsertPushRuleError::InvalidRuleId);
         }
-        if after.map_or(false, |s| s.starts_with('.')) {
+        if after.is_some_and(|s| s.starts_with('.')) {
             return Err(InsertPushRuleError::RelativeToServerDefaultRule);
         }
-        if before.map_or(false, |s| s.starts_with('.')) {
+        if before.is_some_and(|s| s.starts_with('.')) {
             return Err(InsertPushRuleError::RelativeToServerDefaultRule);
         }
 
@@ -291,7 +291,7 @@ impl Ruleset {
     ) -> Option<AnyPushRuleRef<'_>> {
         let event = FlattenedJson::from_raw(event);
 
-        if event.get_str("sender").map_or(false, |sender| sender == context.user_id) {
+        if event.get_str("sender").is_some_and(|sender| sender == context.user_id) {
             // no need to look at the rules if the event was by the user themselves
             None
         } else {
@@ -619,7 +619,7 @@ impl PatternedPushRule {
             return false;
         }
 
-        if event.get_str("sender").map_or(false, |sender| sender == context.user_id) {
+        if event.get_str("sender").is_some_and(|sender| sender == context.user_id) {
             return false;
         }
 

--- a/crates/ruma-common/src/push/condition.rs
+++ b/crates/ruma-common/src/push/condition.rs
@@ -157,7 +157,7 @@ impl PushCondition {
     /// * `event` - The flattened JSON representation of a room message event.
     /// * `context` - The context of the room at the time of the event.
     pub fn applies(&self, event: &FlattenedJson, context: &PushConditionRoomCtx) -> bool {
-        if event.get_str("sender").map_or(false, |sender| sender == context.user_id) {
+        if event.get_str("sender").is_some_and(|sender| sender == context.user_id) {
             return false;
         }
 
@@ -198,11 +198,11 @@ impl PushCondition {
                 }
                 RoomVersionFeature::_Custom(_) => false,
             },
-            Self::EventPropertyIs { key, value } => event.get(key).map_or(false, |v| v == value),
+            Self::EventPropertyIs { key, value } => event.get(key).is_some_and(|v| v == value),
             Self::EventPropertyContains { key, value } => event
                 .get(key)
                 .and_then(FlattenedJsonValue::as_array)
-                .map_or(false, |a| a.contains(value)),
+                .is_some_and(|a| a.contains(value)),
             Self::_Custom(_) => false,
         }
     }
@@ -395,7 +395,7 @@ impl StrExt for str {
 
                     // Look if the match has word boundaries.
                     let word_boundary_start = !self.char_at(start).is_word_char()
-                        || self.find_prev_char(start).map_or(true, |c| !c.is_word_char());
+                        || !self.find_prev_char(start).is_some_and(|c| c.is_word_char());
 
                     if word_boundary_start {
                         let word_boundary_end = end == self.len()

--- a/crates/ruma-common/src/push/iter.rs
+++ b/crates/ruma-common/src/push/iter.rs
@@ -221,7 +221,7 @@ impl<'a> AnyPushRuleRef<'a> {
     /// * `event` - The flattened JSON representation of a room message event.
     /// * `context` - The context of the room at the time of the event.
     pub fn applies(self, event: &FlattenedJson, context: &PushConditionRoomCtx) -> bool {
-        if event.get_str("sender").map_or(false, |sender| sender == context.user_id) {
+        if event.get_str("sender").is_some_and(|sender| sender == context.user_id) {
             return false;
         }
 

--- a/crates/ruma-macros/src/events/event_content.rs
+++ b/crates/ruma-macros/src/events/event_content.rs
@@ -238,7 +238,7 @@ impl TryFrom<ContentMeta> for ContentAttrs {
             ));
         }
 
-        if prefix.is_some() && !event_kind.map_or(false, |k| k.is_account_data()) {
+        if prefix.is_some() && !event_kind.is_some_and(|k| k.is_account_data()) {
             return Err(syn::Error::new_spanned(
                 event_type,
                 "only account data events may contain a `.*` suffix",

--- a/crates/ruma-state-res/src/event_auth.rs
+++ b/crates/ruma-state-res/src/event_auth.rs
@@ -716,7 +716,7 @@ fn can_send_event(event: impl Event, ple: Option<impl Event>, user_level: Int) -
         return false;
     }
 
-    if event.state_key().map_or(false, |k| k.starts_with('@'))
+    if event.state_key().is_some_and(|k| k.starts_with('@'))
         && event.state_key() != Some(event.sender().as_str())
     {
         return false; // permission required to post in this room

--- a/crates/ruma/CHANGELOG.md
+++ b/crates/ruma/CHANGELOG.md
@@ -1,5 +1,7 @@
 # [unreleased]
 
+- Bump MSRV to 1.70
+
 # 0.8.2
 
 Please refer to the changelogs of:

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -12,7 +12,7 @@ mod spec_links;
 
 use spec_links::check_spec_links;
 
-const MSRV: &str = "1.65";
+const MSRV: &str = "1.70";
 
 #[derive(Args)]
 pub struct CiArgs {


### PR DESCRIPTION
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->





<!-- Replace -->
----
Preview: https://pr-1621--ruma-docs.surge.sh
<!-- Replace -->
