### PR TITLE
MatrixRTC: fix call member parsing by using the correct `focus_active` format.

### DIFF
--- a/crates/ruma-events/src/call/member/focus.rs
+++ b/crates/ruma-events/src/call/member/focus.rs
@@ -59,7 +59,7 @@ pub enum ActiveFocus {
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
 pub struct ActiveLivekitFocus {
     /// The selection method used to select the LiveKit focus for the rtc session.
-    pub focus_select: FocusSelection,
+    pub focus_selection: FocusSelection,
 }
 
 impl ActiveLivekitFocus {
@@ -67,10 +67,10 @@ impl ActiveLivekitFocus {
     ///
     /// # Arguments
     ///
-    /// * `focus_select` - The selection method used to select the LiveKit focus for the rtc
+    /// * `focus_selection` - The selection method used to select the LiveKit focus for the rtc
     ///   session.
     pub fn new() -> Self {
-        Self { focus_select: FocusSelection::OldestMembership }
+        Self { focus_selection: FocusSelection::OldestMembership }
     }
 }
 

--- a/crates/ruma-events/src/call/member/member_data.rs
+++ b/crates/ruma-events/src/call/member/member_data.rs
@@ -58,7 +58,7 @@ impl<'a> MembershipData<'a> {
     pub fn focus_active(&self) -> &ActiveFocus {
         match self {
             MembershipData::Legacy(_) => &ActiveFocus::Livekit(ActiveLivekitFocus {
-                focus_select: super::focus::FocusSelection::OldestMembership,
+                focus_selection: super::focus::FocusSelection::OldestMembership,
             }),
             MembershipData::Session(data) => &data.focus_active,
         }


### PR DESCRIPTION
The focus active format has been named differently in the js sdk and the rust sdk.
We will rename the contradicting property how it is defined in the js-sdk here:
`focus_select` -> `focus_selection`

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
