### PR TITLE
Accept any string as a key for `m.direct` account data

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -1,5 +1,12 @@
 # [unreleased]
 
+Breaking changes:
+
+- Take newly introduced `DirectUserIdentifier(str)` as a key for `DirectEventContent`.
+  This change allows to have an email or MSISDN phone number as a key for example,
+  which can be used when issuing invites through third-party systems.
+  `DirectUserIdentifier` can easily be converted to an `UserId`.
+
 # 0.29.1
 
 Bug fixes:

--- a/crates/ruma-events/src/direct.rs
+++ b/crates/ruma-events/src/direct.rs
@@ -123,7 +123,7 @@ impl PartialEq<OwnedUserId> for OwnedDirectUserIdentifier {
 
 /// The content of an `m.direct` event.
 ///
-/// A mapping of [`DirectUserIdentifier`]s to a list of [`RoomId`]s which are considered *direct*
+/// A mapping of `DirectUserIdentifier`s to a list of `RoomId`s which are considered *direct*
 /// for that particular user.
 ///
 /// Informs the client about the rooms that are considered direct by a user.

--- a/crates/ruma-events/src/direct.rs
+++ b/crates/ruma-events/src/direct.rs
@@ -7,23 +7,80 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
-use ruma_common::{OwnedRoomId, OwnedUserId};
-use ruma_macros::EventContent;
+use ruma_common::{IdParseError, OwnedRoomId, OwnedUserId, UserId};
+use ruma_macros::{EventContent, IdZst};
 use serde::{Deserialize, Serialize};
+
+/// An user identifier, it can be a MXID or a third-party identifier
+/// like an email or a phone number.
+///
+/// There is no validation on this type, any string is allowed,
+/// but you can use `to_user_id` to try to get a MXID.
+#[repr(transparent)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdZst)]
+pub struct DirectUserIdentifier(str);
+
+impl TryFrom<OwnedDirectUserIdentifier> for OwnedUserId {
+    type Error = IdParseError;
+
+    fn try_from(value: OwnedDirectUserIdentifier) -> Result<Self, Self::Error> {
+        Self::try_from(&value.0)
+    }
+}
+
+impl TryFrom<&OwnedDirectUserIdentifier> for OwnedUserId {
+    type Error = IdParseError;
+
+    fn try_from(value: &OwnedDirectUserIdentifier) -> Result<Self, Self::Error> {
+        Self::try_from(&value.0)
+    }
+}
+
+impl TryFrom<&DirectUserIdentifier> for OwnedUserId {
+    type Error = IdParseError;
+
+    fn try_from(value: &DirectUserIdentifier) -> Result<Self, Self::Error> {
+        Self::try_from(&value.0)
+    }
+}
+
+impl From<OwnedUserId> for OwnedDirectUserIdentifier {
+    fn from(value: OwnedUserId) -> Self {
+        DirectUserIdentifier::from_borrowed(value.as_str()).to_owned()
+    }
+}
+
+impl From<&OwnedUserId> for OwnedDirectUserIdentifier {
+    fn from(value: &OwnedUserId) -> Self {
+        DirectUserIdentifier::from_borrowed(value.as_str()).to_owned()
+    }
+}
+
+impl From<&UserId> for OwnedDirectUserIdentifier {
+    fn from(value: &UserId) -> Self {
+        DirectUserIdentifier::from_borrowed(value.as_str()).to_owned()
+    }
+}
+
+impl<'a> From<&'a UserId> for &'a DirectUserIdentifier {
+    fn from(value: &'a UserId) -> Self {
+        DirectUserIdentifier::from_borrowed(value.as_str())
+    }
+}
 
 /// The content of an `m.direct` event.
 ///
-/// A mapping of `UserId`s to a list of `RoomId`s which are considered *direct* for that particular
-/// user.
+/// A mapping of `DirectUserIdentifier`s to a list of `RoomId`s which are considered *direct* for
+/// that particular user.
 ///
 /// Informs the client about the rooms that are considered direct by a user.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, EventContent)]
 #[allow(clippy::exhaustive_structs)]
 #[ruma_event(type = "m.direct", kind = GlobalAccountData)]
-pub struct DirectEventContent(pub BTreeMap<OwnedUserId, Vec<OwnedRoomId>>);
+pub struct DirectEventContent(pub BTreeMap<OwnedDirectUserIdentifier, Vec<OwnedRoomId>>);
 
 impl Deref for DirectEventContent {
-    type Target = BTreeMap<OwnedUserId, Vec<OwnedRoomId>>;
+    type Target = BTreeMap<OwnedDirectUserIdentifier, Vec<OwnedRoomId>>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -37,18 +94,18 @@ impl DerefMut for DirectEventContent {
 }
 
 impl IntoIterator for DirectEventContent {
-    type Item = (OwnedUserId, Vec<OwnedRoomId>);
-    type IntoIter = btree_map::IntoIter<OwnedUserId, Vec<OwnedRoomId>>;
+    type Item = (OwnedDirectUserIdentifier, Vec<OwnedRoomId>);
+    type IntoIter = btree_map::IntoIter<OwnedDirectUserIdentifier, Vec<OwnedRoomId>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
     }
 }
 
-impl FromIterator<(OwnedUserId, Vec<OwnedRoomId>)> for DirectEventContent {
+impl FromIterator<(OwnedDirectUserIdentifier, Vec<OwnedRoomId>)> for DirectEventContent {
     fn from_iter<T>(iter: T) -> Self
     where
-        T: IntoIterator<Item = (OwnedUserId, Vec<OwnedRoomId>)>,
+        T: IntoIterator<Item = (OwnedDirectUserIdentifier, Vec<OwnedRoomId>)>,
     {
         Self(BTreeMap::from_iter(iter))
     }
@@ -58,18 +115,20 @@ impl FromIterator<(OwnedUserId, Vec<OwnedRoomId>)> for DirectEventContent {
 mod tests {
     use std::collections::BTreeMap;
 
-    use ruma_common::{owned_room_id, owned_user_id};
+    use ruma_common::{owned_room_id, user_id, OwnedUserId};
+    // use ruma_macros::user_id;
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     use super::{DirectEvent, DirectEventContent};
+    use crate::direct::{DirectUserIdentifier, OwnedDirectUserIdentifier};
 
     #[test]
     fn serialization() {
         let mut content = DirectEventContent(BTreeMap::new());
-        let alice = owned_user_id!("@alice:ruma.io");
+        let alice = DirectUserIdentifier::from_borrowed("@alice:ruma.io");
         let rooms = vec![owned_room_id!("!1:ruma.io")];
 
-        content.insert(alice.clone(), rooms.clone());
+        content.insert(alice.to_owned(), rooms.clone());
 
         let json_data = json!({
             alice: rooms,
@@ -80,20 +139,43 @@ mod tests {
 
     #[test]
     fn deserialization() {
-        let alice = owned_user_id!("@alice:ruma.io");
+        let alice = DirectUserIdentifier::from_borrowed("@alice:ruma.io");
         let rooms = vec![owned_room_id!("!1:ruma.io"), owned_room_id!("!2:ruma.io")];
 
         let json_data = json!({
             "content": {
-                alice.to_string(): rooms,
+                alice: rooms,
+                "alice@ruma.io": vec![owned_room_id!("!3:ruma.io")],
             },
             "type": "m.direct"
         });
 
         let event: DirectEvent = from_json_value(json_data).unwrap();
-        let direct_rooms = event.content.get(&alice).unwrap();
+        let direct_rooms = event.content.get(alice).unwrap();
 
         assert!(direct_rooms.contains(&rooms[0]));
         assert!(direct_rooms.contains(&rooms[1]));
+    }
+
+    #[test]
+    fn user_id_conversion() {
+        let alice_direct_uid = DirectUserIdentifier::from_borrowed("@alice:ruma.io");
+        let alice_owned_user_id: OwnedUserId = alice_direct_uid
+            .to_owned()
+            .try_into()
+            .expect("@alice:ruma.io should be convertible into a Matrix user ID");
+        assert_eq!(alice_direct_uid.as_str(), alice_owned_user_id.as_str());
+
+        let alice_direct_uid_mail = DirectUserIdentifier::from_borrowed("alice@ruma.io");
+        OwnedUserId::try_from(alice_direct_uid_mail.to_owned())
+            .expect_err("alice@ruma.io should not be convertible into a Matrix user ID");
+
+        let alice_user_id = user_id!("@alice:ruma.io");
+        let alice_direct_uid_mail: &DirectUserIdentifier = alice_user_id.into();
+        assert_eq!(alice_direct_uid_mail.as_str(), alice_user_id.as_str());
+
+        let alice_user_id = user_id!("@alice:ruma.io");
+        let alice_direct_uid_mail: OwnedDirectUserIdentifier = alice_user_id.into();
+        assert_eq!(alice_direct_uid_mail.as_str(), alice_user_id.as_str());
     }
 }

--- a/crates/ruma-events/src/direct.rs
+++ b/crates/ruma-events/src/direct.rs
@@ -65,6 +65,14 @@ impl TryFrom<&DirectUserIdentifier> for OwnedUserId {
     }
 }
 
+impl<'a> TryFrom<&'a DirectUserIdentifier> for &'a UserId {
+    type Error = IdParseError;
+
+    fn try_from(value: &'a DirectUserIdentifier) -> Result<Self, Self::Error> {
+        value.0.try_into()
+    }
+}
+
 impl From<OwnedUserId> for OwnedDirectUserIdentifier {
     fn from(value: OwnedUserId) -> Self {
         DirectUserIdentifier::from_borrowed(value.as_str()).to_owned()

--- a/crates/ruma-events/src/direct.rs
+++ b/crates/ruma-events/src/direct.rs
@@ -21,14 +21,14 @@ use serde::{Deserialize, Serialize};
 pub struct DirectUserIdentifier(str);
 
 impl DirectUserIdentifier {
-    /// Get this `DirectUserIdentifier` as an &[`UserId`] if it is one.
+    /// Get this `DirectUserIdentifier` as an [`UserId`] if it is one.
     pub fn as_user_id(&self) -> Option<&UserId> {
         self.0.try_into().ok()
     }
 }
 
 impl OwnedDirectUserIdentifier {
-    /// Get this `OwnedDirectUserIdentifier` as an &[`UserId`] if it is one.
+    /// Get this `OwnedDirectUserIdentifier` as an [`UserId`] if it is one.
     pub fn as_user_id(&self) -> Option<&UserId> {
         self.0.try_into().ok()
     }
@@ -97,25 +97,49 @@ impl<'a> From<&'a UserId> for &'a DirectUserIdentifier {
 
 impl PartialEq<&UserId> for &DirectUserIdentifier {
     fn eq(&self, other: &&UserId) -> bool {
-        &self.0 == other.as_str()
+        self.0.eq(other.as_str())
+    }
+}
+
+impl PartialEq<&DirectUserIdentifier> for &UserId {
+    fn eq(&self, other: &&DirectUserIdentifier) -> bool {
+        other.0.eq(self.as_str())
     }
 }
 
 impl PartialEq<OwnedUserId> for &DirectUserIdentifier {
     fn eq(&self, other: &OwnedUserId) -> bool {
-        &self.0 == other.as_str()
+        self.0.eq(other.as_str())
+    }
+}
+
+impl PartialEq<&DirectUserIdentifier> for OwnedUserId {
+    fn eq(&self, other: &&DirectUserIdentifier) -> bool {
+        other.0.eq(self.as_str())
     }
 }
 
 impl PartialEq<&UserId> for OwnedDirectUserIdentifier {
     fn eq(&self, other: &&UserId) -> bool {
-        &self.0 == other.as_str()
+        self.0.eq(other.as_str())
+    }
+}
+
+impl PartialEq<OwnedDirectUserIdentifier> for &UserId {
+    fn eq(&self, other: &OwnedDirectUserIdentifier) -> bool {
+        other.0.eq(self.as_str())
     }
 }
 
 impl PartialEq<OwnedUserId> for OwnedDirectUserIdentifier {
     fn eq(&self, other: &OwnedUserId) -> bool {
-        &self.0 == other.as_str()
+        self.0.eq(other.as_str())
+    }
+}
+
+impl PartialEq<OwnedDirectUserIdentifier> for OwnedUserId {
+    fn eq(&self, other: &OwnedDirectUserIdentifier) -> bool {
+        other.0.eq(self.as_str())
     }
 }
 
@@ -166,7 +190,7 @@ impl FromIterator<(OwnedDirectUserIdentifier, Vec<OwnedRoomId>)> for DirectEvent
 mod tests {
     use std::collections::BTreeMap;
 
-    use ruma_common::{owned_room_id, owned_user_id, user_id, OwnedUserId};
+    use ruma_common::{owned_room_id, user_id, OwnedUserId};
     // use ruma_macros::user_id;
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
@@ -176,12 +200,12 @@ mod tests {
     #[test]
     fn serialization() {
         let mut content = DirectEventContent(BTreeMap::new());
-        let alice = owned_user_id!("@alice:ruma.io");
+        let alice = user_id!("@alice:ruma.io");
         let alice_mail = "alice@ruma.io";
         let rooms = vec![owned_room_id!("!1:ruma.io")];
         let mail_rooms = vec![owned_room_id!("!3:ruma.io")];
 
-        content.insert(alice.clone().into(), rooms.clone());
+        content.insert(alice.into(), rooms.clone());
         content.insert(alice_mail.into(), mail_rooms.clone());
 
         let json_data = json!({
@@ -194,14 +218,14 @@ mod tests {
 
     #[test]
     fn deserialization() {
-        let alice = owned_user_id!("@alice:ruma.io");
+        let alice = user_id!("@alice:ruma.io");
         let alice_mail = "alice@ruma.io";
         let rooms = vec![owned_room_id!("!1:ruma.io"), owned_room_id!("!2:ruma.io")];
         let mail_rooms = vec![owned_room_id!("!3:ruma.io")];
 
         let json_data = json!({
             "content": {
-                alice.clone(): rooms,
+                alice: rooms,
                 alice_mail: mail_rooms,
             },
             "type": "m.direct"
@@ -209,12 +233,12 @@ mod tests {
 
         let event: DirectEvent = from_json_value(json_data).unwrap();
 
-        let direct_rooms = event.content.get(&OwnedDirectUserIdentifier::from(alice)).unwrap();
+        let direct_rooms = event.content.get(<&DirectUserIdentifier>::from(alice)).unwrap();
         assert!(direct_rooms.contains(&rooms[0]));
         assert!(direct_rooms.contains(&rooms[1]));
 
         let email_direct_rooms =
-            event.content.get(&OwnedDirectUserIdentifier::from(alice_mail)).unwrap();
+            event.content.get(<&DirectUserIdentifier>::from(alice_mail)).unwrap();
         assert!(email_direct_rooms.contains(&mail_rooms[0]));
     }
 
@@ -234,9 +258,15 @@ mod tests {
         let alice_user_id = user_id!("@alice:ruma.io");
         let alice_direct_uid_mail: &DirectUserIdentifier = alice_user_id.into();
         assert_eq!(alice_direct_uid_mail, alice_user_id);
+        assert_eq!(alice_direct_uid_mail, alice_user_id.to_owned());
+        assert_eq!(alice_user_id, alice_direct_uid_mail);
+        assert_eq!(alice_user_id.to_owned(), alice_direct_uid_mail);
 
         let alice_user_id = user_id!("@alice:ruma.io");
         let alice_direct_uid_mail: OwnedDirectUserIdentifier = alice_user_id.into();
         assert_eq!(alice_direct_uid_mail, alice_user_id);
+        assert_eq!(alice_direct_uid_mail, alice_user_id.to_owned());
+        assert_eq!(alice_user_id, alice_direct_uid_mail);
+        assert_eq!(alice_user_id.to_owned(), alice_direct_uid_mail);
     }
 }

--- a/crates/ruma-events/src/direct.rs
+++ b/crates/ruma-events/src/direct.rs
@@ -179,12 +179,16 @@ mod tests {
     fn serialization() {
         let mut content = DirectEventContent(BTreeMap::new());
         let alice = owned_user_id!("@alice:ruma.io");
+        let alice_mail = "alice@ruma.io";
         let rooms = vec![owned_room_id!("!1:ruma.io")];
+        let mail_rooms = vec![owned_room_id!("!3:ruma.io")];
 
         content.insert(alice.clone().into(), rooms.clone());
+        content.insert(alice_mail.into(), mail_rooms.clone());
 
         let json_data = json!({
             alice: rooms,
+            alice_mail: mail_rooms,
         });
 
         assert_eq!(to_json_value(&content).unwrap(), json_data);

--- a/crates/ruma-events/src/direct.rs
+++ b/crates/ruma-events/src/direct.rs
@@ -223,7 +223,7 @@ mod tests {
             .to_owned()
             .try_into()
             .expect("@alice:ruma.io should be convertible into a Matrix user ID");
-        assert_eq!(alice_direct_uid.as_str(), alice_owned_user_id.as_str());
+        assert_eq!(alice_direct_uid, alice_owned_user_id);
 
         let alice_direct_uid_mail = DirectUserIdentifier::from_borrowed("alice@ruma.io");
         OwnedUserId::try_from(alice_direct_uid_mail.to_owned())
@@ -231,10 +231,10 @@ mod tests {
 
         let alice_user_id = user_id!("@alice:ruma.io");
         let alice_direct_uid_mail: &DirectUserIdentifier = alice_user_id.into();
-        assert_eq!(alice_direct_uid_mail.as_str(), alice_user_id.as_str());
+        assert_eq!(alice_direct_uid_mail, alice_user_id);
 
         let alice_user_id = user_id!("@alice:ruma.io");
         let alice_direct_uid_mail: OwnedDirectUserIdentifier = alice_user_id.into();
-        assert_eq!(alice_direct_uid_mail.as_str(), alice_user_id.as_str());
+        assert_eq!(alice_direct_uid_mail, alice_user_id);
     }
 }

--- a/crates/ruma-events/src/direct.rs
+++ b/crates/ruma-events/src/direct.rs
@@ -191,7 +191,6 @@ mod tests {
     use std::collections::BTreeMap;
 
     use ruma_common::{owned_room_id, user_id, OwnedUserId};
-    // use ruma_macros::user_id;
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     use super::{DirectEvent, DirectEventContent};

--- a/crates/ruma-events/src/direct.rs
+++ b/crates/ruma-events/src/direct.rs
@@ -23,7 +23,6 @@ pub struct DirectUserIdentifier(str);
 impl DirectUserIdentifier {
     /// Get this `DirectUserIdentifier` as an &[`UserId`] if it is one.
     pub fn as_user_id(&self) -> Option<&UserId> {
-        // TODO does it allocate ? Can we avoid it ?
         self.0.try_into().ok()
     }
 }
@@ -31,7 +30,6 @@ impl DirectUserIdentifier {
 impl OwnedDirectUserIdentifier {
     /// Get this `OwnedDirectUserIdentifier` as an &[`UserId`] if it is one.
     pub fn as_user_id(&self) -> Option<&UserId> {
-        // TODO does it allocate ? Can we avoid it ?
         self.0.try_into().ok()
     }
 


### PR DESCRIPTION
This is because a lot of `m.direct` in the wild have [non valid data](https://github.com/element-hq/element-x-android/issues/3074), and an email or phone number can end up as a key here when doing 3pid invites.

Current behavior is that `m.direct` parsing fully failed in this case, so there is [no DMs](https://github.com/element-hq/element-x-android/issues/3818) [anymore](https://github.com/element-hq/element-x-ios/issues/3489).

You can trigger that easily by trying to invite an email with no MXID bound to it with Element Web.