### PR TITLE
Add allow(clippy::exhaustive_structs) in MembershipInit

### DIFF
--- a/crates/ruma-events/src/call/member.rs
+++ b/crates/ruma-events/src/call/member.rs
@@ -160,7 +160,7 @@ impl Membership {
 
 /// Initial set of fields of [`Membership`].
 #[derive(Debug)]
-#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+#[allow(clippy::exhaustive_structs)]
 pub struct MembershipInit {
     /// The type of the matrixRTC session the membership belongs to.
     ///


### PR DESCRIPTION
This is a hotix for the Call Membership pr. It is needed to write test in the matrix-rust-sdk: https://github.com/matrix-org/matrix-rust-sdk/pull/2742
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->


<!-- Replace -->
----
Preview Removed
<!-- Replace -->
