### PR TITLE
client-api: Add `GET /auth_issuer` endpoint from MSC2965

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -9,6 +9,8 @@ Breaking changes:
 Improvements:
 
 - Point links to the Matrix 1.9 specification
+- Add the `get_authentication_issuer` endpoint from MSC2965 behind the
+  `unstable-msc2965` feature.
 
 # 0.17.4
 

--- a/crates/ruma-client-api/src/discovery.rs
+++ b/crates/ruma-client-api/src/discovery.rs
@@ -1,5 +1,7 @@
 //! Server discovery endpoints.
 
 pub mod discover_homeserver;
+#[cfg(feature = "unstable-msc2965")]
+pub mod get_authentication_issuer;
 pub mod get_capabilities;
 pub mod get_supported_versions;

--- a/crates/ruma-client-api/src/discovery/get_authentication_issuer.rs
+++ b/crates/ruma-client-api/src/discovery/get_authentication_issuer.rs
@@ -1,0 +1,49 @@
+//! `GET /_matrix/client/*/auth_issuer`
+//!
+//! Get the OpenID Connect Provider that is trusted by the homeserver.
+
+pub mod msc2965 {
+    //! `MSC2965` ([MSC])
+    //!
+    //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/2965
+
+    use ruma_common::{
+        api::{request, response, Metadata},
+        metadata,
+    };
+
+    const METADATA: Metadata = metadata! {
+        method: GET,
+        rate_limited: false,
+        authentication: None,
+        history: {
+            unstable => "/_matrix/client/unstable/org.matrix.msc2965/auth_issuer",
+        }
+    };
+
+    /// Request type for the `auth_issuer` endpoint.
+    #[request(error = crate::Error)]
+    #[derive(Default)]
+    pub struct Request {}
+
+    /// Request type for the `auth_issuer` endpoint.
+    #[response(error = crate::Error)]
+    pub struct Response {
+        /// The OpenID Connect Provider that is trusted by the homeserver.
+        pub issuer: String,
+    }
+
+    impl Request {
+        /// Creates a new empty `Request`.
+        pub fn new() -> Self {
+            Self {}
+        }
+    }
+
+    impl Response {
+        /// Creates a new `Response` with the given issuer.
+        pub fn new(issuer: String) -> Self {
+            Self { issuer }
+        }
+    }
+}


### PR DESCRIPTION
[MSC2965](https://github.com/matrix-org/matrix-spec-proposals/pull/2965)

Note that the MSC also removes the fields from the `.well-known` response, but we might want to wait before doing that as the endpoint has [just been implemented in Synapse](https://github.com/matrix-org/synapse/pull/16726) and clients will need new types in mas-oidc-client to have all the features.







<!-- Replace -->
----
Preview: https://pr-1711--ruma-docs.surge.sh
<!-- Replace -->
