### PR TITLE
Added shared_history flag to room key events

### DIFF
--- a/crates/ruma-events/Cargo.toml
+++ b/crates/ruma-events/Cargo.toml
@@ -22,6 +22,7 @@ unstable-exhaustive-types = []
 unstable-msc1767 = []
 unstable-msc2448 = []
 unstable-msc2747 = []
+unstable-msc3061 = []
 unstable-msc3245 = ["unstable-msc3246"]
 # Support the m.room.message fallback fields from the first version of MSC3245,
 # implemented in Element Web and documented at

--- a/crates/ruma-events/src/forwarded_room_key.rs
+++ b/crates/ruma-events/src/forwarded_room_key.rs
@@ -43,6 +43,10 @@ pub struct ToDeviceForwardedRoomKeyEventContent {
     /// key is forwarded from A to B to C, this field is empty between A and B, and contains
     /// A's Curve25519 key between B and C.
     pub forwarding_curve25519_key_chain: Vec<String>,
+
+    /// Used to mark key if allowed for shared history
+    #[serde(default, rename = "org.matrix.msc3061.shared_history")]
+    pub shared_history: bool,
 }
 
 /// Initial set of fields of `ToDeviceForwardedRoomKeyEventContent`.
@@ -81,6 +85,9 @@ pub struct ToDeviceForwardedRoomKeyEventContentInit {
     /// key is forwarded from A to B to C, this field is empty between A and B, and contains
     /// A's Curve25519 key between B and C.
     pub forwarding_curve25519_key_chain: Vec<String>,
+
+    /// Used to mark key if allowed for shared history
+    pub shared_history: bool,
 }
 
 impl From<ToDeviceForwardedRoomKeyEventContentInit> for ToDeviceForwardedRoomKeyEventContent {
@@ -93,6 +100,7 @@ impl From<ToDeviceForwardedRoomKeyEventContentInit> for ToDeviceForwardedRoomKey
             session_key: init.session_key,
             sender_claimed_ed25519_key: init.sender_claimed_ed25519_key,
             forwarding_curve25519_key_chain: init.forwarding_curve25519_key_chain,
+            shared_history: init.shared_history,
         }
     }
 }

--- a/crates/ruma-events/src/forwarded_room_key.rs
+++ b/crates/ruma-events/src/forwarded_room_key.rs
@@ -45,7 +45,11 @@ pub struct ToDeviceForwardedRoomKeyEventContent {
     pub forwarding_curve25519_key_chain: Vec<String>,
 
     /// Used to mark key if allowed for shared history
-    #[serde(default, rename = "org.matrix.msc3061.shared_history")]
+    #[serde(
+        default,
+        rename = "org.matrix.msc3061.shared_history",
+        skip_serializing_if = "ruma_common::serde::is_default"
+    )]
     pub shared_history: bool,
 }
 

--- a/crates/ruma-events/src/forwarded_room_key.rs
+++ b/crates/ruma-events/src/forwarded_room_key.rs
@@ -44,7 +44,9 @@ pub struct ToDeviceForwardedRoomKeyEventContent {
     /// A's Curve25519 key between B and C.
     pub forwarding_curve25519_key_chain: Vec<String>,
 
-    /// Used to mark key if allowed for shared history
+    /// Used to mark key if allowed for shared history.
+    ///
+    /// Defaults to `false`.
     #[cfg(feature = "unstable-msc3061")]
     #[serde(
         default,

--- a/crates/ruma-events/src/forwarded_room_key.rs
+++ b/crates/ruma-events/src/forwarded_room_key.rs
@@ -45,6 +45,7 @@ pub struct ToDeviceForwardedRoomKeyEventContent {
     pub forwarding_curve25519_key_chain: Vec<String>,
 
     /// Used to mark key if allowed for shared history
+    #[cfg(feature = "unstable-msc3061")]
     #[serde(
         default,
         rename = "org.matrix.msc3061.shared_history",
@@ -91,6 +92,7 @@ pub struct ToDeviceForwardedRoomKeyEventContentInit {
     pub forwarding_curve25519_key_chain: Vec<String>,
 
     /// Used to mark key if allowed for shared history
+    #[cfg(feature = "unstable-msc3061")]
     pub shared_history: bool,
 }
 
@@ -104,6 +106,7 @@ impl From<ToDeviceForwardedRoomKeyEventContentInit> for ToDeviceForwardedRoomKey
             session_key: init.session_key,
             sender_claimed_ed25519_key: init.sender_claimed_ed25519_key,
             forwarding_curve25519_key_chain: init.forwarding_curve25519_key_chain,
+            #[cfg(feature = "unstable-msc3061")]
             shared_history: init.shared_history,
         }
     }

--- a/crates/ruma-events/src/forwarded_room_key.rs
+++ b/crates/ruma-events/src/forwarded_room_key.rs
@@ -92,10 +92,6 @@ pub struct ToDeviceForwardedRoomKeyEventContentInit {
     /// key is forwarded from A to B to C, this field is empty between A and B, and contains
     /// A's Curve25519 key between B and C.
     pub forwarding_curve25519_key_chain: Vec<String>,
-
-    /// Used to mark key if allowed for shared history
-    #[cfg(feature = "unstable-msc3061")]
-    pub shared_history: bool,
 }
 
 impl From<ToDeviceForwardedRoomKeyEventContentInit> for ToDeviceForwardedRoomKeyEventContent {

--- a/crates/ruma-events/src/forwarded_room_key.rs
+++ b/crates/ruma-events/src/forwarded_room_key.rs
@@ -109,7 +109,7 @@ impl From<ToDeviceForwardedRoomKeyEventContentInit> for ToDeviceForwardedRoomKey
             sender_claimed_ed25519_key: init.sender_claimed_ed25519_key,
             forwarding_curve25519_key_chain: init.forwarding_curve25519_key_chain,
             #[cfg(feature = "unstable-msc3061")]
-            shared_history: init.shared_history,
+            shared_history: false,
         }
     }
 }

--- a/crates/ruma-events/src/room_key.rs
+++ b/crates/ruma-events/src/room_key.rs
@@ -47,7 +47,6 @@ impl ToDeviceRoomKeyEventContent {
         room_id: OwnedRoomId,
         session_id: String,
         session_key: String,
-        #[cfg(feature = "unstable-msc3061")] shared_history: bool,
     ) -> Self {
         Self {
             algorithm,

--- a/crates/ruma-events/src/room_key.rs
+++ b/crates/ruma-events/src/room_key.rs
@@ -53,7 +53,7 @@ impl ToDeviceRoomKeyEventContent {
             session_id,
             session_key,
             #[cfg(feature = "unstable-msc3061")]
-            shared_history,
+            shared_history: false,
         }
     }
 }

--- a/crates/ruma-events/src/room_key.rs
+++ b/crates/ruma-events/src/room_key.rs
@@ -26,6 +26,10 @@ pub struct ToDeviceRoomKeyEventContent {
 
     /// The key to be exchanged.
     pub session_key: String,
+
+    /// Used to mark key if allowed for shared history
+    #[serde(default, rename = "org.matrix.msc3061.shared_history")]
+    pub shared_history: bool,
 }
 
 impl ToDeviceRoomKeyEventContent {
@@ -36,8 +40,9 @@ impl ToDeviceRoomKeyEventContent {
         room_id: OwnedRoomId,
         session_id: String,
         session_key: String,
+        shared_history: bool,
     ) -> Self {
-        Self { algorithm, room_id, session_id, session_key }
+        Self { algorithm, room_id, session_id, session_key, shared_history }
     }
 }
 
@@ -56,6 +61,7 @@ mod tests {
             room_id: owned_room_id!("!testroomid:example.org"),
             session_id: "SessId".into(),
             session_key: "SessKey".into(),
+            shared_history: true,
         };
 
         assert_eq!(
@@ -65,6 +71,7 @@ mod tests {
                 "room_id": "!testroomid:example.org",
                 "session_id": "SessId",
                 "session_key": "SessKey",
+                "org.matrix.msc3061.shared_history": true,
             })
         );
     }

--- a/crates/ruma-events/src/room_key.rs
+++ b/crates/ruma-events/src/room_key.rs
@@ -28,6 +28,7 @@ pub struct ToDeviceRoomKeyEventContent {
     pub session_key: String,
 
     /// Used to mark key if allowed for shared history
+    #[cfg(feature = "unstable-msc3061")]
     #[serde(
         default,
         rename = "org.matrix.msc3061.shared_history",
@@ -44,9 +45,16 @@ impl ToDeviceRoomKeyEventContent {
         room_id: OwnedRoomId,
         session_id: String,
         session_key: String,
-        shared_history: bool,
+        #[cfg(feature = "unstable-msc3061")] shared_history: bool,
     ) -> Self {
-        Self { algorithm, room_id, session_id, session_key, shared_history }
+        Self {
+            algorithm,
+            room_id,
+            session_id,
+            session_key,
+            #[cfg(feature = "unstable-msc3061")]
+            shared_history,
+        }
     }
 }
 
@@ -65,9 +73,22 @@ mod tests {
             room_id: owned_room_id!("!testroomid:example.org"),
             session_id: "SessId".into(),
             session_key: "SessKey".into(),
+            #[cfg(feature = "unstable-msc3061")]
             shared_history: true,
         };
 
+        #[cfg(not(feature = "unstable-msc3061"))]
+        assert_eq!(
+            to_json_value(content).unwrap(),
+            json!({
+                "algorithm": "m.megolm.v1.aes-sha2",
+                "room_id": "!testroomid:example.org",
+                "session_id": "SessId",
+                "session_key": "SessKey",
+            })
+        );
+
+        #[cfg(feature = "unstable-msc3061")]
         assert_eq!(
             to_json_value(content).unwrap(),
             json!({

--- a/crates/ruma-events/src/room_key.rs
+++ b/crates/ruma-events/src/room_key.rs
@@ -27,7 +27,9 @@ pub struct ToDeviceRoomKeyEventContent {
     /// The key to be exchanged.
     pub session_key: String,
 
-    /// Used to mark key if allowed for shared history
+    /// Used to mark key if allowed for shared history.
+    ///
+    /// Defaults to `false`.
     #[cfg(feature = "unstable-msc3061")]
     #[serde(
         default,

--- a/crates/ruma-events/src/room_key.rs
+++ b/crates/ruma-events/src/room_key.rs
@@ -28,7 +28,11 @@ pub struct ToDeviceRoomKeyEventContent {
     pub session_key: String,
 
     /// Used to mark key if allowed for shared history
-    #[serde(default, rename = "org.matrix.msc3061.shared_history")]
+    #[serde(
+        default,
+        rename = "org.matrix.msc3061.shared_history",
+        skip_serializing_if = "ruma_common::serde::is_default"
+    )]
     pub shared_history: bool,
 }
 

--- a/crates/ruma-events/tests/it/to_device.rs
+++ b/crates/ruma-events/tests/it/to_device.rs
@@ -9,6 +9,7 @@ fn serialization() {
         owned_room_id!("!testroomid:example.org"),
         "SessId".into(),
         "SessKey".into(),
+        true,
     );
 
     assert_eq!(
@@ -18,6 +19,7 @@ fn serialization() {
             "room_id": "!testroomid:example.org",
             "session_id": "SessId",
             "session_key": "SessKey",
+            "org.matrix.msc3061.shared_history": true,
         })
     );
 }

--- a/crates/ruma-events/tests/it/to_device.rs
+++ b/crates/ruma-events/tests/it/to_device.rs
@@ -9,9 +9,22 @@ fn serialization() {
         owned_room_id!("!testroomid:example.org"),
         "SessId".into(),
         "SessKey".into(),
+        #[cfg(feature = "unstable-msc3061")]
         true,
     );
 
+    #[cfg(not(feature = "unstable-msc3061"))]
+    assert_eq!(
+        to_json_value(&content).unwrap(),
+        json!({
+            "algorithm": "m.megolm.v1.aes-sha2",
+            "room_id": "!testroomid:example.org",
+            "session_id": "SessId",
+            "session_key": "SessKey",
+        })
+    );
+
+    #[cfg(feature = "unstable-msc3061")]
     assert_eq!(
         to_json_value(&content).unwrap(),
         json!({

--- a/crates/ruma-events/tests/it/to_device.rs
+++ b/crates/ruma-events/tests/it/to_device.rs
@@ -9,11 +9,8 @@ fn serialization() {
         owned_room_id!("!testroomid:example.org"),
         "SessId".into(),
         "SessKey".into(),
-        #[cfg(feature = "unstable-msc3061")]
-        true,
     );
 
-    #[cfg(not(feature = "unstable-msc3061"))]
     assert_eq!(
         to_json_value(&content).unwrap(),
         json!({
@@ -21,18 +18,6 @@ fn serialization() {
             "room_id": "!testroomid:example.org",
             "session_id": "SessId",
             "session_key": "SessKey",
-        })
-    );
-
-    #[cfg(feature = "unstable-msc3061")]
-    assert_eq!(
-        to_json_value(&content).unwrap(),
-        json!({
-            "algorithm": "m.megolm.v1.aes-sha2",
-            "room_id": "!testroomid:example.org",
-            "session_id": "SessId",
-            "session_key": "SessKey",
-            "org.matrix.msc3061.shared_history": true,
         })
     );
 }

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -186,6 +186,7 @@ unstable-msc2747 = ["ruma-events?/unstable-msc2747"]
 unstable-msc2870 = ["ruma-common/unstable-msc2870"]
 unstable-msc2965 = ["ruma-client-api?/unstable-msc2965"]
 unstable-msc2967 = ["ruma-client-api?/unstable-msc2967"]
+unstable-msc3061 = ["ruma-events?/unstable-msc3061"]
 unstable-msc3202 = ["ruma-appservice-api?/unstable-msc3202"]
 unstable-msc3245 = ["ruma-events?/unstable-msc3245"]
 # Support the m.room.message fallback fields from the first version of MSC3245,
@@ -232,6 +233,7 @@ __ci = [
     "unstable-msc2870",
     "unstable-msc2965",
     "unstable-msc2967",
+    "unstable-msc3061",
     "unstable-msc3202",
     "unstable-msc3245",
     "unstable-msc3245-v1-compat",


### PR DESCRIPTION
Fixes #1104 

Added `shared_history` flag for MSC 3061 implementation. See following PR for more details: https://github.com/matrix-org/matrix-rust-sdk/pull/2650

Signed-off-by: Michael Hollister <michael@futo.org>

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->


<!-- Replace -->
----
Preview Removed
<!-- Replace -->
