### PR TITLE
events: Make some fields of `Candidate` optional

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -15,6 +15,8 @@ Breaking changes:
     and `user_can_redact_event_of_other`,
   - `PowerLevelAction::Redact` is split into `RedactOwn` and `RedactOther`.
 - Use `OwnedRoomId` instead of `String` for the `state_key` field of `HierarchySpaceChildEvent`
+- The `sdp_mid` and `sdp_m_line_index` fields of `Candidate` are now optional,
+  for better compatibility with the WebRTC specification.
 
 Improvements:
 

--- a/crates/ruma-events/src/call/candidates.rs
+++ b/crates/ruma-events/src/call/candidates.rs
@@ -69,15 +69,28 @@ pub struct Candidate {
     pub candidate: String,
 
     /// The SDP media type this candidate is intended for.
-    pub sdp_mid: String,
+    ///
+    /// At least one of `sdp_mid` or `sdp_m_line_index` is required, unless
+    /// `candidate` is empty.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sdp_mid: Option<String>,
 
     /// The index of the SDP "m" line this candidate is intended for.
-    pub sdp_m_line_index: UInt,
+    ///
+    /// At least one of `sdp_mid` or `sdp_m_line_index` is required, unless
+    /// `candidate` is empty.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sdp_m_line_index: Option<UInt>,
 }
 
 impl Candidate {
-    /// Creates a new `Candidate` with the given "a" line, SDP media type and SDP "m" line.
-    pub fn new(candidate: String, sdp_mid: String, sdp_m_line_index: UInt) -> Self {
-        Self { candidate, sdp_mid, sdp_m_line_index }
+    /// Creates a new `Candidate` with the given "a" line.
+    pub fn new(candidate: String) -> Self {
+        Self { candidate, sdp_mid: None, sdp_m_line_index: None }
+    }
+
+    /// Creates a new `Candidate` with all the required fields in VoIP version 0.
+    pub fn version_0(candidate: String, sdp_mid: String, sdp_m_line_index: UInt) -> Self {
+        Self { candidate, sdp_mid: Some(sdp_mid), sdp_m_line_index: Some(sdp_m_line_index) }
     }
 }

--- a/crates/ruma-events/tests/it/call.rs
+++ b/crates/ruma-events/tests/it/call.rs
@@ -164,7 +164,7 @@ fn invite_v0_content_serialization() {
 fn candidates_v0_content_serialization() {
     let event_content = CallCandidatesEventContent::version_0(
         "abcdef".into(),
-        vec![Candidate::new("not a real candidate".to_owned(), "0".to_owned(), uint!(0))],
+        vec![Candidate::version_0("not a real candidate".to_owned(), "0".to_owned(), uint!(0))],
     );
 
     assert_eq!(
@@ -351,8 +351,9 @@ fn candidates_v1_event_serialization() {
         "abcdef".into(),
         "9876".into(),
         vec![
-            Candidate::new("not a real candidate".to_owned(), "0".to_owned(), uint!(0)),
-            Candidate::new("another fake candidate".to_owned(), "0".to_owned(), uint!(1)),
+            Candidate::version_0("not a real candidate".to_owned(), "0".to_owned(), uint!(0)),
+            Candidate::version_0("another fake candidate".to_owned(), "0".to_owned(), uint!(1)),
+            Candidate::new("".to_owned()),
         ],
     );
 
@@ -372,6 +373,9 @@ fn candidates_v1_event_serialization() {
                     "candidate": "another fake candidate",
                     "sdpMid": "0",
                     "sdpMLineIndex": 1,
+                },
+                {
+                    "candidate": "",
                 },
             ],
         })
@@ -396,6 +400,9 @@ fn candidates_v1_event_deserialization() {
                     "sdpMid": "0",
                     "sdpMLineIndex": 1,
                 },
+                {
+                    "candidate": "",
+                },
             ],
         },
         "event_id": "$event:notareal.hs",
@@ -414,13 +421,16 @@ fn candidates_v1_event_deserialization() {
     assert_eq!(content.call_id, "abcdef");
     assert_eq!(content.party_id.unwrap(), "9876");
     assert_eq!(content.version, VoipVersionId::V1);
-    assert_eq!(content.candidates.len(), 2);
+    assert_eq!(content.candidates.len(), 3);
     assert_eq!(content.candidates[0].candidate, "not a real candidate");
-    assert_eq!(content.candidates[0].sdp_mid, "0");
-    assert_eq!(content.candidates[0].sdp_m_line_index, uint!(0));
+    assert_eq!(content.candidates[0].sdp_mid.as_deref(), Some("0"));
+    assert_eq!(content.candidates[0].sdp_m_line_index, Some(uint!(0)));
     assert_eq!(content.candidates[1].candidate, "another fake candidate");
-    assert_eq!(content.candidates[1].sdp_mid, "0");
-    assert_eq!(content.candidates[1].sdp_m_line_index, uint!(1));
+    assert_eq!(content.candidates[1].sdp_mid.as_deref(), Some("0"));
+    assert_eq!(content.candidates[1].sdp_m_line_index, Some(uint!(1)));
+    assert_eq!(content.candidates[2].candidate, "");
+    assert_eq!(content.candidates[2].sdp_mid, None);
+    assert_eq!(content.candidates[2].sdp_m_line_index, None);
 }
 
 #[test]


### PR DESCRIPTION
For compatiblity with the [WebRTC spec](https://www.w3.org/TR/webrtc/#dictionary-rtcicecandidateinit-members).

Notably the last `Candidate` received should only contain the `candidate` field with an empty string.

See also https://github.com/matrix-org/matrix-spec/pull/1742.

Fixes #1739.







<!-- Replace -->
----
Preview Removed
<!-- Replace -->
