### PR TITLE
client-api: Add support for the Retry-After header

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -16,6 +16,9 @@ Breaking changes:
 - `Error` is now non-exhaustive.
 - `ErrorKind::Forbidden` is now a non-exhaustive struct variant that can be
   constructed with `ErrorKind::forbidden()`.
+- The `retry_after_ms` field of `ErrorKind::LimitExceeded` was renamed to
+  `retry_after` and is now an `Option<RetryAfter>`, to add support for the
+  Retry-After header, according to MSC4041 / Matrix 1.10 
 
 Improvements:
 

--- a/crates/ruma-client-api/Cargo.toml
+++ b/crates/ruma-client-api/Cargo.toml
@@ -52,6 +52,7 @@ unstable-msc3983 = []
 as_variant = { workspace = true }
 assign = { workspace = true }
 bytes = "1.0.1"
+date_header = "1.0.5"
 http = { workspace = true }
 js_int = { workspace = true, features = ["serde"] }
 js_option = "0.1.1"
@@ -61,6 +62,7 @@ ruma-events = { workspace = true }
 serde = { workspace = true }
 serde_html_form = { workspace = true }
 serde_json = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 assert_matches2 = { workspace = true }

--- a/crates/ruma-client-api/Cargo.toml
+++ b/crates/ruma-client-api/Cargo.toml
@@ -63,6 +63,7 @@ serde = { workspace = true }
 serde_html_form = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+web-time = { workspace = true }
 
 [dev-dependencies]
 assert_matches2 = { workspace = true }

--- a/crates/ruma-client-api/src/error.rs
+++ b/crates/ruma-client-api/src/error.rs
@@ -422,6 +422,7 @@ impl OutgoingResponse for Error {
             .header(http::header::CONTENT_TYPE, "application/json")
             .status(self.status_code);
 
+        #[allow(clippy::collapsible_match)]
         if let ErrorBody::Standard { kind, .. } = &self.body {
             match kind {
                 #[cfg(feature = "unstable-msc2967")]

--- a/crates/ruma-client-api/src/error.rs
+++ b/crates/ruma-client-api/src/error.rs
@@ -548,7 +548,7 @@ impl TryFrom<&AuthenticateError> for http::HeaderValue {
     }
 }
 
-/// How long a client should wait before they can try again.
+/// How long a client should wait before it tries again.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(clippy::exhaustive_enums)]
 pub enum RetryAfter {

--- a/crates/ruma-common/src/api/error.rs
+++ b/crates/ruma-common/src/api/error.rs
@@ -129,6 +129,13 @@ pub enum IntoHttpError {
     #[error("header serialization failed: {0}")]
     Header(#[from] http::header::InvalidHeaderValue),
 
+    /// Retry-After header serialization failed because the datetime provided is after the year
+    /// 9999.
+    #[error(
+        "Retry-After header serialization failed: the year of the datetime is bigger than 9999"
+    )]
+    RetryAfterInvalidDatetime,
+
     /// HTTP request construction failed.
     #[error("HTTP request construction failed: {0}")]
     Http(#[from] http::Error),


### PR DESCRIPTION
According to [MSC4041](https://github.com/matrix-org/matrix-spec-proposals/pull/4041) / Matrix 1.10 ([Spec PR](https://github.com/matrix-org/matrix-spec/pull/1737))

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->














<!-- Replace -->
----
Preview: https://pr-1757--ruma-docs.surge.sh
<!-- Replace -->
