### PR TITLE
events: don't serialize the `rel_type` twice for Thread relationships

### DIFF
--- a/crates/ruma-events/src/relation.rs
+++ b/crates/ruma-events/src/relation.rs
@@ -84,7 +84,6 @@ impl<C> Replacement<C> {
 /// [thread]: https://spec.matrix.org/latest/client-server-api/#threading
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-#[serde(tag = "rel_type", rename = "m.thread")]
 pub struct Thread {
     /// The ID of the root message in the thread.
     pub event_id: OwnedEventId,


### PR DESCRIPTION
It's not required to save the `rel_type` at the `Thread` level manually, since the embedder (`Relation`) will include it already. This leads to duplicating the `rel_type` field in the JSON, which then gets lost when deserializing the `rel_type` later. The included test is a regression test.

Fixes #1865. This seems to pass the local tests, as well as the Matrix SDK tests suite, for what it's worth, so I'm highly confident with it.