### PR TITLE
common: Allow padding when decoding the `Base64` type from a string

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -17,6 +17,7 @@ Breaking changes:
 
 Improvements:
 
+- Allow padding when decoding the `Base64` type from a string
 - Add convenience methods for `push::Ruleset`:
   - To update the server-default push rules
   - To remove a user-defined push rule

--- a/crates/ruma-common/src/serde/base64.rs
+++ b/crates/ruma-common/src/serde/base64.rs
@@ -3,7 +3,7 @@
 use std::{fmt, marker::PhantomData};
 
 use base64::{
-    engine::{general_purpose, GeneralPurpose, GeneralPurposeConfig},
+    engine::{general_purpose, DecodePaddingMode, GeneralPurpose, GeneralPurposeConfig},
     Engine,
 };
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
@@ -57,8 +57,9 @@ impl Base64Config for UrlSafe {
 
 impl<C: Base64Config, B> Base64<C, B> {
     // See https://github.com/matrix-org/matrix-spec/issues/838
-    const CONFIG: GeneralPurposeConfig =
-        general_purpose::NO_PAD.with_decode_allow_trailing_bits(true);
+    const CONFIG: GeneralPurposeConfig = general_purpose::NO_PAD
+        .with_decode_allow_trailing_bits(true)
+        .with_decode_padding_mode(DecodePaddingMode::Indifferent);
     const ENGINE: GeneralPurpose = GeneralPurpose::new(&C::CONF.0, Self::CONFIG);
 }
 
@@ -155,6 +156,10 @@ mod tests {
     fn slightly_malformed_base64() {
         const INPUT: &str = "3UmJnEIzUr2xWyaUnJg5fXwRybwG5FVC6Gq\
             MHverEUn0ztuIsvVxX89JXX2pvdTsOBbLQx+4TVL02l4Cp5wPCm";
+        const INPUT_WITH_PADDING: &str = "im9+knCkMNQNh9o6sbdcZw==";
+
         Base64::<Standard>::parse(INPUT).unwrap();
+        Base64::<Standard>::parse(INPUT_WITH_PADDING)
+            .expect("We should be able to decode padded Base64");
     }
 }

--- a/crates/ruma-common/src/serde/base64.rs
+++ b/crates/ruma-common/src/serde/base64.rs
@@ -56,8 +56,8 @@ impl Base64Config for UrlSafe {
 }
 
 impl<C: Base64Config, B> Base64<C, B> {
-    // See https://github.com/matrix-org/matrix-spec/issues/838
     const CONFIG: GeneralPurposeConfig = general_purpose::NO_PAD
+        // See https://github.com/matrix-org/matrix-spec/issues/838
         .with_decode_allow_trailing_bits(true)
         .with_decode_padding_mode(DecodePaddingMode::Indifferent);
     const ENGINE: GeneralPurpose = GeneralPurpose::new(&C::CONF.0, Self::CONFIG);


### PR DESCRIPTION
The spec contains this snippet about decoding `Base64`[[1]]:

> When decoding Base64, implementations SHOULD accept input with or without padding characters wherever possible, to ensure maximum interoperability.

This PR ensures that we're indifferent towards the Base64 padding when decoding.

[1]: https://spec.matrix.org/v1.8/appendices/#unpadded-base64







<!-- Replace -->
----
Preview: https://pr-1660--ruma-docs.surge.sh
<!-- Replace -->
