### PR TITLE
events: Add `is_redacted` accessor to event enums

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -22,6 +22,8 @@ Improvements:
 
 - Add unstable support for the `is_animated` flag for images, according to MSC4230.
 - Add unstable support for MSC2545 for image packs.
+- Add `is_redacted()` accessor to `Any(Sync){MessageLike/State}Event` event enums
+  to know if an event is redacted without needing to clone its content.
 
 # 0.30.0
 

--- a/crates/ruma-events/tests/it/enums.rs
+++ b/crates/ruma-events/tests/it/enums.rs
@@ -169,7 +169,7 @@ fn aliases_event_sync_deserialization() {
 }
 
 #[test]
-fn message_room_event_deserialization() {
+fn message_event_deserialization() {
     let json_data = message_event();
 
     assert_matches!(
@@ -201,7 +201,7 @@ fn message_event_serialization() {
 }
 
 #[test]
-fn alias_room_event_deserialization() {
+fn alias_event_deserialization() {
     let json_data = aliases_event();
 
     assert_matches!(
@@ -238,37 +238,6 @@ fn custom_state_event_deserialization() {
     );
     assert!(!state_ev.is_redacted());
     assert_eq!(state_ev.event_id(), "$h29iv0s8:example.com");
-}
-
-#[test]
-fn message_event_deserialization() {
-    let json_data = message_event();
-
-    assert_matches!(
-        from_json_value::<AnyTimelineEvent>(json_data),
-        Ok(AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::RoomMessage(
-            MessageLikeEvent::Original(OriginalMessageLikeEvent {
-                content: RoomMessageEventContent { msgtype: MessageType::Text(text_content), .. },
-                ..
-            })
-        )))
-    );
-    assert_eq!(text_content.body, "baba");
-    let formatted = text_content.formatted.unwrap();
-    assert_eq!(formatted.body, "<strong>baba</strong>");
-}
-
-#[test]
-fn alias_event_deserialization() {
-    let json_data = aliases_event();
-
-    assert_matches!(
-        from_json_value::<AnyTimelineEvent>(json_data),
-        Ok(AnyTimelineEvent::State(AnyStateEvent::RoomAliases(StateEvent::Original(
-            OriginalStateEvent { content: RoomAliasesEventContent { aliases, .. }, .. }
-        ))))
-    );
-    assert_eq!(aliases, vec![room_alias_id!("#somewhere:localhost")]);
 }
 
 #[test]

--- a/crates/ruma-events/tests/it/redacted.rs
+++ b/crates/ruma-events/tests/it/redacted.rs
@@ -47,10 +47,11 @@ fn redacted_aliases_event_serialize_with_content() {
 }
 
 #[test]
-fn deserialize_redacted_aliases() {
+fn deserialize_redacted_state() {
     let redacted = json!({
         "content": {},
         "event_id": "$h29iv0s8:example.com",
+        "room_id": "!roomid:room.com",
         "origin_server_ts": 1,
         "sender": "@carl:example.com",
         "state_key": "hello",
@@ -60,16 +61,17 @@ fn deserialize_redacted_aliases() {
 
     assert_matches!(
         from_json_value::<AnySyncTimelineEvent>(redacted),
-        Ok(AnySyncTimelineEvent::State(AnySyncStateEvent::RoomAliases(SyncStateEvent::Redacted(
-            redacted
-        ),)))
+        Ok(AnySyncTimelineEvent::State(event))
     );
+    assert!(event.is_redacted());
+
+    assert_matches!(event, AnySyncStateEvent::RoomAliases(SyncStateEvent::Redacted(redacted)));
     assert_eq!(redacted.event_id, "$h29iv0s8:example.com");
     assert_eq!(redacted.content.aliases, None);
 }
 
 #[test]
-fn deserialize_redacted_any_room() {
+fn deserialize_redacted_message_like() {
     let redacted = json!({
         "content": {},
         "event_id": "$h29iv0s8:example.com",
@@ -82,16 +84,17 @@ fn deserialize_redacted_any_room() {
 
     assert_matches!(
         from_json_value::<AnyTimelineEvent>(redacted),
-        Ok(AnyTimelineEvent::MessageLike(AnyMessageLikeEvent::RoomMessage(
-            MessageLikeEvent::Redacted(redacted),
-        )))
+        Ok(AnyTimelineEvent::MessageLike(event))
     );
+    assert!(event.is_redacted());
+
+    assert_matches!(event, AnyMessageLikeEvent::RoomMessage(MessageLikeEvent::Redacted(redacted)));
     assert_eq!(redacted.event_id, "$h29iv0s8:example.com");
     assert_eq!(redacted.room_id, "!roomid:room.com");
 }
 
 #[test]
-fn deserialize_redacted_any_room_sync() {
+fn deserialize_redacted_sync_message_like() {
     let redacted = json!({
         "content": {},
         "event_id": "$h29iv0s8:example.com",
@@ -103,16 +106,20 @@ fn deserialize_redacted_any_room_sync() {
 
     assert_matches!(
         from_json_value::<AnySyncTimelineEvent>(redacted),
-        Ok(AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::RoomMessage(
-            SyncMessageLikeEvent::Redacted(redacted),
-        )))
+        Ok(AnySyncTimelineEvent::MessageLike(event))
+    );
+    assert!(event.is_redacted());
+
+    assert_matches!(
+        event,
+        AnySyncMessageLikeEvent::RoomMessage(SyncMessageLikeEvent::Redacted(redacted))
     );
     assert_eq!(redacted.event_id, "$h29iv0s8:example.com");
 }
 
 #[test]
 #[allow(deprecated)]
-fn deserialize_redacted_state_event() {
+fn deserialize_redacted_sync_state() {
     let redacted = json!({
         "content": {
             "creator": "@carl:example.com",
@@ -127,16 +134,17 @@ fn deserialize_redacted_state_event() {
 
     assert_matches!(
         from_json_value::<AnySyncTimelineEvent>(redacted),
-        Ok(AnySyncTimelineEvent::State(AnySyncStateEvent::RoomCreate(SyncStateEvent::Redacted(
-            redacted
-        ),)))
+        Ok(AnySyncTimelineEvent::State(event))
     );
+    assert!(event.is_redacted());
+
+    assert_matches!(event, AnySyncStateEvent::RoomCreate(SyncStateEvent::Redacted(redacted)));
     assert_eq!(redacted.event_id, "$h29iv0s8:example.com");
     assert_eq!(redacted.content.creator.unwrap(), "@carl:example.com");
 }
 
 #[test]
-fn deserialize_redacted_custom_event() {
+fn deserialize_redacted_custom_sync_state() {
     let redacted = json!({
         "content": {},
         "event_id": "$h29iv0s8:example.com",
@@ -151,6 +159,7 @@ fn deserialize_redacted_custom_event() {
         from_json_value::<AnySyncTimelineEvent>(redacted),
         Ok(AnySyncTimelineEvent::State(state_ev))
     );
+    assert!(state_ev.is_redacted());
     assert_eq!(state_ev.event_id(), "$h29iv0s8:example.com");
 }
 

--- a/crates/ruma-macros/src/events/event_enum.rs
+++ b/crates/ruma-macros/src/events/event_enum.rs
@@ -549,6 +549,18 @@ fn expand_accessor_methods(
                     }),
                 }
             }
+
+            /// Returns whether this event is redacted.
+            pub fn is_redacted(&self) -> bool {
+                match self {
+                    #(
+                        #self_variants(event) => {
+                            event.as_original().is_none()
+                        }
+                    )*
+                    Self::_Custom(event) => event.as_original().is_none(),
+                }
+            }
         };
 
         if kind == EventKind::State {


### PR DESCRIPTION
Allows to know if an event is redacted without calling `original_content()`, which clones the content.

cc @bnjbvr 
