### PR TITLE
Use web-time to return a SystemTime that works under WASM

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -14,6 +14,9 @@ Breaking changes:
 
 Improvements:
 
+- Use the [web-time](https://github.com/daxpedda/web-time) crate to return a
+  `SystemTime` that works under WASM in the
+  `MilliSecondsSinceUnixEpoch::to_system_time()` method.
 - Stabilize support for `.m.rule.suppress_edits` push rule (MSC3958 / Matrix 1.9)
 - Add `MatrixVersion::V1_9`
 - Point links to the Matrix 1.9 specification

--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -23,7 +23,7 @@ server = []
 
 api = ["dep:http", "dep:konst"]
 canonical-json = []
-js = ["dep:js-sys", "getrandom?/js", "uuid?/js"]
+js = ["dep:js-sys", "dep:web-time", "getrandom?/js", "uuid?/js"]
 rand = ["dep:rand", "dep:uuid"]
 unstable-exhaustive-types = []
 unstable-msc2870 = []
@@ -81,6 +81,7 @@ wildmatch = "2.0.0"
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 js-sys = { version = "0.3", optional = true }
+web-time = { version = "1.1.0", optional = true }
 
 [dev-dependencies]
 assert_matches2 = { workspace = true }

--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -23,7 +23,7 @@ server = []
 
 api = ["dep:http", "dep:konst"]
 canonical-json = []
-js = ["dep:js-sys", "dep:web-time", "getrandom?/js", "uuid?/js"]
+js = ["dep:js-sys", "getrandom?/js", "uuid?/js"]
 rand = ["dep:rand", "dep:uuid"]
 unstable-exhaustive-types = []
 unstable-msc2870 = []
@@ -77,11 +77,11 @@ time = "0.3.34"
 tracing = { workspace = true, features = ["attributes"] }
 url = "2.2.2"
 uuid = { version = "1.0.0", optional = true, features = ["v4"] }
+web-time = "1.1.0"
 wildmatch = "2.0.0"
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 js-sys = { version = "0.3", optional = true }
-web-time = { version = "1.1.0", optional = true }
 
 [dev-dependencies]
 assert_matches2 = { workspace = true }

--- a/crates/ruma-common/src/time.rs
+++ b/crates/ruma-common/src/time.rs
@@ -1,5 +1,3 @@
-#[cfg(not(all(target_arch = "wasm32", target_os = "unknown", feature = "js")))]
-use std::time::SystemTime;
 use std::{
     fmt,
     time::{Duration, UNIX_EPOCH},
@@ -8,7 +6,6 @@ use std::{
 use js_int::{uint, UInt};
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
-#[cfg(all(target_arch = "wasm32", target_os = "unknown", feature = "js"))]
 use web_time::SystemTime;
 
 /// A timestamp represented as the number of milliseconds since the unix epoch.

--- a/crates/ruma-common/src/time.rs
+++ b/crates/ruma-common/src/time.rs
@@ -1,11 +1,15 @@
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown", feature = "js")))]
+use std::time::SystemTime;
 use std::{
     fmt,
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    time::{Duration, UNIX_EPOCH},
 };
 
 use js_int::{uint, UInt};
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
+#[cfg(all(target_arch = "wasm32", target_os = "unknown", feature = "js"))]
+use web_time::SystemTime;
 
 /// A timestamp represented as the number of milliseconds since the unix epoch.
 #[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]


### PR DESCRIPTION
The `MilliSecondsSinceUnixEpoch::to_system_time()` method returns the `SystemTime` type from the standard library.

The `std::time::SystemTime::elapsed()` method sadly panics under WASM. Instead of returning the `SystemTime` from the standard library we're now returning a drop-in replacement of this type coming from the web-time crate.







<!-- Replace -->
----
Preview Removed
<!-- Replace -->
