### PR TITLE
api: Clean up the API of `MatrixVersion`

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -3,6 +3,8 @@
 Breaking changes:
 
 - Use `AuthType` for the `auth_type` of `get_uiaa_fallback_page`'s Request.
+- `get_supported_versions::Response::known_versions()` returns a
+  `BTreeSet<MatrixVersion>` instead of a `DoubleEndedIterator`.
 
 # 0.20.1
 

--- a/crates/ruma-client/src/client/builder.rs
+++ b/crates/ruma-client/src/client/builder.rs
@@ -82,6 +82,7 @@ impl ClientBuilder {
                 )
                 .await?
                 .known_versions()
+                .into_iter()
                 .collect(),
         };
 

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -14,6 +14,11 @@ Breaking changes:
 - `(owned_)room_alias_id!` macros disallow the `NUL` byte for the localpart, due
   to a clarification in the spec.
 
+Improvements:
+
+- `MatrixVersion` implements `PartialOrd` and `Ord`. The variants are ordered by
+  release date, with a newer version being greater than an older version.
+
 # 0.15.1
 
 Improvements:

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -16,6 +16,9 @@ Breaking changes:
 - `MatrixVersion` does not implement `Display` anymore as it is not correct to
   convert `V1_0` to a string. Instead `MatrixVersion::as_str()` can be used that
   only returns `None` for that same variant.
+- `MatrixVersion::(into/from)_parts` are no longer exposed as public methods.
+  They were usually used to sort `MatrixVersion`s, now the `PartialOrd` and
+  `Ord` implementations can be used instead.
 
 Improvements:
 

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -13,6 +13,9 @@ Breaking changes:
   the spec.
 - `(owned_)room_alias_id!` macros disallow the `NUL` byte for the localpart, due
   to a clarification in the spec.
+- `MatrixVersion` does not implement `Display` anymore as it is not correct to
+  convert `V1_0` to a string. Instead `MatrixVersion::as_str()` can be used that
+  only returns `None` for that same variant.
 
 Improvements:
 

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -20,6 +20,11 @@ Improvements:
 
 - Add `MatrixVersion::V1_13`.
 
+Bug fixes:
+
+- `MatrixVersion::V1_0` now also matches Identity Service API versions r0.2.0 to
+  r0.3.0.
+
 # 0.15.0
 
 Breaking changes:

--- a/crates/ruma-common/src/api/error.rs
+++ b/crates/ruma-common/src/api/error.rs
@@ -113,7 +113,10 @@ pub enum IntoHttpError {
 
     /// Tried to create a request with [`MatrixVersion`]s for all of which this endpoint was
     /// removed.
-    #[error("could not create any path variant for endpoint, as it was removed in version {0}")]
+    #[error(
+        "could not create any path variant for endpoint, as it was removed in version {}",
+        .0.as_str().expect("no endpoint was removed in Matrix 1.0")
+    )]
     EndpointRemoved(MatrixVersion),
 
     /// JSON serialization failed.

--- a/crates/ruma-common/src/api/metadata.rs
+++ b/crates/ruma-common/src/api/metadata.rs
@@ -487,9 +487,17 @@ pub enum VersioningDecision {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub enum MatrixVersion {
-    /// Version 1.0 of the Matrix specification.
+    /// Matrix 1.0 was a release prior to the global versioning system and does not correspond to a
+    /// version of the Matrix specification.
     ///
-    /// Retroactively defined as <https://spec.matrix.org/latest/#legacy-versioning>.
+    /// It is used to represent the following per-API versions:
+    ///
+    /// * Client-Server API: r0.5.0 to r0.6.1
+    /// * Identity Service API: r0.2.0 to r0.3.0
+    ///
+    /// The other APIs are not supported because they do not have a `GET /versions` endpoint.
+    ///
+    /// See <https://spec.matrix.org/latest/#legacy-versioning>.
     V1_0,
 
     /// Version 1.1 of the Matrix specification, released in Q4 2021.
@@ -565,9 +573,10 @@ impl TryFrom<&str> for MatrixVersion {
         use MatrixVersion::*;
 
         Ok(match value {
-            // FIXME: these are likely not entirely correct; https://github.com/ruma/ruma/issues/852
-            "v1.0" |
-            // Additional definitions according to https://spec.matrix.org/latest/#legacy-versioning
+            // Identity service API versions between Matrix 1.0 and 1.1.
+            // They might match older client-server API versions but that should not be a problem in practice.
+            "r0.2.0" | "r0.2.1" | "r0.3.0" |
+            // Client-server API versions between Matrix 1.0 and 1.1.
             "r0.5.0" | "r0.6.0" | "r0.6.1" => V1_0,
             "v1.1" => V1_1,
             "v1.2" => V1_2,

--- a/crates/ruma-common/src/api/metadata.rs
+++ b/crates/ruma-common/src/api/metadata.rs
@@ -652,7 +652,7 @@ impl MatrixVersion {
     }
 
     /// Decompose the Matrix version into its major and minor number.
-    pub const fn into_parts(self) -> (u8, u8) {
+    const fn into_parts(self) -> (u8, u8) {
         match self {
             MatrixVersion::V1_0 => (1, 0),
             MatrixVersion::V1_1 => (1, 1),
@@ -672,7 +672,7 @@ impl MatrixVersion {
     }
 
     /// Try to turn a pair of (major, minor) version components back into a `MatrixVersion`.
-    pub const fn from_parts(major: u8, minor: u8) -> Result<Self, UnknownVersionError> {
+    const fn from_parts(major: u8, minor: u8) -> Result<Self, UnknownVersionError> {
         match (major, minor) {
             (1, 0) => Ok(MatrixVersion::V1_0),
             (1, 1) => Ok(MatrixVersion::V1_1),

--- a/crates/ruma-common/src/api/metadata.rs
+++ b/crates/ruma-common/src/api/metadata.rs
@@ -1,6 +1,6 @@
 use std::{
     cmp::Ordering,
-    fmt::{self, Display, Write},
+    fmt::{Display, Write},
     str::FromStr,
 };
 
@@ -624,6 +624,33 @@ impl MatrixVersion {
         self >= other
     }
 
+    /// Get a string representation of this Matrix version.
+    ///
+    /// This is the string that can be found in the response to one of the `GET /versions`
+    /// endpoints. Parsing this string will give the same variant.
+    ///
+    /// Returns `None` for [`MatrixVersion::V1_0`] because it can match several per-API versions.
+    pub const fn as_str(self) -> Option<&'static str> {
+        let string = match self {
+            MatrixVersion::V1_0 => return None,
+            MatrixVersion::V1_1 => "v1.1",
+            MatrixVersion::V1_2 => "v1.2",
+            MatrixVersion::V1_3 => "v1.3",
+            MatrixVersion::V1_4 => "v1.4",
+            MatrixVersion::V1_5 => "v1.5",
+            MatrixVersion::V1_6 => "v1.6",
+            MatrixVersion::V1_7 => "v1.7",
+            MatrixVersion::V1_8 => "v1.8",
+            MatrixVersion::V1_9 => "v1.9",
+            MatrixVersion::V1_10 => "v1.10",
+            MatrixVersion::V1_11 => "v1.11",
+            MatrixVersion::V1_12 => "v1.12",
+            MatrixVersion::V1_13 => "v1.13",
+        };
+
+        Some(string)
+    }
+
     /// Decompose the Matrix version into its major and minor number.
     pub const fn into_parts(self) -> (u8, u8) {
         match self {
@@ -766,13 +793,6 @@ impl MatrixVersion {
     }
 }
 
-impl Display for MatrixVersion {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let (major, minor) = self.into_parts();
-        f.write_str(&format!("v{major}.{minor}"))
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use assert_matches2::assert_matches;
@@ -898,5 +918,16 @@ mod tests {
         const LIT: MatrixVersion = MatrixVersion::from_lit("1.0");
 
         assert_eq!(LIT, V1_0);
+    }
+
+    #[test]
+    fn parse_as_str_sanity() {
+        let version = MatrixVersion::try_from("r0.5.0").unwrap();
+        assert_eq!(version, V1_0);
+        assert_eq!(version.as_str(), None);
+
+        let version = MatrixVersion::try_from("v1.1").unwrap();
+        assert_eq!(version, V1_1);
+        assert_eq!(version.as_str(), Some("v1.1"));
     }
 }

--- a/crates/ruma-common/src/api/metadata.rs
+++ b/crates/ruma-common/src/api/metadata.rs
@@ -473,10 +473,11 @@ pub enum VersioningDecision {
 /// The Matrix versions Ruma currently understands to exist.
 ///
 /// Matrix, since fall 2021, has a quarterly release schedule, using a global `vX.Y` versioning
-/// scheme.
+/// scheme. Usually `Y` is bumped for new backwards compatible changes, but `X` can be bumped
+/// instead when a large number of `Y` changes feel deserving of a major version increase.
 ///
-/// Every new minor version denotes stable support for endpoints in a *relatively*
-/// backwards-compatible manner.
+/// Every new version denotes stable support for endpoints in a *relatively* backwards-compatible
+/// manner.
 ///
 /// Matrix has a deprecation policy, read more about it here: <https://spec.matrix.org/latest/#deprecation-policy>.
 ///
@@ -484,13 +485,18 @@ pub enum VersioningDecision {
 /// select the right endpoint stability variation to use depending on which Matrix versions you
 /// pass to [`try_into_http_request`](super::OutgoingRequest::try_into_http_request), see its
 /// respective documentation for more information.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+///
+/// The `PartialOrd` and `Ord` implementations of this type sort the variants by release date. A
+/// newer release is greater than an older release.
+///
+/// `MatrixVersion::is_superset_of()` is used to keep track of compatibility between versions.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub enum MatrixVersion {
     /// Matrix 1.0 was a release prior to the global versioning system and does not correspond to a
     /// version of the Matrix specification.
     ///
-    /// It is used to represent the following per-API versions:
+    /// It matches the following per-API versions:
     ///
     /// * Client-Server API: r0.5.0 to r0.6.1
     /// * Identity Service API: r0.2.0 to r0.3.0
@@ -607,23 +613,15 @@ impl FromStr for MatrixVersion {
 impl MatrixVersion {
     /// Checks whether a version is compatible with another.
     ///
-    /// A is compatible with B as long as B is equal or less, so long as A and B have the same
-    /// major versions.
+    /// Currently, all versions of Matrix are considered backwards compatible with all the previous
+    /// versions, so this is equivalent to `self >= other`. This behaviour may change in the future,
+    /// if a new release is considered to be breaking compatibility with the previous ones.
     ///
-    /// For example, v1.2 is compatible with v1.1, as it is likely only some additions of
-    /// endpoints on top of v1.1, but v1.1 would not be compatible with v1.2, as v1.1
-    /// cannot represent all of v1.2, in a manner similar to set theory.
-    ///
-    /// Warning: Matrix has a deprecation policy, and Matrix versioning is not as
-    /// straight-forward as this function makes it out to be. This function only exists
-    /// to prune major version differences, and versions too new for `self`.
-    ///
-    /// This (considering if major versions are the same) is equivalent to a `self >= other`
-    /// check.
+    /// > ⚠ Matrix has a deprecation policy, and Matrix versioning is not as straightforward as this
+    /// > function makes it out to be. This function only exists to prune breaking changes between
+    /// > versions, and versions too new for `self`.
     pub fn is_superset_of(self, other: Self) -> bool {
-        let (major_l, minor_l) = self.into_parts();
-        let (major_r, minor_r) = other.into_parts();
-        major_l == major_r && minor_l >= minor_r
+        self >= other
     }
 
     /// Decompose the Matrix version into its major and minor number.

--- a/crates/ruma-identity-service-api/CHANGELOG.md
+++ b/crates/ruma-identity-service-api/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [unreleased]
 
+Breaking changes:
+
+- `get_supported_versions::Response::known_versions()` returns a
+  `BTreeSet<MatrixVersion>` instead of a `DoubleEndedIterator`.
+
 # 0.11.0
 
 Improvements:

--- a/crates/ruma-identity-service-api/src/discovery/get_supported_versions.rs
+++ b/crates/ruma-identity-service-api/src/discovery/get_supported_versions.rs
@@ -10,7 +10,7 @@
 //!
 //! [spec]: https://spec.matrix.org/latest/identity-service-api/#get_matrixidentityversions
 
-use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 
 use ruma_common::{
     api::{request, response, MatrixVersion, Metadata},
@@ -58,17 +58,12 @@ impl Response {
     /// The versions returned will be sorted from oldest to latest. Use [`.find()`][Iterator::find]
     /// or [`.rfind()`][DoubleEndedIterator::rfind] to look for a minimum or maximum version to use
     /// given some constraint.
-    pub fn known_versions(&self) -> impl DoubleEndedIterator<Item = MatrixVersion> {
+    pub fn known_versions(&self) -> BTreeSet<MatrixVersion> {
         self.versions
             .iter()
             // Parse, discard unknown versions
             .flat_map(|s| s.parse::<MatrixVersion>())
-            // Map to key-value pairs where the key is the major-minor representation
-            // (which can be used as a BTreeMap unlike MatrixVersion itself)
-            .map(|v| (v.into_parts(), v))
-            // Collect to BTreeMap
-            .collect::<BTreeMap<_, _>>()
-            // Return an iterator over just the values (`MatrixVersion`s)
-            .into_values()
+            // Collect to BTreeSet
+            .collect()
     }
 }


### PR DESCRIPTION
Given that we already know that Matrix 2.0 is going to have a symbolic major version bump, we need to fix the previous API that assumed that a major version bump broke backwards compatibility. Since the reasons that can lead to a major version bump are plenty and sometimes vague, let's just worry about the current state of the versions which are always backwards compatible an this rhythm is not likely to change in the near future. Implementing `PartialOrd` and `Ord` makes for a nicer API in my opinion.

This also fixes/clarifies the docs of `MatrixVersion::V1_0` according to https://github.com/matrix-org/matrix-spec/pull/2045. And for correctness, this variant cannot be converted to a string anymore.

Fixes #852.