### PR TITLE
fix: Allow configure exhaustive types when environment variable is set

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -28,6 +28,7 @@ Bug fixes:
 
 - `MatrixVersion::V1_0` now also matches Identity Service API versions r0.2.0 to
   r0.3.0.
+- Allow configure exhaustive types via `RUMA_UNSTABLE_EXHAUSTIVE_TYPES` environment variable
 
 Improvements:
 

--- a/crates/ruma-common/build.rs
+++ b/crates/ruma-common/build.rs
@@ -7,4 +7,11 @@ fn main() {
     }
 
     println!("cargo:rerun-if-env-changed=RUMA_IDENTIFIERS_STORAGE");
+
+    // Set the `ruma_unstable_exhaustive_types` configuration from an environment variable.
+    if env::var("RUMA_UNSTABLE_EXHAUSTIVE_TYPES").is_ok() {
+        println!("cargo:rustc-cfg=ruma_unstable_exhaustive_types");
+    }
+
+    println!("cargo:rerun-if-env-changed=RUMA_UNSTABLE_EXHAUSTIVE_TYPES");
 }


### PR DESCRIPTION
Allow configure exhaustive types via the
`RUMA_UNSTABLE_EXHAUSTIVE_TYPES` environment variable in the same way as done in other crates.

`ruma-common` contains, at least, `NewPushRule` which may be configured as exhaustive. `ruma-client-api` uses the mentioned type and, when the environment variable is set, it fails to compile the project (the following command  leads to a compilation error in main: `RUMA_UNSTABLE_EXHAUSTIVE_TYPES=true cargo build --features client-api`).



