### PR TITLE
Add the M_WRONG_ROOM_KEYS_VERSION ErrorKind variant

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [unreleased]
 
+Improvements:
+
+- Add a ErrorKind variant for the "M_WRONG_ROOM_KEYS_VERSION" Matrix error.
+
 # 0.17.0
 
 Breaking changes:


### PR DESCRIPTION
This error kind is a bit hidden in the spec, it's under the room key backup section.

Spec URL: https://spec.matrix.org/v1.3/client-server-api/#put_matrixclientv3room_keyskeysroomid

<!-- Replace -->
----
Preview Removed
<!-- Replace -->
