### PR TITLE
client-api: make user_id of SlidingSyncRoomHero mandatory

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -14,6 +14,10 @@ Improvements:
   both have a new `include_heroes` field. `SlidingSyncRoom` has a new `heroes`
   field, with a new type `SlidingSyncRoomHero`.
 
+Bug fixes:
+
+- `user_id` of `SlidingSyncRoomHero` is now mandatory
+
 # 0.18.0
 
 Bug fixes:

--- a/crates/ruma-client-api/src/sync/sync_events/v4.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v4.rs
@@ -504,12 +504,11 @@ impl SlidingSyncRoom {
 }
 
 /// A sliding sync room hero.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct SlidingSyncRoomHero {
     /// The user ID of the hero.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub user_id: Option<OwnedUserId>,
+    pub user_id: OwnedUserId,
 
     /// The name of the hero.
     #[serde(rename = "displayname", skip_serializing_if = "Option::is_none")]
@@ -518,6 +517,13 @@ pub struct SlidingSyncRoomHero {
     /// The avatar of the hero.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub avatar: Option<OwnedMxcUri>,
+}
+
+impl SlidingSyncRoomHero {
+    /// Creates a new `SlidingSyncRoomHero` with the given user id.
+    pub fn new(user_id: OwnedUserId) -> Self {
+        Self { user_id, name: None, avatar: None }
+    }
 }
 
 /// Sliding-Sync extension configuration.


### PR DESCRIPTION
It is never stated it is optional, [only `avatar_url` and `displayname` are](https://github.com/matrix-org/matrix-spec-proposals/blob/7036c29db2b0ea40dccb0c505d6ef4b6085bf192/proposals/3575-sync.md?plain=1#L516-L520)

Also, sorry for forgetting to namespace the branch.
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
