### PR TITLE
client-api: remove support for custom presence values

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -11,6 +11,8 @@ Breaking changes:
   `m.room.power_levels`.
 - Add support for endpoints that take an optional authentication
 - Add support for endpoints that require authentication for appservices
+- Remove support for custom `presence` values, as they are not namespaced and hence only values
+  specified in the spec are allowed.
 
 Improvements:
 

--- a/crates/ruma-common/src/presence.rs
+++ b/crates/ruma-common/src/presence.rs
@@ -2,13 +2,12 @@
 //!
 //! [presence]: https://spec.matrix.org/latest/client-server-api/#presence
 
-use crate::{serde::StringEnum, PrivOwnedStr};
+use serde::{Deserialize, Serialize};
 
 /// A description of a user's connectivity and availability for chat.
-#[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, Default, PartialEq, Eq, StringEnum)]
-#[ruma_enum(rename_all = "snake_case")]
-#[non_exhaustive]
+#[derive(Clone, Default, PartialEq, Eq, Deserialize, Serialize, Debug)]
+#[serde(rename_all = "lowercase")]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub enum PresenceState {
     /// Disconnected from the service.
     Offline,
@@ -19,9 +18,6 @@ pub enum PresenceState {
 
     /// Connected to the service but not available for chat.
     Unavailable,
-
-    #[doc(hidden)]
-    _Custom(PrivOwnedStr),
 }
 
 impl Default for &'_ PresenceState {


### PR DESCRIPTION
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
As per [conversation with Travis](https://matrix.to/#/%23matrix-spec%3Amatrix.org/%24ovLQXcJLVzkexmErDBkUloU6iNQax7W9MWykeRaNcP4?via=ahouansou.cz&via=l1qu1d.net&via=0x1a8510f2.space&via=the-apothecary.club)


<!-- Replace -->
----
Preview Removed
<!-- Replace -->
