### PR TITLE
client-api: Fix position of entry in changelog

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [unreleased]
 
+Breaking changes:
+
+- `RoomSummary::heroes` now properly contains only `UserId` instead of `String`
+  as before.
+
 Improvements:
 
 - Add support for MSC4108 OIDC sign in and E2EE set up via QR code
@@ -36,8 +41,6 @@ Breaking changes:
   It will now return the proper status code and headers depending on the variant
   used.
 - The http crate had a major version bump to version 1.1
-- `RoomSummary::heroes` now properly contains only `UserId` instead of `String`
-  as before.
 
 Improvements:
 


### PR DESCRIPTION
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
