### PR TITLE
syncv3: use RoomTypeFilter in sync filters

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -27,6 +27,9 @@ Improvements:
   to send `Future` events and update `Future` events with `future_tokens`.
   (`Future` events are scheduled messages that can be controlled
   with `future_tokens` to send on demand or restart the timeout)
+- Change types of `SyncRequestListFilters::{room_types,not_room_types}` to
+  `Vec<Option<RoomType>>` instead of a vector of strings
+  - This is a breaking change, but only for users of `unstable-msc3575`
 
 Bug fixes:
 

--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -28,7 +28,7 @@ Improvements:
   (`Future` events are scheduled messages that can be controlled
   with `future_tokens` to send on demand or restart the timeout)
 - Change types of `SyncRequestListFilters::{room_types,not_room_types}` to
-  `Vec<Option<RoomType>>` instead of a vector of strings
+  `Vec<RoomTypeFilter>` instead of a vector of strings
   - This is a breaking change, but only for users of `unstable-msc3575`
 
 Bug fixes:

--- a/crates/ruma-client-api/src/sync/sync_events/v4.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v4.rs
@@ -11,6 +11,7 @@ use js_option::JsOption;
 use ruma_common::{
     api::{request, response, Metadata},
     metadata,
+    room::RoomType,
     serde::{deserialize_cow_str, duration::opt_ms, Raw},
     DeviceKeyAlgorithm, MilliSecondsSinceUnixEpoch, OwnedMxcUri, OwnedRoomId, OwnedUserId, RoomId,
 };
@@ -230,14 +231,14 @@ pub struct SyncRequestListFilters {
     /// returned regardless of type. This can be used to get the initial set of spaces for an
     /// account.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub room_types: Vec<String>,
+    pub room_types: Vec<Option<RoomType>>,
 
     /// Only list rooms that are not of these create-types, or all.
     ///
     /// Same as "room_types" but inverted. This can be used to filter out spaces from the room
     /// list.
     #[serde(default, skip_serializing_if = "<[_]>::is_empty")]
-    pub not_room_types: Vec<String>,
+    pub not_room_types: Vec<Option<RoomType>>,
 
     /// Only list rooms matching the given string, or all.
     ///

--- a/crates/ruma-client-api/src/sync/sync_events/v4.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v4.rs
@@ -10,8 +10,8 @@ use js_int::UInt;
 use js_option::JsOption;
 use ruma_common::{
     api::{request, response, Metadata},
+    directory::RoomTypeFilter,
     metadata,
-    room::RoomType,
     serde::{deserialize_cow_str, duration::opt_ms, Raw},
     DeviceKeyAlgorithm, MilliSecondsSinceUnixEpoch, OwnedMxcUri, OwnedRoomId, OwnedUserId, RoomId,
 };
@@ -231,14 +231,14 @@ pub struct SyncRequestListFilters {
     /// returned regardless of type. This can be used to get the initial set of spaces for an
     /// account.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub room_types: Vec<Option<RoomType>>,
+    pub room_types: Vec<RoomTypeFilter>,
 
     /// Only list rooms that are not of these create-types, or all.
     ///
     /// Same as "room_types" but inverted. This can be used to filter out spaces from the room
     /// list.
     #[serde(default, skip_serializing_if = "<[_]>::is_empty")]
-    pub not_room_types: Vec<Option<RoomType>>,
+    pub not_room_types: Vec<RoomTypeFilter>,
 
     /// Only list rooms matching the given string, or all.
     ///

--- a/crates/ruma-common/src/directory.rs
+++ b/crates/ruma-common/src/directory.rs
@@ -223,12 +223,32 @@ where
     }
 }
 
+impl From<Option<RoomType>> for RoomTypeFilter {
+    fn from(t: Option<RoomType>) -> Self {
+        match t {
+            None => Self::Default,
+            Some(s) => match s {
+                RoomType::Space => Self::Space,
+                _ => Self::from(Some(s.as_str())),
+            },
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use assert_matches2::assert_matches;
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     use super::{Filter, RoomNetwork, RoomTypeFilter};
+    use crate::room::RoomType;
+
+    #[test]
+    fn test_from_room_type() {
+        let test = RoomType::Space;
+        let other: RoomTypeFilter = RoomTypeFilter::from(Some(test));
+        assert_eq!(other, RoomTypeFilter::Space);
+    }
 
     #[test]
     fn serialize_matrix_network_only() {


### PR DESCRIPTION
(cherry picked from commit 5b2ce304010d7c4d1dc1b53af5d49eb1171422ed)
Signed-off-by: morguldir <morguldir@protonmail.com>

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
