### PR TITLE
client-api: add deprecated `user` field to password and appservice login types

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -14,6 +14,10 @@ Improvements:
 - Add `error_kind` accessor method to `ruma_client_api::Error`
 - Add `FromHttpResponseErrorExt` trait that adds an `error_kind` accessor to
   `FromHttpResponseError<ruma_client_api::Error>`
+- Add deprecated `user` fields for `m.login.password` and `m.login.appservice`
+  login types.
+- Add deprecated `address` and `medium` 3PID fields for `m.login.password`
+  login type.
 
 # 0.17.4
 


### PR DESCRIPTION
(Context from Ruma Matrix room: https://matrix.to/#/!veagCdDBjKrMsOCzrq:privacytools.io/$RkWPDr9Z1PkgerrJOiYMOtuodiyWrTX2oC3GYpOi7cs?via=matrix.org&via=envs.net&via=mozilla.org)

I ran `cargo xtask ci` but only like 70% of it worked since Rust on Apple Silicon seems to be a 3rd-class citizen :< and started throwing extremely weird missing crate errors on core Rust stuff, so I just fixed the tests that were warning/erroring that I could see.

Changing `identifier` fields to be Option's is a breaking change, but this is how I imagine it should be, as if a user specifies only `user` and `password` there wouldn't be an identifier specified, and if a user uses the modern login format (`identifier` and `password`) there wouldn't be a `user` specified.

<!-- Replace -->
----
Preview Removed
<!-- Replace -->
