### PR TITLE
server-util: make destination parameter of XMatrix::new mandatory

### DIFF
--- a/crates/ruma-server-util/CHANGELOG.md
+++ b/crates/ruma-server-util/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [unreleased]
 
+Breaking changes:
+
+- The `XMatrix::new` method now takes `OwnedServerName` instead of `Option<OwnedServerName>`
+  for the destination, since servers must always set the destination.
+
 # 0.3.0
 
 Breaking changes:

--- a/crates/ruma-server-util/src/authorization.rs
+++ b/crates/ruma-server-util/src/authorization.rs
@@ -31,11 +31,11 @@ impl XMatrix {
     /// Construct a new X-Matrix Authorization header.
     pub fn new(
         origin: OwnedServerName,
-        destination: Option<OwnedServerName>,
+        destination: OwnedServerName,
         key: OwnedServerSigningKeyId,
         sig: String,
     ) -> Self {
-        Self { origin, destination, key, sig }
+        Self { origin, destination: Some(destination), key, sig }
     }
 }
 
@@ -259,7 +259,7 @@ mod tests {
         assert_eq!(credentials.key, key);
         assert_eq!(credentials.sig, sig);
 
-        let credentials = XMatrix::new(origin, None, key, sig);
+        let credentials = XMatrix { origin, destination: None, key, sig };
 
         assert_eq!(credentials.encode(), header);
     }
@@ -277,7 +277,7 @@ mod tests {
         assert_eq!(credentials.key, key);
         assert_eq!(credentials.sig, sig);
 
-        let credentials = XMatrix::new(origin, Some(destination), key, sig);
+        let credentials = XMatrix::new(origin, destination, key, sig);
 
         assert_eq!(credentials.encode(), header);
     }


### PR DESCRIPTION
https://spec.matrix.org/unstable/server-server-api/#request-authentication
> `destination`: [Added in v1.3] the server name of the receiving server. This is the same as the destination field from the JSON described in step 1. For compatibility with older servers, recipients should accept requests without this parameter, but MUST always send it

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
