### PR TITLE
Add support for Matrix 1.8

### DIFF
--- a/crates/ruma-client-api/src/membership/invite_user.rs
+++ b/crates/ruma-client-api/src/membership/invite_user.rs
@@ -9,8 +9,8 @@ pub mod v3 {
     //! [by their Matrix identifier][spec-mxid], and one to invite a user
     //! [by their third party identifier][spec-3pid].
     //!
-    //! [spec-mxid]: https://spec.matrix.org/v1.7/client-server-api/#post_matrixclientv3roomsroomidinvite
-    //! [spec-3pid]: https://spec.matrix.org/v1.7/client-server-api/#post_matrixclientv3roomsroomidinvite-1
+    //! [spec-mxid]: https://spec.matrix.org/v1.8/client-server-api/#post_matrixclientv3roomsroomidinvite
+    //! [spec-3pid]: https://spec.matrix.org/v1.8/client-server-api/#post_matrixclientv3roomsroomidinvite-1
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -26,15 +26,15 @@ Breaking changes:
   `RoomMessageEventContentWithoutRelation` instead of a `MessageType`
 - Make the `redacts` field of `Original(Sync)RoomRedactionEvent` optional to handle the format
   where the `redacts` key is moved inside the `content`, as introduced in room version 11,
-  according to MSC2174 / MSC3820
+  according to MSC2174 / MSC3820 / Matrix 1.8
     - `RoomRedactionEventContent::new()` was renamed to `new_v1()`, and `with_reason()` is no
       longer a constructor but a builder-type method
 - Make the `creator` field of `RoomCreateEventContent` optional and deprecate it, as it was removed
-  in room version 11, according to MSC2175 / MSC3820
+  in room version 11, according to MSC2175 / MSC3820 / Matrix 1.8
     - `RoomCreateEventContent::new()` was renamed to `new_v1()`
     - `RedactedRoomCreateEventContent` is now a typedef over `RoomCreateEventContent`
 - Add preserved fields to match the new redaction algorithm in room version 11, according to
-  MSC2176 / MSC3821 / MSC3820, for the following types:
+  MSC2176 / MSC3821 / MSC3820 / Matrix 1.8, for the following types:
   - `RedactedRoomRedactionEventContent`,
   - `RedactedRoomPowerLevelsEventContent`,
   - `RedactedRoomMemberEventContent`
@@ -63,7 +63,7 @@ Improvements:
   - `user_can_send_state`
   - `user_can_trigger_room_notification`
 - Add `MessageType::sanitize` behind the `unstable-sanitize` feature
-- Add `MatrixVersion::V1_7`
+- Add `MatrixVersion::V1_7` and `MatrixVersion::V1_8`
 - Stabilize support for annotations and reactions (MSC2677 / Matrix 1.7)
 - Add support for intentional mentions push rules (MSC3952 / Matrix 1.7)
 - Stabilize support for VoIP signalling improvements (MSC2746 / Matrix 1.7)

--- a/crates/ruma-common/src/api/metadata.rs
+++ b/crates/ruma-common/src/api/metadata.rs
@@ -516,6 +516,11 @@ pub enum MatrixVersion {
     ///
     /// See <https://spec.matrix.org/v1.7/>.
     V1_7,
+
+    /// Version 1.8 of the Matrix specification, released in Q3 2023.
+    ///
+    /// See <https://spec.matrix.org/v1.8/>.
+    V1_8,
 }
 
 impl TryFrom<&str> for MatrixVersion {
@@ -536,6 +541,7 @@ impl TryFrom<&str> for MatrixVersion {
             "v1.5" => V1_5,
             "v1.6" => V1_6,
             "v1.7" => V1_7,
+            "v1.8" => V1_8,
             _ => return Err(UnknownVersionError),
         })
     }
@@ -582,6 +588,7 @@ impl MatrixVersion {
             MatrixVersion::V1_5 => (1, 5),
             MatrixVersion::V1_6 => (1, 6),
             MatrixVersion::V1_7 => (1, 7),
+            MatrixVersion::V1_8 => (1, 8),
         }
     }
 
@@ -596,6 +603,7 @@ impl MatrixVersion {
             (1, 5) => Ok(MatrixVersion::V1_5),
             (1, 6) => Ok(MatrixVersion::V1_6),
             (1, 7) => Ok(MatrixVersion::V1_7),
+            (1, 8) => Ok(MatrixVersion::V1_8),
             _ => Err(UnknownVersionError),
         }
     }
@@ -684,7 +692,9 @@ impl MatrixVersion {
             // <https://spec.matrix.org/v1.6/rooms/#complete-list-of-room-versions>
             MatrixVersion::V1_6
             // <https://spec.matrix.org/v1.7/rooms/#complete-list-of-room-versions>
-            | MatrixVersion::V1_7 => RoomVersionId::V10,
+            | MatrixVersion::V1_7
+            // <https://spec.matrix.org/v1.8/rooms/#complete-list-of-room-versions>
+            | MatrixVersion::V1_8 => RoomVersionId::V10,
         }
     }
 }

--- a/crates/ruma-common/src/push/condition.rs
+++ b/crates/ruma-common/src/push/condition.rs
@@ -586,7 +586,7 @@ mod tests {
         assert!(!"m".matches_word("[[:alpha:]]?"));
         assert!("[[:alpha:]]!".matches_word("[[:alpha:]]?"));
 
-        // From the spec: <https://spec.matrix.org/v1.7/client-server-api/#conditions-1>
+        // From the spec: <https://spec.matrix.org/v1.8/client-server-api/#conditions-1>
         assert!("An example event.".matches_word("ex*ple"));
         assert!("exple".matches_word("ex*ple"));
         assert!("An exciting triple-whammy".matches_word("ex*ple"));
@@ -635,7 +635,7 @@ mod tests {
         assert!("".matches_pattern("*", false));
         assert!(!"foo".matches_pattern("", false));
 
-        // From the spec: <https://spec.matrix.org/v1.7/client-server-api/#conditions-1>
+        // From the spec: <https://spec.matrix.org/v1.8/client-server-api/#conditions-1>
         assert!("Lunch plans".matches_pattern("lunc?*", false));
         assert!("LUNCH".matches_pattern("lunc?*", false));
         assert!(!" lunch".matches_pattern("lunc?*", false));

--- a/crates/ruma-identifiers-validation/CHANGELOG.md
+++ b/crates/ruma-identifiers-validation/CHANGELOG.md
@@ -8,7 +8,7 @@ Bug fixes:
 
 Improvements:
 
-- Allow `+` in the localpart of user IDs according to MSC4009
+- Allow `+` in the localpart of user IDs according to MSC4009 / Matrix 1.8
 
 # 0.9.1
 

--- a/crates/ruma-identifiers-validation/src/error.rs
+++ b/crates/ruma-identifiers-validation/src/error.rs
@@ -77,7 +77,7 @@ pub enum MxcUriError {
     /// Media identifier malformed due to invalid characters detected.
     ///
     /// Valid characters are (in regex notation) `[A-Za-z0-9_-]+`.
-    /// See [here](https://spec.matrix.org/v1.7/client-server-api/#security-considerations-5) for more details.
+    /// See [here](https://spec.matrix.org/v1.8/client-server-api/#security-considerations-5) for more details.
     #[error("Media Identifier malformed, invalid characters")]
     MediaIdMalformed,
 

--- a/crates/ruma-identifiers-validation/src/mxc_uri.rs
+++ b/crates/ruma-identifiers-validation/src/mxc_uri.rs
@@ -17,7 +17,7 @@ pub fn validate(uri: &str) -> Result<NonZeroU8, MxcUriError> {
 
     let server_name = &uri[..index];
     let media_id = &uri[index + 1..];
-    // See: https://spec.matrix.org/v1.7/client-server-api/#security-considerations-5
+    // See: https://spec.matrix.org/v1.8/client-server-api/#security-considerations-5
     let media_id_is_valid =
         media_id.bytes().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'z' | b'A'..=b'Z' | b'-' ));
 

--- a/crates/ruma-state-res/CHANGELOG.md
+++ b/crates/ruma-state-res/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Improvements:
 
-- Add `RoomVersion::V11` according to MSC3820
+- Add `RoomVersion::V11` according to MSC3820 / Matrix 1.8
 
 # 0.9.1
 

--- a/xtask/src/ci/spec_links.rs
+++ b/xtask/src/ci/spec_links.rs
@@ -18,7 +18,7 @@ const OLD_URL_WHITELIST: &[&str] =
 
 /// Authorized versions in URLs pointing to the new specs.
 const NEW_VERSION_WHITELIST: &[&str] = &[
-    "v1.1", "v1.2", "v1.3", "v1.4", "v1.5", "v1.6", "v1.7",
+    "v1.1", "v1.2", "v1.3", "v1.4", "v1.5", "v1.6", "v1.7", "v1.8",
     "latest",
     // This should only be enabled if a legitimate use case is found.
     // "unstable",


### PR DESCRIPTION
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->





<!-- Replace -->
----
Preview: https://pr-1639--ruma-docs.surge.sh
<!-- Replace -->
