### PR TITLE
Fix warnings in UI tests

### DIFF
--- a/crates/ruma-common/tests/api/ui/move-value.rs
+++ b/crates/ruma-common/tests/api/ui/move-value.rs
@@ -1,7 +1,7 @@
 // This tests that the "body" fields are moved after all other fields because they
 // consume the request/response.
 
-mod newtype_body {
+pub mod newtype_body {
     use http::header::CONTENT_TYPE;
     use ruma_common::{
         api::{request, response, Metadata},
@@ -47,7 +47,7 @@ mod newtype_body {
     }
 }
 
-mod raw_body {
+pub mod raw_body {
     use http::header::CONTENT_TYPE;
     use ruma_common::{
         api::{request, response, Metadata},
@@ -90,7 +90,7 @@ mod raw_body {
     }
 }
 
-mod plain {
+pub mod plain {
     use http::header::CONTENT_TYPE;
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-events/tests/it/ui/13-private-event-content-type.rs
+++ b/crates/ruma-events/tests/it/ui/13-private-event-content-type.rs
@@ -1,4 +1,5 @@
-#![deny(private_in_public)]
+#![deny(private_interfaces, private_bounds, unnameable_types)]
+#![allow(dead_code)]
 
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
The first commit is because the compiler complained that we were using `pub` inside private modules.

The second commit was a deprecated lint replaced by [other lints](https://rust-lang.github.io/rfcs/2145-type-privacy.html). We also need to allow dead code otherwise there is a warning that `MacroTestContent` is unused.
