### PR TITLE
client-api: Add new error codes

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -9,6 +9,7 @@ Improvements:
   variable, or inside `.cargo/config.toml`. It can also be enabled by setting
   the `RUMA_UNSTABLE_EXHAUSTIVE_TYPES` environment variable.
 - Add `ErrorKind::ThreepidMediumNotSupported`, according to MSC4178.
+- Add `ErrorKind::UserSuspended`, according to MSC3823.
 
 # 0.19.0
 

--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -8,6 +8,7 @@ Improvements:
   settings, it can be enabled at compile-time with the `RUSTFLAGS` environment
   variable, or inside `.cargo/config.toml`. It can also be enabled by setting
   the `RUMA_UNSTABLE_EXHAUSTIVE_TYPES` environment variable.
+- Add `ErrorKind::ThreepidMediumNotSupported`, according to MSC4178.
 
 # 0.19.0
 

--- a/crates/ruma-client-api/src/error.rs
+++ b/crates/ruma-client-api/src/error.rs
@@ -210,6 +210,9 @@ pub enum ErrorKind {
     /// M_USER_LOCKED
     UserLocked,
 
+    /// M_USER_SUSPENDED
+    UserSuspended,
+
     #[doc(hidden)]
     _Custom { errcode: PrivOwnedStr, extra: Extra },
 }
@@ -288,6 +291,7 @@ impl AsRef<str> for ErrorKind {
             #[cfg(feature = "unstable-msc3843")]
             Self::Unactionable => "M_UNACTIONABLE",
             Self::UserLocked => "M_USER_LOCKED",
+            Self::UserSuspended => "M_USER_SUSPENDED",
             Self::_Custom { errcode, .. } => &errcode.0,
         }
     }

--- a/crates/ruma-client-api/src/error.rs
+++ b/crates/ruma-client-api/src/error.rs
@@ -106,6 +106,9 @@ pub enum ErrorKind {
     /// M_THREEPID_DENIED
     ThreepidDenied,
 
+    /// M_THREEPID_MEDIUM_NOT_SUPPORTED
+    ThreepidMediumNotSupported,
+
     /// M_SERVER_NOT_TRUSTED
     ServerNotTrusted,
 
@@ -254,6 +257,7 @@ impl AsRef<str> for ErrorKind {
             Self::ThreepidNotFound => "M_THREEPID_NOT_FOUND",
             Self::ThreepidAuthFailed => "M_THREEPID_AUTH_FAILED",
             Self::ThreepidDenied => "M_THREEPID_DENIED",
+            Self::ThreepidMediumNotSupported => "M_THREEPID_MEDIUM_NOT_SUPPORTED",
             Self::ServerNotTrusted => "M_SERVER_NOT_TRUSTED",
             Self::UnsupportedRoomVersion => "M_UNSUPPORTED_ROOM_VERSION",
             Self::IncompatibleRoomVersion { .. } => "M_INCOMPATIBLE_ROOM_VERSION",

--- a/crates/ruma-client-api/src/error/kind_serde.rs
+++ b/crates/ruma-client-api/src/error/kind_serde.rs
@@ -254,6 +254,7 @@ impl<'de> Visitor<'de> for ErrorKindVisitor {
             #[cfg(feature = "unstable-msc3843")]
             ErrCode::Unactionable => ErrorKind::Unactionable,
             ErrCode::UserLocked => ErrorKind::UserLocked,
+            ErrCode::UserSuspended => ErrorKind::UserSuspended,
             ErrCode::_Custom(errcode) => ErrorKind::_Custom { errcode, extra },
         })
     }
@@ -314,6 +315,7 @@ enum ErrCode {
     #[cfg(feature = "unstable-msc3843")]
     Unactionable,
     UserLocked,
+    UserSuspended,
     _Custom(PrivOwnedStr),
 }
 

--- a/crates/ruma-client-api/src/error/kind_serde.rs
+++ b/crates/ruma-client-api/src/error/kind_serde.rs
@@ -198,6 +198,7 @@ impl<'de> Visitor<'de> for ErrorKindVisitor {
             ErrCode::ThreepidNotFound => ErrorKind::ThreepidNotFound,
             ErrCode::ThreepidAuthFailed => ErrorKind::ThreepidAuthFailed,
             ErrCode::ThreepidDenied => ErrorKind::ThreepidDenied,
+            ErrCode::ThreepidMediumNotSupported => ErrorKind::ThreepidMediumNotSupported,
             ErrCode::ServerNotTrusted => ErrorKind::ServerNotTrusted,
             ErrCode::UnsupportedRoomVersion => ErrorKind::UnsupportedRoomVersion,
             ErrCode::IncompatibleRoomVersion => ErrorKind::IncompatibleRoomVersion {
@@ -280,6 +281,7 @@ enum ErrCode {
     ThreepidNotFound,
     ThreepidAuthFailed,
     ThreepidDenied,
+    ThreepidMediumNotSupported,
     ServerNotTrusted,
     UnsupportedRoomVersion,
     IncompatibleRoomVersion,


### PR DESCRIPTION
- `ErrorKind::ThreepidMediumNotSupported`: [MSC4178](https://github.com/matrix-org/matrix-spec-proposals/pull/4178) / [Spec PR](https://github.com/matrix-org/matrix-spec/issues/1944)
- `ErrorKind::UserSuspended`: [MSC3823](https://github.com/matrix-org/matrix-spec-proposals/pull/3823) / [Spec PR](https://github.com/matrix-org/matrix-spec/issues/2014)
