### PR TITLE
ci: Update cargo-deny config

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -8,23 +8,20 @@ exclude = [
 ]
 
 [advisories]
-vulnerability = "deny"
-unmaintained = "deny"
+version = 2
 
 [licenses]
-default = "deny"
-unlicensed = "deny"
+version = 2
 allow = [
     "Apache-2.0",
     "BSD-3-Clause",
     "ISC",
     "MIT",
+    "MPL-2.0",
     "OpenSSL",
     "Unicode-DFS-2016",
     "Zlib",
 ]
-# MPL-2.0 is copyleft but not "infectuous" like GPL
-copyleft = "allow"
 private = { ignore = true }
 
 [[licenses.clarify]]

--- a/.deny.toml
+++ b/.deny.toml
@@ -19,6 +19,7 @@ allow = [
     "MIT",
     "MPL-2.0",
     "OpenSSL",
+    "Unicode-3.0",
     "Unicode-DFS-2016",
     "Zlib",
 ]


### PR DESCRIPTION
To fix the [error in CI](https://github.com/ruma/ruma/actions/runs/9452255090/job/26035024836?pr=1837):

1. Get rid of the warnings by using version 2 of licenses and advisories configs (see https://github.com/EmbarkStudios/cargo-deny/pull/611).
2. Get rid of the new errors by allowing the [`Unicode-3.0` license](https://opensource.org/license/unicode-license-v3), due to new dependencies in the tree of the `url` crate that was updated today. This is an OSI-approved license.