### PR TITLE
make it possible to construct `{Matrix,}ErrorBody`

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -37,6 +37,7 @@ Improvements:
 - Add the `get_login_token` field to `Capabilities`, according to a
   clarification in the spec.
 - Add support for account locking, according to MSC3939.
+- Allow constructing `error::ErrorBody::NotJson` outside of this crate.
 
 Bug fixes:
 

--- a/crates/ruma-client-api/src/error.rs
+++ b/crates/ruma-client-api/src/error.rs
@@ -312,7 +312,6 @@ pub enum ErrorBody {
     Json(JsonValue),
 
     /// A response body that is not valid JSON.
-    #[non_exhaustive]
     NotJson {
         /// The raw bytes of the response body.
         bytes: Bytes,

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -28,6 +28,8 @@ Improvements:
 - Constructing a Matrix URI for an event with a room alias is deprecated,
   according to MSC4132 / Matrix 1.11
 - Implement `Eq` and `PartialEq` for `Metadata`
+- Allow constructing `api::error::MatrixErrorBody::NotJson` outside of this
+  crate.
 
 # 0.13.0
 

--- a/crates/ruma-common/src/api/error.rs
+++ b/crates/ruma-common/src/api/error.rs
@@ -70,7 +70,6 @@ pub enum MatrixErrorBody {
     Json(JsonValue),
 
     /// A response body that is not valid JSON.
-    #[non_exhaustive]
     NotJson {
         /// The raw bytes of the response body.
         bytes: Bytes,


### PR DESCRIPTION
The spec only defines the standard error response in the client-server and identity sections and the other sections don't make any reference to it. Because of this, Ruma currently only uses a very generic error type (`ruma::api::error::MatrixError`) everywhere except the client-server section, which uses a more structured type (`ruma::api::client::Error`).

Currently, for the server-server API, Grapevine (and probably the others, we inherited this from Conduit) [ignores `IncomingResponse::EndpointError` completely](https://gitlab.computer.surgery/matrix/grapevine/-/blob/e14b7f28f2c4d5be9e40ebbfaa8ec5ac169596cb/src/api/server_server.rs#L338-350) and instead [tries to deserialize into `ruma::api::client::Error`](https://gitlab.computer.surgery/matrix/grapevine/-/blob/e14b7f28f2c4d5be9e40ebbfaa8ec5ac169596cb/src/api/server_server.rs#L330-335). This is... not optimal.

In the short term, we would like to work around this by writing a better conversion from `ruma::api::error::MatrixError` to `ruma::api::client::Error`, but this is not possible because of the `#[non_exhaustive]`. This change seems reasonable to me because Ruma doesn't seem to be too afraid of breaking API changes and checking git blame (a8ba82d5859b42293c78c58b04840b67f7e77ef4) doesn't immediately reveal to me why this was put in place.

In the longer term, [Tulir confirmed in `#matrix-spec-discussion:neko.dev` that the error response description is intended to apply to all sections and a PR to fix this would be accepted](https://matrix.to/#/!sHZXzAloyuPhkpjLLW:neko.dev/$Y2yTCeR_AeW6g_4jViFbx4gTE_AwF0RN7yrHJ25F5Q8?via=neko.dev&via=matrix.org&via=computer.surgery). After that gets implemented, there will probably need to be some more invasive changes in Ruma to accommodate that.