### PR TITLE
push: Implement `AsRef<str>` and `kind()` for predefined rule IDs

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -5,6 +5,7 @@ Improvements:
 - Stabilize support for `.m.rule.suppress_edits` push rule (MSC3958 / Matrix 1.9)
 - Add `MatrixVersion::V1_9`
 - Point links to the Matrix 1.9 specification
+- Implement `as_str()` and `AsRef<str>` for `push::PredefinedRuleId`
 
 # 0.12.1
 

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -6,6 +6,7 @@ Improvements:
 - Add `MatrixVersion::V1_9`
 - Point links to the Matrix 1.9 specification
 - Implement `as_str()` and `AsRef<str>` for `push::PredefinedRuleId`
+- Implement `kind()` for `push::Predefined{*}RuleId`
 
 # 0.12.1
 

--- a/crates/ruma-common/src/push/predefined.rs
+++ b/crates/ruma-common/src/push/predefined.rs
@@ -555,6 +555,23 @@ pub enum PredefinedRuleId {
     Content(PredefinedContentRuleId),
 }
 
+impl PredefinedRuleId {
+    /// Creates a string slice from this `PredefinedRuleId`.
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Override(id) => id.as_str(),
+            Self::Underride(id) => id.as_str(),
+            Self::Content(id) => id.as_str(),
+        }
+    }
+}
+
+impl AsRef<str> for PredefinedRuleId {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
 /// The rule IDs of the predefined override server push rules.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, StringEnum)]

--- a/crates/ruma-common/src/push/predefined.rs
+++ b/crates/ruma-common/src/push/predefined.rs
@@ -6,7 +6,7 @@ use ruma_macros::StringEnum;
 
 use super::{
     Action::*, ConditionalPushRule, PatternedPushRule, PushCondition::*, RoomMemberCountIs,
-    Ruleset, Tweak,
+    RuleKind, Ruleset, Tweak,
 };
 use crate::{PrivOwnedStr, UserId};
 
@@ -564,6 +564,15 @@ impl PredefinedRuleId {
             Self::Content(id) => id.as_str(),
         }
     }
+
+    /// Get the kind of this `PredefinedRuleId`.
+    pub fn kind(&self) -> RuleKind {
+        match self {
+            Self::Override(id) => id.kind(),
+            Self::Underride(id) => id.kind(),
+            Self::Content(id) => id.kind(),
+        }
+    }
 }
 
 impl AsRef<str> for PredefinedRuleId {
@@ -631,6 +640,13 @@ pub enum PredefinedOverrideRuleId {
     _Custom(PrivOwnedStr),
 }
 
+impl PredefinedOverrideRuleId {
+    /// Get the kind of this `PredefinedOverrideRuleId`.
+    pub fn kind(&self) -> RuleKind {
+        RuleKind::Override
+    }
+}
+
 /// The rule IDs of the predefined underride server push rules.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, StringEnum)]
@@ -692,6 +708,13 @@ pub enum PredefinedUnderrideRuleId {
     _Custom(PrivOwnedStr),
 }
 
+impl PredefinedUnderrideRuleId {
+    /// Get the kind of this `PredefinedUnderrideRuleId`.
+    pub fn kind(&self) -> RuleKind {
+        RuleKind::Underride
+    }
+}
+
 /// The rule IDs of the predefined content server push rules.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, StringEnum)]
@@ -704,6 +727,13 @@ pub enum PredefinedContentRuleId {
 
     #[doc(hidden)]
     _Custom(PrivOwnedStr),
+}
+
+impl PredefinedContentRuleId {
+    /// Get the kind of this `PredefinedContentRuleId`.
+    pub fn kind(&self) -> RuleKind {
+        RuleKind::Content
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Allows to simplify the use of the `Ruleset` methods or the push rules API with predefined rule IDs.




<!-- Replace -->
----
Preview Removed
<!-- Replace -->
