### PR TITLE
federation-api: Allow old_verify_keys to be missing when deserializing ServerSigningKeys

### DIFF
--- a/crates/ruma-federation-api/CHANGELOG.md
+++ b/crates/ruma-federation-api/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [unreleased]
 
+Bug fixes:
+
+- `ServerSigningKeys` can be deserialized when `old_verify_keys` is missing, due to a
+  clarification in the spec.
+
 Improvements:
 
 - Add support for authenticated media endpoints, according to MSC3916 / Matrix 1.11

--- a/crates/ruma-federation-api/src/discovery.rs
+++ b/crates/ruma-federation-api/src/discovery.rs
@@ -48,7 +48,6 @@ impl OldVerifyKey {
     }
 }
 
-// Spec is wrong, all fields are required (see https://github.com/matrix-org/matrix-spec/issues/613)
 /// Queried server key, signed by the notary server.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
@@ -60,6 +59,9 @@ pub struct ServerSigningKeys {
     pub verify_keys: BTreeMap<OwnedServerSigningKeyId, VerifyKey>,
 
     /// Public keys that the homeserver used to use and when it stopped using them.
+    // This field is optional, but all fields were assumed to be required before clarification
+    // in https://github.com/matrix-org/matrix-spec/pull/1930, so we still send it.
+    #[serde(default)]
     pub old_verify_keys: BTreeMap<OwnedServerSigningKeyId, OldVerifyKey>,
 
     /// Digital signatures of this object signed using the verify_keys.


### PR DESCRIPTION
Due to this clarification in the spec: https://github.com/matrix-org/matrix-spec/pull/1930