### PR TITLE
push: Make power levels optional in PushConditionRoomCtx

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -1,5 +1,11 @@
 # [unreleased]
 
+Breaking changes:
+- The power levels fields in `PushConditionRoomCtx` are grouped in an optional `power_levels` field.
+  If the field is missing, push rules that depend on it will never match. However, this allows to
+  match the `.m.rule.invite_for_me` push rule because usually the `invite_state` doesn't include
+  `m.room.power_levels`.
+
 Improvements:
 
 - Stabilize support for `.m.rule.suppress_edits` push rule (MSC3958 / Matrix 1.9)

--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -9,6 +9,7 @@ Improvements:
 - Don't fail event content parsing on invalid relation
   - We previously already accepted custom or slightly malformed relations
   - Now, even invalid / missing `rel_type` and `event_id` are accepted
+- Implement `From<RoomPowerLevels>` for `ruma_common::push::PushConditionPowerLevelsCtx`
 
 # 0.27.11
 

--- a/crates/ruma-events/src/room/power_levels.rs
+++ b/crates/ruma-events/src/room/power_levels.rs
@@ -7,6 +7,7 @@ use std::{cmp::max, collections::BTreeMap};
 use js_int::{int, Int};
 use ruma_common::{
     power_levels::{default_power_level, NotificationPowerLevels},
+    push::PushConditionPowerLevelsCtx,
     OwnedUserId, RoomVersionId, UserId,
 };
 use ruma_macros::EventContent;
@@ -497,6 +498,12 @@ impl From<RoomPowerLevels> for RoomPowerLevelsEventContent {
             users_default: c.users_default,
             notifications: c.notifications,
         }
+    }
+}
+
+impl From<RoomPowerLevels> for PushConditionPowerLevelsCtx {
+    fn from(c: RoomPowerLevels) -> Self {
+        Self { users: c.users, users_default: c.users_default, notifications: c.notifications }
     }
 }
 


### PR DESCRIPTION
Otherwise it's not possible to match `m.rule.invite_for_me`, because the power levels are usually not part of `invite_state`.

I chose to ignore push rules that require the power levels (right now its the `@room` rules), because it shouldn't really have an impact with the predefined push rules. We could instead choose to stop trying to match other rules, to avoid triggering custom push rules. That would require more breaking changes, i.e. `PushCondition::applies()` should return a `Result<bool>` instead.







<!-- Replace -->
----
Preview: https://pr-1710--ruma-docs.surge.sh
<!-- Replace -->
