### PR TITLE
client-api: Don't require the failures field in the signatures upload response

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -8,6 +8,8 @@ Breaking changes:
 
 Improvements:
 
+- Don't require the `failures` field in the
+  `ruma_client_api::keys::upload_signatures::Response` type.
 - Point links to the Matrix 1.9 specification
 - Add the `get_authentication_issuer` endpoint from MSC2965 behind the
   `unstable-msc2965` feature.

--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -8,8 +8,6 @@ Breaking changes:
 
 Improvements:
 
-- Don't require the `failures` field in the
-  `ruma_client_api::keys::upload_signatures::Response` type.
 - Point links to the Matrix 1.9 specification
 - Add the `get_authentication_issuer` endpoint from MSC2965 behind the
   `unstable-msc2965` feature.
@@ -20,6 +18,11 @@ Improvements:
   login types.
 - Add deprecated `address` and `medium` 3PID fields for `m.login.password`
   login type.
+
+Bug fixes:
+
+- Don't require the `failures` field in the
+  `ruma_client_api::keys::upload_signatures::Response` type.
 
 # 0.17.4
 

--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [unreleased]
 
+Bug fixes:
+
+- Don't require the `failures` field in the
+  `ruma_client_api::keys::upload_signatures::Response` type.
+
 Breaking changes:
 
 - The conversion from `PushRule` to `ConditionalPushRule` is infallible since
@@ -18,11 +23,6 @@ Improvements:
   login types.
 - Add deprecated `address` and `medium` 3PID fields for `m.login.password`
   login type.
-
-Bug fixes:
-
-- Don't require the `failures` field in the
-  `ruma_client_api::keys::upload_signatures::Response` type.
 
 # 0.17.4
 

--- a/crates/ruma-client-api/src/keys/upload_signatures.rs
+++ b/crates/ruma-client-api/src/keys/upload_signatures.rs
@@ -151,7 +151,7 @@ pub mod v3 {
         fn deserialize_empty_response() {
             const JSON: &str = r#"{}"#;
 
-            let parsed: ResponseBody = serde_json::from_str(JSON)
+            let _parsed: ResponseBody = serde_json::from_str(JSON)
                 .expect("We should be able to deserialize an empty keys/signatures/upload");
         }
     }

--- a/crates/ruma-client-api/src/keys/upload_signatures.rs
+++ b/crates/ruma-client-api/src/keys/upload_signatures.rs
@@ -118,7 +118,7 @@ pub mod v3 {
         _Custom(PrivOwnedStr),
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, feature = "client"))]
     mod tests {
         use super::ResponseBody;
 

--- a/crates/ruma-client-api/src/keys/upload_signatures.rs
+++ b/crates/ruma-client-api/src/keys/upload_signatures.rs
@@ -120,13 +120,15 @@ pub mod v3 {
 
     #[cfg(test)]
     mod tests {
-        use ruma_common::user_id;
-
-        use super::{FailureErrorCode, ResponseBody};
+        use super::ResponseBody;
 
         #[cfg(feature = "compat-upload-signatures")]
         #[test]
         fn deserialize_synapse_response() {
+            use ruma_common::user_id;
+
+            use super::FailureErrorCode;
+
             const JSON: &str = r#"{
                 "failures": {
                     "@richvdh:sw1v.org": {


### PR DESCRIPTION
The field is not marked as required in the spec[^1] and at least one homeserver, namely Dendrite, omits the field if it's empty.

[^1]: https://spec.matrix.org/unstable/client-server-api/#post_matrixclientv3keyssignaturesupload













<!-- Replace -->
----
Preview Removed
<!-- Replace -->
