### PR TITLE
client: Replace async-trait with RPITIT / AFIT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         run: target/debug/xtask ci lint
 
   msrv:
-    name: Rust 1.70 / ${{ matrix.name }}
+    name: Rust 1.75 / ${{ matrix.name }}
     needs: xtask
     runs-on: ubuntu-latest
     strategy:
@@ -92,17 +92,17 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Install rust 1.70 toolchain
+      - name: Install rust 1.75 toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.70"
+          toolchain: "1.75"
 
       - uses: Swatinem/rust-cache@v2
         with:
           # A stable compiler update should automatically not reuse old caches.
           # Add the MSRV as a stable cache key too so bumping it also gets us a
           # fresh cache.
-          shared-key: msrv1.70
+          shared-key: msrv1.75
 
       - name: Get xtask
         uses: actions/cache@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-rust-version = "1.70"
+rust-version = "1.75"
 
 [workspace.dependencies]
 as_variant = "1.2.0"

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Minimum Rust version
 
-Ruma currently requires Rust 1.70. In general, we will never require beta or
+Ruma currently requires Rust 1.75. In general, we will never require beta or
 nightly for crates.io releases of our crates, and we will try to avoid releasing
 crates that depend on features that were only just stabilized.
 

--- a/crates/ruma-client-api/src/discovery/get_supported_versions.rs
+++ b/crates/ruma-client-api/src/discovery/get_supported_versions.rs
@@ -56,7 +56,7 @@ impl Response {
     /// The versions returned will be sorted from oldest to latest. Use [`.find()`][Iterator::find]
     /// or [`.rfind()`][DoubleEndedIterator::rfind] to look for a minimum or maximum version to use
     /// given some constraint.
-    pub fn known_versions(&self) -> impl Iterator<Item = MatrixVersion> + DoubleEndedIterator {
+    pub fn known_versions(&self) -> impl DoubleEndedIterator<Item = MatrixVersion> {
         self.versions
             .iter()
             // Parse, discard unknown versions

--- a/crates/ruma-client/Cargo.toml
+++ b/crates/ruma-client/Cargo.toml
@@ -34,7 +34,6 @@ reqwest-rustls-native-roots = ["reqwest", "reqwest?/rustls-tls-native-roots"]
 [dependencies]
 assign = { workspace = true }
 async-stream = "0.3.0"
-async-trait = "0.1.50"
 bytes = "1.0.1"
 futures-core = "0.3.8"
 futures-lite = { version = "1.11.3", optional = true }

--- a/crates/ruma-client/src/http_client.rs
+++ b/crates/ruma-client/src/http_client.rs
@@ -3,7 +3,6 @@
 
 use std::{future::Future, pin::Pin};
 
-use async_trait::async_trait;
 use bytes::BufMut;
 use ruma_common::{
     api::{MatrixVersion, OutgoingRequest, SendAccessToken},
@@ -31,7 +30,6 @@ pub use self::isahc::Isahc;
 pub use self::reqwest::Reqwest;
 
 /// An HTTP client that can be used to send requests to a Matrix homeserver.
-#[async_trait]
 pub trait HttpClient: Sync {
     /// The type to use for `try_into_http_request`.
     type RequestBody: Default + BufMut + Send;
@@ -43,10 +41,10 @@ pub trait HttpClient: Sync {
     type Error: Send + Unpin;
 
     /// Send an `http::Request` to get back an `http::Response`.
-    async fn send_http_request(
+    fn send_http_request(
         &self,
         req: http::Request<Self::RequestBody>,
-    ) -> Result<http::Response<Self::ResponseBody>, Self::Error>;
+    ) -> impl Future<Output = Result<http::Response<Self::ResponseBody>, Self::Error>> + Send;
 }
 
 /// An HTTP client that has a default configuration.
@@ -126,7 +124,6 @@ pub trait HttpClientExt: HttpClient {
     }
 }
 
-#[async_trait]
 impl<T: HttpClient> HttpClientExt for T {}
 
 #[doc(hidden)]
@@ -134,7 +131,6 @@ impl<T: HttpClient> HttpClientExt for T {}
 #[allow(clippy::exhaustive_structs)]
 pub struct Dummy;
 
-#[async_trait]
 impl HttpClient for Dummy {
     type RequestBody = Vec<u8>;
     type ResponseBody = Vec<u8>;

--- a/crates/ruma-client/src/http_client.rs
+++ b/crates/ruma-client/src/http_client.rs
@@ -140,6 +140,7 @@ impl HttpClient for Dummy {
     type ResponseBody = Vec<u8>;
     type Error = ();
 
+    #[allow(clippy::diverging_sub_expression)]
     async fn send_http_request(
         &self,
         _req: http::Request<Self::RequestBody>,

--- a/crates/ruma-client/src/http_client/hyper.rs
+++ b/crates/ruma-client/src/http_client/hyper.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use bytes::{Bytes, BytesMut};
 use hyper::client::{connect::Connect, HttpConnector};
 
@@ -20,7 +19,6 @@ pub type HyperNativeTls = hyper::Client<hyper_tls::HttpsConnector<HttpConnector>
 #[cfg(feature = "hyper-rustls")]
 pub type HyperRustls = hyper::Client<hyper_rustls::HttpsConnector<HttpConnector>>;
 
-#[async_trait]
 impl<C> HttpClient for hyper::Client<C>
 where
     C: Connect + Clone + Send + Sync + 'static,

--- a/crates/ruma-client/src/http_client/isahc.rs
+++ b/crates/ruma-client/src/http_client/isahc.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use futures_lite::AsyncReadExt;
 
 use super::HttpClient;
@@ -6,7 +5,6 @@ use super::HttpClient;
 /// The `isahc` crate's `HttpClient`.
 pub type Isahc = isahc::HttpClient;
 
-#[async_trait]
 impl HttpClient for Isahc {
     type RequestBody = Vec<u8>;
     type ResponseBody = Vec<u8>;

--- a/crates/ruma-client/src/http_client/reqwest.rs
+++ b/crates/ruma-client/src/http_client/reqwest.rs
@@ -1,6 +1,5 @@
 use std::mem;
 
-use async_trait::async_trait;
 use bytes::{Bytes, BytesMut};
 
 use super::{DefaultConstructibleHttpClient, HttpClient};
@@ -8,7 +7,6 @@ use super::{DefaultConstructibleHttpClient, HttpClient};
 /// The `reqwest` crate's `Client`.
 pub type Reqwest = reqwest::Client;
 
-#[async_trait]
 impl HttpClient for Reqwest {
     type RequestBody = BytesMut;
     type ResponseBody = Bytes;

--- a/crates/ruma-identity-service-api/src/discovery/get_supported_versions.rs
+++ b/crates/ruma-identity-service-api/src/discovery/get_supported_versions.rs
@@ -58,7 +58,7 @@ impl Response {
     /// The versions returned will be sorted from oldest to latest. Use [`.find()`][Iterator::find]
     /// or [`.rfind()`][DoubleEndedIterator::rfind] to look for a minimum or maximum version to use
     /// given some constraint.
-    pub fn known_versions(&self) -> impl Iterator<Item = MatrixVersion> + DoubleEndedIterator {
+    pub fn known_versions(&self) -> impl DoubleEndedIterator<Item = MatrixVersion> {
         self.versions
             .iter()
             // Parse, discard unknown versions

--- a/crates/ruma/CHANGELOG.md
+++ b/crates/ruma/CHANGELOG.md
@@ -1,5 +1,7 @@
 # [unreleased]
 
+- Bump MSRV to 1.75
+
 # 0.9.4
 
 Upgrade `ruma-events` and re-export its new `unstable-msc4075` feature.

--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -138,7 +138,7 @@ impl Package {
         };
 
         let changes = match changelog[changes_start..changes_end].trim() {
-            s if s.is_empty() => "No changes for this version",
+            "" => "No changes for this version",
             s => s,
         };
 

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -277,7 +277,7 @@ impl CiTask {
         cmd!(
             "
             rustup run {NIGHTLY} cargo clippy --target wasm32-unknown-unknown
-                -p ruma-common --features api,events,js,markdown,rand
+                -p ruma-common --features api,js,rand
             "
         )
         .run()

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -12,7 +12,7 @@ mod spec_links;
 
 use spec_links::check_spec_links;
 
-const MSRV: &str = "1.70";
+const MSRV: &str = "1.75";
 
 #[derive(Args)]
 pub struct CiArgs {


### PR DESCRIPTION
Some improvements around the client crate, most notably getting rid of the `async-trait` crate that is no longer needed with Rust 1.75.




<!-- Replace -->
----
Preview Removed
<!-- Replace -->
