### PR TITLE
events: Improve markdown syntax detection

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -7,6 +7,8 @@ Bug fixes:
 - Fix serialization of `room::message::Relation` and `room::encrypted::Relation`
   which could cause duplicate `rel_type` keys. 
 - `Restricted` no longer fails to deserialize when the `allow` field is missing
+- Markdown text constructors now also detect markdown syntax like backslash
+  escapes and entity references to decide if the text should be sent as HTML.
 
 Improvements:
 

--- a/crates/ruma-events/Cargo.toml
+++ b/crates/ruma-events/Cargo.toml
@@ -65,7 +65,7 @@ indexmap = { version = "2.0.0", features = ["serde"] }
 js_int = { workspace = true, features = ["serde"] }
 js_option = "0.1.0"
 percent-encoding = "2.1.0"
-pulldown-cmark = { version = "0.11.0", optional = true, default-features = false, features = ["html"] }
+pulldown-cmark = { version = "0.12.1", optional = true, default-features = false, features = ["html"] }
 regex = { version = "1.5.6", default-features = false, features = ["std", "perf"] }
 ruma-common = { workspace = true }
 ruma-html = { workspace = true, optional = true }

--- a/crates/ruma-events/tests/it/room_message.rs
+++ b/crates/ruma-events/tests/it/room_message.rs
@@ -201,9 +201,9 @@ fn markdown_detection() {
     let formatted_body = FormattedBody::markdown("A message\nwith\n\nmultiple\n\nparagraphs");
     formatted_body.unwrap();
 
-    // HTML entities don't trigger markdown.
+    // "Less than" symbol triggers markdown.
     let formatted_body = FormattedBody::markdown("A message with & HTML < entities");
-    assert_matches!(formatted_body, None);
+    assert_matches!(formatted_body, Some(_));
 
     // HTML triggers markdown.
     let formatted_body = FormattedBody::markdown("<span>An HTML message</span>");


### PR DESCRIPTION
Also detect backslash escapes and entity references.

It turns out that contrary to what I believed in #1872, pulldown-cmark has a list of static strings for entity references so we still encounter borrowed strings if those were replaced. However that still splits the string into several slices so we can detect it the same as we detect backslash escapes.

I am wondering if this will cause false-positives with longer, more complex text but I could not figure out how to trigger one.

Fixes #1872.
