### PR TITLE
client-api: Add `unstable-msc4186` inside the `CHANGELOG`

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -15,6 +15,8 @@ Breaking changes:
 
 Improvements:
 
+- Add support for MSC4186, aka simplified sliding sync, behind
+  `unstable-msc4186`.
 - Add support for MSC4108 OIDC sign in and E2EE set up via QR code
 - Heroes in `sync::sync_events::v4`: `SyncRequestList` and `RoomSubscription`
   both have a new `include_heroes` field. `SlidingSyncRoom` has a new `heroes`


### PR DESCRIPTION
Does exactly what it says on the tin.

This is a follow-up of https://github.com/ruma/ruma/pull/1907.