### PR TITLE
api: Fix location of changelog

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -20,6 +20,11 @@ Breaking changes:
   They were usually used to sort `MatrixVersion`s, now the `PartialOrd` and
   `Ord` implementations can be used instead.
 
+Bug fixes:
+
+- `MatrixVersion::V1_0` now also matches Identity Service API versions r0.2.0 to
+  r0.3.0.
+
 Improvements:
 
 - `MatrixVersion` implements `PartialOrd` and `Ord`. The variants are ordered by
@@ -30,11 +35,6 @@ Improvements:
 Improvements:
 
 - Add `MatrixVersion::V1_13`.
-
-Bug fixes:
-
-- `MatrixVersion::V1_0` now also matches Identity Service API versions r0.2.0 to
-  r0.3.0.
 
 # 0.15.0
 


### PR DESCRIPTION
It was put in the wrong place after the ruma-common 0.15.1 release was merged back into main.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
