### PR TITLE
 feat(client-api): `v4::SyncRequestList` has a new `include_heroes` field

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -3,6 +3,9 @@
 Improvements:
 
 - Add support for MSC4108 OIDC sign in and E2EE set up via QR code
+- Heroes in `sync::sync_events::v4`: `SyncRequestList` and `RoomSubscription`
+  both have a new `include_heroes` field. `SlidingSyncRoom` has a new `heroes`
+  field, with a new type `SlidingSyncRoomHero`.
 
 # 0.18.0
 

--- a/crates/ruma-client-api/src/sync/sync_events/v4.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v4.rs
@@ -298,7 +298,7 @@ pub struct SyncRequestList {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub include_old_rooms: Option<IncludeOldRooms>,
 
-    /// Return a stripped variant of membership events for the users used to calculate the room
+    /// Request a stripped variant of membership events for the users used to calculate the room
     /// name.
     ///
     /// Sticky.

--- a/crates/ruma-client-api/src/sync/sync_events/v4.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v4.rs
@@ -294,9 +294,16 @@ pub struct SyncRequestList {
     #[serde(flatten)]
     pub room_details: RoomDetailsConfig,
 
-    /// If tombstoned rooms should be returned and if so, with what information attached
+    /// If tombstoned rooms should be returned and if so, with what information attached.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub include_old_rooms: Option<IncludeOldRooms>,
+
+    /// Return a stripped variant of membership events for the users used to calculate the room
+    /// name.
+    ///
+    /// Sticky.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub include_heroes: Option<bool>,
 
     /// Filters to apply to the list before sorting. Sticky.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/ruma-client-api/src/sync/sync_events/v4.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v4.rs
@@ -512,7 +512,7 @@ pub struct SlidingSyncRoomHero {
     pub user_id: Option<OwnedUserId>,
 
     /// The name of the hero.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "displayname", skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 
     /// The avatar of the hero.


### PR DESCRIPTION
This patch is twofold:

* It adds `v4::SyncRequestList::include_heroes`
* It renames `v4::SyncSyncRoomHero::name` to `displayname` when seriarializing or deserializing.