### PR TITLE
client-api: Add support for terms of service at registration

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -18,6 +18,8 @@ Improvements:
   1.11.
   - They replace the newly deprecated `media::get_*` endpoints.
 - Stabilize support for animated thumbnails, according to Matrix 1.11
+- Add support for terms of service at registration, according to MSC1692 /
+  Matrix 1.11
 
 Bug fixes:
 


### PR DESCRIPTION
According to [MSC1692](https://github.com/matrix-org/matrix-spec-proposals/pull/1692) / [Matrix 1.11](https://github.com/matrix-org/matrix-spec/issues/1812)