### PR TITLE
events: Deprecate relations `event_id` methods

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -1,5 +1,11 @@
 # [unreleased]
 
+Deprecations:
+
+- Deprecate `event_id` methods on `Relation` types
+  - They will be removed in the next breaking-change release
+  - Please open an issue if you are currently using them
+
 # 0.27.9
 
 Bug fixes:

--- a/crates/ruma-events/src/room/encrypted.rs
+++ b/crates/ruma-events/src/room/encrypted.rs
@@ -126,6 +126,7 @@ impl Relation {
     ///
     /// This is the `event_id` field at the root of an `m.relates_to` object, except in the case of
     /// a reply relation where it's the `event_id` field in the `m.in_reply_to` object.
+    #[deprecated = "Please open an issue if you use this"]
     pub fn event_id(&self) -> &EventId {
         match self {
             Relation::Reply { in_reply_to } => &in_reply_to.event_id,

--- a/crates/ruma-events/src/room/message/relation.rs
+++ b/crates/ruma-events/src/room/message/relation.rs
@@ -42,6 +42,7 @@ impl<C> Relation<C> {
     ///
     /// This is the `event_id` field at the root of an `m.relates_to` object, except in the case of
     /// a reply relation where it's the `event_id` field in the `m.in_reply_to` object.
+    #[deprecated = "Please open an issue if you use this"]
     pub fn event_id(&self) -> &EventId {
         match self {
             Relation::Reply { in_reply_to } => &in_reply_to.event_id,
@@ -105,6 +106,7 @@ impl RelationWithoutReplacement {
     ///
     /// This is the `event_id` field at the root of an `m.relates_to` object, except in the case of
     /// a reply relation where it's the `event_id` field in the `m.in_reply_to` object.
+    #[deprecated = "Please open an issue if you use this"]
     pub fn event_id(&self) -> &EventId {
         match self {
             Self::Reply { in_reply_to } => &in_reply_to.event_id,

--- a/crates/ruma-events/tests/it/encrypted.rs
+++ b/crates/ruma-events/tests/it/encrypted.rs
@@ -463,7 +463,6 @@ fn custom_relation_deserialization() {
 
     let relation = content.relates_to.unwrap();
     assert_eq!(relation.rel_type().unwrap().as_str(), "io.ruma.custom");
-    assert_eq!(relation.event_id(), "$related_event");
     let data = relation.data();
     assert_eq!(data.get("field").unwrap().as_str(), Some("value"));
 }

--- a/crates/ruma-events/tests/it/relations.rs
+++ b/crates/ruma-events/tests/it/relations.rs
@@ -269,7 +269,6 @@ fn custom_deserialize() {
         })
     );
     assert_eq!(relation.rel_type().unwrap().as_str(), "io.ruma.unknown");
-    assert_eq!(relation.event_id().as_str(), "$related_event");
     let data = relation.data();
     assert_eq!(data.get("key").unwrap().as_str(), Some("value"));
 }


### PR DESCRIPTION
Note the base branch 😉 

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
