### PR TITLE
events: Add support for multi-stream VoIP

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -31,6 +31,7 @@ Improvements:
 - Implement `From<JoinRule>` for `SpaceRoomJoinRule`
 - Add `filename` and `formatted` fields to media event contents to support media captions
   as per [MSC2530](https://github.com/matrix-org/matrix-spec-proposals/pull/2530) / Matrix 1.10
+- Add support for multi-stream VoIP, according to MSC3077 / Matrix 1.10
 
 # 0.27.11
 

--- a/crates/ruma-events/src/call.rs
+++ b/crates/ruma-events/src/call.rs
@@ -65,18 +65,18 @@ impl StreamMetadata {
 /// The purpose of a VoIP stream.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
 #[derive(Clone, PartialEq, Eq, StringEnum)]
-#[ruma_enum(rename_all = "m.snake_case")]
+#[ruma_enum(rename_all = "m.lowercase")]
 #[non_exhaustive]
 pub enum StreamPurpose {
     /// `m.usermedia`.
     ///
     /// A stream that contains the webcam and/or microphone tracks.
-    Usermedia,
+    UserMedia,
 
     /// `m.screenshare`.
     ///
     /// A stream with the screen-sharing tracks.
-    Screenshare,
+    ScreenShare,
 
     #[doc(hidden)]
     _Custom(PrivOwnedStr),

--- a/crates/ruma-events/src/call.rs
+++ b/crates/ruma-events/src/call.rs
@@ -14,7 +14,10 @@ pub mod notify;
 pub mod reject;
 pub mod select_answer;
 
+use ruma_macros::StringEnum;
 use serde::{Deserialize, Serialize};
+
+use crate::PrivOwnedStr;
 
 /// A VoIP session description.
 ///
@@ -42,6 +45,41 @@ impl SessionDescription {
     pub fn new(session_type: String, sdp: String) -> Self {
         Self { session_type, sdp }
     }
+}
+
+/// Metadata about a VoIP stream.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+pub struct StreamMetadata {
+    /// The purpose of the stream.
+    pub purpose: StreamPurpose,
+}
+
+impl StreamMetadata {
+    /// Creates a new `StreamMetadata` with the given purpose.
+    pub fn new(purpose: StreamPurpose) -> Self {
+        Self { purpose }
+    }
+}
+
+/// The purpose of a VoIP stream.
+#[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
+#[derive(Clone, PartialEq, Eq, StringEnum)]
+#[ruma_enum(rename_all = "m.snake_case")]
+#[non_exhaustive]
+pub enum StreamPurpose {
+    /// `m.usermedia`.
+    ///
+    /// A stream that contains the webcam and/or microphone tracks.
+    Usermedia,
+
+    /// `m.screenshare`.
+    ///
+    /// A stream with the screen-sharing tracks.
+    Screenshare,
+
+    #[doc(hidden)]
+    _Custom(PrivOwnedStr),
 }
 
 /// The capabilities of a client in a VoIP call.

--- a/crates/ruma-events/src/call/answer.rs
+++ b/crates/ruma-events/src/call/answer.rs
@@ -2,13 +2,15 @@
 //!
 //! [`m.call.answer`]: https://spec.matrix.org/latest/client-server-api/#mcallanswer
 
+use std::collections::BTreeMap;
+
 use ruma_common::{OwnedVoipId, VoipVersionId};
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "unstable-msc2747")]
 use super::CallCapabilities;
-use super::SessionDescription;
+use super::{SessionDescription, StreamMetadata};
 
 /// The content of an `m.call.answer` event.
 ///
@@ -34,6 +36,12 @@ pub struct CallAnswerEventContent {
     /// The VoIP capabilities of the client.
     #[serde(default, skip_serializing_if = "CallCapabilities::is_default")]
     pub capabilities: CallCapabilities,
+
+    /// **Added in VoIP version 1.** Metadata describing the streams that will be sent.
+    ///
+    /// This is a map of stream ID to metadata about the stream.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub sdp_stream_metadata: BTreeMap<String, StreamMetadata>,
 }
 
 impl CallAnswerEventContent {
@@ -46,6 +54,7 @@ impl CallAnswerEventContent {
             version,
             #[cfg(feature = "unstable-msc2747")]
             capabilities: Default::default(),
+            sdp_stream_metadata: Default::default(),
         }
     }
 
@@ -69,6 +78,7 @@ impl CallAnswerEventContent {
             version: VoipVersionId::V1,
             #[cfg(feature = "unstable-msc2747")]
             capabilities: Default::default(),
+            sdp_stream_metadata: Default::default(),
         }
     }
 }

--- a/crates/ruma-events/src/call/invite.rs
+++ b/crates/ruma-events/src/call/invite.rs
@@ -2,6 +2,8 @@
 //!
 //! [`m.call.invite`]: https://spec.matrix.org/latest/client-server-api/#mcallinvite
 
+use std::collections::BTreeMap;
+
 use js_int::UInt;
 use ruma_common::{OwnedUserId, OwnedVoipId, VoipVersionId};
 use ruma_macros::EventContent;
@@ -9,7 +11,7 @@ use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "unstable-msc2747")]
 use super::CallCapabilities;
-use super::SessionDescription;
+use super::{SessionDescription, StreamMetadata};
 
 /// The content of an `m.call.invite` event.
 ///
@@ -49,6 +51,12 @@ pub struct CallInviteEventContent {
     /// The invite should be ignored if the invitee is set and doesn't match the user's ID.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub invitee: Option<OwnedUserId>,
+
+    /// **Added in VoIP version 1.** Metadata describing the streams that will be sent.
+    ///
+    /// This is a map of stream ID to metadata about the stream.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub sdp_stream_metadata: BTreeMap<String, StreamMetadata>,
 }
 
 impl CallInviteEventContent {
@@ -69,6 +77,7 @@ impl CallInviteEventContent {
             #[cfg(feature = "unstable-msc2747")]
             capabilities: Default::default(),
             invitee: None,
+            sdp_stream_metadata: Default::default(),
         }
     }
 
@@ -95,6 +104,7 @@ impl CallInviteEventContent {
             #[cfg(feature = "unstable-msc2747")]
             capabilities: Default::default(),
             invitee: None,
+            sdp_stream_metadata: Default::default(),
         }
     }
 }

--- a/crates/ruma-events/src/call/negotiate.rs
+++ b/crates/ruma-events/src/call/negotiate.rs
@@ -2,12 +2,14 @@
 //!
 //! [`m.call.negotiate`]: https://spec.matrix.org/latest/client-server-api/#mcallnegotiate
 
+use std::collections::BTreeMap;
+
 use js_int::UInt;
 use ruma_common::{OwnedVoipId, VoipVersionId};
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
-use super::SessionDescription;
+use super::{SessionDescription, StreamMetadata};
 
 /// **Added in VoIP version 1.** The content of an `m.call.negotiate` event.
 ///
@@ -37,6 +39,12 @@ pub struct CallNegotiateEventContent {
 
     /// The session description of the negotiation.
     pub description: SessionDescription,
+
+    /// Metadata describing the streams that will be sent.
+    ///
+    /// This is a map of stream ID to metadata about the stream.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub sdp_stream_metadata: BTreeMap<String, StreamMetadata>,
 }
 
 impl CallNegotiateEventContent {
@@ -49,7 +57,14 @@ impl CallNegotiateEventContent {
         lifetime: UInt,
         description: SessionDescription,
     ) -> Self {
-        Self { call_id, party_id, version, lifetime, description }
+        Self {
+            call_id,
+            party_id,
+            version,
+            lifetime,
+            description,
+            sdp_stream_metadata: Default::default(),
+        }
     }
 
     /// Convenience method to create a version 1 `CallNegotiateEventContent` with all the required

--- a/crates/ruma-macros/src/serde/case.rs
+++ b/crates/ruma-macros/src/serde/case.rs
@@ -36,6 +36,8 @@ pub enum RenameRule {
     /// Rename direct children to "M_MATRIX_ERROR_CASE" style, as used for responses with error in
     /// Matrix spec.
     MatrixErrorCase,
+    /// Rename the direct children to "m.lowercase" style.
+    MatrixLowerCase,
     /// Rename the direct children to "m.snake_case" style.
     MatrixSnakeCase,
     /// Rename the direct children to "m.dotted.case" style.
@@ -68,6 +70,7 @@ impl RenameRule {
             KebabCase => SnakeCase.apply_to_variant(variant).replace('_', "-"),
             ScreamingKebabCase => ScreamingSnakeCase.apply_to_variant(variant).replace('_', "-"),
             MatrixErrorCase => String::from("M_") + &ScreamingSnakeCase.apply_to_variant(variant),
+            MatrixLowerCase => String::from("m.") + &LowerCase.apply_to_variant(variant),
             MatrixSnakeCase => String::from("m.") + &SnakeCase.apply_to_variant(variant),
             MatrixDottedCase => {
                 String::from("m.") + &SnakeCase.apply_to_variant(variant).replace('_', ".")
@@ -106,6 +109,7 @@ impl RenameRule {
             KebabCase => field.replace('_', "-"),
             ScreamingKebabCase => ScreamingSnakeCase.apply_to_field(field).replace('_', "-"),
             MatrixErrorCase => String::from("M_") + &ScreamingSnakeCase.apply_to_field(field),
+            MatrixLowerCase => String::from("m.") + field,
             MatrixSnakeCase => String::from("m.") + field,
             MatrixDottedCase => String::from("m.") + &field.replace('_', "."),
             MatrixRuleSnakeCase => String::from(".m.rule.") + field,
@@ -129,6 +133,7 @@ impl FromStr for RenameRule {
             "SCREAMING-KEBAB-CASE" => Ok(ScreamingKebabCase),
             "M_MATRIX_ERROR_CASE" => Ok(MatrixErrorCase),
             "m.snake_case" => Ok(MatrixSnakeCase),
+            "m.lowercase" => Ok(MatrixLowerCase),
             "m.dotted.case" => Ok(MatrixDottedCase),
             ".m.rule.snake_case" => Ok(MatrixRuleSnakeCase),
             "m.role.snake_case" => Ok(MatrixRoleSnakeCase),
@@ -149,6 +154,7 @@ fn rename_variants() {
         kebab,
         screaming_kebab,
         matrix_error,
+        m_lower,
         m_snake,
         m_dotted,
         m_rule_snake,
@@ -166,6 +172,7 @@ fn rename_variants() {
             "M_OUTCOME",
             "m.outcome",
             "m.outcome",
+            "m.outcome",
             ".m.rule.outcome",
             "m.role.outcome",
         ),
@@ -179,12 +186,28 @@ fn rename_variants() {
             "very-tasty",
             "VERY-TASTY",
             "M_VERY_TASTY",
+            "m.verytasty",
             "m.very_tasty",
             "m.very.tasty",
             ".m.rule.very_tasty",
             "m.role.very_tasty",
         ),
-        ("A", "a", "A", "a", "a", "A", "a", "A", "M_A", "m.a", "m.a", ".m.rule.a", "m.role.a"),
+        (
+            "A",
+            "a",
+            "A",
+            "a",
+            "a",
+            "A",
+            "a",
+            "A",
+            "M_A",
+            "m.a",
+            "m.a",
+            "m.a",
+            ".m.rule.a",
+            "m.role.a",
+        ),
         (
             "Z42",
             "z42",
@@ -195,6 +218,7 @@ fn rename_variants() {
             "z42",
             "Z42",
             "M_Z42",
+            "m.z42",
             "m.z42",
             "m.z42",
             ".m.rule.z42",
@@ -211,6 +235,7 @@ fn rename_variants() {
         assert_eq!(KebabCase.apply_to_variant(original), kebab);
         assert_eq!(ScreamingKebabCase.apply_to_variant(original), screaming_kebab);
         assert_eq!(MatrixErrorCase.apply_to_variant(original), matrix_error);
+        assert_eq!(MatrixLowerCase.apply_to_variant(original), m_lower);
         assert_eq!(MatrixSnakeCase.apply_to_variant(original), m_snake);
         assert_eq!(MatrixDottedCase.apply_to_variant(original), m_dotted);
         assert_eq!(MatrixRuleSnakeCase.apply_to_variant(original), m_rule_snake);
@@ -229,6 +254,7 @@ fn rename_fields() {
         kebab,
         screaming_kebab,
         matrix_error,
+        m_lower,
         m_snake,
         m_dotted,
         m_rule_snake,
@@ -245,6 +271,7 @@ fn rename_fields() {
             "M_OUTCOME",
             "m.outcome",
             "m.outcome",
+            "m.outcome",
             ".m.rule.outcome",
             "m.role.outcome",
         ),
@@ -258,11 +285,12 @@ fn rename_fields() {
             "VERY-TASTY",
             "M_VERY_TASTY",
             "m.very_tasty",
+            "m.very_tasty",
             "m.very.tasty",
             ".m.rule.very_tasty",
             "m.role.very_tasty",
         ),
-        ("a", "A", "A", "a", "A", "a", "A", "M_A", "m.a", "m.a", ".m.rule.a", "m.role.a"),
+        ("a", "A", "A", "a", "A", "a", "A", "M_A", "m.a", "m.a", "m.a", ".m.rule.a", "m.role.a"),
         (
             "z42",
             "Z42",
@@ -272,6 +300,7 @@ fn rename_fields() {
             "z42",
             "Z42",
             "M_Z42",
+            "m.z42",
             "m.z42",
             "m.z42",
             ".m.rule.z42",
@@ -287,6 +316,7 @@ fn rename_fields() {
         assert_eq!(KebabCase.apply_to_field(original), kebab);
         assert_eq!(ScreamingKebabCase.apply_to_field(original), screaming_kebab);
         assert_eq!(MatrixErrorCase.apply_to_field(original), matrix_error);
+        assert_eq!(MatrixLowerCase.apply_to_field(original), m_lower);
         assert_eq!(MatrixSnakeCase.apply_to_field(original), m_snake);
         assert_eq!(MatrixDottedCase.apply_to_field(original), m_dotted);
         assert_eq!(MatrixRuleSnakeCase.apply_to_field(original), m_rule_snake);


### PR DESCRIPTION
According to [MSC3077](https://github.com/matrix-org/matrix-spec-proposals/pull/3077) / Matrix 1.10 ([Spec PR](https://github.com/matrix-org/matrix-spec/pull/1735))

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->








<!-- Replace -->
----
Preview Removed
<!-- Replace -->
