### PR TITLE
ruma: Add missing unstable features to `__ci`

### DIFF
--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -256,14 +256,18 @@ __ci = [
     "unstable-msc3618",
     "unstable-msc3723",
     "unstable-msc3814",
+    "unstable-msc3843",
     "unstable-msc3927",
     "unstable-msc3930",
+    "unstable-msc3931",
     "unstable-msc3932",
     "unstable-msc3954",
     "unstable-msc3955",
     "unstable-msc3956",
     "unstable-msc3983",
     "unstable-msc4075",
+    "unstable-msc4121",
+    "unstable-msc4125",
 ]
 
 [dependencies]


### PR DESCRIPTION
It looks like we forgot to keep it up-to-date with the last PRs.





<!-- Replace -->
----
Preview Removed
<!-- Replace -->
