### PR TITLE
docs: Improve docs about tokens necessary for releases

### DIFF
--- a/contrib/how_to_release.md
+++ b/contrib/how_to_release.md
@@ -1,5 +1,15 @@
 # How to release new versions of the Ruma crates
 
+## Pre-requisites
+
+You need to have valid tokens to create the releases and publish the crates:
+
+* a non-expired GitHub access token with the proper permissions set up in
+  `/xtask/config.toml`.
+* a non-expired [crates.io token](https://crates.io/settings/tokens) with the
+  `publish-update` scope and that it is enrolled with `cargo login`
+ 
+
 Releasing one of the crates is very simple since it is entirely automated.
 The only thing you have to do is to run
 

--- a/xtask/config.toml.sample
+++ b/xtask/config.toml.sample
@@ -1,7 +1,15 @@
 [github]
 # The username to use for authentication.
 user = ""
-# The personal access token to use for authentication. Needs permission to create releases.
+# The personal access token to use for authentication.
+#
 # Can be created at https://github.com/settings/personal-access-tokens/new
-# Docs at https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token
+#
+# Settings for a fine-grained personal access token:
+#
+# * Resource owner: ruma
+# * Repository access > Only select repositories: ruma/ruma
+# * Permissions > Repository permissions > Contents: Read and write
+#
+# Docs at https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens
 token = ""


### PR DESCRIPTION
That way I won't have to look into the docs every time :slightly_smiling_face:.