### PR TITLE
sliding sync: use a `JsOption` for the `avatar` field in responses

### DIFF
--- a/crates/ruma-client-api/src/sync/sync_events/v4.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v4.rs
@@ -7,6 +7,7 @@
 use std::{collections::BTreeMap, time::Duration};
 
 use js_int::UInt;
+use js_option::JsOption;
 use ruma_common::{
     api::{request, response, Metadata},
     metadata,
@@ -421,8 +422,8 @@ pub struct SlidingSyncRoom {
     pub name: Option<String>,
 
     /// The avatar of the room.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub avatar: Option<OwnedMxcUri>,
+    #[serde(skip_serializing_if = "JsOption::is_undefined")]
+    pub avatar: JsOption<OwnedMxcUri>,
 
     /// Was this an initial response.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/ruma-client-api/src/sync/sync_events/v4.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v4.rs
@@ -422,7 +422,7 @@ pub struct SlidingSyncRoom {
     pub name: Option<String>,
 
     /// The avatar of the room.
-    #[serde(skip_serializing_if = "JsOption::is_undefined")]
+    #[serde(default, skip_serializing_if = "JsOption::is_undefined")]
     pub avatar: JsOption<OwnedMxcUri>,
 
     /// Was this an initial response.


### PR DESCRIPTION
The `avatar` field has different semantics whether it's `undefined` (hasn't changed since previous time) vs `null` (it's now unset). Let's reflect this in the API of the `SlidingSyncRoom` response. While a public breaking API change, sliding sync is still considered experimental, so we're not bumping the main version here.

<!-- Replace -->
----
Preview Removed
<!-- Replace -->
