### PR TITLE
Fix X-Matrix encoding

### DIFF
--- a/crates/ruma-server-util/CHANGELOG.md
+++ b/crates/ruma-server-util/CHANGELOG.md
@@ -4,6 +4,8 @@ Breaking changes:
 
 - The `XMatrix::new` method now takes `OwnedServerName` instead of `Option<OwnedServerName>`
   for the destination, since servers must always set the destination.
+- The `sig` field in `XMatrix` has been changed from `String` to `Base64` to more accurately
+  mirror its allowed values in the type system.
 
 Improvements:
 

--- a/crates/ruma-server-util/CHANGELOG.md
+++ b/crates/ruma-server-util/CHANGELOG.md
@@ -5,6 +5,10 @@ Breaking changes:
 - The `XMatrix::new` method now takes `OwnedServerName` instead of `Option<OwnedServerName>`
   for the destination, since servers must always set the destination.
 
+Improvements:
+
+- When encoding to a header value, `XMatrix` fields are now quoted and escaped correctly.
+
 # 0.3.0
 
 Breaking changes:

--- a/crates/ruma-server-util/src/authorization.rs
+++ b/crates/ruma-server-util/src/authorization.rs
@@ -51,6 +51,9 @@ fn parse_token<'a>(tokens: &mut impl Tokens<Item = &'a u8>) -> Option<Vec<u8>> {
     })
 }
 
+// Matrix spec:
+// > For compatibility with older servers, the recipient should allow colons to be included in
+// > values without requiring the value to be enclosed in quotes.
 fn parse_token_with_colons<'a>(tokens: &mut impl Tokens<Item = &'a u8>) -> Option<Vec<u8>> {
     tokens.optional(|t| {
         let token: Vec<u8> =


### PR DESCRIPTION
Just quoting the values is neither sufficient nor necessary, they need to be escaped properly if they contain non-`tchar` characters.