### PR TITLE
client-api: don't require `ts` request parameter for URL previews

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -10,6 +10,7 @@ Breaking changes:
 - The conversion from `PushRule` to `ConditionalPushRule` is infallible since
   the `conditions` field is optional.
   - `MissingConditionsError` was removed.
+- The `ts` field in `Request` for `get_media_preview` is now `Option`.
 
 Improvements:
 

--- a/crates/ruma-client-api/src/media/get_media_preview.rs
+++ b/crates/ruma-client-api/src/media/get_media_preview.rs
@@ -33,7 +33,8 @@ pub mod v3 {
 
         /// Preferred point in time (in milliseconds) to return a preview for.
         #[ruma_api(query)]
-        pub ts: MilliSecondsSinceUnixEpoch,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub ts: Option<MilliSecondsSinceUnixEpoch>,
     }
 
     /// Response type for the `get_media_preview` endpoint.
@@ -49,9 +50,9 @@ pub mod v3 {
     }
 
     impl Request {
-        /// Creates a new `Request` with the given url and timestamp.
-        pub fn new(url: String, ts: MilliSecondsSinceUnixEpoch) -> Self {
-            Self { url, ts }
+        /// Creates a new `Request` with the given url.
+        pub fn new(url: String) -> Self {
+            Self { url, ts: None }
         }
     }
 


### PR DESCRIPTION
A user of my Conduit fork, which implements URL previews, reported that when using Element Android (legacy) with URL previews they received an influx of Ruma deserialisation errors in their logs:

```
conduwuit-1  | 2024-03-08T19:39:17.965861Z  WARN conduit::api::ruma_wrapper::axum: try_from_http_request failed: Deserialization(Query(Error("missing field `ts`")))
conduwuit-1  | 2024-03-08T19:39:17.987669Z  WARN conduit::api::ruma_wrapper::axum: try_from_http_request failed: Deserialization(Query(Error("missing field `ts`")))
conduwuit-1  | 2024-03-08T19:39:18.211610Z  WARN conduit::api::ruma_wrapper::axum: try_from_http_request failed: Deserialization(Query(Error("missing field `ts`")))
conduwuit-1  | 2024-03-08T19:39:18.211782Z  WARN conduit::api::ruma_wrapper::axum: try_from_http_request failed: Deserialization(Query(Error("missing field `ts`")))

conduwuit-1  | 2024-03-08T20:00:56.660004Z  WARN http_request{path=/_matrix/media/r0/preview_url}: conduit::api::ruma_wrapper::axum: try_from_http_request failed: Deserialization(Query(Error("missing field `ts`")))
```

After some digging, Element Android is requesting URL previews without the `ts` query parameter.

It seems that Ruma is requiring the `ts` parameter, but according to spec for [`/_matrix/media/v3/preview_url`](https://spec.matrix.org/v1.9/client-server-api/#get_matrixmediav3preview_url), it doesn't say that `ts` is required and it's just if a client **prefers** to see URL preview data from a certain point in time if available.

Not sure if just making this field `Option` in the struct is the best way to do it, but somewhere in Ruma this field needs to be optional.

For what it's worth, Synapse just sets the timestamp to the current server's timestamp if it was never specified: https://github.com/element-hq/synapse/blob/696cc9e802f63ba8657856d85f6982f49de14f27/synapse/rest/media/preview_url_resource.py#L75-L77

<!-- Replace -->
----
Preview Removed
<!-- Replace -->
