### PR TITLE
fix(client-api): `sync::v5::response::Room::bump_stamp` can be negative

### DIFF
--- a/crates/ruma-client-api/src/sync/sync_events/v5.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v5.rs
@@ -461,6 +461,7 @@ impl Response {
 
 /// HTTP types related to a [`Response`].
 pub mod response {
+    use js_int::Int;
     use ruma_common::DeviceKeyAlgorithm;
     use ruma_events::{
         receipt::SyncReceiptEvent, typing::SyncTypingEvent, AnyGlobalAccountDataEvent,
@@ -549,8 +550,10 @@ pub mod response {
         /// index”. For example, consider `roomA` with `bump_stamp = 2`, `roomB`
         /// with `bump_stamp = 1` and `roomC` with `bump_stamp = 0`. If `roomC`
         /// receives an update, its `bump_stamp` will be 3.
+        ///
+        /// Note that this number can be negative.
         #[serde(skip_serializing_if = "Option::is_none")]
-        pub bump_stamp: Option<UInt>,
+        pub bump_stamp: Option<Int>,
 
         /// Heroes of the room, if requested.
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -768,7 +771,7 @@ impl From<v4::SlidingSyncRoom> for response::Room {
             joined_count: value.joined_count,
             invited_count: value.invited_count,
             num_live: value.num_live,
-            bump_stamp: value.timestamp.map(|t| t.0),
+            bump_stamp: value.timestamp.map(|t| t.0.into()),
             heroes: value.heroes.map(|heroes| heroes.into_iter().map(Into::into).collect()),
         }
     }

--- a/crates/ruma-client-api/src/sync/sync_events/v5.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v5.rs
@@ -551,7 +551,10 @@ pub mod response {
         /// with `bump_stamp = 1` and `roomC` with `bump_stamp = 0`. If `roomC`
         /// receives an update, its `bump_stamp` will be 3.
         ///
-        /// Note that this number can be negative.
+        /// Note that this number can be negative. It happened in the past where
+        /// a homeserver was sending negative values. It doesn't really matter
+        /// if the value is positive or negative, and at the time of writing
+        /// (2024-09-23), the MSC is unclear about that.
         #[serde(skip_serializing_if = "Option::is_none")]
         pub bump_stamp: Option<Int>,
 


### PR DESCRIPTION
This patch changes `Room::bump_stamp` from `Option<UInt>` to
`Option<Int>`.
