### PR TITLE
events: Add unstable support for `is_animated` image flag

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -13,6 +13,10 @@ Breaking changes:
     event.
   - `make_replacement` does not take the replied-to message anymore.
 
+Improvements:
+
+- Add unstable support for the `is_animated` flag for images, according to MSC4230.
+
 # 0.30.0
 
 Breaking changes:

--- a/crates/ruma-events/Cargo.toml
+++ b/crates/ruma-events/Cargo.toml
@@ -43,6 +43,7 @@ unstable-msc3956 = ["unstable-msc1767"]
 unstable-msc4075 = ["unstable-msc3401"]
 unstable-msc4095 = []
 unstable-msc4171 = []
+unstable-msc4230 = []
 unstable-pdu = []
 
 # Allow some mandatory fields to be missing, defaulting them to an empty string

--- a/crates/ruma-events/src/room.rs
+++ b/crates/ruma-events/src/room.rs
@@ -104,6 +104,15 @@ pub struct ImageInfo {
     #[cfg(feature = "unstable-msc2448")]
     #[serde(rename = "xyz.amorgan.blurhash", skip_serializing_if = "Option::is_none")]
     pub blurhash: Option<String>,
+
+    /// Whether the image is animated.
+    ///
+    /// This uses the unstable prefix in [MSC4230].
+    ///
+    /// [MSC4230]: https://github.com/matrix-org/matrix-spec-proposals/pull/4230
+    #[cfg(feature = "unstable-msc4230")]
+    #[serde(rename = "org.matrix.msc4230.is_animated", skip_serializing_if = "Option::is_none")]
+    pub is_animated: Option<bool>,
 }
 
 impl ImageInfo {

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -221,6 +221,7 @@ unstable-msc4140 = ["ruma-client-api?/unstable-msc4140"]
 unstable-msc4151 = ["ruma-client-api?/unstable-msc4151"]
 unstable-msc4171 = ["ruma-events?/unstable-msc4171"]
 unstable-msc4186 = ["ruma-client-api?/unstable-msc4186"]
+unstable-msc4230 = ["ruma-events?/unstable-msc4230"]
 unstable-pdu = ["ruma-events?/unstable-pdu"]
 unstable-unspecified = [
     "ruma-common/unstable-unspecified",
@@ -275,6 +276,7 @@ __unstable-mscs = [
     "unstable-msc4151",
     "unstable-msc4171",
     "unstable-msc4186",
+    "unstable-msc4230",
 ]
 __ci = [
     "full",


### PR DESCRIPTION
According to [MSC4230](https://github.com/matrix-org/matrix-spec-proposals/pull/4230).

