### PR TITLE
federation-api: Remove KeyObject

### DIFF
--- a/crates/ruma-federation-api/CHANGELOG.md
+++ b/crates/ruma-federation-api/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [unreleased]
 
+Breaking changes:
+
+- Remove the unused `KeyObject` struct. It is actually supposed to be the same type
+  as `ruma_common::encryption::SignedKey`.
+
 Bug fixes:
 
 - `ServerSigningKeys` can be deserialized when `old_verify_keys` is missing, due to a

--- a/crates/ruma-federation-api/src/keys/claim_keys.rs
+++ b/crates/ruma-federation-api/src/keys/claim_keys.rs
@@ -13,10 +13,9 @@ pub mod v1 {
         api::{request, response, Metadata},
         encryption::OneTimeKey,
         metadata,
-        serde::{Base64, Raw},
+        serde::Raw,
         DeviceKeyAlgorithm, OwnedDeviceId, OwnedDeviceKeyId, OwnedUserId,
     };
-    use serde::{Deserialize, Serialize};
 
     const METADATA: Metadata = metadata! {
         method: POST,
@@ -61,25 +60,4 @@ pub mod v1 {
     /// One time keys for use in pre-key messages
     pub type OneTimeKeys =
         BTreeMap<OwnedUserId, BTreeMap<OwnedDeviceId, BTreeMap<OwnedDeviceKeyId, Raw<OneTimeKey>>>>;
-
-    /// A key and its signature
-    #[derive(Debug, Clone, Serialize, Deserialize)]
-    #[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
-    pub struct KeyObject {
-        /// The key, encoded using unpadded base64.
-        pub key: Base64,
-
-        /// Signature of the key object.
-        pub signatures: BTreeMap<OwnedUserId, BTreeMap<OwnedDeviceKeyId, String>>,
-    }
-
-    impl KeyObject {
-        /// Creates a new `KeyObject` with the given key and signatures.
-        pub fn new(
-            key: Base64,
-            signatures: BTreeMap<OwnedUserId, BTreeMap<OwnedDeviceKeyId, String>>,
-        ) -> Self {
-            Self { key, signatures }
-        }
-    }
 }


### PR DESCRIPTION
It is unused and is actually supposed to be the same type as [`ruma_common::encryption::SignedKey`](https://docs.ruma.dev/ruma_common/encryption/struct.SignedKey.html).

