### PR TITLE
events: Handle existing mentions in `make_replacement`

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -4,6 +4,8 @@ Improvements:
 
 - Implement `make_for_thread` and `make_replacement` for
   `RoomMessageEventContentWithoutRelation`
+- `RoomMessageEventContent::set_mentions` is deprecated and replaced by
+  `add_mentions` that should be called before `make_replacement`.
 
 # 0.28.0
 

--- a/crates/ruma-events/src/room/message.rs
+++ b/crates/ruma-events/src/room/message.rs
@@ -241,9 +241,9 @@ impl RoomMessageEventContent {
     /// `original_message`.
     #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/rich_reply.md"))]
     ///
-    /// If the message that is replaced contains [`Mentions`], they are copied into
-    /// `m.new_content` to keep the same mentions, but not into `content` to avoid repeated
-    /// notifications.
+    /// If this message contains [`Mentions`], they are copied into `m.new_content` to keep the same
+    /// mentions, but the ones in `content` are filtered with the ones in the
+    /// [`ReplacementMetadata`] so only new mentions will trigger a notification.
     ///
     /// # Panics
     ///
@@ -270,6 +270,7 @@ impl RoomMessageEventContent {
     /// used instead.
     ///
     /// [mentions]: https://spec.matrix.org/latest/client-server-api/#user-and-room-mentions
+    #[deprecated = "Call add_mentions before adding the relation instead."]
     pub fn set_mentions(mut self, mentions: Mentions) -> Self {
         if let Some(Relation::Replacement(replacement)) = &mut self.relates_to {
             let old_mentions = &replacement.new_content.mentions;
@@ -306,9 +307,8 @@ impl RoomMessageEventContent {
     /// mentions by extending the previous `user_ids` with the new ones, and applies a logical OR to
     /// the values of `room`.
     ///
-    /// This is recommended over [`Self::set_mentions()`] to avoid to overwrite any mentions set
-    /// automatically by another method, like [`Self::make_reply_to()`]. However, this method has no
-    /// special support for replacements.
+    /// This should be called before methods that add a relation, like [`Self::make_reply_to()`] and
+    /// [`Self::make_replacement()`], for the mentions to be correctly set.
     ///
     /// [mentions]: https://spec.matrix.org/latest/client-server-api/#user-and-room-mentions
     pub fn add_mentions(mut self, mentions: Mentions) -> Self {

--- a/crates/ruma-events/tests/it/room_message.rs
+++ b/crates/ruma-events/tests/it/room_message.rs
@@ -1164,6 +1164,7 @@ fn video_msgtype_deserialization() {
 }
 
 #[test]
+#[allow(deprecated)]
 fn set_mentions() {
     let mut content = RoomMessageEventContent::text_plain("you!");
     let mentions = content.mentions.take();
@@ -1176,7 +1177,7 @@ fn set_mentions() {
 }
 
 #[test]
-fn make_replacement_set_mentions() {
+fn make_replacement_add_mentions() {
     let alice = owned_user_id!("@alice:localhost");
     let bob = owned_user_id!("@bob:localhost");
     let original_message_json = json!({
@@ -1200,15 +1201,9 @@ fn make_replacement_set_mentions() {
         "This is _an edited_ message.",
         "This is <em>an edited</em> message.",
     );
+    content = content.add_mentions(Mentions::with_user_ids(vec![alice.clone(), bob.clone()]));
     content = content.make_replacement(&original_message, None);
-    let content_clone = content.clone();
 
-    assert_matches!(content.mentions, None);
-    assert_matches!(content.relates_to, Some(Relation::Replacement(replacement)));
-    let mentions = replacement.new_content.mentions.unwrap();
-    assert_eq!(mentions.user_ids, [alice.clone()].into());
-
-    content = content_clone.set_mentions(Mentions::with_user_ids(vec![alice.clone(), bob.clone()]));
     let mentions = content.mentions.unwrap();
     assert_eq!(mentions.user_ids, [bob.clone()].into());
     assert_matches!(content.relates_to, Some(Relation::Replacement(replacement)));


### PR DESCRIPTION
Based on #1810 (because of conflicts).

This allows to only use one method to add mentions, `add_mentions`. `set_mentions` is deprecated.

This is also necessary for the SDK that provides APIs to set the relation and send an event, so the mentions need to be added before that.