### PR TITLE
events(fix): add mentions in the plain edit event when replacing an event with no initial mentions

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -13,6 +13,11 @@ Breaking changes:
     event.
   - `make_replacement` does not take the replied-to message anymore.
 
+Bug fixes:
+
+- `make_replacement` now correctly sets the mentions on the plain replacement event, when the
+  edited event had no initial mentions.
+
 Improvements:
 
 - Add unstable support for the `is_animated` flag for images, according to MSC4230.

--- a/crates/ruma-events/src/room/message/without_relation.rs
+++ b/crates/ruma-events/src/room/message/without_relation.rs
@@ -199,22 +199,25 @@ impl RoomMessageEventContentWithoutRelation {
 
         // Only set mentions that were not there before.
         if let Some(mentions) = &mentions {
-            let new_mentions = metadata.mentions.map(|old_mentions| {
-                let mut new_mentions = Mentions::new();
+            let new_mentions = metadata
+                .mentions
+                .map(|old_mentions| {
+                    let mut new_mentions = Mentions::new();
 
-                new_mentions.user_ids = mentions
-                    .user_ids
-                    .iter()
-                    .filter(|u| !old_mentions.user_ids.contains(*u))
-                    .cloned()
-                    .collect();
+                    new_mentions.user_ids = mentions
+                        .user_ids
+                        .iter()
+                        .filter(|u| !old_mentions.user_ids.contains(*u))
+                        .cloned()
+                        .collect();
 
-                new_mentions.room = mentions.room && !old_mentions.room;
+                    new_mentions.room = mentions.room && !old_mentions.room;
 
-                new_mentions
-            });
+                    new_mentions
+                })
+                .unwrap_or_else(|| mentions.clone());
 
-            self.mentions = new_mentions;
+            self.mentions = Some(new_mentions);
         };
 
         // Prepare relates_to with the untouched msgtype.


### PR DESCRIPTION
When creating a replacement event, there are two places where we set mentions, if provided:

- on the event content itself,
- on the `m.new_content` field.

Mentions are fully included in the `m.new_content` variant, but for the event content itself, mentions that were already present were filtered out. Unfortunately, this code was no correct when the original event had no mentions at all: in this case, the mentions present in the event content itself would be empty, because of a lack of a special case in the code handling those mentions.

The new test introduced acts as a regression test; it fails on `main` at line 869, because mentions are set to `None` there.

Found while working on https://github.com/matrix-org/matrix-rust-sdk/pull/4464.