### PR TITLE
xtask: Upgrade xshell to 0.2

### DIFF
--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -16,7 +16,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 toml = { version = "0.8.2", default-features = false, features = ["parse"] }
 toml_edit = { version = "0.22.22", optional = true }
-xshell = "0.1.17"
+xshell = "0.2.7"
 
 [lints]
 workspace = true

--- a/xtask/src/doc.rs
+++ b/xtask/src/doc.rs
@@ -1,4 +1,5 @@
 use clap::Args;
+use xshell::Shell;
 
 use crate::{cmd, Result, NIGHTLY};
 
@@ -20,7 +21,8 @@ impl DocTask {
             rustdocflags += " -Dwarnings";
         }
 
-        let mut cmd = cmd!("rustup run {NIGHTLY} cargo doc --all-features --no-deps")
+        let sh = Shell::new()?;
+        let mut cmd = cmd!(sh, "rustup run {NIGHTLY} cargo doc --all-features --no-deps")
             .env("RUSTDOCFLAGS", rustdocflags);
 
         if self.open {


### PR DESCRIPTION
I tried to do something with `thread_local` to keep the old API but it becomes complicated with `pushd` / `Shell::push_dir` that keeps a reference to the `Shell`, but we cannot have a `'static` reference.

So instead we just pass the `Shell` around. It's not _too_ ugly.