### PR TITLE
Add `create_ts` to `MembershipInit` and make it constructable outside of ruma.

### DIFF
--- a/crates/ruma-events/src/call/member.rs
+++ b/crates/ruma-events/src/call/member.rs
@@ -179,6 +179,12 @@ pub struct MembershipInit {
     /// `MIN(content.created_ts, event.origin_server_ts)`
     pub expires: Duration,
 
+    /// Stores a copy of the `origin_server_ts` of the initial session event.
+    ///
+    /// If the membership is updated this field will be used to track to
+    /// original `origin_server_ts`.
+    pub created_ts: Option<MilliSecondsSinceUnixEpoch>,
+
     /// A list of the focuses (foci) in use for this membership.
     pub foci_active: Vec<Focus>,
 
@@ -192,8 +198,15 @@ pub struct MembershipInit {
 
 impl From<MembershipInit> for Membership {
     fn from(init: MembershipInit) -> Self {
-        let MembershipInit { application, device_id, expires, foci_active, membership_id } = init;
-        Self { application, device_id, expires, created_ts: None, foci_active, membership_id }
+        let MembershipInit {
+            application,
+            device_id,
+            expires,
+            created_ts,
+            foci_active,
+            membership_id,
+        } = init;
+        Self { application, device_id, expires, created_ts, foci_active, membership_id }
     }
 }
 

--- a/crates/ruma-events/src/call/member.rs
+++ b/crates/ruma-events/src/call/member.rs
@@ -160,7 +160,7 @@ impl Membership {
 
 /// Initial set of fields of [`Membership`].
 #[derive(Debug)]
-#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+#[allow(clippy::exhaustive_structs)]
 pub struct MembershipInit {
     /// The type of the matrixRTC session the membership belongs to.
     ///


### PR DESCRIPTION
 - MembershipInit was non_exhaustive even though it should be.
 - The missing `created_ts` field in the intializer made it hard to write tests.
This is required for: https://github.com/matrix-org/matrix-rust-sdk/pull/2742
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->


<!-- Replace -->
----
Preview Removed
<!-- Replace -->
