### PR TITLE
client-api: fix comment on async upload declaring incorrect http method

### DIFF
--- a/crates/ruma-client-api/src/media/create_content_async.rs
+++ b/crates/ruma-client-api/src/media/create_content_async.rs
@@ -1,4 +1,4 @@
-//! `POST /_matrix/media/*/upload/{serverName}/{mediaId}`
+//! `PUT /_matrix/media/*/upload/{serverName}/{mediaId}`
 //!
 //! Upload media to an MXC URI that was created with create_mxc_uri.
 


### PR DESCRIPTION
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
