### PR TITLE
events: Allow to add mentions automatically when generating reply

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -37,7 +37,9 @@ Breaking changes:
   MSC2176 / MSC3821 / MSC3820, for the following types:
   - `RedactedRoomRedactionEventContent`,
   - `RedactedRoomPowerLevelsEventContent`,
-  - `RedactedRoomMemberEventContent` 
+  - `RedactedRoomMemberEventContent`
+- `RoomMessageEventContent::make_reply_to()` and `make_for_thread()` have an extra parameter to
+  support the recommended behavior for intentional mentions in replies according to Matrix 1.7
 
 Improvements:
 

--- a/crates/ruma-common/src/events.rs
+++ b/crates/ruma-common/src/events.rs
@@ -102,6 +102,8 @@
 //! ));
 //! ```
 
+use std::collections::BTreeSet;
+
 use serde::{de::IgnoredAny, Deserialize, Serialize, Serializer};
 
 use crate::{EventEncryptionAlgorithm, OwnedUserId, RoomVersionId};
@@ -231,9 +233,9 @@ pub fn serialize_custom_event_error<T, S: Serializer>(_: &T, _: S) -> Result<S::
 pub struct Mentions {
     /// The list of mentioned users.
     ///
-    /// Defaults to an empty `Vec`.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub user_ids: Vec<OwnedUserId>,
+    /// Defaults to an empty `BTreeSet`.
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    pub user_ids: BTreeSet<OwnedUserId>,
 
     /// Whether the whole room is mentioned.
     ///
@@ -249,8 +251,8 @@ impl Mentions {
     }
 
     /// Create a `Mentions` for the given user IDs.
-    pub fn with_user_ids(user_ids: Vec<OwnedUserId>) -> Self {
-        Self { user_ids, ..Default::default() }
+    pub fn with_user_ids(user_ids: impl IntoIterator<Item = OwnedUserId>) -> Self {
+        Self { user_ids: BTreeSet::from_iter(user_ids), ..Default::default() }
     }
 
     /// Create a `Mentions` for a room mention.

--- a/crates/ruma-common/src/events/room/message.rs
+++ b/crates/ruma-common/src/events/room/message.rs
@@ -150,6 +150,7 @@ impl RoomMessageEventContent {
         mut self,
         original_message: &OriginalRoomMessageEvent,
         forward_thread: ForwardThread,
+        add_mentions: AddMentions,
     ) -> Self {
         let empty_formatted_body = || FormattedBody::html(String::new());
 
@@ -205,6 +206,17 @@ impl RoomMessageEventContent {
         };
         self.relates_to = Some(relates_to);
 
+        if add_mentions == AddMentions::Yes {
+            // Copy the mentioned users.
+            let mut user_ids = match &original_message.content.mentions {
+                Some(m) => m.user_ids.clone(),
+                None => Default::default(),
+            };
+            // Add the sender.
+            user_ids.insert(original_message.sender.clone());
+            self.mentions = Some(Mentions { user_ids, ..Default::default() });
+        }
+
         self
     }
 
@@ -227,9 +239,10 @@ impl RoomMessageEventContent {
         mut self,
         previous_message: &OriginalRoomMessageEvent,
         is_reply: ReplyWithinThread,
+        add_mentions: AddMentions,
     ) -> Self {
         if is_reply == ReplyWithinThread::Yes {
-            self = self.make_reply_to(previous_message, ForwardThread::No);
+            self = self.make_reply_to(previous_message, ForwardThread::No, add_mentions);
         }
 
         let thread_root = if let Some(Relation::Thread(Thread { event_id, .. })) =
@@ -323,7 +336,7 @@ impl RoomMessageEventContent {
 
         // Add reply fallback if needed.
         if let Some(original_message) = replied_to_message {
-            self = self.make_reply_to(original_message, ForwardThread::No);
+            self = self.make_reply_to(original_message, ForwardThread::No, AddMentions::No);
         }
 
         self.relates_to = Some(relates_to);
@@ -470,6 +483,24 @@ pub enum ForwardThread {
     /// Create a reply in the main conversation even if the original message is in a thread.
     ///
     /// This should be used if you client supports threads and you explicitly want that behavior.
+    No,
+}
+
+/// Whether or not to add intentional [`Mentions`] when sending a reply.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[allow(clippy::exhaustive_enums)]
+pub enum AddMentions {
+    /// Add automatic intentional mentions to the reply.
+    ///
+    /// Set this if your client supports intentional mentions.
+    ///
+    /// The sender of the original event will be added to the mentions of this message, along with
+    /// every user mentioned in the original event.
+    Yes,
+
+    /// Do not add intentional mentions to the reply.
+    ///
+    /// Set this if your client does not support intentional mentions.
     No,
 }
 


### PR DESCRIPTION
As recommended in Matrix 1.7: [Spec](https://spec.matrix.org/v1.7/client-server-api/#mentioning-the-replied-to-user).








<!-- Replace -->
----
Preview Removed
<!-- Replace -->
