### PR TITLE
Add Thread::without_fallback

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [unreleased]
 
+Improvements:
+
+- Add `Thread::without_fallback` as a constructor that initializes the minimal
+  set of required fields
+
 # 0.27.3
 
 Improvements:

--- a/crates/ruma-events/src/relation.rs
+++ b/crates/ruma-events/src/relation.rs
@@ -107,14 +107,14 @@ pub struct Thread {
 }
 
 impl Thread {
-    /// Convenience method to create a regular `Thread` with the given event ID and latest
-    /// message-like event ID.
+    /// Convenience method to create a regular `Thread` relation with the given root event ID and
+    /// latest message-like event ID.
     pub fn plain(event_id: OwnedEventId, latest_event_id: OwnedEventId) -> Self {
         Self { event_id, in_reply_to: Some(InReplyTo::new(latest_event_id)), is_falling_back: true }
     }
 
-    /// Convenience method to create a reply `Thread` with the given event ID and replied-to event
-    /// ID.
+    /// Convenience method to create a reply `Thread` relation with the given root event ID and
+    /// replied-to event ID.
     pub fn reply(event_id: OwnedEventId, reply_to_event_id: OwnedEventId) -> Self {
         Self {
             event_id,

--- a/crates/ruma-events/src/relation.rs
+++ b/crates/ruma-events/src/relation.rs
@@ -113,6 +113,12 @@ impl Thread {
         Self { event_id, in_reply_to: Some(InReplyTo::new(latest_event_id)), is_falling_back: true }
     }
 
+    /// Convenience method to create a regular `Thread` relation with the given root event ID and
+    /// *without* the recommended reply fallback.
+    pub fn without_fallback(event_id: OwnedEventId) -> Self {
+        Self { event_id, in_reply_to: None, is_falling_back: false }
+    }
+
     /// Convenience method to create a reply `Thread` relation with the given root event ID and
     /// replied-to event ID.
     pub fn reply(event_id: OwnedEventId, reply_to_event_id: OwnedEventId) -> Self {


### PR DESCRIPTION
… to allow converting `Option<InReplyToDetails>` plus `Option<OwnedEventId>` (thread root) representation soon to be used by the Rust SDK back to a regular `Relation` in a non-weird way.

Also because the set of constructors was in a way incomplete previously.




<!-- Replace -->
----
Preview: https://pr-1683--ruma-docs.surge.sh
<!-- Replace -->
