### PR TITLE
thirdparty: Move instance_id field out of unstable-unspecified

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,6 @@ Ruma 0.11.0 supports all events and REST endpoints of Matrix 1.12.
 Various changes from in-progress or finished MSCs are also implemented, gated
 behind the `unstable-mscXXXX` (where `XXXX` is the MSC number) Cargo features.
 
-A few less formalized things are gated behind the `unstable-unspecified` Cargo
-feature.
-
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/crates/ruma-appservice-api/CHANGELOG.md
+++ b/crates/ruma-appservice-api/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [unreleased]
 
+Breaking changes:
+
+- The`thirdparty::get_protocol` response uses `AppserviceProtocolInstance`
+  instead of `ProtocolInstance`.
+
 # 0.12.1
 
 Improvements:

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -19,11 +19,14 @@ Breaking changes:
 - `MatrixVersion::(into/from)_parts` are no longer exposed as public methods.
   They were usually used to sort `MatrixVersion`s, now the `PartialOrd` and
   `Ord` implementations can be used instead.
+- `Protocol` and `ProtocolInit` are generic on the protocol instance type.
 
 Improvements:
 
 - `MatrixVersion` implements `PartialOrd` and `Ord`. The variants are ordered by
   release date, with a newer version being greater than an older version.
+- `ProtocolInstance` has an `instance_id` field, due to a clarification in the
+  spec.
 
 # 0.15.1
 

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -27,6 +27,7 @@ Improvements:
   release date, with a newer version being greater than an older version.
 - `ProtocolInstance` has an `instance_id` field, due to a clarification in the
   spec.
+- The `unstable-unspecified` cargo feature was removed.
 
 # 0.15.1
 

--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -28,7 +28,6 @@ unstable-msc2870 = []
 unstable-msc3930 = []
 unstable-msc3931 = []
 unstable-msc3932 = ["unstable-msc3931"]
-unstable-unspecified = []
 
 # Allow IDs to exceed 255 bytes.
 compat-arbitrary-length-ids = ["ruma-identifiers-validation/compat-arbitrary-length-ids"]

--- a/crates/ruma/CHANGELOG.md
+++ b/crates/ruma/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - The deprecated global `compat` cargo feature was removed. The `compat-*` cargo
   features need to be enabled individually.
+- The `unstable-unspecified` cargo feature was removed.
 
 # 0.12.1
 

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -211,9 +211,6 @@ unstable-msc4186 = ["ruma-client-api?/unstable-msc4186"]
 unstable-msc4203 = ["ruma-appservice-api?/unstable-msc4203"]
 unstable-msc4230 = ["ruma-events?/unstable-msc4230"]
 unstable-pdu = ["ruma-events?/unstable-pdu"]
-unstable-unspecified = [
-    "ruma-common/unstable-unspecified",
-]
 
 # Private features, only used in test / benchmarking code
 __unstable-mscs = [
@@ -270,7 +267,6 @@ __ci = [
     "full",
     "compat-upload-signatures",
     "__unstable-mscs",
-    "unstable-unspecified",
 ]
 __compat = [
     "compat-arbitrary-length-ids",

--- a/crates/ruma/src/lib.rs
+++ b/crates/ruma/src/lib.rs
@@ -60,8 +60,6 @@
 //!
 //! * `unstable-mscXXXX`, where `XXXX` is the MSC number -- Upcoming Matrix features that may be
 //!   subject to change or removal.
-//! * `unstable-unspecified` -- Undocumented Matrix features that may be subject to change or
-//!   removal.
 //!
 //! # Common features
 //!

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -311,7 +311,7 @@ impl CiTask {
             &self.sh,
             "
             rustup run {NIGHTLY} cargo clippy --target wasm32-unknown-unknown -p ruma --features
-                __unstable-mscs,api,canonical-json,client-api,events,html-matrix,identity-service-api,js,markdown,rand,signatures,unstable-unspecified -- -D warnings
+                __unstable-mscs,api,canonical-json,client-api,events,html-matrix,identity-service-api,js,markdown,rand,signatures -- -D warnings
             "
         )
         .env("CLIPPY_CONF_DIR", ".wasm")


### PR DESCRIPTION
Due to a [clarification in the spec](https://github.com/matrix-org/matrix-spec/pull/2051).

Requires to have two different `ProtocolInstance` types, as this field is added by the homeserver to the response returned by the appservice.

I made two types which duplicates the fields, but maybe we should use `serde(flatten)` to have `HomeserverProtocolInstance` use `AppserviceProtocolInstance`.

Also instead of having `AppserviceProtocol` and `HomeserverProtocol`, maybe we should just have `Protocol` which is generic over the instance type.

And we can now get rid of the `unstable-unspecified` cargo feature!