### PR TITLE
identifiers: Deprecate constructing Matrix URI for event with room alias

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -23,6 +23,8 @@ Improvements:
 - Add `MatrixVersion::V1_11`
 - Clarify in the docs of `AuthScheme` that sending an access token via a query
   parameter is deprecated, according to MSC4126 / Matrix 1.11.
+- Constructing a Matrix URI for an event with a room alias is deprecated,
+  according to MSC4132 / Matrix 1.11
 
 # 0.13.0
 

--- a/crates/ruma-common/src/identifiers/matrix_uri.rs
+++ b/crates/ruma-common/src/identifiers/matrix_uri.rs
@@ -32,6 +32,9 @@ pub enum MatrixId {
     User(OwnedUserId),
 
     /// An event ID.
+    ///
+    /// Constructing this variant from an `OwnedRoomAliasId` is deprecated, because room aliases
+    /// are mutable, so the URI might break after a while.
     Event(OwnedRoomOrAliasId, OwnedEventId),
 }
 
@@ -572,12 +575,11 @@ mod tests {
                 .to_string(),
             "https://matrix.to/#/!ruma:notareal.hs?via=notareal.hs"
         );
-        assert_eq!(
-            room_alias_id!("#ruma:notareal.hs")
-                .matrix_to_event_uri(event_id!("$event:notareal.hs"))
-                .to_string(),
-            "https://matrix.to/#/%23ruma:notareal.hs/$event:notareal.hs"
-        );
+        #[allow(deprecated)]
+        let uri = room_alias_id!("#ruma:notareal.hs")
+            .matrix_to_event_uri(event_id!("$event:notareal.hs"))
+            .to_string();
+        assert_eq!(uri, "https://matrix.to/#/%23ruma:notareal.hs/$event:notareal.hs");
         assert_eq!(
             room_id!("!ruma:notareal.hs")
                 .matrix_to_event_uri(event_id!("$event:notareal.hs"))
@@ -869,12 +871,11 @@ mod tests {
                 .to_string(),
             "matrix:roomid/ruma:notareal.hs?via=notareal.hs&via=anotherunreal.hs&action=join"
         );
-        assert_eq!(
-            room_alias_id!("#ruma:notareal.hs")
-                .matrix_event_uri(event_id!("$event:notareal.hs"))
-                .to_string(),
-            "matrix:r/ruma:notareal.hs/e/event:notareal.hs"
-        );
+        #[allow(deprecated)]
+        let uri = room_alias_id!("#ruma:notareal.hs")
+            .matrix_event_uri(event_id!("$event:notareal.hs"))
+            .to_string();
+        assert_eq!(uri, "matrix:r/ruma:notareal.hs/e/event:notareal.hs");
         assert_eq!(
             room_id!("!ruma:notareal.hs")
                 .matrix_event_uri(event_id!("$event:notareal.hs"))

--- a/crates/ruma-common/src/identifiers/room_alias_id.rs
+++ b/crates/ruma-common/src/identifiers/room_alias_id.rs
@@ -37,6 +37,9 @@ impl RoomAliasId {
     }
 
     /// Create a `matrix.to` URI for an event scoped under this room alias ID.
+    ///
+    /// This is deprecated because room aliases are mutable, so the URI might break after a while.
+    #[deprecated = "Use `RoomId::matrix_to_event_uri` instead."]
     pub fn matrix_to_event_uri(&self, ev_id: impl Into<OwnedEventId>) -> MatrixToUri {
         MatrixToUri::new((self.to_owned(), ev_id.into()).into(), Vec::new())
     }
@@ -49,6 +52,9 @@ impl RoomAliasId {
     }
 
     /// Create a `matrix:` URI for an event scoped under this room alias ID.
+    ///
+    /// This is deprecated because room aliases are mutable, so the URI might break after a while.
+    #[deprecated = "Use `RoomId::matrix_event_uri` instead."]
     pub fn matrix_event_uri(&self, ev_id: impl Into<OwnedEventId>) -> MatrixUri {
         MatrixUri::new((self.to_owned(), ev_id.into()).into(), Vec::new(), None)
     }


### PR DESCRIPTION
According to [MSC4132](https://github.com/matrix-org/matrix-spec-proposals/pull/4132) / [Matrix 1.11](https://github.com/matrix-org/matrix-spec/issues/1823)

