### PR TITLE
 client-api: allow /register and /login to support authentication from appservices 

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -29,6 +29,7 @@ Improvements:
   according to MSC4025.
 - Allow `discovery::get_supported_versions::v1` to optionally accept
   authentication, according to MSC4026.
+- Allow `account::register::v3` to accept authentication for appservices.
 
 # 0.17.4
 

--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -29,7 +29,8 @@ Improvements:
   according to MSC4025.
 - Allow `discovery::get_supported_versions::v1` to optionally accept
   authentication, according to MSC4026.
-- Allow `account::register::v3` to accept authentication for appservices.
+- Allow `account::register::v3` and `account::login::v3` to accept
+  authentication for appservices.
 
 # 0.17.4
 

--- a/crates/ruma-client-api/src/account/register.rs
+++ b/crates/ruma-client-api/src/account/register.rs
@@ -22,7 +22,7 @@ pub mod v3 {
     const METADATA: Metadata = metadata! {
         method: POST,
         rate_limited: true,
-        authentication: None,
+        authentication: AppserviceToken,
         history: {
             1.0 => "/_matrix/client/r0/register",
             1.1 => "/_matrix/client/v3/register",

--- a/crates/ruma-client-api/src/session/login.rs
+++ b/crates/ruma-client-api/src/session/login.rs
@@ -26,7 +26,7 @@ pub mod v3 {
     const METADATA: Metadata = metadata! {
         method: POST,
         rate_limited: true,
-        authentication: None,
+        authentication: AppserviceToken,
         history: {
             1.0 => "/_matrix/client/r0/login",
             1.1 => "/_matrix/client/v3/login",

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -10,6 +10,7 @@ Breaking changes:
   match the `.m.rule.invite_for_me` push rule because usually the `invite_state` doesn't include
   `m.room.power_levels`.
 - Add support for endpoints that take an optional authentication
+- Add support for endpoints that require authentication for appservices
 
 Improvements:
 

--- a/crates/ruma-common/src/api.rs
+++ b/crates/ruma-common/src/api.rs
@@ -318,6 +318,10 @@ pub enum SendAccessToken<'a> {
     /// Always add the access token.
     Always(&'a str),
 
+    /// Add the given appservice token to the request only if the `METADATA` on the request
+    /// requires it.
+    Appservice(&'a str),
+
     /// Don't add an access token.
     ///
     /// This will lead to an error if the request endpoint requires authentication
@@ -329,7 +333,7 @@ impl<'a> SendAccessToken<'a> {
     ///
     /// Returns `Some(_)` if `self` contains an access token.
     pub fn get_required_for_endpoint(self) -> Option<&'a str> {
-        as_variant!(self, Self::IfRequired | Self::Always)
+        as_variant!(self, Self::IfRequired | Self::Appservice | Self::Always)
     }
 
     /// Get the access token for an endpoint that should not require one.
@@ -337,6 +341,14 @@ impl<'a> SendAccessToken<'a> {
     /// Returns `Some(_)` only if `self` is `SendAccessToken::Always(_)`.
     pub fn get_not_required_for_endpoint(self) -> Option<&'a str> {
         as_variant!(self, Self::Always)
+    }
+
+    /// Gets the access token for an endpoint that requires one for appservices.
+    ///
+    /// Returns `Some(_)` if `self` is either `SendAccessToken::Appservice(_)`
+    /// or `SendAccessToken::Always(_)`
+    pub fn get_required_for_appservice(self) -> Option<&'a str> {
+        as_variant!(self, Self::Appservice | Self::Always)
     }
 }
 
@@ -489,6 +501,12 @@ pub enum AuthScheme {
     ///
     /// It is recommended to use the header over the query parameter.
     AccessTokenOptional,
+
+    /// Authentication is only performed for appservices, by including an access token in the
+    /// `Authentication` http header, or an `access_token` query parameter.
+    ///
+    /// It is recommended to use the header over the query parameter.
+    AppserviceToken,
 
     /// Authentication is performed by including X-Matrix signatures in the request headers,
     /// as defined in the federation API.

--- a/crates/ruma-common/src/api/metadata.rs
+++ b/crates/ruma-common/src/api/metadata.rs
@@ -79,6 +79,11 @@ impl Metadata {
                 None => None,
             },
 
+            AuthScheme::AppserviceToken => match access_token.get_required_for_appservice() {
+                Some(token) => Some((header::AUTHORIZATION, format!("Bearer {token}").try_into()?)),
+                None => None,
+            },
+
             AuthScheme::ServerSignatures => None,
         })
     }


### PR DESCRIPTION
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->


<!-- Replace -->
----
Preview Removed
<!-- Replace -->
