### PR TITLE
events: Make `via` required in space child and parent events

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -34,6 +34,7 @@ Breaking changes:
 - In Markdown, soft line breaks are transformed into hard line breaks when compiled into HTML.
 - Move the HTML functions in `events::room::message::sanitize` to the ruma-html crate
   - The `unstable-sanitize` cargo feature was renamed to `html`
+- Make `via` required in `Space(Child|Parent)EventContent` according to a spec clarification
 
 Improvements:
 

--- a/crates/ruma-events/src/space/child.rs
+++ b/crates/ruma-events/src/space/child.rs
@@ -13,13 +13,12 @@ use serde::{Deserialize, Serialize};
 ///
 /// The `state_key` is the ID of a child room or space, and the content must contain a `via` key
 /// which gives a list of candidate servers that can be used to join the room.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, EventContent)]
+#[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[ruma_event(type = "m.space.child", kind = State, state_key_type = OwnedRoomId)]
 pub struct SpaceChildEventContent {
     /// List of candidate servers that can be used to join the room.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub via: Option<Vec<OwnedServerName>>,
+    pub via: Vec<OwnedServerName>,
 
     /// Provide a default ordering of siblings in the room list.
     ///
@@ -44,9 +43,9 @@ pub struct SpaceChildEventContent {
 }
 
 impl SpaceChildEventContent {
-    /// Creates a new `ChildEventContent`.
-    pub fn new() -> Self {
-        Self::default()
+    /// Creates a new `SpaceChildEventContent` with the given routing servers.
+    pub fn new(via: Vec<OwnedServerName>) -> Self {
+        Self { via, order: None, suggested: false }
     }
 }
 
@@ -79,7 +78,7 @@ mod tests {
     #[test]
     fn space_child_serialization() {
         let content = SpaceChildEventContent {
-            via: Some(vec![server_name!("example.com").to_owned()]),
+            via: vec![server_name!("example.com").to_owned()],
             order: Some("uwu".to_owned()),
             suggested: false,
         };
@@ -94,9 +93,9 @@ mod tests {
 
     #[test]
     fn space_child_empty_serialization() {
-        let content = SpaceChildEventContent { via: None, order: None, suggested: false };
+        let content = SpaceChildEventContent { via: vec![], order: None, suggested: false };
 
-        let json = json!({});
+        let json = json!({ "via": [] });
 
         assert_eq!(to_json_value(&content).unwrap(), json);
     }
@@ -119,9 +118,7 @@ mod tests {
         assert_eq!(ev.origin_server_ts, MilliSecondsSinceUnixEpoch(uint!(1_629_413_349)));
         assert_eq!(ev.sender, "@alice:example.org");
         assert_eq!(ev.state_key, "!a:example.org");
-        let via = ev.content.via.unwrap();
-        assert_eq!(via.len(), 1);
-        assert_eq!(via[0], "example.org");
+        assert_eq!(ev.content.via, ["example.org"]);
         assert_eq!(ev.content.order, None);
         assert!(!ev.content.suggested);
     }

--- a/crates/ruma-events/src/space/child.rs
+++ b/crates/ruma-events/src/space/child.rs
@@ -38,6 +38,8 @@ pub struct SpaceChildEventContent {
     /// example by showing them eagerly in the room list. A child which is missing the `suggested`
     /// property is treated identically to a child with `"suggested": false`. A suggested child may
     /// be a room or a subspace.
+    ///
+    /// Defaults to `false`.
     #[serde(default, skip_serializing_if = "ruma_common::serde::is_default")]
     pub suggested: bool,
 }

--- a/crates/ruma-events/src/space/parent.rs
+++ b/crates/ruma-events/src/space/parent.rs
@@ -18,8 +18,7 @@ use serde::{Deserialize, Serialize};
 #[ruma_event(type = "m.space.parent", kind = State, state_key_type = OwnedRoomId)]
 pub struct SpaceParentEventContent {
     /// List of candidate servers that can be used to join the room.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub via: Option<Vec<OwnedServerName>>,
+    pub via: Vec<OwnedServerName>,
 
     /// Determines whether this is the main parent for the space.
     ///
@@ -33,9 +32,9 @@ pub struct SpaceParentEventContent {
 }
 
 impl SpaceParentEventContent {
-    /// Creates a new `ParentEventContent` with the given canonical flag.
-    pub fn new(canonical: bool) -> Self {
-        Self { via: None, canonical }
+    /// Creates a new `SpaceParentEventContent` with the given routing servers and canonical flag.
+    pub fn new(via: Vec<OwnedServerName>, canonical: bool) -> Self {
+        Self { via, canonical }
     }
 }
 
@@ -49,7 +48,7 @@ mod tests {
     #[test]
     fn space_parent_serialization() {
         let content = SpaceParentEventContent {
-            via: Some(vec![server_name!("example.com").to_owned()]),
+            via: vec![server_name!("example.com").to_owned()],
             canonical: true,
         };
 
@@ -63,9 +62,9 @@ mod tests {
 
     #[test]
     fn space_parent_empty_serialization() {
-        let content = SpaceParentEventContent { via: None, canonical: false };
+        let content = SpaceParentEventContent { via: vec![], canonical: false };
 
-        let json = json!({});
+        let json = json!({ "via": [] });
 
         assert_eq!(to_json_value(&content).unwrap(), json);
     }

--- a/crates/ruma-events/src/space/parent.rs
+++ b/crates/ruma-events/src/space/parent.rs
@@ -27,14 +27,16 @@ pub struct SpaceParentEventContent {
     /// together. In practice, well behaved rooms should only have one `canonical` parent, but
     /// given this is not enforced: if multiple are present the client should select the one with
     /// the lowest room ID, as determined via a lexicographic ordering of the Unicode code-points.
+    ///
+    /// Defaults to `false`.
     #[serde(default, skip_serializing_if = "ruma_common::serde::is_default")]
     pub canonical: bool,
 }
 
 impl SpaceParentEventContent {
-    /// Creates a new `SpaceParentEventContent` with the given routing servers and canonical flag.
-    pub fn new(via: Vec<OwnedServerName>, canonical: bool) -> Self {
-        Self { via, canonical }
+    /// Creates a new `SpaceParentEventContent` with the given routing servers.
+    pub fn new(via: Vec<OwnedServerName>) -> Self {
+        Self { via, canonical: false }
     }
 }
 


### PR DESCRIPTION
According to a [spec clarification](https://github.com/matrix-org/matrix-spec/issues/1618)




<!-- Replace -->
----
Preview: https://pr-1656--ruma-docs.surge.sh
<!-- Replace -->
