### PR TITLE
Change Box<ClientSecret> types to OwnedClientSecret

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -4,6 +4,8 @@ Breaking changes:
 
 - `RoomSummary::heroes` now properly contains only `UserId` instead of `String`
   as before.
+- Change type of `client_secret` field in `ThirdpartyIdCredentials`
+  from `Box<ClientSecret>` to `OwnedClientSecret`
 
 Improvements:
 

--- a/crates/ruma-client-api/src/uiaa.rs
+++ b/crates/ruma-client-api/src/uiaa.rs
@@ -9,7 +9,7 @@ use ruma_common::{
     api::{error::IntoHttpError, EndpointError, OutgoingResponse},
     serde::{from_raw_json_value, JsonObject, StringEnum},
     thirdparty::Medium,
-    ClientSecret, OwnedSessionId, OwnedUserId,
+    OwnedClientSecret, OwnedSessionId, OwnedUserId,
 };
 use serde::{
     de::{self, DeserializeOwned},
@@ -546,7 +546,7 @@ pub struct ThirdpartyIdCredentials {
     pub sid: OwnedSessionId,
 
     /// Identity server client secret.
-    pub client_secret: Box<ClientSecret>,
+    pub client_secret: OwnedClientSecret,
 
     /// Identity server URL.
     pub id_server: String,
@@ -560,7 +560,7 @@ impl ThirdpartyIdCredentials {
     /// server address and access token.
     pub fn new(
         sid: OwnedSessionId,
-        client_secret: Box<ClientSecret>,
+        client_secret: OwnedClientSecret,
         id_server: String,
         id_access_token: String,
     ) -> Self {

--- a/crates/ruma-identity-service-api/CHANGELOG.md
+++ b/crates/ruma-identity-service-api/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [unreleased]
 
+Breaking changes:
+
+- Change type of `client_secret` field in `ThreePidOwnershipProof`
+  from `Box<ClientSecret>` to `OwnedClientSecret`
+
 # 0.9.0
 
 Breaking changes:

--- a/crates/ruma-identity-service-api/src/association/unbind_3pid.rs
+++ b/crates/ruma-identity-service-api/src/association/unbind_3pid.rs
@@ -11,7 +11,7 @@ pub mod v2 {
         api::{request, response, Metadata},
         metadata,
         thirdparty::Medium,
-        ClientSecret, OwnedSessionId, OwnedUserId,
+        OwnedClientSecret, OwnedSessionId, OwnedUserId,
     };
     use serde::{Deserialize, Serialize};
 
@@ -96,12 +96,12 @@ pub mod v2 {
         pub sid: OwnedSessionId,
 
         /// The client secret passed to the `requestToken` call.
-        pub client_secret: Box<ClientSecret>,
+        pub client_secret: OwnedClientSecret,
     }
 
     impl ThreePidOwnershipProof {
         /// Creates a new `ThreePidOwnershipProof` with the given session ID and client secret.
-        pub fn new(sid: OwnedSessionId, client_secret: Box<ClientSecret>) -> Self {
+        pub fn new(sid: OwnedSessionId, client_secret: OwnedClientSecret) -> Self {
             Self { sid, client_secret }
         }
     }


### PR DESCRIPTION
Came up today in the Matrix SDK dev room.