### PR TITLE
Use `Signatures` in more places

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -24,6 +24,8 @@ Breaking changes:
 - Use `OwnedCrossSigningOrDeviceSigningKeyId` instead of `OwnedDeviceKeyId` to
   identify signing keys in `BackupAlgorithm::MegolmBackupV1Curve25519AesSha2`'s
   `signatures`.
+- Use `CrossSigningOrDeviceSignatures` for the `signatures` of `BackupAlgorithm`.
+- Use `ServerSignatures` for the `signatures` of `ThirdPartySigned`.
 
 Improvements:
 

--- a/crates/ruma-client-api/src/backup.rs
+++ b/crates/ruma-client-api/src/backup.rs
@@ -20,7 +20,7 @@ use std::collections::BTreeMap;
 use js_int::UInt;
 use ruma_common::{
     serde::{Base64, Raw},
-    OwnedCrossSigningOrDeviceSigningKeyId, OwnedUserId,
+    CrossSigningOrDeviceSignatures,
 };
 use serde::{Deserialize, Serialize};
 
@@ -51,7 +51,7 @@ pub enum BackupAlgorithm {
         public_key: Base64,
 
         /// Signatures of the auth_data as Signed JSON.
-        signatures: BTreeMap<OwnedUserId, BTreeMap<OwnedCrossSigningOrDeviceSigningKeyId, String>>,
+        signatures: CrossSigningOrDeviceSignatures,
     },
 }
 

--- a/crates/ruma-client-api/src/membership.rs
+++ b/crates/ruma-client-api/src/membership.rs
@@ -14,9 +14,7 @@ pub mod leave_room;
 pub mod mutual_rooms;
 pub mod unban_user;
 
-use std::collections::BTreeMap;
-
-use ruma_common::{thirdparty::Medium, OwnedServerName, OwnedServerSigningKeyId, OwnedUserId};
+use ruma_common::{thirdparty::Medium, OwnedUserId, ServerSignatures};
 use serde::{Deserialize, Serialize};
 
 /// A signature of an `m.third_party_invite` token to prove that this user owns a third party
@@ -34,7 +32,7 @@ pub struct ThirdPartySigned {
     pub token: String,
 
     /// A signatures object containing a signature of the entire signed object.
-    pub signatures: BTreeMap<OwnedServerName, BTreeMap<OwnedServerSigningKeyId, String>>,
+    pub signatures: ServerSignatures,
 }
 
 impl ThirdPartySigned {
@@ -44,7 +42,7 @@ impl ThirdPartySigned {
         sender: OwnedUserId,
         mxid: OwnedUserId,
         token: String,
-        signatures: BTreeMap<OwnedServerName, BTreeMap<OwnedServerSigningKeyId, String>>,
+        signatures: ServerSignatures,
     ) -> Self {
         Self { sender, mxid, token, signatures }
     }

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -39,6 +39,10 @@ Breaking changes:
 - `(Owned)DeviceKeyId` is now a type alias of `(Owned)KeyId`.
   - Remove the `(owned_)device_key_id` macro, instead use
     `DeviceKeyId::from_parts`.
+- Use `CrossSigningOrDeviceSignatures` for the `signatures` of `DeviceKeys`.
+- Remove `SignedKeySignatures` and replace it with `DeviceSignatures`.
+- Remove `CrossSigningKeySignatures` and replace it with
+  `CrossSigningOrDeviceSignatures`.
 
 Improvements:
 

--- a/crates/ruma-common/src/identifiers.rs
+++ b/crates/ruma-common/src/identifiers.rs
@@ -42,7 +42,10 @@ pub use self::{
     server_name::{OwnedServerName, ServerName},
     server_signing_key_version::{OwnedServerSigningKeyVersion, ServerSigningKeyVersion},
     session_id::{OwnedSessionId, SessionId},
-    signatures::{DeviceSignatures, EntitySignatures, ServerSignatures, Signatures},
+    signatures::{
+        CrossSigningOrDeviceSignatures, DeviceSignatures, EntitySignatures, ServerSignatures,
+        Signatures,
+    },
     transaction_id::{OwnedTransactionId, TransactionId},
     user_id::{OwnedUserId, UserId},
     voip_id::{OwnedVoipId, VoipId},

--- a/crates/ruma-common/src/identifiers/signatures.rs
+++ b/crates/ruma-common/src/identifiers/signatures.rs
@@ -6,7 +6,8 @@ use std::{
 use serde::{Deserialize, Serialize};
 
 use super::{
-    DeviceId, KeyName, OwnedServerName, OwnedSigningKeyId, OwnedUserId, ServerSigningKeyVersion,
+    Base64PublicKeyOrDeviceId, DeviceId, KeyName, OwnedServerName, OwnedSigningKeyId, OwnedUserId,
+    ServerSigningKeyVersion,
 };
 
 /// Map of key identifier to signature values.
@@ -57,6 +58,9 @@ pub type ServerSignatures = Signatures<OwnedServerName, ServerSigningKeyVersion>
 
 /// Map of device signatures, grouped by user.
 pub type DeviceSignatures = Signatures<OwnedUserId, DeviceId>;
+
+/// Map of cross-signing or device signatures, grouped by user.
+pub type CrossSigningOrDeviceSignatures = Signatures<OwnedUserId, Base64PublicKeyOrDeviceId>;
 
 impl<E, K> Clone for Signatures<E, K>
 where

--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -36,6 +36,7 @@ Improvements:
 Breaking changes:
 
 - `StickerEventContent::url` was replaced by `StickerEventContent::source` which is a `StickerMediaSource`
+- Use `ServerSignatures` for the `signatures` of `RoomV1Pdu`, `RoomV3Pdu` and `SignedContent`.
 
 # 0.28.1
 

--- a/crates/ruma-events/src/pdu.rs
+++ b/crates/ruma-events/src/pdu.rs
@@ -9,8 +9,7 @@ use std::collections::BTreeMap;
 
 use js_int::UInt;
 use ruma_common::{
-    MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedServerName,
-    OwnedServerSigningKeyId, OwnedUserId,
+    MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedUserId, ServerSignatures,
 };
 use serde::{
     de::{Error as _, IgnoredAny},
@@ -87,7 +86,7 @@ pub struct RoomV1Pdu {
     pub hashes: EventHash,
 
     /// Signatures for the PDU.
-    pub signatures: BTreeMap<OwnedServerName, BTreeMap<OwnedServerSigningKeyId, String>>,
+    pub signatures: ServerSignatures,
 }
 
 /// A 'persistent data unit' (event) for room versions 3 and beyond.
@@ -140,7 +139,7 @@ pub struct RoomV3Pdu {
     pub hashes: EventHash,
 
     /// Signatures for the PDU.
-    pub signatures: BTreeMap<OwnedServerName, BTreeMap<OwnedServerSigningKeyId, String>>,
+    pub signatures: ServerSignatures,
 }
 
 /// Content hashes of a PDU.

--- a/crates/ruma-events/tests/it/pdu.rs
+++ b/crates/ruma-events/tests/it/pdu.rs
@@ -4,8 +4,8 @@ use std::collections::BTreeMap;
 
 use js_int::uint;
 use ruma_common::{
-    event_id, owned_event_id, owned_room_id, owned_user_id, server_name,
-    server_signing_key_version, MilliSecondsSinceUnixEpoch, ServerSigningKeyId,
+    event_id, owned_event_id, owned_room_id, owned_server_name, owned_user_id,
+    server_signing_key_version, MilliSecondsSinceUnixEpoch, ServerSignatures, ServerSigningKeyId,
     SigningKeyAlgorithm,
 };
 use ruma_events::{
@@ -19,16 +19,16 @@ use serde_json::{
 
 #[test]
 fn serialize_pdu_as_v1() {
-    let mut signatures = BTreeMap::new();
-    let mut inner_signature = BTreeMap::new();
-    inner_signature.insert(
-        ServerSigningKeyId::from_parts(
-            SigningKeyAlgorithm::Ed25519,
-            server_signing_key_version!("key_version"),
-        ),
-        "86BytesOfSignatureOfTheRedactedEvent".into(),
+    let mut signatures = ServerSignatures::new();
+    let key_id = ServerSigningKeyId::from_parts(
+        SigningKeyAlgorithm::Ed25519,
+        server_signing_key_version!("key_version"),
     );
-    signatures.insert(server_name!("example.com").to_owned(), inner_signature);
+    signatures.insert_signature(
+        owned_server_name!("example.com"),
+        key_id,
+        "86BytesOfSignatureOfTheRedactedEvent".to_owned(),
+    );
 
     let mut unsigned = BTreeMap::new();
     unsigned.insert("somekey".into(), to_raw_json_value(&json!({ "a": 456 })).unwrap());
@@ -87,16 +87,16 @@ fn serialize_pdu_as_v1() {
 
 #[test]
 fn serialize_pdu_as_v3() {
-    let mut signatures = BTreeMap::new();
-    let mut inner_signature = BTreeMap::new();
-    inner_signature.insert(
-        ServerSigningKeyId::from_parts(
-            SigningKeyAlgorithm::Ed25519,
-            server_signing_key_version!("key_version"),
-        ),
-        "86BytesOfSignatureOfTheRedactedEvent".into(),
+    let mut signatures = ServerSignatures::new();
+    let key_id = ServerSigningKeyId::from_parts(
+        SigningKeyAlgorithm::Ed25519,
+        server_signing_key_version!("key_version"),
     );
-    signatures.insert(server_name!("example.com").to_owned(), inner_signature);
+    signatures.insert_signature(
+        owned_server_name!("example.com"),
+        key_id,
+        "86BytesOfSignatureOfTheRedactedEvent".to_owned(),
+    );
 
     let mut unsigned = BTreeMap::new();
     unsigned.insert("somekey".into(), to_raw_json_value(&json!({ "a": 456 })).unwrap());

--- a/crates/ruma-federation-api/CHANGELOG.md
+++ b/crates/ruma-federation-api/CHANGELOG.md
@@ -7,6 +7,7 @@ Breaking changes:
 - Use `OwnedOneTimeKeyId` and `OneTimeKeyAlgorithm` instead of
   `OwnedDeviceKeyId` and `DeviceKeyAlgorithm` respectively to identify one-time
   and fallback keys and their algorithm.
+- Use `ServerSignatures` for the `signatures` or `ServerSigningKeys`.
 
 Bug fixes:
 

--- a/crates/ruma-federation-api/src/discovery.rs
+++ b/crates/ruma-federation-api/src/discovery.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeMap;
 
 use ruma_common::{
     serde::Base64, MilliSecondsSinceUnixEpoch, OwnedServerName, OwnedServerSigningKeyId,
+    ServerSignatures,
 };
 use serde::{Deserialize, Serialize};
 
@@ -67,7 +68,7 @@ pub struct ServerSigningKeys {
     /// Digital signatures of this object signed using the verify_keys.
     ///
     /// Map of server name to keys by key ID.
-    pub signatures: BTreeMap<OwnedServerName, BTreeMap<OwnedServerSigningKeyId, String>>,
+    pub signatures: ServerSignatures,
 
     /// Timestamp when the keys should be refreshed.
     ///
@@ -84,7 +85,7 @@ impl ServerSigningKeys {
             server_name,
             verify_keys: BTreeMap::new(),
             old_verify_keys: BTreeMap::new(),
-            signatures: BTreeMap::new(),
+            signatures: ServerSignatures::default(),
             valid_until_ts,
         }
     }

--- a/crates/ruma-state-res/src/test_utils.rs
+++ b/crates/ruma-state-res/src/test_utils.rs
@@ -10,7 +10,7 @@ use std::{
 use js_int::{int, uint};
 use ruma_common::{
     event_id, room_id, user_id, EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, RoomId,
-    RoomVersionId, UserId,
+    RoomVersionId, ServerSignatures, UserId,
 };
 use ruma_events::{
     pdu::{EventHash, Pdu, RoomV3Pdu},
@@ -395,7 +395,7 @@ pub(crate) fn to_init_pdu_event(
             prev_events: vec![],
             depth: uint!(0),
             hashes: EventHash::new("".to_owned()),
-            signatures: BTreeMap::new(),
+            signatures: ServerSignatures::default(),
         }),
     })
 }
@@ -433,7 +433,7 @@ where
             prev_events,
             depth: uint!(0),
             hashes: EventHash::new("".to_owned()),
-            signatures: BTreeMap::new(),
+            signatures: ServerSignatures::default(),
         }),
     })
 }


### PR DESCRIPTION
The first commit is a fix for the bounds and types used in `Signatures`. The others are more uses of `Signatures` where possible.
