### PR TITLE
ci: Bump the version of Rust nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
   # Keep in sync with version in `rust-toolchain.toml` and `xtask/src/ci.rs`
-  NIGHTLY: nightly-2024-07-29
+  NIGHTLY: nightly-2024-09-06
 
 on:
   push:

--- a/crates/ruma-common/src/serde/raw.rs
+++ b/crates/ruma-common/src/serde/raw.rs
@@ -11,10 +11,7 @@ use serde::{
 };
 use serde_json::value::{to_raw_value as to_raw_json_value, RawValue as RawJsonValue};
 
-/// A wrapper around `Box<RawValue>`.
-///
-/// To be used in place of any type in the Matrix endpoint definition to allow request and response
-/// types to contain that said type represented by the generic argument `Ev`.
+/// A wrapper around `Box<RawValue>` with a generic parameter for the expected Rust type.
 ///
 /// Ruma offers the `Raw` wrapper to enable passing around JSON text that is only partially
 /// validated. This is useful when a client receives events that do not follow the spec perfectly

--- a/crates/ruma-common/src/serde/raw.rs
+++ b/crates/ruma-common/src/serde/raw.rs
@@ -11,9 +11,10 @@ use serde::{
 };
 use serde_json::value::{to_raw_value as to_raw_json_value, RawValue as RawJsonValue};
 
-/// A wrapper around `Box<RawValue>`, to be used in place of any type in the Matrix endpoint
-/// definition to allow request and response types to contain that said type represented by
-/// the generic argument `Ev`.
+/// A wrapper around `Box<RawValue>`.
+///
+/// To be used in place of any type in the Matrix endpoint definition to allow request and response
+/// types to contain that said type represented by the generic argument `Ev`.
 ///
 /// Ruma offers the `Raw` wrapper to enable passing around JSON text that is only partially
 /// validated. This is useful when a client receives events that do not follow the spec perfectly

--- a/crates/ruma-common/src/serde/strings.rs
+++ b/crates/ruma-common/src/serde/strings.rs
@@ -9,6 +9,7 @@ use serde::{
 
 /// Serde deserialization decorator to map empty Strings to None,
 /// and forward non-empty Strings to the Deserialize implementation for T.
+///
 /// Useful for the typical
 /// "A room with an X event with an absent, null, or empty Y field
 /// should be treated the same as a room with no such event."

--- a/crates/ruma-events/src/call/member.rs
+++ b/crates/ruma-events/src/call/member.rs
@@ -147,7 +147,9 @@ pub struct EmptyMembershipData {
 }
 
 /// This is the optional value for an empty membership event content:
-/// [`CallMemberEventContent::Empty`]. It is used when the user disconnected and a Future ([MSC4140](https://github.com/matrix-org/matrix-spec-proposals/pull/4140))
+/// [`CallMemberEventContent::Empty`].
+///
+/// It is used when the user disconnected and a Future ([MSC4140](https://github.com/matrix-org/matrix-spec-proposals/pull/4140))
 /// was used to update the membership after the client was not reachable anymore.  
 #[derive(Clone, PartialEq, StringEnum)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 # Keep in sync with version in `xtask/src/ci.rs` and `.github/workflows/ci.yml`
-channel = "nightly-2024-07-29"
+channel = "nightly-2024-09-06"
 components = ["rustfmt", "clippy"]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -15,7 +15,7 @@ use serde::Deserialize;
 use serde_json::from_str as from_json_str;
 
 // Keep in sync with version in `rust-toolchain.toml` and `.github/workflows/ci.yml`
-const NIGHTLY: &str = "nightly-2024-07-29";
+const NIGHTLY: &str = "nightly-2024-09-06";
 
 mod cargo;
 mod ci;


### PR DESCRIPTION
Triggers a new (nice) clippy lint, [`too_long_first_doc_paragraph`](https://rust-lang.github.io/rust-clippy/master/index.html#/too_long_first_doc_paragraph).

I realized when I handled the lint that I don't really understand what the second sentente for `Raw` actually means. I mean I have an idea what it is trying to say but the wording is not very clear.