### PR TITLE
appservice-api: Make the `url` field of `Registration` an `Option`

### DIFF
--- a/crates/ruma-appservice-api/CHANGELOG.md
+++ b/crates/ruma-appservice-api/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [unreleased]
 
+Breaking changes:
+
+* The `url` field of `Registration` is now an `Option<String>`. This should have
+  always been the case.
+
 # 0.9.0
 
 Improvements:

--- a/crates/ruma-appservice-api/src/lib.rs
+++ b/crates/ruma-appservice-api/src/lib.rs
@@ -74,7 +74,9 @@ pub struct Registration {
     pub id: String,
 
     /// The URL for the application service.
-    pub url: String,
+    ///
+    /// Optionally set to `null` if no traffic is required.
+    pub url: Option<String>,
 
     /// A unique token for application services to use to authenticate requests to Homeservers.
     pub as_token: String,
@@ -112,7 +114,9 @@ pub struct RegistrationInit {
     pub id: String,
 
     /// The URL for the application service.
-    pub url: String,
+    ///
+    /// Optionally set to `null` if no traffic is required.
+    pub url: Option<String>,
 
     /// A unique token for application services to use to authenticate requests to Homeservers.
     pub as_token: String,

--- a/crates/ruma-appservice-api/tests/appservice_registration.rs
+++ b/crates/ruma-appservice-api/tests/appservice_registration.rs
@@ -21,7 +21,7 @@ fn registration_deserialization() {
     let observed: Registration = serde_yaml::from_str(registration_config).unwrap();
 
     assert_eq!(observed.id, "IRC Bridge");
-    assert_eq!(observed.url, "http://127.0.0.1:1234");
+    assert_eq!(observed.url.unwrap(), "http://127.0.0.1:1234");
     assert_eq!(
         observed.as_token,
         "30c05ae90a248a4188e620216fa72e349803310ec83e2a77b34fe90be6081f46"
@@ -59,5 +59,5 @@ fn config_with_optional_url() {
           rooms: []
         "#;
     assert_matches!(serde_yaml::from_str(registration_config).unwrap(), Registration { url, .. });
-    assert_eq!(url, "null");
+    assert_eq!(url, None);
 }


### PR DESCRIPTION
This was reported [in the Ruma room](https://matrix.to/#/!veagCdDBjKrMsOCzrq:privacytools.io/$Aj4MlOg0T5T9w8f3hkgHgPrUHfmYtFoaac0sSenxj-E?via=matrix.org&via=envs.net&via=mozilla.org).

It was always possible to set it to `null`, [according to the Matrix spec](https://spec.matrix.org/v1.9/application-service-api/#definition-registration). Note that the spec still says that the field is required, which is why we don't use `#[serde(skip_serializing_if = "Option::is_none")]`.

According to the tests, deserializing a `null` value worked and resulted in `"null"`, which is not very intuitive. And there would probably be no way to serialize to that value.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->


<!-- Replace -->
----
Preview Removed
<!-- Replace -->
