### PR TITLE
Disallow invite->knock membership transition 

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [unreleased]
 
+Bug fixes:
+
+- The `MembershipState::Invite` to `MembershipState::Knock` membership change
+  now returns `MembershipChange::Error`, due to a spec clarification
+
 Breaking changes:
 
 - The properties of `SecretStorageV1AesHmacSha2Properties` are now `Option`al.

--- a/crates/ruma-events/src/room/member/change.rs
+++ b/crates/ruma-events/src/room/member/change.rs
@@ -126,6 +126,7 @@ pub(super) fn membership_change<'a>(
         | (St::Ban, St::Invite)
         | (St::Ban, St::Join)
         | (St::Join, St::Knock)
+        | (St::Invite, St::Knock)
         | (St::Ban, St::Knock)
         | (St::Knock, St::Join) => Ch::Error,
         (St::Join, St::Join)
@@ -143,7 +144,7 @@ pub(super) fn membership_change<'a>(
         (St::Join, St::Ban) => Ch::KickedAndBanned,
         (St::Leave, St::Invite) => Ch::Invited,
         (St::Ban, St::Leave) => Ch::Unbanned,
-        (St::Leave, St::Knock) | (St::Invite, St::Knock) => Ch::Knocked,
+        (St::Leave, St::Knock) => Ch::Knocked,
         (St::Knock, St::Invite) => Ch::KnockAccepted,
         (St::Knock, St::Leave) if sender == state_key => Ch::KnockRetracted,
         (St::Knock, St::Leave) => Ch::KnockDenied,

--- a/crates/ruma-state-res/CHANGELOG.md
+++ b/crates/ruma-state-res/CHANGELOG.md
@@ -1,5 +1,11 @@
 # [unreleased]
 
+Bug fixes:
+
+* Disallow `invite` -> `knock` membership transition
+  * The spec was determined to be right about rejecting it in the first place:
+    <https://github.com/matrix-org/matrix-spec/pull/1717>
+
 # 0.10.0
 
 Improvements:

--- a/crates/ruma-state-res/src/event_auth.rs
+++ b/crates/ruma-state-res/src/event_auth.rs
@@ -702,7 +702,7 @@ fn valid_membership_change(
                 false
             } else {
                 // 2. If `sender` does not match `state_key`, reject.
-                // 3. If the `sender`'s current membership is not `ban` or `join`, allow.
+                // 3. If the `sender`'s current membership is not `ban`, `invite`, or `join`, allow.
                 // 4. Otherwise, reject.
                 if sender != target_user {
                     warn!(
@@ -711,11 +711,13 @@ fn valid_membership_change(
                         "Can't make another user join, sender did not match target"
                     );
                     false
-                } else if matches!(sender_membership, MembershipState::Ban | MembershipState::Join)
-                {
+                } else if matches!(
+                    sender_membership,
+                    MembershipState::Ban | MembershipState::Invite | MembershipState::Join
+                ) {
                     warn!(
                         ?target_user_membership_event_id,
-                        "Membership state of ban or join are invalid",
+                        "Membership state of ban, invite or join are invalid",
                     );
                     false
                 } else {


### PR DESCRIPTION
Due to a spec clarification that reverts the previous spec clarification: https://github.com/matrix-org/matrix-spec/pull/1717.







<!-- Replace -->
----
Preview Removed
<!-- Replace -->
