### PR TITLE
Export web_time as time in the ruma crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ serde_html_form = "0.2.0"
 serde_json = "1.0.87"
 thiserror = "1.0.37"
 tracing = { version = "0.1.37", default-features = false, features = ["std"] }
+web-time = "1.1.0"
 
 [profile.dev]
 # Speeds up test times by more than 10% in a simple test

--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -77,7 +77,7 @@ time = "0.3.34"
 tracing = { workspace = true, features = ["attributes"] }
 url = "2.2.2"
 uuid = { version = "1.0.0", optional = true, features = ["v4"] }
-web-time = "1.1.0"
+web-time = { workspace = true }
 wildmatch = "2.0.0"
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -283,5 +283,7 @@ ruma-federation-api = { workspace = true, optional = true }
 ruma-identity-service-api = { workspace = true, optional = true }
 ruma-push-gateway-api = { workspace = true, optional = true }
 
+web-time = { workspace = true }
+
 [dev-dependencies]
 serde = { workspace = true }

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -267,6 +267,7 @@ __ci = [
 assign = { workspace = true }
 js_int = { workspace = true }
 js_option = "0.1.1"
+web-time = { workspace = true }
 
 ruma-common = { workspace = true }
 
@@ -282,8 +283,6 @@ ruma-client-api = { workspace = true, optional = true }
 ruma-federation-api = { workspace = true, optional = true }
 ruma-identity-service-api = { workspace = true, optional = true }
 ruma-push-gateway-api = { workspace = true, optional = true }
-
-web-time = { workspace = true }
 
 [dev-dependencies]
 serde = { workspace = true }

--- a/crates/ruma/src/lib.rs
+++ b/crates/ruma/src/lib.rs
@@ -130,3 +130,5 @@ pub use js_option::JsOption;
 #[cfg(feature = "client-ext-client-api")]
 pub use ruma_client::Client;
 pub use ruma_common::*;
+
+pub use web_time as time;

--- a/crates/ruma/src/lib.rs
+++ b/crates/ruma/src/lib.rs
@@ -130,5 +130,4 @@ pub use js_option::JsOption;
 #[cfg(feature = "client-ext-client-api")]
 pub use ruma_client::Client;
 pub use ruma_common::*;
-
 pub use web_time as time;


### PR DESCRIPTION
As discussed in https://github.com/matrix-org/matrix-rust-sdk/pull/3264#issuecomment-2014508027

export web_time so that code that uses `ruma_common::time` functions (e.g. `fromSystemTime`) doesn't have to include its own dependency on web_time.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->


<!-- Replace -->
----
Preview Removed
<!-- Replace -->
