### PR TITLE
fix(beacon_info): use web-time package instead of std

### DIFF
--- a/crates/ruma-events/Cargo.toml
+++ b/crates/ruma-events/Cargo.toml
@@ -76,6 +76,7 @@ serde_json = { workspace = true, features = ["raw_value"] }
 thiserror = { workspace = true }
 tracing = { workspace = true, features = ["attributes"] }
 url = { workspace = true }
+web-time = { workspace = true }
 wildmatch = "2.0.0"
 
 # dev-dependencies can't be optional, so this is a regular dependency

--- a/crates/ruma-events/src/beacon_info.rs
+++ b/crates/ruma-events/src/beacon_info.rs
@@ -3,11 +3,10 @@
 //!
 //! [MSC3489]: https://github.com/matrix-org/matrix-spec-proposals/pull/3489
 
-use std::time::{Duration, SystemTime};
-
 use ruma_common::{MilliSecondsSinceUnixEpoch, OwnedUserId};
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
+use web_time::{Duration, SystemTime};
 
 use crate::location::AssetContent;
 


### PR DESCRIPTION
Fix the typing bug introduced in https://github.com/ruma/ruma/commit/f60c79727a826b0df2056d0d4ea36945991febe8 which uses `std:time` instead of the preferred `web-time`