### PR TITLE
client-api: Make `get_uiaa_fallback::v3::Response` an enum

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -20,7 +20,10 @@ Breaking changes:
   constructed with `ErrorKind::forbidden()`.
 - The `retry_after_ms` field of `ErrorKind::LimitExceeded` was renamed to
   `retry_after` and is now an `Option<RetryAfter>`, to add support for the
-  Retry-After header, according to MSC4041 / Matrix 1.10 
+  Retry-After header, according to MSC4041 / Matrix 1.10
+- Make `get_uiaa_fallback::v3::Response` an enum for a redirect or an HTML page.
+  It will now return the proper status code and headers depending on the variant
+  used.
 
 Improvements:
 

--- a/crates/ruma-client-api/src/uiaa/get_uiaa_fallback_page.rs
+++ b/crates/ruma-client-api/src/uiaa/get_uiaa_fallback_page.rs
@@ -43,7 +43,7 @@ pub mod v3 {
 
     /// Response type for the `authorize_fallback` endpoint.
     #[derive(Debug, Clone)]
-    #[non_exhaustive]
+    #[allow(clippy::exhaustive_enums)]
     pub enum Response {
         /// The response is a redirect.
         Redirect(Redirect),
@@ -54,7 +54,7 @@ pub mod v3 {
 
     /// The data of a redirect.
     #[derive(Debug, Clone)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     pub struct Redirect {
         /// The URL to redirect the user to.
         pub url: String,
@@ -62,7 +62,7 @@ pub mod v3 {
 
     /// The data of a HTML page.
     #[derive(Debug, Clone)]
-    #[non_exhaustive]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     pub struct HtmlPage {
         /// The body of the HTML page.
         pub body: Vec<u8>,

--- a/crates/ruma-client-api/src/uiaa/get_uiaa_fallback_page.rs
+++ b/crates/ruma-client-api/src/uiaa/get_uiaa_fallback_page.rs
@@ -7,9 +7,8 @@ pub mod v3 {
     //!
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#fallback
 
-    use http::header::LOCATION;
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, Metadata},
         metadata,
     };
 
@@ -35,19 +34,6 @@ pub mod v3 {
         pub session: String,
     }
 
-    /// Response type for the `authorize_fallback` endpoint.
-    #[response(error = crate::Error)]
-    #[derive(Default)]
-    pub struct Response {
-        /// Optional URI to redirect to.
-        #[ruma_api(header = LOCATION)]
-        pub redirect_url: Option<String>,
-
-        /// HTML to return to client.
-        #[ruma_api(raw_body)]
-        pub body: Vec<u8>,
-    }
-
     impl Request {
         /// Creates a new `Request` with the given auth type and session ID.
         pub fn new(auth_type: String, session: String) -> Self {
@@ -55,15 +41,172 @@ pub mod v3 {
         }
     }
 
+    /// Response type for the `authorize_fallback` endpoint.
+    #[derive(Debug, Clone)]
+    #[non_exhaustive]
+    pub enum Response {
+        /// The response is a redirect.
+        Redirect(Redirect),
+
+        /// The response is an HTML page.
+        Html(HtmlPage),
+    }
+
+    /// The data of a redirect.
+    #[derive(Debug, Clone)]
+    #[non_exhaustive]
+    pub struct Redirect {
+        /// The URL to redirect the user to.
+        pub url: String,
+    }
+
+    /// The data of a HTML page.
+    #[derive(Debug, Clone)]
+    #[non_exhaustive]
+    pub struct HtmlPage {
+        /// The body of the HTML page.
+        pub body: Vec<u8>,
+    }
+
     impl Response {
-        /// Creates a new `Response` with the given HTML body.
-        pub fn new(body: Vec<u8>) -> Self {
-            Self { redirect_url: None, body }
+        /// Creates a new HTML `Response` with the given HTML body.
+        pub fn html(body: Vec<u8>) -> Self {
+            Self::Html(HtmlPage { body })
         }
 
-        /// Creates a new `Response` with the given redirect URL and an empty body.
+        /// Creates a new HTML `Response` with the given redirect URL.
         pub fn redirect(url: String) -> Self {
-            Self { redirect_url: Some(url), body: Vec::new() }
+            Self::Redirect(Redirect { url })
+        }
+    }
+
+    #[cfg(feature = "server")]
+    impl ruma_common::api::OutgoingResponse for Response {
+        fn try_into_http_response<T: Default + bytes::BufMut>(
+            self,
+        ) -> Result<http::Response<T>, ruma_common::api::error::IntoHttpError> {
+            match self {
+                Response::Redirect(Redirect { url }) => Ok(http::Response::builder()
+                    .status(http::StatusCode::FOUND)
+                    .header(http::header::LOCATION, url)
+                    .body(T::default())?),
+                Response::Html(HtmlPage { body }) => Ok(http::Response::builder()
+                    .status(http::StatusCode::OK)
+                    .header(http::header::CONTENT_TYPE, "text/html")
+                    .body(ruma_common::serde::slice_to_buf(&body))?),
+            }
+        }
+    }
+
+    #[cfg(feature = "client")]
+    impl ruma_common::api::IncomingResponse for Response {
+        type EndpointError = crate::Error;
+
+        fn try_from_http_response<T: AsRef<[u8]>>(
+            response: http::Response<T>,
+        ) -> Result<Self, ruma_common::api::error::FromHttpResponseError<Self::EndpointError>>
+        {
+            use ruma_common::api::{
+                error::{DeserializationError, FromHttpResponseError},
+                EndpointError,
+            };
+
+            if response.status().as_u16() >= 400 {
+                return Err(FromHttpResponseError::Server(
+                    Self::EndpointError::from_http_response(response),
+                ));
+            }
+
+            if let Some(location) = response.headers().get(http::header::LOCATION) {
+                let url = location.to_str()?;
+                return Ok(Self::Redirect(Redirect { url: url.to_owned() }));
+            }
+
+            if response
+                .headers()
+                .get(http::header::CONTENT_TYPE)
+                .and_then(|value| value.to_str().ok())
+                .is_some_and(|content_type| content_type == "text/html")
+            {
+                let body = response.into_body().as_ref().to_owned();
+                return Ok(Self::Html(HtmlPage { body }));
+            }
+
+            Err(FromHttpResponseError::Deserialization(DeserializationError::UnknownVariant))
+        }
+    }
+
+    #[cfg(all(test, any(feature = "client", feature = "server")))]
+    mod tests {
+        use assert_matches2::assert_matches;
+        use http::header::{CONTENT_TYPE, LOCATION};
+        #[cfg(feature = "client")]
+        use ruma_common::api::IncomingResponse;
+        #[cfg(feature = "server")]
+        use ruma_common::api::OutgoingResponse;
+
+        use super::Response;
+
+        #[cfg(feature = "client")]
+        #[test]
+        fn incoming_redirect() {
+            use super::Redirect;
+
+            let http_response = http::Response::builder()
+                .status(http::StatusCode::FOUND)
+                .header(LOCATION, "http://localhost/redirect")
+                .body(Vec::<u8>::new())
+                .unwrap();
+
+            let response = Response::try_from_http_response(http_response).unwrap();
+            assert_matches!(response, Response::Redirect(Redirect { url }));
+            assert_eq!(url, "http://localhost/redirect");
+        }
+
+        #[cfg(feature = "client")]
+        #[test]
+        fn incoming_html() {
+            use super::HtmlPage;
+
+            let http_response = http::Response::builder()
+                .status(http::StatusCode::OK)
+                .header(CONTENT_TYPE, "text/html")
+                .body(b"<h1>My Page</h1>")
+                .unwrap();
+
+            let response = Response::try_from_http_response(http_response).unwrap();
+            assert_matches!(response, Response::Html(HtmlPage { body }));
+            assert_eq!(body, b"<h1>My Page</h1>");
+        }
+
+        #[cfg(feature = "server")]
+        #[test]
+        fn outgoing_redirect() {
+            let response = Response::redirect("http://localhost/redirect".to_owned());
+
+            let http_response = response.try_into_http_response::<Vec<u8>>().unwrap();
+
+            assert_eq!(http_response.status(), http::StatusCode::FOUND);
+            assert_eq!(
+                http_response.headers().get(LOCATION).unwrap().to_str().unwrap(),
+                "http://localhost/redirect"
+            );
+            assert!(http_response.into_body().is_empty());
+        }
+
+        #[cfg(feature = "server")]
+        #[test]
+        fn outgoing_html() {
+            let response = Response::html(b"<h1>My Page</h1>".to_vec());
+
+            let http_response = response.try_into_http_response::<Vec<u8>>().unwrap();
+
+            assert_eq!(http_response.status(), http::StatusCode::OK);
+            assert_eq!(
+                http_response.headers().get(CONTENT_TYPE).unwrap().to_str().unwrap(),
+                "text/html"
+            );
+            assert_eq!(http_response.into_body(), b"<h1>My Page</h1>");
         }
     }
 }

--- a/crates/ruma-client-api/src/uiaa/get_uiaa_fallback_page.rs
+++ b/crates/ruma-client-api/src/uiaa/get_uiaa_fallback_page.rs
@@ -92,7 +92,7 @@ pub mod v3 {
                     .body(T::default())?),
                 Response::Html(HtmlPage { body }) => Ok(http::Response::builder()
                     .status(http::StatusCode::OK)
-                    .header(http::header::CONTENT_TYPE, "text/html")
+                    .header(http::header::CONTENT_TYPE, "text/html; charset=utf-8")
                     .body(ruma_common::serde::slice_to_buf(&body))?),
             }
         }
@@ -170,7 +170,7 @@ pub mod v3 {
 
             let http_response = http::Response::builder()
                 .status(http::StatusCode::OK)
-                .header(CONTENT_TYPE, "text/html")
+                .header(CONTENT_TYPE, "text/html; charset=utf-8")
                 .body(b"<h1>My Page</h1>")
                 .unwrap();
 
@@ -204,7 +204,7 @@ pub mod v3 {
             assert_eq!(http_response.status(), http::StatusCode::OK);
             assert_eq!(
                 http_response.headers().get(CONTENT_TYPE).unwrap().to_str().unwrap(),
-                "text/html"
+                "text/html; charset=utf-8"
             );
             assert_eq!(http_response.into_body(), b"<h1>My Page</h1>");
         }

--- a/crates/ruma-client-api/src/uiaa/get_uiaa_fallback_page.rs
+++ b/crates/ruma-client-api/src/uiaa/get_uiaa_fallback_page.rs
@@ -131,18 +131,8 @@ pub mod v3 {
                 return Ok(Self::Redirect(Redirect { url: url.to_owned() }));
             }
 
-            if response
-                .headers()
-                .get(http::header::CONTENT_TYPE)
-                .map(|value| value.to_str())
-                .transpose()?
-                .is_some_and(|content_type| content_type == "text/html")
-            {
-                let body = response.into_body().as_ref().to_owned();
-                return Ok(Self::Html(HtmlPage { body }));
-            }
-
-            Err(DeserializationError::UnknownVariant.into())
+            let body = response.into_body().as_ref().to_owned();
+            Ok(Self::Html(HtmlPage { body }))
         }
     }
 

--- a/crates/ruma-common/src/api/error.rs
+++ b/crates/ruma-common/src/api/error.rs
@@ -244,6 +244,10 @@ pub enum DeserializationError {
     /// Header value deserialization failed.
     #[error(transparent)]
     Header(#[from] HeaderDeserializationError),
+
+    /// The response is an enum and it cannot be deserialized to one of its variants.
+    #[error("unknown variant")]
+    UnknownVariant,
 }
 
 impl From<std::convert::Infallible> for DeserializationError {

--- a/crates/ruma-common/src/api/error.rs
+++ b/crates/ruma-common/src/api/error.rs
@@ -244,10 +244,6 @@ pub enum DeserializationError {
     /// Header value deserialization failed.
     #[error(transparent)]
     Header(#[from] HeaderDeserializationError),
-
-    /// The response is an enum and it cannot be deserialized to one of its variants.
-    #[error("unknown variant")]
-    UnknownVariant,
 }
 
 impl From<std::convert::Infallible> for DeserializationError {


### PR DESCRIPTION
It is now either a redirect or a HTML page, with the proper status code, headers and body.

Supersedes #1788.