### PR TITLE
canonical-json: Adapt the redaction algorithm for room version 11

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -33,11 +33,6 @@ Breaking changes:
   in room version 11, according to MSC2175 / MSC3820 / Matrix 1.8
     - `RoomCreateEventContent::new()` was renamed to `new_v1()`
     - `RedactedRoomCreateEventContent` is now a typedef over `RoomCreateEventContent`
-- Add preserved fields to match the new redaction algorithm in room version 11, according to
-  MSC2176 / MSC3821 / MSC3820 / Matrix 1.8, for the following types:
-  - `RedactedRoomRedactionEventContent`,
-  - `RedactedRoomPowerLevelsEventContent`,
-  - `RedactedRoomMemberEventContent`
 - `RoomMessageEventContent::make_reply_to()` and `make_for_thread()` have an extra parameter to
   support the recommended behavior for intentional mentions in replies according to Matrix 1.7
 - In Markdown, soft line breaks are transformed into hard line breaks when compiled into HTML.
@@ -75,6 +70,13 @@ Improvements:
 - Make the generated and stripped plain text reply fallback behavior more compatible with most
   of the Matrix ecosystem.
 - Add support for intentional mentions according to MSC3952 / Matrix 1.7
+- Add support for room version 11 according to MSC3820
+  - Adapt the redaction algorithm in `canonical_json`
+  - Add preserved fields to match the new redaction algorithm, according to
+    MSC2176 / MSC3821, for the following types:
+    - `RedactedRoomRedactionEventContent`,
+    - `RedactedRoomPowerLevelsEventContent`,
+    - `RedactedRoomMemberEventContent` 
 
 # 0.11.3
 

--- a/crates/ruma-common/src/canonical_json.rs
+++ b/crates/ruma-common/src/canonical_json.rs
@@ -260,15 +260,26 @@ static ALLOWED_KEYS: &[&str] = &[
 fn allowed_content_keys_for(event_type: &str, version: &RoomVersionId) -> &'static [&'static str] {
     match event_type {
         "m.room.member" => match version {
-            RoomVersionId::V9 | RoomVersionId::V10 => {
-                &["membership", "join_authorised_via_users_server"]
-            }
-            _ => &["membership"],
+            RoomVersionId::V1
+            | RoomVersionId::V2
+            | RoomVersionId::V3
+            | RoomVersionId::V4
+            | RoomVersionId::V5
+            | RoomVersionId::V6
+            | RoomVersionId::V7
+            | RoomVersionId::V8 => &["membership"],
+            _ => &["membership", "join_authorised_via_users_server"],
         },
         "m.room.create" => &["creator"],
         "m.room.join_rules" => match version {
-            RoomVersionId::V8 | RoomVersionId::V9 | RoomVersionId::V10 => &["join_rule", "allow"],
-            _ => &["join_rule"],
+            RoomVersionId::V1
+            | RoomVersionId::V2
+            | RoomVersionId::V3
+            | RoomVersionId::V4
+            | RoomVersionId::V5
+            | RoomVersionId::V6
+            | RoomVersionId::V7 => &["join_rule"],
+            _ => &["join_rule", "allow"],
         },
         "m.room.power_levels" => &[
             "ban",

--- a/crates/ruma-common/src/canonical_json.rs
+++ b/crates/ruma-common/src/canonical_json.rs
@@ -362,6 +362,14 @@ static ROOM_MEMBER_V1: AllowedKeys = AllowedKeys::some(&["membership"]);
 /// Allowed keys in `m.room.member`'s content according to room version 9.
 static ROOM_MEMBER_V9: AllowedKeys =
     AllowedKeys::some(&["membership", "join_authorised_via_users_server"]);
+/// Allowed keys in `m.room.member`'s content according to room version 11.
+static ROOM_MEMBER_V11: AllowedKeys = AllowedKeys::some_nested(
+    &["membership", "join_authorised_via_users_server"],
+    &[("third_party_invite", &ROOM_MEMBER_THIRD_PARTY_INVITE_V11)],
+);
+/// Allowed keys in the `third_party_invite` field of `m.room.member`'s content according to room
+/// version 11.
+static ROOM_MEMBER_THIRD_PARTY_INVITE_V11: AllowedKeys = AllowedKeys::some(&["signed"]);
 
 /// Allowed keys in `m.room.create`'s content according to room version 1.
 static ROOM_CREATE_V1: AllowedKeys = AllowedKeys::some(&["creator"]);
@@ -420,7 +428,8 @@ fn allowed_content_keys_for(event_type: &str, version: &RoomVersionId) -> &'stat
             | RoomVersionId::V6
             | RoomVersionId::V7
             | RoomVersionId::V8 => &ROOM_MEMBER_V1,
-            _ => &ROOM_MEMBER_V9,
+            RoomVersionId::V9 | RoomVersionId::V10 => &ROOM_MEMBER_V9,
+            _ => &ROOM_MEMBER_V11,
         },
         "m.room.create" => match version {
             RoomVersionId::V1

--- a/crates/ruma-common/src/canonical_json.rs
+++ b/crates/ruma-common/src/canonical_json.rs
@@ -318,7 +318,6 @@ fn allowed_event_keys_for(version: &RoomVersionId) -> &'static [&'static str] {
             "depth",
             "prev_events",
             "auth_events",
-            "origin",
             "origin_server_ts",
         ],
     }


### PR DESCRIPTION
According to [MSC3820](https://github.com/matrix-org/matrix-spec-proposals/pull/3820) (and sub-MSCs) / [Spec PR](https://github.com/matrix-org/matrix-spec/pull/1604)

I moved a changelog entry because it was not actually a breaking change to add new fields, given that the types are non-exhaustive.

This completes support for room version 11.







<!-- Replace -->
----
Preview: https://pr-1624--ruma-docs.surge.sh
<!-- Replace -->
