### PR TITLE
client-api: Fix deserialization of `KnockedRoom`

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -8,6 +8,12 @@ Breaking changes:
   same result, use `ErrorKind::errcode()`. The `ErrorCode` that is returned
   implements those traits.
 
+Bug fixes:
+
+- `knock_state` in `KnockedRoom` and `events` in `KnockState` are no longer
+  required during deserialization and are no longer serialized if they are empty.
+  This was a deviation from the spec, those fields were never required.
+
 Improvements:
 
 - Add unstable support for reporting rooms, according to MSC4151.

--- a/crates/ruma-client-api/src/sync/sync_events/v3.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v3.rs
@@ -316,20 +316,52 @@ impl JoinedRoom {
     }
 }
 
-/// Updates to knocked rooms.
+/// Updates to a room that the user has knocked upon.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct KnockedRoom {
-    /// The knock state.
+    /// Updates to the stripped state of the room.
+    #[serde(default, skip_serializing_if = "KnockState::is_empty")]
     pub knock_state: KnockState,
 }
 
-/// A mapping from a key `events` to a list of `StrippedStateEvent`.
+impl KnockedRoom {
+    /// Creates an empty `KnockedRoom`.
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Whether there are updates for this room.
+    pub fn is_empty(&self) -> bool {
+        self.knock_state.is_empty()
+    }
+}
+
+impl From<KnockState> for KnockedRoom {
+    fn from(knock_state: KnockState) -> Self {
+        KnockedRoom { knock_state, ..Default::default() }
+    }
+}
+
+/// Stripped state updates of a room that the user has knocked upon.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct KnockState {
-    /// The list of events.
+    /// The stripped state of a room that the user has knocked upon.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub events: Vec<Raw<AnyStrippedStateEvent>>,
+}
+
+impl KnockState {
+    /// Creates an empty `KnockState`.
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Whether there are stripped state updates in this room.
+    pub fn is_empty(&self) -> bool {
+        self.events.is_empty()
+    }
 }
 
 /// Events in the room.


### PR DESCRIPTION
`knock_state` in `KnockedRoom` and `events` in `KnockState` are no longer required during deserialization and are no longer serialized if they are empty.

This was a deviation from the spec, those fields were never required.

I also improved the docs and added constructors to both types. They could be constructed because they derive `Default`, but we usually have constructors for all types.
