### PR TITLE
client-api: Add m.get_login_token capability

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -34,6 +34,8 @@ Improvements:
 - Change types of `SyncRequestListFilters::{room_types,not_room_types}` to
   `Vec<RoomTypeFilter>` instead of a vector of strings
   - This is a breaking change, but only for users of `unstable-msc3575`
+- Add the `get_login_token` field to `Capabilities`, according to a
+  clarification in the spec.
 
 Bug fixes:
 

--- a/crates/ruma-client-api/src/discovery/get_capabilities.rs
+++ b/crates/ruma-client-api/src/discovery/get_capabilities.rs
@@ -63,6 +63,15 @@ pub struct Capabilities {
     )]
     pub thirdparty_id_changes: ThirdPartyIdChangesCapability,
 
+    /// Capability to indicate if the user can generate tokens to log further clients into their
+    /// account.
+    #[serde(
+        rename = "m.get_login_token",
+        default,
+        skip_serializing_if = "GetLoginTokenCapability::is_default"
+    )]
+    pub get_login_token: GetLoginTokenCapability,
+
     /// Any other custom capabilities that the server supports outside of the specification,
     /// labeled using the Java package naming convention and stored as arbitrary JSON values.
     #[serde(flatten)]
@@ -289,6 +298,26 @@ impl ThirdPartyIdChangesCapability {
 impl Default for ThirdPartyIdChangesCapability {
     fn default() -> Self {
         Self { enabled: true }
+    }
+}
+
+/// Information about the `m.get_login_token` capability.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+pub struct GetLoginTokenCapability {
+    /// Whether the user can request a login token.
+    pub enabled: bool,
+}
+
+impl GetLoginTokenCapability {
+    /// Creates a new `GetLoginTokenCapability` with the given enabled flag.
+    pub fn new(enabled: bool) -> Self {
+        Self { enabled }
+    }
+
+    /// Returns whether all fields have their default value.
+    pub fn is_default(&self) -> bool {
+        !self.enabled
     }
 }
 


### PR DESCRIPTION
According to a clarification in https://github.com/matrix-org/matrix-spec/pull/1908. It was forgotten when [MSC3882](https://github.com/matrix-org/matrix-spec-proposals/pull/3882) was merged in the spec last year.