### PR TITLE
client-api: Return proper status code for SSO login endpoints

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -7,6 +7,7 @@ Bug fixes:
 - `sync::sync_events::v3::Timeline::is_empty` now returns `false` when the
   `limited` or `prev_batch` fields are set.
 - `login_fallback::Response` now returns the proper content type
+- `sso_login[_with_provider]` responses now use the proper HTTP status code.
 
 Breaking changes:
 

--- a/crates/ruma-client-api/src/session/sso_login.rs
+++ b/crates/ruma-client-api/src/session/sso_login.rs
@@ -32,7 +32,7 @@ pub mod v3 {
     }
 
     /// Response type for the `sso_login` endpoint.
-    #[response(error = crate::Error)]
+    #[response(error = crate::Error, status = FOUND)]
     pub struct Response {
         /// Redirect URL to the SSO identity provider.
         #[ruma_api(header = LOCATION)]

--- a/crates/ruma-client-api/src/session/sso_login_with_provider.rs
+++ b/crates/ruma-client-api/src/session/sso_login_with_provider.rs
@@ -38,7 +38,7 @@ pub mod v3 {
     }
 
     /// Response type for the `sso_login_with_provider` endpoint.
-    #[response(error = crate::Error)]
+    #[response(error = crate::Error, status = FOUND)]
     pub struct Response {
         /// Redirect URL to the SSO identity provider.
         #[ruma_api(header = LOCATION)]


### PR DESCRIPTION
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
