### PR TITLE
events: change type of state_key field of HierarchySpaceChildEvent to OwnedRoomId

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -9,6 +9,7 @@ Breaking changes:
   -`RoomPowerLevels::user_can_redact` is split into `user_can_redact_own_event`
     and `user_can_redact_event_of_other`,
   - `PowerLevelAction::Redact` is split into `RedactOwn` and `RedactOther`.
+- Use `OwnedRoomId` instead of `String` for the `state_key` field of `HierarchySpaceChildEvent`
 
 Improvements:
 

--- a/crates/ruma-events/src/space/child.rs
+++ b/crates/ruma-events/src/space/child.rs
@@ -63,7 +63,7 @@ pub struct HierarchySpaceChildEvent {
     pub sender: OwnedUserId,
 
     /// The room ID of the child.
-    pub state_key: String,
+    pub state_key: OwnedRoomId,
 
     /// Timestamp in milliseconds on originating homeserver when this event was sent.
     pub origin_server_ts: MilliSecondsSinceUnixEpoch,


### PR DESCRIPTION
 
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->


<!-- Replace -->
----
Preview Removed
<!-- Replace -->
