### PR TITLE
events: Add method on RoomMessageEventContent to apply a replacement

### DIFF
--- a/crates/ruma-events/src/room/message.rs
+++ b/crates/ruma-events/src/room/message.rs
@@ -420,6 +420,13 @@ impl RoomMessageEventContent {
         self.msgtype.body()
     }
 
+    /// Apply the given new content from a [`Replacement`] to this message.
+    pub fn apply_replacement(&mut self, new_content: RoomMessageEventContentWithoutRelation) {
+        let RoomMessageEventContentWithoutRelation { msgtype, mentions } = new_content;
+        self.msgtype = msgtype;
+        self.mentions = mentions;
+    }
+
     /// Sanitize this message.
     ///
     /// If this message contains HTML, this removes the [tags and attributes] that are not listed in


### PR DESCRIPTION
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->





<!-- Replace -->
----
Preview Removed
<!-- Replace -->
