### PR TITLE
identifiers: Make KeyId::key_name take the string after the colon, not before

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [unreleased]
 
+Bug fixes:
+
+- The `KeyId::key_name` method now returns the key name. In 0.14.0, `key_name`
+  mistakenly returned the algorithm.
+
 # 0.14.0
 
 Bug fixes:


### PR DESCRIPTION
Fixes #1940 