### PR TITLE
federation-api: Implement From<SpaceHierarchyParentSummary> for SpaceHierarchyChildSummary

### DIFF
--- a/crates/ruma-federation-api/CHANGELOG.md
+++ b/crates/ruma-federation-api/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [unreleased]
 
+Improvements:
+
+* Implement `From<SpaceHierarchyParentSummary>` for `SpaceHierarchyChildSummary`
+
 # 0.8.0
 
 Bug fixes:

--- a/crates/ruma-federation-api/src/space.rs
+++ b/crates/ruma-federation-api/src/space.rs
@@ -263,3 +263,36 @@ impl From<SpaceHierarchyChildSummaryInit> for SpaceHierarchyChildSummary {
         }
     }
 }
+
+impl From<SpaceHierarchyParentSummary> for SpaceHierarchyChildSummary {
+    fn from(parent: SpaceHierarchyParentSummary) -> Self {
+        let SpaceHierarchyParentSummary {
+            canonical_alias,
+            name,
+            num_joined_members,
+            room_id,
+            topic,
+            world_readable,
+            guest_can_join,
+            avatar_url,
+            join_rule,
+            room_type,
+            children_state: _,
+            allowed_room_ids,
+        } = parent;
+
+        Self {
+            canonical_alias,
+            name,
+            num_joined_members,
+            room_id,
+            topic,
+            world_readable,
+            guest_can_join,
+            avatar_url,
+            join_rule,
+            room_type,
+            allowed_room_ids,
+        }
+    }
+}


### PR DESCRIPTION
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->


<!-- Replace -->
----
Preview Removed
<!-- Replace -->
