### PR TITLE
identifiers: Add a compat flag to allow arbitrary-length IDs

### DIFF
--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -33,6 +33,9 @@ unstable-msc3932 = ["unstable-msc3931"]
 unstable-msc3958 = []
 unstable-unspecified = []
 
+# Allow IDs to exceed 255 bytes.
+compat-arbitrary-length-ids = ["ruma-identifiers-validation/compat-arbitrary-length-ids"]
+
 # Don't validate the version part in `KeyId`.
 compat-key-id = ["ruma-identifiers-validation/compat-key-id"]
 

--- a/crates/ruma-identifiers-validation/Cargo.toml
+++ b/crates/ruma-identifiers-validation/Cargo.toml
@@ -12,8 +12,12 @@ rust-version = { workspace = true }
 all-features = true
 
 [features]
+# Allow IDs to exceed 255 bytes.
+compat-arbitrary-length-ids = []
+
 # Don't validate the version part in `key_id::validate`.
 compat-key-id = []
+
 # Allow some user IDs that are invalid even with the specified historical
 # user ID scheme.
 compat-user-id = []

--- a/crates/ruma-identifiers-validation/src/lib.rs
+++ b/crates/ruma-identifiers-validation/src/lib.rs
@@ -18,10 +18,12 @@ pub mod voip_version_id;
 pub use error::Error;
 
 /// All identifiers must be 255 bytes or less.
+#[cfg(not(feature = "compat-arbitrary-length-ids"))]
 const MAX_BYTES: usize = 255;
 
 /// Checks if an identifier is valid.
 fn validate_id(id: &str, valid_sigils: &[char]) -> Result<(), Error> {
+    #[cfg(not(feature = "compat-arbitrary-length-ids"))]
     if id.len() > MAX_BYTES {
         return Err(Error::MaximumLengthExceeded);
     }

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -104,9 +104,11 @@ compat = [
 ]
 # Don't validate the version part in `KeyId`.
 compat-key-id = ["ruma-common/compat-key-id"]
+
 # Allow some user IDs that are invalid even with the specified historical
 # user ID scheme.
 compat-user-id = ["ruma-common/compat-user-id"]
+
 # Allow some mandatory fields in requests / responses to be missing, defaulting
 # them to an empty string in deserialization.
 compat-empty-string-null = [
@@ -115,26 +117,33 @@ compat-empty-string-null = [
     "ruma-events?/compat-empty-string-null",
     "ruma-federation-api?/compat-empty-string-null",
 ]
+
 # Allow certain fields to be `null` for compatibility, treating that the same as
 # the field being absent.
 compat-null = ["ruma-common/compat-null"]
+
 # Allow certain fields to be absent even though the spec marks them as
 # mandatory. Deserialization will yield a default value like an empty string.
 compat-optional = [
     "ruma-common/compat-optional",
     "ruma-events?/compat-optional",
 ]
+
 # Unset avatars by sending an empty string, same as what Element Web does, c.f.
 # https://github.com/matrix-org/matrix-spec/issues/378#issuecomment-1055831264
 compat-unset-avatar = ["ruma-client-api?/compat-unset-avatar"]
+
 # Always serialize the threepids response field in `get_3pids::v3::Response`,
 # even if its value is an empty list.
 compat-get-3pids = ["ruma-client-api?/compat-get-3pids"]
+
 # Accept `message` as an alias for `error` in `upload_signatures::v3::Failure`,
 # since that's what Synapse sends.
 compat-upload-signatures = ["ruma-client-api?/compat-upload-signatures"]
+
 # Allow extra characters in signature IDs not allowed in the specification.
 compat-signature-id = ["ruma-signatures?/compat-signature-id"]
+
 # Allow TagInfo to contain a stringified floating-point value for the `order` field.
 compat-tag-info = ["ruma-events?/compat-tag-info"]
 

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -102,6 +102,10 @@ compat = [
     "compat-signature-id",
     "compat-tag-info",
 ]
+
+# Allow IDs to exceed 255 bytes.
+compat-arbitrary-length-ids = ["ruma-common/compat-arbitrary-length-ids"]
+
 # Don't validate the version part in `KeyId`.
 compat-key-id = ["ruma-common/compat-key-id"]
 


### PR DESCRIPTION
It's not much of a secret anymore that this is required for compatibility with some servers.




<!-- Replace -->
----
Preview Removed
<!-- Replace -->
