### PR TITLE
events: Stabilize support for marked unread room account data

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -25,6 +25,10 @@ Improvements:
   This guarantees correct formatting of the event key.
 - Add helpers for captions on audio, file, image and video messages.
 - Add helpers for filenames on audio, file, image and video messages.
+- Stabilize support for the `m.marked_unread` room account data according to Matrix 1.12. The
+  unstable `com.famedly.marked_unread` room account data is still available behind the
+  `unstable-msc2867` cargo feature to be able to migrate data from the unstable to the stable
+  prefix.
 
 Breaking changes:
 

--- a/crates/ruma-events/src/enums.rs
+++ b/crates/ruma-events/src/enums.rs
@@ -23,8 +23,9 @@ event_enum! {
     enum RoomAccountData {
         "m.fully_read" => super::fully_read,
         "m.tag" => super::tag,
+        "m.marked_unread" => super::marked_unread,
         #[cfg(feature = "unstable-msc2867")]
-        #[ruma_enum(alias = "m.marked_unread")]
+        #[ruma_enum(ident = UnstableMarkedUnread)]
         "com.famedly.marked_unread" => super::marked_unread,
     }
 

--- a/crates/ruma-events/src/lib.rs
+++ b/crates/ruma-events/src/lib.rs
@@ -161,7 +161,6 @@ pub mod image;
 pub mod key;
 #[cfg(feature = "unstable-msc3488")]
 pub mod location;
-#[cfg(feature = "unstable-msc2867")]
 pub mod marked_unread;
 #[cfg(feature = "unstable-msc1767")]
 pub mod message;

--- a/crates/ruma-events/src/marked_unread.rs
+++ b/crates/ruma-events/src/marked_unread.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.marked_unread`] event.
 //!
-//! [`m.marked_unread`]: https://github.com/matrix-org/matrix-spec-proposals/pull/2867
+//! [`m.marked_unread`]: https://spec.matrix.org/latest/client-server-api/#unread-markers
 
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 /// This event appears in the user's room account data for the room the marker is applicable for.
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-#[ruma_event(type = "com.famedly.marked_unread", kind = RoomAccountData)]
+#[ruma_event(type = "m.marked_unread", kind = RoomAccountData)]
 pub struct MarkedUnreadEventContent {
     /// The current unread state.
     pub unread: bool,
@@ -22,5 +22,111 @@ impl MarkedUnreadEventContent {
     /// Creates a new `MarkedUnreadEventContent` with the given value.
     pub fn new(unread: bool) -> Self {
         Self { unread }
+    }
+}
+
+/// The content of a [`com.famedly.marked_unread`] event, the unstable version of
+/// [MarkedUnreadEventContent].
+///
+/// Whether the room has been explicitly marked as unread.
+///
+/// This event appears in the user's room account data for the room the marker is applicable for.
+///
+/// [`com.famedly.marked_unread`]: https://github.com/matrix-org/matrix-spec-proposals/pull/2867
+#[cfg(feature = "unstable-msc2867")]
+#[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+#[ruma_event(type = "com.famedly.marked_unread", kind = RoomAccountData)]
+#[serde(transparent)]
+pub struct UnstableMarkedUnreadEventContent(pub MarkedUnreadEventContent);
+
+#[cfg(feature = "unstable-msc2867")]
+impl std::ops::Deref for UnstableMarkedUnreadEventContent {
+    type Target = MarkedUnreadEventContent;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[cfg(feature = "unstable-msc2867")]
+impl From<MarkedUnreadEventContent> for UnstableMarkedUnreadEventContent {
+    fn from(value: MarkedUnreadEventContent) -> Self {
+        Self(value)
+    }
+}
+
+#[cfg(feature = "unstable-msc2867")]
+impl From<UnstableMarkedUnreadEventContent> for MarkedUnreadEventContent {
+    fn from(value: UnstableMarkedUnreadEventContent) -> Self {
+        value.0
+    }
+}
+
+#[cfg(all(test, feature = "unstable-msc2867"))]
+mod tests {
+    use assert_matches2::assert_matches;
+    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+
+    use super::{MarkedUnreadEventContent, UnstableMarkedUnreadEventContent};
+    use crate::{AnyRoomAccountDataEvent, RoomAccountDataEvent};
+
+    #[test]
+    fn deserialize() {
+        let raw_unstable_marked_unread = json!({
+            "type": "com.famedly.marked_unread",
+            "content": {
+                "unread": true,
+            },
+        });
+        let unstable_marked_unread_account_data =
+            from_json_value::<AnyRoomAccountDataEvent>(raw_unstable_marked_unread).unwrap();
+        assert_matches!(
+            unstable_marked_unread_account_data,
+            AnyRoomAccountDataEvent::UnstableMarkedUnread(unstable_marked_unread)
+        );
+        assert!(unstable_marked_unread.content.unread);
+
+        let raw_marked_unread = json!({
+            "type": "m.marked_unread",
+            "content": {
+                "unread": true,
+            },
+        });
+        let marked_unread_account_data =
+            from_json_value::<AnyRoomAccountDataEvent>(raw_marked_unread).unwrap();
+        assert_matches!(
+            marked_unread_account_data,
+            AnyRoomAccountDataEvent::MarkedUnread(marked_unread)
+        );
+        assert!(marked_unread.content.unread);
+    }
+
+    #[test]
+    fn serialize() {
+        let marked_unread = MarkedUnreadEventContent::new(true);
+        let marked_unread_account_data = RoomAccountDataEvent { content: marked_unread.clone() };
+        assert_eq!(
+            to_json_value(marked_unread_account_data).unwrap(),
+            json!({
+                "type": "m.marked_unread",
+                "content": {
+                    "unread": true,
+                },
+            })
+        );
+
+        let unstable_marked_unread = UnstableMarkedUnreadEventContent::from(marked_unread);
+        let unstable_marked_unread_account_data =
+            RoomAccountDataEvent { content: unstable_marked_unread };
+        assert_eq!(
+            to_json_value(unstable_marked_unread_account_data).unwrap(),
+            json!({
+                "type": "com.famedly.marked_unread",
+                "content": {
+                    "unread": true,
+                },
+            })
+        );
     }
 }


### PR DESCRIPTION
According to [MSC2867](https://github.com/matrix-org/matrix-spec-proposals/pull/2867) / [Spec PR](https://github.com/matrix-org/matrix-spec/pull/1895).

The unstable `com.famedly.marked_unread` room account data is still available behind the `unstable-msc2867` cargo feature to be able to migrate data from the unstable to the stable prefix.

I was surprised that it was so easy, but it seems to work :smile:.

The CI will fail until the next version of Matrix is released because of the link to the spec.