### PR TITLE
client-api: Make Error non-exhaustive and move `authenticate` field

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -14,6 +14,8 @@ Breaking changes:
 - The query parameter of `check_registration_token_validity` endpoint
   has been renamed from `registration_token` to `token`
 - `Error` is now non-exhaustive.
+- `ErrorKind::Forbidden` is now a non-exhaustive struct variant that can be
+  constructed with `ErrorKind::forbidden()`.
 
 Improvements:
 

--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -13,6 +13,7 @@ Breaking changes:
 - The `ts` field in `Request` for `get_media_preview` is now `Option`.
 - The query parameter of `check_registration_token_validity` endpoint
   has been renamed from `registration_token` to `token`
+- `Error` is now non-exhaustive.
 
 Improvements:
 

--- a/crates/ruma-client-api/src/error.rs
+++ b/crates/ruma-client-api/src/error.rs
@@ -298,7 +298,7 @@ pub struct StandardErrorBody {
 
 /// A Matrix Error
 #[derive(Debug, Clone)]
-#[allow(clippy::exhaustive_structs)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct Error {
     /// The http status code.
     pub status_code: http::StatusCode,
@@ -312,6 +312,18 @@ pub struct Error {
 }
 
 impl Error {
+    /// Constructs a new `Error` with the given status code and body.
+    ///
+    /// This is equivalent to calling `body.into_error(status_code)`.
+    pub fn new(status_code: http::StatusCode, body: ErrorBody) -> Self {
+        Self {
+            status_code,
+            #[cfg(feature = "unstable-msc2967")]
+            authenticate: None,
+            body,
+        }
+    }
+
     /// If `self` is a server error in the `errcode` + `error` format expected
     /// for client-server API endpoints, returns the error kind (`errcode`).
     pub fn error_kind(&self) -> Option<&ErrorKind> {
@@ -368,6 +380,8 @@ impl std::error::Error for Error {}
 
 impl ErrorBody {
     /// Convert the ErrorBody into an Error by adding the http status code.
+    ///
+    /// This is equivalent to calling `Error::new(status_code, self)`.
     pub fn into_error(self, status_code: http::StatusCode) -> Error {
         Error {
             status_code,

--- a/crates/ruma-client-api/src/error/kind_serde.rs
+++ b/crates/ruma-client-api/src/error/kind_serde.rs
@@ -165,7 +165,7 @@ impl<'de> Visitor<'de> for ErrorKindVisitor {
         let extra = Extra(extra);
 
         Ok(match errcode {
-            ErrCode::Forbidden => ErrorKind::Forbidden,
+            ErrCode::Forbidden => ErrorKind::forbidden(),
             ErrCode::UnknownToken => ErrorKind::UnknownToken {
                 soft_logout: soft_logout
                     .map(from_json_value)
@@ -361,7 +361,13 @@ mod tests {
     #[test]
     fn deserialize_forbidden() {
         let deserialized: ErrorKind = from_json_value(json!({ "errcode": "M_FORBIDDEN" })).unwrap();
-        assert_eq!(deserialized, ErrorKind::Forbidden);
+        assert_eq!(
+            deserialized,
+            ErrorKind::Forbidden {
+                #[cfg(feature = "unstable-msc2967")]
+                authenticate: None
+            }
+        );
     }
 
     #[test]
@@ -372,7 +378,13 @@ mod tests {
         }))
         .unwrap();
 
-        assert_eq!(deserialized, ErrorKind::Forbidden);
+        assert_eq!(
+            deserialized,
+            ErrorKind::Forbidden {
+                #[cfg(feature = "unstable-msc2967")]
+                authenticate: None
+            }
+        );
     }
 
     #[test]

--- a/crates/ruma-client-api/tests/uiaa.rs
+++ b/crates/ruma-client-api/tests/uiaa.rs
@@ -125,7 +125,7 @@ fn deserialize_uiaa_info() {
     assert_eq!(info.flows[1].stages, vec![AuthType::EmailIdentity, AuthType::Msisdn]);
     assert_eq!(info.session.as_deref(), Some("xxxxxx"));
     let auth_error = info.auth_error.unwrap();
-    assert_eq!(auth_error.kind, ErrorKind::Forbidden);
+    assert_matches!(auth_error.kind, ErrorKind::Forbidden { .. });
     assert_eq!(auth_error.message, "Invalid password");
     assert_eq!(
         from_json_str::<JsonValue>(info.params.get()).unwrap(),
@@ -207,7 +207,7 @@ fn try_uiaa_response_from_http_response() {
     assert_eq!(info.flows[1].stages, vec![AuthType::EmailIdentity, AuthType::Msisdn]);
     assert_eq!(info.session.as_deref(), Some("xxxxxx"));
     let auth_error = info.auth_error.unwrap();
-    assert_eq!(auth_error.kind, ErrorKind::Forbidden);
+    assert_matches!(auth_error.kind, ErrorKind::Forbidden { .. });
     assert_eq!(auth_error.message, "Invalid password");
     assert_eq!(
         from_json_str::<JsonValue>(info.params.get()).unwrap(),


### PR DESCRIPTION
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->











<!-- Replace -->
----
Preview: https://pr-1758--ruma-docs.surge.sh
<!-- Replace -->
