### PR TITLE
ci: Add lint to check if all sub-crates features can be enabled from ruma crate

### DIFF
--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -30,6 +30,7 @@ client-hyper = ["client", "ruma-client?/hyper"]
 client-hyper-native-tls = ["client", "ruma-client?/hyper-native-tls"]
 client-reqwest = ["client", "ruma-client?/reqwest"]
 client-reqwest-native-tls = ["client", "ruma-client?/reqwest-native-tls"]
+client-reqwest-native-tls-alpn = ["client", "ruma-client?/reqwest-native-tls-alpn"]
 client-reqwest-native-tls-vendored = ["client", "ruma-client?/reqwest-native-tls-vendored"]
 client-reqwest-rustls-manual-roots = ["client", "ruma-client?/reqwest-rustls-manual-roots"]
 client-reqwest-rustls-webpki-roots = ["client", "ruma-client?/reqwest-rustls-webpki-roots"]
@@ -164,6 +165,7 @@ unstable-exhaustive-types = [
     "ruma-federation-api?/unstable-exhaustive-types",
     "ruma-identity-service-api?/unstable-exhaustive-types",
     "ruma-push-gateway-api?/unstable-exhaustive-types",
+    "ruma-signatures?/unstable-exhaustive-types",
     "ruma-state-res?/unstable-exhaustive-types",
     "ruma-events?/unstable-exhaustive-types"
 ]

--- a/xtask/src/ci/reexport_features.rs
+++ b/xtask/src/ci/reexport_features.rs
@@ -1,0 +1,54 @@
+use crate::{Metadata, Result};
+
+/// Check that the ruma crate allows to enable all the features of the other ruma-* crates.
+///
+/// For simplicity, this function assumes that:
+///
+/// - Those dependencies are not renamed.
+/// - ruma does not use `default-features = false` on those dependencies.
+///
+/// This does not check if all features are re-exported individually, as that is not always wanted.
+pub(crate) fn check_reexport_features(metadata: &Metadata) -> Result<()> {
+    println!("Checking all features can be enabled from ruma…");
+    let mut n_errors = 0;
+
+    let Some(ruma) = metadata.find_package("ruma") else {
+        return Err("ruma package not found in workspace".into());
+    };
+
+    for package in ruma.dependencies.iter().filter_map(|dep| metadata.find_package(&dep.name)) {
+        println!("Checking features of {}…", package.name);
+
+        // Exclude ruma and xtask.
+        if !package.name.starts_with("ruma-") {
+            continue;
+        }
+
+        // Filter features that are enabled by other features of the same package.
+        let features = package.features.keys().filter(|feature_name| {
+            !package.features.values().flatten().any(|activated_feature| {
+                activated_feature.trim_start_matches("dep:") == *feature_name
+            })
+        });
+
+        for feature_name in features {
+            // Let's assume that ruma never has `default-features = false`.
+            if feature_name == "default" {
+                continue;
+            }
+
+            if !ruma.can_enable_feature(&package.name, feature_name) {
+                println!(r#"  Missing feature "{}/{feature_name}""#, package.name);
+                n_errors += 1;
+            }
+        }
+    }
+
+    if n_errors > 0 {
+        // Visual aid to separate the end error message.
+        println!();
+        return Err(format!("Found {n_errors} missing features").into());
+    }
+
+    Ok(())
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -17,7 +17,6 @@ use serde_json::from_str as from_json_str;
 // Keep in sync with version in `rust-toolchain.toml` and `.github/workflows/ci.yml`
 const NIGHTLY: &str = "nightly-2024-02-14";
 
-#[cfg(feature = "default")]
 mod cargo;
 mod ci;
 mod doc;
@@ -26,6 +25,7 @@ mod release;
 #[cfg(feature = "default")]
 mod util;
 
+use cargo::Package;
 use ci::{CiArgs, CiTask};
 use doc::DocTask;
 #[cfg(feature = "default")]
@@ -70,8 +70,7 @@ fn main() -> Result<()> {
 #[derive(Clone, Debug, Deserialize)]
 struct Metadata {
     pub workspace_root: PathBuf,
-    #[cfg(feature = "default")]
-    pub packages: Vec<cargo::Package>,
+    pub packages: Vec<Package>,
 }
 
 impl Metadata {
@@ -79,6 +78,11 @@ impl Metadata {
     pub fn load() -> Result<Metadata> {
         let metadata_json = cmd!("cargo metadata --no-deps --format-version 1").read()?;
         Ok(from_json_str(&metadata_json)?)
+    }
+
+    /// Find the package with the given name.
+    pub fn find_package(&self, name: &str) -> Option<&Package> {
+        self.packages.iter().find(|p| p.name == name)
     }
 }
 


### PR DESCRIPTION
Part of #867.

This could be improved, if for example we want to make sure that all `unstable-msc*` features are re-exported individually. This is not the case currently because some MSCs can be dependencies of other MSCs.