### PR TITLE
client-api: rename avatar to avatar_url for SS room heros

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -14,6 +14,10 @@ Improvements:
   both have a new `include_heroes` field. `SlidingSyncRoom` has a new `heroes`
   field, with a new type `SlidingSyncRoomHero`.
 
+Bug fixes:
+
+- Rename `avatar` to `avatar_url` when (De)serializing
+
 # 0.18.0
 
 Bug fixes:

--- a/crates/ruma-client-api/src/sync/sync_events/v4.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v4.rs
@@ -516,7 +516,7 @@ pub struct SlidingSyncRoomHero {
     pub name: Option<String>,
 
     /// The avatar of the hero.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "avatar_url", skip_serializing_if = "Option::is_none")]
     pub avatar: Option<OwnedMxcUri>,
 }
 


### PR DESCRIPTION
https://github.com/matrix-org/matrix-spec-proposals/blob/7036c29db2b0ea40dccb0c505d6ef4b6085bf192/proposals/3575-sync.md?plain=1#L516-L520

Not sure whether this counts as a "breaking change", since it only "breaks" the deserialization if it was using the wrong format before, and doesn't change anything for api consumers.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
