### PR TITLE
Set m.call.member event default power level to 0

### DIFF
--- a/crates/ruma-events/Cargo.toml
+++ b/crates/ruma-events/Cargo.toml
@@ -54,6 +54,7 @@ compat-optional = []
 compat-tag-info = []
 
 [dependencies]
+maplit = { workspace = true }
 as_variant = { workspace = true }
 indexmap = { version = "2.0.0", features = ["serde"] }
 js_int = { workspace = true, features = ["serde"] }
@@ -79,7 +80,6 @@ criterion = { workspace = true, optional = true }
 assert_matches2 = { workspace = true }
 assign = { workspace = true }
 http = { workspace = true }
-maplit = { workspace = true }
 trybuild = "1.0.71"
 
 [[bench]]

--- a/crates/ruma-events/Cargo.toml
+++ b/crates/ruma-events/Cargo.toml
@@ -54,11 +54,11 @@ compat-optional = []
 compat-tag-info = []
 
 [dependencies]
-maplit = { workspace = true }
 as_variant = { workspace = true }
 indexmap = { version = "2.0.0", features = ["serde"] }
 js_int = { workspace = true, features = ["serde"] }
 js_option = "0.1.0"
+maplit = { workspace = true }
 percent-encoding = "2.1.0"
 pulldown-cmark = { version = "0.9.1", default-features = false, optional = true }
 regex = { version = "1.5.6", default-features = false, features = ["std", "perf"] }

--- a/crates/ruma-events/src/room/power_levels.rs
+++ b/crates/ruma-events/src/room/power_levels.rs
@@ -5,6 +5,7 @@
 use std::{cmp::max, collections::BTreeMap};
 
 use js_int::{int, Int};
+use maplit::btreemap;
 use ruma_common::{
     power_levels::{default_power_level, NotificationPowerLevels},
     OwnedUserId, RoomVersionId, UserId,
@@ -112,12 +113,13 @@ impl RoomPowerLevelsEventContent {
     pub fn new() -> Self {
         // events_default, users_default and invite having a default of 0 while the others have a
         // default of 50 is not an oversight, these defaults are from the Matrix specification.
-        let mut events = BTreeMap::new();
-        #[cfg(feature = "unstable-msc3401")]
-        events = BTreeMap::from([(TimelineEventType::CallMember, int!(0))]);
+
         Self {
             ban: default_power_level(),
-            events,
+            events: btreemap! {
+                #[cfg(feature = "unstable-msc3401")]
+                TimelineEventType::CallMember => int!(0),
+            },
             events_default: int!(0),
             invite: int!(0),
             kick: default_power_level(),
@@ -553,12 +555,12 @@ mod tests {
     #[test]
     fn serialization_with_optional_fields_as_none() {
         let default = default_power_level();
-        let mut events = btreemap! {};
-        #[cfg(feature = "unstable-msc3401")]
-        events = btreemap! {TimelineEventType::CallMember=> default};
         let power_levels = RoomPowerLevelsEventContent {
             ban: default,
-            events,
+            events: btreemap! {
+                #[cfg(feature = "unstable-msc3401")]
+                TimelineEventType::CallMember => int!(0)
+            },
             events_default: int!(0),
             invite: int!(0),
             kick: default,

--- a/crates/ruma-events/src/room/power_levels.rs
+++ b/crates/ruma-events/src/room/power_levels.rs
@@ -113,7 +113,6 @@ impl RoomPowerLevelsEventContent {
     pub fn new() -> Self {
         // events_default, users_default and invite having a default of 0 while the others have a
         // default of 50 is not an oversight, these defaults are from the Matrix specification.
-
         Self {
             ban: default_power_level(),
             events: btreemap! {

--- a/crates/ruma-events/src/room/power_levels.rs
+++ b/crates/ruma-events/src/room/power_levels.rs
@@ -559,7 +559,7 @@ mod tests {
             ban: default,
             events: btreemap! {
                 #[cfg(feature = "unstable-msc3401")]
-                TimelineEventType::CallMember => int!(0)
+                TimelineEventType::CallMember => int!(0),
             },
             events_default: int!(0),
             invite: int!(0),

--- a/crates/ruma-events/src/room/power_levels.rs
+++ b/crates/ruma-events/src/room/power_levels.rs
@@ -112,9 +112,12 @@ impl RoomPowerLevelsEventContent {
     pub fn new() -> Self {
         // events_default, users_default and invite having a default of 0 while the others have a
         // default of 50 is not an oversight, these defaults are from the Matrix specification.
+        let mut events = BTreeMap::new();
+        #[cfg(feature = "unstable-msc3401")]
+        events = BTreeMap::from([(TimelineEventType::CallMember, int!(0))]);
         Self {
             ban: default_power_level(),
-            events: BTreeMap::new(),
+            events,
             events_default: int!(0),
             invite: int!(0),
             kick: default_power_level(),
@@ -545,14 +548,17 @@ mod tests {
     use serde_json::{json, to_value as to_json_value};
 
     use super::{default_power_level, NotificationPowerLevels, RoomPowerLevelsEventContent};
+    use crate::TimelineEventType;
 
     #[test]
     fn serialization_with_optional_fields_as_none() {
         let default = default_power_level();
-
+        let mut events = btreemap! {};
+        #[cfg(feature = "unstable-msc3401")]
+        events = btreemap! {TimelineEventType::CallMember=> default};
         let power_levels = RoomPowerLevelsEventContent {
             ban: default,
-            events: BTreeMap::new(),
+            events,
             events_default: int!(0),
             invite: int!(0),
             kick: default,


### PR DESCRIPTION
Even for just participating in a call one needs a power level of 0. 

Since call participation should be available to all participants the default should be 0.
This pr adds the call.member event to the default power levels with level 0.
Signed-off-by: Timo K <toger5@hotmail.de>

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->


<!-- Replace -->
----
Preview Removed
<!-- Replace -->
