### PR TITLE
feat(client-api): Add `timestamp` onto `SlidingSyncRoom`

### DIFF
--- a/crates/ruma-client-api/src/sync/sync_events/v4.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v4.rs
@@ -17,7 +17,7 @@ use ruma_common::{
     },
     metadata,
     serde::{duration::opt_ms, Raw},
-    DeviceKeyAlgorithm, OwnedMxcUri, OwnedRoomId,
+    DeviceKeyAlgorithm, MilliSecondsSinceUnixEpoch, OwnedMxcUri, OwnedRoomId,
 };
 use serde::{Deserialize, Serialize};
 
@@ -468,6 +468,15 @@ pub struct SlidingSyncRoom {
     /// The number of timeline events which have just occurred and are not historical.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub num_live: Option<UInt>,
+
+    /// The timestamp of the room.
+    ///
+    /// It's not to be confused with `origin_server_ts` of the latest event in the
+    /// timeline. `bump_event_types` might "ignore” some events when computing the
+    /// timestamp of the room. Thus, using this `timestamp` value is more accurate than
+    /// relying on the latest event.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<MilliSecondsSinceUnixEpoch>,
 }
 
 impl SlidingSyncRoom {


### PR DESCRIPTION
This has been added in
https://github.com/matrix-org/sliding-sync/pull/247. This is not part of the MSC yet.

<!-- Replace -->
----
Preview Removed
<!-- Replace -->
