### PR TITLE
events: Improve compatibility of unstable voice messages

### DIFF
--- a/crates/ruma-events/Cargo.toml
+++ b/crates/ruma-events/Cargo.toml
@@ -27,7 +27,7 @@ unstable-msc3245 = ["unstable-msc3246"]
 # Support the m.room.message fallback fields from the first version of MSC3245,
 # implemented in Element Web and documented at
 # https://github.com/matrix-org/matrix-spec-proposals/blob/83f6c5b469c1d78f714e335dcaa25354b255ffa5/proposals/3245-voice-messages.md
-unstable-msc3245-v1-compat = ["unstable-msc3246"]
+unstable-msc3245-v1-compat = []
 unstable-msc3246 = ["unstable-msc3927"]
 unstable-msc3381 = ["unstable-msc1767"]
 unstable-msc3488 = ["unstable-msc1767"]

--- a/crates/ruma-events/src/room/message/audio.rs
+++ b/crates/ruma-events/src/room/message/audio.rs
@@ -4,8 +4,6 @@ use js_int::UInt;
 use ruma_common::OwnedMxcUri;
 use serde::{Deserialize, Serialize};
 
-#[cfg(feature = "unstable-msc3245-v1-compat")]
-use crate::audio::Amplitude;
 use crate::room::{EncryptedFile, MediaSource};
 
 /// The payload for an audio message.
@@ -112,21 +110,24 @@ impl AudioInfo {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct UnstableAudioDetailsContentBlock {
-    /// The duration of the audio in seconds.
-    #[serde(with = "ruma_common::serde::duration::secs")]
+    /// The duration of the audio in milliseconds.
+    ///
+    /// Note that the MSC says this should be in seconds but for compatibility with the Element
+    /// clients, this uses milliseconds.
+    #[serde(with = "ruma_common::serde::duration::ms")]
     pub duration: Duration,
 
     /// The waveform representation of the audio content, if any.
     ///
     /// This is optional and defaults to an empty array.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub waveform: Vec<Amplitude>,
+    pub waveform: Vec<UnstableAmplitude>,
 }
 
 #[cfg(feature = "unstable-msc3245-v1-compat")]
 impl UnstableAudioDetailsContentBlock {
     /// Creates a new `UnstableAudioDetailsContentBlock ` with the given duration and waveform.
-    pub fn new(duration: Duration, waveform: Vec<Amplitude>) -> Self {
+    pub fn new(duration: Duration, waveform: Vec<UnstableAmplitude>) -> Self {
         Self { duration, waveform }
     }
 }
@@ -145,5 +146,51 @@ impl UnstableVoiceContentBlock {
     /// Creates a new `UnstableVoiceContentBlock`.
     pub fn new() -> Self {
         Self::default()
+    }
+}
+
+/// The unstable version of the amplitude of a waveform sample.
+///
+/// Must be an integer between 0 and 1024.
+#[cfg(feature = "unstable-msc3245-v1-compat")]
+#[derive(Clone, Copy, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+pub struct UnstableAmplitude(UInt);
+
+#[cfg(feature = "unstable-msc3245-v1-compat")]
+impl UnstableAmplitude {
+    /// The smallest value that can be represented by this type, 0.
+    pub const MIN: u16 = 0;
+
+    /// The largest value that can be represented by this type, 1024.
+    pub const MAX: u16 = 1024;
+
+    /// Creates a new `UnstableAmplitude` with the given value.
+    ///
+    /// It will saturate if it is bigger than [`UnstableAmplitude::MAX`].
+    pub fn new(value: u16) -> Self {
+        Self(value.min(Self::MAX).into())
+    }
+
+    /// The value of this `UnstableAmplitude`.
+    pub fn get(&self) -> UInt {
+        self.0
+    }
+}
+
+#[cfg(feature = "unstable-msc3245-v1-compat")]
+impl From<u16> for UnstableAmplitude {
+    fn from(value: u16) -> Self {
+        Self::new(value)
+    }
+}
+
+#[cfg(feature = "unstable-msc3245-v1-compat")]
+impl<'de> Deserialize<'de> for UnstableAmplitude {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let uint = UInt::deserialize(deserializer)?;
+        Ok(Self(uint.min(Self::MAX.into())))
     }
 }


### PR DESCRIPTION
Use the same parameters as Element clients.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->





<!-- Replace -->
----
Preview: https://pr-1681--ruma-docs.surge.sh
<!-- Replace -->
