### PR TITLE
Remove unstable-unspecified feature of federation-api and global compat feature

### DIFF
--- a/crates/ruma-events/tests/it/sticker.rs
+++ b/crates/ruma-events/tests/it/sticker.rs
@@ -222,7 +222,7 @@ fn replace_content_deserialization() {
     {
         let encrypted_content =
             from_json_value::<StickerEventContent>(encrypted_json_data).unwrap();
-        assert_eq!(encrypted_content.body, "Upload: my_image.jpg");
+        assert_eq!(encrypted_content.body, "* Upload: my_image.jpg");
         assert_matches!(
             encrypted_content.source,
             StickerMediaSource::Encrypted(encrypted_sticker_url)

--- a/crates/ruma-federation-api/CHANGELOG.md
+++ b/crates/ruma-federation-api/CHANGELOG.md
@@ -5,6 +5,13 @@ Breaking changes:
 - Remove the `origin` field in `create_join_event::{v1/v2}::RoomState` due to a
   clarification in the spec.
 
+Improvements:
+
+- The `unstable-unspecified` cargo feature was removed. The `pdus` field of
+  `send_transaction_message::v1::Request` is always serialized. To allow this
+  field to be missing during deserialization, use the `compat-optional-txn-pdus`
+  cargo feature.
+
 # 0.11.0
 
 Improvements:

--- a/crates/ruma-federation-api/Cargo.toml
+++ b/crates/ruma-federation-api/Cargo.toml
@@ -19,6 +19,10 @@ all-features = true
 # them to an empty string in deserialization.
 compat-empty-string-null = []
 
+# Allow the `pdus` field in a transaction request to be missing, defaulting to
+# an empty `Vec` in deserialization.
+compat-optional-txn-pdus = []
+
 client = ["dep:httparse", "dep:memchr"]
 server = ["dep:bytes", "dep:rand"]
 unstable-msc2448 = []
@@ -26,7 +30,6 @@ unstable-msc3618 = []
 unstable-msc3723 = []
 unstable-msc3843 = []
 unstable-msc4125 = []
-unstable-unspecified = []
 
 [dependencies]
 bytes = { workspace = true, optional = true }

--- a/crates/ruma-federation-api/src/transactions/send_transaction_message.rs
+++ b/crates/ruma-federation-api/src/transactions/send_transaction_message.rs
@@ -46,12 +46,9 @@ pub mod v1 {
         ///
         /// Must not be more than 50 items.
         ///
-        /// With the `unstable-unspecified` feature, sending `pdus` is optional.
-        /// See [matrix-spec#705](https://github.com/matrix-org/matrix-spec/issues/705).
-        #[cfg_attr(
-            feature = "unstable-unspecified",
-            serde(default, skip_serializing_if = "<[_]>::is_empty")
-        )]
+        /// With the `compat-optional-pdus` feature, this field is optional in deserialization,
+        /// defaulting to an empty `Vec`.
+        #[cfg_attr(feature = "compat-optional-txn-pdus", serde(default))]
         pub pdus: Vec<Box<RawJsonValue>>,
 
         /// List of ephemeral messages.

--- a/crates/ruma/CHANGELOG.md
+++ b/crates/ruma/CHANGELOG.md
@@ -1,5 +1,8 @@
 # [unreleased]
 
+- The deprecated global `compat` cargo feature was removed. The `compat-*` cargo
+  features need to be enabled individually.
+
 # 0.12.1
 
 Please refer to the changelogs of:

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -101,6 +101,7 @@ compat = [
     "compat-get-3pids",
     "compat-signature-id",
     "compat-tag-info",
+    "compat-optional-txn-pdus",
 ]
 
 # Allow IDs to exceed 255 bytes.
@@ -150,6 +151,10 @@ compat-tag-info = ["ruma-events?/compat-tag-info"]
 # Support encrypted stickers, as sent by several bridges.
 # https://github.com/matrix-org/matrix-spec/issues/1667
 compat-encrypted-stickers = ["ruma-events?/compat-encrypted-stickers"]
+
+# Allow the `pdus` field in a federation transaction request to be missing,
+# defaulting to an empty `Vec` in deserialization.
+compat-optional-txn-pdus = ["ruma-federation-api?/compat-optional-txn-pdus"]
 
 # Specific compatibility for past ring public/private key documents.
 ring-compat = ["dep:ruma-signatures", "ruma-signatures?/ring-compat"]
@@ -221,7 +226,6 @@ unstable-msc4230 = ["ruma-events?/unstable-msc4230"]
 unstable-pdu = ["ruma-events?/unstable-pdu"]
 unstable-unspecified = [
     "ruma-common/unstable-unspecified",
-    "ruma-federation-api?/unstable-unspecified",
 ]
 
 # Private features, only used in test / benchmarking code

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -91,19 +91,6 @@ full = [
     "html-matrix",
 ]
 
-# Enable all compatibility hacks. Deprecated.
-compat = [
-    "compat-server-signing-key-version",
-    "compat-empty-string-null",
-    "compat-null",
-    "compat-optional",
-    "compat-unset-avatar",
-    "compat-get-3pids",
-    "compat-signature-id",
-    "compat-tag-info",
-    "compat-optional-txn-pdus",
-]
-
 # Allow IDs to exceed 255 bytes.
 compat-arbitrary-length-ids = ["ruma-common/compat-arbitrary-length-ids"]
 
@@ -284,6 +271,17 @@ __ci = [
     "compat-upload-signatures",
     "__unstable-mscs",
     "unstable-unspecified",
+]
+__compat = [
+    "compat-server-signing-key-version",
+    "compat-empty-string-null",
+    "compat-null",
+    "compat-optional",
+    "compat-unset-avatar",
+    "compat-get-3pids",
+    "compat-signature-id",
+    "compat-tag-info",
+    "compat-optional-txn-pdus",
 ]
 
 [dependencies]

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -273,14 +273,17 @@ __ci = [
     "unstable-unspecified",
 ]
 __compat = [
+    "compat-arbitrary-length-ids",
     "compat-server-signing-key-version",
     "compat-empty-string-null",
     "compat-null",
     "compat-optional",
     "compat-unset-avatar",
     "compat-get-3pids",
+    "compat-upload-signatures",
     "compat-signature-id",
     "compat-tag-info",
+    "compat-encrypted-stickers",
     "compat-optional-txn-pdus",
 ]
 

--- a/crates/ruma/src/lib.rs
+++ b/crates/ruma/src/lib.rs
@@ -29,10 +29,20 @@
 //!   * `client-api-c` -- The Client-Server API optimized for the client side.
 //!   * `client-api-s` -- The Client-Server API optimized for the server side.
 //!
-//! # Compatibility feature
+//! # Compatibility features
 //!
-//! * `compat` increases compatibility with other parts of the Matrix ecosystem, at the expense of
-//!   deviating from the specification.
+//! By default, the ruma crates are only able to handle strictly spec-compliant data and behaviour.
+//! However, due to the fact that Matrix is federated, that it is used by various implementations
+//! that might have different bugs, and that much of its data is immutable, they need to be able to
+//! interoperate with data that might differ slightly from the specification.
+//!
+//! This is the role of the `compat-*` cargo features. They allow the crates be more tolerant of
+//! external data and incoming requests for known and reasonable deviations from the spec, usually
+//! for historical reasons. They however do not permit the ruma crates to generate data that is not
+//! spec-compliant.
+//!
+//! Each cargo feature is documented briefly in the cargo manifest of the crate, and more thoroughly
+//! where the feature applies.
 //!
 //! # Convenience features
 //!

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -223,7 +223,7 @@ impl CiTask {
     /// Run tests on all crates with almost all features and the compat features with the stable
     /// version.
     fn test_compat(&self) -> Result<()> {
-        cmd!(&self.sh, "rustup run stable cargo test --tests --features __ci,compat")
+        cmd!(&self.sh, "rustup run stable cargo test --tests --features __ci,__compat")
             .run()
             .map_err(Into::into)
     }
@@ -325,7 +325,7 @@ impl CiTask {
             &self.sh,
             "
             rustup run {NIGHTLY} cargo clippy
-                --workspace --all-targets --features=__ci,compat -- -D warnings
+                --workspace --all-targets --features=__ci,__compat -- -D warnings
             "
         )
         .run()


### PR DESCRIPTION
I wanted to make 2 PRs but they would have had obvious conflicts. This can be reviewed commit by commit.

Closes #614.