### PR TITLE
Add filename helper methods for audio, file, image and video messages.

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -24,6 +24,7 @@ The new format (Session) is required to reliably display the call member count (
 - `CallMemberStateKey` (instead of `OwnedUserId`) is now used as the state key type for `CallMemberEventContent`.
 This guarantees correct formatting of the event key.
 - Add helpers for captions on audio, file, image and video messages.
+- Add helpers for filenames on audio, file, image and video messages.
 
 Breaking changes:
 

--- a/crates/ruma-events/src/room/message/audio.rs
+++ b/crates/ruma-events/src/room/message/audio.rs
@@ -27,7 +27,10 @@ pub struct AudioMessageEventContent {
     #[serde(flatten)]
     pub formatted: Option<FormattedBody>,
 
-    /// The original filename of the uploaded file.
+    /// The original filename of the uploaded file as deserialized from the event.
+    ///
+    /// It is recommended to use the `filename` method to get the filename which automatically
+    /// falls back to the `body` field when the `filename` field is not set.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub filename: Option<String>,
 
@@ -90,6 +93,14 @@ impl AudioMessageEventContent {
     /// as a shorthand for that, because it is very common to set this field.
     pub fn info(self, info: impl Into<Option<Box<AudioInfo>>>) -> Self {
         Self { info: info.into(), ..self }
+    }
+
+    /// Computes the filename for the audio file as defined by the [spec](https://spec.matrix.org/latest/client-server-api/#media-captions).
+    ///
+    /// This differs from the `filename` field as this method falls back to the `body` field when
+    /// the `filename` field is not set.
+    pub fn filename(&self) -> &str {
+        self.filename.as_deref().unwrap_or(&self.body)
     }
 
     /// Returns the caption for the audio as defined by the [spec](https://spec.matrix.org/latest/client-server-api/#media-captions).

--- a/crates/ruma-events/src/room/message/file.rs
+++ b/crates/ruma-events/src/room/message/file.rs
@@ -25,7 +25,10 @@ pub struct FileMessageEventContent {
     #[serde(flatten)]
     pub formatted: Option<FormattedBody>,
 
-    /// The original filename of the uploaded file.
+    /// The original filename of the uploaded file as deserialized from the event.
+    ///
+    /// It is recommended to use the `filename` method to get the filename which automatically
+    /// falls back to the `body` field when the `filename` field is not set.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub filename: Option<String>,
 
@@ -62,6 +65,14 @@ impl FileMessageEventContent {
     /// as a shorthand for that, because it is very common to set this field.
     pub fn info(self, info: impl Into<Option<Box<FileInfo>>>) -> Self {
         Self { info: info.into(), ..self }
+    }
+
+    /// Computes the filename for the file as defined by the [spec](https://spec.matrix.org/latest/client-server-api/#media-captions).
+    ///
+    /// This differs from the `filename` field as this method falls back to the `body` field when
+    /// the `filename` field is not set.
+    pub fn filename(&self) -> &str {
+        self.filename.as_deref().unwrap_or(&self.body)
     }
 
     /// Returns the caption of the media file as defined by the [spec](https://spec.matrix.org/latest/client-server-api/#media-captions).

--- a/crates/ruma-events/src/room/message/image.rs
+++ b/crates/ruma-events/src/room/message/image.rs
@@ -24,7 +24,10 @@ pub struct ImageMessageEventContent {
     #[serde(flatten)]
     pub formatted: Option<FormattedBody>,
 
-    /// The original filename of the uploaded file.
+    /// The original filename of the uploaded file as deserialized from the event.
+    ///
+    /// It is recommended to use the `filename` method to get the filename which automatically
+    /// falls back to the `body` field when the `filename` field is not set.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub filename: Option<String>,
 
@@ -61,6 +64,14 @@ impl ImageMessageEventContent {
     /// as a shorthand for that, because it is very common to set this field.
     pub fn info(self, info: impl Into<Option<Box<ImageInfo>>>) -> Self {
         Self { info: info.into(), ..self }
+    }
+
+    /// Computes the filename of the image as defined by the [spec](https://spec.matrix.org/latest/client-server-api/#media-captions).
+    ///
+    /// This differs from the `filename` field as this method falls back to the `body` field when
+    /// the `filename` field is not set.
+    pub fn filename(&self) -> &str {
+        self.filename.as_deref().unwrap_or(&self.body)
     }
 
     /// Returns the caption for the image as defined by the [spec](https://spec.matrix.org/latest/client-server-api/#media-captions).

--- a/crates/ruma-events/src/room/message/video.rs
+++ b/crates/ruma-events/src/room/message/video.rs
@@ -27,7 +27,10 @@ pub struct VideoMessageEventContent {
     #[serde(flatten)]
     pub formatted: Option<FormattedBody>,
 
-    /// The original filename of the uploaded file.
+    /// The original filename of the uploaded file as deserialized from the event.
+    ///
+    /// It is recommended to use the `filename` method to get the filename which automatically
+    /// falls back to the `body` field when the `filename` field is not set.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub filename: Option<String>,
 
@@ -64,6 +67,14 @@ impl VideoMessageEventContent {
     /// as a shorthand for that, because it is very common to set this field.
     pub fn info(self, info: impl Into<Option<Box<VideoInfo>>>) -> Self {
         Self { info: info.into(), ..self }
+    }
+
+    /// Computes the filename of the video as defined by the [spec](https://spec.matrix.org/latest/client-server-api/#media-captions).
+    ///
+    /// This differs from the `filename` field as this method falls back to the `body` field when
+    /// the `filename` field is not set.
+    pub fn filename(&self) -> &str {
+        self.filename.as_deref().unwrap_or(&self.body)
     }
 
     /// Returns the caption of the video as defined by the [spec](https://spec.matrix.org/latest/client-server-api/#media-captions).

--- a/crates/ruma-events/tests/it/room_message.rs
+++ b/crates/ruma-events/tests/it/room_message.rs
@@ -1336,6 +1336,19 @@ fn invalid_replacement() {
 }
 
 #[test]
+fn test_audio_filename() {
+    let mut content = AudioMessageEventContent::plain(
+        "my_sound.ogg".to_owned(),
+        mxc_uri!("mxc://notareal.hs/abcdef").to_owned(),
+    );
+    assert_eq!(content.filename(), "my_sound.ogg");
+
+    content.body = "This was a great podcast episode".to_owned();
+    content.filename = Some("sound.ogg".to_owned());
+    assert_eq!(content.filename(), "sound.ogg");
+}
+
+#[test]
 fn test_audio_caption() {
     let mut content = AudioMessageEventContent::plain(
         "my_sound.ogg".to_owned(),
@@ -1359,6 +1372,19 @@ fn test_audio_caption() {
         content.formatted_caption().map(|f| f.body.clone()),
         Some("This was a <em>great</em> podcast episode".to_owned())
     );
+}
+
+#[test]
+fn test_file_filename() {
+    let mut content = FileMessageEventContent::plain(
+        "my_file.txt".to_owned(),
+        mxc_uri!("mxc://notareal.hs/abcdef").to_owned(),
+    );
+    assert_eq!(content.filename(), "my_file.txt");
+
+    content.body = "Please check these notes".to_owned();
+    content.filename = Some("notes.txt".to_owned());
+    assert_eq!(content.filename(), "notes.txt");
 }
 
 #[test]
@@ -1388,6 +1414,19 @@ fn test_file_caption() {
 }
 
 #[test]
+fn test_image_filename() {
+    let mut content = ImageMessageEventContent::plain(
+        "my_image.jpg".to_owned(),
+        mxc_uri!("mxc://notareal.hs/abcdef").to_owned(),
+    );
+    assert_eq!(content.filename(), "my_image.jpg");
+
+    content.body = "Check it out 😎".to_owned();
+    content.filename = Some("image.jpg".to_owned());
+    assert_eq!(content.filename(), "image.jpg");
+}
+
+#[test]
 fn test_image_caption() {
     let mut content = ImageMessageEventContent::plain(
         "my_image.jpg".to_owned(),
@@ -1410,6 +1449,19 @@ fn test_image_caption() {
         content.formatted_caption().map(|f| f.body.clone()),
         Some("<h3>Check it out 😎</h3>".to_owned())
     );
+}
+
+#[test]
+fn test_video_filename() {
+    let mut content = VideoMessageEventContent::plain(
+        "my_video.mp4".to_owned(),
+        mxc_uri!("mxc://notareal.hs/abcdef").to_owned(),
+    );
+    assert_eq!(content.filename(), "my_video.mp4");
+
+    content.body = "You missed a great evening".to_owned();
+    content.filename = Some("video.mp4".to_owned());
+    assert_eq!(content.filename(), "video.mp4");
 }
 
 #[test]


### PR DESCRIPTION
Follow-up to #1919, this PR adds helper methods for filenames too.

Note: Everything is in the last commit as I based it on top of the captions branch. Realising just now that I can't target that branch for the PR as it isn't in this repo 🤦‍♂️