### PR TITLE
Fix a documentation typo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Check spelling
-        uses: crate-ci/typos@v1.24.5
+        uses: crate-ci/typos@v1.27.1
 
       - name: Install cargo-sort
         uses: taiki-e/cache-cargo-install-action@v2

--- a/crates/ruma-common/src/push.rs
+++ b/crates/ruma-common/src/push.rs
@@ -633,9 +633,9 @@ impl PatternedPushRule {
     }
 }
 
-/// Initial set of fields of `PatterenedPushRule`.
+/// Initial set of fields of `PatternedPushRule`.
 ///
-/// This struct will not be updated even if additional fields are added to `PatterenedPushRule` in a
+/// This struct will not be updated even if additional fields are added to `PatternedPushRule` in a
 /// new (non-breaking) release of the Matrix specification.
 #[derive(Debug)]
 #[allow(clippy::exhaustive_structs)]


### PR DESCRIPTION
Wasn't sure whether to use `docs:`, `push:` or sth. else for the prefix of the first commit's message. Defaulted to nothing, lmk what you prefer.