### PR TITLE
ci: Upgrade actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,10 +50,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Check spelling
-        uses: crate-ci/typos@v1.20.3
+        uses: crate-ci/typos@v1.24.5
 
       - name: Install cargo-sort
-        uses: taiki-e/cache-cargo-install-action@v1
+        uses: taiki-e/cache-cargo-install-action@v2
         with:
           tool: cargo-sort
 

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: EmbarkStudios/cargo-deny-action@v1
+      - uses: EmbarkStudios/cargo-deny-action@v2
         with:
           command: check bans licenses sources
 
@@ -31,6 +31,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: EmbarkStudios/cargo-deny-action@v1
+      - uses: EmbarkStudios/cargo-deny-action@v2
         with:
           command: check advisories


### PR DESCRIPTION
Upgrading typos gives us new checks.\
Upgrading taiki-e/cache-cargo-install-action to a new major version gets rid of a warning about using a node16 action.\
Upgrading cargo-deny to a new major version to get new updates.