### PR TITLE
Add error_kind accessor methods for client-server API errors

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -11,6 +11,9 @@ Improvements:
 - Point links to the Matrix 1.9 specification
 - Add the `get_authentication_issuer` endpoint from MSC2965 behind the
   `unstable-msc2965` feature.
+- Add `error_kind` accessor method to `ruma_client_api::Error`
+- Add `FromHttpResponseErrorExt` trait that adds an `error_kind` accessor to
+  `FromHttpResponseError<ruma_client_api::Error>`
 
 # 0.17.4
 

--- a/crates/ruma-client-api/Cargo.toml
+++ b/crates/ruma-client-api/Cargo.toml
@@ -49,6 +49,7 @@ unstable-msc3814 = []
 unstable-msc3983 = []
 
 [dependencies]
+as_variant = { workspace = true }
 assign = { workspace = true }
 bytes = "1.0.1"
 http = { workspace = true }

--- a/crates/ruma-client/CHANGELOG.md
+++ b/crates/ruma-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [unreleased]
 
+Improvements:
+
+- Add `error_kind` accessor method to `Error<E, ruma_client_api::Error>`
+
 # 0.12.0
 
 No changes for this version

--- a/crates/ruma-client/Cargo.toml
+++ b/crates/ruma-client/Cargo.toml
@@ -16,7 +16,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-client-api = ["dep:ruma-client-api"]
+client-api = ["dep:as_variant", "dep:ruma-client-api"]
 
 # HTTP clients
 hyper = ["dep:hyper"]
@@ -32,6 +32,7 @@ reqwest-rustls-webpki-roots = ["reqwest", "reqwest?/rustls-tls-webpki-roots"]
 reqwest-rustls-native-roots = ["reqwest", "reqwest?/rustls-tls-native-roots"]
 
 [dependencies]
+as_variant = { workspace = true, optional = true }
 assign = { workspace = true }
 async-stream = "0.3.0"
 bytes = "1.0.1"

--- a/crates/ruma-client/src/error.rs
+++ b/crates/ruma-client/src/error.rs
@@ -24,6 +24,18 @@ pub enum Error<E, F> {
     FromHttpResponse(FromHttpResponseError<F>),
 }
 
+#[cfg(feature = "client-api")]
+impl<E> Error<E, ruma_client_api::Error> {
+    /// If `self` is a server error in the `errcode` + `error` format expected
+    /// for client-server API endpoints, returns the error kind (`errcode`).
+    pub fn error_kind(&self) -> Option<&ruma_client_api::error::ErrorKind> {
+        use as_variant::as_variant;
+        use ruma_client_api::error::FromHttpResponseErrorExt as _;
+
+        as_variant!(self, Self::FromHttpResponse)?.error_kind()
+    }
+}
+
 impl<E: Display, F: Display> Display for Error<E, F> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {


### PR DESCRIPTION
We already have these kinds of accessor in Matrix Rust SDK, and it's nice if users of ruma-client can have similar convenience methods.




<!-- Replace -->
----
Preview Removed
<!-- Replace -->
