### PR TITLE
api: Disallow `#[serde(flatten)]` for single-body-fields of requests and responses

### DIFF
--- a/crates/ruma-client-api/src/typing/create_typing_event.rs
+++ b/crates/ruma-client-api/src/typing/create_typing_event.rs
@@ -37,7 +37,7 @@ pub mod v3 {
         pub user_id: OwnedUserId,
 
         /// Whether the user is typing within a length of time or not.
-        #[serde(flatten)]
+        #[ruma_api(body)]
         pub state: Typing,
     }
 

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [unreleased]
 
+Breaking changes:
+
+- `#[serde(flatten)]` on the only body field of a `#[request]` or `#[response]`
+  struct is disallowed. `#[ruma_api(body)]` must be used instead.
+
 Improvements:
 
 - The `ruma_identifiers_storage` compile-time `cfg` setting can also be

--- a/crates/ruma-common/tests/it/api/ruma_api.rs
+++ b/crates/ruma-common/tests/it/api/ruma_api.rs
@@ -7,4 +7,6 @@ fn ui() {
     t.pass("tests/it/api/ui/response-only.rs");
     t.compile_fail("tests/it/api/ui/deprecated-without-added.rs");
     t.compile_fail("tests/it/api/ui/removed-without-deprecated.rs");
+    t.compile_fail("tests/it/api/ui/serde-flatten-request-body.rs");
+    t.compile_fail("tests/it/api/ui/serde-flatten-response-body.rs");
 }

--- a/crates/ruma-common/tests/it/api/ui/serde-flatten-request-body.rs
+++ b/crates/ruma-common/tests/it/api/ui/serde-flatten-request-body.rs
@@ -1,0 +1,30 @@
+use ruma_common::{
+    api::{request, response, Metadata},
+    metadata,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CustomRequestBody {
+    pub bar: String,
+}
+
+const METADATA: Metadata = metadata! {
+    method: POST, // An `http::Method` constant. No imports required.
+    rate_limited: false,
+    authentication: None,
+    history: {
+        unstable => "/_matrix/some/endpoint",
+    }
+};
+
+#[request]
+pub struct Request {
+    #[serde(flatten)]
+    pub foo: CustomRequestBody,
+}
+
+#[response]
+pub struct Response;
+
+fn main() {}

--- a/crates/ruma-common/tests/it/api/ui/serde-flatten-request-body.stderr
+++ b/crates/ruma-common/tests/it/api/ui/serde-flatten-request-body.stderr
@@ -1,0 +1,6 @@
+error: Use `#[ruma_api(body)]` to represent the JSON body as a single field
+  --> tests/it/api/ui/serde-flatten-request-body.rs:23:5
+   |
+23 | /     #[serde(flatten)]
+24 | |     pub foo: CustomRequestBody,
+   | |______________________________^

--- a/crates/ruma-common/tests/it/api/ui/serde-flatten-response-body.rs
+++ b/crates/ruma-common/tests/it/api/ui/serde-flatten-response-body.rs
@@ -1,0 +1,30 @@
+use ruma_common::{
+    api::{request, response, Metadata},
+    metadata,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CustomResponseBody {
+    pub bar: String,
+}
+
+const METADATA: Metadata = metadata! {
+    method: GET, // An `http::Method` constant. No imports required.
+    rate_limited: false,
+    authentication: None,
+    history: {
+        unstable => "/_matrix/some/endpoint",
+    }
+};
+
+#[request]
+pub struct Request;
+
+#[response]
+pub struct Response {
+    #[serde(flatten)]
+    pub foo: CustomResponseBody,
+}
+
+fn main() {}

--- a/crates/ruma-common/tests/it/api/ui/serde-flatten-response-body.stderr
+++ b/crates/ruma-common/tests/it/api/ui/serde-flatten-response-body.stderr
@@ -1,0 +1,33 @@
+error: Use `#[ruma_api(body)]` to represent the JSON body as a single field
+  --> tests/it/api/ui/serde-flatten-response-body.rs:26:5
+   |
+26 | /     #[serde(flatten)]
+27 | |     pub foo: CustomResponseBody,
+   | |_______________________________^
+
+error[E0277]: the trait bound `Response: IncomingResponse` is not satisfied
+  --> tests/it/api/ui/serde-flatten-response-body.rs:21:1
+   |
+21 | #[request]
+   | ^^^^^^^^^^ the trait `IncomingResponse` is not implemented for `Response`
+   |
+note: required by a bound in `ruma_common::api::OutgoingRequest::IncomingResponse`
+  --> src/api.rs
+   |
+   |     type IncomingResponse: IncomingResponse<EndpointError = Self::EndpointError>;
+   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `OutgoingRequest::IncomingResponse`
+   = note: this error originates in the derive macro `::ruma_common::exports::ruma_macros::Request` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Response: OutgoingResponse` is not satisfied
+  --> tests/it/api/ui/serde-flatten-response-body.rs:21:1
+   |
+21 | #[request]
+   | ^^^^^^^^^^ the trait `OutgoingResponse` is not implemented for `Response`
+   |
+   = help: the trait `OutgoingResponse` is implemented for `MatrixError`
+note: required by a bound in `ruma_common::api::IncomingRequest::OutgoingResponse`
+  --> src/api.rs
+   |
+   |     type OutgoingResponse: OutgoingResponse;
+   |                            ^^^^^^^^^^^^^^^^ required by this bound in `IncomingRequest::OutgoingResponse`
+   = note: this error originates in the derive macro `::ruma_common::exports::ruma_macros::Request` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
`#[ruma_api(body)]` must be used instead.

Closes #825