### PR TITLE
client-api: Update the query parameter of `check_registration_token_validity` request

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -11,6 +11,8 @@ Breaking changes:
   the `conditions` field is optional.
   - `MissingConditionsError` was removed.
 - The `ts` field in `Request` for `get_media_preview` is now `Option`.
+- The query parameter of `check_registration_token_validity` endpoint
+  has been renamed from `registration_token` to `token`
 
 Improvements:
 

--- a/crates/ruma-client-api/src/account/check_registration_token_validity.rs
+++ b/crates/ruma-client-api/src/account/check_registration_token_validity.rs
@@ -27,7 +27,7 @@ pub mod v1 {
     pub struct Request {
         /// The registration token to check the validity of.
         #[ruma_api(query)]
-        pub registration_token: String,
+        pub token: String,
     }
 
     /// Response type for the `check_registration_token_validity` endpoint.
@@ -39,8 +39,8 @@ pub mod v1 {
 
     impl Request {
         /// Creates a new `Request` with the given registration token.
-        pub fn new(registration_token: String) -> Self {
-            Self { registration_token }
+        pub fn new(token: String) -> Self {
+            Self { token }
         }
     }
 


### PR DESCRIPTION
According to [specification](https://spec.matrix.org/latest/client-server-api/#get_matrixclientv1registermloginregistration_tokenvalidity) the query parameter should be simply `token`.

Let me know, if I'm missing something.

Tested with synapse `{"server_version":"1.99.0"}`

<!-- Replace -->
----
Preview Removed
<!-- Replace -->
