### PR TITLE
Expose missing preview types

### DIFF
--- a/crates/ruma-events/src/room/message.rs
+++ b/crates/ruma-events/src/room/message.rs
@@ -47,7 +47,7 @@ pub use self::audio::{
     UnstableAmplitude, UnstableAudioDetailsContentBlock, UnstableVoiceContentBlock,
 };
 #[cfg(feature = "unstable-msc4095")]
-pub use self::url_preview::UrlPreview;
+pub use self::url_preview::{PreviewImage, PreviewImageSource, UrlPreview};
 pub use self::{
     audio::{AudioInfo, AudioMessageEventContent},
     emote::EmoteMessageEventContent,

--- a/crates/ruma-events/src/room/message/url_preview.rs
+++ b/crates/ruma-events/src/room/message/url_preview.rs
@@ -4,9 +4,13 @@ use crate::room::{EncryptedFile, OwnedMxcUri, UInt};
 
 /// The Source of the PreviewImage.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[allow(clippy::exhaustive_enums)]
 pub enum PreviewImageSource {
+    /// Source of the PreviewImage as encrypted file data
     #[serde(rename = "beeper:image:encryption", alias = "matrix:image:encryption")]
     EncryptedImage(EncryptedFile),
+
+    /// Source of the PreviewImage as a simple MxcUri
     #[serde(rename = "og:image", alias = "og:image:url")]
     Url(OwnedMxcUri),
 }


### PR DESCRIPTION
`PreviewImage` and `PreviewImageSource` were not missed to expose in #1933 , making it impossible for anyone to actually use them. This just adds them to the public API.