### PR TITLE
Simplify docsrs feature usage

### DIFF
--- a/crates/ruma-client-api/Cargo.toml
+++ b/crates/ruma-client-api/Cargo.toml
@@ -13,7 +13,6 @@ rust-version = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 # OutgoingRequest and IncomingResponse implementations

--- a/crates/ruma-client-api/build.rs
+++ b/crates/ruma-client-api/build.rs
@@ -1,6 +1,0 @@
-fn main() {
-    // Prevent unnecessary rerunning of this build script
-    println!("cargo:rerun-if-changed=build.rs");
-    // Prevent nightly CI from erroring on docsrs attributes
-    println!("cargo:rustc-check-cfg=cfg(docsrs)");
-}

--- a/crates/ruma-client/Cargo.toml
+++ b/crates/ruma-client/Cargo.toml
@@ -13,7 +13,6 @@ rust-version = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 client-api = ["dep:as_variant", "dep:ruma-client-api"]

--- a/crates/ruma-client/build.rs
+++ b/crates/ruma-client/build.rs
@@ -3,8 +3,6 @@ use std::{env, process};
 fn main() {
     // Prevent unnecessary rerunning of this build script
     println!("cargo:rerun-if-changed=build.rs");
-    // Prevent nightly CI from erroring on docsrs attributes
-    println!("cargo:rustc-check-cfg=cfg(docsrs)");
 
     let tls_features = [
         ("tls-native", env::var_os("CARGO_FEATURE_TLS_NATIVE").is_some()),

--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -12,7 +12,6 @@ rust-version = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 # These feature gates exist only for the tests. Disabling them results in a

--- a/crates/ruma-common/build.rs
+++ b/crates/ruma-common/build.rs
@@ -1,6 +1,0 @@
-fn main() {
-    // Prevent unnecessary rerunning of this build script
-    println!("cargo:rerun-if-changed=build.rs");
-    // Prevent nightly CI from erroring on docsrs attributes
-    println!("cargo:rustc-check-cfg=cfg(docsrs)");
-}

--- a/crates/ruma-events/Cargo.toml
+++ b/crates/ruma-events/Cargo.toml
@@ -12,7 +12,6 @@ rust-version = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 canonical-json = ["ruma-common/canonical-json"]

--- a/crates/ruma-federation-api/Cargo.toml
+++ b/crates/ruma-federation-api/Cargo.toml
@@ -13,7 +13,6 @@ rust-version = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 # Allow some mandatory fields in requests / responses to be missing, defaulting

--- a/crates/ruma-federation-api/build.rs
+++ b/crates/ruma-federation-api/build.rs
@@ -1,6 +1,0 @@
-fn main() {
-    // Prevent unnecessary rerunning of this build script
-    println!("cargo:rerun-if-changed=build.rs");
-    // Prevent nightly CI from erroring on docsrs attributes
-    println!("cargo:rustc-check-cfg=cfg(docsrs)");
-}

--- a/crates/ruma-html/Cargo.toml
+++ b/crates/ruma-html/Cargo.toml
@@ -12,7 +12,6 @@ rust-version = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 matrix = ["dep:ruma-common"]

--- a/crates/ruma-html/build.rs
+++ b/crates/ruma-html/build.rs
@@ -1,6 +1,0 @@
-fn main() {
-    // Prevent unnecessary rerunning of this build script
-    println!("cargo:rerun-if-changed=build.rs");
-    // Prevent nightly CI from erroring on docsrs attributes
-    println!("cargo:rustc-check-cfg=cfg(docsrs)");
-}

--- a/crates/ruma-server-util/Cargo.toml
+++ b/crates/ruma-server-util/Cargo.toml
@@ -13,7 +13,6 @@ rust-version = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 headers = "0.4.0"

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -13,7 +13,6 @@ rust-version = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 api = ["ruma-common/api"]

--- a/crates/ruma/build.rs
+++ b/crates/ruma/build.rs
@@ -1,6 +1,0 @@
-fn main() {
-    // Prevent unnecessary rerunning of this build script
-    println!("cargo:rerun-if-changed=build.rs");
-    // Prevent nightly CI from erroring on docsrs attributes
-    println!("cargo:rustc-check-cfg=cfg(docsrs)");
-}


### PR DESCRIPTION
- Don't instruct docs.rs to set it, it does so by default now: https://github.com/rust-lang/docs.rs/pull/2390
- Because of that, check-cfg also recognizes it and does not need extra configuration either.