### PR TITLE
Add a test case for reply to threaded message fallback

### DIFF
--- a/crates/ruma-events/tests/it/room_message.rs
+++ b/crates/ruma-events/tests/it/room_message.rs
@@ -351,8 +351,6 @@ fn escape_tags_in_plain_reply_body() {
 #[test]
 #[cfg(feature = "html")]
 fn reply_sanitize() {
-    use ruma_events::room::message::ForwardThread;
-
     let first_message = OriginalRoomMessageEvent {
         content: RoomMessageEventContent::text_html(
             "# This is the first message",


### PR DESCRIPTION
We're seeing some problems in EX with replies to threaded messages no longer falling back to being threaded messages themselves, and I didn't find any tests for this aspect of `make_reply_to` so added one. It passes, so the problem is probably in the SDK.




<!-- Replace -->
----
Preview Removed
<!-- Replace -->
