### PR TITLE
html: Remove support for `name` attribute

### DIFF
--- a/crates/ruma-html/CHANGELOG.md
+++ b/crates/ruma-html/CHANGELOG.md
@@ -3,6 +3,7 @@
 Breaking Changes:
 
 - `MatrixElement::Div` is now a newtype variant.
+- `AnchorData`'s `name` field was removed, according to MSC4159.
 
 Improvements:
 

--- a/crates/ruma-html/src/html/matrix.rs
+++ b/crates/ruma-html/src/html/matrix.rs
@@ -337,9 +337,6 @@ impl PartialEq<u8> for HeadingLevel {
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct AnchorData {
-    /// The name of the anchor.
-    pub name: Option<StrTendril>,
-
     /// Where to display the linked URL.
     pub target: Option<StrTendril>,
 
@@ -350,7 +347,7 @@ pub struct AnchorData {
 impl AnchorData {
     /// Construct an empty `AnchorData`.
     fn new() -> Self {
-        Self { name: None, target: None, href: None }
+        Self { target: None, href: None }
     }
 
     /// Parse the given attributes to construct a new `AnchorData`.
@@ -368,9 +365,6 @@ impl AnchorData {
             }
 
             match attr.name.local.as_bytes() {
-                b"name" => {
-                    data.name = Some(attr.value.clone());
-                }
                 b"target" => {
                     data.target = Some(attr.value.clone());
                 }

--- a/crates/ruma-html/src/sanitizer_config/clean.rs
+++ b/crates/ruma-html/src/sanitizer_config/clean.rs
@@ -32,7 +32,7 @@ static ALLOWED_ATTRIBUTES_STRICT: Map<&str, &Set<&str>> = phf_map! {
 };
 static ALLOWED_ATTRIBUTES_SPAN_STRICT: Set<&str> =
     phf_set! { "data-mx-bg-color", "data-mx-color", "data-mx-spoiler", "data-mx-maths" };
-static ALLOWED_ATTRIBUTES_A_STRICT: Set<&str> = phf_set! { "name", "target", "href" };
+static ALLOWED_ATTRIBUTES_A_STRICT: Set<&str> = phf_set! { "target", "href" };
 static ALLOWED_ATTRIBUTES_IMG_STRICT: Set<&str> =
     phf_set! { "width", "height", "alt", "title", "src" };
 static ALLOWED_ATTRIBUTES_OL_STRICT: Set<&str> = phf_set! { "start" };

--- a/crates/ruma-html/tests/it/html/matrix.rs
+++ b/crates/ruma-html/tests/it/html/matrix.rs
@@ -84,11 +84,7 @@ fn span_attributes() {
 #[test]
 fn a_attributes() {
     let raw_html = "\
-        <a \
-            name=\"my_anchor\" \
-            target=\"_blank\" \
-            href=\"https://localhost/\"\
-        >\
+        <a target=\"_blank\" href=\"https://localhost/\">\
             Link with all supported attributes\
         </a>\
         <a href=\"matrix:r/somewhere:localhost\">Link with valid matrix scheme URI</a>\
@@ -105,7 +101,6 @@ fn a_attributes() {
     let element = node.as_element().unwrap().to_matrix();
 
     assert_matches!(element.element, MatrixElement::A(anchor));
-    assert_eq!(anchor.name.unwrap().as_ref(), "my_anchor");
     assert_eq!(anchor.target.unwrap().as_ref(), "_blank");
     assert_matches!(anchor.href.unwrap(), AnchorUri::Other(uri));
     assert_eq!(uri.as_ref(), "https://localhost/");
@@ -116,7 +111,6 @@ fn a_attributes() {
     let element = node.as_element().unwrap().to_matrix();
 
     assert_matches!(element.element, MatrixElement::A(anchor));
-    assert!(anchor.name.is_none());
     assert!(anchor.target.is_none());
     assert_matches!(anchor.href.unwrap(), AnchorUri::Matrix(uri));
     assert_eq!(uri.to_string(), "matrix:r/somewhere:localhost");
@@ -127,7 +121,6 @@ fn a_attributes() {
     let element = node.as_element().unwrap().to_matrix();
 
     assert_matches!(element.element, MatrixElement::A(anchor));
-    assert!(anchor.name.is_none());
     assert!(anchor.target.is_none());
     assert!(anchor.href.is_none());
     // The `href` attribute is in the unsupported attributes.
@@ -138,7 +131,6 @@ fn a_attributes() {
     let element = node.as_element().unwrap().to_matrix();
 
     assert_matches!(element.element, MatrixElement::A(anchor));
-    assert!(anchor.name.is_none());
     assert!(anchor.target.is_none());
     assert_matches!(anchor.href.unwrap(), AnchorUri::MatrixTo(uri));
     assert_eq!(uri.to_string(), "https://matrix.to/#/%23somewhere:example.org");
@@ -149,7 +141,6 @@ fn a_attributes() {
     let element = node.as_element().unwrap().to_matrix();
 
     assert_matches!(element.element, MatrixElement::A(anchor));
-    assert!(anchor.name.is_none());
     assert!(anchor.target.is_none());
     assert!(anchor.href.is_none());
     // The `href` attribute is in the unsupported attributes.
@@ -160,7 +151,6 @@ fn a_attributes() {
     let element = node.as_element().unwrap().to_matrix();
 
     assert_matches!(element.element, MatrixElement::A(anchor));
-    assert!(anchor.name.is_none());
     assert!(anchor.target.is_none());
     assert!(anchor.href.is_none());
     // The `href` attribute is in the unsupported attributes.


### PR DESCRIPTION
According to [MSC4159](https://github.com/matrix-org/matrix-spec-proposals/pull/4159) / [Spec PR](https://github.com/matrix-org/matrix-spec/pull/1870).

The Matrix version for this is not out yet but it has probably never been used so I believe it's fine to merge this right away.