### PR TITLE
events: add recommened stripped state event types constant

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -13,6 +13,11 @@ Breaking changes:
     event.
   - `make_replacement` does not take the replied-to message anymore.
 
+Improvements:
+
+- Add `RECOMMENDED_STRIPPED_STATE_EVENT_TYPES` constant for servers to filter/get recommended
+  stripped state events.
+
 # 0.30.1
 
 Bug fixes:

--- a/crates/ruma-events/src/enums.rs
+++ b/crates/ruma-events/src/enums.rs
@@ -8,6 +8,20 @@ use serde_json::value::RawValue as RawJsonValue;
 
 use super::room::encrypted;
 
+/// Event types that servers should send as [stripped state] to help clients identify a room when
+/// they can't access the full room state.
+///
+/// [stripped state]: https://spec.matrix.org/latest/client-server-api/#stripped-state
+pub const RECOMMENDED_STRIPPED_STATE_EVENT_TYPES: &[StateEventType] = &[
+    StateEventType::RoomCreate,
+    StateEventType::RoomName,
+    StateEventType::RoomAvatar,
+    StateEventType::RoomTopic,
+    StateEventType::RoomJoinRules,
+    StateEventType::RoomCanonicalAlias,
+    StateEventType::RoomEncryption,
+];
+
 event_enum! {
     /// Any global account data event.
     enum GlobalAccountData {


### PR DESCRIPTION
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
