### PR TITLE
federation-api: make /v1/send_join use RawValue for body rather than using query parameters

### DIFF
--- a/crates/ruma-federation-api/CHANGELOG.md
+++ b/crates/ruma-federation-api/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [unreleased]
 
+Breaking changes:
+
+* Use `RawValue` to represent body of `/v1/send_join` request, rather than incorrectly using
+  query parameters
+
 Improvements:
 
 * Implement `From<SpaceHierarchyParentSummary>` for `SpaceHierarchyChildSummary`


### PR DESCRIPTION
https://spec.matrix.org/v1.10/server-server-api/#put_matrixfederationv1send_leaveroomideventid
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->


<!-- Replace -->
----
Preview Removed
<!-- Replace -->
