### PR TITLE
client-api: Add support for account locking

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -36,6 +36,7 @@ Improvements:
   - This is a breaking change, but only for users of `unstable-msc3575`
 - Add the `get_login_token` field to `Capabilities`, according to a
   clarification in the spec.
+- Add support for account locking, according to MSC3939.
 
 Bug fixes:
 

--- a/crates/ruma-client-api/src/error/kind_serde.rs
+++ b/crates/ruma-client-api/src/error/kind_serde.rs
@@ -252,6 +252,7 @@ impl<'de> Visitor<'de> for ErrorKindVisitor {
             },
             #[cfg(feature = "unstable-msc3843")]
             ErrCode::Unactionable => ErrorKind::Unactionable,
+            ErrCode::UserLocked => ErrorKind::UserLocked,
             ErrCode::_Custom(errcode) => ErrorKind::_Custom { errcode, extra },
         })
     }
@@ -310,6 +311,7 @@ enum ErrCode {
     WrongRoomKeysVersion,
     #[cfg(feature = "unstable-msc3843")]
     Unactionable,
+    UserLocked,
     _Custom(PrivOwnedStr),
 }
 
@@ -330,7 +332,7 @@ impl Serialize for ErrorKind {
         let mut st = serializer.serialize_map(None)?;
         st.serialize_entry("errcode", self.as_ref())?;
         match self {
-            Self::UnknownToken { soft_logout: true } => {
+            Self::UnknownToken { soft_logout: true } | Self::UserLocked => {
                 st.serialize_entry("soft_logout", &true)?;
             }
             Self::LimitExceeded { retry_after: Some(RetryAfter::Delay(duration)) } => {


### PR DESCRIPTION
According to [MSC3939](https://github.com/matrix-org/matrix-spec-proposals/pull/3939) / [Spec PR](https://github.com/matrix-org/matrix-spec/pull/1934).

This does not expose the `soft_logout` field because it is only here for backwards compatibility, it is otherwise unused and its value is fixed. It is only added during serialization.