### PR TITLE
events: Add compat feature to send empty string to unset room name

### DIFF
--- a/crates/ruma-events/Cargo.toml
+++ b/crates/ruma-events/Cargo.toml
@@ -48,6 +48,10 @@ compat-empty-string-null = []
 # mandatory. Deserialization will yield a default value like an empty string.
 compat-optional = []
 
+# Unset the room name by sending an empty string,
+# c.f. https://github.com/matrix-org/matrix-spec/issues/1632
+compat-unset-room-name = []
+
 # Allow TagInfo to contain a stringified floating-point value for the `order` field.
 compat-tag-info = []
 

--- a/crates/ruma-events/src/room/name.rs
+++ b/crates/ruma-events/src/room/name.rs
@@ -15,7 +15,19 @@ use crate::EmptyStateKey;
 #[ruma_event(type = "m.room.name", kind = State, state_key_type = EmptyStateKey)]
 pub struct RoomNameEventContent {
     /// The name of the room.
+    ///
+    /// If you activate the `compat-unset-room-name` feature, this field being `None` will result
+    /// in an empty string in serialization, (c.f.
+    /// <https://github.com/matrix-org/matrix-spec/issues/1632>).
     #[serde(default, deserialize_with = "ruma_common::serde::empty_string_as_none")]
+    #[cfg_attr(
+        feature = "compat-unset-room-name",
+        serde(serialize_with = "ruma_common::serde::none_as_empty_string")
+    )]
+    #[cfg_attr(
+        not(feature = "compat-unset-room-name"),
+        serde(skip_serializing_if = "Option::is_none")
+    )]
     pub name: Option<String>,
 }
 

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -123,6 +123,9 @@ compat-optional = ["ruma-common/compat-optional"]
 # Unset avatars by sending an empty string, same as what Element Web does, c.f.
 # https://github.com/matrix-org/matrix-spec/issues/378#issuecomment-1055831264
 compat-unset-avatar = ["ruma-client-api?/compat-unset-avatar"]
+# Unset the room name by sending an empty string,
+# c.f. https://github.com/matrix-org/matrix-spec/issues/1632
+compat-unset-room-name = ["ruma-events?/compat-unset-room-name"]
 # Always serialize the threepids response field in `get_3pids::v3::Response`,
 # even if its value is an empty list.
 compat-get-3pids = ["ruma-client-api?/compat-get-3pids"]

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -112,6 +112,7 @@ compat-user-id = ["ruma-common/compat-user-id"]
 compat-empty-string-null = [
     "ruma-common/compat-empty-string-null",
     "ruma-client-api?/compat-empty-string-null",
+    "ruma-events?/compat-empty-string-null",
     "ruma-federation-api?/compat-empty-string-null",
 ]
 # Allow certain fields to be `null` for compatibility, treating that the same as
@@ -119,7 +120,10 @@ compat-empty-string-null = [
 compat-null = ["ruma-common/compat-null"]
 # Allow certain fields to be absent even though the spec marks them as
 # mandatory. Deserialization will yield a default value like an empty string.
-compat-optional = ["ruma-common/compat-optional"]
+compat-optional = [
+    "ruma-common/compat-optional",
+    "ruma-events?/compat-optional",
+]
 # Unset avatars by sending an empty string, same as what Element Web does, c.f.
 # https://github.com/matrix-org/matrix-spec/issues/378#issuecomment-1055831264
 compat-unset-avatar = ["ruma-client-api?/compat-unset-avatar"]


### PR DESCRIPTION
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->





<!-- Replace -->
----
Preview Removed
<!-- Replace -->
