### PR TITLE
client-api: Use `AuthType` in `get_uiaa_fallback_page`'s Request

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [unreleased]
 
+Breaking changes:
+
+- Use `AuthType` for the `auth_type` of `get_uiaa_fallback_page`'s Request.
+
 Improvements:
 
 - Add support for new dehydration format, according to the latest draft of

--- a/crates/ruma-client-api/src/uiaa/get_uiaa_fallback_page.rs
+++ b/crates/ruma-client-api/src/uiaa/get_uiaa_fallback_page.rs
@@ -12,6 +12,8 @@ pub mod v3 {
         metadata,
     };
 
+    use crate::uiaa::AuthType;
+
     const METADATA: Metadata = metadata! {
         method: GET,
         rate_limited: false,
@@ -25,9 +27,9 @@ pub mod v3 {
     /// Request type for the `authorize_fallback` endpoint.
     #[request(error = crate::Error)]
     pub struct Request {
-        /// The type name ("m.login.dummy", etc.) of the uiaa stage to get a fallback page for.
+        /// The type name (`m.login.dummy`, etc.) of the UIAA stage to get a fallback page for.
         #[ruma_api(path)]
-        pub auth_type: String,
+        pub auth_type: AuthType,
 
         /// The ID of the session given by the homeserver.
         #[ruma_api(query)]
@@ -36,7 +38,7 @@ pub mod v3 {
 
     impl Request {
         /// Creates a new `Request` with the given auth type and session ID.
-        pub fn new(auth_type: String, session: String) -> Self {
+        pub fn new(auth_type: AuthType, session: String) -> Self {
             Self { auth_type, session }
         }
     }


### PR DESCRIPTION
Since the `auth_type` should come from [`AuthData::auth_type()`](https://docs.ruma.dev/ruma/api/client/uiaa/enum.AuthData.html#method.auth_type), it makes sense to use the same type.
