### PR TITLE
client-api: Remove `RuleScope`

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -12,6 +12,9 @@ Breaking changes:
   `ContentDisposition` instead of strings.
 - Replace `server_name` on `knock::knock_room::v3::Request` and 
   `membership::join_room_by_id_or_alias::v3::Request` with `via` as per MSC4156.
+- Remove `RuleScope`, due to a clarification in the Matrix 1.12 where the `global`
+  scope is now hardcoded.
+  - The `push` endpoints don't take a scope anymore.
 
 Improvements:
 

--- a/crates/ruma-client-api/src/push.rs
+++ b/crates/ruma-client-api/src/push.rs
@@ -8,11 +8,9 @@ use ruma_common::{
         HttpPusherData, PatternedPushRule, PatternedPushRuleInit, PushCondition, SimplePushRule,
         SimplePushRuleInit,
     },
-    serde::{JsonObject, StringEnum},
+    serde::JsonObject,
 };
 use serde::{Deserialize, Serialize};
-
-use crate::PrivOwnedStr;
 
 pub mod delete_pushrule;
 pub mod get_notifications;
@@ -305,17 +303,4 @@ impl EmailPusherData {
 pub struct CustomPusherData {
     kind: String,
     data: JsonObject,
-}
-
-/// The scope of a push rule.
-#[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, PartialEq, Eq, StringEnum)]
-#[ruma_enum(rename_all = "lowercase")]
-#[non_exhaustive]
-pub enum RuleScope {
-    /// The global rules.
-    Global,
-
-    #[doc(hidden)]
-    _Custom(PrivOwnedStr),
 }

--- a/crates/ruma-client-api/src/push/delete_pushrule.rs
+++ b/crates/ruma-client-api/src/push/delete_pushrule.rs
@@ -1,36 +1,32 @@
-//! `DELETE /_matrix/client/*/pushrules/{scope}/{kind}/{ruleId}`
+//! `DELETE /_matrix/client/*/pushrules/global/{kind}/{ruleId}`
 //!
 //! This endpoint removes the push rule defined in the path.
 
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/latest/client-server-api/#delete_matrixclientv3pushrulesscopekindruleid
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#delete_matrixclientv3pushrulesglobalkindruleid
 
     use ruma_common::{
         api::{request, response, Metadata},
         metadata,
     };
 
-    use crate::push::{RuleKind, RuleScope};
+    use crate::push::RuleKind;
 
     const METADATA: Metadata = metadata! {
         method: DELETE,
         rate_limited: false,
         authentication: AccessToken,
         history: {
-            1.0 => "/_matrix/client/r0/pushrules/:scope/:kind/:rule_id",
-            1.1 => "/_matrix/client/v3/pushrules/:scope/:kind/:rule_id",
+            1.0 => "/_matrix/client/r0/pushrules/global/:kind/:rule_id",
+            1.1 => "/_matrix/client/v3/pushrules/global/:kind/:rule_id",
         }
     };
 
     /// Request type for the `delete_pushrule` endpoint.
     #[request(error = crate::Error)]
     pub struct Request {
-        /// The scope to delete from.
-        #[ruma_api(path)]
-        pub scope: RuleScope,
-
         /// The kind of rule
         #[ruma_api(path)]
         pub kind: RuleKind,
@@ -46,9 +42,9 @@ pub mod v3 {
     pub struct Response {}
 
     impl Request {
-        /// Creates a new `Request` with the given scope, kind and rule ID.
-        pub fn new(scope: RuleScope, kind: RuleKind, rule_id: String) -> Self {
-            Self { scope, kind, rule_id }
+        /// Creates a new `Request` with the given kind and rule ID.
+        pub fn new(kind: RuleKind, rule_id: String) -> Self {
+            Self { kind, rule_id }
         }
     }
 

--- a/crates/ruma-client-api/src/push/get_pushrule.rs
+++ b/crates/ruma-client-api/src/push/get_pushrule.rs
@@ -1,36 +1,32 @@
-//! `GET /_matrix/client/*/pushrules/{scope}/{kind}/{ruleId}`
+//! `GET /_matrix/client/*/pushrules/global/{kind}/{ruleId}`
 //!
 //! Retrieve a single specified push rule.
 
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3pushrulesscopekindruleid
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3pushrulesglobalkindruleid
 
     use ruma_common::{
         api::{request, response, Metadata},
         metadata,
     };
 
-    use crate::push::{PushRule, RuleKind, RuleScope};
+    use crate::push::{PushRule, RuleKind};
 
     const METADATA: Metadata = metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
         history: {
-            1.0 => "/_matrix/client/r0/pushrules/:scope/:kind/:rule_id",
-            1.1 => "/_matrix/client/v3/pushrules/:scope/:kind/:rule_id",
+            1.0 => "/_matrix/client/r0/pushrules/global/:kind/:rule_id",
+            1.1 => "/_matrix/client/v3/pushrules/global/:kind/:rule_id",
         }
     };
 
     /// Request type for the `get_pushrule` endpoint.
     #[request(error = crate::Error)]
     pub struct Request {
-        /// The scope to fetch rules from.
-        #[ruma_api(path)]
-        pub scope: RuleScope,
-
         /// The kind of rule.
         #[ruma_api(path)]
         pub kind: RuleKind,
@@ -49,9 +45,9 @@ pub mod v3 {
     }
 
     impl Request {
-        /// Creates a new `Request` with the given scope, rule kind and rule ID.
-        pub fn new(scope: RuleScope, kind: RuleKind, rule_id: String) -> Self {
-            Self { scope, kind, rule_id }
+        /// Creates a new `Request` with the given rule kind and rule ID.
+        pub fn new(kind: RuleKind, rule_id: String) -> Self {
+            Self { kind, rule_id }
         }
     }
 

--- a/crates/ruma-client-api/src/push/get_pushrule_actions.rs
+++ b/crates/ruma-client-api/src/push/get_pushrule_actions.rs
@@ -1,11 +1,11 @@
-//! `GET /_matrix/client/*/pushrules/{scope}/{kind}/{ruleId}/actions`
+//! `GET /_matrix/client/*/pushrules/global/{kind}/{ruleId}/actions`
 //!
 //! This endpoint get the actions for the specified push rule.
 
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3pushrulesscopekindruleidactions
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3pushrulesglobalkindruleidactions
 
     use ruma_common::{
         api::{request, response, Metadata},
@@ -13,25 +13,21 @@ pub mod v3 {
         push::Action,
     };
 
-    use crate::push::{RuleKind, RuleScope};
+    use crate::push::RuleKind;
 
     const METADATA: Metadata = metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
         history: {
-            1.0 => "/_matrix/client/r0/pushrules/:scope/:kind/:rule_id/actions",
-            1.1 => "/_matrix/client/v3/pushrules/:scope/:kind/:rule_id/actions",
+            1.0 => "/_matrix/client/r0/pushrules/global/:kind/:rule_id/actions",
+            1.1 => "/_matrix/client/v3/pushrules/global/:kind/:rule_id/actions",
         }
     };
 
     /// Request type for the `get_pushrule_actions` endpoint.
     #[request(error = crate::Error)]
     pub struct Request {
-        /// The scope to fetch a rule from.
-        #[ruma_api(path)]
-        pub scope: RuleScope,
-
         /// The kind of rule
         #[ruma_api(path)]
         pub kind: RuleKind,
@@ -49,9 +45,9 @@ pub mod v3 {
     }
 
     impl Request {
-        /// Creates a new `Request` with the given scope, kind and rule ID.
-        pub fn new(scope: RuleScope, kind: RuleKind, rule_id: String) -> Self {
-            Self { scope, kind, rule_id }
+        /// Creates a new `Request` with the given kind and rule ID.
+        pub fn new(kind: RuleKind, rule_id: String) -> Self {
+            Self { kind, rule_id }
         }
     }
 

--- a/crates/ruma-client-api/src/push/get_pushrule_enabled.rs
+++ b/crates/ruma-client-api/src/push/get_pushrule_enabled.rs
@@ -1,36 +1,32 @@
-//! `GET /_matrix/client/*/pushrules/{scope}/{kind}/{ruleId}/enabled`
+//! `GET /_matrix/client/*/pushrules/global/{kind}/{ruleId}/enabled`
 //!
 //! This endpoint gets whether the specified push rule is enabled.
 
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3pushrulesscopekindruleidenabled
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3pushrulesglobalkindruleidenabled
 
     use ruma_common::{
         api::{request, response, Metadata},
         metadata,
     };
 
-    use crate::push::{RuleKind, RuleScope};
+    use crate::push::RuleKind;
 
     const METADATA: Metadata = metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
         history: {
-            1.0 => "/_matrix/client/r0/pushrules/:scope/:kind/:rule_id/enabled",
-            1.1 => "/_matrix/client/v3/pushrules/:scope/:kind/:rule_id/enabled",
+            1.0 => "/_matrix/client/r0/pushrules/global/:kind/:rule_id/enabled",
+            1.1 => "/_matrix/client/v3/pushrules/global/:kind/:rule_id/enabled",
         }
     };
 
     /// Request type for the `get_pushrule_enabled` endpoint.
     #[request(error = crate::Error)]
     pub struct Request {
-        /// The scope to fetch a rule from.
-        #[ruma_api(path)]
-        pub scope: RuleScope,
-
         /// The kind of rule
         #[ruma_api(path)]
         pub kind: RuleKind,
@@ -48,9 +44,9 @@ pub mod v3 {
     }
 
     impl Request {
-        /// Creates a new `Request` with the given scope, rule kind and rule ID.
-        pub fn new(scope: RuleScope, kind: RuleKind, rule_id: String) -> Self {
-            Self { scope, kind, rule_id }
+        /// Creates a new `Request` with the given rule kind and rule ID.
+        pub fn new(kind: RuleKind, rule_id: String) -> Self {
+            Self { kind, rule_id }
         }
     }
 

--- a/crates/ruma-client-api/src/push/get_pushrules_global_scope.rs
+++ b/crates/ruma-client-api/src/push/get_pushrules_global_scope.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3pushrules
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3pushrulesglobal
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/push/set_pushrule.rs
+++ b/crates/ruma-client-api/src/push/set_pushrule.rs
@@ -1,11 +1,11 @@
-//! `PUT /_matrix/client/*/pushrules/{scope}/{kind}/{ruleId}`
+//! `PUT /_matrix/client/*/pushrules/global/{kind}/{ruleId}`
 //!
 //! This endpoint allows the creation and modification of push rules for this user ID.
 
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3pushrulesscopekindruleid
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3pushrulesglobalkindruleid
 
     use ruma_common::{
         api::{response, Metadata},
@@ -14,15 +14,13 @@ pub mod v3 {
     };
     use serde::{Deserialize, Serialize};
 
-    use crate::push::RuleScope;
-
     const METADATA: Metadata = metadata! {
         method: PUT,
         rate_limited: true,
         authentication: AccessToken,
         history: {
-            1.0 => "/_matrix/client/r0/pushrules/:scope/:kind/:rule_id",
-            1.1 => "/_matrix/client/v3/pushrules/:scope/:kind/:rule_id",
+            1.0 => "/_matrix/client/r0/pushrules/global/:kind/:rule_id",
+            1.1 => "/_matrix/client/v3/pushrules/global/:kind/:rule_id",
         }
     };
 
@@ -30,9 +28,6 @@ pub mod v3 {
     #[derive(Clone, Debug)]
     #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
     pub struct Request {
-        /// The scope to set the rule in.
-        pub scope: RuleScope,
-
         /// The rule.
         pub rule: NewPushRule,
 
@@ -51,9 +46,9 @@ pub mod v3 {
     pub struct Response {}
 
     impl Request {
-        /// Creates a new `Request` with the given scope and rule.
-        pub fn new(scope: RuleScope, rule: NewPushRule) -> Self {
-            Self { scope, rule, before: None, after: None }
+        /// Creates a new `Request` with the given rule.
+        pub fn new(rule: NewPushRule) -> Self {
+            Self { rule, before: None, after: None }
         }
     }
 
@@ -87,7 +82,7 @@ pub mod v3 {
             let url = METADATA.make_endpoint_url(
                 considering_versions,
                 base_url,
-                &[&self.scope, &self.rule.kind(), &self.rule.rule_id()],
+                &[&self.rule.kind(), &self.rule.rule_id()],
                 &query_string,
             )?;
 
@@ -147,7 +142,7 @@ pub mod v3 {
                 after: Option<String>,
             }
 
-            let (scope, kind, rule_id): (RuleScope, RuleKind, String) =
+            let (kind, rule_id): (RuleKind, String) =
                 Deserialize::deserialize(serde::de::value::SeqDeserializer::<
                     _,
                     serde::de::value::Error,
@@ -190,7 +185,7 @@ pub mod v3 {
                 }
             };
 
-            Ok(Self { scope, rule, before, after })
+            Ok(Self { rule, before, after })
         }
     }
 

--- a/crates/ruma-client-api/src/push/set_pushrule_actions.rs
+++ b/crates/ruma-client-api/src/push/set_pushrule_actions.rs
@@ -1,4 +1,4 @@
-//! `PUT /_matrix/client/*/pushrules/{scope}/{kind}/{ruleId}/actions`
+//! `PUT /_matrix/client/*/pushrules/global/{kind}/{ruleId}/actions`
 //!
 //! This endpoint allows clients to change the actions of a push rule. This can be used to change
 //! the actions of builtin rules.
@@ -6,7 +6,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3pushrulesscopekindruleidactions
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3pushrulesglobalkindruleidactions
 
     use ruma_common::{
         api::{request, response, Metadata},
@@ -14,25 +14,21 @@ pub mod v3 {
         push::Action,
     };
 
-    use crate::push::{RuleKind, RuleScope};
+    use crate::push::RuleKind;
 
     const METADATA: Metadata = metadata! {
         method: PUT,
         rate_limited: false,
         authentication: AccessToken,
         history: {
-            1.0 => "/_matrix/client/r0/pushrules/:scope/:kind/:rule_id/actions",
-            1.1 => "/_matrix/client/v3/pushrules/:scope/:kind/:rule_id/actions",
+            1.0 => "/_matrix/client/r0/pushrules/global/:kind/:rule_id/actions",
+            1.1 => "/_matrix/client/v3/pushrules/global/:kind/:rule_id/actions",
         }
     };
 
     /// Request type for the `set_pushrule_actions` endpoint.
     #[request(error = crate::Error)]
     pub struct Request {
-        /// The scope to fetch a rule from.
-        #[ruma_api(path)]
-        pub scope: RuleScope,
-
         /// The kind of rule
         #[ruma_api(path)]
         pub kind: RuleKind,
@@ -51,14 +47,9 @@ pub mod v3 {
     pub struct Response {}
 
     impl Request {
-        /// Creates a new `Request` with the given scope, rule kind, rule ID and actions.
-        pub fn new(
-            scope: RuleScope,
-            kind: RuleKind,
-            rule_id: String,
-            actions: Vec<Action>,
-        ) -> Self {
-            Self { scope, kind, rule_id, actions }
+        /// Creates a new `Request` with the given rule kind, rule ID and actions.
+        pub fn new(kind: RuleKind, rule_id: String, actions: Vec<Action>) -> Self {
+            Self { kind, rule_id, actions }
         }
     }
 

--- a/crates/ruma-client-api/src/push/set_pushrule_enabled.rs
+++ b/crates/ruma-client-api/src/push/set_pushrule_enabled.rs
@@ -1,36 +1,32 @@
-//! `PUT /_matrix/client/*/pushrules/{scope}/{kind}/{ruleId}/enabled`
+//! `PUT /_matrix/client/*/pushrules/global/{kind}/{ruleId}/enabled`
 //!
 //! This endpoint allows clients to enable or disable the specified push rule.
 
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3pushrulesscopekindruleidenabled
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3pushrulesglobalkindruleidenabled
 
     use ruma_common::{
         api::{request, response, Metadata},
         metadata,
     };
 
-    use crate::push::{RuleKind, RuleScope};
+    use crate::push::RuleKind;
 
     const METADATA: Metadata = metadata! {
         method: PUT,
         rate_limited: false,
         authentication: AccessToken,
         history: {
-            1.0 => "/_matrix/client/r0/pushrules/:scope/:kind/:rule_id/enabled",
-            1.1 => "/_matrix/client/v3/pushrules/:scope/:kind/:rule_id/enabled",
+            1.0 => "/_matrix/client/r0/pushrules/global/:kind/:rule_id/enabled",
+            1.1 => "/_matrix/client/v3/pushrules/global/:kind/:rule_id/enabled",
         }
     };
 
     /// Request type for the `set_pushrule_enabled` endpoint.
     #[request(error = crate::Error)]
     pub struct Request {
-        /// The scope to fetch a rule from.
-        #[ruma_api(path)]
-        pub scope: RuleScope,
-
         /// The kind of rule
         #[ruma_api(path)]
         pub kind: RuleKind,
@@ -49,19 +45,19 @@ pub mod v3 {
     pub struct Response {}
 
     impl Request {
-        /// Creates a new `Request` with the given scope, rule kind, rule ID and enabled flag.
-        pub fn new(scope: RuleScope, kind: RuleKind, rule_id: String, enabled: bool) -> Self {
-            Self { scope, kind, rule_id, enabled }
+        /// Creates a new `Request` with the given rule kind, rule ID and enabled flag.
+        pub fn new(kind: RuleKind, rule_id: String, enabled: bool) -> Self {
+            Self { kind, rule_id, enabled }
         }
 
         /// Creates a new `Request` to enable the given rule.
-        pub fn enable(scope: RuleScope, kind: RuleKind, rule_id: String) -> Self {
-            Self::new(scope, kind, rule_id, true)
+        pub fn enable(kind: RuleKind, rule_id: String) -> Self {
+            Self::new(kind, rule_id, true)
         }
 
         /// Creates a new `Request` to disable the given rule.
-        pub fn disable(scope: RuleScope, kind: RuleKind, rule_id: String) -> Self {
-            Self::new(scope, kind, rule_id, false)
+        pub fn disable(kind: RuleKind, rule_id: String) -> Self {
+            Self::new(kind, rule_id, false)
         }
     }
 


### PR DESCRIPTION
The `global` scope is now hardcoded due to a clarification in the spec: https://github.com/matrix-org/matrix-spec/pull/1842.

Because this changes the URI fragments of the `push` APIs, CI should fail until the next version is released (which should be next week on October 3rd).

Closes #1892.