### PR TITLE
give `ruma_common::media::Method` the ability becoming the key of a `Map`

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -34,7 +34,7 @@ Improvements:
   spec.
 - The `unstable-unspecified` cargo feature was removed.
 - `Signatures` implements `IntoIterator`.
-- Give `ruma_common::media::Method` the ability becoming the key of a Map.
+- Implement `PartialEqAsRefStr`, `Eq`, `PartialOrdAsRefStr`, `OrdAsRefStr` for `ruma_common::media::Method`.
 
 # 0.15.1
 

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -33,7 +33,8 @@ Improvements:
 - `ProtocolInstance` has an `instance_id` field, due to a clarification in the
   spec.
 - The `unstable-unspecified` cargo feature was removed.
-- `Signatures` implements `IntoIterator`
+- `Signatures` implements `IntoIterator`.
+- Give `ruma_common::media::Method` the ability becoming the key of a Map.
 
 # 0.15.1
 

--- a/crates/ruma-common/src/media.rs
+++ b/crates/ruma-common/src/media.rs
@@ -8,7 +8,7 @@ use crate::{serde::StringEnum, PrivOwnedStr};
 
 /// The desired resizing method for a thumbnail.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, StringEnum, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, StringEnum, PartialEqAsRefStr, Eq, PartialOrdAsRefStr, OrdAsRefStr)]
 #[ruma_enum(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum Method {

--- a/crates/ruma-common/src/media.rs
+++ b/crates/ruma-common/src/media.rs
@@ -4,6 +4,8 @@
 
 use std::time::Duration;
 
+use ruma_macros::{OrdAsRefStr, PartialEqAsRefStr, PartialOrdAsRefStr};
+
 use crate::{serde::StringEnum, PrivOwnedStr};
 
 /// The desired resizing method for a thumbnail.

--- a/crates/ruma-common/src/media.rs
+++ b/crates/ruma-common/src/media.rs
@@ -8,7 +8,7 @@ use crate::{serde::StringEnum, PrivOwnedStr};
 
 /// The desired resizing method for a thumbnail.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, StringEnum)]
+#[derive(Clone, StringEnum, PartialEq, Eq, PartialOrd, Ord)]
 #[ruma_enum(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum Method {


### PR DESCRIPTION
matrix_rust_sdk relayed on this: https://github.com/matrix-org/matrix-rust-sdk/issues/4721