### PR TITLE
identifiers: Add signature-id compat mode for KeyId

### DIFF
--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -38,6 +38,10 @@ compat-arbitrary-length-ids = ["ruma-identifiers-validation/compat-arbitrary-len
 # Don't validate the version part in `KeyId`.
 compat-key-id = ["ruma-identifiers-validation/compat-key-id"]
 
+# Allow extra characters in the version part of `KeyId`. `compat-key-id` has
+# precedence over this.
+compat-signature-id = ["ruma-identifiers-validation/compat-signature-id"]
+
 # Allow some user IDs that are invalid even with the specified historical
 # user ID scheme.
 compat-user-id = ["ruma-identifiers-validation/compat-user-id"]

--- a/crates/ruma-identifiers-validation/Cargo.toml
+++ b/crates/ruma-identifiers-validation/Cargo.toml
@@ -18,6 +18,10 @@ compat-arbitrary-length-ids = []
 # Don't validate the version part in `key_id::validate`.
 compat-key-id = []
 
+# Allow extra characters in `key_id::validate`. `compat-key-id` has precedence
+# over this.
+compat-signature-id = []
+
 # Allow some user IDs that are invalid even with the specified historical
 # user ID scheme.
 compat-user-id = []

--- a/crates/ruma-identifiers-validation/src/key_id.rs
+++ b/crates/ruma-identifiers-validation/src/key_id.rs
@@ -16,9 +16,21 @@ pub fn validate(s: &str) -> Result<NonZeroU8, Error> {
 fn validate_version(version: &str) -> Result<(), Error> {
     if version.is_empty() {
         return Err(Error::Empty);
-    } else if !version.chars().all(|c| c.is_alphanumeric() || c == '_') {
+    }
+
+    if !version.chars().all(is_valid_version_char) {
         return Err(Error::InvalidCharacters);
     }
 
     Ok(())
+}
+
+#[cfg(not(feature = "compat-key-id"))]
+fn is_valid_version_char(c: char) -> bool {
+    let is_valid = c.is_alphanumeric() || c == '_';
+
+    #[cfg(feature = "compat-signature-id")]
+    let is_valid = is_valid || c == '+' || c = '/';
+
+    is_valid
 }

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -147,8 +147,12 @@ compat-get-3pids = ["ruma-client-api?/compat-get-3pids"]
 # since that's what Synapse sends.
 compat-upload-signatures = ["ruma-client-api?/compat-upload-signatures"]
 
-# Allow extra characters in signature IDs not allowed in the specification.
-compat-signature-id = ["ruma-signatures?/compat-signature-id"]
+# Allow extra characters in the version part of `KeyId`. `compat-key-id` has
+# precedence over this.
+compat-signature-id = [
+    "ruma-common/compat-signature-id",
+    "ruma-signatures?/compat-signature-id",
+]
 
 # Allow TagInfo to contain a stringified floating-point value for the `order` field.
 compat-tag-info = ["ruma-events?/compat-tag-info"]


### PR DESCRIPTION
Allows to replace `split_id` in ruma-signatures with `KeyId::parse` while having the exact same behavior.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
