### PR TITLE
state-res: Don't propagate errors from auth_check() in resolve()

### DIFF
--- a/crates/ruma-state-res/CHANGELOG.md
+++ b/crates/ruma-state-res/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [unreleased]
 
+Bug fixes:
+
+- Don't propagate errors from `auth_check()` in `resolve()`. If an event fails
+  the authorization check, it should just be ignored for the resolved state.
+
 # 0.13.0
 
 Bug fixes:


### PR DESCRIPTION
[According to the spec](https://spec.matrix.org/v1.13/rooms/v11/#definitions) (in the definition of "iterative auth checks"), if an event fails the authorization check, it should just be ignored for the resolved state.

Fixes #1944.