### PR TITLE
identifiers-validation: Allow `+` in the localpart of user IDs

### DIFF
--- a/crates/ruma-identifiers-validation/CHANGELOG.md
+++ b/crates/ruma-identifiers-validation/CHANGELOG.md
@@ -1,8 +1,14 @@
 # [unreleased]
 
+Bug fixes:
+
 - Don't consider empty localpart of a user ID as valid
   - It is accepted under the `compat-user-id` feature, but not considered
     fully-conforming
+
+Improvements:
+
+- Allow `+` in the localpart of user IDs according to MSC4009
 
 # 0.9.1
 

--- a/crates/ruma-identifiers-validation/src/user_id.rs
+++ b/crates/ruma-identifiers-validation/src/user_id.rs
@@ -20,9 +20,9 @@ pub fn validate(s: &str) -> Result<(), Error> {
 pub fn localpart_is_fully_conforming(localpart: &str) -> Result<bool, Error> {
     // See https://spec.matrix.org/latest/appendices/#user-identifiers
     let is_fully_conforming = !localpart.is_empty()
-        && localpart
-            .bytes()
-            .all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'z' | b'-' | b'.' | b'=' | b'_' | b'/'));
+        && localpart.bytes().all(
+            |b| matches!(b, b'0'..=b'9' | b'a'..=b'z' | b'-' | b'.' | b'=' | b'_' | b'/' | b'+'),
+        );
 
     if !is_fully_conforming {
         // If it's not fully conforming, check if it contains characters that are also disallowed


### PR DESCRIPTION
According to [MSC4009](https://github.com/matrix-org/matrix-spec-proposals/pull/4009) / [Spec PR](https://github.com/matrix-org/matrix-spec/pull/1583).

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->





<!-- Replace -->
----
Preview: https://pr-1625--ruma-docs.surge.sh
<!-- Replace -->
