### PR TITLE
Transition to type privacy lints

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,7 +6,6 @@ crates-io = "https://docs.rs/"
 
 [target.'cfg(all())']
 rustflags = [
-    "-Wprivate_in_public",
     "-Wrust_2018_idioms",
     "-Wsemicolon_in_expressions_from_macros",
     "-Wunreachable_pub",

--- a/crates/ruma-common/src/identifiers/room_version_id.rs
+++ b/crates/ruma-common/src/identifiers/room_version_id.rs
@@ -237,6 +237,7 @@ impl PartialEq<RoomVersionId> for String {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[doc(hidden)]
+#[allow(unknown_lints, unnameable_types)]
 pub struct CustomRoomVersion(Box<str>);
 
 #[doc(hidden)]

--- a/crates/ruma-common/src/push/action.rs
+++ b/crates/ruma-common/src/push/action.rs
@@ -110,6 +110,7 @@ impl Serialize for Action {
 
 /// An unknown action.
 #[doc(hidden)]
+#[allow(unknown_lints, unnameable_types)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum CustomAction {

--- a/crates/ruma-events/src/room/message.rs
+++ b/crates/ruma-events/src/room/message.rs
@@ -41,7 +41,9 @@ mod video;
 mod without_relation;
 
 #[cfg(feature = "unstable-msc3245-v1-compat")]
-pub use self::audio::{UnstableAudioDetailsContentBlock, UnstableVoiceContentBlock};
+pub use self::audio::{
+    UnstableAmplitude, UnstableAudioDetailsContentBlock, UnstableVoiceContentBlock,
+};
 pub use self::{
     audio::{AudioInfo, AudioMessageEventContent},
     emote::EmoteMessageEventContent,

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -226,10 +226,19 @@ impl CiTask {
     ///
     /// Also checks that all features that are used in the code exist.
     fn nightly_all(&self) -> Result<()> {
-        cmd!("rustup run {NIGHTLY} cargo check --workspace --all-features -Z unstable-options -Z check-cfg")
-            .env("RUSTFLAGS", "-D warnings")
-            .run()
-            .map_err(Into::into)
+        cmd!(
+            "
+            rustup run {NIGHTLY} cargo check
+                --workspace --all-features -Z unstable-options -Z check-cfg
+            "
+        )
+        .env(
+            "RUSTFLAGS",
+            "-Z crate-attr=feature(type_privacy_lints) \
+             -D private_bounds,private_interfaces,unnameable_types,warnings",
+        )
+        .run()
+        .map_err(Into::into)
     }
 
     /// Check ruma-common with `ruma_identifiers_storage="Box"`


### PR DESCRIPTION
~~For some reason, out of the three new lints, only `unnameable_types` is unstable. It wouldn't have caused errors to also add it to `.cargo/config.toml`, but there were a lot of warnings in the `xtask ci` output, so I changed that one to only be checked in `xtask ci nightly-all`.~~

New lints only run in one CI job because there's unknown-lint errors in the MSRV CI job otherwise.

Fixes a bug where we failed to re-export a type! 🙌🏼 

Background: [`private_in_public` is deprecated](https://rust-lang.github.io/rfcs/2145-type-privacy.html#lint-4-private_in_public)




<!-- Replace -->
----
Preview: https://pr-1695--ruma-docs.surge.sh
<!-- Replace -->
