### PR TITLE
client-api: `RoomSummary::heroes` must be `OwnedUserId`s, in fact

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -36,6 +36,8 @@ Breaking changes:
   It will now return the proper status code and headers depending on the variant
   used.
 - The http crate had a major version bump to version 1.1
+- `RoomSummary::heroes` now properly contains only `UserId` instead of `String`
+  as before.
 
 Improvements:
 

--- a/crates/ruma-client-api/src/sync/sync_events/v3.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v3.rs
@@ -10,7 +10,7 @@ use ruma_common::{
     metadata,
     presence::PresenceState,
     serde::Raw,
-    DeviceKeyAlgorithm, OwnedEventId, OwnedRoomId,
+    DeviceKeyAlgorithm, OwnedEventId, OwnedRoomId, OwnedUserId,
 };
 use ruma_events::{
     presence::PresenceEvent, AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent,
@@ -470,7 +470,7 @@ pub struct RoomSummary {
     ///
     /// Required if room name or canonical aliases are not set or empty.
     #[serde(rename = "m.heroes", default, skip_serializing_if = "Vec::is_empty")]
-    pub heroes: Vec<String>,
+    pub heroes: Vec<OwnedUserId>,
 
     /// Number of users whose membership status is `join`.
     /// Required if field has changed since last sync; otherwise, it may be


### PR DESCRIPTION
This is imprecise from the spec wording [1], apart from a hint [2], but these should really be user ids. In practice, this is what Synapse returns too

[1] https://spec.matrix.org/latest/client-server-api/#_matrixclientv3sync_roomsummary
[2] "The list must never include the client’s own user ID."
