### PR TITLE
federation-api: add unstable support for MSC4125

### DIFF
--- a/crates/ruma-federation-api/CHANGELOG.md
+++ b/crates/ruma-federation-api/CHANGELOG.md
@@ -8,6 +8,8 @@ Breaking changes:
 Improvements:
 
 * Implement `From<SpaceHierarchyParentSummary>` for `SpaceHierarchyChildSummary`
+* Add unstable support for optional `via` field on the `create_invite` endpoint request from
+  MSC4125 behind the `unstable-msc4125` feature.
 
 # 0.8.0
 

--- a/crates/ruma-federation-api/Cargo.toml
+++ b/crates/ruma-federation-api/Cargo.toml
@@ -26,6 +26,7 @@ unstable-exhaustive-types = []
 unstable-msc2448 = []
 unstable-msc3618 = []
 unstable-msc3723 = []
+unstable-msc4125 = []
 unstable-unspecified = []
 
 [dependencies]

--- a/crates/ruma-federation-api/src/membership/create_invite/v2.rs
+++ b/crates/ruma-federation-api/src/membership/create_invite/v2.rs
@@ -2,6 +2,8 @@
 //!
 //! [spec]: https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv2inviteroomideventid
 
+#[cfg(feature = "unstable-msc4125")]
+use ruma_common::OwnedServerName;
 use ruma_common::{
     api::{request, response, Metadata},
     metadata,
@@ -39,6 +41,14 @@ pub struct Request {
 
     /// An optional list of simplified events to help the receiver of the invite identify the room.
     pub invite_room_state: Vec<Raw<AnyStrippedStateEvent>>,
+
+    /// An optional list of servers the invited homeserver should attempt to join or leave via,
+    /// according to [MSC4125](https://github.com/matrix-org/matrix-spec-proposals/pull/4125).
+    ///
+    /// If present, it must not be empty.
+    #[cfg(feature = "unstable-msc4125")]
+    #[serde(skip_serializing_if = "Option::is_none", rename = "org.matrix.msc4125.via")]
+    pub via: Option<Vec<OwnedServerName>>,
 }
 
 /// Response type for the `create_invite` endpoint.
@@ -58,7 +68,15 @@ impl Request {
         event: Box<RawJsonValue>,
         invite_room_state: Vec<Raw<AnyStrippedStateEvent>>,
     ) -> Self {
-        Self { room_id, event_id, room_version, event, invite_room_state }
+        Self {
+            room_id,
+            event_id,
+            room_version,
+            event,
+            invite_room_state,
+            #[cfg(feature = "unstable-msc4125")]
+            via: None,
+        }
     }
 }
 

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -216,6 +216,7 @@ unstable-msc3956 = ["ruma-events?/unstable-msc3956"]
 unstable-msc3983 = ["ruma-client-api?/unstable-msc3983"]
 unstable-msc4075 = ["ruma-events?/unstable-msc4075"]
 unstable-msc4121 = ["ruma-client-api?/unstable-msc4121"]
+unstable-msc4125 = ["ruma-federation-api?/unstable-msc4125"]
 unstable-pdu = ["ruma-events?/unstable-pdu"]
 unstable-unspecified = [
     "ruma-common/unstable-unspecified",


### PR DESCRIPTION
See [MSC4125](https://github.com/matrix-org/matrix-spec-proposals/pull/4125).

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->


<!-- Replace -->
----
Preview Removed
<!-- Replace -->
