### PR TITLE
ci: Fix rust-cache action config key name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
           # A stable compiler update should automatically not reuse old caches.
           # Add the MSRV as a stable cache key too so bumping it also gets us a
           # fresh cache.
-          sharedKey: msrv1.70
+          shared-key: msrv1.70
 
       - name: Get xtask
         uses: actions/cache@v3


### PR DESCRIPTION
I am not sure when the key was changed but there are [warnings that show up in CI](https://github.com/ruma/ruma/actions/runs/6417129710).

<!-- Replace -->
----
Preview Removed
<!-- Replace -->
