### PR TITLE
signatures: use OwnedKeyId instead of String for PublicKeySet index

### DIFF
--- a/crates/ruma-signatures/CHANGELOG.md
+++ b/crates/ruma-signatures/CHANGELOG.md
@@ -1,5 +1,8 @@
 # [unreleased]
 
+Breaking changes:
+- Use `OwnedServerSigningKeyId` for the keys of `PublicKeySet`  instead of `String`.
+
 # 0.15.0
 
 No changes for this version

--- a/crates/ruma-signatures/src/keys.rs
+++ b/crates/ruma-signatures/src/keys.rs
@@ -9,7 +9,7 @@ use ed25519_dalek::{pkcs8::ALGORITHM_OID, SecretKey, Signer, SigningKey, PUBLIC_
 use pkcs8::{
     der::zeroize::Zeroizing, DecodePrivateKey, EncodePrivateKey, ObjectIdentifier, PrivateKeyInfo,
 };
-use ruma_common::serde::Base64;
+use ruma_common::{serde::Base64, OwnedServerSigningKeyId};
 
 use crate::{signatures::Signature, Algorithm, Error, ParseError};
 
@@ -181,7 +181,7 @@ pub type PublicKeyMap = BTreeMap<String, PublicKeySet>;
 /// A set of public keys for a single homeserver.
 ///
 /// This is represented as a map from key ID to base64-encoded signature.
-pub type PublicKeySet = BTreeMap<String, Base64>;
+pub type PublicKeySet = BTreeMap<OwnedServerSigningKeyId, Base64>;
 
 #[cfg(test)]
 mod tests {

--- a/crates/ruma-signatures/src/lib.rs
+++ b/crates/ruma-signatures/src/lib.rs
@@ -111,6 +111,7 @@ mod tests {
 
     use pkcs8::{der::Decode, PrivateKeyInfo};
     use ruma_common::{
+        owned_server_signing_key_id,
         serde::{base64::Standard, Base64},
         RoomVersionId,
     };
@@ -248,7 +249,7 @@ mod tests {
         let value = from_json_str(r#"{"signatures":{"domain":{"ed25519:1":"lXjsnvhVlz8t3etR+6AEJ0IT70WujeHC1CFjDDsVx0xSig1Bx7lvoi1x3j/2/GPNjQM4a2gD34UqsXFluaQEBA"}}}"#).unwrap();
 
         let mut signature_set = BTreeMap::new();
-        signature_set.insert("ed25519:1".into(), public_key_string());
+        signature_set.insert(owned_server_signing_key_id!("ed25519:1"), public_key_string());
 
         let mut public_key_map = BTreeMap::new();
         public_key_map.insert("domain".into(), signature_set);
@@ -285,7 +286,7 @@ mod tests {
         ).unwrap();
 
         let mut signature_set = BTreeMap::new();
-        signature_set.insert("ed25519:1".into(), public_key_string());
+        signature_set.insert(owned_server_signing_key_id!("ed25519:1"), public_key_string());
 
         let mut public_key_map = BTreeMap::new();
         public_key_map.insert("domain".into(), signature_set);
@@ -304,7 +305,7 @@ mod tests {
         let value = from_json_str(r#"{"not":"empty","signatures":{"domain":"lXjsnvhVlz8t3etR+6AEJ0IT70WujeHC1CFjDDsVx0xSig1Bx7lvoi1x3j/2/GPNjQM4a2gD34UqsXFluaQEBA"}}"#).unwrap();
 
         let mut signature_set = BTreeMap::new();
-        signature_set.insert("ed25519:1".into(), public_key_string());
+        signature_set.insert(owned_server_signing_key_id!("ed25519:1"), public_key_string());
 
         let mut public_key_map = BTreeMap::new();
         public_key_map.insert("domain".into(), signature_set);
@@ -374,7 +375,7 @@ mod tests {
     #[test]
     fn verify_minimal_event() {
         let mut signature_set = BTreeMap::new();
-        signature_set.insert("ed25519:1".into(), public_key_string());
+        signature_set.insert(owned_server_signing_key_id!("ed25519:1"), public_key_string());
 
         let mut public_key_map = BTreeMap::new();
         public_key_map.insert("domain".into(), signature_set);

--- a/crates/ruma-signatures/tests/tests.rs
+++ b/crates/ruma-signatures/tests/tests.rs
@@ -11,7 +11,7 @@ fn add_key_to_map(public_key_map: &mut PublicKeyMap, name: &str, pair: &Ed25519K
     let version =
         ServerSigningKeyId::from_parts(SigningKeyAlgorithm::Ed25519, pair.version().into());
 
-    sender_key_map.insert(version.to_string(), encoded_public_key);
+    sender_key_map.insert(version, encoded_public_key);
 }
 
 #[test]


### PR DESCRIPTION
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
