### PR TITLE
client-api: Fix deserialization of `claim_keys` responses

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -6,6 +6,10 @@ Breaking changes:
   the `conditions` field is optional.
   - `MissingConditionsError` was removed.
 
+Bug fixes:
+
+- Fix deserialization of `claim_keys` responses without a `failures` field
+
 # 0.17.2
 
 Improvements:

--- a/crates/ruma-client-api/src/keys/claim_keys/v3.rs
+++ b/crates/ruma-client-api/src/keys/claim_keys/v3.rs
@@ -44,6 +44,7 @@ pub struct Request {
 pub struct Response {
     /// If any remote homeservers could not be reached, they are recorded here.
     /// The names of the properties are the names of the unreachable servers.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub failures: BTreeMap<String, JsonValue>,
 
     /// One-time keys for the queried devices.

--- a/crates/ruma-client-api/src/keys/claim_keys/v3.rs
+++ b/crates/ruma-client-api/src/keys/claim_keys/v3.rs
@@ -43,6 +43,7 @@ pub struct Request {
 #[response(error = crate::Error)]
 pub struct Response {
     /// If any remote homeservers could not be reached, they are recorded here.
+    ///
     /// The names of the properties are the names of the unreachable servers.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub failures: BTreeMap<String, JsonValue>,

--- a/crates/ruma-client-api/src/keys/claim_keys/v4.rs
+++ b/crates/ruma-client-api/src/keys/claim_keys/v4.rs
@@ -42,6 +42,7 @@ pub struct Request {
 #[response(error = crate::Error)]
 pub struct Response {
     /// If any remote homeservers could not be reached, they are recorded here.
+    ///
     /// The names of the properties are the names of the unreachable servers.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub failures: BTreeMap<String, JsonValue>,

--- a/crates/ruma-client-api/src/keys/claim_keys/v4.rs
+++ b/crates/ruma-client-api/src/keys/claim_keys/v4.rs
@@ -43,6 +43,7 @@ pub struct Request {
 pub struct Response {
     /// If any remote homeservers could not be reached, they are recorded here.
     /// The names of the properties are the names of the unreachable servers.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub failures: BTreeMap<String, JsonValue>,
 
     /// One-time keys for the queried devices.


### PR DESCRIPTION
… without a `failures` field.

[Spec](https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3keysclaim) does not say that the field is required, so it's allowed to be absent.




<!-- Replace -->
----
Preview Removed
<!-- Replace -->
