### PR TITLE
client-api: Expose the `ErrorCode` of `ErrorKind`

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -1,5 +1,11 @@
 # [unreleased]
 
+Breaking changes:
+
+- `ErrorKind` does not implement `AsRef<str>` and `Display` anymore. To get the
+  same result, use `ErrorKind::errcode()`. The `ErrorCode` that is returned
+  implements those traits.
+
 Improvements:
 
 - Add unstable support for reporting rooms, according to MSC4151.


### PR DESCRIPTION
It does not really make sense to implement `AsRef<str>` and `Display` for `ErrorKind` since some variants include more data than the error code.

Besides, since `ErrCode` was only used for deserialization, there was a possibility that the 2 types could get out of sync, resulting in variants not being able to be deserialized.

We expose `ErrCode` as `ErrorCode` so that users that want the error code can access it, and we use `ErrorCode` during serialization, with the conversion making sure that the types stay in sync.
