### PR TITLE
api: Clarify that access tokens using query parameter are deprecated

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -13,6 +13,8 @@ Improvements:
 - Implement `Eq`/`Hash`/`PartialEq` for `ThirdPartyIdentifier`, to check whether 
   a `ThirdPartyIdentifier` has already been added by another user.
 - Add `MatrixVersion::V1_11`
+- Clarify in the docs of `AuthScheme` that sending an access token via a query
+  parameter is deprecated, according to MSC4126 / Matrix 1.11.
 
 # 0.13.0
 

--- a/crates/ruma-common/src/api.rs
+++ b/crates/ruma-common/src/api.rs
@@ -497,19 +497,19 @@ pub enum AuthScheme {
     /// Authentication is performed by including an access token in the `Authentication` http
     /// header, or an `access_token` query parameter.
     ///
-    /// It is recommended to use the header over the query parameter.
+    /// Using the query parameter is deprecated since Matrix 1.11.
     AccessToken,
 
     /// Authentication is optional, and it is performed by including an access token in the
     /// `Authentication` http header, or an `access_token` query parameter.
     ///
-    /// It is recommended to use the header over the query parameter.
+    /// Using the query parameter is deprecated since Matrix 1.11.
     AccessTokenOptional,
 
     /// Authentication is only performed for appservices, by including an access token in the
     /// `Authentication` http header, or an `access_token` query parameter.
     ///
-    /// It is recommended to use the header over the query parameter.
+    /// Using the query parameter is deprecated since Matrix 1.11.
     AppserviceToken,
 
     /// Authentication is performed by including X-Matrix signatures in the request headers,


### PR DESCRIPTION
According to MSC4126 / Matrix 1.11

Part of #1782.