### PR TITLE
client-api: Sort and improve docs of ErrorKind and ErrorCode variants

### DIFF
--- a/crates/ruma-client-api/src/error.rs
+++ b/crates/ruma-client-api/src/error.rs
@@ -33,7 +33,50 @@ mod kind_serde;
 /// Items may contain additional information.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
+// Please keep the variants sorted alphabetically.
 pub enum ErrorKind {
+    /// M_BAD_ALIAS
+    BadAlias,
+
+    /// M_BAD_JSON
+    BadJson,
+
+    /// M_BAD_STATE
+    BadState,
+
+    /// M_BAD_STATUS
+    BadStatus {
+        /// The HTTP status code of the response.
+        status: Option<http::StatusCode>,
+
+        /// The body of the response.
+        body: Option<String>,
+    },
+
+    /// M_CANNOT_LEAVE_SERVER_NOTICE_ROOM
+    CannotLeaveServerNoticeRoom,
+
+    /// M_CANNOT_OVERWRITE_MEDIA
+    CannotOverwriteMedia,
+
+    /// M_CAPTCHA_INVALID
+    CaptchaInvalid,
+
+    /// M_CAPTCHA_NEEDED
+    CaptchaNeeded,
+
+    /// M_CONNECTION_FAILED
+    ConnectionFailed,
+
+    /// M_CONNECTION_TIMEOUT
+    ConnectionTimeout,
+
+    /// M_DUPLICATE_ANNOTATION
+    DuplicateAnnotation,
+
+    /// M_EXCLUSIVE
+    Exclusive,
+
     /// M_FORBIDDEN
     #[non_exhaustive]
     Forbidden {
@@ -41,6 +84,95 @@ pub enum ErrorKind {
         #[cfg(feature = "unstable-msc2967")]
         authenticate: Option<AuthenticateError>,
     },
+
+    /// M_GUEST_ACCESS_FORBIDDEN
+    GuestAccessForbidden,
+
+    /// M_INCOMPATIBLE_ROOM_VERSION
+    IncompatibleRoomVersion {
+        /// The room's version.
+        room_version: RoomVersionId,
+    },
+
+    /// M_INVALID_PARAM
+    InvalidParam,
+
+    /// M_INVALID_ROOM_STATE
+    InvalidRoomState,
+
+    /// M_INVALID_USERNAME
+    InvalidUsername,
+
+    /// M_LIMIT_EXCEEDED
+    LimitExceeded {
+        /// How long a client should wait before they can try again.
+        retry_after: Option<RetryAfter>,
+    },
+
+    /// M_MISSING_PARAM
+    MissingParam,
+
+    /// M_MISSING_TOKEN
+    MissingToken,
+
+    /// M_NOT_FOUND
+    NotFound,
+
+    /// M_NOT_JSON
+    NotJson,
+
+    /// M_NOT_YET_UPLOADED
+    NotYetUploaded,
+
+    /// M_RESOURCE_LIMIT_EXCEEDED
+    ResourceLimitExceeded {
+        /// A URI giving a contact method for the server administrator.
+        admin_contact: String,
+    },
+
+    /// M_ROOM_IN_USE
+    RoomInUse,
+
+    /// M_SERVER_NOT_TRUSTED
+    ServerNotTrusted,
+
+    /// M_THREEPID_AUTH_FAILED
+    ThreepidAuthFailed,
+
+    /// M_THREEPID_DENIED
+    ThreepidDenied,
+
+    /// M_THREEPID_IN_USE
+    ThreepidInUse,
+
+    /// M_THREEPID_MEDIUM_NOT_SUPPORTED
+    ThreepidMediumNotSupported,
+
+    /// M_THREEPID_NOT_FOUND
+    ThreepidNotFound,
+
+    /// M_TOO_LARGE
+    TooLarge,
+
+    /// M_UNABLE_TO_AUTHORISE_JOIN
+    UnableToAuthorizeJoin,
+
+    /// M_UNABLE_TO_GRANT_JOIN
+    UnableToGrantJoin,
+
+    /// M_UNACTIONABLE
+    #[cfg(feature = "unstable-msc3843")]
+    Unactionable,
+
+    /// M_UNAUTHORIZED
+    Unauthorized,
+
+    /// M_UNKNOWN
+    Unknown,
+
+    /// M_UNKNOWN_POS for sliding sync
+    #[cfg(any(feature = "unstable-msc3575", feature = "unstable-msc4186"))]
+    UnknownPos,
 
     /// M_UNKNOWN_TOKEN
     UnknownToken {
@@ -53,32 +185,14 @@ pub enum ErrorKind {
         soft_logout: bool,
     },
 
-    /// M_MISSING_TOKEN
-    MissingToken,
-
-    /// M_BAD_JSON
-    BadJson,
-
-    /// M_NOT_JSON
-    NotJson,
-
-    /// M_NOT_FOUND
-    NotFound,
-
-    /// M_LIMIT_EXCEEDED
-    LimitExceeded {
-        /// How long a client should wait before they can try again.
-        retry_after: Option<RetryAfter>,
-    },
-
-    /// M_UNKNOWN
-    Unknown,
-
     /// M_UNRECOGNIZED
     Unrecognized,
 
-    /// M_UNAUTHORIZED
-    Unauthorized,
+    /// M_UNSUPPORTED_ROOM_VERSION
+    UnsupportedRoomVersion,
+
+    /// M_URL_NOT_SET
+    UrlNotSet,
 
     /// M_USER_DEACTIVATED
     UserDeactivated,
@@ -86,133 +200,20 @@ pub enum ErrorKind {
     /// M_USER_IN_USE
     UserInUse,
 
-    /// M_INVALID_USERNAME
-    InvalidUsername,
+    /// M_USER_LOCKED
+    UserLocked,
 
-    /// M_ROOM_IN_USE
-    RoomInUse,
-
-    /// M_INVALID_ROOM_STATE
-    InvalidRoomState,
-
-    /// M_THREEPID_IN_USE
-    ThreepidInUse,
-
-    /// M_THREEPID_NOT_FOUND
-    ThreepidNotFound,
-
-    /// M_THREEPID_AUTH_FAILED
-    ThreepidAuthFailed,
-
-    /// M_THREEPID_DENIED
-    ThreepidDenied,
-
-    /// M_THREEPID_MEDIUM_NOT_SUPPORTED
-    ThreepidMediumNotSupported,
-
-    /// M_SERVER_NOT_TRUSTED
-    ServerNotTrusted,
-
-    /// M_UNSUPPORTED_ROOM_VERSION
-    UnsupportedRoomVersion,
-
-    /// M_INCOMPATIBLE_ROOM_VERSION
-    IncompatibleRoomVersion {
-        /// The room's version.
-        room_version: RoomVersionId,
-    },
-
-    /// M_BAD_STATE
-    BadState,
-
-    /// M_GUEST_ACCESS_FORBIDDEN
-    GuestAccessForbidden,
-
-    /// M_CAPTCHA_NEEDED
-    CaptchaNeeded,
-
-    /// M_CAPTCHA_INVALID
-    CaptchaInvalid,
-
-    /// M_MISSING_PARAM
-    MissingParam,
-
-    /// M_INVALID_PARAM
-    InvalidParam,
-
-    /// M_TOO_LARGE
-    TooLarge,
-
-    /// M_EXCLUSIVE
-    Exclusive,
-
-    /// M_RESOURCE_LIMIT_EXCEEDED
-    ResourceLimitExceeded {
-        /// A URI giving a contact method for the server administrator.
-        admin_contact: String,
-    },
-
-    /// M_CANNOT_LEAVE_SERVER_NOTICE_ROOM
-    CannotLeaveServerNoticeRoom,
+    /// M_USER_SUSPENDED
+    UserSuspended,
 
     /// M_WEAK_PASSWORD
     WeakPassword,
-
-    /// M_UNABLE_TO_AUTHORISE_JOIN
-    UnableToAuthorizeJoin,
-
-    /// M_UNABLE_TO_GRANT_JOIN
-    UnableToGrantJoin,
-
-    /// M_BAD_ALIAS
-    BadAlias,
-
-    /// M_DUPLICATE_ANNOTATION
-    DuplicateAnnotation,
-
-    /// M_NOT_YET_UPLOADED
-    NotYetUploaded,
-
-    /// M_CANNOT_OVERWRITE_MEDIA
-    CannotOverwriteMedia,
-
-    /// M_UNKNOWN_POS for sliding sync
-    #[cfg(any(feature = "unstable-msc3575", feature = "unstable-msc4186"))]
-    UnknownPos,
-
-    /// M_URL_NOT_SET
-    UrlNotSet,
-
-    /// M_BAD_STATUS
-    BadStatus {
-        /// The HTTP status code of the response.
-        status: Option<http::StatusCode>,
-
-        /// The body of the response.
-        body: Option<String>,
-    },
-
-    /// M_CONNECTION_FAILED
-    ConnectionFailed,
-
-    /// M_CONNECTION_TIMEOUT
-    ConnectionTimeout,
 
     /// M_WRONG_ROOM_KEYS_VERSION
     WrongRoomKeysVersion {
         /// The currently active backup version.
         current_version: Option<String>,
     },
-
-    /// M_UNACTIONABLE
-    #[cfg(feature = "unstable-msc3843")]
-    Unactionable,
-
-    /// M_USER_LOCKED
-    UserLocked,
-
-    /// M_USER_SUSPENDED
-    UserSuspended,
 
     #[doc(hidden)]
     _Custom { errcode: PrivOwnedStr, extra: Extra },
@@ -237,57 +238,57 @@ impl ErrorKind {
     /// Get the [`ErrorCode`] for this `ErrorKind`.
     pub fn errcode(&self) -> ErrorCode {
         match self {
-            ErrorKind::Forbidden { .. } => ErrorCode::Forbidden,
-            ErrorKind::UnknownToken { .. } => ErrorCode::UnknownToken,
-            ErrorKind::MissingToken => ErrorCode::MissingToken,
-            ErrorKind::BadJson => ErrorCode::BadJson,
-            ErrorKind::NotJson => ErrorCode::NotJson,
-            ErrorKind::NotFound => ErrorCode::NotFound,
-            ErrorKind::LimitExceeded { .. } => ErrorCode::LimitExceeded,
-            ErrorKind::Unknown => ErrorCode::Unknown,
-            ErrorKind::Unrecognized => ErrorCode::Unrecognized,
-            ErrorKind::Unauthorized => ErrorCode::Unauthorized,
-            ErrorKind::UserDeactivated => ErrorCode::UserDeactivated,
-            ErrorKind::UserInUse => ErrorCode::UserInUse,
-            ErrorKind::InvalidUsername => ErrorCode::InvalidUsername,
-            ErrorKind::RoomInUse => ErrorCode::RoomInUse,
-            ErrorKind::InvalidRoomState => ErrorCode::InvalidRoomState,
-            ErrorKind::ThreepidInUse => ErrorCode::ThreepidInUse,
-            ErrorKind::ThreepidNotFound => ErrorCode::ThreepidNotFound,
-            ErrorKind::ThreepidAuthFailed => ErrorCode::ThreepidAuthFailed,
-            ErrorKind::ThreepidDenied => ErrorCode::ThreepidDenied,
-            ErrorKind::ThreepidMediumNotSupported => ErrorCode::ThreepidMediumNotSupported,
-            ErrorKind::ServerNotTrusted => ErrorCode::ServerNotTrusted,
-            ErrorKind::UnsupportedRoomVersion => ErrorCode::UnsupportedRoomVersion,
-            ErrorKind::IncompatibleRoomVersion { .. } => ErrorCode::IncompatibleRoomVersion,
-            ErrorKind::BadState => ErrorCode::BadState,
-            ErrorKind::GuestAccessForbidden => ErrorCode::GuestAccessForbidden,
-            ErrorKind::CaptchaNeeded => ErrorCode::CaptchaNeeded,
-            ErrorKind::CaptchaInvalid => ErrorCode::CaptchaInvalid,
-            ErrorKind::MissingParam => ErrorCode::MissingParam,
-            ErrorKind::InvalidParam => ErrorCode::InvalidParam,
-            ErrorKind::TooLarge => ErrorCode::TooLarge,
-            ErrorKind::Exclusive => ErrorCode::Exclusive,
-            ErrorKind::ResourceLimitExceeded { .. } => ErrorCode::ResourceLimitExceeded,
-            ErrorKind::CannotLeaveServerNoticeRoom => ErrorCode::CannotLeaveServerNoticeRoom,
-            ErrorKind::WeakPassword => ErrorCode::WeakPassword,
-            ErrorKind::UnableToAuthorizeJoin => ErrorCode::UnableToAuthorizeJoin,
-            ErrorKind::UnableToGrantJoin => ErrorCode::UnableToGrantJoin,
             ErrorKind::BadAlias => ErrorCode::BadAlias,
-            ErrorKind::DuplicateAnnotation => ErrorCode::DuplicateAnnotation,
-            ErrorKind::NotYetUploaded => ErrorCode::NotYetUploaded,
-            ErrorKind::CannotOverwriteMedia => ErrorCode::CannotOverwriteMedia,
-            #[cfg(any(feature = "unstable-msc3575", feature = "unstable-msc4186"))]
-            ErrorKind::UnknownPos => ErrorCode::UnknownPos,
-            ErrorKind::UrlNotSet => ErrorCode::UrlNotSet,
+            ErrorKind::BadJson => ErrorCode::BadJson,
+            ErrorKind::BadState => ErrorCode::BadState,
             ErrorKind::BadStatus { .. } => ErrorCode::BadStatus,
+            ErrorKind::CannotLeaveServerNoticeRoom => ErrorCode::CannotLeaveServerNoticeRoom,
+            ErrorKind::CannotOverwriteMedia => ErrorCode::CannotOverwriteMedia,
+            ErrorKind::CaptchaInvalid => ErrorCode::CaptchaInvalid,
+            ErrorKind::CaptchaNeeded => ErrorCode::CaptchaNeeded,
             ErrorKind::ConnectionFailed => ErrorCode::ConnectionFailed,
             ErrorKind::ConnectionTimeout => ErrorCode::ConnectionTimeout,
-            ErrorKind::WrongRoomKeysVersion { .. } => ErrorCode::WrongRoomKeysVersion,
+            ErrorKind::DuplicateAnnotation => ErrorCode::DuplicateAnnotation,
+            ErrorKind::Exclusive => ErrorCode::Exclusive,
+            ErrorKind::Forbidden { .. } => ErrorCode::Forbidden,
+            ErrorKind::GuestAccessForbidden => ErrorCode::GuestAccessForbidden,
+            ErrorKind::IncompatibleRoomVersion { .. } => ErrorCode::IncompatibleRoomVersion,
+            ErrorKind::InvalidParam => ErrorCode::InvalidParam,
+            ErrorKind::InvalidRoomState => ErrorCode::InvalidRoomState,
+            ErrorKind::InvalidUsername => ErrorCode::InvalidUsername,
+            ErrorKind::LimitExceeded { .. } => ErrorCode::LimitExceeded,
+            ErrorKind::MissingParam => ErrorCode::MissingParam,
+            ErrorKind::MissingToken => ErrorCode::MissingToken,
+            ErrorKind::NotFound => ErrorCode::NotFound,
+            ErrorKind::NotJson => ErrorCode::NotJson,
+            ErrorKind::NotYetUploaded => ErrorCode::NotYetUploaded,
+            ErrorKind::ResourceLimitExceeded { .. } => ErrorCode::ResourceLimitExceeded,
+            ErrorKind::RoomInUse => ErrorCode::RoomInUse,
+            ErrorKind::ServerNotTrusted => ErrorCode::ServerNotTrusted,
+            ErrorKind::ThreepidAuthFailed => ErrorCode::ThreepidAuthFailed,
+            ErrorKind::ThreepidDenied => ErrorCode::ThreepidDenied,
+            ErrorKind::ThreepidInUse => ErrorCode::ThreepidInUse,
+            ErrorKind::ThreepidMediumNotSupported => ErrorCode::ThreepidMediumNotSupported,
+            ErrorKind::ThreepidNotFound => ErrorCode::ThreepidNotFound,
+            ErrorKind::TooLarge => ErrorCode::TooLarge,
+            ErrorKind::UnableToAuthorizeJoin => ErrorCode::UnableToAuthorizeJoin,
+            ErrorKind::UnableToGrantJoin => ErrorCode::UnableToGrantJoin,
             #[cfg(feature = "unstable-msc3843")]
             ErrorKind::Unactionable => ErrorCode::Unactionable,
+            ErrorKind::Unauthorized => ErrorCode::Unauthorized,
+            ErrorKind::Unknown => ErrorCode::Unknown,
+            #[cfg(any(feature = "unstable-msc3575", feature = "unstable-msc4186"))]
+            ErrorKind::UnknownPos => ErrorCode::UnknownPos,
+            ErrorKind::UnknownToken { .. } => ErrorCode::UnknownToken,
+            ErrorKind::Unrecognized => ErrorCode::Unrecognized,
+            ErrorKind::UnsupportedRoomVersion => ErrorCode::UnsupportedRoomVersion,
+            ErrorKind::UrlNotSet => ErrorCode::UrlNotSet,
+            ErrorKind::UserDeactivated => ErrorCode::UserDeactivated,
+            ErrorKind::UserInUse => ErrorCode::UserInUse,
             ErrorKind::UserLocked => ErrorCode::UserLocked,
             ErrorKind::UserSuspended => ErrorCode::UserSuspended,
+            ErrorKind::WeakPassword => ErrorCode::WeakPassword,
+            ErrorKind::WrongRoomKeysVersion { .. } => ErrorCode::WrongRoomKeysVersion,
             ErrorKind::_Custom { errcode, .. } => errcode.0.clone().into(),
         }
     }
@@ -303,57 +304,88 @@ pub struct Extra(BTreeMap<String, JsonValue>);
 #[derive(Clone, StringEnum)]
 #[non_exhaustive]
 #[ruma_enum(rename_all = "M_MATRIX_ERROR_CASE")]
+// Please keep the variants sorted alphabetically.
 pub enum ErrorCode {
-    /// M_FORBIDDEN
-    Forbidden,
-
-    /// M_UNKNOWN_TOKEN
-    UnknownToken,
-
-    /// M_MISSING_TOKEN
-    MissingToken,
+    /// M_BAD_ALIAS
+    BadAlias,
 
     /// M_BAD_JSON
     BadJson,
 
-    /// M_NOT_JSON
-    NotJson,
+    /// M_BAD_STATE
+    BadState,
 
-    /// M_NOT_FOUND
-    NotFound,
+    /// M_BAD_STATUS
+    BadStatus,
 
-    /// M_LIMIT_EXCEEDED
-    LimitExceeded,
+    /// M_CANNOT_LEAVE_SERVER_NOTICE_ROOM
+    CannotLeaveServerNoticeRoom,
 
-    /// M_UNKNOWN
-    Unknown,
+    /// M_CANNOT_OVERWRITE_MEDIA
+    CannotOverwriteMedia,
 
-    /// M_UNRECOGNIZED
-    Unrecognized,
+    /// M_CAPTCHA_INVALID
+    CaptchaInvalid,
 
-    /// M_UNAUTHORIZED
-    Unauthorized,
+    /// M_CAPTCHA_NEEDED
+    CaptchaNeeded,
 
-    /// M_USER_DEACTIVATED
-    UserDeactivated,
+    /// M_CONNECTION_FAILED
+    ConnectionFailed,
 
-    /// M_USER_IN_USE
-    UserInUse,
+    /// M_CONNECTION_TIMEOUT
+    ConnectionTimeout,
 
-    /// M_INVALID_USERNAME
-    InvalidUsername,
+    /// M_DUPLICATE_ANNOTATION
+    DuplicateAnnotation,
 
-    /// M_ROOM_IN_USE
-    RoomInUse,
+    /// M_EXCLUSIVE
+    Exclusive,
+
+    /// M_FORBIDDEN
+    Forbidden,
+
+    /// M_GUEST_ACCESS_FORBIDDEN
+    GuestAccessForbidden,
+
+    /// M_INCOMPATIBLE_ROOM_VERSION
+    IncompatibleRoomVersion,
+
+    /// M_INVALID_PARAM
+    InvalidParam,
 
     /// M_INVALID_ROOM_STATE
     InvalidRoomState,
 
-    /// M_THREEPID_IN_USE
-    ThreepidInUse,
+    /// M_INVALID_USERNAME
+    InvalidUsername,
 
-    /// M_THREEPID_NOT_FOUND
-    ThreepidNotFound,
+    /// M_LIMIT_EXCEEDED
+    LimitExceeded,
+
+    /// M_MISSING_PARAM
+    MissingParam,
+
+    /// M_MISSING_TOKEN
+    MissingToken,
+
+    /// M_NOT_FOUND
+    NotFound,
+
+    /// M_NOT_JSON
+    NotJson,
+
+    /// M_NOT_YET_UPLOADED
+    NotYetUploaded,
+
+    /// M_RESOURCE_LIMIT_EXCEEDED
+    ResourceLimitExceeded,
+
+    /// M_ROOM_IN_USE
+    RoomInUse,
+
+    /// M_SERVER_NOT_TRUSTED
+    ServerNotTrusted,
 
     /// M_THREEPID_AUTH_FAILED
     ThreepidAuthFailed,
@@ -361,50 +393,17 @@ pub enum ErrorCode {
     /// M_THREEPID_DENIED
     ThreepidDenied,
 
+    /// M_THREEPID_IN_USE
+    ThreepidInUse,
+
     /// M_THREEPID_MEDIUM_NOT_SUPPORTED
     ThreepidMediumNotSupported,
 
-    /// M_SERVER_NOT_TRUSTED
-    ServerNotTrusted,
-
-    /// M_UNSUPPORTED_ROOM_VERSION
-    UnsupportedRoomVersion,
-
-    /// M_INCOMPATIBLE_ROOM_VERSION
-    IncompatibleRoomVersion,
-
-    /// M_BAD_STATE
-    BadState,
-
-    /// M_GUEST_ACCESS_FORBIDDEN
-    GuestAccessForbidden,
-
-    /// M_CAPTCHA_NEEDED
-    CaptchaNeeded,
-
-    /// M_CAPTCHA_INVALID
-    CaptchaInvalid,
-
-    /// M_MISSING_PARAM
-    MissingParam,
-
-    /// M_INVALID_PARAM
-    InvalidParam,
+    /// M_THREEPID_NOT_FOUND
+    ThreepidNotFound,
 
     /// M_TOO_LARGE
     TooLarge,
-
-    /// M_EXCLUSIVE
-    Exclusive,
-
-    /// M_RESOURCE_LIMIT_EXCEEDED
-    ResourceLimitExceeded,
-
-    /// M_CANNOT_LEAVE_SERVER_NOTICE_ROOM
-    CannotLeaveServerNoticeRoom,
-
-    /// M_WEAK_PASSWORD
-    WeakPassword,
 
     /// M_UNABLE_TO_AUTHORISE_JOIN
     #[ruma_enum(rename = "M_UNABLE_TO_AUTHORISE_JOIN")]
@@ -413,46 +412,49 @@ pub enum ErrorCode {
     /// M_UNABLE_TO_GRANT_JOIN
     UnableToGrantJoin,
 
-    /// M_BAD_ALIAS
-    BadAlias,
+    /// M_UNACTIONABLE
+    #[cfg(feature = "unstable-msc3843")]
+    Unactionable,
 
-    /// M_DUPLICATE_ANNOTATION
-    DuplicateAnnotation,
+    /// M_UNAUTHORIZED
+    Unauthorized,
 
-    /// M_NOT_YET_UPLOADED
-    NotYetUploaded,
-
-    /// M_CANNOT_OVERWRITE_MEDIA
-    CannotOverwriteMedia,
+    /// M_UNKNOWN
+    Unknown,
 
     /// M_UNKNOWN_POS for sliding sync
     #[cfg(any(feature = "unstable-msc3575", feature = "unstable-msc4186"))]
     UnknownPos,
 
+    /// M_UNKNOWN_TOKEN
+    UnknownToken,
+
+    /// M_UNRECOGNIZED
+    Unrecognized,
+
+    /// M_UNSUPPORTED_ROOM_VERSION
+    UnsupportedRoomVersion,
+
     /// M_URL_NOT_SET
     UrlNotSet,
 
-    /// M_BAD_STATUS
-    BadStatus,
+    /// M_USER_DEACTIVATED
+    UserDeactivated,
 
-    /// M_CONNECTION_FAILED
-    ConnectionFailed,
-
-    /// M_CONNECTION_TIMEOUT
-    ConnectionTimeout,
-
-    /// M_WRONG_ROOM_KEYS_VERSION
-    WrongRoomKeysVersion,
-
-    /// M_UNACTIONABLE
-    #[cfg(feature = "unstable-msc3843")]
-    Unactionable,
+    /// M_USER_IN_USE
+    UserInUse,
 
     /// M_USER_LOCKED
     UserLocked,
 
     /// M_USER_SUSPENDED
     UserSuspended,
+
+    /// M_WEAK_PASSWORD
+    WeakPassword,
+
+    /// M_WRONG_ROOM_KEYS_VERSION
+    WrongRoomKeysVersion,
 
     #[doc(hidden)]
     _Custom(PrivOwnedStr),

--- a/crates/ruma-client-api/src/error.rs
+++ b/crates/ruma-client-api/src/error.rs
@@ -35,16 +35,29 @@ mod kind_serde;
 #[non_exhaustive]
 // Please keep the variants sorted alphabetically.
 pub enum ErrorKind {
-    /// M_BAD_ALIAS
+    /// `M_BAD_ALIAS`
+    ///
+    /// One or more [room aliases] within the `m.room.canonical_alias` event do not point to the
+    /// room ID for which the state event is to be sent to.
+    ///
+    /// [room aliases]: https://spec.matrix.org/latest/client-server-api/#room-aliases
     BadAlias,
 
-    /// M_BAD_JSON
+    /// `M_BAD_JSON`
+    ///
+    /// The request contained valid JSON, but it was malformed in some way, e.g. missing required
+    /// keys, invalid values for keys.
     BadJson,
 
-    /// M_BAD_STATE
+    /// `M_BAD_STATE`
+    ///
+    /// The state change requested cannot be performed, such as attempting to unban a user who is
+    /// not banned.
     BadState,
 
-    /// M_BAD_STATUS
+    /// `M_BAD_STATUS`
+    ///
+    /// The application service returned a bad status.
     BadStatus {
         /// The HTTP status code of the response.
         status: Option<http::StatusCode>,
@@ -53,31 +66,56 @@ pub enum ErrorKind {
         body: Option<String>,
     },
 
-    /// M_CANNOT_LEAVE_SERVER_NOTICE_ROOM
+    /// `M_CANNOT_LEAVE_SERVER_NOTICE_ROOM`
+    ///
+    /// The user is unable to reject an invite to join the [server notices] room.
+    ///
+    /// [server notices]: https://spec.matrix.org/latest/client-server-api/#server-notices
     CannotLeaveServerNoticeRoom,
 
-    /// M_CANNOT_OVERWRITE_MEDIA
+    /// `M_CANNOT_OVERWRITE_MEDIA`
+    ///
+    /// The [`create_content_async`] endpoint was called with a media ID that already has content.
+    ///
+    /// [`create_content_async`]: crate::media::create_content_async
     CannotOverwriteMedia,
 
-    /// M_CAPTCHA_INVALID
+    /// `M_CAPTCHA_INVALID`
+    ///
+    /// The Captcha provided did not match what was expected.
     CaptchaInvalid,
 
-    /// M_CAPTCHA_NEEDED
+    /// `M_CAPTCHA_NEEDED`
+    ///
+    /// A Captcha is required to complete the request.
     CaptchaNeeded,
 
-    /// M_CONNECTION_FAILED
+    /// `M_CONNECTION_FAILED`
+    ///
+    /// The connection to the application service failed.
     ConnectionFailed,
 
-    /// M_CONNECTION_TIMEOUT
+    /// `M_CONNECTION_TIMEOUT`
+    ///
+    /// The connection to the application service timed out.
     ConnectionTimeout,
 
-    /// M_DUPLICATE_ANNOTATION
+    /// `M_DUPLICATE_ANNOTATION`
+    ///
+    /// The request is an attempt to send a [duplicate annotation].
+    ///
+    /// [duplicate annotation]: https://spec.matrix.org/latest/client-server-api/#avoiding-duplicate-annotations
     DuplicateAnnotation,
 
-    /// M_EXCLUSIVE
+    /// `M_EXCLUSIVE`
+    ///
+    /// The resource being requested is reserved by an application service, or the application
+    /// service making the request has not created the resource.
     Exclusive,
 
-    /// M_FORBIDDEN
+    /// `M_FORBIDDEN`
+    ///
+    /// Forbidden access, e.g. joining a room without permission, failed login.
     #[non_exhaustive]
     Forbidden {
         /// The `WWW-Authenticate` header error message.
@@ -85,131 +123,264 @@ pub enum ErrorKind {
         authenticate: Option<AuthenticateError>,
     },
 
-    /// M_GUEST_ACCESS_FORBIDDEN
+    /// `M_GUEST_ACCESS_FORBIDDEN`
+    ///
+    /// The room or resource does not permit [guests] to access it.
+    ///
+    /// [guests]: https://spec.matrix.org/latest/client-server-api/#guest-access
     GuestAccessForbidden,
 
-    /// M_INCOMPATIBLE_ROOM_VERSION
+    /// `M_INCOMPATIBLE_ROOM_VERSION`
+    ///
+    /// The client attempted to join a room that has a version the server does not support.
     IncompatibleRoomVersion {
         /// The room's version.
         room_version: RoomVersionId,
     },
 
-    /// M_INVALID_PARAM
+    /// `M_INVALID_PARAM`
+    ///
+    /// A parameter that was specified has the wrong value. For example, the server expected an
+    /// integer and instead received a string.
     InvalidParam,
 
-    /// M_INVALID_ROOM_STATE
+    /// `M_INVALID_ROOM_STATE`
+    ///
+    /// The initial state implied by the parameters to the [`create_room`] request is invalid, e.g.
+    /// the user's `power_level` is set below that necessary to set the room name.
+    ///
+    /// [`create_room`]: crate::room::create_room
     InvalidRoomState,
 
-    /// M_INVALID_USERNAME
+    /// `M_INVALID_USERNAME`
+    ///
+    /// The desired user name is not valid.
     InvalidUsername,
 
-    /// M_LIMIT_EXCEEDED
+    /// `M_LIMIT_EXCEEDED`
+    ///
+    /// The request has been refused due to [rate limiting]: too many requests have been sent in a
+    /// short period of time.
+    ///
+    /// [rate limiting]: https://spec.matrix.org/latest/client-server-api/#rate-limiting
     LimitExceeded {
         /// How long a client should wait before they can try again.
         retry_after: Option<RetryAfter>,
     },
 
-    /// M_MISSING_PARAM
+    /// `M_MISSING_PARAM`
+    ///
+    /// A required parameter was missing from the request.
     MissingParam,
 
-    /// M_MISSING_TOKEN
+    /// `M_MISSING_TOKEN`
+    ///
+    /// No [access token] was specified for the request, but one is required.
+    ///
+    /// [access token]: https://spec.matrix.org/latest/client-server-api/#client-authentication
     MissingToken,
 
-    /// M_NOT_FOUND
+    /// `M_NOT_FOUND`
+    ///
+    /// No resource was found for this request.
     NotFound,
 
-    /// M_NOT_JSON
+    /// `M_NOT_JSON`
+    ///
+    /// The request did not contain valid JSON.
     NotJson,
 
-    /// M_NOT_YET_UPLOADED
+    /// `M_NOT_YET_UPLOADED`
+    ///
+    /// An `mxc:` URI generated with the [`create_mxc_uri`] endpoint was used and the content is
+    /// not yet available.
+    ///
+    /// [`create_mxc_uri`]: crate::media::create_mxc_uri
     NotYetUploaded,
 
-    /// M_RESOURCE_LIMIT_EXCEEDED
+    /// `M_RESOURCE_LIMIT_EXCEEDED`
+    ///
+    /// The request cannot be completed because the homeserver has reached a resource limit imposed
+    /// on it. For example, a homeserver held in a shared hosting environment may reach a resource
+    /// limit if it starts using too much memory or disk space.
     ResourceLimitExceeded {
         /// A URI giving a contact method for the server administrator.
         admin_contact: String,
     },
 
-    /// M_ROOM_IN_USE
+    /// `M_ROOM_IN_USE`
+    ///
+    /// The [room alias] specified in the [`create_room`] request is already taken.
+    ///
+    /// [`create_room`]: crate::room::create_room
+    /// [room alias]: https://spec.matrix.org/latest/client-server-api/#room-aliases
     RoomInUse,
 
-    /// M_SERVER_NOT_TRUSTED
+    /// `M_SERVER_NOT_TRUSTED`
+    ///
+    /// The client's request used a third-party server, e.g. identity server, that this server does
+    /// not trust.
     ServerNotTrusted,
 
-    /// M_THREEPID_AUTH_FAILED
+    /// `M_THREEPID_AUTH_FAILED`
+    ///
+    /// Authentication could not be performed on the [third-party identifier].
+    ///
+    /// [third-party identifier]: https://spec.matrix.org/latest/client-server-api/#adding-account-administrative-contact-information
     ThreepidAuthFailed,
 
-    /// M_THREEPID_DENIED
+    /// `M_THREEPID_DENIED`
+    ///
+    /// The server does not permit this [third-party identifier]. This may happen if the server
+    /// only permits, for example, email addresses from a particular domain.
+    ///
+    /// [third-party identifier]: https://spec.matrix.org/latest/client-server-api/#adding-account-administrative-contact-information
     ThreepidDenied,
 
-    /// M_THREEPID_IN_USE
+    /// `M_THREEPID_IN_USE`
+    ///
+    /// The [third-party identifier] is already in use by another user.
+    ///
+    /// [third-party identifier]: https://spec.matrix.org/latest/client-server-api/#adding-account-administrative-contact-information
     ThreepidInUse,
 
-    /// M_THREEPID_MEDIUM_NOT_SUPPORTED
+    /// `M_THREEPID_MEDIUM_NOT_SUPPORTED`
+    ///
+    /// The homeserver does not support adding a [third-party identifier] of the given medium.
+    ///
+    /// [third-party identifier]: https://spec.matrix.org/latest/client-server-api/#adding-account-administrative-contact-information
     ThreepidMediumNotSupported,
 
-    /// M_THREEPID_NOT_FOUND
+    /// `M_THREEPID_NOT_FOUND`
+    ///
+    /// No account matching the given [third-party identifier] could be found.
+    ///
+    /// [third-party identifier]: https://spec.matrix.org/latest/client-server-api/#adding-account-administrative-contact-information
     ThreepidNotFound,
 
-    /// M_TOO_LARGE
+    /// `M_TOO_LARGE`
+    ///
+    /// The request or entity was too large.
     TooLarge,
 
-    /// M_UNABLE_TO_AUTHORISE_JOIN
+    /// `M_UNABLE_TO_AUTHORISE_JOIN`
+    ///
+    /// The room is [restricted] and none of the conditions can be validated by the homeserver.
+    /// This can happen if the homeserver does not know about any of the rooms listed as
+    /// conditions, for example.
+    ///
+    /// [restricted]: https://spec.matrix.org/latest/client-server-api/#restricted-rooms
     UnableToAuthorizeJoin,
 
-    /// M_UNABLE_TO_GRANT_JOIN
+    /// `M_UNABLE_TO_GRANT_JOIN`
+    ///
+    /// A different server should be attempted for the join. This is typically because the resident
+    /// server can see that the joining user satisfies one or more conditions, such as in the case
+    /// of [restricted rooms], but the resident server would be unable to meet the authorization
+    /// rules.
+    ///
+    /// [restricted rooms]: https://spec.matrix.org/latest/client-server-api/#restricted-rooms
     UnableToGrantJoin,
 
-    /// M_UNACTIONABLE
+    /// `M_UNACTIONABLE`
+    ///
+    /// The server does not want to handle the [federated report].
+    ///
+    /// [federated report]: https://github.com/matrix-org/matrix-spec-proposals/pull/3843
     #[cfg(feature = "unstable-msc3843")]
     Unactionable,
 
-    /// M_UNAUTHORIZED
+    /// `M_UNAUTHORIZED`
+    ///
+    /// The request was not correctly authorized. Usually due to login failures.
     Unauthorized,
 
-    /// M_UNKNOWN
+    /// `M_UNKNOWN`
+    ///
+    /// An unknown error has occurred.
     Unknown,
 
-    /// M_UNKNOWN_POS for sliding sync
+    /// `M_UNKNOWN_POS`
+    ///
+    /// The sliding sync ([MSC3575] / [MSC4186]) connection was expired by the server.
+    ///
+    /// [MSC3575]: https://github.com/matrix-org/matrix-spec-proposals/pull/3575
+    /// [MSC4186]: https://github.com/matrix-org/matrix-spec-proposals/pull/4186
     #[cfg(any(feature = "unstable-msc3575", feature = "unstable-msc4186"))]
     UnknownPos,
 
-    /// M_UNKNOWN_TOKEN
+    /// `M_UNKNOWN_TOKEN`
+    ///
+    /// The [access or refresh token] specified was not recognized.
+    ///
+    /// [access or refresh token]: https://spec.matrix.org/latest/client-server-api/#client-authentication
     UnknownToken {
-        /// If this is `true`, the client can acquire a new access token by specifying the device
-        /// ID it is already using to the login API.
+        /// If this is `true`, the client is in a "[soft logout]" state, i.e. the server requires
+        /// re-authentication but the session is not invalidated. The client can acquire a new
+        /// access token by specifying the device ID it is already using to the login API.
         ///
-        /// For more information, see [the spec].
-        ///
-        /// [the spec]: https://spec.matrix.org/latest/client-server-api/#soft-logout
+        /// [soft logout]: https://spec.matrix.org/latest/client-server-api/#soft-logout
         soft_logout: bool,
     },
 
-    /// M_UNRECOGNIZED
+    /// `M_UNRECOGNIZED`
+    ///
+    /// The server did not understand the request.
+    ///
+    /// This is expected to be returned with a 404 HTTP status code if the endpoint is not
+    /// implemented or a 405 HTTP status code if the endpoint is implemented, but the incorrect
+    /// HTTP method is used.
     Unrecognized,
 
-    /// M_UNSUPPORTED_ROOM_VERSION
+    /// `M_UNSUPPORTED_ROOM_VERSION`
+    ///
+    /// The request to [`create_room`] used a room version that the server does not support.
+    ///
+    /// [`create_room`]: crate::room::create_room
     UnsupportedRoomVersion,
 
-    /// M_URL_NOT_SET
+    /// `M_URL_NOT_SET`
+    ///
+    /// The application service doesn't have a URL configured.
     UrlNotSet,
 
-    /// M_USER_DEACTIVATED
+    /// `M_USER_DEACTIVATED`
+    ///
+    /// The user ID associated with the request has been deactivated.
     UserDeactivated,
 
-    /// M_USER_IN_USE
+    /// `M_USER_IN_USE`
+    ///
+    /// The desired user ID is already taken.
     UserInUse,
 
-    /// M_USER_LOCKED
+    /// `M_USER_LOCKED`
+    ///
+    /// The account has been [locked] and cannot be used at this time.
+    ///
+    /// [locked]: https://spec.matrix.org/latest/client-server-api/#account-locking
     UserLocked,
 
-    /// M_USER_SUSPENDED
+    /// `M_USER_SUSPENDED`
+    ///
+    /// The account has been [suspended] and can only be used for limited actions at this time.
+    ///
+    /// [suspended]: https://spec.matrix.org/latest/client-server-api/#account-suspension
     UserSuspended,
 
-    /// M_WEAK_PASSWORD
+    /// `M_WEAK_PASSWORD`
+    ///
+    /// The password was [rejected] by the server for being too weak.
+    ///
+    /// [rejected]: https://spec.matrix.org/latest/client-server-api/#notes-on-password-management
     WeakPassword,
 
-    /// M_WRONG_ROOM_KEYS_VERSION
+    /// `M_WRONG_ROOM_KEYS_VERSION`
+    ///
+    /// The version of the [room keys backup] provided in the request does not match the current
+    /// backup version.
+    ///
+    /// [room keys backup]: https://spec.matrix.org/latest/client-server-api/#server-side-key-backups
     WrongRoomKeysVersion {
         /// The currently active backup version.
         current_version: Option<String>,
@@ -306,154 +477,322 @@ pub struct Extra(BTreeMap<String, JsonValue>);
 #[ruma_enum(rename_all = "M_MATRIX_ERROR_CASE")]
 // Please keep the variants sorted alphabetically.
 pub enum ErrorCode {
-    /// M_BAD_ALIAS
+    /// `M_BAD_ALIAS`
+    ///
+    /// One or more [room aliases] within the `m.room.canonical_alias` event do not point to the
+    /// room ID for which the state event is to be sent to.
+    ///
+    /// [room aliases]: https://spec.matrix.org/latest/client-server-api/#room-aliases
     BadAlias,
 
-    /// M_BAD_JSON
+    /// `M_BAD_JSON`
+    ///
+    /// The request contained valid JSON, but it was malformed in some way, e.g. missing required
+    /// keys, invalid values for keys.
     BadJson,
 
-    /// M_BAD_STATE
+    /// `M_BAD_STATE`
+    ///
+    /// The state change requested cannot be performed, such as attempting to unban a user who is
+    /// not banned.
     BadState,
 
-    /// M_BAD_STATUS
+    /// `M_BAD_STATUS`
+    ///
+    /// The application service returned a bad status.
     BadStatus,
 
-    /// M_CANNOT_LEAVE_SERVER_NOTICE_ROOM
+    /// `M_CANNOT_LEAVE_SERVER_NOTICE_ROOM`
+    ///
+    /// The user is unable to reject an invite to join the [server notices] room.
+    ///
+    /// [server notices]: https://spec.matrix.org/latest/client-server-api/#server-notices
     CannotLeaveServerNoticeRoom,
 
-    /// M_CANNOT_OVERWRITE_MEDIA
+    /// `M_CANNOT_OVERWRITE_MEDIA`
+    ///
+    /// The [`create_content_async`] endpoint was called with a media ID that already has content.
+    ///
+    /// [`create_content_async`]: crate::media::create_content_async
     CannotOverwriteMedia,
 
-    /// M_CAPTCHA_INVALID
+    /// `M_CAPTCHA_INVALID`
+    ///
+    /// The Captcha provided did not match what was expected.
     CaptchaInvalid,
 
-    /// M_CAPTCHA_NEEDED
+    /// `M_CAPTCHA_NEEDED`
+    ///
+    /// A Captcha is required to complete the request.
     CaptchaNeeded,
 
-    /// M_CONNECTION_FAILED
+    /// `M_CONNECTION_FAILED`
+    ///
+    /// The connection to the application service failed.
     ConnectionFailed,
 
-    /// M_CONNECTION_TIMEOUT
+    /// `M_CONNECTION_TIMEOUT`
+    ///
+    /// The connection to the application service timed out.
     ConnectionTimeout,
 
-    /// M_DUPLICATE_ANNOTATION
+    /// `M_DUPLICATE_ANNOTATION`
+    ///
+    /// The request is an attempt to send a [duplicate annotation].
+    ///
+    /// [duplicate annotation]: https://spec.matrix.org/latest/client-server-api/#avoiding-duplicate-annotations
     DuplicateAnnotation,
 
-    /// M_EXCLUSIVE
+    /// `M_EXCLUSIVE`
+    ///
+    /// The resource being requested is reserved by an application service, or the application
+    /// service making the request has not created the resource.
     Exclusive,
 
-    /// M_FORBIDDEN
+    /// `M_FORBIDDEN`
+    ///
+    /// Forbidden access, e.g. joining a room without permission, failed login.
     Forbidden,
 
-    /// M_GUEST_ACCESS_FORBIDDEN
+    /// `M_GUEST_ACCESS_FORBIDDEN`
+    ///
+    /// The room or resource does not permit [guests] to access it.
+    ///
+    /// [guests]: https://spec.matrix.org/latest/client-server-api/#guest-access
     GuestAccessForbidden,
 
-    /// M_INCOMPATIBLE_ROOM_VERSION
+    /// `M_INCOMPATIBLE_ROOM_VERSION`
+    ///
+    /// The client attempted to join a room that has a version the server does not support.
     IncompatibleRoomVersion,
 
-    /// M_INVALID_PARAM
+    /// `M_INVALID_PARAM`
+    ///
+    /// A parameter that was specified has the wrong value. For example, the server expected an
+    /// integer and instead received a string.
     InvalidParam,
 
-    /// M_INVALID_ROOM_STATE
+    /// `M_INVALID_ROOM_STATE`
+    ///
+    /// The initial state implied by the parameters to the [`create_room`] request is invalid, e.g.
+    /// the user's `power_level` is set below that necessary to set the room name.
+    ///
+    /// [`create_room`]: crate::room::create_room
     InvalidRoomState,
 
-    /// M_INVALID_USERNAME
+    /// `M_INVALID_USERNAME`
+    ///
+    /// The desired user name is not valid.
     InvalidUsername,
 
-    /// M_LIMIT_EXCEEDED
+    /// `M_LIMIT_EXCEEDED`
+    ///
+    /// The request has been refused due to [rate limiting]: too many requests have been sent in a
+    /// short period of time.
+    ///
+    /// [rate limiting]: https://spec.matrix.org/latest/client-server-api/#rate-limiting
     LimitExceeded,
 
-    /// M_MISSING_PARAM
+    /// `M_MISSING_PARAM`
+    ///
+    /// A required parameter was missing from the request.
     MissingParam,
 
-    /// M_MISSING_TOKEN
+    /// `M_MISSING_TOKEN`
+    ///
+    /// No [access token] was specified for the request, but one is required.
+    ///
+    /// [access token]: https://spec.matrix.org/latest/client-server-api/#client-authentication
     MissingToken,
 
-    /// M_NOT_FOUND
+    /// `M_NOT_FOUND`
+    ///
+    /// No resource was found for this request.
     NotFound,
 
-    /// M_NOT_JSON
+    /// `M_NOT_JSON`
+    ///
+    /// The request did not contain valid JSON.
     NotJson,
 
-    /// M_NOT_YET_UPLOADED
+    /// `M_NOT_YET_UPLOADED`
+    ///
+    /// An `mxc:` URI generated with the [`create_mxc_uri`] endpoint was used and the content is
+    /// not yet available.
+    ///
+    /// [`create_mxc_uri`]: crate::media::create_mxc_uri
     NotYetUploaded,
 
-    /// M_RESOURCE_LIMIT_EXCEEDED
+    /// `M_RESOURCE_LIMIT_EXCEEDED`
+    ///
+    /// The request cannot be completed because the homeserver has reached a resource limit imposed
+    /// on it. For example, a homeserver held in a shared hosting environment may reach a resource
+    /// limit if it starts using too much memory or disk space.
     ResourceLimitExceeded,
 
-    /// M_ROOM_IN_USE
+    /// `M_ROOM_IN_USE`
+    ///
+    /// The [room alias] specified in the [`create_room`] request is already taken.
+    ///
+    /// [`create_room`]: crate::room::create_room
+    /// [room alias]: https://spec.matrix.org/latest/client-server-api/#room-aliases
     RoomInUse,
 
-    /// M_SERVER_NOT_TRUSTED
+    /// `M_SERVER_NOT_TRUSTED`
+    ///
+    /// The client's request used a third-party server, e.g. identity server, that this server does
+    /// not trust.
     ServerNotTrusted,
 
-    /// M_THREEPID_AUTH_FAILED
+    /// `M_THREEPID_AUTH_FAILED`
+    ///
+    /// Authentication could not be performed on the [third-party identifier].
+    ///
+    /// [third-party identifier]: https://spec.matrix.org/latest/client-server-api/#adding-account-administrative-contact-information
     ThreepidAuthFailed,
 
-    /// M_THREEPID_DENIED
+    /// `M_THREEPID_DENIED`
+    ///
+    /// The server does not permit this [third-party identifier]. This may happen if the server
+    /// only permits, for example, email addresses from a particular domain.
+    ///
+    /// [third-party identifier]: https://spec.matrix.org/latest/client-server-api/#adding-account-administrative-contact-information
     ThreepidDenied,
 
-    /// M_THREEPID_IN_USE
+    /// `M_THREEPID_IN_USE`
+    ///
+    /// The [third-party identifier] is already in use by another user.
+    ///
+    /// [third-party identifier]: https://spec.matrix.org/latest/client-server-api/#adding-account-administrative-contact-information
     ThreepidInUse,
 
-    /// M_THREEPID_MEDIUM_NOT_SUPPORTED
+    /// `M_THREEPID_MEDIUM_NOT_SUPPORTED`
+    ///
+    /// The homeserver does not support adding a [third-party identifier] of the given medium.
+    ///
+    /// [third-party identifier]: https://spec.matrix.org/latest/client-server-api/#adding-account-administrative-contact-information
     ThreepidMediumNotSupported,
 
-    /// M_THREEPID_NOT_FOUND
+    /// `M_THREEPID_NOT_FOUND`
+    ///
+    /// No account matching the given [third-party identifier] could be found.
+    ///
+    /// [third-party identifier]: https://spec.matrix.org/latest/client-server-api/#adding-account-administrative-contact-information
     ThreepidNotFound,
 
-    /// M_TOO_LARGE
+    /// `M_TOO_LARGE`
+    ///
+    /// The request or entity was too large.
     TooLarge,
 
-    /// M_UNABLE_TO_AUTHORISE_JOIN
+    /// `M_UNABLE_TO_AUTHORISE_JOIN`
+    ///
+    /// The room is [restricted] and none of the conditions can be validated by the homeserver.
+    /// This can happen if the homeserver does not know about any of the rooms listed as
+    /// conditions, for example.
+    ///
+    /// [restricted]: https://spec.matrix.org/latest/client-server-api/#restricted-rooms
     #[ruma_enum(rename = "M_UNABLE_TO_AUTHORISE_JOIN")]
     UnableToAuthorizeJoin,
 
-    /// M_UNABLE_TO_GRANT_JOIN
+    /// `M_UNABLE_TO_GRANT_JOIN`
+    ///
+    /// A different server should be attempted for the join. This is typically because the resident
+    /// server can see that the joining user satisfies one or more conditions, such as in the case
+    /// of [restricted rooms], but the resident server would be unable to meet the authorization
+    /// rules.
+    ///
+    /// [restricted rooms]: https://spec.matrix.org/latest/client-server-api/#restricted-rooms
     UnableToGrantJoin,
 
-    /// M_UNACTIONABLE
+    /// `M_UNACTIONABLE`
+    ///
+    /// The server does not want to handle the [federated report].
+    ///
+    /// [federated report]: https://github.com/matrix-org/matrix-spec-proposals/pull/3843
     #[cfg(feature = "unstable-msc3843")]
     Unactionable,
 
-    /// M_UNAUTHORIZED
+    /// `M_UNAUTHORIZED`
+    ///
+    /// The request was not correctly authorized. Usually due to login failures.
     Unauthorized,
 
-    /// M_UNKNOWN
+    /// `M_UNKNOWN`
+    ///
+    /// An unknown error has occurred.
     Unknown,
 
-    /// M_UNKNOWN_POS for sliding sync
+    /// `M_UNKNOWN_POS`
+    ///
+    /// The sliding sync ([MSC3575] / [MSC4186]) connection was expired by the server.
+    ///
+    /// [MSC3575]: https://github.com/matrix-org/matrix-spec-proposals/pull/3575
+    /// [MSC4186]: https://github.com/matrix-org/matrix-spec-proposals/pull/4186
     #[cfg(any(feature = "unstable-msc3575", feature = "unstable-msc4186"))]
     UnknownPos,
 
-    /// M_UNKNOWN_TOKEN
+    /// `M_UNKNOWN_TOKEN`
+    ///
+    /// The [access or refresh token] specified was not recognized.
+    ///
+    /// [access or refresh token]: https://spec.matrix.org/latest/client-server-api/#client-authentication
     UnknownToken,
 
-    /// M_UNRECOGNIZED
+    /// `M_UNRECOGNIZED`
+    ///
+    /// The server did not understand the request.
+    ///
+    /// This is expected to be returned with a 404 HTTP status code if the endpoint is not
+    /// implemented or a 405 HTTP status code if the endpoint is implemented, but the incorrect
+    /// HTTP method is used.
     Unrecognized,
 
-    /// M_UNSUPPORTED_ROOM_VERSION
+    /// `M_UNSUPPORTED_ROOM_VERSION`
     UnsupportedRoomVersion,
 
-    /// M_URL_NOT_SET
+    /// `M_URL_NOT_SET`
+    ///
+    /// The application service doesn't have a URL configured.
     UrlNotSet,
 
-    /// M_USER_DEACTIVATED
+    /// `M_USER_DEACTIVATED`
+    ///
+    /// The user ID associated with the request has been deactivated.
     UserDeactivated,
 
-    /// M_USER_IN_USE
+    /// `M_USER_IN_USE`
+    ///
+    /// The desired user ID is already taken.
     UserInUse,
 
-    /// M_USER_LOCKED
+    /// `M_USER_LOCKED`
+    ///
+    /// The account has been [locked] and cannot be used at this time.
+    ///
+    /// [locked]: https://spec.matrix.org/latest/client-server-api/#account-locking
     UserLocked,
 
-    /// M_USER_SUSPENDED
+    /// `M_USER_SUSPENDED`
+    ///
+    /// The account has been [suspended] and can only be used for limited actions at this time.
+    ///
+    /// [suspended]: https://spec.matrix.org/latest/client-server-api/#account-suspension
     UserSuspended,
 
-    /// M_WEAK_PASSWORD
+    /// `M_WEAK_PASSWORD`
+    ///
+    /// The password was [rejected] by the server for being too weak.
+    ///
+    /// [rejected]: https://spec.matrix.org/latest/client-server-api/#notes-on-password-management
     WeakPassword,
 
-    /// M_WRONG_ROOM_KEYS_VERSION
+    /// `M_WRONG_ROOM_KEYS_VERSION`
+    ///
+    /// The version of the [room keys backup] provided in the request does not match the current
+    /// backup version.
+    ///
+    /// [room keys backup]: https://spec.matrix.org/latest/client-server-api/#server-side-key-backups
     WrongRoomKeysVersion,
 
     #[doc(hidden)]

--- a/crates/ruma-client-api/src/error/kind_serde.rs
+++ b/crates/ruma-client-api/src/error/kind_serde.rs
@@ -163,73 +163,9 @@ impl<'de> Visitor<'de> for ErrorKindVisitor {
         let extra = Extra(extra);
 
         Ok(match errcode {
-            ErrorCode::Forbidden => ErrorKind::forbidden(),
-            ErrorCode::UnknownToken => ErrorKind::UnknownToken {
-                soft_logout: soft_logout
-                    .map(from_json_value)
-                    .transpose()
-                    .map_err(de::Error::custom)?
-                    .unwrap_or_default(),
-            },
-            ErrorCode::MissingToken => ErrorKind::MissingToken,
-            ErrorCode::BadJson => ErrorKind::BadJson,
-            ErrorCode::NotJson => ErrorKind::NotJson,
-            ErrorCode::NotFound => ErrorKind::NotFound,
-            ErrorCode::LimitExceeded => ErrorKind::LimitExceeded {
-                retry_after: retry_after_ms
-                    .map(from_json_value::<UInt>)
-                    .transpose()
-                    .map_err(de::Error::custom)?
-                    .map(Into::into)
-                    .map(Duration::from_millis)
-                    .map(RetryAfter::Delay),
-            },
-            ErrorCode::Unknown => ErrorKind::Unknown,
-            ErrorCode::Unrecognized => ErrorKind::Unrecognized,
-            ErrorCode::Unauthorized => ErrorKind::Unauthorized,
-            ErrorCode::UserDeactivated => ErrorKind::UserDeactivated,
-            ErrorCode::UserInUse => ErrorKind::UserInUse,
-            ErrorCode::InvalidUsername => ErrorKind::InvalidUsername,
-            ErrorCode::RoomInUse => ErrorKind::RoomInUse,
-            ErrorCode::InvalidRoomState => ErrorKind::InvalidRoomState,
-            ErrorCode::ThreepidInUse => ErrorKind::ThreepidInUse,
-            ErrorCode::ThreepidNotFound => ErrorKind::ThreepidNotFound,
-            ErrorCode::ThreepidAuthFailed => ErrorKind::ThreepidAuthFailed,
-            ErrorCode::ThreepidDenied => ErrorKind::ThreepidDenied,
-            ErrorCode::ThreepidMediumNotSupported => ErrorKind::ThreepidMediumNotSupported,
-            ErrorCode::ServerNotTrusted => ErrorKind::ServerNotTrusted,
-            ErrorCode::UnsupportedRoomVersion => ErrorKind::UnsupportedRoomVersion,
-            ErrorCode::IncompatibleRoomVersion => ErrorKind::IncompatibleRoomVersion {
-                room_version: from_json_value(
-                    room_version.ok_or_else(|| de::Error::missing_field("room_version"))?,
-                )
-                .map_err(de::Error::custom)?,
-            },
-            ErrorCode::BadState => ErrorKind::BadState,
-            ErrorCode::GuestAccessForbidden => ErrorKind::GuestAccessForbidden,
-            ErrorCode::CaptchaNeeded => ErrorKind::CaptchaNeeded,
-            ErrorCode::CaptchaInvalid => ErrorKind::CaptchaInvalid,
-            ErrorCode::MissingParam => ErrorKind::MissingParam,
-            ErrorCode::InvalidParam => ErrorKind::InvalidParam,
-            ErrorCode::TooLarge => ErrorKind::TooLarge,
-            ErrorCode::Exclusive => ErrorKind::Exclusive,
-            ErrorCode::ResourceLimitExceeded => ErrorKind::ResourceLimitExceeded {
-                admin_contact: from_json_value(
-                    admin_contact.ok_or_else(|| de::Error::missing_field("admin_contact"))?,
-                )
-                .map_err(de::Error::custom)?,
-            },
-            ErrorCode::CannotLeaveServerNoticeRoom => ErrorKind::CannotLeaveServerNoticeRoom,
-            ErrorCode::WeakPassword => ErrorKind::WeakPassword,
-            ErrorCode::UnableToAuthorizeJoin => ErrorKind::UnableToAuthorizeJoin,
-            ErrorCode::UnableToGrantJoin => ErrorKind::UnableToGrantJoin,
             ErrorCode::BadAlias => ErrorKind::BadAlias,
-            ErrorCode::DuplicateAnnotation => ErrorKind::DuplicateAnnotation,
-            ErrorCode::NotYetUploaded => ErrorKind::NotYetUploaded,
-            ErrorCode::CannotOverwriteMedia => ErrorKind::CannotOverwriteMedia,
-            #[cfg(any(feature = "unstable-msc3575", feature = "unstable-msc4186"))]
-            ErrorCode::UnknownPos => ErrorKind::UnknownPos,
-            ErrorCode::UrlNotSet => ErrorKind::UrlNotSet,
+            ErrorCode::BadJson => ErrorKind::BadJson,
+            ErrorCode::BadState => ErrorKind::BadState,
             ErrorCode::BadStatus => ErrorKind::BadStatus {
                 status: status
                     .map(|s| {
@@ -241,18 +177,82 @@ impl<'de> Visitor<'de> for ErrorKindVisitor {
                     .transpose()?,
                 body: body.map(from_json_value).transpose().map_err(de::Error::custom)?,
             },
+            ErrorCode::CannotLeaveServerNoticeRoom => ErrorKind::CannotLeaveServerNoticeRoom,
+            ErrorCode::CannotOverwriteMedia => ErrorKind::CannotOverwriteMedia,
+            ErrorCode::CaptchaInvalid => ErrorKind::CaptchaInvalid,
+            ErrorCode::CaptchaNeeded => ErrorKind::CaptchaNeeded,
             ErrorCode::ConnectionFailed => ErrorKind::ConnectionFailed,
             ErrorCode::ConnectionTimeout => ErrorKind::ConnectionTimeout,
+            ErrorCode::DuplicateAnnotation => ErrorKind::DuplicateAnnotation,
+            ErrorCode::Exclusive => ErrorKind::Exclusive,
+            ErrorCode::Forbidden => ErrorKind::forbidden(),
+            ErrorCode::GuestAccessForbidden => ErrorKind::GuestAccessForbidden,
+            ErrorCode::IncompatibleRoomVersion => ErrorKind::IncompatibleRoomVersion {
+                room_version: from_json_value(
+                    room_version.ok_or_else(|| de::Error::missing_field("room_version"))?,
+                )
+                .map_err(de::Error::custom)?,
+            },
+            ErrorCode::InvalidParam => ErrorKind::InvalidParam,
+            ErrorCode::InvalidRoomState => ErrorKind::InvalidRoomState,
+            ErrorCode::InvalidUsername => ErrorKind::InvalidUsername,
+            ErrorCode::LimitExceeded => ErrorKind::LimitExceeded {
+                retry_after: retry_after_ms
+                    .map(from_json_value::<UInt>)
+                    .transpose()
+                    .map_err(de::Error::custom)?
+                    .map(Into::into)
+                    .map(Duration::from_millis)
+                    .map(RetryAfter::Delay),
+            },
+            ErrorCode::MissingParam => ErrorKind::MissingParam,
+            ErrorCode::MissingToken => ErrorKind::MissingToken,
+            ErrorCode::NotFound => ErrorKind::NotFound,
+            ErrorCode::NotJson => ErrorKind::NotJson,
+            ErrorCode::NotYetUploaded => ErrorKind::NotYetUploaded,
+            ErrorCode::ResourceLimitExceeded => ErrorKind::ResourceLimitExceeded {
+                admin_contact: from_json_value(
+                    admin_contact.ok_or_else(|| de::Error::missing_field("admin_contact"))?,
+                )
+                .map_err(de::Error::custom)?,
+            },
+            ErrorCode::RoomInUse => ErrorKind::RoomInUse,
+            ErrorCode::ServerNotTrusted => ErrorKind::ServerNotTrusted,
+            ErrorCode::ThreepidAuthFailed => ErrorKind::ThreepidAuthFailed,
+            ErrorCode::ThreepidDenied => ErrorKind::ThreepidDenied,
+            ErrorCode::ThreepidInUse => ErrorKind::ThreepidInUse,
+            ErrorCode::ThreepidMediumNotSupported => ErrorKind::ThreepidMediumNotSupported,
+            ErrorCode::ThreepidNotFound => ErrorKind::ThreepidNotFound,
+            ErrorCode::TooLarge => ErrorKind::TooLarge,
+            ErrorCode::UnableToAuthorizeJoin => ErrorKind::UnableToAuthorizeJoin,
+            ErrorCode::UnableToGrantJoin => ErrorKind::UnableToGrantJoin,
+            #[cfg(feature = "unstable-msc3843")]
+            ErrorCode::Unactionable => ErrorKind::Unactionable,
+            ErrorCode::Unauthorized => ErrorKind::Unauthorized,
+            ErrorCode::Unknown => ErrorKind::Unknown,
+            #[cfg(any(feature = "unstable-msc3575", feature = "unstable-msc4186"))]
+            ErrorCode::UnknownPos => ErrorKind::UnknownPos,
+            ErrorCode::UnknownToken => ErrorKind::UnknownToken {
+                soft_logout: soft_logout
+                    .map(from_json_value)
+                    .transpose()
+                    .map_err(de::Error::custom)?
+                    .unwrap_or_default(),
+            },
+            ErrorCode::Unrecognized => ErrorKind::Unrecognized,
+            ErrorCode::UnsupportedRoomVersion => ErrorKind::UnsupportedRoomVersion,
+            ErrorCode::UrlNotSet => ErrorKind::UrlNotSet,
+            ErrorCode::UserDeactivated => ErrorKind::UserDeactivated,
+            ErrorCode::UserInUse => ErrorKind::UserInUse,
+            ErrorCode::UserLocked => ErrorKind::UserLocked,
+            ErrorCode::UserSuspended => ErrorKind::UserSuspended,
+            ErrorCode::WeakPassword => ErrorKind::WeakPassword,
             ErrorCode::WrongRoomKeysVersion => ErrorKind::WrongRoomKeysVersion {
                 current_version: from_json_value(
                     current_version.ok_or_else(|| de::Error::missing_field("current_version"))?,
                 )
                 .map_err(de::Error::custom)?,
             },
-            #[cfg(feature = "unstable-msc3843")]
-            ErrorCode::Unactionable => ErrorKind::Unactionable,
-            ErrorCode::UserLocked => ErrorKind::UserLocked,
-            ErrorCode::UserSuspended => ErrorKind::UserSuspended,
             ErrorCode::_Custom(errcode) => ErrorKind::_Custom { errcode, extra },
         })
     }


### PR DESCRIPTION
Based on #1978, because it touches the same code. I did not make a single PR because this one will fail because of a link in the docs to a section that will be added in Matrix 1.13.

The first commit sorts the variants: given that there are a lot of them, at this point it is easier to find a variant if they are sorted.

The second commit add docs for all those variants. It adds even more duplication between `ErrorKind` and `ErrorCode`, oh well.