### PR TITLE
Add caption helper methods for audio, file, image and video messages.

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -23,6 +23,7 @@ The new format (Session) is required to reliably display the call member count (
 `CallMemberEventContent` is now an enum to model the two different formats.
 - `CallMemberStateKey` (instead of `OwnedUserId`) is now used as the state key type for `CallMemberEventContent`.
 This guarantees correct formatting of the event key.
+- Add helpers for captions on audio, file, image and video messages.
 
 Breaking changes:
 

--- a/crates/ruma-events/src/room/message.rs
+++ b/crates/ruma-events/src/room/message.rs
@@ -30,6 +30,7 @@ mod file;
 mod image;
 mod key_verification_request;
 mod location;
+mod media_caption;
 mod notice;
 mod relation;
 pub(crate) mod relation_serde;

--- a/crates/ruma-events/src/room/message/audio.rs
+++ b/crates/ruma-events/src/room/message/audio.rs
@@ -5,7 +5,10 @@ use ruma_common::OwnedMxcUri;
 use serde::{Deserialize, Serialize};
 
 use super::FormattedBody;
-use crate::room::{EncryptedFile, MediaSource};
+use crate::room::{
+    message::media_caption::{caption, formatted_caption},
+    EncryptedFile, MediaSource,
+};
 
 /// The payload for an audio message.
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -87,6 +90,21 @@ impl AudioMessageEventContent {
     /// as a shorthand for that, because it is very common to set this field.
     pub fn info(self, info: impl Into<Option<Box<AudioInfo>>>) -> Self {
         Self { info: info.into(), ..self }
+    }
+
+    /// Returns the caption for the audio as defined by the [spec](https://spec.matrix.org/latest/client-server-api/#media-captions).
+    ///
+    /// In short, this is the `body` field if the `filename` field exists and has a different value,
+    /// otherwise the media file does not have a caption.
+    pub fn caption(&self) -> Option<&str> {
+        caption(&self.body, self.filename.as_deref())
+    }
+
+    /// Returns the formatted caption for the audio as defined by the [spec](https://spec.matrix.org/latest/client-server-api/#media-captions).
+    ///
+    /// This is the same as `caption`, but returns the formatted body instead of the plain body.
+    pub fn formatted_caption(&self) -> Option<&FormattedBody> {
+        formatted_caption(&self.body, self.formatted.as_ref(), self.filename.as_deref())
     }
 }
 

--- a/crates/ruma-events/src/room/message/file.rs
+++ b/crates/ruma-events/src/room/message/file.rs
@@ -3,7 +3,10 @@ use ruma_common::OwnedMxcUri;
 use serde::{Deserialize, Serialize};
 
 use super::FormattedBody;
-use crate::room::{EncryptedFile, MediaSource, ThumbnailInfo};
+use crate::room::{
+    message::media_caption::{caption, formatted_caption},
+    EncryptedFile, MediaSource, ThumbnailInfo,
+};
 
 /// The payload for a file message.
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -59,6 +62,21 @@ impl FileMessageEventContent {
     /// as a shorthand for that, because it is very common to set this field.
     pub fn info(self, info: impl Into<Option<Box<FileInfo>>>) -> Self {
         Self { info: info.into(), ..self }
+    }
+
+    /// Returns the caption of the media file as defined by the [spec](https://spec.matrix.org/latest/client-server-api/#media-captions).
+    ///
+    /// In short, this is the `body` field if the `filename` field exists and has a different value,
+    /// otherwise the media file does not have a caption.
+    pub fn caption(&self) -> Option<&str> {
+        caption(&self.body, self.filename.as_deref())
+    }
+
+    /// Returns the formatted caption of the media file as defined by the [spec](https://spec.matrix.org/latest/client-server-api/#media-captions).
+    ///
+    /// This is the same as `caption`, but returns the formatted body instead of the plain body.
+    pub fn formatted_caption(&self) -> Option<&FormattedBody> {
+        formatted_caption(&self.body, self.formatted.as_ref(), self.filename.as_deref())
     }
 }
 

--- a/crates/ruma-events/src/room/message/image.rs
+++ b/crates/ruma-events/src/room/message/image.rs
@@ -2,7 +2,10 @@ use ruma_common::OwnedMxcUri;
 use serde::{Deserialize, Serialize};
 
 use super::FormattedBody;
-use crate::room::{EncryptedFile, ImageInfo, MediaSource};
+use crate::room::{
+    message::media_caption::{caption, formatted_caption},
+    EncryptedFile, ImageInfo, MediaSource,
+};
 
 /// The payload for an image message.
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -58,5 +61,20 @@ impl ImageMessageEventContent {
     /// as a shorthand for that, because it is very common to set this field.
     pub fn info(self, info: impl Into<Option<Box<ImageInfo>>>) -> Self {
         Self { info: info.into(), ..self }
+    }
+
+    /// Returns the caption for the image as defined by the [spec](https://spec.matrix.org/latest/client-server-api/#media-captions).
+    ///
+    /// In short, this is the `body` field if the `filename` field exists and has a different value,
+    /// otherwise the media file does not have a caption.
+    pub fn caption(&self) -> Option<&str> {
+        caption(&self.body, self.filename.as_deref())
+    }
+
+    /// Returns the formatted caption for the image as defined by the [spec](https://spec.matrix.org/latest/client-server-api/#media-captions).
+    ///
+    /// This is the same as `caption`, but returns the formatted body instead of the plain body.
+    pub fn formatted_caption(&self) -> Option<&FormattedBody> {
+        formatted_caption(&self.body, self.formatted.as_ref(), self.filename.as_deref())
     }
 }

--- a/crates/ruma-events/src/room/message/media_caption.rs
+++ b/crates/ruma-events/src/room/message/media_caption.rs
@@ -1,0 +1,22 @@
+//! Reusable methods for captioning media files.
+
+use crate::room::message::FormattedBody;
+
+/// Computes the caption of a media file as defined by the [spec](https://spec.matrix.org/latest/client-server-api/#media-captions).
+///
+/// In short, this is the `body` field if the `filename` field exists and has a different value,
+/// otherwise the media file does not have a caption.
+pub(crate) fn caption<'a>(body: &'a str, filename: Option<&str>) -> Option<&'a str> {
+    filename.is_some_and(|filename| body != filename).then_some(body)
+}
+
+/// Computes the formatted caption of a media file as defined by the [spec](https://spec.matrix.org/latest/client-server-api/#media-captions).
+///
+/// This is the same as `caption`, but returns the formatted body instead of the plain body.
+pub(crate) fn formatted_caption<'a>(
+    body: &str,
+    formatted: Option<&'a FormattedBody>,
+    filename: Option<&str>,
+) -> Option<&'a FormattedBody> {
+    filename.is_some_and(|filename| body != filename).then_some(formatted).flatten()
+}

--- a/crates/ruma-events/src/room/message/video.rs
+++ b/crates/ruma-events/src/room/message/video.rs
@@ -5,7 +5,10 @@ use ruma_common::OwnedMxcUri;
 use serde::{Deserialize, Serialize};
 
 use super::FormattedBody;
-use crate::room::{EncryptedFile, MediaSource, ThumbnailInfo};
+use crate::room::{
+    message::media_caption::{caption, formatted_caption},
+    EncryptedFile, MediaSource, ThumbnailInfo,
+};
 
 /// The payload for a video message.
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -61,6 +64,21 @@ impl VideoMessageEventContent {
     /// as a shorthand for that, because it is very common to set this field.
     pub fn info(self, info: impl Into<Option<Box<VideoInfo>>>) -> Self {
         Self { info: info.into(), ..self }
+    }
+
+    /// Returns the caption of the video as defined by the [spec](https://spec.matrix.org/latest/client-server-api/#media-captions).
+    ///
+    /// In short, this is the `body` field if the `filename` field exists and has a different value,
+    /// otherwise the media file does not have a caption.
+    pub fn caption(&self) -> Option<&str> {
+        caption(&self.body, self.filename.as_deref())
+    }
+
+    /// Returns the formatted caption of the video as defined by the [spec](https://spec.matrix.org/latest/client-server-api/#media-captions).
+    ///
+    /// This is the same as `caption`, but returns the formatted body instead of the plain body.
+    pub fn formatted_caption(&self) -> Option<&FormattedBody> {
+        formatted_caption(&self.body, self.formatted.as_ref(), self.filename.as_deref())
     }
 }
 


### PR DESCRIPTION
[MSC2530](https://github.com/tulir/matrix-spec-proposals/blob/body-as-caption/proposals/2530-body-as-caption.md) describes captioning for audio, file, image and video messages.

This is basically the `body` field, but only when the `filename` field is present and the two values don't match.