### PR TITLE
Also use Duration and UNIX_EPOCH from web-time crate

### DIFF
--- a/crates/ruma-common/src/time.rs
+++ b/crates/ruma-common/src/time.rs
@@ -1,12 +1,9 @@
-use std::{
-    fmt,
-    time::{Duration, UNIX_EPOCH},
-};
+use std::fmt;
 
 use js_int::{uint, UInt};
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
-use web_time::SystemTime;
+use web_time::{Duration, SystemTime, UNIX_EPOCH};
 
 /// A timestamp represented as the number of milliseconds since the unix epoch.
 #[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]


### PR DESCRIPTION
As a follow-up to https://github.com/ruma/ruma/pull/1747, we also need to use `Duration` and `UNIX_EPOCH` from the `web-time` crate, otherwise when it compiles under wasm, it will complain about mismatched types.

<!-- Replace -->
----
Preview Removed
<!-- Replace -->
