### PR TITLE
Bump MSRV to 1.81

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,14 +92,14 @@ jobs:
       - name: Install MSRV toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.80"
+          toolchain: "1.81"
 
       - uses: Swatinem/rust-cache@v2
         with:
           # A stable compiler update should automatically not reuse old caches.
           # Add the MSRV as a stable cache key too so bumping it also gets us a
           # fresh cache.
-          shared-key: msrv1.80
+          shared-key: msrv1.81
 
       - name: Get xtask
         uses: actions/cache@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-rust-version = "1.80"
+rust-version = "1.81"
 
 [workspace.dependencies]
 as_variant = "1.2.0"

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Minimum Rust version
 
-Ruma currently requires Rust 1.80. In general, we will never require beta or
+Ruma currently requires Rust 1.81. In general, we will never require beta or
 nightly for crates.io releases of our crates, and we will try to avoid releasing
 crates that depend on features that were only just stabilized.
 

--- a/crates/ruma/CHANGELOG.md
+++ b/crates/ruma/CHANGELOG.md
@@ -3,7 +3,7 @@
 - The deprecated global `compat` cargo feature was removed. The `compat-*` cargo
   features need to be enabled individually.
 - The `unstable-unspecified` cargo feature was removed.
-- Bump MSRV to 1.80
+- Bump MSRV to 1.81
 
 # 0.12.1
 

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -16,7 +16,7 @@ use reexport_features::check_reexport_features;
 use spec_links::check_spec_links;
 use unused_features::check_unused_features;
 
-const MSRV: &str = "1.80";
+const MSRV: &str = "1.81";
 
 #[derive(Args)]
 pub struct CiArgs {


### PR DESCRIPTION
New crates that bumped their MSRV in a patch release: https://github.com/ruma/ruma/actions/runs/13569096125/job/37929186253.

The good news is that we are slightly approaching Rust 1.84 where this won't be a problem anymore.