### PR TITLE
client-api: `sync::v5::Request::timeline_limit` is not optional

### DIFF
--- a/crates/ruma-client-api/src/sync/sync_events/v4.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v4.rs
@@ -980,7 +980,7 @@ impl From<v5::request::List> for SyncRequestList {
 #[cfg(feature = "unstable-msc4186")]
 impl From<v5::request::RoomDetails> for RoomDetailsConfig {
     fn from(value: v5::request::RoomDetails) -> Self {
-        Self { required_state: value.required_state, timeline_limit: value.timeline_limit }
+        Self { required_state: value.required_state, timeline_limit: Some(value.timeline_limit) }
     }
 }
 
@@ -1000,7 +1000,7 @@ impl From<v5::request::RoomSubscription> for RoomSubscription {
     fn from(value: v5::request::RoomSubscription) -> Self {
         Self {
             required_state: value.required_state,
-            timeline_limit: value.timeline_limit,
+            timeline_limit: Some(value.timeline_limit),
             include_heroes: value.include_heroes,
         }
     }

--- a/crates/ruma-client-api/src/sync/sync_events/v5.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v5.rs
@@ -154,8 +154,7 @@ pub mod request {
         pub required_state: Vec<(StateEventType, String)>,
 
         /// The maximum number of timeline events to return per room.
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub timeline_limit: Option<UInt>,
+        pub timeline_limit: UInt,
 
         /// Include the room heroes.
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -171,8 +170,7 @@ pub mod request {
         pub required_state: Vec<(StateEventType, String)>,
 
         /// The maximum number of timeline events to return per room.
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub timeline_limit: Option<UInt>,
+        pub timeline_limit: UInt,
     }
 
     /// Sliding sync request extensions (see [`super::Request::extensions`]).


### PR DESCRIPTION
Contrary to MSC3575, MSC4186 has `timeline_limit` which is not optional.

This patch changes `timeline_limit: Option<UInt>` to `Int` directly.
