### PR TITLE
client-api: Make authentication optional for change_password and deactivate

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -17,6 +17,8 @@ Improvements:
 Bug fixes:
 
 - Rename `avatar` to `avatar_url` when (De)serializing
+- Make authentication with access token optional for the `change_password` and
+  `deactivate` endpoints.
 
 # 0.18.0
 

--- a/crates/ruma-client-api/src/account/change_password.rs
+++ b/crates/ruma-client-api/src/account/change_password.rs
@@ -17,7 +17,7 @@ pub mod v3 {
     const METADATA: Metadata = metadata! {
         method: POST,
         rate_limited: true,
-        authentication: AccessToken,
+        authentication: AccessTokenOptional,
         history: {
             1.0 => "/_matrix/client/r0/account/password",
             1.1 => "/_matrix/client/v3/account/password",

--- a/crates/ruma-client-api/src/account/deactivate.rs
+++ b/crates/ruma-client-api/src/account/deactivate.rs
@@ -20,7 +20,7 @@ pub mod v3 {
     const METADATA: Metadata = metadata! {
         method: POST,
         rate_limited: true,
-        authentication: AccessToken,
+        authentication: AccessTokenOptional,
         history: {
             1.0 => "/_matrix/client/r0/account/deactivate",
             1.1 => "/_matrix/client/v3/account/deactivate",


### PR DESCRIPTION
See also https://github.com/matrix-org/matrix-spec/pull/1843

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
