### PR TITLE
Add support for new dehydrated device format

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -1,5 +1,7 @@
 # [unreleased]
 
+Improvements:
+
 - Add support for new dehydration format, according to the latest draft of
   MSC3814.
 

--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -1,5 +1,8 @@
 # [unreleased]
 
+- Add support for new dehydration format, according to the latest draft of
+  MSC3814.
+
 # 0.20.0
 
 Breaking changes:

--- a/crates/ruma-client-api/src/dehydrated_device.rs
+++ b/crates/ruma-client-api/src/dehydrated_device.rs
@@ -17,6 +17,8 @@ pub mod put_dehydrated_device;
 pub enum DehydratedDeviceData {
     /// The `org.matrix.msc3814.v1.olm` variant of a dehydrated device.
     V1(DehydratedDeviceV1),
+    /// The `org.matrix.msc3814.v2` variant of a dehydrated device.
+    V2(DehydratedDeviceV2),
 }
 
 impl DehydratedDeviceData {
@@ -24,6 +26,7 @@ impl DehydratedDeviceData {
     pub fn algorithm(&self) -> DeviceDehydrationAlgorithm {
         match self {
             DehydratedDeviceData::V1(_) => DeviceDehydrationAlgorithm::V1,
+            DehydratedDeviceData::V2(_) => DeviceDehydrationAlgorithm::V2,
         }
     }
 }
@@ -46,6 +49,26 @@ impl DehydratedDeviceV1 {
     }
 }
 
+/// The `org.matrix.msc3814.v2` variant of a dehydrated device.
+#[derive(Clone, Debug)]
+#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+pub struct DehydratedDeviceV2 {
+    /// The pickle of the `Olm` account of the device.
+    ///
+    /// The pickle will contain the private parts of the long-term identity keys of the device as
+    /// well as a collection of one-time keys.
+    pub device_pickle: String,
+    /// The nonce used to encrypt the pickle.
+    pub nonce: String,
+}
+
+impl DehydratedDeviceV2 {
+    /// Create a [`DehydratedDeviceV2`] struct from a device pickle.
+    pub fn new(device_pickle: String, nonce: String) -> Self {
+        Self { device_pickle, nonce }
+    }
+}
+
 /// The algorithms used for dehydrated devices.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
 #[derive(Clone, PartialEq, Eq, StringEnum)]
@@ -54,6 +77,9 @@ pub enum DeviceDehydrationAlgorithm {
     /// The `org.matrix.msc3814.v1.olm` device dehydration algorithm.
     #[ruma_enum(rename = "org.matrix.msc3814.v1.olm")]
     V1,
+    /// The `org.matrix.msc3814.v2` device dehydration algorithm.
+    #[ruma_enum(rename = "org.matrix.msc3814.v2")]
+    V2,
     #[doc(hidden)]
     _Custom(PrivOwnedStr),
 }
@@ -62,6 +88,8 @@ pub enum DeviceDehydrationAlgorithm {
 struct Helper {
     algorithm: DeviceDehydrationAlgorithm,
     device_pickle: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    nonce: Option<String>,
 }
 
 impl TryFrom<Helper> for DehydratedDeviceData {
@@ -71,6 +99,10 @@ impl TryFrom<Helper> for DehydratedDeviceData {
         match value.algorithm {
             DeviceDehydrationAlgorithm::V1 => Ok(DehydratedDeviceData::V1(DehydratedDeviceV1 {
                 device_pickle: value.device_pickle,
+            })),
+            DeviceDehydrationAlgorithm::V2 => Ok(DehydratedDeviceData::V2(DehydratedDeviceV2 {
+                device_pickle: value.device_pickle,
+                nonce: value.nonce.ok_or(serde::de::Error::custom("Missing nonce in v2 dehydrated device."))?,
             })),
             _ => Err(serde::de::Error::custom("Unsupported device dehydration algorithm.")),
         }
@@ -82,7 +114,8 @@ impl From<DehydratedDeviceData> for Helper {
         let algorithm = value.algorithm();
 
         match value {
-            DehydratedDeviceData::V1(d) => Self { algorithm, device_pickle: d.device_pickle },
+            DehydratedDeviceData::V1(d) => Self { algorithm, device_pickle: d.device_pickle, nonce: None },
+            DehydratedDeviceData::V2(d) => Self { algorithm, device_pickle: d.device_pickle, nonce: Some(d.nonce) },
         }
     }
 }

--- a/crates/ruma-client-api/src/dehydrated_device.rs
+++ b/crates/ruma-client-api/src/dehydrated_device.rs
@@ -51,7 +51,7 @@ impl DehydratedDeviceV1 {
 
 /// The `org.matrix.msc3814.v2` variant of a dehydrated device.
 #[derive(Clone, Debug)]
-#[cfg_attr(not(feature = "unstable-exhaustive-types"), non_exhaustive)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct DehydratedDeviceV2 {
     /// The pickle of the `Olm` account of the device.
     ///
@@ -102,7 +102,9 @@ impl TryFrom<Helper> for DehydratedDeviceData {
             })),
             DeviceDehydrationAlgorithm::V2 => Ok(DehydratedDeviceData::V2(DehydratedDeviceV2 {
                 device_pickle: value.device_pickle,
-                nonce: value.nonce.ok_or(serde::de::Error::custom("Missing nonce in v2 dehydrated device."))?,
+                nonce: value
+                    .nonce
+                    .ok_or(serde::de::Error::custom("Missing nonce in v2 dehydrated device."))?,
             })),
             _ => Err(serde::de::Error::custom("Unsupported device dehydration algorithm.")),
         }
@@ -114,8 +116,12 @@ impl From<DehydratedDeviceData> for Helper {
         let algorithm = value.algorithm();
 
         match value {
-            DehydratedDeviceData::V1(d) => Self { algorithm, device_pickle: d.device_pickle, nonce: None },
-            DehydratedDeviceData::V2(d) => Self { algorithm, device_pickle: d.device_pickle, nonce: Some(d.nonce) },
+            DehydratedDeviceData::V1(d) => {
+                Self { algorithm, device_pickle: d.device_pickle, nonce: None }
+            }
+            DehydratedDeviceData::V2(d) => {
+                Self { algorithm, device_pickle: d.device_pickle, nonce: Some(d.nonce) }
+            }
         }
     }
 }


### PR DESCRIPTION
The latest version of [MSC3814](https://github.com/matrix-org/matrix-spec-proposals/pull/3814) specifies a new format for dehydrated devices, adding a new field and bumping the algorithm name.  This PR adds support for this.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
