### PR TITLE
events: allow deserializing an event content with a type

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -11,6 +11,8 @@ Improvements:
 - Add unstable support for MSC3489 `m.beacon` & `m.beacon_info` events
   (unstable types `org.matrix.msc3489.beacon` & `org.matrix.msc3489.beacon_info`)
 - Stabilize support for muting in VoIP calls, according to Matrix 1.11
+- All the root `Any*EventContent` types now have a `EventContentFromType` implementations
+  automatically derived by the `event_enum!` macro.
 
 Breaking changes:
 

--- a/crates/ruma-events/src/content.rs
+++ b/crates/ruma-events/src/content.rs
@@ -95,7 +95,6 @@ pub trait ToDeviceEventContent: EventContent<EventType = ToDeviceEventType> {}
 /// Event content that can be deserialized with its event type.
 pub trait EventContentFromType: EventContent {
     /// Constructs this event content from the given event type and JSON.
-    #[doc(hidden)]
     fn from_parts(event_type: &str, content: &RawJsonValue) -> serde_json::Result<Self>;
 }
 

--- a/crates/ruma-events/tests/it/event_enums.rs
+++ b/crates/ruma-events/tests/it/event_enums.rs
@@ -71,7 +71,7 @@ fn text_msgtype_plain_text_deserialization_as_any() {
 }
 
 #[test]
-fn text_msgtype_secret_storage_key_text_deserialization_as_any() {
+fn secret_storage_key_deserialization_as_any() {
     let serialized = to_raw_json_value(&json!({
         "name": "my_key",
         "algorithm": "m.secret_storage.v1.aes-hmac-sha2",

--- a/crates/ruma-events/tests/it/event_enums.rs
+++ b/crates/ruma-events/tests/it/event_enums.rs
@@ -1,8 +1,15 @@
 use assert_matches2::assert_matches;
 use js_int::uint;
-use ruma_common::{serde::CanBeEmpty, MilliSecondsSinceUnixEpoch, VoipVersionId};
-use ruma_events::{AnyMessageLikeEvent, MessageLikeEvent};
-use serde_json::{from_value as from_json_value, json};
+use ruma_common::{
+    serde::{CanBeEmpty, Raw},
+    MilliSecondsSinceUnixEpoch, VoipVersionId,
+};
+use ruma_events::{
+    secret_storage::key::{SecretStorageEncryptionAlgorithm, SecretStorageV1AesHmacSha2Properties},
+    AnyGlobalAccountDataEventContent, AnyMessageLikeEvent, AnyMessageLikeEventContent,
+    MessageLikeEvent, RawExt as _,
+};
+use serde_json::{from_value as from_json_value, json, value::to_raw_value as to_raw_json_value};
 
 #[test]
 fn ui() {
@@ -45,4 +52,54 @@ fn deserialize_message_event() {
     assert_eq!(content.answer.sdp, "Hello");
     assert_eq!(content.call_id, "foofoo");
     assert_eq!(content.version, VoipVersionId::V0);
+}
+
+#[test]
+fn text_msgtype_plain_text_deserialization_as_any() {
+    let serialized = json!({
+        "body": "Hello world!",
+        "msgtype": "m.text"
+    });
+
+    let raw_event: Raw<AnyMessageLikeEventContent> =
+        Raw::from_json_string(serialized.to_string()).unwrap();
+
+    let event = raw_event.deserialize_with_type("m.room.message".into()).unwrap();
+
+    assert_matches!(event, AnyMessageLikeEventContent::RoomMessage(content));
+    assert_eq!(content.body(), "Hello world!");
+}
+
+#[test]
+fn text_msgtype_secret_storage_key_text_deserialization_as_any() {
+    let serialized = to_raw_json_value(&json!({
+        "name": "my_key",
+        "algorithm": "m.secret_storage.v1.aes-hmac-sha2",
+        "iv": "YWJjZGVmZ2hpamtsbW5vcA",
+        "mac": "aWRvbnRrbm93d2hhdGFtYWNsb29rc2xpa2U"
+    }))
+    .unwrap();
+
+    let raw_event: Raw<AnyGlobalAccountDataEventContent> =
+        Raw::from_json_string(serialized.to_string()).unwrap();
+
+    let event = raw_event.deserialize_with_type("m.secret_storage.key.test".into()).unwrap();
+
+    assert_matches!(event, AnyGlobalAccountDataEventContent::SecretStorageKey(content));
+
+    assert_eq!(content.name.unwrap(), "my_key");
+    assert_eq!(content.key_id, "test");
+    assert_matches!(content.passphrase, None);
+
+    assert_matches!(
+        content.algorithm,
+        SecretStorageEncryptionAlgorithm::V1AesHmacSha2(SecretStorageV1AesHmacSha2Properties {
+            iv: Some(iv),
+            mac: Some(mac),
+            ..
+        })
+    );
+
+    assert_eq!(iv.encode(), "YWJjZGVmZ2hpamtsbW5vcA");
+    assert_eq!(mac.encode(), "aWRvbnRrbm93d2hhdGFtYWNsb29rc2xpa2U");
 }

--- a/crates/ruma-events/tests/it/room_message.rs
+++ b/crates/ruma-events/tests/it/room_message.rs
@@ -19,7 +19,7 @@ use ruma_events::{
         },
         EncryptedFileInit, JsonWebKeyInit, MediaSource,
     },
-    AnyMessageLikeEventContent, AnySyncTimelineEvent, Mentions, MessageLikeUnsigned, RawExt as _,
+    AnySyncTimelineEvent, Mentions, MessageLikeUnsigned,
 };
 use serde_json::{
     from_value as from_json_value, json, to_value as to_json_value, Value as JsonValue,
@@ -103,22 +103,6 @@ fn text_msgtype_plain_text_serialization() {
             "msgtype": "m.text"
         })
     );
-}
-
-#[test]
-fn text_msgtype_plain_text_deserialization_as_any() {
-    let serialized = json!({
-        "body": "Hello world!",
-        "msgtype": "m.text"
-    });
-
-    let raw_event: Raw<AnyMessageLikeEventContent> =
-        Raw::from_json_string(serialized.to_string()).unwrap();
-
-    let event = raw_event.deserialize_with_type("m.room.message".into()).unwrap();
-
-    assert_matches!(event, AnyMessageLikeEventContent::RoomMessage(message));
-    assert_eq!(message.body(), "Hello world!");
 }
 
 #[test]

--- a/crates/ruma-events/tests/it/room_message.rs
+++ b/crates/ruma-events/tests/it/room_message.rs
@@ -19,7 +19,7 @@ use ruma_events::{
         },
         EncryptedFileInit, JsonWebKeyInit, MediaSource,
     },
-    AnySyncTimelineEvent, Mentions, MessageLikeUnsigned,
+    AnyMessageLikeEventContent, AnySyncTimelineEvent, Mentions, MessageLikeUnsigned, RawExt as _,
 };
 use serde_json::{
     from_value as from_json_value, json, to_value as to_json_value, Value as JsonValue,
@@ -103,6 +103,22 @@ fn text_msgtype_plain_text_serialization() {
             "msgtype": "m.text"
         })
     );
+}
+
+#[test]
+fn text_msgtype_plain_text_deserialization_as_any() {
+    let serialized = json!({
+        "body": "Hello world!",
+        "msgtype": "m.text"
+    });
+
+    let raw_event: Raw<AnyMessageLikeEventContent> =
+        Raw::from_json_string(serialized.to_string()).unwrap();
+
+    let event = raw_event.deserialize_with_type("m.room.message".into()).unwrap();
+
+    assert_matches!(event, AnyMessageLikeEventContent::RoomMessage(message));
+    assert_eq!(message.body(), "Hello world!");
 }
 
 #[test]

--- a/crates/ruma-macros/src/events/event_enum.rs
+++ b/crates/ruma-macros/src/events/event_enum.rs
@@ -350,7 +350,17 @@ fn expand_content_enum(
             };
             let self_variant = variant.ctor(quote! { Self });
 
-            let ev_types = event.aliases.iter().chain([&event.ev_type]);
+            let ev_types = event.aliases.iter().chain([&event.ev_type]).map(|ev_type| {
+                if event.has_type_fragment() {
+                    let ev_type = ev_type.value();
+                    let prefix = ev_type
+                        .strip_suffix('*')
+                        .expect("event type with type fragment should end with *");
+                    quote! { t if t.starts_with(#prefix) }
+                } else {
+                    quote! { #ev_type }
+                }
+            });
 
             let deserialize_content = if event.has_type_fragment() {
                 // If the event has a type fragment, then it implements EventContentFromType itself;

--- a/crates/ruma-macros/src/events/event_enum.rs
+++ b/crates/ruma-macros/src/events/event_enum.rs
@@ -355,7 +355,7 @@ fn expand_content_enum(
                     let ev_type = ev_type.value();
                     let prefix = ev_type
                         .strip_suffix('*')
-                        .expect("event type with type fragment should end with *");
+                        .expect("event type with type fragment must end with *");
                     quote! { t if t.starts_with(#prefix) }
                 } else {
                     quote! { #ev_type }


### PR DESCRIPTION
This allows deserializing all the `*EventContent` types into a parent `Any{...}EventContent`, assuming we know the type of the underlying event.

Required for serializing/deserializing the content of events we'd like to send, across application restarts, as in https://github.com/matrix-org/matrix-rust-sdk/issues/3361 for the Rust SDK.