### PR TITLE
feat(events): Re-export `pulldown_cmark`

### DIFF
--- a/crates/ruma-events/src/lib.rs
+++ b/crates/ruma-events/src/lib.rs
@@ -133,6 +133,10 @@ pub mod macros {
     pub use ruma_macros::{Event, EventContent};
 }
 
+/// Re-export the Markdown parser.
+#[cfg(feature = "markdown")]
+pub use pulldown_cmark as markdown;
+
 #[cfg(feature = "unstable-msc3927")]
 pub mod audio;
 pub mod call;


### PR DESCRIPTION
Ruma uses `pulldown_cmark` to parse and compile Markdown. It's behind the `markdown` feature flag.

This patch re-exports `pulldown_cmark`, so that projects using Ruma that want to manipulate Markdown a little bit for Matrix purposes, don't need to match the dependency versions exactly. It's purely for convenience, and to avoid having duplicated code in case upstream projects forgot to match `pulldown_cmark`'s version from Ruma.

<!-- Replace -->
----
Preview Removed
<!-- Replace -->
