### PR TITLE
events: allow deserialize a `m.tag`'s `order` as an integer

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -11,6 +11,8 @@ Breaking changes:
   `m.room.power_levels`.
 - Add support for endpoints that take an optional authentication
 - Add support for endpoints that require authentication for appservices
+- `deserialize_as_f64_or_string` has been extended to also support parsing integers, and renamed to
+  `deserialize_as_number_or_string` to reflect that.
 
 Improvements:
 

--- a/crates/ruma-common/src/serde.rs
+++ b/crates/ruma-common/src/serde.rs
@@ -26,9 +26,9 @@ pub use self::{
     cow::deserialize_cow_str,
     raw::Raw,
     strings::{
-        btreemap_deserialize_v1_powerlevel_values, deserialize_as_f64_or_int_or_string,
-        deserialize_as_optional_f64_or_int_or_string, deserialize_v1_powerlevel,
-        empty_string_as_none, none_as_empty_string,
+        btreemap_deserialize_v1_powerlevel_values, deserialize_as_number_or_string,
+        deserialize_as_optional_number_or_string, deserialize_v1_powerlevel, empty_string_as_none,
+        none_as_empty_string,
     },
 };
 

--- a/crates/ruma-common/src/serde.rs
+++ b/crates/ruma-common/src/serde.rs
@@ -26,9 +26,9 @@ pub use self::{
     cow::deserialize_cow_str,
     raw::Raw,
     strings::{
-        btreemap_deserialize_v1_powerlevel_values, deserialize_as_f64_or_string,
-        deserialize_as_optional_f64_or_string, deserialize_v1_powerlevel, empty_string_as_none,
-        none_as_empty_string,
+        btreemap_deserialize_v1_powerlevel_values, deserialize_as_f64_or_int_or_string,
+        deserialize_as_optional_f64_or_int_or_string, deserialize_v1_powerlevel,
+        empty_string_as_none, none_as_empty_string,
     },
 };
 

--- a/crates/ruma-common/src/serde/strings.rs
+++ b/crates/ruma-common/src/serde/strings.rs
@@ -52,8 +52,8 @@ where
 /// Take either a floating point number or a string and deserialize to an floating-point number.
 ///
 /// To be used like this:
-/// `#[serde(deserialize_with = "deserialize_as_f64_or_int_or_string")]`
-pub fn deserialize_as_f64_or_int_or_string<'de, D>(de: D) -> Result<f64, D::Error>
+/// `#[serde(deserialize_with = "deserialize_as_number_or_string")]`
+pub fn deserialize_as_number_or_string<'de, D>(de: D) -> Result<f64, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -111,18 +111,16 @@ where
 }
 
 #[derive(Deserialize)]
-struct F64OrStringOrIntWrapper(
-    #[serde(deserialize_with = "deserialize_as_f64_or_int_or_string")] f64,
-);
+struct NumberOrStringWrapper(#[serde(deserialize_with = "deserialize_as_number_or_string")] f64);
 
-/// Deserializes an `Option<f64>` as encoded as a f64 or a string or an integer (i64 or u64).
-pub fn deserialize_as_optional_f64_or_int_or_string<'de, D>(
+/// Deserializes an `Option<f64>` from an encoded f64 or string or integer (i64 or u64).
+pub fn deserialize_as_optional_number_or_string<'de, D>(
     deserializer: D,
 ) -> Result<Option<f64>, D::Error>
 where
     D: Deserializer<'de>,
 {
-    Ok(Option::<F64OrStringOrIntWrapper>::deserialize(deserializer)?.map(|w| w.0))
+    Ok(Option::<NumberOrStringWrapper>::deserialize(deserializer)?.map(|w| w.0))
 }
 
 /// Take either an integer number or a string and deserialize to an integer number.

--- a/crates/ruma-events/src/tag.rs
+++ b/crates/ruma-events/src/tag.rs
@@ -5,7 +5,7 @@
 use std::{collections::BTreeMap, error::Error, fmt, str::FromStr};
 
 #[cfg(feature = "compat-tag-info")]
-use ruma_common::serde::deserialize_as_optional_f64_or_int_or_string;
+use ruma_common::serde::deserialize_as_optional_number_or_string;
 use ruma_common::serde::deserialize_cow_str;
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
@@ -180,7 +180,7 @@ pub struct TagInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg_attr(
         feature = "compat-tag-info",
-        serde(default, deserialize_with = "deserialize_as_optional_f64_or_int_or_string")
+        serde(default, deserialize_with = "deserialize_as_optional_number_or_string")
     )]
     pub order: Option<f64>,
 }

--- a/crates/ruma-events/src/tag.rs
+++ b/crates/ruma-events/src/tag.rs
@@ -5,7 +5,7 @@
 use std::{collections::BTreeMap, error::Error, fmt, str::FromStr};
 
 #[cfg(feature = "compat-tag-info")]
-use ruma_common::serde::deserialize_as_optional_f64_or_string;
+use ruma_common::serde::deserialize_as_optional_f64_or_int_or_string;
 use ruma_common::serde::deserialize_cow_str;
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
@@ -180,7 +180,7 @@ pub struct TagInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg_attr(
         feature = "compat-tag-info",
-        serde(default, deserialize_with = "deserialize_as_optional_f64_or_string")
+        serde(default, deserialize_with = "deserialize_as_optional_f64_or_int_or_string")
     )]
     pub order: Option<f64>,
 }
@@ -232,6 +232,9 @@ mod tests {
 
         let json = json!({ "order": null });
         assert_eq!(from_json_value::<TagInfo>(json).unwrap(), TagInfo::default());
+
+        let json = json!({ "order": 1 });
+        assert_eq!(from_json_value::<TagInfo>(json).unwrap(), TagInfo { order: Some(1.) });
 
         let json = json!({ "order": 0.42 });
         assert_eq!(from_json_value::<TagInfo>(json).unwrap(), TagInfo { order: Some(0.42) });


### PR DESCRIPTION
Some servers use an integer to represent e.g. `1` for the order, instead of the double representation (that would be `1.` or `1.0)`. This makes it possible to parse such values as integers too, since they're technically not double. Implementing `visit_u64` and `visit_i64` covers all the smaller sizes too, so I've implemented only that here.

<!-- Replace -->
----
Preview Removed
<!-- Replace -->
