### PR TITLE
events: Be a little smarter when removing plain reply fallback

### DIFF
--- a/crates/ruma-events/src/room/message/sanitize.rs
+++ b/crates/ruma-events/src/room/message/sanitize.rs
@@ -4,7 +4,10 @@
 ///
 /// [rich reply fallback]: https://spec.matrix.org/latest/client-server-api/#fallbacks-for-rich-replies
 pub fn remove_plain_reply_fallback(mut s: &str) -> &str {
-    if !s.starts_with("> ") {
+    // A reply fallback must begin with a mention of the original sender between `<` and `>`, and
+    // emotes add `*` as a prefix. If there is no newline, removing the detected fallback would
+    // result in an empty string.
+    if (!s.starts_with("> <") && !s.starts_with("> * <")) || !s.contains('\n') {
         return s;
     }
 


### PR DESCRIPTION
Given that the default algorithm from the spec would also remove the beginning of a message starting with a markdown blockquote, let's be more conservative an check that the beginning really looks like the fallback that was defined in the spec.

This is especially important now that reply fallbacks have been removed from the spec.