### PR TITLE
canonical-json: Allow to converted (Sync)RoomRedactionEvent to RedactedBecause

### DIFF
--- a/crates/ruma-common/src/canonical_json.rs
+++ b/crates/ruma-common/src/canonical_json.rs
@@ -10,7 +10,10 @@ mod value;
 use crate::RoomVersionId;
 #[cfg(feature = "events")]
 use crate::{
-    events::room::redaction::{OriginalRoomRedactionEvent, OriginalSyncRoomRedactionEvent},
+    events::room::redaction::{
+        OriginalRoomRedactionEvent, OriginalSyncRoomRedactionEvent, RoomRedactionEvent,
+        SyncRoomRedactionEvent,
+    },
     serde::Raw,
 };
 
@@ -147,6 +150,24 @@ impl TryFrom<&Raw<OriginalSyncRoomRedactionEvent>> for RedactedBecause {
     type Error = serde_json::Error;
 
     fn try_from(value: &Raw<OriginalSyncRoomRedactionEvent>) -> Result<Self, Self::Error> {
+        value.deserialize_as().map(Self)
+    }
+}
+
+#[cfg(feature = "events")]
+impl TryFrom<&Raw<RoomRedactionEvent>> for RedactedBecause {
+    type Error = serde_json::Error;
+
+    fn try_from(value: &Raw<RoomRedactionEvent>) -> Result<Self, Self::Error> {
+        value.deserialize_as().map(Self)
+    }
+}
+
+#[cfg(feature = "events")]
+impl TryFrom<&Raw<SyncRoomRedactionEvent>> for RedactedBecause {
+    type Error = serde_json::Error;
+
+    fn try_from(value: &Raw<SyncRoomRedactionEvent>) -> Result<Self, Self::Error> {
         value.deserialize_as().map(Self)
     }
 }


### PR DESCRIPTION
With room version 11, even a redacted `m.room.redaction` event has a redacts field, so it can be in redacted_because.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->





<!-- Replace -->
----
Preview Removed
<!-- Replace -->
