### PR TITLE
macros: Remove dependency to once_cell

### DIFF
--- a/crates/ruma-macros/Cargo.toml
+++ b/crates/ruma-macros/Cargo.toml
@@ -22,7 +22,6 @@ __internal_macro_expand = ["syn/visit-mut"]
 
 [dependencies]
 cfg-if = "1.0.0"
-once_cell = "1.13.0"
 proc-macro-crate = "3.1.0"
 proc-macro2 = "1.0.24"
 quote = "1.0.8"


### PR DESCRIPTION
Use the types in std instead. Bumps the MSRV to 1.80.

