### PR TITLE
client-api: Don't skip all no-event timelines when serializing sync response

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -4,6 +4,8 @@ Bug fixes:
 
 - Don't require the `failures` field in the
   `ruma_client_api::keys::upload_signatures::Response` type.
+- `sync::sync_events::v3::Timeline::is_empty` now returns `false` when the
+  `limited` or `prev_batch` fields are set.
 
 Breaking changes:
 

--- a/crates/ruma-client-api/src/sync/sync_events/v3.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v3.rs
@@ -360,8 +360,11 @@ impl Timeline {
     }
 
     /// Returns true if there are no timeline updates.
+    ///
+    /// A `Timeline` is considered non-empty if it has at least one event, a
+    /// `prev_batch` value, or `limited` is `true`.
     pub fn is_empty(&self) -> bool {
-        self.events.is_empty()
+        !self.limited && self.prev_batch.is_none() && self.events.is_empty()
     }
 }
 

--- a/crates/ruma-client-api/src/sync/sync_events/v3.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v3.rs
@@ -349,7 +349,6 @@ pub struct Timeline {
     pub prev_batch: Option<String>,
 
     /// A list of events.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub events: Vec<Raw<AnySyncTimelineEvent>>,
 }
 
@@ -606,16 +605,17 @@ mod tests {
     #[test]
     fn timeline_serde() {
         let timeline = assign!(Timeline::new(), { limited: true });
-        let timeline_serialized = json!({ "limited": true });
+        let timeline_serialized = json!({ "events": [], "limited": true });
         assert_eq!(to_json_value(timeline).unwrap(), timeline_serialized);
 
         let timeline_deserialized = from_json_value::<Timeline>(timeline_serialized).unwrap();
         assert!(timeline_deserialized.limited);
 
         let timeline_default = Timeline::default();
-        assert_eq!(to_json_value(timeline_default).unwrap(), json!({}));
+        assert_eq!(to_json_value(timeline_default).unwrap(), json!({ "events": [] }));
 
-        let timeline_default_deserialized = from_json_value::<Timeline>(json!({})).unwrap();
+        let timeline_default_deserialized =
+            from_json_value::<Timeline>(json!({ "events": [] })).unwrap();
         assert!(!timeline_default_deserialized.limited);
     }
 }


### PR DESCRIPTION
There are some cases where a timeline can have zero events but should still be included in the api response. For example, when calling `/sync` with a filter that rejects all events after `since`, but does not necessarily reject all events in the room's history, the response should include a `prev_batch` field so that the client can search for earlier events matching the filter using `/messages`.

The way I fixed this here is to change the semantics of the `Timeline::is_empty` method, but if we want to avoid the breaking change we could instead add a new method.