### PR TITLE
Allow to deserialize (New)ConditionalPushRule without conditions

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -1,5 +1,11 @@
 # [unreleased]
 
+Breaking changes:
+
+- The conversion from `PushRule` to `ConditionalPushRule` is infallible since
+  the `conditions` field is optional.
+  - `MissingConditionsError` was removed.
+
 # 0.17.2
 
 Improvements:

--- a/crates/ruma-client-api/src/push.rs
+++ b/crates/ruma-client-api/src/push.rs
@@ -173,32 +173,18 @@ impl TryFrom<PushRule> for PatternedPushRule {
     }
 }
 
-/// An error that happens when `PushRule` cannot
-/// be converted into `ConditionalPushRule`
-#[derive(Debug)]
-#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-pub struct MissingConditionsError;
+impl From<PushRule> for ConditionalPushRule {
+    fn from(push_rule: PushRule) -> Self {
+        let PushRule { actions, default, enabled, rule_id, conditions, .. } = push_rule;
 
-impl fmt::Display for MissingConditionsError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Push rule has no conditions.")
-    }
-}
-
-impl Error for MissingConditionsError {}
-
-impl TryFrom<PushRule> for ConditionalPushRule {
-    type Error = MissingConditionsError;
-
-    fn try_from(push_rule: PushRule) -> Result<Self, Self::Error> {
-        if let PushRule {
-            actions, default, enabled, rule_id, conditions: Some(conditions), ..
-        } = push_rule
-        {
-            Ok(ConditionalPushRuleInit { actions, default, enabled, rule_id, conditions }.into())
-        } else {
-            Err(MissingConditionsError)
+        ConditionalPushRuleInit {
+            actions,
+            default,
+            enabled,
+            rule_id,
+            conditions: conditions.unwrap_or_default(),
         }
+        .into()
     }
 }
 

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [unreleased]
 
+Bug fixes:
+
+- Allow to deserialize `(New)ConditionalPushRule` with a missing `conditions` field.
+
 # 0.12.0
 
 Bug fixes:

--- a/crates/ruma-common/src/push.rs
+++ b/crates/ruma-common/src/push.rs
@@ -466,6 +466,7 @@ pub struct ConditionalPushRule {
     /// event.
     ///
     /// A rule with no conditions always matches.
+    #[serde(default)]
     pub conditions: Vec<PushCondition>,
 }
 
@@ -870,6 +871,7 @@ pub struct NewConditionalPushRule {
     /// event.
     ///
     /// A rule with no conditions always matches.
+    #[serde(default)]
     pub conditions: Vec<PushCondition>,
 
     /// Actions to determine if and how a notification is delivered for events matching this


### PR DESCRIPTION
The spec allows the field to be missing, even for push rules that rely on conditions.

I didn't put `skip_serializing_if = "Vec::is_empty"`, because, for example, the `.m.rule.master` push rule's JSON is defined with an empty array, not with a missing field. However I guess we could do it.

We noticed that in Fractal after some push rules from another client (Nheko it seems) failed to deserialize.










<!-- Replace -->
----
Preview: https://pr-1697--ruma-docs.surge.sh
<!-- Replace -->
