### PR TITLE
client-api: Return proper content type in `login_fallback::Response`

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -6,6 +6,7 @@ Bug fixes:
   `ruma_client_api::keys::upload_signatures::Response` type.
 - `sync::sync_events::v3::Timeline::is_empty` now returns `false` when the
   `limited` or `prev_batch` fields are set.
+- `login_fallback::Response` now returns the proper content type
 
 Breaking changes:
 

--- a/crates/ruma-client-api/src/session/login_fallback.rs
+++ b/crates/ruma-client-api/src/session/login_fallback.rs
@@ -5,7 +5,7 @@
 //! [spec]: https://spec.matrix.org/latest/client-server-api/#login-fallback
 
 use ruma_common::{
-    api::{request, response, Metadata},
+    api::{request, Metadata},
     metadata, OwnedDeviceId,
 };
 
@@ -35,14 +35,6 @@ pub struct Request {
     pub initial_device_display_name: Option<String>,
 }
 
-/// Response type for the `login_fallback` endpoint.
-#[response(error = crate::Error)]
-pub struct Response {
-    /// HTML to return to client.
-    #[ruma_api(raw_body)]
-    pub body: Vec<u8>,
-}
-
 impl Request {
     /// Creates a new `Request` with the given auth type and session ID.
     pub fn new(
@@ -53,9 +45,49 @@ impl Request {
     }
 }
 
+/// Response type for the `login_fallback` endpoint.
+#[derive(Debug, Clone)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+pub struct Response {
+    /// HTML to return to client.
+    pub body: Vec<u8>,
+}
+
 impl Response {
     /// Creates a new `Response` with the given HTML body.
     pub fn new(body: Vec<u8>) -> Self {
         Self { body }
+    }
+}
+
+#[cfg(feature = "server")]
+impl ruma_common::api::OutgoingResponse for Response {
+    fn try_into_http_response<T: Default + bytes::BufMut>(
+        self,
+    ) -> Result<http::Response<T>, ruma_common::api::error::IntoHttpError> {
+        Ok(http::Response::builder()
+            .status(http::StatusCode::OK)
+            .header(http::header::CONTENT_TYPE, "text/html")
+            .body(ruma_common::serde::slice_to_buf(&self.body))?)
+    }
+}
+
+#[cfg(feature = "client")]
+impl ruma_common::api::IncomingResponse for Response {
+    type EndpointError = crate::Error;
+
+    fn try_from_http_response<T: AsRef<[u8]>>(
+        response: http::Response<T>,
+    ) -> Result<Self, ruma_common::api::error::FromHttpResponseError<Self::EndpointError>> {
+        use ruma_common::api::{error::FromHttpResponseError, EndpointError};
+
+        if response.status().as_u16() >= 400 {
+            return Err(FromHttpResponseError::Server(Self::EndpointError::from_http_response(
+                response,
+            )));
+        }
+
+        let body = response.into_body().as_ref().to_owned();
+        Ok(Self { body })
     }
 }


### PR DESCRIPTION
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
