### PR TITLE
xtask: Fix finding changes when version title exists in changelog

### DIFF
--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -173,18 +173,18 @@ impl Package {
             ..self.version.clone()
         };
 
-        let update = if changelog.contains(&format!("# {version}\n")) {
-            false
+        let (update, title_start) = if let Some(pos) = changelog.find(&format!("# {version}\n")) {
+            (false, pos)
         } else if changelog.starts_with(&format!("# {version} (unreleased)\n"))
             || changelog.starts_with("# [unreleased]\n")
         {
-            update
+            (update, 0)
         } else {
             return Err("Could not find version title in changelog".into());
         };
 
-        let changes_start = match changelog.find('\n') {
-            Some(p) => p + 1,
+        let changes_start = match changelog[title_start..].find('\n') {
+            Some(p) => title_start + p + 1,
             None => {
                 return Err("Could not find end of version title in changelog".into());
             }

--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -76,11 +76,15 @@ impl ReleaseTask {
             ["ruma-identifiers-validation", "ruma-macros"].contains(&self.package.name.as_str());
 
         println!(
-            "Starting {} for {title}…",
+            "Starting {}{} for {title}…",
             match prerelease {
                 true => "pre-release",
                 false => "release",
             },
+            match self.dry_run {
+                true => " dry run",
+                false => "",
+            }
         );
 
         if self.is_released()? {
@@ -120,6 +124,10 @@ impl ReleaseTask {
         };
 
         let changes = &self.package.changes(&self.sh, !prerelease && !self.dry_run)?;
+
+        if self.dry_run {
+            println!("Changes:\n{changes}");
+        }
 
         if create_commit {
             self.commit()?;


### PR DESCRIPTION
We were always assuming that the content of the changes were after the first title in the changelog, which is not always true, e.g. if the changelog was updated in an incomplete previous call to `xtask release` the first title would be `# [unreleased]` and the next one would be the title we are interested in. So we use the position of the title that we are interested in to find the position of the changes.

The second small commit here provides more helpful logs when using the `--dry-run` option.

Fixes #1703.