### PR TITLE
events: make allow field for restricted rooms optional

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -6,6 +6,7 @@ Bug fixes:
   fragment.
 - Fix serialization of `room::message::Relation` and `room::encrypted::Relation`
   which could cause duplicate `rel_type` keys. 
+- `Restricted` no longer fails to deserialize when the `allow` field is missing
 
 Improvements:
 

--- a/crates/ruma-events/src/room/join_rules.rs
+++ b/crates/ruma-events/src/room/join_rules.rs
@@ -168,6 +168,7 @@ impl From<JoinRule> for SpaceRoomJoinRule {
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct Restricted {
     /// Allow rules which describe conditions that allow joining a room.
+    #[serde(default)]
     pub allow: Vec<AllowRule>,
 }
 
@@ -322,6 +323,16 @@ mod tests {
         let allow_rule: AllowRule = serde_json::from_str(json).unwrap();
         assert_matches!(&allow_rule, AllowRule::_Custom(_));
         assert_eq!(serde_json::to_string(&allow_rule).unwrap(), json);
+    }
+
+    #[test]
+    fn restricted_room_no_allow_field() {
+        let json = r#"{"join_rule":"restricted"}"#;
+        let join_rules: RoomJoinRulesEventContent = serde_json::from_str(json).unwrap();
+        assert_matches!(
+            join_rules,
+            RoomJoinRulesEventContent { join_rule: JoinRule::Restricted(_) }
+        );
     }
 
     #[test]


### PR DESCRIPTION
In the spec, it doesn't state that it is a required field, even for restricted rooms:

https://spec.matrix.org/v1.10/client-server-api/#mroomjoin_rules
> For restricted rooms, the conditions the user will be tested against.

This is not the case for other fields which are required under certain conditions, such as with the [`/send_join`](https://spec.matrix.org/v1.10/server-server-api/#put_matrixfederationv2send_joinroomideventid) response:
> Required if the room is [restricted](https://spec.matrix.org/v1.10/client-server-api/#restricted-rooms) and is joining through one of the conditions available. If the user is responding to an invite, this is not required.


<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
