### PR TITLE
client-api: Add support for local user erasure

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -24,6 +24,8 @@ Improvements:
 - Add deprecated `address` and `medium` 3PID fields for `m.login.password`
   login type.
 - Add optional cookie field to `session::sso_login*::v3` responses.
+- Add support for local user erasure to `account::deactivate::v3::Request`,
+  according to MSC4025.
 
 # 0.17.4
 

--- a/crates/ruma-client-api/src/account/deactivate.rs
+++ b/crates/ruma-client-api/src/account/deactivate.rs
@@ -39,6 +39,13 @@ pub mod v3 {
         /// identifier.
         #[serde(skip_serializing_if = "Option::is_none")]
         pub id_server: Option<String>,
+
+        /// Whether the user would like their content to be erased as much as possible from the
+        /// server.
+        ///
+        /// Defaults to `false`.
+        #[serde(default, skip_serializing_if = "ruma_common::serde::is_default")]
+        pub erase: bool,
     }
 
     /// Response type for the `deactivate` endpoint.


### PR DESCRIPTION
According to [MSC4025](https://github.com/matrix-org/matrix-spec-proposals/pull/4025) / [Spec PR](https://github.com/matrix-org/matrix-spec/pull/1730).

I didn't put it behind a cargo feature because it's already merged in the spec, and it has been implemented in Synapse for a long time.

Part of #1735.




<!-- Replace -->
----
Preview Removed
<!-- Replace -->
