### PR TITLE
events: Move all methods to construct a relation to `RoomMessageEventContentWithoutRelation`

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [unreleased]
 
+Improvements:
+
+- Implement `make_for_thread` and `make_replacement` for
+  `RoomMessageEventContentWithoutRelation`
+
 # 0.28.0
 
 Bug fixes:


### PR DESCRIPTION
Allows to have a more streamlined experience when constructing messages with relations, by avoiding to have to use a different type depending on the type of relation.

Would allow the SDK to always take a `RoomMessageEventContentWithoutRelation` when sending messages with relations.