### PR TITLE
signatures: Do not check signature of invite that result from third-party invite

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -11,3 +11,7 @@ Wya = "Wya"
 sing = "sign"
 singed = "signed"
 singing = "signing"
+
+[type.snap]
+extend-glob = ["*.snap"]
+check-file = false

--- a/crates/ruma-signatures/CHANGELOG.md
+++ b/crates/ruma-signatures/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [unreleased]
 
+Bug fixes:
+
+- Do not check the signature of the server of the sender of `m.room.member`
+  invite events with a `third_party_invite` field.
+
 # 0.17.0
 
 Improvements:

--- a/crates/ruma-signatures/tests/snapshots/tests__verify_event_check_signatures_for_authorized_user.snap
+++ b/crates/ruma-signatures/tests/snapshots/tests__verify_event_check_signatures_for_authorized_user.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ruma-signatures/tests/tests.rs
 expression: signature
+snapshot_kind: text
 ---
-k9EFMDj9rmGt+BECNS1U/bU39/Bqc7Rm/U7PzQNk7DHFAYM8EK3lJTQr1R6hZxTHNtJuiRFDZYwBPzRgs54SDg
+R258cU0L4dWp5oCluQv3ffXctzob7aneCt60xpo4Y0htpLMgf+iLMPUGyYBnF8PdjQrsX/0cKFCZVAV0UFU3BQ

--- a/crates/ruma-signatures/tests/tests.rs
+++ b/crates/ruma-signatures/tests/tests.rs
@@ -24,7 +24,9 @@ fn verify_event_check_signatures_for_authorized_user() {
         r#"{
             "event_id": "$event_id:domain-event",
             "auth_events": [],
-            "content": {},
+            "content": {
+                "membership": "join"
+            },
             "depth": 3,
             "hashes": {
                 "sha256": "5jM4wQpv6lnBo7CLIghJuHdW+s2CMBJPUOGOC89ncos"


### PR DESCRIPTION
It seems that [the text from the spec](https://spec.matrix.org/latest/server-server-api/#validating-hashes-and-signatures-on-received-events) was misinterpreted. It is not the server of the sender of `m.room.third_party_invite` events that must not be checked, but the server of the sender of `m.room.member` invite events that **result** from a third-party invite.
