### PR TITLE
Add support for MSC2867 - Manually marking rooms as unread

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -18,6 +18,8 @@ Improvements:
 - Implement `From<RoomPowerLevels>` for `ruma_common::push::PushConditionPowerLevelsCtx`
 - Add methods on `PowerLevels` to check if some actions are permitted based on
   the target user's power level.
+- Add unstable support for manually marking rooms as unread through [MSC2867](https://github.com/matrix-org/matrix-spec-proposals/pull/2867) 
+  and the room account data `m.marked_unread` event (unstable type `com.famedly.marked_unread `)
 
 # 0.27.11
 

--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -19,7 +19,7 @@ Improvements:
 - Add methods on `PowerLevels` to check if some actions are permitted based on
   the target user's power level.
 - Add unstable support for manually marking rooms as unread through [MSC2867](https://github.com/matrix-org/matrix-spec-proposals/pull/2867) 
-  and the room account data `m.marked_unread` event (unstable type `com.famedly.marked_unread `)
+  and the room account data `m.marked_unread` event (unstable type `com.famedly.marked_unread`)
 
 # 0.27.11
 

--- a/crates/ruma-events/Cargo.toml
+++ b/crates/ruma-events/Cargo.toml
@@ -22,6 +22,7 @@ unstable-exhaustive-types = []
 unstable-msc1767 = []
 unstable-msc2448 = []
 unstable-msc2747 = []
+unstable-msc2867 = []
 unstable-msc3061 = []
 unstable-msc3245 = ["unstable-msc3246"]
 # Support the m.room.message fallback fields from the first version of MSC3245,

--- a/crates/ruma-events/src/enums.rs
+++ b/crates/ruma-events/src/enums.rs
@@ -23,6 +23,9 @@ event_enum! {
     enum RoomAccountData {
         "m.fully_read" => super::fully_read,
         "m.tag" => super::tag,
+        #[cfg(feature = "unstable-msc2867")]
+        #[ruma_enum(alias = "m.marked_unread")]
+        "com.famedly.marked_unread" => super::marked_unread,
     }
 
     /// Any ephemeral room event.

--- a/crates/ruma-events/src/lib.rs
+++ b/crates/ruma-events/src/lib.rs
@@ -157,6 +157,8 @@ pub mod image;
 pub mod key;
 #[cfg(feature = "unstable-msc3488")]
 pub mod location;
+#[cfg(feature = "unstable-msc2867")]
+pub mod marked_unread;
 #[cfg(feature = "unstable-msc1767")]
 pub mod message;
 #[cfg(feature = "unstable-pdu")]

--- a/crates/ruma-events/src/marked_unread.rs
+++ b/crates/ruma-events/src/marked_unread.rs
@@ -1,0 +1,26 @@
+//! Types for the [`m.marked_unread`] event.
+//!
+//! [`m.marked_unread`]: https://github.com/matrix-org/matrix-spec-proposals/pull/2867
+
+use ruma_macros::EventContent;
+use serde::{Deserialize, Serialize};
+
+/// The content of an `m.marked_unread` event.
+///
+/// Whether the room has been explicitly marked as unread
+///
+/// This event appears in the user's room account data for the room the marker is applicable for.
+#[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+#[ruma_event(type = "com.famedly.marked_unread", kind = RoomAccountData)]
+pub struct MarkedUnreadEventContent {
+    /// The current unread state
+    pub unread: bool,
+}
+
+impl MarkedUnreadEventContent {
+    /// Creates a new `MarkedUnreadEventContent` with the given value.
+    pub fn new(unread: bool) -> Self {
+        Self { unread }
+    }
+}

--- a/crates/ruma-events/src/marked_unread.rs
+++ b/crates/ruma-events/src/marked_unread.rs
@@ -7,14 +7,14 @@ use serde::{Deserialize, Serialize};
 
 /// The content of an `m.marked_unread` event.
 ///
-/// Whether the room has been explicitly marked as unread
+/// Whether the room has been explicitly marked as unread.
 ///
 /// This event appears in the user's room account data for the room the marker is applicable for.
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[ruma_event(type = "com.famedly.marked_unread", kind = RoomAccountData)]
 pub struct MarkedUnreadEventContent {
-    /// The current unread state
+    /// The current unread state.
     pub unread: bool,
 }
 

--- a/crates/ruma/CHANGELOG.md
+++ b/crates/ruma/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [unreleased]
 
 - Bump MSRV to 1.75
+- re-export the `ruma-events`'s `unstable-msc2867` feature, manually marking rooms as unread
 
 # 0.9.4
 

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -183,6 +183,7 @@ unstable-msc2448 = [
 unstable-msc2654 = ["ruma-client-api?/unstable-msc2654"]
 unstable-msc2666 = ["ruma-client-api?/unstable-msc2666"]
 unstable-msc2747 = ["ruma-events?/unstable-msc2747"]
+unstable-msc2867 = ["ruma-events?/unstable-msc2867"]
 unstable-msc2870 = ["ruma-common/unstable-msc2870"]
 unstable-msc2965 = ["ruma-client-api?/unstable-msc2965"]
 unstable-msc2967 = ["ruma-client-api?/unstable-msc2967"]
@@ -232,6 +233,7 @@ __ci = [
     "unstable-msc2654",
     "unstable-msc2666",
     "unstable-msc2747",
+    "unstable-msc2867",
     "unstable-msc2870",
     "unstable-msc2965",
     "unstable-msc2967",


### PR DESCRIPTION
This PR add support for manually marking rooms as unread through [MSC2867](https://github.com/matrix-org/matrix-spec-proposals/pull/2867)
* it exposes a `MarkedUnreadEventContent` type that can be used together with the `set_room_account_data::v3::Request` to explicitly flag a room as unread

<!-- Replace -->
----
Preview Removed
<!-- Replace -->
