### PR TITLE
events: Add support for custom `SecretEncryptionAlgorithm`

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -39,7 +39,8 @@ Breaking changes:
 - Make `via` required in `Space(Child|Parent)EventContent` according to a spec clarification
 - Make `name` required in `RoomNameEventContent`, the wording of the spec was confusing
 - Rename `SecretEncryptionAlgorithm` to `SecretStorageEncryptionAlgorithm` and its
-  `SecretStorageV1AesHmacSha2` variant to `V1AesHmacSha2`
+  `SecretStorageV1AesHmacSha2` variant to `V1AesHmacSha2`. This variant is also a tuple variant
+  instead of a struct variant
 
 Improvements:
 

--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -38,6 +38,8 @@ Breaking changes:
   - The `unstable-sanitize` cargo feature was renamed to `html`
 - Make `via` required in `Space(Child|Parent)EventContent` according to a spec clarification
 - Make `name` required in `RoomNameEventContent`, the wording of the spec was confusing
+- Rename `SecretEncryptionAlgorithm` to `SecretStorageEncryptionAlgorithm` and its
+  `SecretStorageV1AesHmacSha2` variant to `V1AesHmacSha2`
 
 Improvements:
 

--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -69,6 +69,7 @@ Improvements:
     - `RedactedRoomPowerLevelsEventContent`,
     - `RedactedRoomMemberEventContent`
 - Add `RoomMessageEventContent::make_reply_to_raw` to build replies to any event
+- Add support for custom `SecretStorageEncryptionAlgorithm`
 
 # 0.26.1
 

--- a/crates/ruma-events/src/secret_storage/key.rs
+++ b/crates/ruma-events/src/secret_storage/key.rs
@@ -62,7 +62,7 @@ pub struct SecretStorageKeyEventContent {
     ///
     /// Currently, only `m.secret_storage.v1.aes-hmac-sha2` is supported.
     #[serde(flatten)]
-    pub algorithm: SecretEncryptionAlgorithm,
+    pub algorithm: SecretStorageEncryptionAlgorithm,
 
     /// The passphrase from which to generate the key.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -71,7 +71,7 @@ pub struct SecretStorageKeyEventContent {
 
 impl SecretStorageKeyEventContent {
     /// Creates a `KeyDescription` with the given name.
-    pub fn new(key_id: String, algorithm: SecretEncryptionAlgorithm) -> Self {
+    pub fn new(key_id: String, algorithm: SecretStorageEncryptionAlgorithm) -> Self {
         Self { key_id, name: None, algorithm, passphrase: None }
     }
 }
@@ -80,13 +80,13 @@ impl SecretStorageKeyEventContent {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(tag = "algorithm")]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-pub enum SecretEncryptionAlgorithm {
+pub enum SecretStorageEncryptionAlgorithm {
     #[serde(rename = "m.secret_storage.v1.aes-hmac-sha2")]
     /// Encrypted using the `m.secrect_storage.v1.aes-hmac-sha2` algorithm.
     ///
     /// Secrets using this method are encrypted using AES-CTR-256 and authenticated using
     /// HMAC-SHA-256.
-    SecretStorageV1AesHmacSha2 {
+    V1AesHmacSha2 {
         /// The 16-byte initialization vector, encoded as base64.
         iv: Base64,
 
@@ -105,14 +105,14 @@ mod tests {
         value::to_raw_value as to_raw_json_value,
     };
 
-    use super::{PassPhrase, SecretEncryptionAlgorithm, SecretStorageKeyEventContent};
+    use super::{PassPhrase, SecretStorageEncryptionAlgorithm, SecretStorageKeyEventContent};
     use crate::{EventContentFromType, GlobalAccountDataEvent};
 
     #[test]
     fn test_key_description_serialization() {
         let mut content = SecretStorageKeyEventContent::new(
             "my_key".into(),
-            SecretEncryptionAlgorithm::SecretStorageV1AesHmacSha2 {
+            SecretStorageEncryptionAlgorithm::V1AesHmacSha2 {
                 iv: Base64::parse("YWJjZGVmZ2hpamtsbW5vcA").unwrap(),
                 mac: Base64::parse("aWRvbnRrbm93d2hhdGFtYWNsb29rc2xpa2U").unwrap(),
             },
@@ -146,7 +146,7 @@ mod tests {
 
         assert_matches!(
             content.algorithm,
-            SecretEncryptionAlgorithm::SecretStorageV1AesHmacSha2 { iv, mac }
+            SecretStorageEncryptionAlgorithm::V1AesHmacSha2 { iv, mac }
         );
         assert_eq!(iv.encode(), "YWJjZGVmZ2hpamtsbW5vcA");
         assert_eq!(mac.encode(), "aWRvbnRrbm93d2hhdGFtYWNsb29rc2xpa2U");
@@ -168,7 +168,7 @@ mod tests {
 
         assert_matches!(
             content.algorithm,
-            SecretEncryptionAlgorithm::SecretStorageV1AesHmacSha2 { iv, mac }
+            SecretStorageEncryptionAlgorithm::V1AesHmacSha2 { iv, mac }
         );
         assert_eq!(iv.encode(), "YWJjZGVmZ2hpamtsbW5vcA");
         assert_eq!(mac.encode(), "aWRvbnRrbm93d2hhdGFtYWNsb29rc2xpa2U");
@@ -180,7 +180,7 @@ mod tests {
             passphrase: Some(PassPhrase::new("rocksalt".into(), uint!(8))),
             ..SecretStorageKeyEventContent::new(
                 "my_key".into(),
-                SecretEncryptionAlgorithm::SecretStorageV1AesHmacSha2 {
+                SecretStorageEncryptionAlgorithm::V1AesHmacSha2 {
                     iv: Base64::parse("YWJjZGVmZ2hpamtsbW5vcA").unwrap(),
                     mac: Base64::parse("aWRvbnRrbm93d2hhdGFtYWNsb29rc2xpa2U").unwrap(),
                 },
@@ -231,7 +231,7 @@ mod tests {
 
         assert_matches!(
             content.algorithm,
-            SecretEncryptionAlgorithm::SecretStorageV1AesHmacSha2 { iv, mac }
+            SecretStorageEncryptionAlgorithm::V1AesHmacSha2 { iv, mac }
         );
         assert_eq!(iv.encode(), "YWJjZGVmZ2hpamtsbW5vcA");
         assert_eq!(mac.encode(), "aWRvbnRrbm93d2hhdGFtYWNsb29rc2xpa2U");
@@ -241,7 +241,7 @@ mod tests {
     fn test_event_serialization() {
         let mut content = SecretStorageKeyEventContent::new(
             "my_key_id".into(),
-            SecretEncryptionAlgorithm::SecretStorageV1AesHmacSha2 {
+            SecretStorageEncryptionAlgorithm::V1AesHmacSha2 {
                 iv: Base64::parse("YWJjZGVmZ2hpamtsbW5vcA").unwrap(),
                 mac: Base64::parse("aWRvbnRrbm93d2hhdGFtYWNsb29rc2xpa2U").unwrap(),
             },
@@ -278,7 +278,7 @@ mod tests {
 
         assert_matches!(
             ev.content.algorithm,
-            SecretEncryptionAlgorithm::SecretStorageV1AesHmacSha2 { iv, mac }
+            SecretStorageEncryptionAlgorithm::V1AesHmacSha2 { iv, mac }
         );
         assert_eq!(iv.encode(), "YWJjZGVmZ2hpamtsbW5vcA");
         assert_eq!(mac.encode(), "aWRvbnRrbm93d2hhdGFtYWNsb29rc2xpa2U");

--- a/crates/ruma-events/src/secret_storage/key/secret_encryption_algorithm_serde.rs
+++ b/crates/ruma-events/src/secret_storage/key/secret_encryption_algorithm_serde.rs
@@ -1,0 +1,64 @@
+use serde::{de, Deserialize, Serialize};
+
+use super::{
+    CustomSecretEncryptionAlgorithm, SecretStorageEncryptionAlgorithm,
+    SecretStorageV1AesHmacSha2Properties,
+};
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum SecretStorageEncryptionAlgorithmDeHelper {
+    Known(KnownSecretStorageEncryptionAlgorithmDeHelper),
+    Unknown(CustomSecretEncryptionAlgorithm),
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "algorithm")]
+enum KnownSecretStorageEncryptionAlgorithmDeHelper {
+    #[serde(rename = "m.secret_storage.v1.aes-hmac-sha2")]
+    V1AesHmacSha2(SecretStorageV1AesHmacSha2Properties),
+}
+
+impl<'de> Deserialize<'de> for SecretStorageEncryptionAlgorithm {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        let helper = SecretStorageEncryptionAlgorithmDeHelper::deserialize(deserializer)?;
+
+        Ok(match helper {
+            SecretStorageEncryptionAlgorithmDeHelper::Known(k) => match k {
+                KnownSecretStorageEncryptionAlgorithmDeHelper::V1AesHmacSha2(p) => {
+                    Self::V1AesHmacSha2(p)
+                }
+            },
+            SecretStorageEncryptionAlgorithmDeHelper::Unknown(c) => Self::_Custom(c),
+        })
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct SecretStorageEncryptionAlgorithmSerHelper<'a, T: Serialize> {
+    algorithm: &'a str,
+    #[serde(flatten)]
+    properties: T,
+}
+
+impl Serialize for SecretStorageEncryptionAlgorithm {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let algorithm = self.algorithm();
+        match self {
+            Self::V1AesHmacSha2(properties) => {
+                SecretStorageEncryptionAlgorithmSerHelper { algorithm, properties }
+                    .serialize(serializer)
+            }
+            Self::_Custom(properties) => {
+                SecretStorageEncryptionAlgorithmSerHelper { algorithm, properties }
+                    .serialize(serializer)
+            }
+        }
+    }
+}


### PR DESCRIPTION
In the process, rename it to `SecretStorageEncryptionAlgorithm`, and rename its variant, to match the namespacing of the algorithm.

Fixes #1661.




<!-- Replace -->
----
Preview Removed
<!-- Replace -->
