### PR TITLE
identifiers: Improve API of Signatures

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -25,6 +25,8 @@ Breaking changes:
 - The `(owned_)server_signing_key_id` macros were removed. For compile-time
   validated construction, use `ServerSigningKeyId::from_parts` with a
   `SigningKeyAlgorithm` and the `server_signing_key_version` macro.
+- Rename `Signatures::insert` to `Signatures::insert_signature`.
+  `Signatures::insert` is now dereferenced to `BTreeMap::insert`.
 
 Improvements:
 
@@ -40,6 +42,9 @@ Improvements:
 - Implement `Eq` and `PartialEq` for `Metadata`
 - Allow constructing `api::error::MatrixErrorBody::NotJson` outside of this
   crate.
+- Improve the API of `Signatures`, by implementing `Deref` and `DerefMut`, as
+  well as `From`, `Extend` and `FromIterator` from a list of
+  `(entity, key_identifier, value)` tuples.
 
 # 0.13.0
 

--- a/crates/ruma-common/src/identifiers/signatures.rs
+++ b/crates/ruma-common/src/identifiers/signatures.rs
@@ -1,4 +1,7 @@
-use std::{borrow::Borrow, collections::BTreeMap};
+use std::{
+    collections::BTreeMap,
+    ops::{Deref, DerefMut},
+};
 
 use serde::{Deserialize, Serialize};
 
@@ -10,7 +13,7 @@ use super::{
 /// Map of key identifier to signature values.
 pub type EntitySignatures<K> = BTreeMap<OwnedSigningKeyId<K>, String>;
 
-/// Map of all signatures, grouped by entity
+/// Map of all signatures, grouped by entity.
 ///
 /// ```
 /// # use ruma_common::{server_name, server_signing_key_version, ServerSigningKeyId, Signatures, SigningKeyAlgorithm};
@@ -22,37 +25,28 @@ pub type EntitySignatures<K> = BTreeMap<OwnedSigningKeyId<K>, String>;
 /// let server_name = server_name!("example.org");
 /// let signature =
 ///     "YbJva03ihSj5mPk+CHMJKUKlCXCPFXjXOK6VqBnN9nA2evksQcTGn6hwQfrgRHIDDXO2le49x7jnWJHMJrJoBQ";
-/// signatures.insert(server_name, key_identifier, signature.into());
+/// signatures.insert_signature(server_name, key_identifier, signature.into());
 /// ```
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct Signatures<E: Ord, K: KeyName + ?Sized>(BTreeMap<E, EntitySignatures<K>>);
 
 impl<E: Ord, K: KeyName + ?Sized> Signatures<E, K> {
     /// Creates an empty signature map.
     pub fn new() -> Self {
-        Self(BTreeMap::new())
+        Self::default()
     }
 
-    /// Add a signature for the given server name and key identifier.
+    /// Add a signature for the given entity and key identifier.
     ///
     /// If there was already one, it is returned.
-    pub fn insert(
+    pub fn insert_signature(
         &mut self,
         entity: E,
         key_identifier: OwnedSigningKeyId<K>,
         value: String,
     ) -> Option<String> {
         self.0.entry(entity).or_default().insert(key_identifier, value)
-    }
-
-    /// Returns a reference to the signatures corresponding to the entities.
-    pub fn get<Q>(&self, entity: &Q) -> Option<&EntitySignatures<K>>
-    where
-        E: Borrow<Q>,
-        Q: Ord + ?Sized,
-    {
-        self.0.get(entity)
     }
 }
 
@@ -61,3 +55,50 @@ pub type ServerSignatures = Signatures<OwnedServerName, OwnedServerSigningKeyVer
 
 /// Map of device signatures for an event, grouped by user.
 pub type DeviceSignatures = Signatures<OwnedUserId, OwnedDeviceId>;
+
+impl<E: Ord, K: KeyName + ?Sized> Default for Signatures<E, K> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
+impl<E: Ord, K: KeyName + ?Sized> Deref for Signatures<E, K> {
+    type Target = BTreeMap<E, EntitySignatures<K>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<E: Ord, K: KeyName + ?Sized> DerefMut for Signatures<E, K> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<E: Ord, K: KeyName + ?Sized, const N: usize> From<[(E, OwnedSigningKeyId<K>, String); N]>
+    for Signatures<E, K>
+{
+    fn from(value: [(E, OwnedSigningKeyId<K>, String); N]) -> Self {
+        value.into_iter().collect()
+    }
+}
+
+impl<E: Ord, K: KeyName + ?Sized> FromIterator<(E, OwnedSigningKeyId<K>, String)>
+    for Signatures<E, K>
+{
+    fn from_iter<T: IntoIterator<Item = (E, OwnedSigningKeyId<K>, String)>>(iter: T) -> Self {
+        iter.into_iter().fold(Self::new(), |mut acc, (entity, key_identifier, value)| {
+            acc.insert_signature(entity, key_identifier, value);
+            acc
+        })
+    }
+}
+
+impl<E: Ord, K: KeyName + ?Sized> Extend<(E, OwnedSigningKeyId<K>, String)> for Signatures<E, K> {
+    fn extend<T: IntoIterator<Item = (E, OwnedSigningKeyId<K>, String)>>(&mut self, iter: T) {
+        for (entity, key_identifier, value) in iter {
+            self.insert_signature(entity, key_identifier, value);
+        }
+    }
+}


### PR DESCRIPTION
I noticed that there are several places where we could use these `Signatures` types, where we still use nested `BTreeMap`s. However before making this change I believe it's important to improve its API so it is easier to construct/mutate/access:

- Implement `Deref` and `DerefMut` to `BTreeMap`.
- Implement `From`, `Extend` and `FromIterator` from a list of `(entity, key_identifier, value)` tuples
- Rename `Signatures::insert` to `Signatures::insert_signature` to let `Signatures::insert` dereference to `BTreeMap::insert`.
- Implement `Default` manually to avoid unnecessary `Default` bounds on the generic types.
