### PR TITLE
events: More relation serde fixes

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -4,6 +4,8 @@ Bug fixes:
 
 - Fix deserialization of `AnyGlobalAccountDataEvent` for variants with a type
   fragment.
+- Fix serialization of `room::message::Relation` and `room::encrypted::Relation`
+  which could cause duplicate `rel_type` keys. 
 
 Improvements:
 

--- a/crates/ruma-events/src/reaction.rs
+++ b/crates/ruma-events/src/reaction.rs
@@ -37,7 +37,7 @@ impl From<Annotation> for ReactionEventContent {
 #[cfg(test)]
 mod tests {
     use assert_matches2::assert_matches;
-    use ruma_common::owned_event_id;
+    use ruma_common::{owned_event_id, serde::Raw};
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     use super::ReactionEventContent;
@@ -78,5 +78,19 @@ mod tests {
                 }
             })
         );
+    }
+
+    #[test]
+    fn serialization_roundtrip() {
+        let content = ReactionEventContent::new(Annotation::new(
+            owned_event_id!("$my_reaction"),
+            "🏠".to_owned(),
+        ));
+
+        let json_content = Raw::new(&content).unwrap();
+        let deser_content = json_content.deserialize().unwrap();
+
+        assert_eq!(deser_content.relates_to.event_id, content.relates_to.event_id);
+        assert_eq!(deser_content.relates_to.key, content.relates_to.key);
     }
 }

--- a/crates/ruma-events/src/relation.rs
+++ b/crates/ruma-events/src/relation.rs
@@ -84,6 +84,7 @@ impl<C> Replacement<C> {
 /// [thread]: https://spec.matrix.org/latest/client-server-api/#threading
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+#[serde(tag = "rel_type", rename = "m.thread")]
 pub struct Thread {
     /// The ID of the root message in the thread.
     pub event_id: OwnedEventId,

--- a/crates/ruma-events/src/room/encrypted.rs
+++ b/crates/ruma-events/src/room/encrypted.rs
@@ -165,6 +165,7 @@ impl<C> From<message::Relation<C>> for Relation {
 /// [replaces another event]: https://spec.matrix.org/latest/client-server-api/#event-replacements
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+#[serde(tag = "rel_type", rename = "m.replace")]
 pub struct Replacement {
     /// The ID of the event being replaced.
     pub event_id: OwnedEventId,

--- a/crates/ruma-events/src/room/encrypted/relation_serde.rs
+++ b/crates/ruma-events/src/room/encrypted/relation_serde.rs
@@ -74,27 +74,11 @@ impl Serialize for Relation {
                 st.serialize_field("m.in_reply_to", in_reply_to)?;
                 st.end()
             }
-            Relation::Replacement(data) => {
-                RelationSerHelper { rel_type: "m.replace", data }.serialize(serializer)
-            }
-            Relation::Reference(data) => {
-                RelationSerHelper { rel_type: "m.reference", data }.serialize(serializer)
-            }
-            Relation::Annotation(data) => {
-                RelationSerHelper { rel_type: "m.annotation", data }.serialize(serializer)
-            }
-            Relation::Thread(data) => {
-                RelationSerHelper { rel_type: "m.thread", data }.serialize(serializer)
-            }
+            Relation::Replacement(data) => data.serialize(serializer),
+            Relation::Reference(data) => data.serialize(serializer),
+            Relation::Annotation(data) => data.serialize(serializer),
+            Relation::Thread(data) => data.serialize(serializer),
             Relation::_Custom(c) => c.serialize(serializer),
         }
     }
-}
-
-#[derive(Serialize)]
-struct RelationSerHelper<'a, T> {
-    rel_type: &'a str,
-
-    #[serde(flatten)]
-    data: &'a T,
 }

--- a/crates/ruma-events/src/room/message/relation_serde.rs
+++ b/crates/ruma-events/src/room/message/relation_serde.rs
@@ -157,7 +157,7 @@ pub(super) enum RelationSerHelper {
     Replacement(ReplacementJsonRepr),
 
     /// An event that belongs to a thread, with stable names.
-    #[serde(rename = "m.thread")]
+    #[serde(untagged)]
     Thread(Thread),
 
     /// An unknown relation type.


### PR DESCRIPTION
Follow-up to #1866.

It seems that we can't count on `serde_json::to_value` to detect duplicate keys, because it swallows them instead of returning an error. The only solution then is to serialize to string and try to deserialize again.

This adds this test for every relation type, as well as fixing the tests that failed.

cc @bnjbvr.
