### PR TITLE
client-api: Deprecate server_name as per MSC4156

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -27,6 +27,7 @@ Improvements:
   to send `Future` events and update `Future` events with `future_tokens`.
   (`Future` events are scheduled messages that can be controlled
   with `future_tokens` to send on demand or restart the timeout)
+- Introduce `via` and deprecate `server_name` as per MSC4156 / Matrix 1.12.
 
 Bug fixes:
 

--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -10,6 +10,8 @@ Breaking changes:
 - The `content_disposition` fields of `media::get_content::v3::Response` and
   `media::get_content_as_filename::v3::Response` use now the strongly typed
   `ContentDisposition` instead of strings.
+- Replace `server_name` on `knock::knock_room::v3::Request` and 
+  `membership::join_room_by_id_or_alias::v3::Request` with `via` as per MSC4156.
 
 Improvements:
 
@@ -27,7 +29,6 @@ Improvements:
   to send `Future` events and update `Future` events with `future_tokens`.
   (`Future` events are scheduled messages that can be controlled
   with `future_tokens` to send on demand or restart the timeout)
-- Introduce `via` and deprecate `server_name` as per MSC4156 / Matrix 1.12.
 
 Bug fixes:
 

--- a/crates/ruma-client-api/Cargo.toml
+++ b/crates/ruma-client-api/Cargo.toml
@@ -15,7 +15,6 @@ rust-version = { workspace = true }
 all-features = true
 
 [features]
-default = ["client", "server"]
 # OutgoingRequest and IncomingResponse implementations
 client = []
 # IncomingRequest and OutgoingResponse implementations

--- a/crates/ruma-client-api/Cargo.toml
+++ b/crates/ruma-client-api/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = { workspace = true }
 all-features = true
 
 [features]
+default = ["client", "server"]
 # OutgoingRequest and IncomingResponse implementations
 client = []
 # IncomingRequest and OutgoingResponse implementations

--- a/crates/ruma-client-api/src/knock/knock_room.rs
+++ b/crates/ruma-client-api/src/knock/knock_room.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3knockroomidoralias
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{response, Metadata},
         metadata, OwnedRoomId, OwnedRoomOrAliasId, OwnedServerName,
     };
 
@@ -23,30 +23,129 @@ pub mod v3 {
     };
 
     /// Request type for the `knock_room` endpoint.
-    #[request(error = crate::Error)]
+    #[derive(Clone, Debug)]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     pub struct Request {
         /// The room the user should knock on.
-        #[ruma_api(path)]
+        // #[ruma_api(path)]
         pub room_id_or_alias: OwnedRoomOrAliasId,
 
         /// The reason for joining a room.
-        #[serde(skip_serializing_if = "Option::is_none")]
+        // #[serde(skip_serializing_if = "Option::is_none")]
         pub reason: Option<String>,
 
         /// The servers to attempt to knock on the room through.
         ///
         /// One of the servers must be participating in the room.
-        #[ruma_api(query)]
+        // #[ruma_api(query)]
+        // #[serde(default, skip_serializing_if = "<[_]>::is_empty")]
+        pub via: Vec<OwnedServerName>,
+    }
+    /// Data in the request's query string.
+    #[cfg_attr(feature = "client", derive(serde::Serialize))]
+    #[cfg_attr(feature = "server", derive(serde::Deserialize))]
+    struct RequestQuery {
+        /// The servers to attempt to knock on the room through.
         #[serde(default, skip_serializing_if = "<[_]>::is_empty")]
-        #[deprecated = "Since Matrix 1.12, clients should use `knock::knock_room::v3::Request::via`."]
-        pub server_name: Vec<OwnedServerName>,
+        via: Vec<OwnedServerName>,
 
         /// The servers to attempt to knock on the room through.
-        ///
-        /// One of the servers must be participating in the room.
-        #[ruma_api(query)]
         #[serde(default, skip_serializing_if = "<[_]>::is_empty")]
-        pub via: Vec<OwnedServerName>,
+        #[deprecated = "Since Matrix 1.12, clients should use `knock::knock_room::v3::RequestQuery::via`."]
+        server_name: Vec<OwnedServerName>,
+    }
+
+    /// Data in the request's body.
+    #[cfg_attr(feature = "client", derive(serde::Serialize))]
+    #[cfg_attr(feature = "server", derive(serde::Deserialize))]
+    struct RequestBody {
+        /// The reason for joining a room.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub reason: Option<String>,
+    }
+
+    #[cfg(feature = "client")]
+    impl ruma_common::api::OutgoingRequest for Request {
+        type EndpointError = crate::Error;
+        type IncomingResponse = Response;
+
+        const METADATA: Metadata = METADATA;
+
+        #[allow(deprecated)]
+        fn try_into_http_request<T: Default + bytes::BufMut>(
+            self,
+            base_url: &str,
+            access_token: ruma_common::api::SendAccessToken<'_>,
+            considering_versions: &'_ [ruma_common::api::MatrixVersion],
+        ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
+            use http::header::{self, HeaderValue};
+
+            let query_string = serde_html_form::to_string(RequestQuery {
+                server_name: self.via.to_owned(),
+                via: self.via.to_owned(),
+            })?;
+
+            let http_request = http::Request::builder()
+                .method(METADATA.method)
+                .uri(METADATA.make_endpoint_url(
+                    considering_versions,
+                    base_url,
+                    &[&self.room_id_or_alias],
+                    &query_string,
+                )?)
+                .header(header::CONTENT_TYPE, "application/json")
+                .header(
+                    header::AUTHORIZATION,
+                    HeaderValue::from_str(&format!(
+                        "Bearer {}",
+                        access_token
+                            .get_required_for_endpoint()
+                            .ok_or(ruma_common::api::error::IntoHttpError::NeedsAuthentication)?
+                    ))?,
+                )
+                .body(ruma_common::serde::json_to_buf(&RequestBody { reason: self.reason })?)?;
+
+            Ok(http_request)
+        }
+    }
+
+    #[cfg(feature = "server")]
+    impl ruma_common::api::IncomingRequest for Request {
+        type EndpointError = crate::Error;
+        type OutgoingResponse = Response;
+
+        const METADATA: Metadata = METADATA;
+
+        #[allow(deprecated)]
+        fn try_from_http_request<B, S>(
+            request: http::Request<B>,
+            path_args: &[S],
+        ) -> Result<Self, ruma_common::api::error::FromHttpRequestError>
+        where
+            B: AsRef<[u8]>,
+            S: AsRef<str>,
+        {
+            // let (room_id_or_alias): (OwnedRoomOrAliasId) =
+            let (room_id_or_alias,) =
+                serde::Deserialize::deserialize(serde::de::value::SeqDeserializer::<
+                    _,
+                    serde::de::value::Error,
+                >::new(
+                    path_args.iter().map(::std::convert::AsRef::as_ref),
+                ))?;
+
+            let request_query: RequestQuery =
+                serde_html_form::from_str(request.uri().query().unwrap_or(""))?;
+            let via = if request_query.via.is_empty() {
+                request_query.server_name
+            } else {
+                request_query.via
+            };
+
+            let body: RequestBody = serde_json::from_slice(request.body().as_ref())?;
+
+            Ok(Self { room_id_or_alias, reason: body.reason, via })
+        }
     }
 
     /// Response type for the `knock_room` endpoint.
@@ -58,9 +157,8 @@ pub mod v3 {
 
     impl Request {
         /// Creates a new `Request` with the given room ID or alias.
-        #[allow(deprecated)]
         pub fn new(room_id_or_alias: OwnedRoomOrAliasId) -> Self {
-            Self { room_id_or_alias, reason: None, server_name: vec![], via: vec![] }
+            Self { room_id_or_alias, reason: None, via: vec![] }
         }
     }
 
@@ -68,6 +166,85 @@ pub mod v3 {
         /// Creates a new `Response` with the given room ID.
         pub fn new(room_id: OwnedRoomId) -> Self {
             Self { room_id }
+        }
+    }
+
+    #[cfg(all(test, any(feature = "client", feature = "server")))]
+    mod tests {
+        use ruma_common::{
+            api::{IncomingRequest as _, MatrixVersion, OutgoingRequest, SendAccessToken},
+            owned_room_id, owned_server_name,
+        };
+
+        use super::Request;
+
+        #[cfg(feature = "client")]
+        #[test]
+        fn serialize_request() {
+            let mut req = Request::new(owned_room_id!("!foo:b.ar").into());
+            req.via = vec![owned_server_name!("f.oo")];
+            let req = req
+                .try_into_http_request::<Vec<u8>>(
+                    "https://matrix.org",
+                    SendAccessToken::IfRequired("tok"),
+                    &[MatrixVersion::V1_1],
+                )
+                .unwrap();
+            assert_eq!(req.uri().query(), Some("via=f.oo&server_name=f.oo"));
+        }
+
+        #[cfg(feature = "server")]
+        #[test]
+        fn deserialize_request_only_via() {
+            let req = Request::try_from_http_request(
+                http::Request::builder()
+                    .method(http::Method::POST)
+                    .uri("https://matrix.org/_matrix/client/v3/knock/!foo:b.ar?via=f.oo")
+                    .body(b"{ \"reason\": \"Let me in already!\" }" as &[u8])
+                    .unwrap(),
+                &["!foo:b.ar"],
+            )
+            .unwrap();
+
+            assert_eq!(req.room_id_or_alias, "!foo:b.ar");
+            assert_eq!(req.reason, Some("Let me in already!".to_string()));
+            assert_eq!(req.via, vec![owned_server_name!("f.oo")]);
+        }
+
+        #[cfg(feature = "server")]
+        #[test]
+        fn deserialize_request_only_server_name() {
+            let req = Request::try_from_http_request(
+                http::Request::builder()
+                    .method(http::Method::POST)
+                    .uri("https://matrix.org/_matrix/client/v3/knock/!foo:b.ar?server_name=f.oo")
+                    .body(b"{ \"reason\": \"Let me in already!\" }" as &[u8])
+                    .unwrap(),
+                &["!foo:b.ar"],
+            )
+            .unwrap();
+
+            assert_eq!(req.room_id_or_alias, "!foo:b.ar");
+            assert_eq!(req.reason, Some("Let me in already!".to_string()));
+            assert_eq!(req.via, vec![owned_server_name!("f.oo")]);
+        }
+
+        #[cfg(feature = "server")]
+        #[test]
+        fn deserialize_request_via_and_server_name() {
+            let req = Request::try_from_http_request(
+                http::Request::builder()
+                    .method(http::Method::POST)
+                    .uri("https://matrix.org/_matrix/client/v3/knock/!foo:b.ar?via=f.oo&server_name=b.ar")
+                    .body(b"{ \"reason\": \"Let me in already!\" }" as &[u8])
+                    .unwrap(),
+                &["!foo:b.ar"],
+            )
+            .unwrap();
+
+            assert_eq!(req.room_id_or_alias, "!foo:b.ar");
+            assert_eq!(req.reason, Some("Let me in already!".to_string()));
+            assert_eq!(req.via, vec![owned_server_name!("f.oo")]);
         }
     }
 }

--- a/crates/ruma-client-api/src/knock/knock_room.rs
+++ b/crates/ruma-client-api/src/knock/knock_room.rs
@@ -48,7 +48,7 @@ pub mod v3 {
 
         /// The servers to attempt to knock on the room through.
         ///
-        /// Deprecated in Matrix >1.11 in favour of `knock::knock_room::v3::RequestQuery::via`.
+        /// Deprecated in Matrix >1.11 in favour of `via`.
         #[serde(default, skip_serializing_if = "<[_]>::is_empty")]
         server_name: Vec<OwnedServerName>,
     }

--- a/crates/ruma-client-api/src/knock/knock_room.rs
+++ b/crates/ruma-client-api/src/knock/knock_room.rs
@@ -59,7 +59,7 @@ pub mod v3 {
     struct RequestBody {
         /// The reason for joining a room.
         #[serde(skip_serializing_if = "Option::is_none")]
-        pub reason: Option<String>,
+        reason: Option<String>,
     }
 
     #[cfg(feature = "client")]

--- a/crates/ruma-client-api/src/knock/knock_room.rs
+++ b/crates/ruma-client-api/src/knock/knock_room.rs
@@ -50,8 +50,9 @@ pub mod v3 {
         via: Vec<OwnedServerName>,
 
         /// The servers to attempt to knock on the room through.
+        ///
+        /// Deprecated in Matrix >1.11 in favour of `knock::knock_room::v3::RequestQuery::via`.
         #[serde(default, skip_serializing_if = "<[_]>::is_empty")]
-        #[deprecated = "Since Matrix 1.12, clients should use `knock::knock_room::v3::RequestQuery::via`."]
         server_name: Vec<OwnedServerName>,
     }
 
@@ -71,7 +72,6 @@ pub mod v3 {
 
         const METADATA: Metadata = METADATA;
 
-        #[allow(deprecated)]
         fn try_into_http_request<T: Default + bytes::BufMut>(
             self,
             base_url: &str,
@@ -116,7 +116,6 @@ pub mod v3 {
 
         const METADATA: Metadata = METADATA;
 
-        #[allow(deprecated)]
         fn try_from_http_request<B, S>(
             request: http::Request<B>,
             path_args: &[S],

--- a/crates/ruma-client-api/src/knock/knock_room.rs
+++ b/crates/ruma-client-api/src/knock/knock_room.rs
@@ -27,18 +27,14 @@ pub mod v3 {
     #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     pub struct Request {
         /// The room the user should knock on.
-        // #[ruma_api(path)]
         pub room_id_or_alias: OwnedRoomOrAliasId,
 
         /// The reason for joining a room.
-        // #[serde(skip_serializing_if = "Option::is_none")]
         pub reason: Option<String>,
 
         /// The servers to attempt to knock on the room through.
         ///
         /// One of the servers must be participating in the room.
-        // #[ruma_api(query)]
-        // #[serde(default, skip_serializing_if = "<[_]>::is_empty")]
         pub via: Vec<OwnedServerName>,
     }
     /// Data in the request's query string.

--- a/crates/ruma-client-api/src/knock/knock_room.rs
+++ b/crates/ruma-client-api/src/knock/knock_room.rs
@@ -35,6 +35,12 @@ pub mod v3 {
         /// The servers to attempt to knock on the room through.
         ///
         /// One of the servers must be participating in the room.
+        ///
+        /// When serializing, this field is mapped to both `server_name` and `via`
+        /// with identical values.
+        ///
+        /// When deserializing, the value is read from `via` if it's not missing or
+        /// empty and `server_name` otherwise.
         pub via: Vec<OwnedServerName>,
     }
 

--- a/crates/ruma-client-api/src/knock/knock_room.rs
+++ b/crates/ruma-client-api/src/knock/knock_room.rs
@@ -81,7 +81,7 @@ pub mod v3 {
             use http::header::{self, HeaderValue};
 
             let query_string = serde_html_form::to_string(RequestQuery {
-                server_name: self.via.to_owned(),
+                server_name: self.via.clone(),
                 via: self.via.to_owned(),
             })?;
 

--- a/crates/ruma-client-api/src/knock/knock_room.rs
+++ b/crates/ruma-client-api/src/knock/knock_room.rs
@@ -82,7 +82,7 @@ pub mod v3 {
 
             let query_string = serde_html_form::to_string(RequestQuery {
                 server_name: self.via.clone(),
-                via: self.via.to_owned(),
+                via: self.via,
             })?;
 
             let http_request = http::Request::builder()

--- a/crates/ruma-client-api/src/knock/knock_room.rs
+++ b/crates/ruma-client-api/src/knock/knock_room.rs
@@ -38,7 +38,15 @@ pub mod v3 {
         /// One of the servers must be participating in the room.
         #[ruma_api(query)]
         #[serde(default, skip_serializing_if = "<[_]>::is_empty")]
+        #[deprecated = "Since Matrix 1.12, clients should use `knock::knock_room::v3::Request::via`."]
         pub server_name: Vec<OwnedServerName>,
+
+        /// The servers to attempt to knock on the room through.
+        ///
+        /// One of the servers must be participating in the room.
+        #[ruma_api(query)]
+        #[serde(default, skip_serializing_if = "<[_]>::is_empty")]
+        pub via: Vec<OwnedServerName>,
     }
 
     /// Response type for the `knock_room` endpoint.
@@ -50,8 +58,9 @@ pub mod v3 {
 
     impl Request {
         /// Creates a new `Request` with the given room ID or alias.
+        #[allow(deprecated)]
         pub fn new(room_id_or_alias: OwnedRoomOrAliasId) -> Self {
-            Self { room_id_or_alias, reason: None, server_name: vec![] }
+            Self { room_id_or_alias, reason: None, server_name: vec![], via: vec![] }
         }
     }
 

--- a/crates/ruma-client-api/src/knock/knock_room.rs
+++ b/crates/ruma-client-api/src/knock/knock_room.rs
@@ -37,6 +37,7 @@ pub mod v3 {
         /// One of the servers must be participating in the room.
         pub via: Vec<OwnedServerName>,
     }
+
     /// Data in the request's query string.
     #[cfg_attr(feature = "client", derive(serde::Serialize))]
     #[cfg_attr(feature = "server", derive(serde::Deserialize))]

--- a/crates/ruma-client-api/src/knock/knock_room.rs
+++ b/crates/ruma-client-api/src/knock/knock_room.rs
@@ -207,7 +207,7 @@ pub mod v3 {
             .unwrap();
 
             assert_eq!(req.room_id_or_alias, "!foo:b.ar");
-            assert_eq!(req.reason, Some("Let me in already!".to_string()));
+            assert_eq!(req.reason, Some("Let me in already!".to_owned()));
             assert_eq!(req.via, vec![owned_server_name!("f.oo")]);
         }
 
@@ -225,7 +225,7 @@ pub mod v3 {
             .unwrap();
 
             assert_eq!(req.room_id_or_alias, "!foo:b.ar");
-            assert_eq!(req.reason, Some("Let me in already!".to_string()));
+            assert_eq!(req.reason, Some("Let me in already!".to_owned()));
             assert_eq!(req.via, vec![owned_server_name!("f.oo")]);
         }
 
@@ -243,7 +243,7 @@ pub mod v3 {
             .unwrap();
 
             assert_eq!(req.room_id_or_alias, "!foo:b.ar");
-            assert_eq!(req.reason, Some("Let me in already!".to_string()));
+            assert_eq!(req.reason, Some("Let me in already!".to_owned()));
             assert_eq!(req.via, vec![owned_server_name!("f.oo")]);
         }
     }

--- a/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
+++ b/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
@@ -25,7 +25,8 @@ pub mod v3 {
     };
 
     /// Request type for the `join_room_by_id_or_alias` endpoint.
-    #[request(error = crate::Error)]
+    #[derive(Clone, Debug)]
+    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     pub struct Request {
         /// The room where the user should be invited.
         #[ruma_api(path)]

--- a/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
+++ b/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
@@ -54,8 +54,7 @@ pub mod v3 {
 
         /// The servers to attempt to join the room through.
         ///
-        /// Deprecated in Matrix >1.11 in favour of
-        /// `membership::join_room_by_id_or_alias::v3::RequestQuery::via`.
+        /// Deprecated in Matrix >1.11 in favour of `via`.
         #[serde(default, skip_serializing_if = "<[_]>::is_empty")]
         server_name: Vec<OwnedServerName>,
     }

--- a/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
+++ b/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
@@ -54,7 +54,8 @@ pub mod v3 {
 
         /// The servers to attempt to knock on the room through.
         ///
-        /// Deprecated in Matrix >1.11 in favour of `membership::join_room_by_id_or_alias::v3::RequestQuery::via`.
+        /// Deprecated in Matrix >1.11 in favour of
+        /// `membership::join_room_by_id_or_alias::v3::RequestQuery::via`.
         #[serde(default, skip_serializing_if = "<[_]>::is_empty")]
         server_name: Vec<OwnedServerName>,
     }

--- a/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
+++ b/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
@@ -66,11 +66,11 @@ pub mod v3 {
         /// The signature of a `m.third_party_invite` token to prove that this user owns a third
         /// party identity which has been invited to the room.
         #[serde(skip_serializing_if = "Option::is_none")]
-        pub third_party_signed: Option<ThirdPartySigned>,
+        third_party_signed: Option<ThirdPartySigned>,
 
         /// Optional reason for joining the room.
         #[serde(skip_serializing_if = "Option::is_none")]
-        pub reason: Option<String>,
+        reason: Option<String>,
     }
 
     #[cfg(feature = "client")]

--- a/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
+++ b/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
@@ -184,7 +184,6 @@ pub mod v3 {
 
     impl Request {
         /// Creates a new `Request` with the given room ID or alias ID.
-        #[allow(deprecated)]
         pub fn new(room_id_or_alias: OwnedRoomOrAliasId) -> Self {
             Self { room_id_or_alias, via: vec![], third_party_signed: None, reason: None }
         }

--- a/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
+++ b/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
@@ -48,11 +48,11 @@ pub mod v3 {
     #[cfg_attr(feature = "client", derive(serde::Serialize))]
     #[cfg_attr(feature = "server", derive(serde::Deserialize))]
     struct RequestQuery {
-        /// The servers to attempt to knock on the room through.
+        /// The servers to attempt to join the room through.
         #[serde(default, skip_serializing_if = "<[_]>::is_empty")]
         via: Vec<OwnedServerName>,
 
-        /// The servers to attempt to knock on the room through.
+        /// The servers to attempt to join the room through.
         ///
         /// Deprecated in Matrix >1.11 in favour of
         /// `membership::join_room_by_id_or_alias::v3::RequestQuery::via`.

--- a/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
+++ b/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
@@ -54,7 +54,7 @@ pub mod v3 {
 
         /// The servers to attempt to knock on the room through.
         ///
-        /// Deprecated in Matrix >1.11 in favour of `knock::knock_room::v3::RequestQuery::via`.
+        /// Deprecated in Matrix >1.11 in favour of `membership::join_room_by_id_or_alias::v3::RequestQuery::via`.
         #[serde(default, skip_serializing_if = "<[_]>::is_empty")]
         server_name: Vec<OwnedServerName>,
     }

--- a/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
+++ b/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3joinroomidoralias
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{response, Metadata},
         metadata, OwnedRoomId, OwnedRoomOrAliasId, OwnedServerName,
     };
 
@@ -29,24 +29,40 @@ pub mod v3 {
     #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     pub struct Request {
         /// The room where the user should be invited.
-        #[ruma_api(path)]
         pub room_id_or_alias: OwnedRoomOrAliasId,
 
-        /// The servers to attempt to join the room through.
-        ///
-        /// One of the servers must be participating in the room.
-        #[ruma_api(query)]
-        #[serde(default, skip_serializing_if = "<[_]>::is_empty")]
-        #[deprecated = "Since Matrix 1.12, clients should use `membership::join_room_by_id_or_alias::v3::Request::via`."]
-        pub server_name: Vec<OwnedServerName>,
+        /// The signature of a `m.third_party_invite` token to prove that this user owns a third
+        /// party identity which has been invited to the room.
+        pub third_party_signed: Option<ThirdPartySigned>,
+
+        /// Optional reason for joining the room.
+        pub reason: Option<String>,
 
         /// The servers to attempt to join the room through.
         ///
         /// One of the servers must be participating in the room.
-        #[ruma_api(query)]
-        #[serde(default, skip_serializing_if = "<[_]>::is_empty")]
         pub via: Vec<OwnedServerName>,
+    }
 
+    /// Data in the request's query string.
+    #[cfg_attr(feature = "client", derive(serde::Serialize))]
+    #[cfg_attr(feature = "server", derive(serde::Deserialize))]
+    struct RequestQuery {
+        /// The servers to attempt to knock on the room through.
+        #[serde(default, skip_serializing_if = "<[_]>::is_empty")]
+        via: Vec<OwnedServerName>,
+
+        /// The servers to attempt to knock on the room through.
+        ///
+        /// Deprecated in Matrix >1.11 in favour of `knock::knock_room::v3::RequestQuery::via`.
+        #[serde(default, skip_serializing_if = "<[_]>::is_empty")]
+        server_name: Vec<OwnedServerName>,
+    }
+
+    /// Data in the request's body.
+    #[cfg_attr(feature = "client", derive(serde::Serialize))]
+    #[cfg_attr(feature = "server", derive(serde::Deserialize))]
+    struct RequestBody {
         /// The signature of a `m.third_party_invite` token to prove that this user owns a third
         /// party identity which has been invited to the room.
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -55,6 +71,102 @@ pub mod v3 {
         /// Optional reason for joining the room.
         #[serde(skip_serializing_if = "Option::is_none")]
         pub reason: Option<String>,
+    }
+
+    #[cfg(feature = "client")]
+    impl ruma_common::api::OutgoingRequest for Request {
+        type EndpointError = crate::Error;
+        type IncomingResponse = Response;
+
+        const METADATA: Metadata = METADATA;
+
+        fn try_into_http_request<T: Default + bytes::BufMut>(
+            self,
+            base_url: &str,
+            access_token: ruma_common::api::SendAccessToken<'_>,
+            considering_versions: &'_ [ruma_common::api::MatrixVersion],
+        ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
+            use http::header::{self, HeaderValue};
+
+            let query_string = serde_html_form::to_string(RequestQuery {
+                server_name: self.via.clone(),
+                via: self.via,
+            })?;
+
+            let http_request = http::Request::builder()
+                .method(METADATA.method)
+                .uri(METADATA.make_endpoint_url(
+                    considering_versions,
+                    base_url,
+                    &[&self.room_id_or_alias],
+                    &query_string,
+                )?)
+                .header(header::CONTENT_TYPE, "application/json")
+                .header(
+                    header::AUTHORIZATION,
+                    HeaderValue::from_str(&format!(
+                        "Bearer {}",
+                        access_token
+                            .get_required_for_endpoint()
+                            .ok_or(ruma_common::api::error::IntoHttpError::NeedsAuthentication)?
+                    ))?,
+                )
+                .body(ruma_common::serde::json_to_buf(&RequestBody {
+                    third_party_signed: self.third_party_signed,
+                    reason: self.reason,
+                })?)?;
+
+            Ok(http_request)
+        }
+    }
+
+    #[cfg(feature = "server")]
+    impl ruma_common::api::IncomingRequest for Request {
+        type EndpointError = crate::Error;
+        type OutgoingResponse = Response;
+
+        const METADATA: Metadata = METADATA;
+
+        fn try_from_http_request<B, S>(
+            request: http::Request<B>,
+            path_args: &[S],
+        ) -> Result<Self, ruma_common::api::error::FromHttpRequestError>
+        where
+            B: AsRef<[u8]>,
+            S: AsRef<str>,
+        {
+            if request.method() != METADATA.method {
+                return Err(ruma_common::api::error::FromHttpRequestError::MethodMismatch {
+                    expected: METADATA.method,
+                    received: request.method().clone(),
+                });
+            }
+
+            let (room_id_or_alias,) =
+                serde::Deserialize::deserialize(serde::de::value::SeqDeserializer::<
+                    _,
+                    serde::de::value::Error,
+                >::new(
+                    path_args.iter().map(::std::convert::AsRef::as_ref),
+                ))?;
+
+            let request_query: RequestQuery =
+                serde_html_form::from_str(request.uri().query().unwrap_or(""))?;
+            let via = if request_query.via.is_empty() {
+                request_query.server_name
+            } else {
+                request_query.via
+            };
+
+            let body: RequestBody = serde_json::from_slice(request.body().as_ref())?;
+
+            Ok(Self {
+                room_id_or_alias,
+                reason: body.reason,
+                third_party_signed: body.third_party_signed,
+                via,
+            })
+        }
     }
 
     /// Response type for the `join_room_by_id_or_alias` endpoint.
@@ -68,13 +180,7 @@ pub mod v3 {
         /// Creates a new `Request` with the given room ID or alias ID.
         #[allow(deprecated)]
         pub fn new(room_id_or_alias: OwnedRoomOrAliasId) -> Self {
-            Self {
-                room_id_or_alias,
-                server_name: vec![],
-                via: vec![],
-                third_party_signed: None,
-                reason: None,
-            }
+            Self { room_id_or_alias, via: vec![], third_party_signed: None, reason: None }
         }
     }
 
@@ -82,6 +188,99 @@ pub mod v3 {
         /// Creates a new `Response` with the given room ID.
         pub fn new(room_id: OwnedRoomId) -> Self {
             Self { room_id }
+        }
+    }
+
+    #[cfg(all(test, any(feature = "client", feature = "server")))]
+    mod tests {
+        use ruma_common::{
+            api::{IncomingRequest as _, MatrixVersion, OutgoingRequest, SendAccessToken},
+            owned_room_id, owned_server_name,
+        };
+
+        use super::Request;
+
+        #[cfg(feature = "client")]
+        #[test]
+        fn serialize_request() {
+            let mut req = Request::new(owned_room_id!("!foo:b.ar").into());
+            req.via = vec![owned_server_name!("f.oo")];
+            let req = req
+                .try_into_http_request::<Vec<u8>>(
+                    "https://matrix.org",
+                    SendAccessToken::IfRequired("tok"),
+                    &[MatrixVersion::V1_1],
+                )
+                .unwrap();
+            assert_eq!(req.uri().query(), Some("via=f.oo&server_name=f.oo"));
+        }
+
+        #[cfg(feature = "server")]
+        #[test]
+        fn deserialize_request_wrong_method() {
+            Request::try_from_http_request(
+                http::Request::builder()
+                    .method(http::Method::GET)
+                    .uri("https://matrix.org/_matrix/client/v3/join/!foo:b.ar?via=f.oo")
+                    .body(b"{ \"reason\": \"Let me in already!\" }" as &[u8])
+                    .unwrap(),
+                &["!foo:b.ar"],
+            )
+            .expect_err("Should not deserialize request with illegal method");
+        }
+
+        #[cfg(feature = "server")]
+        #[test]
+        fn deserialize_request_only_via() {
+            let req = Request::try_from_http_request(
+                http::Request::builder()
+                    .method(http::Method::POST)
+                    .uri("https://matrix.org/_matrix/client/v3/join/!foo:b.ar?via=f.oo")
+                    .body(b"{ \"reason\": \"Let me in already!\" }" as &[u8])
+                    .unwrap(),
+                &["!foo:b.ar"],
+            )
+            .unwrap();
+
+            assert_eq!(req.room_id_or_alias, "!foo:b.ar");
+            assert_eq!(req.reason, Some("Let me in already!".to_owned()));
+            assert_eq!(req.via, vec![owned_server_name!("f.oo")]);
+        }
+
+        #[cfg(feature = "server")]
+        #[test]
+        fn deserialize_request_only_server_name() {
+            let req = Request::try_from_http_request(
+                http::Request::builder()
+                    .method(http::Method::POST)
+                    .uri("https://matrix.org/_matrix/client/v3/join/!foo:b.ar?server_name=f.oo")
+                    .body(b"{ \"reason\": \"Let me in already!\" }" as &[u8])
+                    .unwrap(),
+                &["!foo:b.ar"],
+            )
+            .unwrap();
+
+            assert_eq!(req.room_id_or_alias, "!foo:b.ar");
+            assert_eq!(req.reason, Some("Let me in already!".to_owned()));
+            assert_eq!(req.via, vec![owned_server_name!("f.oo")]);
+        }
+
+        #[cfg(feature = "server")]
+        #[test]
+        fn deserialize_request_via_and_server_name() {
+            let req = Request::try_from_http_request(
+                http::Request::builder()
+                    .method(http::Method::POST)
+                    .uri("https://matrix.org/_matrix/client/v3/join/!foo:b.ar?via=f.oo&server_name=b.ar")
+                    .body(b"{ \"reason\": \"Let me in already!\" }" as &[u8])
+                    .unwrap(),
+                &["!foo:b.ar"],
+            )
+            .unwrap();
+
+            assert_eq!(req.room_id_or_alias, "!foo:b.ar");
+            assert_eq!(req.reason, Some("Let me in already!".to_owned()));
+            assert_eq!(req.via, vec![owned_server_name!("f.oo")]);
         }
     }
 }

--- a/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
+++ b/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
@@ -33,10 +33,18 @@ pub mod v3 {
 
         /// The servers to attempt to join the room through.
         ///
-        /// One of the servers  must be participating in the room.
+        /// One of the servers must be participating in the room.
         #[ruma_api(query)]
         #[serde(default, skip_serializing_if = "<[_]>::is_empty")]
+        #[deprecated = "Since Matrix 1.12, clients should use `membership::join_room_by_id_or_alias::v3::Request::via`."]
         pub server_name: Vec<OwnedServerName>,
+
+        /// The servers to attempt to join the room through.
+        ///
+        /// One of the servers must be participating in the room.
+        #[ruma_api(query)]
+        #[serde(default, skip_serializing_if = "<[_]>::is_empty")]
+        pub via: Vec<OwnedServerName>,
 
         /// The signature of a `m.third_party_invite` token to prove that this user owns a third
         /// party identity which has been invited to the room.
@@ -57,8 +65,15 @@ pub mod v3 {
 
     impl Request {
         /// Creates a new `Request` with the given room ID or alias ID.
+        #[allow(deprecated)]
         pub fn new(room_id_or_alias: OwnedRoomOrAliasId) -> Self {
-            Self { room_id_or_alias, server_name: vec![], third_party_signed: None, reason: None }
+            Self {
+                room_id_or_alias,
+                server_name: vec![],
+                via: vec![],
+                third_party_signed: None,
+                reason: None,
+            }
         }
     }
 

--- a/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
+++ b/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
@@ -41,6 +41,12 @@ pub mod v3 {
         /// The servers to attempt to join the room through.
         ///
         /// One of the servers must be participating in the room.
+        ///
+        /// When serializing, this field is mapped to both `server_name` and `via`
+        /// with identical values.
+        ///
+        /// When deserializing, the value is read from `via` if it's not missing or
+        /// empty and `server_name` otherwise.
         pub via: Vec<OwnedServerName>,
     }
 


### PR DESCRIPTION
This deprecates `server_name` as per [MSC4156](https://github.com/matrix-org/matrix-spec-proposals/pull/4156).

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
