### PR TITLE
client-api: only allow appservices to call `/ping` and `/directory/list/appservice/*`

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -5,6 +5,8 @@ Breaking changes:
 - Use `AuthType` for the `auth_type` of `get_uiaa_fallback_page`'s Request.
 - `get_supported_versions::Response::known_versions()` returns a
   `BTreeSet<MatrixVersion>` instead of a `DoubleEndedIterator`.
+- Only allow appservices to call `appservice::request_ping::v1` and
+  `appservice::set_room_visibility::v1`
 
 Improvements:
 

--- a/crates/ruma-client-api/src/account/register.rs
+++ b/crates/ruma-client-api/src/account/register.rs
@@ -22,7 +22,7 @@ pub mod v3 {
     const METADATA: Metadata = metadata! {
         method: POST,
         rate_limited: true,
-        authentication: AppserviceToken,
+        authentication: AppserviceTokenOptional,
         history: {
             1.0 => "/_matrix/client/r0/register",
             1.1 => "/_matrix/client/v3/register",

--- a/crates/ruma-client-api/src/appservice/request_ping.rs
+++ b/crates/ruma-client-api/src/appservice/request_ping.rs
@@ -17,7 +17,7 @@ pub mod v1 {
     const METADATA: Metadata = metadata! {
         method: POST,
         rate_limited: false,
-        authentication: AccessToken,
+        authentication: AppserviceToken,
         history: {
             unstable => "/_matrix/client/unstable/fi.mau.msc2659/appservice/:appservice_id/ping",
             1.7 => "/_matrix/client/v1/appservice/:appservice_id/ping",

--- a/crates/ruma-client-api/src/appservice/set_room_visibility.rs
+++ b/crates/ruma-client-api/src/appservice/set_room_visibility.rs
@@ -17,7 +17,7 @@ pub mod v3 {
     const METADATA: Metadata = metadata! {
         method: PUT,
         rate_limited: false,
-        authentication: AccessToken,
+        authentication: AppserviceToken,
         history: {
             1.0 => "/_matrix/client/r0/directory/list/appservice/:network_id/:room_id",
             1.1 => "/_matrix/client/v3/directory/list/appservice/:network_id/:room_id",

--- a/crates/ruma-client-api/src/session/login.rs
+++ b/crates/ruma-client-api/src/session/login.rs
@@ -26,7 +26,7 @@ pub mod v3 {
     const METADATA: Metadata = metadata! {
         method: POST,
         rate_limited: true,
-        authentication: AppserviceToken,
+        authentication: AppserviceTokenOptional,
         history: {
             1.0 => "/_matrix/client/r0/login",
             1.1 => "/_matrix/client/v3/login",

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -20,6 +20,9 @@ Breaking changes:
   They were usually used to sort `MatrixVersion`s, now the `PartialOrd` and
   `Ord` implementations can be used instead.
 - `Protocol` and `ProtocolInit` are generic on the protocol instance type.
+- Add support for endpoints that only allow appservices to call them, renaming
+  `AppserviceToken` to `AppserviceTokenOptional`, with the new variant taking
+  `AppserviceToken`'s place.
 
 Bug fixes:
 

--- a/crates/ruma-common/src/api.rs
+++ b/crates/ruma-common/src/api.rs
@@ -526,11 +526,19 @@ pub enum AuthScheme {
     /// Using the query parameter is deprecated since Matrix 1.11.
     AccessTokenOptional,
 
-    /// Authentication is only performed for appservices, by including an access token in the
-    /// `Authentication` http header, or an `access_token` query parameter.
+    /// Authentication is required, and can only be performed for appservices, by including an
+    /// appservice access token in the `Authentication` http header, or `access_token` query
+    /// parameter.
     ///
     /// Using the query parameter is deprecated since Matrix 1.11.
     AppserviceToken,
+
+    /// No authentication is performed for clients, but it can be performed for appservices, by
+    /// including an appservice access token in the `Authentication` http header, or an
+    /// `access_token` query parameter.
+    ///
+    /// Using the query parameter is deprecated since Matrix 1.11.
+    AppserviceTokenOptional,
 
     /// Authentication is performed by including X-Matrix signatures in the request headers,
     /// as defined in the federation API.

--- a/crates/ruma-common/src/api/metadata.rs
+++ b/crates/ruma-common/src/api/metadata.rs
@@ -79,7 +79,16 @@ impl Metadata {
                 None => None,
             },
 
-            AuthScheme::AppserviceToken => match access_token.get_required_for_appservice() {
+            AuthScheme::AppserviceToken => {
+                let token = access_token
+                    .get_required_for_appservice()
+                    .ok_or(IntoHttpError::NeedsAuthentication)?;
+
+                Some((header::AUTHORIZATION, format!("Bearer {token}").try_into()?))
+            }
+
+            AuthScheme::AppserviceTokenOptional => match access_token.get_required_for_appservice()
+            {
                 Some(token) => Some((header::AUTHORIZATION, format!("Bearer {token}").try_into()?)),
                 None => None,
             },


### PR DESCRIPTION
[As discussed in `#ruma-dev`](https://matrix.to/#/%23ruma-dev%3Aflipdot.org/%24-cA8DMppYHYv8EW36fNNtuopYnx8nmKQzY8eSFSmRd0?via=flipdot.org&via=matrix.org&via=computer.surgery), the name `AppserviceTokenOptional` might not be the best choice, and I'm open to other options.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
