### PR TITLE
client-api: Add helper methods to convert `SystemTime` from/to a HTTP date

### DIFF
--- a/crates/ruma-client-api/src/http_headers.rs
+++ b/crates/ruma-client-api/src/http_headers.rs
@@ -1,10 +1,40 @@
-//! Custom HTTP headers not defined in the `http` crate.
+//! Helpers for HTTP headers with the `http` crate.
 #![allow(clippy::declare_interior_mutable_const)]
 
-use http::header::HeaderName;
+use http::{header::HeaderName, HeaderValue};
+use ruma_common::api::error::{HeaderDeserializationError, HeaderSerializationError};
+use web_time::{Duration, SystemTime, UNIX_EPOCH};
 
 /// The [`Cross-Origin-Resource-Policy`] HTTP response header.
 ///
 /// [`Cross-Origin-Resource-Policy`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Resource-Policy
 pub const CROSS_ORIGIN_RESOURCE_POLICY: HeaderName =
     HeaderName::from_static("cross-origin-resource-policy");
+
+/// Convert as `SystemTime` to a HTTP date header value.
+pub fn system_time_to_http_date(
+    time: &SystemTime,
+) -> Result<HeaderValue, HeaderSerializationError> {
+    let mut buffer = [0; 29];
+
+    let duration =
+        time.duration_since(UNIX_EPOCH).map_err(|_| HeaderSerializationError::InvalidHttpDate)?;
+    date_header::format(duration.as_secs(), &mut buffer)
+        .map_err(|_| HeaderSerializationError::InvalidHttpDate)?;
+
+    Ok(http::HeaderValue::from_bytes(&buffer)
+        .expect("date_header should produce a valid header value"))
+}
+
+/// Convert a header value representing a HTTP date to a `SystemTime`.
+pub fn http_date_to_system_time(
+    value: &HeaderValue,
+) -> Result<SystemTime, HeaderDeserializationError> {
+    let bytes = value.as_bytes();
+
+    let ts = date_header::parse(bytes).map_err(|_| HeaderDeserializationError::InvalidHttpDate)?;
+
+    UNIX_EPOCH
+        .checked_add(Duration::from_secs(ts))
+        .ok_or(HeaderDeserializationError::InvalidHttpDate)
+}

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -5,6 +5,7 @@ Bug fixes:
 - Allow to deserialize `Ruleset` with missing fields.
 
 Breaking changes:
+
 - The power levels fields in `PushConditionRoomCtx` are grouped in an optional `power_levels` field.
   If the field is missing, push rules that depend on it will never match. However, this allows to
   match the `.m.rule.invite_for_me` push rule because usually the `invite_state` doesn't include
@@ -14,6 +15,7 @@ Breaking changes:
 - `deserialize_as_f64_or_string` has been extended to also support parsing integers, and renamed to
   `deserialize_as_number_or_string` to reflect that.
 - The http crate had a major version bump to version 1.1
+- `IntoHttpError::Header` now contains a `HeaderSerializationError`
 
 Improvements:
 


### PR DESCRIPTION
This will help reuse the code in the future (like in #1800) for example.
