### PR TITLE
Add initial support for Matrix 1.10

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -28,9 +28,9 @@ Improvements:
   login type.
 - Add optional cookie field to `session::sso_login*::v3` responses.
 - Add support for local user erasure to `account::deactivate::v3::Request`,
-  according to MSC4025.
+  according to MSC4025 / Matrix 1.10.
 - Allow `discovery::get_supported_versions::v1` to optionally accept
-  authentication, according to MSC4026.
+  authentication, according to MSC4026 / Matrix 1.10.
 - Allow `account::register::v3` and `account::login::v3` to accept
   authentication for appservices.
 

--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -16,7 +16,7 @@ Breaking changes:
 
 Improvements:
 
-- Point links to the Matrix 1.9 specification
+- Point links to the Matrix 1.10 specification
 - Add the `get_authentication_issuer` endpoint from MSC2965 behind the
   `unstable-msc2965` feature.
 - Add `error_kind` accessor method to `ruma_client_api::Error`

--- a/crates/ruma-client-api/src/membership/invite_user.rs
+++ b/crates/ruma-client-api/src/membership/invite_user.rs
@@ -9,8 +9,8 @@ pub mod v3 {
     //! [by their Matrix identifier][spec-mxid], and one to invite a user
     //! [by their third party identifier][spec-3pid].
     //!
-    //! [spec-mxid]: https://spec.matrix.org/v1.9/client-server-api/#post_matrixclientv3roomsroomidinvite
-    //! [spec-3pid]: https://spec.matrix.org/v1.9/client-server-api/#post_matrixclientv3roomsroomidinvite-1
+    //! [spec-mxid]: https://spec.matrix.org/v1.10/client-server-api/#post_matrixclientv3roomsroomidinvite
+    //! [spec-3pid]: https://spec.matrix.org/v1.10/client-server-api/#post_matrixclientv3roomsroomidinvite-1
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -19,7 +19,7 @@ Improvements:
   `MilliSecondsSinceUnixEpoch::to_system_time()` method.
 - Stabilize support for `.m.rule.suppress_edits` push rule (MSC3958 / Matrix 1.9)
 - Add `MatrixVersion::V1_9` and `V1_10`
-- Point links to the Matrix 1.9 specification
+- Point links to the Matrix 1.10 specification
 - Implement `as_str()` and `AsRef<str>` for `push::PredefinedRuleId`
 - Implement `kind()` for `push::Predefined{*}RuleId`
 

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -18,7 +18,7 @@ Improvements:
   `SystemTime` that works under WASM in the
   `MilliSecondsSinceUnixEpoch::to_system_time()` method.
 - Stabilize support for `.m.rule.suppress_edits` push rule (MSC3958 / Matrix 1.9)
-- Add `MatrixVersion::V1_9`
+- Add `MatrixVersion::V1_9` and `V1_10`
 - Point links to the Matrix 1.9 specification
 - Implement `as_str()` and `AsRef<str>` for `push::PredefinedRuleId`
 - Implement `kind()` for `push::Predefined{*}RuleId`

--- a/crates/ruma-common/src/api/metadata.rs
+++ b/crates/ruma-common/src/api/metadata.rs
@@ -536,6 +536,11 @@ pub enum MatrixVersion {
     ///
     /// See <https://spec.matrix.org/v1.9/>.
     V1_9,
+
+    /// Version 1.10 of the Matrix specification, released in Q1 2024.
+    ///
+    /// See <https://spec.matrix.org/v1.10/>.
+    V1_10,
 }
 
 impl TryFrom<&str> for MatrixVersion {
@@ -558,6 +563,7 @@ impl TryFrom<&str> for MatrixVersion {
             "v1.7" => V1_7,
             "v1.8" => V1_8,
             "v1.9" => V1_9,
+            "v1.10" => V1_10,
             _ => return Err(UnknownVersionError),
         })
     }
@@ -606,6 +612,7 @@ impl MatrixVersion {
             MatrixVersion::V1_7 => (1, 7),
             MatrixVersion::V1_8 => (1, 8),
             MatrixVersion::V1_9 => (1, 9),
+            MatrixVersion::V1_10 => (1, 10),
         }
     }
 
@@ -622,6 +629,7 @@ impl MatrixVersion {
             (1, 7) => Ok(MatrixVersion::V1_7),
             (1, 8) => Ok(MatrixVersion::V1_8),
             (1, 9) => Ok(MatrixVersion::V1_9),
+            (1, 10) => Ok(MatrixVersion::V1_10),
             _ => Err(UnknownVersionError),
         }
     }
@@ -714,7 +722,9 @@ impl MatrixVersion {
             // <https://spec.matrix.org/v1.8/rooms/#complete-list-of-room-versions>
             | MatrixVersion::V1_8
             // <https://spec.matrix.org/v1.9/rooms/#complete-list-of-room-versions>
-            | MatrixVersion::V1_9 => RoomVersionId::V10,
+            | MatrixVersion::V1_9
+            // <https://spec.matrix.org/v1.10/rooms/#complete-list-of-room-versions>
+            | MatrixVersion::V1_10 => RoomVersionId::V10,
         }
     }
 }

--- a/crates/ruma-common/src/push/condition.rs
+++ b/crates/ruma-common/src/push/condition.rs
@@ -602,7 +602,7 @@ mod tests {
         assert!(!"m".matches_word("[[:alpha:]]?"));
         assert!("[[:alpha:]]!".matches_word("[[:alpha:]]?"));
 
-        // From the spec: <https://spec.matrix.org/v1.9/client-server-api/#conditions-1>
+        // From the spec: <https://spec.matrix.org/v1.10/client-server-api/#conditions-1>
         assert!("An example event.".matches_word("ex*ple"));
         assert!("exple".matches_word("ex*ple"));
         assert!("An exciting triple-whammy".matches_word("ex*ple"));
@@ -651,7 +651,7 @@ mod tests {
         assert!("".matches_pattern("*", false));
         assert!(!"foo".matches_pattern("", false));
 
-        // From the spec: <https://spec.matrix.org/v1.9/client-server-api/#conditions-1>
+        // From the spec: <https://spec.matrix.org/v1.10/client-server-api/#conditions-1>
         assert!("Lunch plans".matches_pattern("lunc?*", false));
         assert!("LUNCH".matches_pattern("lunc?*", false));
         assert!(!" lunch".matches_pattern("lunc?*", false));

--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -29,7 +29,8 @@ Improvements:
 - Add unstable support for manually marking rooms as unread through [MSC2867](https://github.com/matrix-org/matrix-spec-proposals/pull/2867) 
   and the room account data `m.marked_unread` event (unstable type `com.famedly.marked_unread`)
 - Implement `From<JoinRule>` for `SpaceRoomJoinRule`
-- Add `filename` and `formatted` fields to media event contents to support media captions as per [MSC2530](https://github.com/matrix-org/matrix-spec-proposals/pull/2530)
+- Add `filename` and `formatted` fields to media event contents to support media captions
+  as per [MSC2530](https://github.com/matrix-org/matrix-spec-proposals/pull/2530) / Matrix 1.10
 
 # 0.27.11
 

--- a/crates/ruma-events/src/secret_storage/key.rs
+++ b/crates/ruma-events/src/secret_storage/key.rs
@@ -57,7 +57,7 @@ fn is_default_bits(val: &UInt) -> bool {
 ///
 /// The only algorithm currently specified is `m.secret_storage.v1.aes-hmac-sha2`, so this
 /// essentially represents `AesHmacSha2KeyDescription` in the
-/// [spec](https://spec.matrix.org/v1.9/client-server-api/#msecret_storagev1aes-hmac-sha2).
+/// [spec](https://spec.matrix.org/latest/client-server-api/#msecret_storagev1aes-hmac-sha2).
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 #[derive(Clone, Debug, Serialize, EventContent)]
 #[ruma_event(type = "m.secret_storage.key.*", kind = GlobalAccountData)]
@@ -137,7 +137,7 @@ impl SecretStorageEncryptionAlgorithm {
 /// The key properties for the `m.secret_storage.v1.aes-hmac-sha2` algorithm.
 ///
 /// Corresponds to the AES-specific properties of `AesHmacSha2KeyDescription` in the
-/// [spec](https://spec.matrix.org/v1.9/client-server-api/#msecret_storagev1aes-hmac-sha2).
+/// [spec](https://spec.matrix.org/latest/client-server-api/#msecret_storagev1aes-hmac-sha2).
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct SecretStorageV1AesHmacSha2Properties {

--- a/crates/ruma-identifiers-validation/CHANGELOG.md
+++ b/crates/ruma-identifiers-validation/CHANGELOG.md
@@ -10,7 +10,7 @@ Bug fixes:
 
 Improvements:
 
-- Point links to the Matrix 1.9 specification
+- Point links to the Matrix 1.10 specification
 
 # 0.9.3
 

--- a/crates/ruma-identifiers-validation/src/error.rs
+++ b/crates/ruma-identifiers-validation/src/error.rs
@@ -77,7 +77,7 @@ pub enum MxcUriError {
     /// Media identifier malformed due to invalid characters detected.
     ///
     /// Valid characters are (in regex notation) `[A-Za-z0-9_-]+`.
-    /// See [here](https://spec.matrix.org/v1.9/client-server-api/#security-considerations-5) for more details.
+    /// See [here](https://spec.matrix.org/v1.10/client-server-api/#security-considerations-5) for more details.
     #[error("Media Identifier malformed, invalid characters")]
     MediaIdMalformed,
 

--- a/crates/ruma-identifiers-validation/src/mxc_uri.rs
+++ b/crates/ruma-identifiers-validation/src/mxc_uri.rs
@@ -17,7 +17,7 @@ pub fn validate(uri: &str) -> Result<NonZeroU8, MxcUriError> {
 
     let server_name = &uri[..index];
     let media_id = &uri[index + 1..];
-    // See: https://spec.matrix.org/v1.9/client-server-api/#security-considerations-5
+    // See: https://spec.matrix.org/v1.10/client-server-api/#security-considerations-5
     let media_id_is_valid = media_id
         .bytes()
         .all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'z' | b'A'..=b'Z' | b'-' | b'_' ));

--- a/xtask/src/ci/spec_links.rs
+++ b/xtask/src/ci/spec_links.rs
@@ -18,7 +18,7 @@ const OLD_URL_WHITELIST: &[&str] =
 
 /// Authorized versions in URLs pointing to the new specs.
 const NEW_VERSION_WHITELIST: &[&str] = &[
-    "v1.1", "v1.2", "v1.3", "v1.4", "v1.5", "v1.6", "v1.7", "v1.8", "v1.9",
+    "v1.1", "v1.2", "v1.3", "v1.4", "v1.5", "v1.6", "v1.7", "v1.8", "v1.9", "v1.10",
     "latest",
     // This should only be enabled if a legitimate use case is found.
     // "unstable",


### PR DESCRIPTION
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->





<!-- Replace -->
----
Preview Removed
<!-- Replace -->
