### PR TITLE
state-res: add snapshot tests and fix tiebreaking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target
 Cargo.lock
 .DS_Store
 .idea
+*.snap.new

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,9 @@ js_int = "0.2.2"
 maplit = "1.0.2"
 rand = "0.8.5"
 ruma-appservice-api = { version = "0.11.0", path = "crates/ruma-appservice-api" }
-ruma-common = { version = "0.14.1", path = "crates/ruma-common" }
 ruma-client = { version = "0.14.0", path = "crates/ruma-client" }
 ruma-client-api = { version = "0.19.0", path = "crates/ruma-client-api" }
+ruma-common = { version = "0.14.1", path = "crates/ruma-common" }
 ruma-events = { version = "0.29.1", path = "crates/ruma-events" }
 ruma-federation-api = { version = "0.10.0", path = "crates/ruma-federation-api" }
 ruma-html = { version = "0.3.0", path = "crates/ruma-html" }
@@ -29,8 +29,8 @@ ruma-identifiers-validation = { version = "0.10.0", path = "crates/ruma-identifi
 ruma-identity-service-api = { version = "0.10.0", path = "crates/ruma-identity-service-api" }
 ruma-macros = { version = "=0.14.0", path = "crates/ruma-macros" }
 ruma-push-gateway-api = { version = "0.10.0", path = "crates/ruma-push-gateway-api" }
-ruma-signatures = { version = "0.16.0", path = "crates/ruma-signatures" }
 ruma-server-util = { version = "0.4.0", path = "crates/ruma-server-util" }
+ruma-signatures = { version = "0.16.0", path = "crates/ruma-signatures" }
 ruma-state-res = { version = "0.12.0", path = "crates/ruma-state-res" }
 serde = { version = "1.0.164", features = ["derive"] }
 serde_html_form = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ base64 = "0.22.0"
 bytes = "1.0.1"
 criterion = "0.5.0"
 http = "1.1.0"
+insta = { version = "1.41.1", features = ["json"] }
 js_int = "0.2.2"
 maplit = "1.0.2"
 rand = "0.8.5"
@@ -35,6 +36,7 @@ ruma-state-res = { version = "0.12.0", path = "crates/ruma-state-res" }
 serde = { version = "1.0.164", features = ["derive"] }
 serde_html_form = "0.2.0"
 serde_json = "1.0.87"
+similar = "2.6.0"
 thiserror = "2.0.0"
 tracing = { version = "0.1.37", default-features = false, features = ["std"] }
 url = { version = "2.5.0" }
@@ -81,4 +83,6 @@ debug = 0
 
 [profile.dev.package]
 # Also speeds up test times a little bit
+insta = { opt-level = 3 }
 quote = { opt-level = 2 }
+similar = { opt-level = 3 }

--- a/crates/ruma-signatures/Cargo.toml
+++ b/crates/ruma-signatures/Cargo.toml
@@ -32,7 +32,7 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 assert_matches2 = { workspace = true }
-insta = "1.31.0"
+insta = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/ruma-state-res/CHANGELOG.md
+++ b/crates/ruma-state-res/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [unreleased]
 
+Bug fixes:
+
+- Fix tiebreaking logic in state resolution.
+
 # 0.12.0
 
 Upgrade `ruma-events` to 0.29.0.

--- a/crates/ruma-state-res/Cargo.toml
+++ b/crates/ruma-state-res/Cargo.toml
@@ -31,10 +31,12 @@ tracing = { workspace = true }
 criterion = { workspace = true, optional = true }
 
 [dev-dependencies]
+insta = { workspace = true }
 maplit = { workspace = true }
 rand = { workspace = true }
 ruma-events = { workspace = true, features = ["unstable-pdu"] }
-tracing-subscriber = "0.3.16"
+similar = { workspace = true }
+tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 
 [[bench]]
 name = "state_res_bench"

--- a/crates/ruma-state-res/src/lib.rs
+++ b/crates/ruma-state-res/src/lib.rs
@@ -318,7 +318,7 @@ where
             // Only push on the heap once older events have been cleared
             out.remove(node.borrow());
             if out.is_empty() {
-                let (power_level, age) = key_fn(node.borrow())?;
+                let (power_level, age) = key_fn(parent.borrow())?;
                 heap.push(Reverse(TieBreaker {
                     inv_power_level: -power_level,
                     age,

--- a/crates/ruma-state-res/tests/it/fixtures/bootstrap-private-chat.json
+++ b/crates/ruma-state-res/tests/it/fixtures/bootstrap-private-chat.json
@@ -1,0 +1,103 @@
+[
+  {
+    "event_id": "$00-m-room-create",
+    "room_id": "!room:example.com",
+    "sender": "@alice:example.com",
+    "type": "m.room.create",
+    "content": {
+      "creator": "@alice:example.com",
+      "room_version": "10"
+    },
+    "state_key": "",
+    "origin_server_ts": 0,
+    "prev_events": [],
+    "auth_events": []
+  },
+  {
+    "event_id": "$00-m-room-member-join-alice",
+    "room_id": "!room:example.com",
+    "sender": "@alice:example.com",
+    "type": "m.room.member",
+    "content": {
+      "displayname": "alice",
+      "membership": "join"
+    },
+    "state_key": "@alice:example.com",
+    "origin_server_ts": 1,
+    "prev_events": [
+      "$00-m-room-create"
+    ],
+    "auth_events": [
+      "$00-m-room-create"
+    ]
+  },
+  {
+    "event_id": "$00-m-room-power_levels",
+    "room_id": "!room:example.com",
+    "sender": "@alice:example.com",
+    "type": "m.room.power_levels",
+    "content": {
+      "users": {
+        "@alice:example.com": 100
+      }
+    },
+    "state_key": "",
+    "origin_server_ts": 2,
+    "prev_events": [],
+    "auth_events": [
+      "$00-m-room-create",
+      "$00-m-room-member-join-alice"
+    ]
+  },
+  {
+    "event_id": "$00-m-room-join_rules",
+    "room_id": "!room:example.com",
+    "sender": "@alice:example.com",
+    "type": "m.room.join_rules",
+    "content": {
+      "join_rule": "invite"
+    },
+    "state_key": "",
+    "origin_server_ts": 3,
+    "prev_events": [],
+    "auth_events": [
+      "$00-m-room-create",
+      "$00-m-room-member-join-alice",
+      "$00-m-room-power_levels"
+    ]
+  },
+  {
+    "event_id": "$00-m-room-history_visibility",
+    "room_id": "!room:example.com",
+    "sender": "@alice:example.com",
+    "type": "m.room.history_visibility",
+    "content": {
+      "history_visibility": "shared"
+    },
+    "state_key": "",
+    "origin_server_ts": 4,
+    "prev_events": [],
+    "auth_events": [
+      "$00-m-room-create",
+      "$00-m-room-member-join-alice",
+      "$00-m-room-power_levels"
+    ]
+  },
+  {
+    "event_id": "$00-m-room-guest_access",
+    "room_id": "!room:example.com",
+    "sender": "@alice:example.com",
+    "type": "m.room.guest_access",
+    "content": {
+      "guest_access": "can_join"
+    },
+    "state_key": "",
+    "origin_server_ts": 5,
+    "prev_events": [],
+    "auth_events": [
+      "$00-m-room-create",
+      "$00-m-room-member-join-alice",
+      "$00-m-room-power_levels"
+    ]
+  }
+]

--- a/crates/ruma-state-res/tests/it/fixtures/origin-server-ts-tiebreak.json
+++ b/crates/ruma-state-res/tests/it/fixtures/origin-server-ts-tiebreak.json
@@ -1,0 +1,54 @@
+[
+  {
+    "test-comments": [
+      "NOTE: It is very important that the `event_id` of this PDU is ",
+      "lexicographically larger than the `event_id` of the following PDU, to ",
+      "ensure that the tiebreaking is done by the `origin_server_ts` field ",
+      "and not by the `event_id` field."
+    ],
+    "event_id": "$02-m-room-join_rules",
+    "room_id": "!room:example.com",
+    "sender": "@alice:example.com",
+    "type": "m.room.join_rules",
+    "content": {
+      "join_rule": "restricted",
+      "allow": [
+        {
+          "room_id": "!other:example.com",
+          "type": "m.room_membership"
+        }
+      ]
+    },
+    "state_key": "",
+    "origin_server_ts": 6,
+    "prev_events": [],
+    "auth_events": [
+      "$00-m-room-create",
+      "$00-m-room-member-join-alice",
+      "$00-m-room-power_levels"
+    ]
+  },
+  {
+    "test-comments": [
+      "NOTE: It is very important that the `event_id` of this PDU is ",
+      "lexicographically smaller than the `event_id` of the previous PDU, to ",
+      "ensure that the tiebreaking is done by the `origin_server_ts` field ",
+      "and not by the `event_id` field."
+    ],
+    "event_id": "$01-m-room-join_rules",
+    "room_id": "!room:example.com",
+    "sender": "@alice:example.com",
+    "type": "m.room.join_rules",
+    "content": {
+      "join_rule": "public"
+    },
+    "state_key": "",
+    "origin_server_ts": 7,
+    "prev_events": [],
+    "auth_events": [
+      "$00-m-room-create",
+      "$00-m-room-member-join-alice",
+      "$00-m-room-power_levels"
+    ]
+  }
+]

--- a/crates/ruma-state-res/tests/it/main.rs
+++ b/crates/ruma-state-res/tests/it/main.rs
@@ -1,0 +1,3 @@
+//! Integration tests entrypoint.
+
+mod resolve;

--- a/crates/ruma-state-res/tests/it/resolve.rs
+++ b/crates/ruma-state-res/tests/it/resolve.rs
@@ -1,0 +1,344 @@
+//! State resolution integration tests.
+
+use std::{
+    cmp::Ordering,
+    collections::{BTreeSet, HashMap, HashSet},
+    error::Error,
+    fs,
+    path::Path,
+};
+
+use ruma_common::{
+    MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedUserId, RoomId, RoomVersionId,
+    UserId,
+};
+use ruma_events::{StateEventType, TimelineEventType};
+use ruma_state_res::{resolve, Event, StateMap};
+use serde::{Deserialize, Serialize};
+use serde_json::{
+    from_str as from_json_str, to_string_pretty as to_json_string_pretty,
+    to_value as to_json_value, value::RawValue as RawJsonValue, Error as JsonError,
+    Value as JsonValue,
+};
+use similar::{udiff::unified_diff, Algorithm};
+use tracing_subscriber::{util::SubscriberInitExt, EnvFilter};
+
+/// Create a new snapshot test.
+///
+/// # Arguments
+///
+/// * The test function's name.
+/// * A list of JSON files relative to `tests/it/fixtures` to load PDUs to resolve from.
+macro_rules! snapshot_test {
+    ($name:ident, $paths:expr $(,)?) => {
+        #[test]
+        fn $name() {
+            let crate::resolve::Snapshots {
+                resolved_state,
+            } = crate::resolve::test_resolve(&$paths);
+
+            insta::with_settings!({
+                description => "Resolved state",
+                omit_expression => true,
+                snapshot_suffix => "resolved_state",
+            }, {
+                insta::assert_json_snapshot!(&resolved_state);
+            });
+        }
+    };
+}
+
+// This module must be defined lexically after the `snapshot_test` macro.
+mod snapshot_tests;
+
+/// A persistent data unit.
+#[derive(Deserialize, Clone)]
+struct Pdu {
+    event_id: OwnedEventId,
+    room_id: OwnedRoomId,
+    sender: OwnedUserId,
+    origin_server_ts: MilliSecondsSinceUnixEpoch,
+    #[serde(rename = "type")]
+    kind: TimelineEventType,
+    content: Box<RawJsonValue>,
+    state_key: Option<String>,
+    prev_events: Vec<OwnedEventId>,
+    auth_events: Vec<OwnedEventId>,
+    redacts: Option<OwnedEventId>,
+}
+
+impl Event for Pdu {
+    type Id = OwnedEventId;
+
+    fn event_id(&self) -> &Self::Id {
+        &self.event_id
+    }
+
+    fn room_id(&self) -> &RoomId {
+        &self.room_id
+    }
+
+    fn sender(&self) -> &UserId {
+        &self.sender
+    }
+
+    fn origin_server_ts(&self) -> MilliSecondsSinceUnixEpoch {
+        self.origin_server_ts
+    }
+
+    fn event_type(&self) -> &TimelineEventType {
+        &self.kind
+    }
+
+    fn content(&self) -> &RawJsonValue {
+        &self.content
+    }
+
+    fn state_key(&self) -> Option<&str> {
+        self.state_key.as_deref()
+    }
+
+    fn prev_events(&self) -> Box<dyn DoubleEndedIterator<Item = &Self::Id> + '_> {
+        Box::new(self.prev_events.iter())
+    }
+
+    fn auth_events(&self) -> Box<dyn DoubleEndedIterator<Item = &Self::Id> + '_> {
+        Box::new(self.auth_events.iter())
+    }
+
+    fn redacts(&self) -> Option<&Self::Id> {
+        self.redacts.as_ref()
+    }
+}
+
+/// Extract `.content.room_version` from a PDU.
+#[derive(Deserialize)]
+struct ExtractRoomVersion {
+    room_version: RoomVersionId,
+}
+
+/// Type describing a resolved state event.
+#[derive(Serialize)]
+struct ResolvedStateEvent {
+    kind: StateEventType,
+    state_key: String,
+    event_id: OwnedEventId,
+
+    // Ignored in `PartialEq` and `Ord` because we don't want to consider it while sorting.
+    content: JsonValue,
+}
+
+impl PartialEq for ResolvedStateEvent {
+    fn eq(&self, other: &Self) -> bool {
+        self.kind == other.kind
+            && self.state_key == other.state_key
+            && self.event_id == other.event_id
+    }
+}
+
+impl Eq for ResolvedStateEvent {}
+
+impl Ord for ResolvedStateEvent {
+    fn cmp(&self, other: &Self) -> Ordering {
+        Ordering::Equal
+            .then(self.kind.cmp(&other.kind))
+            .then(self.state_key.cmp(&other.state_key))
+            .then(self.event_id.cmp(&other.event_id))
+    }
+}
+
+impl PartialOrd for ResolvedStateEvent {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// Information to be captured in snapshot assertions
+struct Snapshots {
+    /// The resolved state of the room.
+    resolved_state: BTreeSet<ResolvedStateEvent>,
+}
+
+/// Test a list of JSON files containing a list of PDUs and return the results.
+///
+/// State resolution is run both atomically for all PDUs and in batches of PDUs by file.
+fn test_resolve(paths: &[&str]) -> Snapshots {
+    // Run `cargo test -- --show-output` to view traces, set `RUST_LOG` to control filtering.
+    let _subscriber = tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .with_test_writer()
+        .finish()
+        .set_default();
+
+    let fixtures_path = Path::new("tests/it/fixtures");
+
+    let pdu_batches = paths
+        .iter()
+        .map(|x| {
+            from_json_str(
+                &fs::read_to_string(fixtures_path.join(x))
+                    .expect("should be able to read JSON file of PDUs"),
+            )
+            .expect("should be able to deserialize JSON file of PDUs")
+        })
+        .collect::<Vec<Vec<Pdu>>>();
+
+    let room_version = {
+        let first_pdu = pdu_batches
+            .first()
+            .expect("there should be at least one file of PDUs")
+            .first()
+            .expect("there should be at least one PDU in the first file");
+
+        assert_eq!(
+            first_pdu.kind,
+            TimelineEventType::RoomCreate,
+            "the first PDU in the first file should be an m.room.create event",
+        );
+
+        from_json_str::<ExtractRoomVersion>(first_pdu.content.get())
+            .expect("the m.room.create PDU's content should be valid")
+            .room_version
+    };
+
+    // Resolve PDUs in batches by file
+    let mut pdus_by_id = HashMap::new();
+    let mut batched_resolved_state = None;
+    for pdus in &pdu_batches {
+        batched_resolved_state = Some(
+            resolve_batch(&room_version, pdus, &mut pdus_by_id, &mut batched_resolved_state)
+                .expect("batched state resolution step should succeed"),
+        );
+    }
+    let batched_resolved_state =
+        batched_resolved_state.expect("batched state resolution should have run at least once");
+
+    // Resolve all PDUs in a single step
+    let atomic_resolved_state = resolve_batch(
+        &room_version,
+        pdu_batches.iter().flat_map(|x| x.iter()),
+        &mut HashMap::new(),
+        &mut None,
+    )
+    .expect("atomic state resolution should succeed");
+
+    // Reshape the data a bit to make the diff and snapshots easier to compare.
+    let reshape = |x: StateMap<_>| {
+        x.into_iter()
+            .map(|((kind, state_key), event_id)| {
+                Ok(ResolvedStateEvent {
+                    kind,
+                    state_key,
+                    content: to_json_value(pdus_by_id[&event_id].content())?,
+                    event_id,
+                })
+            })
+            .collect::<Result<_, JsonError>>()
+    };
+
+    let batched_resolved_state =
+        reshape(batched_resolved_state).expect("should be able to reshape batched resolved state");
+    let atomic_resolved_state =
+        reshape(atomic_resolved_state).expect("should be able to reshape atomic resolved state");
+
+    if batched_resolved_state != atomic_resolved_state {
+        let diff = unified_diff(
+            Algorithm::default(),
+            &to_json_string_pretty(&batched_resolved_state)
+                .expect("should be able to serialize batched resolved state"),
+            &to_json_string_pretty(&atomic_resolved_state)
+                .expect("should be able to serialize atomic resolved state"),
+            3,
+            Some(("batched", "atomic")),
+        );
+
+        panic!("batched and atomic results should match; but they differ:\n{diff}");
+    }
+
+    Snapshots { resolved_state: batched_resolved_state }
+}
+
+/// Perform state resolution on a batch of PDUs.
+///
+/// This function can be used to resolve the state of a room in a single call if all PDUs are
+/// provided at once, or across multiple calls if given PDUs in batches in a loop. The latter form
+/// simulates the case commonly experienced by homeservers during normal operation.
+///
+/// # Arguments
+///
+/// * `room_version`: The room's version.
+/// * `pdus`: An iterator of [`Pdu`]s to resolve, either alone or against the `prev_state`.
+/// * `pdus_by_id`: A map of [`OwnedEventId`]s to the [`Pdu`] with that ID.
+///   * Should be empty for the first call.
+///   * Should not be mutated outside of this function.
+/// * `prev_state`: The state returned by a previous call to this function, if any.
+///   * Should be `None` for the first call.
+///   * Should not be mutated outside of this function.
+fn resolve_batch<'a, I, II>(
+    room_version: &RoomVersionId,
+    pdus: II,
+    pdus_by_id: &mut HashMap<OwnedEventId, Pdu>,
+    prev_state: &mut Option<StateMap<OwnedEventId>>,
+) -> Result<StateMap<OwnedEventId>, Box<dyn Error>>
+where
+    I: Iterator<Item = &'a Pdu>,
+    II: IntoIterator<IntoIter = I> + Clone,
+{
+    let mut state_sets = prev_state.take().map(|x| vec![x]).unwrap_or_default();
+
+    for pdu in pdus.clone() {
+        // Insert each state event into its own StateMap because we don't know any valid groupings.
+        let mut state_map = StateMap::new();
+        state_map.insert(
+            (
+                pdu.event_type().to_string().into(),
+                pdu.state_key().ok_or("all PDUs should be state events")?.to_owned(),
+            ),
+            pdu.event_id().clone(),
+        );
+
+        state_sets.push(state_map);
+    }
+
+    pdus_by_id
+        .extend(pdus.clone().into_iter().map(|pdu| (pdu.event_id().to_owned(), pdu.to_owned())));
+
+    let mut auth_chain_sets = Vec::new();
+    for pdu in pdus {
+        auth_chain_sets.push(auth_events_dfs(&*pdus_by_id, pdu)?);
+    }
+
+    resolve(room_version, &state_sets, auth_chain_sets, |x| pdus_by_id.get(x).cloned())
+        .map_err(Into::into)
+}
+
+/// Depth-first search for the `auth_events` of the given PDU.
+///
+/// # Errors
+///
+/// Fails if `pdus` does not contain a PDU that appears in the recursive `auth_events` of `pdu`.
+fn auth_events_dfs(
+    pdus_by_id: &HashMap<OwnedEventId, Pdu>,
+    pdu: &Pdu,
+) -> Result<HashSet<OwnedEventId>, Box<dyn Error>> {
+    let mut out = HashSet::new();
+    let mut stack = pdu.auth_events().cloned().collect::<Vec<_>>();
+
+    while let Some(event_id) = stack.pop() {
+        if out.contains(&event_id) {
+            continue;
+        }
+
+        out.insert(event_id.clone());
+
+        stack.extend(
+            pdus_by_id
+                .get(&event_id)
+                .ok_or_else(|| format!("missing required PDU: {}", event_id))?
+                .auth_events()
+                .cloned(),
+        );
+    }
+
+    Ok(out)
+}

--- a/crates/ruma-state-res/tests/it/resolve/snapshot_tests.rs
+++ b/crates/ruma-state-res/tests/it/resolve/snapshot_tests.rs
@@ -1,0 +1,5 @@
+//! Snapshot tests.
+
+// Test the minimal set of events required to create a room with the
+// "private_chat" preset.
+snapshot_test!(minimal_private_chat, ["bootstrap-private-chat.json"]);

--- a/crates/ruma-state-res/tests/it/resolve/snapshot_tests.rs
+++ b/crates/ruma-state-res/tests/it/resolve/snapshot_tests.rs
@@ -3,3 +3,13 @@
 // Test the minimal set of events required to create a room with the
 // "private_chat" preset.
 snapshot_test!(minimal_private_chat, ["bootstrap-private-chat.json"]);
+
+// Start with a private room, then transition its join rules to restricted, then
+// to public. The events in the second file are tied topologically, so they must
+// have the tiebreaking algorithm applied. The ordering should be decided by
+// the `origin_server_ts` fields of these events, not the `event_id` fields. The
+// power levels of these events are equivalent, so they don't really matter.
+snapshot_test!(
+    origin_server_ts_tiebreak,
+    ["bootstrap-private-chat.json", "origin-server-ts-tiebreak.json"],
+);

--- a/crates/ruma-state-res/tests/it/resolve/snapshots/it__resolve__snapshot_tests__minimal_private_chat@resolved_state.snap
+++ b/crates/ruma-state-res/tests/it/resolve/snapshots/it__resolve__snapshot_tests__minimal_private_chat@resolved_state.snap
@@ -1,0 +1,58 @@
+---
+source: crates/ruma-state-res/tests/it/resolve/snapshot_tests.rs
+description: Resolved state
+---
+[
+  {
+    "kind": "m.room.create",
+    "state_key": "",
+    "event_id": "$00-m-room-create",
+    "content": {
+      "creator": "@alice:example.com",
+      "room_version": "10"
+    }
+  },
+  {
+    "kind": "m.room.guest_access",
+    "state_key": "",
+    "event_id": "$00-m-room-guest_access",
+    "content": {
+      "guest_access": "can_join"
+    }
+  },
+  {
+    "kind": "m.room.history_visibility",
+    "state_key": "",
+    "event_id": "$00-m-room-history_visibility",
+    "content": {
+      "history_visibility": "shared"
+    }
+  },
+  {
+    "kind": "m.room.join_rules",
+    "state_key": "",
+    "event_id": "$00-m-room-join_rules",
+    "content": {
+      "join_rule": "invite"
+    }
+  },
+  {
+    "kind": "m.room.member",
+    "state_key": "@alice:example.com",
+    "event_id": "$00-m-room-member-join-alice",
+    "content": {
+      "displayname": "alice",
+      "membership": "join"
+    }
+  },
+  {
+    "kind": "m.room.power_levels",
+    "state_key": "",
+    "event_id": "$00-m-room-power_levels",
+    "content": {
+      "users": {
+        "@alice:example.com": 100
+      }
+    }
+  }
+]

--- a/crates/ruma-state-res/tests/it/resolve/snapshots/it__resolve__snapshot_tests__origin_server_ts_tiebreak@resolved_state.snap
+++ b/crates/ruma-state-res/tests/it/resolve/snapshots/it__resolve__snapshot_tests__origin_server_ts_tiebreak@resolved_state.snap
@@ -31,15 +31,9 @@ description: Resolved state
   {
     "kind": "m.room.join_rules",
     "state_key": "",
-    "event_id": "$02-m-room-join_rules",
+    "event_id": "$01-m-room-join_rules",
     "content": {
-      "allow": [
-        {
-          "room_id": "!other:example.com",
-          "type": "m.room_membership"
-        }
-      ],
-      "join_rule": "restricted"
+      "join_rule": "public"
     }
   },
   {

--- a/crates/ruma-state-res/tests/it/resolve/snapshots/it__resolve__snapshot_tests__origin_server_ts_tiebreak@resolved_state.snap
+++ b/crates/ruma-state-res/tests/it/resolve/snapshots/it__resolve__snapshot_tests__origin_server_ts_tiebreak@resolved_state.snap
@@ -1,0 +1,64 @@
+---
+source: crates/ruma-state-res/tests/it/resolve/snapshot_tests.rs
+description: Resolved state
+---
+[
+  {
+    "kind": "m.room.create",
+    "state_key": "",
+    "event_id": "$00-m-room-create",
+    "content": {
+      "creator": "@alice:example.com",
+      "room_version": "10"
+    }
+  },
+  {
+    "kind": "m.room.guest_access",
+    "state_key": "",
+    "event_id": "$00-m-room-guest_access",
+    "content": {
+      "guest_access": "can_join"
+    }
+  },
+  {
+    "kind": "m.room.history_visibility",
+    "state_key": "",
+    "event_id": "$00-m-room-history_visibility",
+    "content": {
+      "history_visibility": "shared"
+    }
+  },
+  {
+    "kind": "m.room.join_rules",
+    "state_key": "",
+    "event_id": "$02-m-room-join_rules",
+    "content": {
+      "allow": [
+        {
+          "room_id": "!other:example.com",
+          "type": "m.room_membership"
+        }
+      ],
+      "join_rule": "restricted"
+    }
+  },
+  {
+    "kind": "m.room.member",
+    "state_key": "@alice:example.com",
+    "event_id": "$00-m-room-member-join-alice",
+    "content": {
+      "displayname": "alice",
+      "membership": "join"
+    }
+  },
+  {
+    "kind": "m.room.power_levels",
+    "state_key": "",
+    "event_id": "$00-m-room-power_levels",
+    "content": {
+      "users": {
+        "@alice:example.com": 100
+      }
+    }
+  }
+]


### PR DESCRIPTION
This makes it very easy to add new state resolution tests and compare/update test results across implementation revisions. Since the input data is just a JSON list of PDUs, this can also be helpful for ad-hoc debugging against the captured state of a real room.

Future possibilities:

* [ ] A snapshot file with a graphviz DOT language representation of the resolved state and its auth chain for visualization purposes
* [ ] A snapshot file containing a list of edges between PDUs in the resolved state and its auth chain
* [ ] A snapshot file containing the event IDs of rejected events, and ideally an associated reason for each rejection

Note to reviewers: there is a lot of detail in some of the commit messages, so please be sure to read them :)