### PR TITLE
client-api: Fix string representation of `CodeChallengeMethod`

### DIFF
--- a/crates/ruma-client-api/src/discovery/get_authorization_server_metadata.rs
+++ b/crates/ruma-client-api/src/discovery/get_authorization_server_metadata.rs
@@ -294,7 +294,6 @@ pub mod msc2965 {
     /// The code challenge method to use at the authorization endpoint.
     #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
     #[derive(Clone, StringEnum, PartialEqAsRefStr, Eq, PartialOrdAsRefStr, OrdAsRefStr)]
-    #[ruma_enum(rename_all = "lowercase")]
     #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
     pub enum CodeChallengeMethod {
         /// Use a SHA-256, base64url-encoded code challenge ([RFC7636]).
@@ -392,7 +391,7 @@ mod tests {
             "response_modes_supported": ["query", "fragment"],
             "grant_types_supported": ["authorization_code", "refresh_token"],
             "revocation_endpoint": "https://server.local/revoke",
-            "code_challenge_methods_supported": ["s256"],
+            "code_challenge_methods_supported": ["S256"],
             "account_management_uri": "https://server.local/account",
             "account_management_actions_supported": [
                 "org.matrix.profile",

--- a/crates/ruma-client-api/src/discovery/get_authorization_server_metadata/serde.rs
+++ b/crates/ruma-client-api/src/discovery/get_authorization_server_metadata/serde.rs
@@ -85,7 +85,7 @@ impl<'de> Deserialize<'de> for AuthorizationServerMetadata {
         // Require `S256` in `code_challenge_methods_supported`.
         if !code_challenge_methods_supported.contains(&CodeChallengeMethod::S256) {
             return Err(de::Error::custom(
-                "missing value `s256` in `code_challenge_methods_supported`",
+                "missing value `S256` in `code_challenge_methods_supported`",
             ));
         }
 


### PR DESCRIPTION
The `S` in `S256` is actually uppercase, as can be seen in [the IANA list](https://www.iana.org/assignments/oauth-parameters/oauth-parameters.xhtml#pkce-code-challenge-method) and [RFC7636](https://www.rfc-editor.org/rfc/rfc7636.html#section-4.2), so we need to remove the `rename_all` rule.
