### PR TITLE
events: Remove use of String for Owned DeviceId

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -18,6 +18,11 @@ Improvements:
 - Stabilize support for muting in VoIP calls, according to Matrix 1.11
 - All the root `Any*EventContent` types now have a `EventContentFromType` implementations
   automatically derived by the `event_enum!` macro.
+- `CallMemberEventContent` now supports two different formats: Session memberships and Legacy memberships.
+The new format (Session) is required to reliably display the call member count (reliable call member events).
+`CallMemberEventContent` is now an enum to model the two different formats.
+- `CallMemberStateKey` (instead of `OwnedUserId`) is now used as the state key type for `CallMemberEventContent`.
+This guarantees correct formatting of the event key.
 
 Breaking changes:
 

--- a/crates/ruma-events/src/call/member.rs
+++ b/crates/ruma-events/src/call/member.rs
@@ -11,7 +11,7 @@ mod member_state_key;
 pub use focus::*;
 pub use member_data::*;
 pub use member_state_key::*;
-use ruma_common::MilliSecondsSinceUnixEpoch;
+use ruma_common::{MilliSecondsSinceUnixEpoch, OwnedDeviceId};
 use ruma_macros::{EventContent, StringEnum};
 use serde::{Deserialize, Serialize};
 
@@ -56,7 +56,7 @@ impl CallMemberEventContent {
     /// Creates a new [`CallMemberEventContent`] with [`SessionMembershipData`].
     pub fn new(
         application: Application,
-        device_id: String,
+        device_id: OwnedDeviceId,
         focus_active: ActiveFocus,
         foci_preferred: Vec<Focus>,
         created_ts: Option<MilliSecondsSinceUnixEpoch>,
@@ -234,8 +234,8 @@ mod tests {
 
     use assert_matches2::assert_matches;
     use ruma_common::{
-        device_id, user_id, MilliSecondsSinceUnixEpoch as TS, OwnedEventId, OwnedRoomId,
-        OwnedUserId,
+        device_id, owned_device_id, user_id, MilliSecondsSinceUnixEpoch as TS, OwnedEventId,
+        OwnedRoomId, OwnedUserId,
     };
     use serde_json::{from_value as from_json_value, json, Value as JsonValue};
 
@@ -257,7 +257,7 @@ mod tests {
                 call_id: "123456".to_owned(),
                 scope: CallScope::Room,
             }),
-            device_id: "ABCDE".to_owned(),
+            device_id: owned_device_id!("ABCDE"),
             expires: Duration::from_secs(3600),
             foci_active: vec![Focus::Livekit(LivekitFocus {
                 alias: "1".to_owned(),
@@ -274,7 +274,7 @@ mod tests {
                 call_id: "123456".to_owned(),
                 scope: CallScope::Room,
             }),
-            "ABCDE".to_owned(),
+            owned_device_id!("ABCDE"),
             ActiveFocus::Livekit(ActiveLivekitFocus {
                 focus_selection: FocusSelection::OldestMembership,
             }),
@@ -354,7 +354,7 @@ mod tests {
                 call_id: "123456".to_owned(),
                 scope: CallScope::Room,
             }),
-            "THIS_DEVICE".to_owned(),
+            owned_device_id!("THIS_DEVICE"),
             ActiveFocus::Livekit(ActiveLivekitFocus {
                 focus_selection: FocusSelection::OldestMembership,
             }),
@@ -404,7 +404,7 @@ mod tests {
                     call_id: "123456".to_owned(),
                     scope: CallScope::Room,
                 }),
-                device_id: "THIS_DEVICE".to_owned(),
+                device_id: owned_device_id!("THIS_DEVICE"),
                 expires: Duration::from_secs(3600),
                 foci_active: vec![Focus::Livekit(LivekitFocus {
                     alias: "room1".to_owned(),
@@ -418,7 +418,7 @@ mod tests {
                     call_id: "".to_owned(),
                     scope: CallScope::Room,
                 }),
-                device_id: "OTHER_DEVICE".to_owned(),
+                device_id: owned_device_id!("OTHER_DEVICE"),
                 expires: Duration::from_secs(3600),
                 foci_active: vec![Focus::Livekit(LivekitFocus {
                     alias: "room2".to_owned(),
@@ -526,7 +526,7 @@ mod tests {
                 call_id: "".to_owned(),
                 scope: CallScope::Room,
             }),
-            device_id: "THIS_DEVICE".to_owned(),
+            device_id: owned_device_id!("THIS_DEVICE"),
             foci_preferred: [Focus::Livekit(LivekitFocus {
                 alias: "room1".to_owned(),
                 service_url: "https://livekit1.com".to_owned(),

--- a/crates/ruma-events/src/call/member/member_data.rs
+++ b/crates/ruma-events/src/call/member/member_data.rs
@@ -5,7 +5,7 @@
 use std::time::Duration;
 
 use as_variant::as_variant;
-use ruma_common::MilliSecondsSinceUnixEpoch;
+use ruma_common::{DeviceId, MilliSecondsSinceUnixEpoch, OwnedDeviceId};
 use ruma_macros::StringEnum;
 use serde::{Deserialize, Serialize};
 use tracing::warn;
@@ -41,7 +41,7 @@ impl<'a> MembershipData<'a> {
     }
 
     /// The device id of this membership.
-    pub fn device_id(&self) -> &String {
+    pub fn device_id(&self) -> &DeviceId {
         match self {
             MembershipData::Legacy(data) => &data.device_id,
             MembershipData::Session(data) => &data.device_id,
@@ -121,7 +121,7 @@ pub struct LegacyMembershipData {
     /// The device id of this membership.
     ///
     /// The same user can join with their phone/computer.
-    pub device_id: String,
+    pub device_id: OwnedDeviceId,
 
     /// The duration in milliseconds relative to the time this membership joined
     /// during which the membership is valid.
@@ -190,7 +190,7 @@ pub struct LegacyMembershipDataInit {
     /// The device id of this membership.
     ///
     /// The same user can join with their phone/computer.
-    pub device_id: String,
+    pub device_id: OwnedDeviceId,
 
     /// The duration in milliseconds relative to the time this membership joined
     /// during which the membership is valid.
@@ -236,7 +236,7 @@ pub struct SessionMembershipData {
     /// The device id of this membership.
     ///
     /// The same user can join with their phone/computer.
-    pub device_id: String,
+    pub device_id: OwnedDeviceId,
 
     /// A list of the foci that this membership proposes to use.
     pub foci_preferred: Vec<Focus>,

--- a/crates/ruma-events/src/call/member/member_state_key.rs
+++ b/crates/ruma-events/src/call/member/member_state_key.rs
@@ -16,11 +16,11 @@ pub struct CallMemberStateKey {
 
 impl CallMemberStateKey {
     /// Constructs a new CallMemberStateKey there are three possible formats:
-    /// - "_{UserId}_{DeviceId}" example: "_@test:user.org_DEVICE". `device_id`: Some`, `underscore:
+    /// - `_{UserId}_{DeviceId}` example: `_@test:user.org_DEVICE`. `device_id: Some`, `underscore:
     ///   true`
-    /// - "{UserId}_{DeviceId}" example: "@test:user.org_DEVICE". `device_id`: Some`, `underscore:
+    /// - `{UserId}_{DeviceId}` example: `@test:user.org_DEVICE`. `device_id: Some`, `underscore:
     ///   false`
-    /// - "{UserId}" example example: "@test:user.org". `device_id`: None`, underscore is ignored:
+    /// - `{UserId}` example: `@test:user.org`. `device_id: None`, underscore is ignored:
     ///   `underscore: false|true`
     ///
     /// Dependent on the parameters the correct CallMemberStateKey will be constructed.


### PR DESCRIPTION
As mentioned here: https://github.com/ruma/ruma/pull/1889#discussion_r1756281643
<!--
PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
