### PR TITLE
client-api: add unstable MSC4121 support (moderator role definition) 

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -44,6 +44,7 @@ Improvements:
 - Add server support discovery endpoint, according to MSC1929 / Matrix 1.10
 - Add `dir` `Request` field on the `get_relating_events_with_rel_types` and
   `get_relating_events_with_rel_type_and_event_type` endpoints
+- Add unstable support for moderator server support discovery, according to MSC4121
 
 # 0.17.4
 
@@ -83,7 +84,7 @@ Breaking changes:
 
 Improvements:
 
-- Add convenience constructors for enabling lazy-loading in filters 
+- Add convenience constructors for enabling lazy-loading in filters
 - Add support for using an existing session to log in another (MSC3882 / Matrix 1.7)
 - Add support for media download redirects (MSC3860 / Matrix 1.7)
 - Stabilize support for asynchronous media uploads (MSC2246 / Matrix 1.7)

--- a/crates/ruma-client-api/Cargo.toml
+++ b/crates/ruma-client-api/Cargo.toml
@@ -47,6 +47,7 @@ unstable-msc3488 = []
 unstable-msc3575 = []
 unstable-msc3814 = []
 unstable-msc3983 = []
+unstable-msc4121 = []
 
 [dependencies]
 as_variant = { workspace = true }

--- a/crates/ruma-client-api/src/discovery/discover_support.rs
+++ b/crates/ruma-client-api/src/discovery/discover_support.rs
@@ -112,6 +112,13 @@ pub enum ContactRole {
     /// A role intended for sensitive requests.
     Security,
 
+    /// A role for moderation-related queries according to [MSC4121](https://github.com/matrix-org/matrix-spec-proposals/pull/4121).
+    ///
+    /// The future prefix for this if accepted will be `m.role.moderator`
+    #[cfg(feature = "unstable-msc4121")]
+    #[ruma_enum(rename = "support.feline.msc4121.role.moderator", alias = "m.role.moderator")]
+    Moderator,
+
     #[doc(hidden)]
     _Custom(PrivOwnedStr),
 }

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -215,6 +215,7 @@ unstable-msc3955 = ["ruma-events?/unstable-msc3955"]
 unstable-msc3956 = ["ruma-events?/unstable-msc3956"]
 unstable-msc3983 = ["ruma-client-api?/unstable-msc3983"]
 unstable-msc4075 = ["ruma-events?/unstable-msc4075"]
+unstable-msc4121 = ["ruma-client-api?/unstable-msc4121"]
 unstable-pdu = ["ruma-events?/unstable-pdu"]
 unstable-unspecified = [
     "ruma-common/unstable-unspecified",


### PR DESCRIPTION
MSC proposal [MSC4121](https://github.com/matrix-org/matrix-spec-proposals/pull/4121) proposes creating another role definition instead of just `m.role.admin` and `m.role.security` for moderation purposes `m.role.moderation`.

A prerequisite for this being merged is an implementation on the server and client sides (https://github.com/matrix-org/matrix-spec-proposals/pull/4121#discussion_r1535994639) with one client implementation already added.
I would like to add server-side support for this in my Conduit fork, Conduwuit, without using `_Custom(PrivOwnedStr)`, and having more easily available implementations of this helps.

<!-- Replace -->
----
Preview Removed
<!-- Replace -->
