### PR TITLE
federation-api: Remove `origin` field in `create_join_event` response

### DIFF
--- a/crates/ruma-federation-api/CHANGELOG.md
+++ b/crates/ruma-federation-api/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [unreleased]
 
+Breaking changes:
+
+- Remove the `origin` field in `create_join_event::{v1/v2}::RoomState` due to a
+  clarification in the spec.
+
 # 0.11.0
 
 Improvements:

--- a/crates/ruma-federation-api/src/membership/create_join_event/v1.rs
+++ b/crates/ruma-federation-api/src/membership/create_join_event/v1.rs
@@ -65,13 +65,9 @@ impl Response {
 }
 
 /// Full state of the room.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct RoomState {
-    #[cfg(not(feature = "unstable-unspecified"))]
-    /// The resident server's DNS name.
-    pub origin: String,
-
     /// The full set of authorization events that make up the state of the room,
     /// and their authorization events, recursively.
     pub auth_chain: Vec<Box<RawJsonValue>>,
@@ -87,29 +83,9 @@ pub struct RoomState {
     pub event: Option<Box<RawJsonValue>>,
 }
 
-#[cfg(feature = "unstable-unspecified")]
-impl Default for RoomState {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl RoomState {
-    #[cfg(not(feature = "unstable-unspecified"))]
-    /// Creates an empty `RoomState` with the given `origin`.
-    ///
-    /// With the `unstable-unspecified` feature, this method doesn't take any parameters.
-    /// See [matrix-spec#374](https://github.com/matrix-org/matrix-spec/issues/374).
-    pub fn new(origin: String) -> Self {
-        Self { origin, auth_chain: Vec::new(), state: Vec::new(), event: None }
-    }
-
-    #[cfg(feature = "unstable-unspecified")]
-    /// Creates an empty `RoomState` with the given `origin`.
-    ///
-    /// Without the `unstable-unspecified` feature, this method takes a parameter for the origin.
-    /// See [matrix-spec#374](https://github.com/matrix-org/matrix-spec/issues/374).
+    /// Creates an empty `RoomState`.
     pub fn new() -> Self {
-        Self { auth_chain: Vec::new(), state: Vec::new(), event: None }
+        Self::default()
     }
 }

--- a/crates/ruma-federation-api/src/membership/create_join_event/v2.rs
+++ b/crates/ruma-federation-api/src/membership/create_join_event/v2.rs
@@ -76,13 +76,9 @@ impl Response {
 }
 
 /// Full state of the room.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct RoomState {
-    #[cfg(not(feature = "unstable-unspecified"))]
-    /// The resident server's DNS name.
-    pub origin: String,
-
     /// Whether `m.room.member` events have been omitted from `state`.
     ///
     /// Defaults to `false`.
@@ -118,42 +114,9 @@ pub struct RoomState {
     pub servers_in_room: Option<Vec<String>>,
 }
 
-#[cfg(feature = "unstable-unspecified")]
-impl Default for RoomState {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl RoomState {
-    #[cfg(not(feature = "unstable-unspecified"))]
-    /// Creates an empty `RoomState` with the given `origin`.
-    ///
-    /// With the `unstable-unspecified` feature, this method doesn't take any parameters.
-    /// See [matrix-spec#374](https://github.com/matrix-org/matrix-spec/issues/374).
-    pub fn new(origin: String) -> Self {
-        Self {
-            origin,
-            auth_chain: Vec::new(),
-            state: Vec::new(),
-            event: None,
-            members_omitted: false,
-            servers_in_room: None,
-        }
-    }
-
-    #[cfg(feature = "unstable-unspecified")]
-    /// Creates an empty `RoomState` with the given `origin`.
-    ///
-    /// Without the `unstable-unspecified` feature, this method takes a parameter for the origin.
-    /// See [matrix-spec#374](https://github.com/matrix-org/matrix-spec/issues/374).
+    /// Creates an empty `RoomState`.
     pub fn new() -> Self {
-        Self {
-            auth_chain: Vec::new(),
-            state: Vec::new(),
-            event: None,
-            members_omitted: false,
-            servers_in_room: None,
-        }
+        Self::default()
     }
 }

--- a/crates/ruma-federation-api/src/serde/v1_pdu.rs
+++ b/crates/ruma-federation-api/src/serde/v1_pdu.rs
@@ -67,7 +67,6 @@ where
     }
 }
 
-#[cfg(not(feature = "unstable-unspecified"))]
 #[cfg(test)]
 mod tests {
     use assert_matches2::assert_matches;
@@ -82,15 +81,13 @@ mod tests {
         let response = json!([
             200,
             {
-                "origin": "example.com",
                 "auth_chain": [],
                 "state": []
             }
         ]);
 
         #[allow(deprecated)]
-        let RoomState { origin, auth_chain, state, event } = deserialize(response).unwrap();
-        assert_eq!(origin, "example.com");
+        let RoomState { auth_chain, state, event } = deserialize(response).unwrap();
         assert_matches!(auth_chain.as_slice(), []);
         assert_matches!(state.as_slice(), []);
         assert_matches!(event, None);
@@ -99,19 +96,13 @@ mod tests {
     #[test]
     fn serialize_response() {
         #[allow(deprecated)]
-        let room_state = RoomState {
-            origin: "matrix.org".into(),
-            auth_chain: Vec::new(),
-            state: Vec::new(),
-            event: None,
-        };
+        let room_state = RoomState { auth_chain: Vec::new(), state: Vec::new(), event: None };
 
         let serialized = serialize(&room_state, serde_json::value::Serializer).unwrap();
         let expected = json!(
             [
                 200,
                 {
-                    "origin": "matrix.org",
                     "auth_chain": [],
                     "state": []
                 }
@@ -150,10 +141,9 @@ mod tests {
 
     #[test]
     fn too_long_array() {
-        let json = json!([200, { "origin": "", "auth_chain": [], "state": [] }, 200]);
+        let json = json!([200, { "auth_chain": [], "state": [] }, 200]);
         #[allow(deprecated)]
-        let RoomState { origin, auth_chain, state, event } = deserialize(json).unwrap();
-        assert_eq!(origin, "");
+        let RoomState { auth_chain, state, event } = deserialize(json).unwrap();
         assert_matches!(auth_chain.as_slice(), []);
         assert_matches!(state.as_slice(), []);
         assert_matches!(event, None);

--- a/crates/ruma-federation-api/tests/it/membership/create_join_event.rs
+++ b/crates/ruma-federation-api/tests/it/membership/create_join_event.rs
@@ -1,5 +1,5 @@
 #[allow(deprecated)]
-#[cfg(all(feature = "server", not(feature = "unstable-unspecified")))]
+#[cfg(feature = "server")]
 mod v1 {
     use ruma_common::api::OutgoingResponse;
     use ruma_federation_api::membership::create_join_event::v1::{Response, RoomState};
@@ -7,13 +7,11 @@ mod v1 {
 
     #[test]
     fn response_body() {
-        let res = Response::new(RoomState::new("ORIGIN".to_owned()))
-            .try_into_http_response::<Vec<u8>>()
-            .unwrap();
+        let res = Response::new(RoomState::new()).try_into_http_response::<Vec<u8>>().unwrap();
 
         assert_eq!(
             from_json_slice::<JsonValue>(res.body()).unwrap(),
-            json!([200, { "auth_chain": [], "origin": "ORIGIN", "state": [] }])
+            json!([200, { "auth_chain": [], "state": [] }])
         );
     }
 }


### PR DESCRIPTION
I opened a clarification in the spec which will hopefully stick : https://github.com/matrix-org/matrix-spec/pull/2050.

Even if it doesn't stick, in its current state the implementation around this field is problematic because it makes `unstable-unspecified` non-additive so we need a better solution.