### PR TITLE
events: Implement From<JoinRule> for SpaceRoomJoinRule

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -20,6 +20,7 @@ Improvements:
   the target user's power level.
 - Add unstable support for manually marking rooms as unread through [MSC2867](https://github.com/matrix-org/matrix-spec-proposals/pull/2867) 
   and the room account data `m.marked_unread` event (unstable type `com.famedly.marked_unread`)
+- Implement `From<JoinRule>` for `SpaceRoomJoinRule`
 
 # 0.27.11
 


### PR DESCRIPTION
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->


<!-- Replace -->
----
Preview Removed
<!-- Replace -->
