### PR TITLE
identifiers: Generate 10 chars long DeviceId by default

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -41,6 +41,7 @@ Improvements:
 - Implement `PartialEqAsRefStr`, `Eq`, `PartialOrdAsRefStr`, `OrdAsRefStr` for `ruma_common::media::Method`.
 - Add `AnyKeyName` as a helper type to use `KeyId` APIs without validating the
   key name.
+- `DeviceId::new()` generates a string with 10 chars instead of 8.
 
 # 0.15.1
 

--- a/crates/ruma-common/src/identifiers/device_id.rs
+++ b/crates/ruma-common/src/identifiers/device_id.rs
@@ -16,7 +16,7 @@ use super::{IdParseError, KeyName};
 ///
 /// # #[cfg(feature = "rand")] {
 /// let random_id = DeviceId::new();
-/// assert_eq!(random_id.as_str().len(), 8);
+/// assert_eq!(random_id.as_str().len(), 10);
 /// # }
 ///
 /// let static_id = device_id!("01234567");
@@ -37,7 +37,7 @@ impl DeviceId {
     #[cfg(feature = "rand")]
     #[allow(clippy::new_ret_no_self)]
     pub fn new() -> OwnedDeviceId {
-        Self::from_borrowed(&generate_localpart(8)).to_owned()
+        Self::from_borrowed(&generate_localpart(10)).to_owned()
     }
 }
 
@@ -60,7 +60,7 @@ mod tests {
     #[cfg(feature = "rand")]
     #[test]
     fn generate_device_id() {
-        assert_eq!(DeviceId::new().as_str().len(), 8);
+        assert_eq!(DeviceId::new().as_str().len(), 10);
     }
 
     #[test]


### PR DESCRIPTION
This is the length that is usually used in homeserver implementations, and this is the minimal length accepted by MAS.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
