### PR TITLE
identifiers: Allow to clone `MatrixToUri` and `MatrixUri`

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -24,6 +24,7 @@ Improvements:
 - Point links to the Matrix 1.10 specification
 - Implement `as_str()` and `AsRef<str>` for `push::PredefinedRuleId`
 - Implement `kind()` for `push::Predefined{*}RuleId`
+- Implement `Clone` for `MatrixToUri` and `MatrixUri`
 
 # 0.12.1
 

--- a/crates/ruma-common/src/identifiers/matrix_uri.rs
+++ b/crates/ruma-common/src/identifiers/matrix_uri.rs
@@ -259,7 +259,7 @@ impl From<(&RoomAliasId, &EventId)> for MatrixId {
 /// in a formatting macro or via `.to_string()`).
 ///
 /// [`matrix.to` URI]: https://spec.matrix.org/latest/appendices/#matrixto-navigation
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MatrixToUri {
     id: MatrixId,
     via: Vec<OwnedServerName>,
@@ -443,7 +443,7 @@ impl From<Box<str>> for UriAction {
 /// in a formatting macro or via `.to_string()`).
 ///
 /// [`matrix:` URI]: https://spec.matrix.org/latest/appendices/#matrix-uri-scheme
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MatrixUri {
     id: MatrixId,
     via: Vec<OwnedServerName>,


### PR DESCRIPTION
I do not see a reason why a user should not be allowed to clone them.




<!-- Replace -->
----
Preview Removed
<!-- Replace -->
