### PR TITLE
Relations request direction

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -36,6 +36,8 @@ Improvements:
 - Add support for recursion on the `get_relating_events` endpoints, according to
   MSC3981 / Matrix 1.10
 - Add server support discovery endpoint, according to MSC1929 / Matrix 1.10
+- Add `dir` `Request` field on the `get_relating_events_with_rel_types` and
+  `get_relating_events_with_rel_type_and_event_type` endpoints
 
 # 0.17.4
 

--- a/crates/ruma-client-api/src/relations/get_relating_events.rs
+++ b/crates/ruma-client-api/src/relations/get_relating_events.rs
@@ -120,7 +120,7 @@ pub mod v1 {
         ///
         /// If `recurse` was not set, this field must be absent.
         #[serde(skip_serializing_if = "Option::is_none")]
-        recursion_depth: Option<UInt>,
+        pub recursion_depth: Option<UInt>,
     }
 
     impl Request {

--- a/crates/ruma-client-api/src/relations/get_relating_events_with_rel_type.rs
+++ b/crates/ruma-client-api/src/relations/get_relating_events_with_rel_type.rs
@@ -126,7 +126,7 @@ pub mod v1 {
         ///
         /// If `recurse` was not set, this field must be absent.
         #[serde(skip_serializing_if = "Option::is_none")]
-        recursion_depth: Option<UInt>,
+        pub recursion_depth: Option<UInt>,
     }
 
     impl Request {

--- a/crates/ruma-client-api/src/relations/get_relating_events_with_rel_type.rs
+++ b/crates/ruma-client-api/src/relations/get_relating_events_with_rel_type.rs
@@ -10,7 +10,7 @@ pub mod v1 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response, Direction, Metadata},
         metadata,
         serde::Raw,
         OwnedEventId, OwnedRoomId,
@@ -55,6 +55,13 @@ pub mod v1 {
         #[serde(skip_serializing_if = "Option::is_none")]
         #[ruma_api(query)]
         pub from: Option<String>,
+
+        /// The direction to return events from.
+        ///
+        /// Defaults to [`Direction::Backward`].
+        #[serde(default, skip_serializing_if = "ruma_common::serde::is_default")]
+        #[ruma_api(query)]
+        pub dir: Direction,
 
         /// The pagination token to stop returning results at.
         ///
@@ -125,7 +132,16 @@ pub mod v1 {
     impl Request {
         /// Creates a new `Request` with the given room ID, parent event ID and relationship type.
         pub fn new(room_id: OwnedRoomId, event_id: OwnedEventId, rel_type: RelationType) -> Self {
-            Self { room_id, event_id, rel_type, from: None, to: None, limit: None, recurse: false }
+            Self {
+                room_id,
+                event_id,
+                dir: Direction::default(),
+                rel_type,
+                from: None,
+                to: None,
+                limit: None,
+                recurse: false,
+            }
         }
     }
 

--- a/crates/ruma-client-api/src/relations/get_relating_events_with_rel_type_and_event_type.rs
+++ b/crates/ruma-client-api/src/relations/get_relating_events_with_rel_type_and_event_type.rs
@@ -10,7 +10,7 @@ pub mod v1 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response, Direction, Metadata},
         metadata,
         serde::Raw,
         OwnedEventId, OwnedRoomId,
@@ -62,6 +62,13 @@ pub mod v1 {
         #[serde(skip_serializing_if = "Option::is_none")]
         #[ruma_api(query)]
         pub from: Option<String>,
+
+        /// The direction to return events from.
+        ///
+        /// Defaults to [`Direction::Backward`].
+        #[serde(default, skip_serializing_if = "ruma_common::serde::is_default")]
+        #[ruma_api(query)]
+        pub dir: Direction,
 
         /// The pagination token to stop returning results at.
         ///
@@ -144,6 +151,7 @@ pub mod v1 {
                 rel_type,
                 event_type,
                 from: None,
+                dir: Direction::default(),
                 to: None,
                 limit: None,
                 recurse: false,

--- a/crates/ruma-client-api/src/relations/get_relating_events_with_rel_type_and_event_type.rs
+++ b/crates/ruma-client-api/src/relations/get_relating_events_with_rel_type_and_event_type.rs
@@ -133,7 +133,7 @@ pub mod v1 {
         ///
         /// If `recurse` was not set, this field must be absent.
         #[serde(skip_serializing_if = "Option::is_none")]
-        recursion_depth: Option<UInt>,
+        pub recursion_depth: Option<UInt>,
     }
 
     impl Request {


### PR DESCRIPTION
Also adds the missing `dir` field on the other relations endpoints ([GET /rooms/{roomId}/relations/{eventId}/{relType}](https://spec.matrix.org/v1.10/client-server-api/#get_matrixclientv1roomsroomidrelationseventidreltype) and [GET /rooms/{roomId}/relations/{eventId}/{relType}/{eventType}](https://spec.matrix.org/v1.10/client-server-api/#get_matrixclientv1roomsroomidrelationseventidreltypeeventtype)).

<!-- Replace -->
----
Preview Removed
<!-- Replace -->
