### PR TITLE
events: Remove p tag around inline markdown

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -9,6 +9,8 @@ Bug fixes:
 - `Restricted` no longer fails to deserialize when the `allow` field is missing
 - Markdown text constructors now also detect markdown syntax like backslash
   escapes and entity references to decide if the text should be sent as HTML.
+- Markdown text with only inline syntax generates HTML that is not wrapped
+  inside a `<p>` element anymore, as recommended by the spec.
 
 Improvements:
 

--- a/crates/ruma-events/tests/it/message.rs
+++ b/crates/ruma-events/tests/it/message.rs
@@ -82,7 +82,7 @@ fn markdown_content_serialization() {
             "org.matrix.msc1767.text": [
                 {
                     "mimetype": "text/html",
-                    "body": "<p>Testing <strong>bold</strong> and <em>italic</em>!</p>\n",
+                    "body": "Testing <strong>bold</strong> and <em>italic</em>!",
                 },
                 {
                     "body": "Testing **bold** and _italic_!",

--- a/crates/ruma-events/tests/it/room_message.rs
+++ b/crates/ruma-events/tests/it/room_message.rs
@@ -117,7 +117,7 @@ fn text_msgtype_markdown_serialization() {
         to_json_value(&formatted_message).unwrap(),
         json!({
             "body": text,
-            "formatted_body": "<p>Testing <strong>bold</strong> and <em>italic</em>!</p>\n",
+            "formatted_body": "Testing <strong>bold</strong> and <em>italic</em>!",
             "format": "org.matrix.custom.html",
             "msgtype": "m.text"
         })
@@ -198,16 +198,20 @@ fn markdown_detection() {
     assert_matches!(formatted_body, None);
 
     // Multiple paragraphs trigger markdown
-    let formatted_body = FormattedBody::markdown("A message\nwith\n\nmultiple\n\nparagraphs");
-    formatted_body.unwrap();
+    let formatted_body =
+        FormattedBody::markdown("A message\nwith\n\nmultiple\n\nparagraphs").unwrap();
+    assert_eq!(
+        formatted_body.body,
+        "<p>A message<br />\nwith</p>\n<p>multiple</p>\n<p>paragraphs</p>\n"
+    );
 
     // "Less than" symbol triggers markdown.
-    let formatted_body = FormattedBody::markdown("A message with & HTML < entities");
-    assert_matches!(formatted_body, Some(_));
+    let formatted_body = FormattedBody::markdown("A message with & HTML < entities").unwrap();
+    assert_eq!(formatted_body.body, "A message with &amp; HTML &lt; entities");
 
     // HTML triggers markdown.
-    let formatted_body = FormattedBody::markdown("<span>An HTML message</span>");
-    formatted_body.unwrap();
+    let formatted_body = FormattedBody::markdown("<span>An HTML message</span>").unwrap();
+    assert_eq!(formatted_body.body, "<span>An HTML message</span>");
 }
 
 #[test]
@@ -232,7 +236,7 @@ fn markdown_options() {
 
     // Strikethrough
     let formatted_body = FormattedBody::markdown("A message with a ~~strike~~");
-    assert_eq!(formatted_body.unwrap().body, "<p>A message with a <del>strike</del></p>\n");
+    assert_eq!(formatted_body.unwrap().body, "A message with a <del>strike</del>");
 }
 
 #[test]


### PR DESCRIPTION
As recommended by the spec in the section about [custom Matrix HTML](https://spec.matrix.org/v1.12/client-server-api/#mroommessage-msgtypes):

> Likewise, clients should not generate HTML that is not needed, such as extra paragraph tags surrounding text due to Rich Text Editors.
