### PR TITLE
stateres: make `separate` O(n) instead of O(n^2)

### DIFF
--- a/crates/ruma-state-res/Cargo.toml
+++ b/crates/ruma-state-res/Cargo.toml
@@ -18,7 +18,6 @@ all-features = true
 unstable-exhaustive-types = []
 
 [dependencies]
-itertools = "0.13.0"
 js_int = { workspace = true }
 ruma-common = { workspace = true }
 ruma-events = { workspace = true }


### PR DESCRIPTION
This way my poor CPU only has to do ~600,000 iterations to resolve Matrix HQ from scratch. The old algorithm required ~85,000,000,000.

As a treat, we can also drop the dependency on itertools.