### PR TITLE
Fix build when `unstable-msc4168 feature` is disabled

### DIFF
--- a/crates/ruma-client-api/src/sync/sync_events/v4.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v4.rs
@@ -22,7 +22,9 @@ use ruma_events::{
 };
 use serde::{de::Error as _, Deserialize, Serialize};
 
-use super::{v5, DeviceLists, UnreadNotificationsCount};
+#[cfg(feature = "unstable-msc4186")]
+use super::v5;
+use super::{DeviceLists, UnreadNotificationsCount};
 
 const METADATA: Metadata = metadata! {
     method: POST,
@@ -927,6 +929,7 @@ impl Typing {
     }
 }
 
+#[cfg(feature = "unstable-msc4186")]
 impl From<v5::Request> for Request {
     fn from(value: v5::Request) -> Self {
         Self {
@@ -951,6 +954,7 @@ impl From<v5::Request> for Request {
     }
 }
 
+#[cfg(feature = "unstable-msc4186")]
 impl From<v5::request::List> for SyncRequestList {
     fn from(value: v5::request::List) -> Self {
         Self {
@@ -973,12 +977,14 @@ impl From<v5::request::List> for SyncRequestList {
     }
 }
 
+#[cfg(feature = "unstable-msc4186")]
 impl From<v5::request::RoomDetails> for RoomDetailsConfig {
     fn from(value: v5::request::RoomDetails) -> Self {
         Self { required_state: value.required_state, timeline_limit: value.timeline_limit }
     }
 }
 
+#[cfg(feature = "unstable-msc4186")]
 impl From<v5::request::ListFilters> for SyncRequestListFilters {
     fn from(value: v5::request::ListFilters) -> Self {
         Self {
@@ -989,6 +995,7 @@ impl From<v5::request::ListFilters> for SyncRequestListFilters {
     }
 }
 
+#[cfg(feature = "unstable-msc4186")]
 impl From<v5::request::RoomSubscription> for RoomSubscription {
     fn from(value: v5::request::RoomSubscription) -> Self {
         Self {
@@ -999,6 +1006,7 @@ impl From<v5::request::RoomSubscription> for RoomSubscription {
     }
 }
 
+#[cfg(feature = "unstable-msc4186")]
 impl From<v5::request::Extensions> for ExtensionsConfig {
     fn from(value: v5::request::Extensions) -> Self {
         Self {
@@ -1013,6 +1021,7 @@ impl From<v5::request::Extensions> for ExtensionsConfig {
     }
 }
 
+#[cfg(feature = "unstable-msc4186")]
 impl From<v5::request::ToDevice> for ToDeviceConfig {
     fn from(value: v5::request::ToDevice) -> Self {
         Self {
@@ -1025,18 +1034,21 @@ impl From<v5::request::ToDevice> for ToDeviceConfig {
     }
 }
 
+#[cfg(feature = "unstable-msc4186")]
 impl From<v5::request::E2EE> for E2EEConfig {
     fn from(value: v5::request::E2EE) -> Self {
         Self { enabled: value.enabled }
     }
 }
 
+#[cfg(feature = "unstable-msc4186")]
 impl From<v5::request::AccountData> for AccountDataConfig {
     fn from(value: v5::request::AccountData) -> Self {
         Self { enabled: value.enabled, lists: value.lists, rooms: value.rooms }
     }
 }
 
+#[cfg(feature = "unstable-msc4186")]
 impl From<v5::request::Receipts> for ReceiptsConfig {
     fn from(value: v5::request::Receipts) -> Self {
         Self {
@@ -1047,6 +1059,7 @@ impl From<v5::request::Receipts> for ReceiptsConfig {
     }
 }
 
+#[cfg(feature = "unstable-msc4186")]
 impl From<v5::request::ReceiptsRoom> for RoomReceiptConfig {
     fn from(value: v5::request::ReceiptsRoom) -> Self {
         match value {
@@ -1056,6 +1069,7 @@ impl From<v5::request::ReceiptsRoom> for RoomReceiptConfig {
     }
 }
 
+#[cfg(feature = "unstable-msc4186")]
 impl From<v5::request::Typing> for TypingConfig {
     fn from(value: v5::request::Typing) -> Self {
         Self { enabled: value.enabled, lists: value.lists, rooms: value.rooms }


### PR DESCRIPTION
Without this feature, the v5 module does not exist, and you get build errors that look like:

```
error[E0432]: unresolved import `super::v5`
  --> /home/[user]/git/ruma/crates/ruma-client-api/src/sync/sync_events/v4.rs:25:13
   |
25 | use super::{v5, DeviceLists, UnreadNotificationsCount};
   |             ^^
   |             |
   |             no `v5` in `sync::sync_events`
   |             help: a similar name exists in the module: `v3`
   |
note: found an item that was configured out
  --> /home/[user]/git/ruma/crates/ruma-client-api/src/sync/sync_events.rs:15:9
   |
15 | pub mod v5;
   |         ^^
note: the item is gated behind the `unstable-msc4186` feature
  --> /home/[user]/git/ruma/crates/ruma-client-api/src/sync/sync_events.rs:14:7
   |
14 | #[cfg(feature = "unstable-msc4186")]
   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
