### PR TITLE
feat: add unstable voice message types initializers

### DIFF
--- a/crates/ruma-events/src/room/message/audio.rs
+++ b/crates/ruma-events/src/room/message/audio.rs
@@ -119,7 +119,6 @@ pub struct UnstableAudioDetailsContentBlock {
     /// The waveform representation of the audio content, if any.
     ///
     /// This is optional and defaults to an empty array.
-    #[cfg(feature = "unstable-msc3246")]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub waveform: Vec<Amplitude>,
 }

--- a/crates/ruma-events/src/room/message/audio.rs
+++ b/crates/ruma-events/src/room/message/audio.rs
@@ -145,6 +145,6 @@ pub struct UnstableVoiceContentBlock {}
 impl UnstableVoiceContentBlock {
     /// Creates a new `UnstableVoiceContentBlock`
     pub fn new() -> Self {
-        Self { }
+        Self {}
     }
 }

--- a/crates/ruma-events/src/room/message/audio.rs
+++ b/crates/ruma-events/src/room/message/audio.rs
@@ -109,7 +109,7 @@ impl AudioInfo {
 ///
 /// [msc]: https://github.com/matrix-org/matrix-spec-proposals/blob/83f6c5b469c1d78f714e335dcaa25354b255ffa5/proposals/3245-voice-messages.md
 #[cfg(feature = "unstable-msc3245-v1-compat")]
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct UnstableAudioDetailsContentBlock {
     /// The duration of the audio in seconds.

--- a/crates/ruma-events/src/room/message/audio.rs
+++ b/crates/ruma-events/src/room/message/audio.rs
@@ -109,7 +109,7 @@ impl AudioInfo {
 ///
 /// [msc]: https://github.com/matrix-org/matrix-spec-proposals/blob/83f6c5b469c1d78f714e335dcaa25354b255ffa5/proposals/3245-voice-messages.md
 #[cfg(feature = "unstable-msc3245-v1-compat")]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct UnstableAudioDetailsContentBlock {
     /// The duration of the audio in seconds.
@@ -137,7 +137,7 @@ impl UnstableAudioDetailsContentBlock {
 ///
 /// [msc]: https://github.com/matrix-org/matrix-spec-proposals/blob/83f6c5b469c1d78f714e335dcaa25354b255ffa5/proposals/3245-voice-messages.md
 #[cfg(feature = "unstable-msc3245-v1-compat")]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct UnstableVoiceContentBlock {}
 
@@ -145,6 +145,6 @@ pub struct UnstableVoiceContentBlock {}
 impl UnstableVoiceContentBlock {
     /// Creates a new `UnstableVoiceContentBlock`.
     pub fn new() -> Self {
-        Self {}
+        Self::default()
     }
 }

--- a/crates/ruma-events/src/room/message/audio.rs
+++ b/crates/ruma-events/src/room/message/audio.rs
@@ -124,6 +124,14 @@ pub struct UnstableAudioDetailsContentBlock {
     pub waveform: Vec<Amplitude>,
 }
 
+#[cfg(feature = "unstable-msc3245-v1-compat")]
+impl UnstableAudioDetailsContentBlock {
+    /// Creates a new `UnstableAudioDetailsContentBlock ` with the given duration and waveform
+    pub fn new(duration: Duration, waveform: Vec<Amplitude>) -> Self {
+        Self { duration, waveform }
+    }
+}
+
 /// Extensible event fallback data for voice messages, from the
 /// [first version of MSC3245][msc].
 ///
@@ -132,3 +140,11 @@ pub struct UnstableAudioDetailsContentBlock {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct UnstableVoiceContentBlock {}
+
+#[cfg(feature = "unstable-msc3245-v1-compat")]
+impl UnstableVoiceContentBlock {
+    /// Creates a new `UnstableVoiceContentBlock`
+    pub fn new() -> Self {
+        Self { }
+    }
+}

--- a/crates/ruma-events/src/room/message/audio.rs
+++ b/crates/ruma-events/src/room/message/audio.rs
@@ -126,7 +126,7 @@ pub struct UnstableAudioDetailsContentBlock {
 
 #[cfg(feature = "unstable-msc3245-v1-compat")]
 impl UnstableAudioDetailsContentBlock {
-    /// Creates a new `UnstableAudioDetailsContentBlock ` with the given duration and waveform
+    /// Creates a new `UnstableAudioDetailsContentBlock ` with the given duration and waveform.
     pub fn new(duration: Duration, waveform: Vec<Amplitude>) -> Self {
         Self { duration, waveform }
     }

--- a/crates/ruma-events/src/room/message/audio.rs
+++ b/crates/ruma-events/src/room/message/audio.rs
@@ -143,7 +143,7 @@ pub struct UnstableVoiceContentBlock {}
 
 #[cfg(feature = "unstable-msc3245-v1-compat")]
 impl UnstableVoiceContentBlock {
-    /// Creates a new `UnstableVoiceContentBlock`
+    /// Creates a new `UnstableVoiceContentBlock`.
     pub fn new() -> Self {
         Self {}
     }


### PR DESCRIPTION
This PR adds the `new()` functions for `UnstableAudioDetailsContentBlock` and `UnstableVoiceContentBlock`. 
These are needed when sending a new voice message.

<!-- Replace -->
----
Preview Removed
<!-- Replace -->
