### PR TITLE
ci: Upgrade upload / deploy pages actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,6 +231,9 @@ jobs:
       - name: Build docs
         run: target/debug/xtask doc --deny-warnings
 
+      - name: Remove .lock file
+        run: rm target/doc/.lock
+
       - name: Compress docs
         if: github.event_name == 'pull_request'
         run: |
@@ -245,10 +248,10 @@ jobs:
 
       - name: Upload docs as pages artifact
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: target/doc
 
       - name: Deploy to GitHub Pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
The reason the deployment was failing before is that there was a  `/.lock` file in the pages artifact that could not be read by all. I found the reason thanks to https://github.com/actions/deploy-pages/issues/303.

I'm not sure where the file comes from in the first place, but I added a step to remove it and that [fixes the deployment in a fork I created](https://github.com/zecakeh/ruma/actions/runs/8520667100/job/23337257473).




<!-- Replace -->
----
Preview Removed
<!-- Replace -->
