### PR TITLE
Remove recently-introduced builder-style methods

### DIFF
--- a/crates/ruma-events/src/room/message/audio.rs
+++ b/crates/ruma-events/src/room/message/audio.rs
@@ -18,7 +18,9 @@ pub struct AudioMessageEventContent {
     /// uploaded file. Otherwise, this should be interpreted as a user-written media caption.
     pub body: String,
 
-    /// Formatted form of the message `body`, if `body` is a caption.
+    /// Formatted form of the message `body`.
+    ///
+    /// This should only be set if the body represents a caption.
     #[serde(flatten)]
     pub formatted: Option<FormattedBody>,
 

--- a/crates/ruma-events/src/room/message/audio.rs
+++ b/crates/ruma-events/src/room/message/audio.rs
@@ -80,24 +80,6 @@ impl AudioMessageEventContent {
         Self::new(body, MediaSource::Encrypted(Box::new(file)))
     }
 
-    /// Creates a new `AudioMessageEventContent` from `self` with the `filename` field set to the
-    /// given value.
-    ///
-    /// Since the field is public, you can also assign to it directly. This method merely acts
-    /// as a shorthand for that, because it is very common to set this field.
-    pub fn filename(self, filename: impl Into<Option<String>>) -> Self {
-        Self { filename: filename.into(), ..self }
-    }
-
-    /// Creates a new `AudioMessageEventContent` from `self` with the `formatted` field set to the
-    /// given value.
-    ///
-    /// Since the field is public, you can also assign to it directly. This method merely acts
-    /// as a shorthand for that, because it is very common to set this field.
-    pub fn formatted(self, formatted: impl Into<Option<FormattedBody>>) -> Self {
-        Self { formatted: formatted.into(), ..self }
-    }
-
     /// Creates a new `AudioMessageEventContent` from `self` with the `info` field set to the given
     /// value.
     ///

--- a/crates/ruma-events/src/room/message/audio.rs
+++ b/crates/ruma-events/src/room/message/audio.rs
@@ -67,7 +67,7 @@ impl AudioMessageEventContent {
         }
     }
 
-    /// Creates a new non-encrypted `AudioMessageEventContent` with the given bod and url.
+    /// Creates a new non-encrypted `AudioMessageEventContent` with the given body and url.
     pub fn plain(body: String, url: OwnedMxcUri) -> Self {
         Self::new(body, MediaSource::Plain(url))
     }

--- a/crates/ruma-events/src/room/message/file.rs
+++ b/crates/ruma-events/src/room/message/file.rs
@@ -52,24 +52,6 @@ impl FileMessageEventContent {
         Self::new(body, MediaSource::Encrypted(Box::new(file)))
     }
 
-    /// Creates a new `FileMessageEventContent` from `self` with the `filename` field set to the
-    /// given value.
-    ///
-    /// Since the field is public, you can also assign to it directly. This method merely acts
-    /// as a shorthand for that, because it is very common to set this field.
-    pub fn filename(self, filename: impl Into<Option<String>>) -> Self {
-        Self { filename: filename.into(), ..self }
-    }
-
-    /// Creates a new `FileMessageEventContent` from `self` with the `formatted` field set to the
-    /// given value.
-    ///
-    /// Since the field is public, you can also assign to it directly. This method merely acts
-    /// as a shorthand for that, because it is very common to set this field.
-    pub fn formatted(self, formatted: impl Into<Option<FormattedBody>>) -> Self {
-        Self { formatted: formatted.into(), ..self }
-    }
-
     /// Creates a new `FileMessageEventContent` from `self` with the `info` field set to the given
     /// value.
     ///

--- a/crates/ruma-events/src/room/message/file.rs
+++ b/crates/ruma-events/src/room/message/file.rs
@@ -16,7 +16,9 @@ pub struct FileMessageEventContent {
     /// uploaded file. Otherwise, this should be interpreted as a user-written media caption.
     pub body: String,
 
-    /// Formatted form of the message `body`, if `body` is a caption.
+    /// Formatted form of the message `body`.
+    ///
+    /// This should only be set if the body represents a caption.
     #[serde(flatten)]
     pub formatted: Option<FormattedBody>,
 

--- a/crates/ruma-events/src/room/message/image.rs
+++ b/crates/ruma-events/src/room/message/image.rs
@@ -15,7 +15,9 @@ pub struct ImageMessageEventContent {
     /// uploaded file. Otherwise, this should be interpreted as a user-written media caption.
     pub body: String,
 
-    /// Formatted form of the message `body`, if `body` is a caption.
+    /// Formatted form of the message `body`.
+    ///
+    /// This should only be set if the body represents a caption.
     #[serde(flatten)]
     pub formatted: Option<FormattedBody>,
 

--- a/crates/ruma-events/src/room/message/image.rs
+++ b/crates/ruma-events/src/room/message/image.rs
@@ -51,24 +51,6 @@ impl ImageMessageEventContent {
         Self::new(body, MediaSource::Encrypted(Box::new(file)))
     }
 
-    /// Creates a new `ImageMessageEventContent` from `self` with the `filename` field set to the
-    /// given value.
-    ///
-    /// Since the field is public, you can also assign to it directly. This method merely acts
-    /// as a shorthand for that, because it is very common to set this field.
-    pub fn filename(self, filename: impl Into<Option<String>>) -> Self {
-        Self { filename: filename.into(), ..self }
-    }
-
-    /// Creates a new `ImageMessageEventContent` from `self` with the `formatted` field set to the
-    /// given value.
-    ///
-    /// Since the field is public, you can also assign to it directly. This method merely acts
-    /// as a shorthand for that, because it is very common to set this field.
-    pub fn formatted(self, formatted: impl Into<Option<FormattedBody>>) -> Self {
-        Self { formatted: formatted.into(), ..self }
-    }
-
     /// Creates a new `ImageMessageEventContent` from `self` with the `info` field set to the given
     /// value.
     ///

--- a/crates/ruma-events/src/room/message/video.rs
+++ b/crates/ruma-events/src/room/message/video.rs
@@ -54,24 +54,6 @@ impl VideoMessageEventContent {
         Self::new(body, MediaSource::Encrypted(Box::new(file)))
     }
 
-    /// Creates a new `VideoMessageEventContent` from `self` with the `filename` field set to the
-    /// given value.
-    ///
-    /// Since the field is public, you can also assign to it directly. This method merely acts
-    /// as a shorthand for that, because it is very common to set this field.
-    pub fn filename(self, filename: impl Into<Option<String>>) -> Self {
-        Self { filename: filename.into(), ..self }
-    }
-
-    /// Creates a new `VideoMessageEventContent` from `self` with the `formatted` field set to the
-    /// given value.
-    ///
-    /// Since the field is public, you can also assign to it directly. This method merely acts
-    /// as a shorthand for that, because it is very common to set this field.
-    pub fn formatted(self, formatted: impl Into<Option<FormattedBody>>) -> Self {
-        Self { formatted: formatted.into(), ..self }
-    }
-
     /// Creates a new `VideoMessageEventContent` from `self` with the `info` field set to the given
     /// value.
     ///

--- a/crates/ruma-events/src/room/message/video.rs
+++ b/crates/ruma-events/src/room/message/video.rs
@@ -18,7 +18,9 @@ pub struct VideoMessageEventContent {
     /// uploaded file. Otherwise, this should be interpreted as a user-written media caption.
     pub body: String,
 
-    /// Formatted form of the message `body`, if `body` is a caption.
+    /// Formatted form of the message `body`.
+    ///
+    /// This should only be set if the body represents a caption.
     #[serde(flatten)]
     pub formatted: Option<FormattedBody>,
 


### PR DESCRIPTION
Follow-up to #1732, cc @zecakeh @SpiritCroc

We have very few builder-style methods overall, and I think they shouldn't just be added for every new field, due to compile times and also so people learn that they can actually just set the fields.

Maybe creation of media with formatted captions / separate filename and caption should be made easier, but I don't think a solution should include a function that takes `impl Into<Option<FormattedBody>>`; elsewhere we have separate constructors for html-formatted events (since that's the only officially-supported formatting anyways).







<!-- Replace -->
----
Preview Removed
<!-- Replace -->
