### PR TITLE
events: Add ReplacementMetadata

### DIFF
--- a/crates/ruma-events/src/content.rs
+++ b/crates/ruma-events/src/content.rs
@@ -22,6 +22,7 @@ pub trait EventContent: Sized + Serialize {
     fn event_type(&self) -> Self::EventType;
 }
 
+/// Extension trait for [`Raw<T>`].
 pub trait RawExt<T: EventContentFromType> {
     /// Try to deserialize the JSON as an event's content with the given event type.
     fn deserialize_with_type(&self, event_type: T::EventType) -> serde_json::Result<T>;

--- a/crates/ruma-events/src/lib.rs
+++ b/crates/ruma-events/src/lib.rs
@@ -100,6 +100,8 @@
 //! ));
 //! ```
 
+#![warn(missing_docs)]
+
 use std::{collections::BTreeSet, fmt};
 
 use ruma_common::{EventEncryptionAlgorithm, OwnedUserId, RoomVersionId};

--- a/crates/ruma-events/src/room/message.rs
+++ b/crates/ruma-events/src/room/message.rs
@@ -945,6 +945,9 @@ impl<C> TryFrom<Relation<C>> for RelationWithoutReplacement {
     }
 }
 
+/// Metadata about an event to be replaced.
+///
+/// To be used with [`RoomMessageEventContent::make_replacement`].
 #[derive(Debug)]
 pub struct ReplacementMetadata {
     event_id: OwnedEventId,
@@ -952,6 +955,7 @@ pub struct ReplacementMetadata {
 }
 
 impl ReplacementMetadata {
+    /// Creates a new `ReplacementMetadata` with the given event ID and mentions.
     pub fn new(event_id: OwnedEventId, mentions: Option<Mentions>) -> Self {
         Self { event_id, mentions }
     }


### PR DESCRIPTION
… to allow creating replacements without having the full original event.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->








<!-- Replace -->
----
Preview Removed
<!-- Replace -->
