### PR TITLE
Fix missing re-export of new unstable types

### DIFF
--- a/crates/ruma-events/Cargo.toml
+++ b/crates/ruma-events/Cargo.toml
@@ -26,7 +26,7 @@ unstable-msc3245 = ["unstable-msc3246"]
 # Support the m.room.message fallback fields from the first version of MSC3245,
 # implemented in Element Web and documented at
 # https://github.com/matrix-org/matrix-spec-proposals/blob/83f6c5b469c1d78f714e335dcaa25354b255ffa5/proposals/3245-voice-messages.md
-unstable-msc3245-v1-compat = []
+unstable-msc3245-v1-compat = ["unstable-msc3246"]
 unstable-msc3246 = ["unstable-msc3927"]
 unstable-msc3381 = ["unstable-msc1767"]
 unstable-msc3488 = ["unstable-msc1767"]

--- a/crates/ruma-events/src/room/message.rs
+++ b/crates/ruma-events/src/room/message.rs
@@ -35,6 +35,8 @@ mod text;
 mod video;
 
 pub use audio::{AudioInfo, AudioMessageEventContent};
+#[cfg(feature = "unstable-msc3245-v1-compat")]
+pub use audio::{UnstableAudioDetailsContentBlock, UnstableVoiceContentBlock};
 pub use emote::EmoteMessageEventContent;
 pub use file::{FileInfo, FileMessageEventContent};
 pub use image::ImageMessageEventContent;


### PR DESCRIPTION
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->





<!-- Replace -->
----
Preview: https://pr-1652--ruma-docs.surge.sh
<!-- Replace -->
