### PR TITLE
state-res: perform extra redaction checks for v1 and v2 rooms rather than v3+

### DIFF
--- a/crates/ruma-state-res/CHANGELOG.md
+++ b/crates/ruma-state-res/CHANGELOG.md
@@ -5,6 +5,8 @@ Bug fixes:
 * Disallow `invite` -> `knock` membership transition
   * The spec was determined to be right about rejecting it in the first place:
     <https://github.com/matrix-org/matrix-spec/pull/1717>
+* Perform extra redaction checks on room versions 1 and 2, rather than for
+  version 3 and onwards
 
 # 0.10.0
 

--- a/crates/ruma-state-res/src/room_version.rs
+++ b/crates/ruma-state-res/src/room_version.rs
@@ -90,7 +90,7 @@ impl RoomVersion {
         special_case_aliases_auth: true,
         strict_canonicaljson: false,
         limit_notifications_power_levels: false,
-        extra_redaction_checks: false,
+        extra_redaction_checks: true,
         allow_knocking: false,
         restricted_join_rules: false,
         knock_restricted_join_rule: false,
@@ -101,7 +101,7 @@ impl RoomVersion {
     pub const V2: Self = Self { state_res: StateResolutionVersion::V2, ..Self::V1 };
 
     pub const V3: Self =
-        Self { event_format: EventFormatVersion::V2, extra_redaction_checks: true, ..Self::V2 };
+        Self { event_format: EventFormatVersion::V2, extra_redaction_checks: false, ..Self::V2 };
 
     pub const V4: Self = Self { event_format: EventFormatVersion::V3, ..Self::V3 };
 


### PR DESCRIPTION
See: https://spec.matrix.org/v1.10/rooms/v3/#handling-redactions
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
