### PR TITLE
Add a test regarding ser/de of an UserId in a DirectUserIdentifier

### DIFF
--- a/crates/ruma-client-api/src/uiaa.rs
+++ b/crates/ruma-client-api/src/uiaa.rs
@@ -713,7 +713,7 @@ impl OutgoingResponse for UiaaResponse {
         match self {
             UiaaResponse::AuthResponse(authentication_info) => http::Response::builder()
                 .header(http::header::CONTENT_TYPE, "application/json")
-                .status(&http::StatusCode::UNAUTHORIZED)
+                .status(http::StatusCode::UNAUTHORIZED)
                 .body(ruma_common::serde::json_to_buf(&authentication_info)?)
                 .map_err(Into::into),
             UiaaResponse::MatrixError(error) => error.try_into_http_response(),

--- a/crates/ruma-events/src/direct.rs
+++ b/crates/ruma-events/src/direct.rs
@@ -269,8 +269,9 @@ mod tests {
         assert_eq!(alice_user_id.to_owned(), alice_direct_uid_mail);
 
         let alice_user_id = user_id!("@alice:ruma.io");
-        let alice_user_id_str = alice_user_id.to_string();
-        let alice_direct_uid_mail = OwnedDirectUserIdentifier::from(alice_user_id_str);
+        let alice_user_id_json = to_json_value(alice_user_id).unwrap();
+        let alice_direct_uid_mail: OwnedDirectUserIdentifier =
+            from_json_value(alice_user_id_json).unwrap();
         assert_eq!(alice_user_id, alice_direct_uid_mail);
     }
 }

--- a/crates/ruma-events/src/direct.rs
+++ b/crates/ruma-events/src/direct.rs
@@ -267,5 +267,10 @@ mod tests {
         assert_eq!(alice_direct_uid_mail, alice_user_id.to_owned());
         assert_eq!(alice_user_id, alice_direct_uid_mail);
         assert_eq!(alice_user_id.to_owned(), alice_direct_uid_mail);
+
+        let alice_user_id = user_id!("@alice:ruma.io");
+        let alice_user_id_str = alice_user_id.to_string();
+        let alice_direct_uid_mail = OwnedDirectUserIdentifier::from(alice_user_id_str);
+        assert_eq!(alice_user_id, alice_direct_uid_mail);
     }
 }


### PR DESCRIPTION
Add a test to check that a serialized `UserId` can be deserialized to an `OwnedDirectUserIdentifier`.

Related to https://github.com/matrix-org/matrix-rust-sdk/pull/4228#issuecomment-2516840289.