### PR TITLE
client-api: Do not send request body for logout and logout_all

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -27,6 +27,8 @@ Bug fixes:
 - `user_id` of `SlidingSyncRoomHero` is now mandatory
 - Make authentication with access token optional for the `change_password` and
   `deactivate` endpoints.
+- Do not send a request body for the `logout` and `logout_all` endpoints, due
+  to a clarification in the spec.
 
 # 0.18.0
 

--- a/crates/ruma-client-api/src/session/logout_all.rs
+++ b/crates/ruma-client-api/src/session/logout_all.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3logoutall
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{response, Metadata},
         metadata,
     };
 
@@ -23,14 +23,9 @@ pub mod v3 {
     };
 
     /// Request type for the `logout_all` endpoint.
-    #[request(error = crate::Error)]
-    #[derive(Default)]
+    #[derive(Debug, Clone, Default)]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     pub struct Request {}
-
-    /// Response type for the `logout_all` endpoint.
-    #[response(error = crate::Error)]
-    #[derive(Default)]
-    pub struct Response {}
 
     impl Request {
         /// Creates an empty `Request`.
@@ -38,6 +33,69 @@ pub mod v3 {
             Self {}
         }
     }
+
+    #[cfg(feature = "client")]
+    impl ruma_common::api::OutgoingRequest for Request {
+        type EndpointError = crate::Error;
+        type IncomingResponse = Response;
+
+        const METADATA: Metadata = METADATA;
+
+        fn try_into_http_request<T: Default + bytes::BufMut>(
+            self,
+            base_url: &str,
+            access_token: ruma_common::api::SendAccessToken<'_>,
+            considering_versions: &'_ [ruma_common::api::MatrixVersion],
+        ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
+            let url = METADATA.make_endpoint_url(considering_versions, base_url, &[], "")?;
+
+            http::Request::builder()
+                .method(METADATA.method)
+                .uri(url)
+                .header(
+                    http::header::AUTHORIZATION,
+                    format!(
+                        "Bearer {}",
+                        access_token
+                            .get_required_for_endpoint()
+                            .ok_or(ruma_common::api::error::IntoHttpError::NeedsAuthentication)?,
+                    ),
+                )
+                .body(T::default())
+                .map_err(Into::into)
+        }
+    }
+
+    #[cfg(feature = "server")]
+    impl ruma_common::api::IncomingRequest for Request {
+        type EndpointError = crate::Error;
+        type OutgoingResponse = Response;
+
+        const METADATA: Metadata = METADATA;
+
+        fn try_from_http_request<B, S>(
+            request: http::Request<B>,
+            _path_args: &[S],
+        ) -> Result<Self, ruma_common::api::error::FromHttpRequestError>
+        where
+            B: AsRef<[u8]>,
+            S: AsRef<str>,
+        {
+            if request.method() != METADATA.method {
+                return Err(ruma_common::api::error::FromHttpRequestError::MethodMismatch {
+                    expected: METADATA.method,
+                    received: request.method().clone(),
+                });
+            }
+
+            Ok(Self {})
+        }
+    }
+
+    /// Response type for the `logout_all` endpoint.
+    #[response(error = crate::Error)]
+    #[derive(Default)]
+    pub struct Response {}
 
     impl Response {
         /// Creates an empty `Response`.


### PR DESCRIPTION
Due to a [clarification in the spec](https://github.com/matrix-org/matrix-spec/pull/1644).
