### PR TITLE
client-api: Allow `/versions` to optionally accept authentication

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -26,6 +26,8 @@ Improvements:
 - Add optional cookie field to `session::sso_login*::v3` responses.
 - Add support for local user erasure to `account::deactivate::v3::Request`,
   according to MSC4025.
+- Allow `discovery::get_supported_versions::v1` to optionally accept
+  authentication, according to MSC4026.
 
 # 0.17.4
 

--- a/crates/ruma-client-api/src/discovery/get_supported_versions.rs
+++ b/crates/ruma-client-api/src/discovery/get_supported_versions.rs
@@ -14,7 +14,7 @@ use ruma_common::{
 const METADATA: Metadata = metadata! {
     method: GET,
     rate_limited: false,
-    authentication: None,
+    authentication: AccessTokenOptional,
     history: {
         1.0 => "/_matrix/client/versions",
     }
@@ -32,6 +32,9 @@ pub struct Response {
     pub versions: Vec<String>,
 
     /// Experimental features supported by the server.
+    ///
+    /// Servers can enable some unstable features only for some users, so this
+    /// list might differ when an access token is provided.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub unstable_features: BTreeMap<String, bool>,
 }

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -9,6 +9,7 @@ Breaking changes:
   If the field is missing, push rules that depend on it will never match. However, this allows to
   match the `.m.rule.invite_for_me` push rule because usually the `invite_state` doesn't include
   `m.room.power_levels`.
+- Add support for endpoints that take an optional authentication
 
 Improvements:
 

--- a/crates/ruma-common/src/api.rs
+++ b/crates/ruma-common/src/api.rs
@@ -484,6 +484,12 @@ pub enum AuthScheme {
     /// It is recommended to use the header over the query parameter.
     AccessToken,
 
+    /// Authentication is optional, and it is performed by including an access token in the
+    /// `Authentication` http header, or an `access_token` query parameter.
+    ///
+    /// It is recommended to use the header over the query parameter.
+    AccessTokenOptional,
+
     /// Authentication is performed by including X-Matrix signatures in the request headers,
     /// as defined in the federation API.
     ServerSignatures,

--- a/crates/ruma-common/src/api/metadata.rs
+++ b/crates/ruma-common/src/api/metadata.rs
@@ -74,6 +74,11 @@ impl Metadata {
                 Some((header::AUTHORIZATION, format!("Bearer {token}").try_into()?))
             }
 
+            AuthScheme::AccessTokenOptional => match access_token.get_required_for_endpoint() {
+                Some(token) => Some((header::AUTHORIZATION, format!("Bearer {token}").try_into()?)),
+                None => None,
+            },
+
             AuthScheme::ServerSignatures => None,
         })
     }


### PR DESCRIPTION
According to [MSC4026](https://github.com/matrix-org/matrix-spec-proposals/pull/4026) / [Spec PR](https://github.com/matrix-org/matrix-spec/pull/1728).

Part of #1735.







<!-- Replace -->
----
Preview: https://pr-1742--ruma-docs.surge.sh
<!-- Replace -->
