### PR TITLE
api: Rename query_map attribute of request macro to query_all and remove bound

### DIFF
--- a/crates/ruma-appservice-api/src/thirdparty/get_location_for_protocol.rs
+++ b/crates/ruma-appservice-api/src/thirdparty/get_location_for_protocol.rs
@@ -33,7 +33,7 @@ pub mod v1 {
 
         /// One or more custom fields to help identify the third party location.
         // The specification is incorrect for this parameter. See [matrix-spec#560](https://github.com/matrix-org/matrix-spec/issues/560).
-        #[ruma_api(query_map)]
+        #[ruma_api(query_all)]
         pub fields: BTreeMap<String, String>,
     }
 

--- a/crates/ruma-appservice-api/src/thirdparty/get_user_for_protocol.rs
+++ b/crates/ruma-appservice-api/src/thirdparty/get_user_for_protocol.rs
@@ -34,7 +34,7 @@ pub mod v1 {
 
         /// One or more custom fields that are passed to the AS to help identify the user.
         // The specification is incorrect for this parameter. See [matrix-spec#560](https://github.com/matrix-org/matrix-spec/issues/560).
-        #[ruma_api(query_map)]
+        #[ruma_api(query_all)]
         pub fields: BTreeMap<String, String>,
     }
 

--- a/crates/ruma-client-api/src/thirdparty/get_location_for_protocol.rs
+++ b/crates/ruma-client-api/src/thirdparty/get_location_for_protocol.rs
@@ -34,7 +34,7 @@ pub mod v3 {
 
         /// One or more custom fields to help identify the third party location.
         // The specification is incorrect for this parameter. See [matrix-spec#560](https://github.com/matrix-org/matrix-spec/issues/560).
-        #[ruma_api(query_map)]
+        #[ruma_api(query_all)]
         pub fields: BTreeMap<String, String>,
     }
 

--- a/crates/ruma-client-api/src/thirdparty/get_user_for_protocol.rs
+++ b/crates/ruma-client-api/src/thirdparty/get_user_for_protocol.rs
@@ -34,7 +34,7 @@ pub mod v3 {
 
         /// One or more custom fields that are passed to the AS to help identify the user.
         // The specification is incorrect for this parameter. See [matrix-spec#560](https://github.com/matrix-org/matrix-spec/issues/560).
-        #[ruma_api(query_map)]
+        #[ruma_api(query_all)]
         pub fields: BTreeMap<String, String>,
     }
 

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -6,6 +6,14 @@ Bug fixes:
   `Option<String>` for `ProtocolInstance`. It made the `unstable-unspecified`
   feature non-additive.
 
+Breaking changes:
+
+- Rename the `query_map` attribute of the `request` macro to `query_all`, and
+  remove the required bound to implement `IntoIterator<Item = (String, String)>`.
+  This allows to use a struct or enum as well as a map to represent the list of
+  query parameters. Note that the (de)serialization of the type used must work
+  with `serde_html_form`.
+
 Improvements:
 
 - Add the `InvalidHeaderValue` variant to the `DeserializationError` struct, for

--- a/crates/ruma-common/src/api.rs
+++ b/crates/ruma-common/src/api.rs
@@ -122,9 +122,11 @@ macro_rules! metadata {
 ///   they are declared must match the order in which they occur in the request path.
 /// * `#[ruma_api(query)]`: Fields with this attribute will be inserting into the URL's query
 ///   string.
-/// * `#[ruma_api(query_map)]`: Instead of individual query fields, one query_map field, of any
-///   type that implements `IntoIterator<Item = (String, String)>` (e.g. `HashMap<String,
-///   String>`, can be used for cases where an endpoint supports arbitrary query parameters.
+/// * `#[ruma_api(query_all)]`: Instead of individual query fields, one query_all field, of any
+///   type that can be (de)serialized by [serde_html_form], can be used for cases where
+///   multiple endpoints should share a query fields type, the query fields are better
+///   expressed as an `enum` rather than a `struct`, or the endpoint supports arbitrary query
+///   parameters.
 /// * No attribute: Fields without an attribute are part of the body. They can use `#[serde]`
 ///   attributes to customize (de)serialization.
 /// * `#[ruma_api(body)]`: Use this if multiple endpoints should share a request body type, or
@@ -209,6 +211,8 @@ macro_rules! metadata {
 ///     # pub struct Response {}
 /// }
 /// ```
+///
+/// [serde_html_form]: https://crates.io/crates/serde_html_form
 pub use ruma_macros::request;
 /// Generates [`OutgoingResponse`] and [`IncomingResponse`] implementations.
 ///

--- a/crates/ruma-common/tests/api/ruma_api_macros.rs
+++ b/crates/ruma-common/tests/api/ruma_api_macros.rs
@@ -133,7 +133,41 @@ pub mod raw_body_endpoint {
     }
 }
 
-pub mod query_map_endpoint {
+pub mod query_all_enum_endpoint {
+    use ruma_common::{
+        api::{request, response, Metadata},
+        metadata,
+    };
+
+    #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+    #[serde(untagged)]
+    pub enum MyCustomQueryEnum {
+        VariantA { field_a: String },
+        VariantB { field_b: String },
+    }
+
+    const METADATA: Metadata = metadata! {
+        method: GET,
+        rate_limited: false,
+        authentication: None,
+        history: {
+            unstable => "/_matrix/some/query/map/endpoint",
+        }
+    };
+
+    /// Request type for the `query_all_enum_endpoint` endpoint.
+    #[request]
+    pub struct Request {
+        #[ruma_api(query_all)]
+        pub query: MyCustomQueryEnum,
+    }
+
+    /// Response type for the `query_all_enum_endpoint` endpoint.
+    #[response]
+    pub struct Response {}
+}
+
+pub mod query_all_vec_endpoint {
     use ruma_common::{
         api::{request, response, Metadata},
         metadata,
@@ -148,14 +182,14 @@ pub mod query_map_endpoint {
         }
     };
 
-    /// Request type for the `newtype_body_endpoint` endpoint.
+    /// Request type for the `query_all_vec_endpoint` endpoint.
     #[request]
     pub struct Request {
-        #[ruma_api(query_map)]
+        #[ruma_api(query_all)]
         pub fields: Vec<(String, String)>,
     }
 
-    /// Response type for the `newtype_body_endpoint` endpoint.
+    /// Response type for the `query_all_vec_endpoint` endpoint.
     #[response]
     pub struct Response {}
 }

--- a/crates/ruma-federation-api/src/query/get_custom_information.rs
+++ b/crates/ruma-federation-api/src/query/get_custom_information.rs
@@ -33,7 +33,7 @@ pub mod v1 {
         pub query_type: String,
 
         /// The query parameters.
-        #[ruma_api(query_map)]
+        #[ruma_api(query_all)]
         pub params: BTreeMap<String, String>,
     }
 

--- a/crates/ruma-macros/src/api/attribute.rs
+++ b/crates/ruma-macros/src/api/attribute.rs
@@ -10,7 +10,7 @@ mod kw {
     syn::custom_keyword!(raw_body);
     syn::custom_keyword!(path);
     syn::custom_keyword!(query);
-    syn::custom_keyword!(query_map);
+    syn::custom_keyword!(query_all);
     syn::custom_keyword!(header);
     syn::custom_keyword!(error);
     syn::custom_keyword!(manual_body_serde);
@@ -22,7 +22,7 @@ pub enum RequestMeta {
     RawBody,
     Path,
     Query,
-    QueryMap,
+    QueryAll,
     Header(Ident),
 }
 
@@ -41,9 +41,9 @@ impl Parse for RequestMeta {
         } else if lookahead.peek(kw::query) {
             let _: kw::query = input.parse()?;
             Ok(Self::Query)
-        } else if lookahead.peek(kw::query_map) {
-            let _: kw::query_map = input.parse()?;
-            Ok(Self::QueryMap)
+        } else if lookahead.peek(kw::query_all) {
+            let _: kw::query_all = input.parse()?;
+            Ok(Self::QueryAll)
         } else if lookahead.peek(kw::header) {
             let _: kw::header = input.parse()?;
             let _: Token![=] = input.parse()?;

--- a/crates/ruma-macros/src/api/request/incoming.rs
+++ b/crates/ruma-macros/src/api/request/incoming.rs
@@ -31,7 +31,7 @@ impl Request {
             (TokenStream::new(), TokenStream::new())
         };
 
-        let (parse_query, query_vars) = if let Some(field) = self.query_map_field() {
+        let (parse_query, query_vars) = if let Some(field) = self.query_all_field() {
             let cfg_attrs =
                 field.attrs.iter().filter(|a| a.path().is_ident("cfg")).collect::<Vec<_>>();
             let field_name = field.ident.as_ref().expect("expected field to have an identifier");


### PR DESCRIPTION
Allows to represent the query fields as a single struct or enum.

This was requested with a valid use case of representing the query strings as an enum at: https://matrix.to/#/!veagCdDBjKrMsOCzrq:privacytools.io/$eNLiLj5-OXZCOyGu8fVIYlCzfZbm-EAnNw6GfT-r34E?via=matrix.org&via=envs.net&via=mozilla.org
