### PR TITLE
Fix fallback text field name for extensible events in `RoomMessageEventContentWithoutRelation::make_reply_to_raw()`

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [unreleased]
 
+Bug fixes:
+
+- Fix the name of the fallback text field for extensible events in
+  `RoomMessageEventContentWithoutRelation::make_reply_to_raw()`
+
 # 0.27.8
 
 Improvements:

--- a/crates/ruma-events/src/room/message/without_relation.rs
+++ b/crates/ruma-events/src/room/message/without_relation.rs
@@ -162,7 +162,7 @@ impl RoomMessageEventContentWithoutRelation {
             #[serde(flatten)]
             formatted: Option<FormattedBody>,
             #[cfg(feature = "unstable-msc1767")]
-            #[serde(rename = "org.matrix.msc1767")]
+            #[serde(rename = "org.matrix.msc1767.text")]
             text: Option<String>,
             #[serde(rename = "m.relates_to")]
             relates_to: Option<crate::room::encrypted::Relation>,


### PR DESCRIPTION
…
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->





<!-- Replace -->
----
Preview Removed
<!-- Replace -->
