### PR TITLE
push: Allow to deserialize Ruleset with missing fields

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [unreleased]
 
+Bug fixes:
+
+- Allow to deserialize `Ruleset` with missing fields.
+
 Breaking changes:
 - The power levels fields in `PushConditionRoomCtx` are grouped in an optional `power_levels` field.
   If the field is missing, push rules that depend on it will never match. However, this allows to

--- a/crates/ruma-common/src/push.rs
+++ b/crates/ruma-common/src/push.rs
@@ -57,23 +57,27 @@ pub use self::{
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct Ruleset {
     /// These rules configure behavior for (unencrypted) messages that match certain patterns.
+    #[serde(default, skip_serializing_if = "IndexSet::is_empty")]
     pub content: IndexSet<PatternedPushRule>,
 
     /// These user-configured rules are given the highest priority.
     ///
     /// This field is named `override_` instead of `override` because the latter is a reserved
     /// keyword in Rust.
-    #[serde(rename = "override")]
+    #[serde(rename = "override", default, skip_serializing_if = "IndexSet::is_empty")]
     pub override_: IndexSet<ConditionalPushRule>,
 
     /// These rules change the behavior of all messages for a given room.
+    #[serde(default, skip_serializing_if = "IndexSet::is_empty")]
     pub room: IndexSet<SimplePushRule<OwnedRoomId>>,
 
     /// These rules configure notification behavior for messages from a specific Matrix user ID.
+    #[serde(default, skip_serializing_if = "IndexSet::is_empty")]
     pub sender: IndexSet<SimplePushRule<OwnedUserId>>,
 
     /// These rules are identical to override rules, but have a lower priority than `content`,
     /// `room` and `sender` rules.
+    #[serde(default, skip_serializing_if = "IndexSet::is_empty")]
     pub underride: IndexSet<ConditionalPushRule>,
 }
 

--- a/crates/ruma-common/src/push.rs
+++ b/crates/ruma-common/src/push.rs
@@ -1279,7 +1279,6 @@ mod tests {
                         "enabled": true
                     },
                 ],
-                "room": [],
                 "content": [
                     {
                         "actions": [
@@ -1298,8 +1297,6 @@ mod tests {
                         "enabled": true
                     }
                 ],
-                "sender": [],
-                "underride": [],
             })
         );
     }


### PR DESCRIPTION
According to the [Matrix Specification](https://spec.matrix.org/v1.9/client-server-api/#mpush_rules), no field is required. One of the users of Fractal with a Dendrite homeserver has an issue with that.




<!-- Replace -->
----
Preview Removed
<!-- Replace -->
