### PR TITLE
events: Make name required in RoomNameEventContent

### DIFF
--- a/crates/ruma-client-api/src/state/send_state_event.rs
+++ b/crates/ruma-client-api/src/state/send_state_event.rs
@@ -217,7 +217,7 @@ pub mod v3 {
         let req = Request::new(
             owned_room_id!("!room:server.tld"),
             &EmptyStateKey,
-            &RoomNameEventContent::new(Some("Test room".to_owned())),
+            &RoomNameEventContent::new("Test room".to_owned()),
         )
         .unwrap()
         .try_into_http_request::<Vec<u8>>(

--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -35,6 +35,7 @@ Breaking changes:
 - Move the HTML functions in `events::room::message::sanitize` to the ruma-html crate
   - The `unstable-sanitize` cargo feature was renamed to `html`
 - Make `via` required in `Space(Child|Parent)EventContent` according to a spec clarification
+- Make `name` required in `RoomNameEventContent`, the wording of the spec was confusing
 
 Improvements:
 

--- a/crates/ruma-events/Cargo.toml
+++ b/crates/ruma-events/Cargo.toml
@@ -48,10 +48,6 @@ compat-empty-string-null = []
 # mandatory. Deserialization will yield a default value like an empty string.
 compat-optional = []
 
-# Unset the room name by sending an empty string,
-# c.f. https://github.com/matrix-org/matrix-spec/issues/1632
-compat-unset-room-name = []
-
 # Allow TagInfo to contain a stringified floating-point value for the `order` field.
 compat-tag-info = []
 

--- a/crates/ruma-events/tests/it/initial_state.rs
+++ b/crates/ruma-events/tests/it/initial_state.rs
@@ -10,5 +10,5 @@ fn deserialize_initial_state_event() {
     }))
     .unwrap();
     assert_matches!(ev, AnyInitialStateEvent::RoomName(ev));
-    assert_eq!(ev.content.name.as_deref(), Some("foo"));
+    assert_eq!(ev.content.name, "foo");
 }

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -127,9 +127,6 @@ compat-optional = [
 # Unset avatars by sending an empty string, same as what Element Web does, c.f.
 # https://github.com/matrix-org/matrix-spec/issues/378#issuecomment-1055831264
 compat-unset-avatar = ["ruma-client-api?/compat-unset-avatar"]
-# Unset the room name by sending an empty string,
-# c.f. https://github.com/matrix-org/matrix-spec/issues/1632
-compat-unset-room-name = ["ruma-events?/compat-unset-room-name"]
 # Always serialize the threepids response field in `get_3pids::v3::Response`,
 # even if its value is an empty list.
 compat-get-3pids = ["ruma-client-api?/compat-get-3pids"]


### PR DESCRIPTION
The wording of the spec was confusing but it is indeed required: [spec issue](https://github.com/matrix-org/matrix-spec/issues/1632), [spec PR](https://github.com/matrix-org/matrix-spec/pull/1639).

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->





<!-- Replace -->
----
Preview: https://pr-1658--ruma-docs.surge.sh
<!-- Replace -->
