### PR TITLE
Enforce import grouping

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,6 +1,7 @@
 comment_width = 100
 format_code_in_doc_comments = true
 imports_granularity = "Crate"
+group_imports = "StdExternalCrate"
 newline_style = "Unix"
 use_field_init_shorthand = true
 use_small_heuristics = "Max"

--- a/crates/ruma-client-api/src/filter.rs
+++ b/crates/ruma-client-api/src/filter.rs
@@ -10,9 +10,8 @@ use js_int::UInt;
 use ruma_common::{serde::StringEnum, OwnedRoomId, OwnedUserId};
 use serde::{Deserialize, Serialize};
 
-use crate::PrivOwnedStr;
-
 pub use self::{lazy_load::LazyLoadOptions, url::UrlFilter};
+use crate::PrivOwnedStr;
 
 /// Format to use for returned events.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]

--- a/crates/ruma-client-api/src/keys/upload_signatures.rs
+++ b/crates/ruma-client-api/src/keys/upload_signatures.rs
@@ -19,9 +19,8 @@ pub mod v3 {
     use serde::{Deserialize, Serialize};
     use serde_json::value::RawValue as RawJsonValue;
 
-    use crate::PrivOwnedStr;
-
     pub use super::iter::SignedKeysIter;
+    use crate::PrivOwnedStr;
 
     const METADATA: Metadata = metadata! {
         method: POST,

--- a/crates/ruma-client-api/src/sync/sync_events/v3.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v3.rs
@@ -4,7 +4,6 @@
 
 use std::{collections::BTreeMap, time::Duration};
 
-use super::{DeviceLists, UnreadNotificationsCount};
 use js_int::UInt;
 use ruma_common::{
     api::{request, response, Metadata},
@@ -20,6 +19,7 @@ use ruma_common::{
 };
 use serde::{Deserialize, Serialize};
 
+use super::{DeviceLists, UnreadNotificationsCount};
 use crate::filter::FilterDefinition;
 
 const METADATA: Metadata = metadata! {

--- a/crates/ruma-client-api/src/sync/sync_events/v4.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v4.rs
@@ -6,7 +6,6 @@
 
 use std::{collections::BTreeMap, time::Duration};
 
-use super::{DeviceLists, UnreadNotificationsCount};
 use js_int::UInt;
 use ruma_common::{
     api::{request, response, Metadata},
@@ -20,6 +19,8 @@ use ruma_common::{
     DeviceKeyAlgorithm, MilliSecondsSinceUnixEpoch, OwnedMxcUri, OwnedRoomId,
 };
 use serde::{Deserialize, Serialize};
+
+use super::{DeviceLists, UnreadNotificationsCount};
 
 const METADATA: Metadata = metadata! {
     method: POST,

--- a/crates/ruma-client-api/src/uiaa/user_serde.rs
+++ b/crates/ruma-client-api/src/uiaa/user_serde.rs
@@ -104,9 +104,10 @@ impl<'de> Deserialize<'de> for UserIdentifier {
 
 #[cfg(test)]
 mod tests {
-    use crate::uiaa::UserIdentifier;
     use assert_matches2::assert_matches;
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+
+    use crate::uiaa::UserIdentifier;
 
     #[test]
     fn serialize() {

--- a/crates/ruma-common/src/api.rs
+++ b/crates/ruma-common/src/api.rs
@@ -17,7 +17,82 @@ use std::{convert::TryInto as _, error::Error as StdError};
 use bytes::BufMut;
 use serde::{Deserialize, Serialize};
 
+use self::error::{FromHttpRequestError, FromHttpResponseError, IntoHttpError};
 use crate::UserId;
+
+/// Convenient constructor for [`Metadata`] constants.
+///
+/// Usage:
+///
+/// ```
+/// # use ruma_common::{metadata, api::Metadata};
+/// const _: Metadata = metadata! {
+///     method: GET, // one of the associated constants of http::Method
+///     rate_limited: true,
+///     authentication: AccessToken, // one of the variants of api::AuthScheme
+///
+///     // history of endpoint paths
+///     // there must be at least one path but otherwise everything is optional
+///     history: {
+///         unstable => "/_matrix/foo/org.bar.msc9000/baz",
+///         unstable => "/_matrix/foo/org.bar.msc9000/qux",
+///         1.0 => "/_matrix/media/r0/qux",
+///         1.1 => "/_matrix/media/v3/qux",
+///         1.2 => deprecated,
+///         1.3 => removed,
+///     }
+/// };
+/// ```
+#[macro_export]
+macro_rules! metadata {
+    ( $( $field:ident: $rhs:tt ),+ $(,)? ) => {
+        $crate::api::Metadata {
+            $( $field: $crate::metadata!(@field $field: $rhs) ),+
+        }
+    };
+
+    ( @field method: $method:ident ) => { $crate::exports::http::Method::$method };
+
+    ( @field authentication: $scheme:ident ) => { $crate::api::AuthScheme::$scheme };
+
+    ( @field history: {
+        $( unstable => $unstable_path:literal, )*
+        $( $( $version:literal => $rhs:tt, )+ )?
+    } ) => {
+        $crate::metadata! {
+            @history_impl
+            [ $($unstable_path),* ]
+            // Flip left and right to avoid macro parsing ambiguities
+            $( $( $rhs = $version ),+ )?
+        }
+    };
+
+    // Simple literal case: used for description, name, rate_limited
+    ( @field $_field:ident: $rhs:expr ) => { $rhs };
+
+    ( @history_impl
+        [ $($unstable_path:literal),* ]
+        $(
+            $( $stable_path:literal = $version:literal ),+
+            $(,
+                deprecated = $deprecated_version:literal
+                $(, removed = $removed_version:literal )?
+            )?
+        )?
+    ) => {
+        $crate::api::VersionHistory::new(
+            &[ $( $unstable_path ),* ],
+            &[ $($(
+                ($crate::api::MatrixVersion::from_lit(stringify!($version)), $stable_path)
+            ),+)? ],
+            $crate::metadata!(@optional_version $($( $deprecated_version )?)?),
+            $crate::metadata!(@optional_version $($($( $removed_version )?)?)?),
+        )
+    };
+
+    ( @optional_version ) => { None };
+    ( @optional_version $version:literal ) => { Some($crate::api::MatrixVersion::from_lit(stringify!($version))) }
+}
 
 /// Generates [`OutgoingRequest`] and [`IncomingRequest`] implementations.
 ///
@@ -134,7 +209,6 @@ use crate::UserId;
 /// }
 /// ```
 pub use ruma_macros::request;
-
 /// Generates [`OutgoingResponse`] and [`IncomingResponse`] implementations.
 ///
 /// The `OutgoingRequest` impl is feature-gated behind `cfg(feature = "client")`.
@@ -230,9 +304,7 @@ pub use ruma_macros::response;
 pub mod error;
 mod metadata;
 
-pub use metadata::{MatrixVersion, Metadata, VersionHistory, VersioningDecision};
-
-use error::{FromHttpRequestError, FromHttpResponseError, IntoHttpError};
+pub use self::metadata::{MatrixVersion, Metadata, VersionHistory, VersioningDecision};
 
 /// An enum to control whether an access token should be added to outgoing requests
 #[derive(Clone, Copy, Debug)]
@@ -434,78 +506,4 @@ pub enum Direction {
     /// Return events forwards in time from the requested `from` token.
     #[serde(rename = "f")]
     Forward,
-}
-
-/// Convenient constructor for [`Metadata`] constants.
-///
-/// Usage:
-///
-/// ```
-/// # use ruma_common::{metadata, api::Metadata};
-/// const _: Metadata = metadata! {
-///     method: GET, // one of the associated constants of http::Method
-///     rate_limited: true,
-///     authentication: AccessToken, // one of the variants of api::AuthScheme
-///
-///     // history of endpoint paths
-///     // there must be at least one path but otherwise everything is optional
-///     history: {
-///         unstable => "/_matrix/foo/org.bar.msc9000/baz",
-///         unstable => "/_matrix/foo/org.bar.msc9000/qux",
-///         1.0 => "/_matrix/media/r0/qux",
-///         1.1 => "/_matrix/media/v3/qux",
-///         1.2 => deprecated,
-///         1.3 => removed,
-///     }
-/// };
-/// ```
-#[macro_export]
-macro_rules! metadata {
-    ( $( $field:ident: $rhs:tt ),+ $(,)? ) => {
-        $crate::api::Metadata {
-            $( $field: $crate::metadata!(@field $field: $rhs) ),+
-        }
-    };
-
-    ( @field method: $method:ident ) => { $crate::exports::http::Method::$method };
-
-    ( @field authentication: $scheme:ident ) => { $crate::api::AuthScheme::$scheme };
-
-    ( @field history: {
-        $( unstable => $unstable_path:literal, )*
-        $( $( $version:literal => $rhs:tt, )+ )?
-    } ) => {
-        $crate::metadata! {
-            @history_impl
-            [ $($unstable_path),* ]
-            // Flip left and right to avoid macro parsing ambiguities
-            $( $( $rhs = $version ),+ )?
-        }
-    };
-
-    // Simple literal case: used for description, name, rate_limited
-    ( @field $_field:ident: $rhs:expr ) => { $rhs };
-
-    ( @history_impl
-        [ $($unstable_path:literal),* ]
-        $(
-            $( $stable_path:literal = $version:literal ),+
-            $(,
-                deprecated = $deprecated_version:literal
-                $(, removed = $removed_version:literal )?
-            )?
-        )?
-    ) => {
-        $crate::api::VersionHistory::new(
-            &[ $( $unstable_path ),* ],
-            &[ $($(
-                ($crate::api::MatrixVersion::from_lit(stringify!($version)), $stable_path)
-            ),+)? ],
-            $crate::metadata!(@optional_version $($( $deprecated_version )?)?),
-            $crate::metadata!(@optional_version $($($( $removed_version )?)?)?),
-        )
-    };
-
-    ( @optional_version ) => { None };
-    ( @optional_version $version:literal ) => { Some($crate::api::MatrixVersion::from_lit(stringify!($version))) }
 }

--- a/crates/ruma-common/src/canonical_json.rs
+++ b/crates/ruma-common/src/canonical_json.rs
@@ -7,14 +7,13 @@ use serde_json::Value as JsonValue;
 
 mod value;
 
+pub use self::value::{CanonicalJsonObject, CanonicalJsonValue};
 use crate::RoomVersionId;
 #[cfg(feature = "events")]
 use crate::{
     events::room::redaction::{OriginalRoomRedactionEvent, OriginalSyncRoomRedactionEvent},
     serde::Raw,
 };
-
-pub use self::value::{CanonicalJsonObject, CanonicalJsonValue};
 
 /// The set of possible errors when serializing to canonical JSON.
 #[cfg(feature = "canonical-json")]

--- a/crates/ruma-common/src/events/content.rs
+++ b/crates/ruma-common/src/events/content.rs
@@ -3,12 +3,11 @@ use std::fmt;
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::{from_str as from_json_str, value::RawValue as RawJsonValue};
 
-use crate::serde::{CanBeEmpty, Raw};
-
 use super::{
     EphemeralRoomEventType, GlobalAccountDataEventType, MessageLikeEventType,
     RoomAccountDataEventType, StateEventType, ToDeviceEventType,
 };
+use crate::serde::{CanBeEmpty, Raw};
 
 /// The base trait that all event content types implement.
 ///

--- a/crates/ruma-common/src/events/direct.rs
+++ b/crates/ruma-common/src/events/direct.rs
@@ -59,10 +59,10 @@ impl FromIterator<(OwnedUserId, Vec<OwnedRoomId>)> for DirectEventContent {
 mod tests {
     use std::collections::BTreeMap;
 
-    use crate::{server_name, RoomId, UserId};
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     use super::{DirectEvent, DirectEventContent};
+    use crate::{server_name, RoomId, UserId};
 
     #[test]
     fn serialization() {

--- a/crates/ruma-common/src/events/poll.rs
+++ b/crates/ruma-common/src/events/poll.rs
@@ -9,13 +9,12 @@ use std::collections::{BTreeMap, BTreeSet};
 use indexmap::IndexMap;
 use js_int::uint;
 
-use crate::{MilliSecondsSinceUnixEpoch, UserId};
-
 use self::{
     response::OriginalSyncPollResponseEvent, start::PollContentBlock,
     unstable_response::OriginalSyncUnstablePollResponseEvent,
     unstable_start::UnstablePollStartContentBlock,
 };
+use crate::{MilliSecondsSinceUnixEpoch, UserId};
 
 pub mod end;
 pub mod response;

--- a/crates/ruma-common/src/events/poll/response.rs
+++ b/crates/ruma-common/src/events/poll/response.rs
@@ -5,9 +5,8 @@ use std::{ops::Deref, vec};
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
-use crate::{events::relation::Reference, OwnedEventId};
-
 use super::start::PollContentBlock;
+use crate::{events::relation::Reference, OwnedEventId};
 
 /// The payload for a poll response event.
 ///

--- a/crates/ruma-common/src/events/poll/start.rs
+++ b/crates/ruma-common/src/events/poll/start.rs
@@ -10,17 +10,16 @@ mod poll_answers_serde;
 
 use poll_answers_serde::PollAnswersDeHelper;
 
-use crate::{
-    events::{message::TextContentBlock, room::message::Relation},
-    serde::StringEnum,
-    PrivOwnedStr,
-};
-
 use super::{
     compile_poll_results,
     end::{PollEndEventContent, PollResultsContentBlock},
     generate_poll_end_fallback_text,
     response::OriginalSyncPollResponseEvent,
+};
+use crate::{
+    events::{message::TextContentBlock, room::message::Relation},
+    serde::StringEnum,
+    PrivOwnedStr,
 };
 
 /// The payload for a poll start event.

--- a/crates/ruma-common/src/events/poll/unstable_response.rs
+++ b/crates/ruma-common/src/events/poll/unstable_response.rs
@@ -6,9 +6,8 @@ use std::ops::Deref;
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
-use crate::{events::relation::Reference, OwnedEventId};
-
 use super::unstable_start::UnstablePollStartContentBlock;
+use crate::{events::relation::Reference, OwnedEventId};
 
 /// The payload for an unstable poll response event.
 ///

--- a/crates/ruma-common/src/events/poll/unstable_start.rs
+++ b/crates/ruma-common/src/events/poll/unstable_start.rs
@@ -9,8 +9,6 @@ use serde::{Deserialize, Serialize};
 mod unstable_poll_answers_serde;
 mod unstable_poll_kind_serde;
 
-use crate::events::room::message::Relation;
-
 use self::unstable_poll_answers_serde::UnstablePollAnswersDeHelper;
 use super::{
     compile_unstable_poll_results, generate_poll_end_fallback_text,
@@ -18,6 +16,7 @@ use super::{
     unstable_end::UnstablePollEndEventContent,
     unstable_response::OriginalSyncUnstablePollResponseEvent,
 };
+use crate::events::room::message::Relation;
 
 /// The payload for an unstable poll start event.
 ///

--- a/crates/ruma-common/src/events/poll/unstable_start/unstable_poll_answers_serde.rs
+++ b/crates/ruma-common/src/events/poll/unstable_start/unstable_poll_answers_serde.rs
@@ -2,9 +2,8 @@
 
 use serde::Deserialize;
 
-use crate::events::poll::start::{PollAnswers, PollAnswersError};
-
 use super::{UnstablePollAnswer, UnstablePollAnswers};
+use crate::events::poll::start::{PollAnswers, PollAnswersError};
 
 #[derive(Debug, Default, Deserialize)]
 pub(crate) struct UnstablePollAnswersDeHelper(Vec<UnstablePollAnswer>);

--- a/crates/ruma-common/src/events/room.rs
+++ b/crates/ruma-common/src/events/room.rs
@@ -282,9 +282,8 @@ mod tests {
     use serde::Deserialize;
     use serde_json::{from_value as from_json_value, json};
 
-    use crate::{mxc_uri, serde::Base64};
-
     use super::{EncryptedFile, JsonWebKey, MediaSource};
+    use crate::{mxc_uri, serde::Base64};
 
     #[derive(Deserialize)]
     struct MsgWithAttachment {

--- a/crates/ruma-common/src/events/room/message/reply.rs
+++ b/crates/ruma-common/src/events/room/message/reply.rs
@@ -124,12 +124,11 @@ pub(crate) fn plain_and_formatted_reply_body(
 
 #[cfg(test)]
 mod tests {
+    use super::OriginalRoomMessageEvent;
     use crate::{
         events::{room::message::RoomMessageEventContent, MessageLikeUnsigned},
         owned_event_id, owned_room_id, owned_user_id, MilliSecondsSinceUnixEpoch,
     };
-
-    use super::OriginalRoomMessageEvent;
 
     #[test]
     fn fallback_multiline() {

--- a/crates/ruma-common/src/events/room/thumbnail_source_serde.rs
+++ b/crates/ruma-common/src/events/room/thumbnail_source_serde.rs
@@ -5,9 +5,8 @@ use serde::{
     Deserialize, Deserializer,
 };
 
-use crate::OwnedMxcUri;
-
 use super::{EncryptedFile, MediaSource};
+use crate::OwnedMxcUri;
 
 /// Serializes a MediaSource to a thumbnail source.
 pub(crate) fn serialize<S>(source: &Option<MediaSource>, serializer: S) -> Result<S::Ok, S::Error>

--- a/crates/ruma-common/src/events/room_key.rs
+++ b/crates/ruma-common/src/events/room_key.rs
@@ -44,10 +44,10 @@ impl ToDeviceRoomKeyEventContent {
 
 #[cfg(test)]
 mod tests {
-    use crate::{owned_room_id, EventEncryptionAlgorithm};
     use serde_json::{json, to_value as to_json_value};
 
     use super::ToDeviceRoomKeyEventContent;
+    use crate::{owned_room_id, EventEncryptionAlgorithm};
 
     #[test]
     fn serialization() {

--- a/crates/ruma-common/src/events/secret_storage/secret.rs
+++ b/crates/ruma-common/src/events/secret_storage/secret.rs
@@ -2,8 +2,9 @@
 
 use std::collections::BTreeMap;
 
-use crate::serde::Base64;
 use serde::{Deserialize, Serialize};
+
+use crate::serde::Base64;
 
 /// A secret and its encrypted contents.
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/ruma-common/src/events/tag.rs
+++ b/crates/ruma-common/src/events/tag.rs
@@ -7,10 +7,9 @@ use std::{collections::BTreeMap, error::Error, fmt, str::FromStr};
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
-use crate::{serde::deserialize_cow_str, PrivOwnedStr};
-
 #[cfg(feature = "compat-tag-info")]
 use crate::serde::deserialize_as_optional_f64_or_string;
+use crate::{serde::deserialize_cow_str, PrivOwnedStr};
 
 /// Map of tag names to tag info.
 pub type Tags = BTreeMap<TagName, TagInfo>;

--- a/crates/ruma-common/src/identifiers.rs
+++ b/crates/ruma-common/src/identifiers.rs
@@ -4,6 +4,11 @@
 // FIXME: Remove once lint doesn't trigger on std::convert::TryFrom in identifiers/macros.rs anymore
 #![allow(unused_qualifications)]
 
+#[doc(inline)]
+pub use ruma_identifiers_validation::error::{
+    Error as IdParseError, MatrixIdError, MatrixToError, MatrixUriError, MxcUriError,
+    VoipVersionIdError,
+};
 use serde::de::{self, Deserializer, Unexpected};
 
 #[doc(inline)]
@@ -33,11 +38,6 @@ pub use self::{
     user_id::{OwnedUserId, UserId},
     voip_id::{OwnedVoipId, VoipId},
     voip_version_id::VoipVersionId,
-};
-#[doc(inline)]
-pub use ruma_identifiers_validation::error::{
-    Error as IdParseError, MatrixIdError, MatrixToError, MatrixUriError, MxcUriError,
-    VoipVersionIdError,
 };
 
 pub mod matrix_uri;

--- a/crates/ruma-common/src/push/condition/flattened_json.rs
+++ b/crates/ruma-common/src/push/condition/flattened_json.rs
@@ -1,7 +1,8 @@
+use std::collections::BTreeMap;
+
 use js_int::Int;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::{to_value as to_json_value, value::Value as JsonValue};
-use std::collections::BTreeMap;
 use thiserror::Error;
 use tracing::{instrument, warn};
 

--- a/crates/ruma-common/src/push/condition/push_condition_serde.rs
+++ b/crates/ruma-common/src/push/condition/push_condition_serde.rs
@@ -1,11 +1,10 @@
 use serde::{de, Deserialize, Serialize, Serializer};
 use serde_json::value::RawValue as RawJsonValue;
 
-use crate::serde::from_raw_json_value;
-
 #[cfg(feature = "unstable-msc3931")]
 use super::RoomVersionFeature;
 use super::{PushCondition, RoomMemberCountIs, ScalarJsonValue};
+use crate::serde::from_raw_json_value;
 
 impl Serialize for PushCondition {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/crates/ruma-common/tests/events/enums.rs
+++ b/crates/ruma-common/tests/events/enums.rs
@@ -1,24 +1,23 @@
 use assert_matches2::assert_matches;
 use js_int::int;
 use ruma_common::{
-    events::{MessageLikeEvent, StateEvent, SyncMessageLikeEvent, SyncStateEvent},
+    events::{
+        room::{
+            aliases::RoomAliasesEventContent,
+            message::{MessageType, RoomMessageEventContent},
+            power_levels::RoomPowerLevelsEventContent,
+        },
+        AnyEphemeralRoomEvent, AnyMessageLikeEvent, AnyStateEvent, AnySyncMessageLikeEvent,
+        AnySyncStateEvent, AnySyncTimelineEvent, AnyTimelineEvent, EphemeralRoomEventType,
+        GlobalAccountDataEventType, MessageLikeEvent, MessageLikeEventType,
+        OriginalMessageLikeEvent, OriginalStateEvent, OriginalSyncMessageLikeEvent,
+        OriginalSyncStateEvent, RoomAccountDataEventType, StateEvent, StateEventType,
+        SyncMessageLikeEvent, SyncStateEvent, ToDeviceEventType,
+    },
     room_alias_id,
     serde::test::serde_json_eq,
 };
 use serde_json::{from_value as from_json_value, json, Value as JsonValue};
-
-use ruma_common::events::{
-    room::{
-        aliases::RoomAliasesEventContent,
-        message::{MessageType, RoomMessageEventContent},
-        power_levels::RoomPowerLevelsEventContent,
-    },
-    AnyEphemeralRoomEvent, AnyMessageLikeEvent, AnyStateEvent, AnySyncMessageLikeEvent,
-    AnySyncStateEvent, AnySyncTimelineEvent, AnyTimelineEvent, EphemeralRoomEventType,
-    GlobalAccountDataEventType, MessageLikeEventType, OriginalMessageLikeEvent, OriginalStateEvent,
-    OriginalSyncMessageLikeEvent, OriginalSyncStateEvent, RoomAccountDataEventType, StateEventType,
-    ToDeviceEventType,
-};
 
 fn message_event() -> JsonValue {
     json!({

--- a/crates/ruma-common/tests/events/ephemeral_event.rs
+++ b/crates/ruma-common/tests/events/ephemeral_event.rs
@@ -2,16 +2,15 @@ use assert_matches2::assert_matches;
 use js_int::uint;
 use maplit::btreemap;
 use ruma_common::{
-    event_id, events::receipt::ReceiptType, owned_event_id, owned_user_id, user_id,
-    MilliSecondsSinceUnixEpoch,
+    event_id,
+    events::{
+        receipt::{Receipt, ReceiptEventContent, ReceiptType},
+        typing::TypingEventContent,
+        AnyEphemeralRoomEvent,
+    },
+    owned_event_id, owned_user_id, user_id, MilliSecondsSinceUnixEpoch,
 };
 use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
-
-use ruma_common::events::{
-    receipt::{Receipt, ReceiptEventContent},
-    typing::TypingEventContent,
-    AnyEphemeralRoomEvent,
-};
 
 #[test]
 fn ephemeral_serialize_typing() {

--- a/crates/ruma-macros/src/events/event_content.rs
+++ b/crates/ruma-macros/src/events/event_content.rs
@@ -12,9 +12,8 @@ use syn::{
     DeriveInput, Field, Ident, LitStr, Meta, Token, Type,
 };
 
-use crate::util::{m_prefix_name_to_type_name, PrivateField};
-
 use super::event_parse::{EventKind, EventKindVariation};
+use crate::util::{m_prefix_name_to_type_name, PrivateField};
 
 mod kw {
     // This `content` field is kept when the event is redacted.

--- a/crates/ruma-server-util/src/authorization.rs
+++ b/crates/ruma-server-util/src/authorization.rs
@@ -1,7 +1,6 @@
 //! Common types for implementing federation authorization.
 
 use headers::{authorization::Credentials, HeaderValue};
-
 use ruma_common::{OwnedServerName, OwnedServerSigningKeyId};
 use tracing::debug;
 use yap::{IntoTokens, TokenLocation, Tokens};

--- a/crates/ruma-signatures/src/keys.rs
+++ b/crates/ruma-signatures/src/keys.rs
@@ -90,9 +90,10 @@ impl Ed25519KeyPair {
     /// generated from the private key. This is a fallback and extra validation against
     /// corruption or
     pub fn from_der(document: &[u8], version: String) -> Result<Self, Error> {
+        use pkcs8::der::Decode;
+
         #[cfg(feature = "ring-compat")]
         use self::compat::CompatibleDocument;
-        use pkcs8::der::Decode;
 
         #[cfg(feature = "ring-compat")]
         let backing: Vec<u8>;

--- a/crates/ruma-signatures/src/lib.rs
+++ b/crates/ruma-signatures/src/lib.rs
@@ -46,14 +46,16 @@
 
 use ruma_common::serde::{AsRefStr, DisplayAsRefStr};
 
-pub use error::{Error, JsonError, ParseError, VerificationError};
-pub use functions::{
-    canonical_json, content_hash, hash_and_sign_event, reference_hash, sign_json, verify_event,
-    verify_json,
+pub use self::{
+    error::{Error, JsonError, ParseError, VerificationError},
+    functions::{
+        canonical_json, content_hash, hash_and_sign_event, reference_hash, sign_json, verify_event,
+        verify_json,
+    },
+    keys::{Ed25519KeyPair, KeyPair, PublicKeyMap, PublicKeySet},
+    signatures::Signature,
+    verification::Verified,
 };
-pub use keys::{Ed25519KeyPair, KeyPair, PublicKeyMap, PublicKeySet};
-pub use signatures::Signature;
-pub use verification::Verified;
 
 mod error;
 mod functions;

--- a/crates/ruma-state-res/src/test_utils.rs
+++ b/crates/ruma-state-res/src/test_utils.rs
@@ -27,9 +27,8 @@ use serde_json::{
 };
 use tracing::info;
 
+pub(crate) use self::event::PduEvent;
 use crate::{auth_types_for_event, Error, Event, EventTypeExt, Result, StateMap};
-
-pub(crate) use event::PduEvent;
 
 static SERVER_TIMESTAMP: AtomicU64 = AtomicU64::new(0);
 

--- a/crates/ruma/src/lib.rs
+++ b/crates/ruma/src/lib.rs
@@ -98,17 +98,16 @@ pub use ruma_state_res as state_res;
 /// [apis]: https://spec.matrix.org/latest/#matrix-apis
 #[cfg(feature = "api")]
 pub mod api {
-    // The metadata macro is also exported at the crate root because `#[macro_export]` always
-    // places things at the crate root of the defining crate and we do a glob re-export of
-    // `ruma_common`, but here is the more logical (preferred) location.
-    pub use ruma_common::{api::*, metadata};
-
     #[cfg(any(feature = "appservice-api-c", feature = "appservice-api-s"))]
     #[doc(inline)]
     pub use ruma_appservice_api as appservice;
     #[cfg(any(feature = "client-api-c", feature = "client-api-s"))]
     #[doc(inline)]
     pub use ruma_client_api as client;
+    // The metadata macro is also exported at the crate root because `#[macro_export]` always
+    // places things at the crate root of the defining crate and we do a glob re-export of
+    // `ruma_common`, but here is the more logical (preferred) location.
+    pub use ruma_common::{api::*, metadata};
     #[cfg(any(feature = "federation-api-c", feature = "federation-api-s"))]
     #[doc(inline)]
     pub use ruma_federation_api as federation;


### PR DESCRIPTION
Includes a few manual changes to make rustfmt behave a bit better.

Pre-requisite for having changed imports automatically grouped when splitting `ruma_common::events` into a separate crate again.




<!-- Replace -->
----
Preview Removed
<!-- Replace -->
