### PR TITLE
 client-api: Add support for MSC4108 OIDC sign in and E2EE set up via QR code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ serde_html_form = "0.2.0"
 serde_json = "1.0.87"
 thiserror = "1.0.37"
 tracing = { version = "0.1.37", default-features = false, features = ["std"] }
+url = { version = "2.5.0" }
 web-time = "1.1.0"
 
 [profile.dev]

--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [unreleased]
 
+Improvements:
+
+- Add support for MSC4108 OIDC sign in and E2EE set up via QR code
+
 # 0.18.0
 
 Bug fixes:

--- a/crates/ruma-client-api/Cargo.toml
+++ b/crates/ruma-client-api/Cargo.toml
@@ -50,6 +50,7 @@ unstable-msc3575 = []
 unstable-msc3814 = []
 unstable-msc3843 = []
 unstable-msc3983 = []
+unstable-msc4108 = []
 unstable-msc4121 = []
 
 [dependencies]
@@ -67,6 +68,7 @@ serde = { workspace = true }
 serde_html_form = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+url = { workspace = true, features = ["serde"] }
 web-time = { workspace = true }
 
 [dev-dependencies]

--- a/crates/ruma-client-api/src/lib.rs
+++ b/crates/ruma-client-api/src/lib.rs
@@ -35,6 +35,8 @@ pub mod read_marker;
 pub mod receipt;
 pub mod redact;
 pub mod relations;
+#[cfg(feature = "unstable-msc4108")]
+pub mod rendezvous;
 pub mod room;
 pub mod search;
 pub mod server;

--- a/crates/ruma-client-api/src/rendezvous.rs
+++ b/crates/ruma-client-api/src/rendezvous.rs
@@ -1,0 +1,3 @@
+//! Endpoints for managing rendezvous sessions.
+
+pub mod create_rendezvous_session;

--- a/crates/ruma-client-api/src/rendezvous/create_rendezvous_session.rs
+++ b/crates/ruma-client-api/src/rendezvous/create_rendezvous_session.rs
@@ -1,0 +1,207 @@
+//! `POST /_matrix/client/*/rendezvous/`
+//!
+//! Create a rendezvous session.
+
+pub mod unstable {
+    //! `msc4108` ([MSC])
+    //!
+    //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/4108
+
+    use http::{
+        header::{CONTENT_LENGTH, CONTENT_TYPE, ETAG, EXPIRES, LAST_MODIFIED},
+        HeaderName,
+    };
+    #[cfg(feature = "client")]
+    use ruma_common::api::error::FromHttpResponseError;
+    use ruma_common::{
+        api::{error::HeaderDeserializationError, Metadata},
+        metadata,
+    };
+    use serde::{Deserialize, Serialize};
+    use url::Url;
+    use web_time::SystemTime;
+
+    const METADATA: Metadata = metadata! {
+        method: POST,
+        rate_limited: true,
+        authentication: None,
+        history: {
+            unstable => "/_matrix/client/unstable/org.matrix.msc4108/rendezvous",
+        }
+    };
+
+    /// Request type for the `POST` `rendezvous` endpoint.
+    #[derive(Debug, Default, Clone)]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+    pub struct Request {
+        /// Any data up to maximum size allowed by the server.
+        pub content: String,
+    }
+
+    #[cfg(feature = "client")]
+    impl ruma_common::api::OutgoingRequest for Request {
+        type EndpointError = crate::Error;
+        type IncomingResponse = Response;
+        const METADATA: Metadata = METADATA;
+
+        fn try_into_http_request<T: Default + bytes::BufMut>(
+            self,
+            base_url: &str,
+            _: ruma_common::api::SendAccessToken<'_>,
+            considering_versions: &'_ [ruma_common::api::MatrixVersion],
+        ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
+            let url = METADATA.make_endpoint_url(considering_versions, base_url, &[], "")?;
+            let body = self.content.as_bytes();
+            let content_length = body.len();
+
+            Ok(http::Request::builder()
+                .method(METADATA.method)
+                .uri(url)
+                .header(CONTENT_TYPE, "text/plain")
+                .header(CONTENT_LENGTH, content_length)
+                .body(ruma_common::serde::slice_to_buf(body))?)
+        }
+    }
+
+    #[cfg(feature = "server")]
+    impl ruma_common::api::IncomingRequest for Request {
+        type EndpointError = crate::Error;
+        type OutgoingResponse = Response;
+        const METADATA: Metadata = METADATA;
+
+        fn try_from_http_request<B, S>(
+            request: http::Request<B>,
+            _path_args: &[S],
+        ) -> Result<Self, ruma_common::api::error::FromHttpRequestError>
+        where
+            B: AsRef<[u8]>,
+            S: AsRef<str>,
+        {
+            const EXPECTED_CONTENT_TYPE: &str = "text/plain";
+
+            use ruma_common::api::error::DeserializationError;
+
+            let content_type = request
+                .headers()
+                .get(CONTENT_TYPE)
+                .ok_or(HeaderDeserializationError::MissingHeader(CONTENT_TYPE.to_string()))?;
+
+            let content_type = content_type.to_str()?;
+
+            if content_type != EXPECTED_CONTENT_TYPE {
+                Err(HeaderDeserializationError::InvalidHeaderValue {
+                    header: CONTENT_TYPE.to_string(),
+                    expected: EXPECTED_CONTENT_TYPE.to_owned(),
+                    unexpected: content_type.to_owned(),
+                }
+                .into())
+            } else {
+                let body = request.into_body().as_ref().to_vec();
+                let content = String::from_utf8(body)
+                    .map_err(|e| DeserializationError::Utf8(e.utf8_error()))?;
+
+                Ok(Self { content })
+            }
+        }
+    }
+
+    impl Request {
+        /// Creates a new `Request` with the given content.
+        pub fn new(content: String) -> Self {
+            Self { content }
+        }
+    }
+
+    /// Response type for the `POST` `rendezvous` endpoint.
+    #[derive(Debug, Clone)]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+    pub struct Response {
+        /// The absolute URL of the rendezvous session.
+        pub url: Url,
+
+        /// ETag for the current payload at the rendezvous session as
+        /// per [RFC7232](https://httpwg.org/specs/rfc7232.html#header.etag).
+        pub etag: String,
+
+        /// The expiry time of the rendezvous as per
+        /// [RFC7234](https://httpwg.org/specs/rfc7234.html#header.expires).
+        pub expires: SystemTime,
+
+        /// The last modified date of the payload as
+        /// per [RFC7232](https://httpwg.org/specs/rfc7232.html#header.last-modified)
+        pub last_modified: SystemTime,
+    }
+
+    #[derive(Serialize, Deserialize)]
+    struct ResponseBody {
+        url: Url,
+    }
+
+    #[cfg(feature = "client")]
+    impl ruma_common::api::IncomingResponse for Response {
+        type EndpointError = crate::Error;
+
+        fn try_from_http_response<T: AsRef<[u8]>>(
+            response: http::Response<T>,
+        ) -> Result<Self, FromHttpResponseError<Self::EndpointError>> {
+            use ruma_common::api::EndpointError;
+
+            if response.status().as_u16() >= 400 {
+                return Err(FromHttpResponseError::Server(
+                    Self::EndpointError::from_http_response(response),
+                ));
+            }
+
+            let get_date = |header: HeaderName| -> Result<SystemTime, FromHttpResponseError<Self::EndpointError>> {
+                let date = response
+                    .headers()
+                    .get(&header)
+                    .ok_or_else(|| HeaderDeserializationError::MissingHeader(header.to_string()))?;
+
+                let date = crate::http_headers::http_date_to_system_time(date)?;
+
+                Ok(date)
+            };
+
+            let etag = response
+                .headers()
+                .get(ETAG)
+                .ok_or(HeaderDeserializationError::MissingHeader(ETAG.to_string()))?
+                .to_str()?
+                .to_owned();
+            let expires = get_date(EXPIRES)?;
+            let last_modified = get_date(LAST_MODIFIED)?;
+
+            let body = response.into_body();
+            let body: ResponseBody = serde_json::from_slice(body.as_ref())?;
+
+            Ok(Self { url: body.url, etag, expires, last_modified })
+        }
+    }
+
+    #[cfg(feature = "server")]
+    impl ruma_common::api::OutgoingResponse for Response {
+        fn try_into_http_response<T: Default + bytes::BufMut>(
+            self,
+        ) -> Result<http::Response<T>, ruma_common::api::error::IntoHttpError> {
+            use http::header::{CACHE_CONTROL, PRAGMA};
+
+            let body = ResponseBody { url: self.url.clone() };
+            let body = serde_json::to_vec(&body)?;
+            let body = ruma_common::serde::slice_to_buf(&body);
+
+            let expires = crate::http_headers::system_time_to_http_date(&self.expires)?;
+            let last_modified = crate::http_headers::system_time_to_http_date(&self.last_modified)?;
+
+            Ok(http::Response::builder()
+                .status(http::StatusCode::OK)
+                .header(CONTENT_TYPE, "application/json")
+                .header(PRAGMA, "no-cache")
+                .header(CACHE_CONTROL, "no-store")
+                .header(ETAG, self.etag)
+                .header(EXPIRES, expires)
+                .header(LAST_MODIFIED, last_modified)
+                .body(body)?)
+        }
+    }
+}

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [unreleased]
 
+Improvements:
+
+- Add the `InvalidHeaderValue` variant to the `DeserializationError` struct, for
+  cases where we receive a HTTP header with an unexpected value.
+
 # 0.13.0
 
 Bug fixes:

--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -75,7 +75,7 @@ serde_json = { workspace = true, features = ["raw_value"] }
 thiserror = { workspace = true }
 time = "0.3.34"
 tracing = { workspace = true, features = ["attributes"] }
-url = "2.2.2"
+url = { workspace = true }
 uuid = { version = "1.0.0", optional = true, features = ["v4"] }
 web-time = { workspace = true }
 wildmatch = "2.0.0"

--- a/crates/ruma-common/src/api/error.rs
+++ b/crates/ruma-common/src/api/error.rs
@@ -276,6 +276,20 @@ pub enum HeaderDeserializationError {
     /// The given required header is missing.
     #[error("missing header `{0}`")]
     MissingHeader(String),
+
+    /// A header was received with a unexpected value.
+    #[error(
+        "The {header} header was received with an unexpected value, \
+         expected {expected}, received {unexpected}"
+    )]
+    InvalidHeaderValue {
+        /// The name of the header containing the invalid value.
+        header: String,
+        /// The value the header should have been set to.
+        expected: String,
+        /// The value we instead received and rejected.
+        unexpected: String,
+    },
 }
 
 /// An error that happens when Ruma cannot understand a Matrix version.

--- a/crates/ruma-events/Cargo.toml
+++ b/crates/ruma-events/Cargo.toml
@@ -72,7 +72,7 @@ serde = { workspace = true }
 serde_json = { workspace = true, features = ["raw_value"] }
 thiserror = { workspace = true }
 tracing = { workspace = true, features = ["attributes"] }
-url = "2.2.2"
+url = { workspace = true }
 wildmatch = "2.0.0"
 
 # dev-dependencies can't be optional, so this is a regular dependency

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -222,6 +222,7 @@ unstable-msc3955 = ["ruma-events?/unstable-msc3955"]
 unstable-msc3956 = ["ruma-events?/unstable-msc3956"]
 unstable-msc3983 = ["ruma-client-api?/unstable-msc3983"]
 unstable-msc4075 = ["ruma-events?/unstable-msc4075"]
+unstable-msc4108 = ["ruma-client-api?/unstable-msc4108"]
 unstable-msc4121 = ["ruma-client-api?/unstable-msc4121"]
 unstable-msc4125 = ["ruma-federation-api?/unstable-msc4125"]
 unstable-pdu = ["ruma-events?/unstable-pdu"]
@@ -275,6 +276,7 @@ __ci = [
     "unstable-msc3956",
     "unstable-msc3983",
     "unstable-msc4075",
+    "unstable-msc4108",
     "unstable-msc4121",
     "unstable-msc4125",
 ]


### PR DESCRIPTION
This adds support to create a rendezvous channel from https://github.com/matrix-org/matrix-spec-proposals/pull/4108. The other rendezvous related request/response types were left out since they expect you to use the `url` from the create response verbatim, which doesn't quite fit into Ruma.

I'm also not quite sure if this is the best way of ensuring that the content-type is `text/plain`.