### PR TITLE
client-api: Deprecate non-authenticated media endpoints

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -16,6 +16,7 @@ Improvements:
   field, with a new type `SlidingSyncRoomHero`.
 - Add support for authenticated media endpoints, according to MSC3916 / Matrix
   1.11.
+  - They replace the newly deprecated `media::get_*` endpoints.
 
 Bug fixes:
 

--- a/crates/ruma-client-api/src/media/get_content.rs
+++ b/crates/ruma-client-api/src/media/get_content.rs
@@ -24,11 +24,16 @@ pub mod v3 {
         history: {
             1.0 => "/_matrix/media/r0/download/:server_name/:media_id",
             1.1 => "/_matrix/media/v3/download/:server_name/:media_id",
+            1.11 => deprecated,
         }
     };
 
     /// Request type for the `get_media_content` endpoint.
     #[request(error = crate::Error)]
+    #[deprecated = "\
+        Since Matrix 1.11, clients should use `authenticated_media::get_content::v1::Request` \
+        instead if the homeserver supports it.\
+    "]
     pub struct Request {
         /// The server name from the mxc:// URI (the authoritory component).
         #[ruma_api(path)]
@@ -98,6 +103,7 @@ pub mod v3 {
         pub cross_origin_resource_policy: Option<String>,
     }
 
+    #[allow(deprecated)]
     impl Request {
         /// Creates a new `Request` with the given media ID and server name.
         pub fn new(media_id: String, server_name: OwnedServerName) -> Self {

--- a/crates/ruma-client-api/src/media/get_content_as_filename.rs
+++ b/crates/ruma-client-api/src/media/get_content_as_filename.rs
@@ -24,11 +24,16 @@ pub mod v3 {
         history: {
             1.0 => "/_matrix/media/r0/download/:server_name/:media_id/:filename",
             1.1 => "/_matrix/media/v3/download/:server_name/:media_id/:filename",
+            1.11 => deprecated,
         }
     };
 
     /// Request type for the `get_media_content_as_filename` endpoint.
     #[request(error = crate::Error)]
+    #[deprecated = "\
+        Since Matrix 1.11, clients should use `authenticated_media::get_content_as_filename::v1::Request` \
+        instead if the homeserver supports it.\
+    "]
     pub struct Request {
         /// The server name from the mxc:// URI (the authoritory component).
         #[ruma_api(path)]
@@ -102,6 +107,7 @@ pub mod v3 {
         pub cross_origin_resource_policy: Option<String>,
     }
 
+    #[allow(deprecated)]
     impl Request {
         /// Creates a new `Request` with the given media ID, server name and filename.
         pub fn new(media_id: String, server_name: OwnedServerName, filename: String) -> Self {

--- a/crates/ruma-client-api/src/media/get_content_thumbnail.rs
+++ b/crates/ruma-client-api/src/media/get_content_thumbnail.rs
@@ -27,11 +27,16 @@ pub mod v3 {
         history: {
             1.0 => "/_matrix/media/r0/thumbnail/:server_name/:media_id",
             1.1 => "/_matrix/media/v3/thumbnail/:server_name/:media_id",
+            1.11 => deprecated,
         }
     };
 
     /// Request type for the `get_content_thumbnail` endpoint.
     #[request(error = crate::Error)]
+    #[deprecated = "\
+        Since Matrix 1.11, clients should use `authenticated_media::get_content_thumbnail::v1::Request` \
+        instead if the homeserver supports it.\
+    "]
     pub struct Request {
         /// The server name from the mxc:// URI (the authoritory component).
         #[ruma_api(path)]
@@ -124,6 +129,7 @@ pub mod v3 {
         pub cross_origin_resource_policy: Option<String>,
     }
 
+    #[allow(deprecated)]
     impl Request {
         /// Creates a new `Request` with the given media ID, server name, desired thumbnail width
         /// and desired thumbnail height.

--- a/crates/ruma-client-api/src/media/get_media_config.rs
+++ b/crates/ruma-client-api/src/media/get_media_config.rs
@@ -20,12 +20,17 @@ pub mod v3 {
         history: {
             1.0 => "/_matrix/media/r0/config",
             1.1 => "/_matrix/media/v3/config",
+            1.11 => deprecated,
         }
     };
 
     /// Request type for the `get_media_config` endpoint.
     #[request(error = crate::Error)]
     #[derive(Default)]
+    #[deprecated = "\
+        Since Matrix 1.11, clients should use `authenticated_media::get_media_config::v1::Request` \
+        instead if the homeserver supports it.\
+    "]
     pub struct Request {}
 
     /// Response type for the `get_media_config` endpoint.
@@ -36,6 +41,7 @@ pub mod v3 {
         pub upload_size: UInt,
     }
 
+    #[allow(deprecated)]
     impl Request {
         /// Creates an empty `Request`.
         pub fn new() -> Self {

--- a/crates/ruma-client-api/src/media/get_media_preview.rs
+++ b/crates/ruma-client-api/src/media/get_media_preview.rs
@@ -21,11 +21,16 @@ pub mod v3 {
         history: {
             1.0 => "/_matrix/media/r0/preview_url",
             1.1 => "/_matrix/media/v3/preview_url",
+            1.11 => deprecated,
         }
     };
 
     /// Request type for the `get_media_preview` endpoint.
     #[request(error = crate::Error)]
+    #[deprecated = "\
+      Since Matrix 1.11, clients should use `authenticated_media::get_media_preview::v1::Request` \
+      instead if the homeserver supports it.\
+    "]
     pub struct Request {
         /// URL to get a preview of.
         #[ruma_api(query)]
@@ -49,6 +54,7 @@ pub mod v3 {
         pub data: Option<Box<RawJsonValue>>,
     }
 
+    #[allow(deprecated)]
     impl Request {
         /// Creates a new `Request` with the given url.
         pub fn new(url: String) -> Self {


### PR DESCRIPTION
According to MSC3916 / Matrix 1.11.

Probably better to merge after #1855.

On top of using the `deprecated` feature of `metadata!`, I decided to deprecate the `Request` types, so that clients have compile-time warnings about it. Deprecating the whole module results in too many warnings (for each type and each method of the types, and for tests…), so I thought that just deprecating the type is enough.
