### PR TITLE
state-res: Add helper types to deserialize auth events lazily

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,14 +92,14 @@ jobs:
       - name: Install MSRV toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.81"
+          toolchain: "1.82"
 
       - uses: Swatinem/rust-cache@v2
         with:
           # A stable compiler update should automatically not reuse old caches.
           # Add the MSRV as a stable cache key too so bumping it also gets us a
           # fresh cache.
-          shared-key: msrv1.81
+          shared-key: msrv1.82
 
       - name: Get xtask
         uses: actions/cache@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-rust-version = "1.81"
+rust-version = "1.82"
 
 [workspace.dependencies]
 as_variant = "1.2.0"

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Minimum Rust version
 
-Ruma currently requires Rust 1.81. In general, we will never require beta or
+Ruma currently requires Rust 1.82. In general, we will never require beta or
 nightly for crates.io releases of our crates, and we will try to avoid releasing
 crates that depend on features that were only just stabilized.
 

--- a/crates/ruma-events/src/poll.rs
+++ b/crates/ruma-events/src/poll.rs
@@ -110,7 +110,7 @@ fn filter_selections<'a>(
         .into_iter()
         .filter(|ev| {
             // Filter out responses after the end_timestamp.
-            end_timestamp.map_or(true, |end_ts| ev.origin_server_ts <= end_ts)
+            end_timestamp.is_none_or(|end_ts| ev.origin_server_ts <= end_ts)
         })
         .fold(BTreeMap::new(), |mut acc, data| {
             let response =

--- a/crates/ruma-html/tests/it/html/sanitize.rs
+++ b/crates/ruma-html/tests/it/html/sanitize.rs
@@ -233,13 +233,12 @@ fn strict_mode_class_remove() {
 #[test]
 fn strict_mode_depth_remove() {
     let config = SanitizerConfig::strict();
-    let deeply_nested_html: String = std::iter::repeat("<div>")
-        .take(100)
+    let deeply_nested_html: String = std::iter::repeat_n("<div>", 100)
         .chain(Some(
             "<span>I am in too deep!</span>\
              I should be fine.",
         ))
-        .chain(std::iter::repeat("</div>").take(100))
+        .chain(std::iter::repeat_n("</div>", 100))
         .collect();
 
     let html = Html::parse(&deeply_nested_html);

--- a/crates/ruma-state-res/CHANGELOG.md
+++ b/crates/ruma-state-res/CHANGELOG.md
@@ -5,7 +5,7 @@ Bug fixes:
 - Don't propagate errors from `auth_check()` in `resolve()`. If an event fails
   the authorization check, it should just be ignored for the resolved state.
 - Don't error on deserialization of malformed fields that are not checked in the
-  authorization rules for `m.room.create` events.
+  authorization rules for `m.room.create` and `m.room.member` events.
 
 Improvements:
 
@@ -14,6 +14,7 @@ Improvements:
   over federation, to avoid erroring on malformed fields that are not checked by
   the authorization rules:
   - `RoomCreateEvent` for `m.room.create` events
+  - `RoomMemberEvent` for `m.room.member` events
 
 # 0.13.0
 

--- a/crates/ruma-state-res/CHANGELOG.md
+++ b/crates/ruma-state-res/CHANGELOG.md
@@ -4,6 +4,16 @@ Bug fixes:
 
 - Don't propagate errors from `auth_check()` in `resolve()`. If an event fails
   the authorization check, it should just be ignored for the resolved state.
+- Don't error on deserialization of malformed fields that are not checked in the
+  authorization rules for `m.room.create` events.
+
+Improvements:
+
+- New types with lazy deserialization that can be used by servers over the
+  stricter types from ruma-events to access the fields of an event when received
+  over federation, to avoid erroring on malformed fields that are not checked by
+  the authorization rules:
+  - `RoomCreateEvent` for `m.room.create` events
 
 # 0.13.0
 

--- a/crates/ruma-state-res/CHANGELOG.md
+++ b/crates/ruma-state-res/CHANGELOG.md
@@ -5,7 +5,8 @@ Bug fixes:
 - Don't propagate errors from `auth_check()` in `resolve()`. If an event fails
   the authorization check, it should just be ignored for the resolved state.
 - Don't error on deserialization of malformed fields that are not checked in the
-  authorization rules for `m.room.create` and `m.room.member` events.
+  authorization rules for `m.room.create`, `m.room.member` and
+  `m.room.power_levels` events.
 
 Improvements:
 
@@ -15,6 +16,7 @@ Improvements:
   the authorization rules:
   - `RoomCreateEvent` for `m.room.create` events
   - `RoomMemberEvent` for `m.room.member` events
+  - `RoomPowerLevelsEvent` for `m.room.power_levels` events
 
 # 0.13.0
 

--- a/crates/ruma-state-res/CHANGELOG.md
+++ b/crates/ruma-state-res/CHANGELOG.md
@@ -5,8 +5,8 @@ Bug fixes:
 - Don't propagate errors from `auth_check()` in `resolve()`. If an event fails
   the authorization check, it should just be ignored for the resolved state.
 - Don't error on deserialization of malformed fields that are not checked in the
-  authorization rules for `m.room.create`, `m.room.member` and
-  `m.room.power_levels` events.
+  authorization rules for `m.room.create`, `m.room.member`,
+  `m.room.power_levels` and `m.room.join_rules` events.
 
 Improvements:
 
@@ -17,6 +17,7 @@ Improvements:
   - `RoomCreateEvent` for `m.room.create` events
   - `RoomMemberEvent` for `m.room.member` events
   - `RoomPowerLevelsEvent` for `m.room.power_levels` events
+  - `RoomJoinRulesEvent` for `m.room.join_rules` events
 
 # 0.13.0
 

--- a/crates/ruma-state-res/Cargo.toml
+++ b/crates/ruma-state-res/Cargo.toml
@@ -16,7 +16,7 @@ all-features = true
 
 [dependencies]
 js_int = { workspace = true }
-ruma-common = { workspace = true }
+ruma-common = { workspace = true, features = ["canonical-json"] }
 ruma-events = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/ruma-state-res/src/error.rs
+++ b/crates/ruma-state-res/src/error.rs
@@ -30,7 +30,10 @@ pub enum Error {
 }
 
 impl Error {
-    pub fn custom<E: std::error::Error + 'static>(e: E) -> Self {
-        Self::Custom(Box::new(e))
+    pub fn custom<E>(e: E) -> Self
+    where
+        E: Into<Box<dyn std::error::Error>>,
+    {
+        Self::Custom(e.into())
     }
 }

--- a/crates/ruma-state-res/src/event_auth.rs
+++ b/crates/ruma-state-res/src/event_auth.rs
@@ -18,7 +18,7 @@ use crate::{
     events::{
         member::{RoomMemberEventContent, RoomMemberEventOptionExt},
         power_levels::{RoomPowerLevelsEventOptionExt, RoomPowerLevelsIntField},
-        RoomCreateEvent, RoomMemberEvent, RoomPowerLevelsEvent,
+        JoinRule, RoomCreateEvent, RoomJoinRulesEvent, RoomMemberEvent, RoomPowerLevelsEvent,
     },
     room_version::RoomVersion,
     Error, Event, Result, StateEventType, TimelineEventType,
@@ -574,6 +574,8 @@ trait FetchStateExt<E: Event> {
     fn user_membership(&self, user_id: &UserId) -> std::result::Result<MembershipState, String>;
 
     fn room_power_levels_event(&self) -> Option<RoomPowerLevelsEvent<E>>;
+
+    fn join_rule(&self) -> std::result::Result<JoinRule, String>;
 }
 
 impl<E, F> FetchStateExt<E> for F
@@ -593,5 +595,12 @@ where
 
     fn room_power_levels_event(&self) -> Option<RoomPowerLevelsEvent<E>> {
         self(&StateEventType::RoomPowerLevels, "").map(RoomPowerLevelsEvent::new)
+    }
+
+    fn join_rule(&self) -> std::result::Result<JoinRule, String> {
+        self(&StateEventType::RoomJoinRules, "")
+            .map(RoomJoinRulesEvent::new)
+            .ok_or_else(|| "no `m.room.join_rules` event in current state".to_owned())?
+            .join_rule()
     }
 }

--- a/crates/ruma-state-res/src/event_auth/room_member.rs
+++ b/crates/ruma-state-res/src/event_auth/room_member.rs
@@ -1,30 +1,29 @@
 use std::borrow::Borrow;
 
 use js_int::int;
-use ruma_common::{serde::Raw, UserId};
+use ruma_common::UserId;
 use ruma_events::{
     room::{
         join_rules::{JoinRule, RoomJoinRulesEventContent},
-        member::{MembershipState, ThirdPartyInvite},
+        member::MembershipState,
         power_levels::RoomPowerLevelsEventContent,
         third_party_invite::RoomThirdPartyInviteEventContent,
     },
     StateEventType,
 };
-use serde::Deserialize;
 use serde_json::from_str as from_json_str;
-use tracing::{debug, warn};
+use tracing::debug;
 
 #[cfg(test)]
 mod tests;
 
-use super::{GetMembership, RoomMemberContentFields};
+use super::FetchStateExt;
 use crate::{
     events::{
         deserialize_power_levels_content_fields, deserialize_power_levels_content_invite,
-        RoomCreateEvent,
+        member::ThirdPartyInvite, RoomCreateEvent, RoomMemberEvent,
     },
-    Error, Event, Result, RoomVersion,
+    Event, RoomVersion,
 };
 
 /// Check whether the given event passes the `m.room.roomber` authorization rules.
@@ -32,32 +31,22 @@ use crate::{
 /// This assumes that `ruma_signatures::verify_event()` was called previously, as some authorization
 /// rules depend on the signatures being valid on the event.
 pub(super) fn check_room_member<E: Event>(
-    room_member_event: impl Event,
+    room_member_event: RoomMemberEvent<impl Event>,
     room_version: &RoomVersion,
     room_create_event: RoomCreateEvent<E>,
     fetch_state: impl Fn(&StateEventType, &str) -> Option<E>,
-) -> Result<bool> {
+) -> Result<(), String> {
     debug!("starting m.room.member check");
 
     // Since v1, if there is no state_key property, or no membership property in content,
     // reject.
-    let state_key = match room_member_event.state_key() {
-        Some(s) => s,
-        None => {
-            warn!("no statekey in member event");
-            return Ok(false);
-        }
+    let Some(state_key) = room_member_event.state_key() else {
+        return Err("missing `state_key` field in `m.room.member` event".to_owned());
     };
-    let target_user =
-        <&UserId>::try_from(state_key).map_err(|e| Error::InvalidPdu(format!("{e}")))?;
+    let target_user = <&UserId>::try_from(state_key)
+        .map_err(|e| format!("invalid `state_key` field in `m.room.member` event: {e}"))?;
 
-    let content: RoomMemberContentFields = from_json_str(room_member_event.content().get())?;
-
-    let Some(target_membership) = content.membership.as_ref().and_then(|m| m.deserialize().ok())
-    else {
-        warn!("no valid membership field found for m.room.member event content");
-        return Ok(false);
-    };
+    let target_membership = room_member_event.membership()?;
 
     // These checks are done `in ruma_signatures::verify_event()`:
     //
@@ -71,7 +60,6 @@ pub(super) fn check_room_member<E: Event>(
         MembershipState::Join => check_room_member_join(
             &room_member_event,
             target_user,
-            content,
             room_version,
             room_create_event,
             fetch_state,
@@ -91,23 +79,19 @@ pub(super) fn check_room_member<E: Event>(
             check_room_member_knock(&room_member_event, target_user, room_version, fetch_state)
         }
         // Since v1, otherwise, the membership is unknown. Reject.
-        _ => {
-            warn!("unknown membership transition");
-            Ok(false)
-        }
+        _ => Err("unknown membership".to_owned()),
     }
 }
 
 /// Check whether the given event passes the `m.room.member` authorization rules with a membership
 /// of `join`.
 fn check_room_member_join<E: Event>(
-    room_member_event: &impl Event,
+    room_member_event: &RoomMemberEvent<impl Event>,
     target_user: &UserId,
-    content: RoomMemberContentFields,
     room_version: &RoomVersion,
     room_create_event: RoomCreateEvent<E>,
     fetch_state: impl Fn(&StateEventType, &str) -> Option<E>,
-) -> Result<bool> {
+) -> Result<(), String> {
     let mut prev_events = room_member_event.prev_events();
     let prev_event_is_room_create_event = prev_events
         .next()
@@ -120,34 +104,32 @@ fn check_room_member_join<E: Event>(
     // Since v11, if the only previous event is an m.room.create and the state_key is the
     // sender of the m.room.create, allow.
     if prev_event_is_only_room_create_event {
-        let creator = room_create_event.creator(room_version).map_err(Error::custom)?;
+        let creator = room_create_event.creator(room_version)?;
 
         if *target_user == *creator {
-            return Ok(true);
+            return Ok(());
         }
     }
 
     // Since v1, if the sender does not match state_key, reject.
     if room_member_event.sender() != target_user {
-        warn!("can't make other user join");
-        return Ok(false);
+        return Err("sender of join event must match target user".to_owned());
     }
 
-    let current_room_member_event = fetch_state(&StateEventType::RoomMember, target_user.as_str());
-    let current_membership = match &current_room_member_event {
-        Some(event) => from_json_str::<GetMembership>(event.content().get())?.membership,
-        None => MembershipState::Leave,
-    };
+    let current_membership = fetch_state.user_membership(target_user)?;
 
     // Since v1, if the sender is banned, reject.
     if current_membership == MembershipState::Ban {
-        warn!(target_user_membership_event_id = ?current_room_member_event.as_ref().map(|event| event.event_id()), "banned user can't join");
-        return Ok(false);
+        return Err("banned user cannot join room".to_owned());
     }
 
     let room_join_rules_event = fetch_state(&StateEventType::RoomJoinRules, "");
     let join_rule = match &room_join_rules_event {
-        Some(event) => from_json_str::<RoomJoinRulesEventContent>(event.content().get())?.join_rule,
+        Some(event) => {
+            from_json_str::<RoomJoinRulesEventContent>(event.content().get())
+                .map_err(|error| error.to_string())?
+                .join_rule
+        }
         None => JoinRule::Invite,
     };
 
@@ -159,7 +141,7 @@ fn check_room_member_join<E: Event>(
         || room_version.allow_knocking && join_rule == JoinRule::Knock)
         && matches!(current_membership, MembershipState::Invite | MembershipState::Join)
     {
-        return Ok(true);
+        return Ok(());
     }
 
     // v8-v9, if the join_rule is restricted:
@@ -170,28 +152,27 @@ fn check_room_member_join<E: Event>(
     {
         // Since v8, if membership state is join or invite, allow.
         if matches!(current_membership, MembershipState::Join | MembershipState::Invite) {
-            return Ok(true);
+            return Ok(());
         }
 
         // Since v8, if the join_authorised_via_users_server key in content is not a
         // user with sufficient permission to invite other users, reject.
         //
         // Otherwise, allow.
-        let Some(authorized_via_user) =
-            content.join_authorised_via_users_server.as_ref().and_then(|u| u.deserialize().ok())
+        let Some(authorized_via_user) = room_member_event.join_authorised_via_users_server()?
         else {
             // The field is absent, we cannot authorize.
-            return Ok(false);
+            return Err(
+                "cannot join restricted room without `join_authorised_via_users_server` field \
+                 if not invited"
+                    .to_owned(),
+            );
         };
 
         // The member needs to be in the room to have any kind of permission.
-        let authorized_via_user_room_member_event =
-            fetch_state(&StateEventType::RoomMember, authorized_via_user.as_str());
-        let authorized_via_user_is_joined = authorized_via_user_room_member_event
-            .and_then(|event| from_json_str::<GetMembership>(event.content().get()).ok())
-            .is_some_and(|content| content.membership == MembershipState::Join);
-        if !authorized_via_user_is_joined {
-            return Ok(false);
+        let authorized_via_user_membership = fetch_state.user_membership(&authorized_via_user)?;
+        if authorized_via_user_membership != MembershipState::Join {
+            return Err("`join_authorised_via_users_server` is not joined".to_owned());
         }
 
         let room_power_levels_event = fetch_state(&StateEventType::RoomPowerLevels, "");
@@ -200,11 +181,13 @@ fn check_room_member_join<E: Event>(
             if let Some(event) = &room_power_levels_event {
                 // TODO Refactor all powerlevel parsing
                 let invite =
-                    deserialize_power_levels_content_invite(event.content().get(), room_version)?
+                    deserialize_power_levels_content_invite(event.content().get(), room_version)
+                        .map_err(|error| error.to_string())?
                         .invite;
 
                 let content =
-                    deserialize_power_levels_content_fields(event.content().get(), room_version)?;
+                    deserialize_power_levels_content_fields(event.content().get(), room_version)
+                        .map_err(|error| error.to_string())?;
                 let user_level = if let Some(user_level) = content.users.get(&authorized_via_user) {
                     *user_level
                 } else {
@@ -216,81 +199,58 @@ fn check_room_member_join<E: Event>(
                 (int!(0), int!(0))
             };
 
-        return Ok(authorized_via_user_level >= invite_level);
+        return if authorized_via_user_level >= invite_level {
+            Ok(())
+        } else {
+            Err("`join_authorised_via_users_server` does not have enough power".to_owned())
+        };
     }
 
     // Since v1, if the join_rule is public, allow.
     // Otherwise, reject.
-    let allow = join_rule == JoinRule::Public;
-
-    if !allow {
-        warn!("Can't join a non-public room");
+    if join_rule == JoinRule::Public {
+        Ok(())
+    } else {
+        Err("cannot join a room that is not `public`".to_owned())
     }
-
-    Ok(allow)
 }
 
 /// Check whether the given event passes the `m.room.member` authorization rules with a membership
 /// of `invite`.
 fn check_room_member_invite<E: Event>(
-    room_member_event: &impl Event,
+    room_member_event: &RoomMemberEvent<impl Event>,
     target_user: &UserId,
     fetch_state: impl Fn(&StateEventType, &str) -> Option<E>,
-) -> Result<bool> {
-    #[derive(Deserialize)]
-    struct GetThirdPartyInvite {
-        third_party_invite: Option<Raw<ThirdPartyInvite>>,
-    }
-
-    let third_party_invite =
-        from_json_str::<GetThirdPartyInvite>(room_member_event.content().get())?.third_party_invite;
+) -> Result<(), String> {
+    let third_party_invite = room_member_event.third_party_invite()?;
 
     // Since v1, if content has a third_party_invite property:
-    if let Some(raw_third_party_invite) = third_party_invite {
+    if let Some(third_party_invite) = third_party_invite {
         return check_third_party_invite(
             room_member_event,
-            raw_third_party_invite,
+            third_party_invite,
             target_user,
             fetch_state,
         );
     }
 
-    let sender_room_member_event =
-        fetch_state(&StateEventType::RoomMember, room_member_event.sender().as_str());
-    let sender_membership = match &sender_room_member_event {
-        Some(event) => from_json_str::<GetMembership>(event.content().get())?.membership,
-        None => MembershipState::Leave,
-    };
+    let sender_membership = fetch_state.user_membership(room_member_event.sender())?;
 
     // Since v1, if the sender’s current membership state is not join, reject.
     if sender_membership != MembershipState::Join {
-        warn!(
-            sender_membership_event_id = ?sender_room_member_event.as_ref().map(|event| event.event_id()),
-            "can't invite user if sender not joined",
-        );
-        return Ok(false);
+        return Err("cannot invite user if sender is not joined".to_owned());
     }
 
-    let current_target_user_room_member_event =
-        fetch_state(&StateEventType::RoomMember, target_user.as_str());
-    let current_target_user_membership = match &current_target_user_room_member_event {
-        Some(event) => from_json_str::<GetMembership>(event.content().get())?.membership,
-        None => MembershipState::Leave,
-    };
+    let current_target_user_membership = fetch_state.user_membership(target_user)?;
 
     // Since v1, if target user’s current membership state is join or ban, reject.
     if matches!(current_target_user_membership, MembershipState::Join | MembershipState::Ban) {
-        warn!(
-            target_user_membership_event_id =
-                ?current_target_user_room_member_event.as_ref().map(|event| event.event_id()),
-            "can't invite user if user is currently joined or banned",
-        );
-        return Ok(false);
+        return Err("cannot invite user that is joined or banned".to_owned());
     }
 
     let room_power_levels_event = fetch_state(&StateEventType::RoomPowerLevels, "");
     let power_levels: RoomPowerLevelsEventContent = match &room_power_levels_event {
-        Some(event) => from_json_str(event.content().get())?,
+        Some(event) => from_json_str(event.content().get()).map_err(|error| error.to_string())?,
         None => RoomPowerLevelsEventContent::default(),
     };
 
@@ -301,73 +261,58 @@ fn check_room_member_invite<E: Event>(
     // level, allow.
     //
     // Otherwise, reject.
-    let allow = sender_level >= &power_levels.invite;
-
-    if !allow {
-        warn!(
-            target_user_membership_event_id =
-                ?current_target_user_room_member_event.as_ref().map(|event| event.event_id()),
-            power_levels_event_id =
-                ?room_power_levels_event.as_ref().map(|event| event.event_id()),
-            "user does not have enough power to invite",
-        );
+    if sender_level >= &power_levels.invite {
+        Ok(())
+    } else {
+        Err("sender does not have enough power to invite".to_owned())
     }
-
-    Ok(allow)
 }
 
 /// Check whether the `third_party_invite` from the `m.room.member` event passes the authorization
 /// rules.
 fn check_third_party_invite<E: Event>(
-    room_member_event: &impl Event,
-    raw_third_party_invite: Raw<ThirdPartyInvite>,
+    room_member_event: &RoomMemberEvent<impl Event>,
+    third_party_invite: ThirdPartyInvite,
     target_user: &UserId,
     fetch_state: impl Fn(&StateEventType, &str) -> Option<E>,
-) -> Result<bool> {
-    let current_target_user_room_member_event =
-        fetch_state(&StateEventType::RoomMember, target_user.as_str());
-    let current_target_user_membership = match &current_target_user_room_member_event {
-        Some(event) => from_json_str::<GetMembership>(event.content().get())?.membership,
-        None => MembershipState::Leave,
-    };
+) -> Result<(), String> {
+    let current_target_user_membership = fetch_state.user_membership(target_user)?;
 
+    // Since v1, if target user is banned, reject.
     if current_target_user_membership == MembershipState::Ban {
-        // Since v1, if target user is banned, reject.
-        warn!(
-            target_user_membership_event_id = ?current_target_user_room_member_event.as_ref().map(|event| event.event_id()),
-            "can't invite banned user"
-        );
-        return Ok(false);
+        return Err("cannot invite user that is banned".to_owned());
     }
 
     // Since v1, if content.third_party_invite does not have a signed property, reject.
     // Since v1, if signed does not have mxid and token properties, reject.
-    let third_party_invite = raw_third_party_invite.deserialize()?;
+    let third_party_invite_token = third_party_invite.token()?;
+    let third_party_invite_mxid = third_party_invite.mxid()?;
 
     // Since v1, if mxid does not match state_key, reject.
-    if target_user != third_party_invite.signed.mxid {
-        warn!("mxid doesn't match state key");
-        return Ok(false);
+    if target_user != third_party_invite_mxid {
+        return Err("third-party invite mxid does not match target user".to_owned());
     }
 
     // Since v1, if there is no m.room.third_party_invite event in the current room state with
     // state_key matching token, reject.
     let Some(room_third_party_invite_event) =
-        fetch_state(&StateEventType::RoomThirdPartyInvite, &third_party_invite.signed.token)
+        fetch_state(&StateEventType::RoomThirdPartyInvite, third_party_invite_token)
     else {
-        warn!("no m.room.third_party_event in state matches the token");
-        return Ok(false);
+        return Err("no `m.room.third_party_invite` in room state matches the token".to_owned());
     };
 
     // Since v1, if sender does not match sender of the m.room.third_party_invite, reject.
     if room_member_event.sender() != room_third_party_invite_event.sender() {
-        warn!("sender of m.room.third_party_invite doesn't match sender of m.room.member");
-        return Ok(false);
+        return Err(
+            "sender of `m.room.third_party_invite` does not match sender of `m.room.member`"
+                .to_owned(),
+        );
     }
 
     let _room_third_party_invite_content = from_json_str::<RoomThirdPartyInviteEventContent>(
         room_third_party_invite_event.content().get(),
-    )?;
+    )
+    .map_err(|error| error.to_string())?;
 
     // Since v1, if any signature in signed matches any public key in the m.room.third_party_invite
     // event, allow.
@@ -376,61 +321,46 @@ fn check_third_party_invite<E: Event>(
     //
     // FIXME: verify the signatures on `signed` with the public keys in `m.room.third_party_invite`.
     // For now let's accept the event.
-    Ok(true)
+    Ok(())
 }
 
 /// Check whether the given event passes the `m.room.member` authorization rules with a membership
 /// of `leave`.
 fn check_room_member_leave<E: Event>(
-    room_member_event: &impl Event,
+    room_member_event: &RoomMemberEvent<impl Event>,
     target_user: &UserId,
     room_version: &RoomVersion,
     fetch_state: impl Fn(&StateEventType, &str) -> Option<E>,
-) -> Result<bool> {
-    let sender_room_member_event =
-        fetch_state(&StateEventType::RoomMember, room_member_event.sender().as_str());
-    let sender_membership = match &sender_room_member_event {
-        Some(event) => from_json_str::<GetMembership>(event.content().get())?.membership,
-        None => MembershipState::Leave,
-    };
+) -> Result<(), String> {
+    let sender_membership = fetch_state.user_membership(room_member_event.sender())?;
 
     // v1-v6, if the sender matches state_key, allow if and only if that user’s current
     // membership state is invite or join.
     // Since v7, if the sender matches state_key, allow if and only if that user’s current
     // membership state is invite, join, or knock.
     if room_member_event.sender() == target_user {
-        let allow = matches!(sender_membership, MembershipState::Join | MembershipState::Invite)
-            || (room_version.allow_knocking && sender_membership == MembershipState::Knock);
+        let membership_is_invite_or_join =
+            matches!(sender_membership, MembershipState::Join | MembershipState::Invite);
+        let membership_is_knock =
+            room_version.allow_knocking && sender_membership == MembershipState::Knock;
 
-        if !allow {
-            warn!(
-                target_user_membership_event_id = ?sender_room_member_event.as_ref().map(|event| event.event_id()),
-                "can't leave if not joined, invited or knocked"
-            );
-        }
-
-        return Ok(allow);
+        return if membership_is_invite_or_join || membership_is_knock {
+            Ok(())
+        } else {
+            Err("cannot leave if not joined, invited or knocked".to_owned())
+        };
     }
 
     // Since v1, if the sender’s current membership state is not join, reject.
     if sender_membership != MembershipState::Join {
-        warn!(
-            sender_membership_event_id = ?sender_room_member_event.as_ref().map(|event| event.event_id()),
-            "can't kick if sender not joined",
-        );
-        return Ok(false);
+        return Err("cannot kick if sender is not joined".to_owned());
     }
 
-    let current_target_user_room_member_event =
-        fetch_state(&StateEventType::RoomMember, target_user.as_str());
-    let current_target_user_membership = match &current_target_user_room_member_event {
-        Some(event) => from_json_str::<GetMembership>(event.content().get())?.membership,
-        None => MembershipState::Leave,
-    };
+    let current_target_user_membership = fetch_state.user_membership(target_user)?;
 
     let room_power_levels_event = fetch_state(&StateEventType::RoomPowerLevels, "");
     let power_levels: RoomPowerLevelsEventContent = match &room_power_levels_event {
-        Some(event) => from_json_str(event.content().get())?,
+        Some(event) => from_json_str(event.content().get()).map_err(|error| error.to_string())?,
         None => RoomPowerLevelsEventContent::default(),
     };
 
@@ -440,12 +370,7 @@ fn check_room_member_leave<E: Event>(
     // Since v1, if the target user’s current membership state is ban, and the sender’s
     // power level is less than the ban level, reject.
     if current_target_user_membership == MembershipState::Ban && sender_level < &power_levels.ban {
-        warn!(
-            target_user_membership_event_id = ?current_target_user_room_member_event.as_ref().map(|event| event.event_id()),
-            sender_membership_event_id = ?sender_room_member_event.as_ref().map(|event| event.event_id()),
-            "can't kick if user is banned and sender can't unban",
-        );
-        return Ok(false);
+        return Err("sender does not have enough power to unban".to_owned());
     }
 
     let target_user_level =
@@ -455,44 +380,30 @@ fn check_room_member_leave<E: Event>(
     // and the target user’s power level is less than the sender’s power level, allow.
     //
     // Otherwise, reject.
-    let allow = sender_level >= &power_levels.kick && target_user_level < sender_level;
-
-    if !allow {
-        warn!(
-            target_user_membership_event_id = ?current_target_user_room_member_event.as_ref().map(|event| event.event_id()),
-            power_levels_event_id = ?room_power_levels_event.as_ref().map(|event| event.event_id()),
-            "sender does not have enough power to kick target user",
-        );
+    if sender_level >= &power_levels.kick && target_user_level < sender_level {
+        Ok(())
+    } else {
+        Err("sender does not have enough power to kick target user".to_owned())
     }
-
-    Ok(allow)
 }
 
 /// Check whether the given event passes the `m.room.member` authorization rules with a membership
 /// of `ban`.
 fn check_room_member_ban<E: Event>(
-    room_member_event: &impl Event,
+    room_member_event: &RoomMemberEvent<impl Event>,
     target_user: &UserId,
     fetch_state: impl Fn(&StateEventType, &str) -> Option<E>,
-) -> Result<bool> {
-    let sender_room_member_event =
-        fetch_state(&StateEventType::RoomMember, room_member_event.sender().as_str());
-    let sender_membership = match &sender_room_member_event {
-        Some(event) => from_json_str::<GetMembership>(event.content().get())?.membership,
-        None => MembershipState::Leave,
-    };
+) -> Result<(), String> {
+    let sender_membership = fetch_state.user_membership(room_member_event.sender())?;
 
     // Since v1, if the sender’s current membership state is not join, reject.
     if sender_membership != MembershipState::Join {
-        warn!(
-            sender_membership_event_id = ?sender_room_member_event.as_ref().map(|event| event.event_id()),
-            "can't ban user if sender is not joined"
-        );
-        return Ok(false);
+        return Err("cannot ban if sender is not joined".to_owned());
     }
+
     let room_power_levels_event = fetch_state(&StateEventType::RoomPowerLevels, "");
     let power_levels: RoomPowerLevelsEventContent = match &room_power_levels_event {
-        Some(event) => from_json_str(event.content().get())?,
+        Some(event) => from_json_str(event.content().get()).map_err(|error| error.to_string())?,
         None => RoomPowerLevelsEventContent::default(),
     };
 
@@ -505,30 +416,28 @@ fn check_room_member_ban<E: Event>(
     // target user’s power level is less than the sender’s power level, allow.
     //
     // Otherwise, reject.
-    let allow = sender_level >= &power_levels.ban && target_user_level < sender_level;
-
-    if !allow {
-        warn!(
-            sender_membership_event_id = ?sender_room_member_event.as_ref().map(|event| event.event_id()),
-            power_levels_event_id = ?room_power_levels_event.as_ref().map(|event| event.event_id()),
-            "sender does not have enough power to ban target user",
-        );
+    if sender_level >= &power_levels.ban && target_user_level < sender_level {
+        Ok(())
+    } else {
+        Err("sender does not have enough power to ban target user".to_owned())
     }
-
-    Ok(allow)
 }
 
 /// Check whether the given event passes the `m.room.member` authorization rules with a membership
 /// of `knock`.
 fn check_room_member_knock<E: Event>(
-    room_member_event: &impl Event,
+    room_member_event: &RoomMemberEvent<impl Event>,
     target_user: &UserId,
     room_version: &RoomVersion,
     fetch_state: impl Fn(&StateEventType, &str) -> Option<E>,
-) -> Result<bool> {
+) -> Result<(), String> {
     let room_join_rules_event = fetch_state(&StateEventType::RoomJoinRules, "");
     let join_rule = match &room_join_rules_event {
-        Some(event) => from_json_str::<RoomJoinRulesEventContent>(event.content().get())?.join_rule,
+        Some(event) => {
+            from_json_str::<RoomJoinRulesEventContent>(event.content().get())
+                .map_err(|error| error.to_string())?
+                .join_rule
+        }
         None => JoinRule::Invite,
     };
 
@@ -539,40 +448,26 @@ fn check_room_member_knock<E: Event>(
         && (room_version.knock_restricted_join_rule
             && !matches!(join_rule, JoinRule::KnockRestricted(_)))
     {
-        warn!("join rule is not set to knock or knock_restricted, knocking is not allowed");
-        return Ok(false);
+        return Err(
+            "join rule is not set to knock or knock_restricted, knocking is not allowed".to_owned()
+        );
     }
 
     // Since v7, if sender does not match state_key, reject.
     if room_member_event.sender() != target_user {
-        warn!(
-            sender = ?room_member_event.sender(),
-            ?target_user,
-            "can't make another user knock, sender did not match target"
-        );
-        return Ok(false);
+        return Err("cannot make another user knock, sender does not match target user".to_owned());
     }
 
-    let sender_room_member_event =
-        fetch_state(&StateEventType::RoomMember, room_member_event.sender().as_str());
-    let sender_membership = match &sender_room_member_event {
-        Some(event) => from_json_str::<GetMembership>(event.content().get())?.membership,
-        None => MembershipState::Leave,
-    };
+    let sender_membership = fetch_state.user_membership(room_member_event.sender())?;
 
     // Since v7, if the sender’s current membership is not ban, invite, or join, allow.
     // Otherwise, reject.
-    let allow = !matches!(
+    if !matches!(
         sender_membership,
         MembershipState::Ban | MembershipState::Invite | MembershipState::Join
-    );
-
-    if !allow {
-        warn!(
-            target_user_membership_event_id = ?sender_room_member_event.as_ref().map(|event| event.event_id()),
-            "cannot knock while current membership state is ban, invite or join",
-        );
+    ) {
+        Ok(())
+    } else {
+        Err("cannot knock if user is banned, invited or joined".to_owned())
     }
-
-    Ok(allow)
 }

--- a/crates/ruma-state-res/src/event_auth/tests.rs
+++ b/crates/ruma-state-res/src/event_auth/tests.rs
@@ -16,7 +16,7 @@ use super::check_room_create;
 use crate::{
     auth_check,
     event_auth::check_room_redaction,
-    events::RoomCreateEvent,
+    events::{RoomCreateEvent, RoomPowerLevelsEvent},
     test_utils::{
         alice, charlie, ella, event_id, init_subscriber, member_content_join,
         room_redaction_pdu_event, room_third_party_invite, to_init_pdu_event, to_pdu_event,
@@ -163,7 +163,7 @@ fn redact_same_power_level() {
         &["IPOWER"],
     );
 
-    let room_power_levels_event = Some(to_pdu_event(
+    let room_power_levels_event = Some(RoomPowerLevelsEvent::new(to_pdu_event(
         "IPOWER",
         alice(),
         TimelineEventType::RoomPowerLevels,
@@ -171,7 +171,7 @@ fn redact_same_power_level() {
         to_raw_json_value(&json!({ "users": { alice(): 100, charlie(): 50 } })).unwrap(),
         &["CREATE", "IMA"],
         &["IMA"],
-    ));
+    )));
 
     // Can redact if redact level is same as user's.
     assert!(check_room_redaction(
@@ -458,7 +458,7 @@ fn room_third_party_invite_not_enough_power() {
     let fetch_state = auth_events.fetch_state_fn();
 
     // Cannot accept `m.room.third_party_invite` if not enough power.
-    assert!(!auth_check(&RoomVersion::V6, incoming_event, fetch_state).unwrap());
+    auth_check(&RoomVersion::V6, incoming_event, fetch_state).unwrap_err();
 }
 
 #[test]

--- a/crates/ruma-state-res/src/event_auth/tests.rs
+++ b/crates/ruma-state-res/src/event_auth/tests.rs
@@ -66,6 +66,33 @@ fn valid_room_create() {
         to_raw_json_value(&content).unwrap(),
     );
     check_room_create(RoomCreateEvent::new(event), &RoomVersion::V11).unwrap();
+
+    // Check various contents that might not match the definition of `m.room.create` in the
+    // spec, to ensure that we only care about a few fields.
+    let contents_to_check = vec![
+        // With an invalid predecessor, but we don't care about it. Inspired by a real-life
+        // example.
+        json!({
+            "room_version": "11",
+            "predecessor": "!XPoLiaavxVgyMSiRwK:localhost",
+        }),
+        // With an invalid type, but we don't care about it.
+        json!({
+            "room_version": "11",
+            "type": true,
+        }),
+    ];
+
+    for content in contents_to_check {
+        let event = to_init_pdu_event(
+            "CREATE",
+            alice(),
+            TimelineEventType::RoomCreate,
+            Some(""),
+            to_raw_json_value(&content).unwrap(),
+        );
+        check_room_create(RoomCreateEvent::new(event), &RoomVersion::V11).unwrap();
+    }
 }
 
 #[test]

--- a/crates/ruma-state-res/src/events.rs
+++ b/crates/ruma-state-res/src/events.rs
@@ -1,12 +1,14 @@
 //! Helper traits and types to work with events (aka PDUs).
 
 mod create;
+mod join_rules;
 pub(crate) mod member;
 pub(crate) mod power_levels;
 mod traits;
 
 pub use self::{
     create::RoomCreateEvent,
+    join_rules::{JoinRule, RoomJoinRulesEvent},
     member::RoomMemberEvent,
     power_levels::{RoomPowerLevelsEvent, RoomPowerLevelsIntField},
     traits::Event,

--- a/crates/ruma-state-res/src/events.rs
+++ b/crates/ruma-state-res/src/events.rs
@@ -2,12 +2,12 @@
 
 mod create;
 pub(crate) mod member;
-mod power_levels;
+pub(crate) mod power_levels;
 mod traits;
 
-pub(crate) use self::power_levels::{
-    deserialize_power_levels, deserialize_power_levels_content_fields,
-    deserialize_power_levels_content_invite, deserialize_power_levels_content_redact,
-    PowerLevelsContentFields,
+pub use self::{
+    create::RoomCreateEvent,
+    member::RoomMemberEvent,
+    power_levels::{RoomPowerLevelsEvent, RoomPowerLevelsIntField},
+    traits::Event,
 };
-pub use self::{create::RoomCreateEvent, member::RoomMemberEvent, traits::Event};

--- a/crates/ruma-state-res/src/events.rs
+++ b/crates/ruma-state-res/src/events.rs
@@ -1,6 +1,7 @@
 //! Helper traits and types to work with events (aka PDUs).
 
 mod create;
+pub(crate) mod member;
 mod power_levels;
 mod traits;
 
@@ -9,4 +10,4 @@ pub(crate) use self::power_levels::{
     deserialize_power_levels_content_invite, deserialize_power_levels_content_redact,
     PowerLevelsContentFields,
 };
-pub use self::{create::RoomCreateEvent, traits::Event};
+pub use self::{create::RoomCreateEvent, member::RoomMemberEvent, traits::Event};

--- a/crates/ruma-state-res/src/events.rs
+++ b/crates/ruma-state-res/src/events.rs
@@ -1,11 +1,12 @@
 //! Helper traits and types to work with events (aka PDUs).
 
+mod create;
 mod power_levels;
 mod traits;
 
-pub(crate) use power_levels::{
+pub(crate) use self::power_levels::{
     deserialize_power_levels, deserialize_power_levels_content_fields,
     deserialize_power_levels_content_invite, deserialize_power_levels_content_redact,
     PowerLevelsContentFields,
 };
-pub use traits::Event;
+pub use self::{create::RoomCreateEvent, traits::Event};

--- a/crates/ruma-state-res/src/events/create.rs
+++ b/crates/ruma-state-res/src/events/create.rs
@@ -1,0 +1,96 @@
+//! Types to deserialize `m.room.create` events.
+
+use std::{borrow::Cow, ops::Deref};
+
+use ruma_common::{serde::from_raw_json_value, OwnedUserId, RoomVersionId, UserId};
+use serde::{de::IgnoredAny, Deserialize};
+
+use super::Event;
+use crate::RoomVersion;
+
+/// A helper type for an [`Event`] of type `m.room.create`.
+///
+/// This is a type that deserializes each field lazily, when requested.
+#[derive(Debug, Clone)]
+pub struct RoomCreateEvent<E: Event>(E);
+
+impl<E: Event> RoomCreateEvent<E> {
+    /// Construct a new `RoomCreateEvent` around the given event.
+    pub fn new(event: E) -> Self {
+        Self(event)
+    }
+
+    /// The version of the room.
+    pub fn room_version(&self) -> Result<RoomVersionId, String> {
+        #[derive(Deserialize)]
+        struct RoomCreateContentRoomVersion {
+            room_version: Option<RoomVersionId>,
+        }
+
+        let content: RoomCreateContentRoomVersion =
+            from_raw_json_value(self.content()).map_err(|err: serde_json::Error| {
+                format!("invalid `room_version` field in `m.room.create` event: {err}")
+            })?;
+        Ok(content.room_version.unwrap_or(RoomVersionId::V1))
+    }
+
+    /// Whether the room is federated.
+    pub fn federate(&self) -> Result<bool, String> {
+        #[derive(Deserialize)]
+        struct RoomCreateContentFederate {
+            #[serde(rename = "m.federate")]
+            federate: Option<bool>,
+        }
+
+        let content: RoomCreateContentFederate =
+            from_raw_json_value(self.content()).map_err(|err: serde_json::Error| {
+                format!("invalid `m.federate` field in `m.room.create` event: {err}")
+            })?;
+        Ok(content.federate.unwrap_or(true))
+    }
+
+    /// The creator of the room.
+    ///
+    /// If the `use_room_create_sender` field of `RoomVersion` is set, the creator is the sender of
+    /// this `m.room.create` event, otherwise it is deserialized from the `creator` field of this
+    /// event's content.
+    pub fn creator(&self, room_version: &RoomVersion) -> Result<Cow<'_, UserId>, String> {
+        #[derive(Deserialize)]
+        struct RoomCreateContentCreator {
+            creator: OwnedUserId,
+        }
+
+        if room_version.use_room_create_sender {
+            Ok(Cow::Borrowed(self.sender()))
+        } else {
+            let content: RoomCreateContentCreator =
+                from_raw_json_value(self.content()).map_err(|err: serde_json::Error| {
+                    format!("missing or invalid `creator` field in `m.room.create` event: {err}")
+                })?;
+
+            Ok(Cow::Owned(content.creator))
+        }
+    }
+
+    /// Whether the event has a `creator` field.
+    pub(crate) fn has_creator(&self) -> Result<bool, String> {
+        #[derive(Deserialize)]
+        struct RoomCreateContentCreator {
+            creator: Option<IgnoredAny>,
+        }
+
+        let content: RoomCreateContentCreator =
+            from_raw_json_value(self.content()).map_err(|err: serde_json::Error| {
+                format!("invalid `creator` field in `m.room.create` event: {err}")
+            })?;
+        Ok(content.creator.is_some())
+    }
+}
+
+impl<E: Event> Deref for RoomCreateEvent<E> {
+    type Target = E;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}

--- a/crates/ruma-state-res/src/events/join_rules.rs
+++ b/crates/ruma-state-res/src/events/join_rules.rs
@@ -1,0 +1,74 @@
+//! Types to deserialize `m.room.join_rules` events.
+
+use std::ops::Deref;
+
+use ruma_common::serde::{from_raw_json_value, PartialEqAsRefStr, StringEnum};
+use serde::Deserialize;
+
+use super::Event;
+
+/// A helper type for an [`Event`] of type `m.room.join_rules`.
+///
+/// This is a type that deserializes each field lazily, when requested.
+#[derive(Debug, Clone)]
+pub struct RoomJoinRulesEvent<E: Event>(E);
+
+impl<E: Event> RoomJoinRulesEvent<E> {
+    /// Construct a new `RoomJoinRulesEvent` around the given event.
+    pub fn new(event: E) -> Self {
+        Self(event)
+    }
+
+    /// The join rule of the room.
+    pub fn join_rule(&self) -> Result<JoinRule, String> {
+        #[derive(Deserialize)]
+        struct RoomJoinRulesContentJoinRule {
+            join_rule: JoinRule,
+        }
+
+        let content: RoomJoinRulesContentJoinRule =
+            from_raw_json_value(self.content()).map_err(|err: serde_json::Error| {
+                format!("missing or invalid `join_rule` field in `m.room.join_rules` event: {err}")
+            })?;
+        Ok(content.join_rule)
+    }
+}
+
+impl<E: Event> Deref for RoomJoinRulesEvent<E> {
+    type Target = E;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Clone, StringEnum, PartialEqAsRefStr)]
+#[ruma_enum(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum JoinRule {
+    /// `public`
+    Public,
+
+    /// `invite`
+    Invite,
+
+    /// `knock`
+    Knock,
+
+    /// `restricted`
+    Restricted,
+
+    /// `KnockRestricted`
+    KnockRestricted,
+
+    #[doc(hidden)]
+    _Custom(PrivOwnedStr),
+}
+
+impl Eq for JoinRule {}
+
+// Wrapper around `Box<str>` that cannot be used in a meaningful way outside of
+// this crate. Used for string enums because their `_Custom` variant can't be
+// truly private (only `#[doc(hidden)]`).
+#[derive(Debug, Clone)]
+pub struct PrivOwnedStr(Box<str>);

--- a/crates/ruma-state-res/src/events/member.rs
+++ b/crates/ruma-state-res/src/events/member.rs
@@ -1,0 +1,162 @@
+//! Types to deserialize `m.room.member` events.
+
+use std::ops::Deref;
+
+use ruma_common::{serde::from_raw_json_value, CanonicalJsonObject, OwnedUserId};
+use ruma_events::room::member::MembershipState;
+use serde::Deserialize;
+use serde_json::value::RawValue as RawJsonValue;
+
+use super::Event;
+
+/// A helper type for an [`Event`] of type `m.room.member`.
+///
+/// This is a type that deserializes each field lazily, as requested.
+#[derive(Debug, Clone)]
+pub struct RoomMemberEvent<E: Event>(E);
+
+impl<E: Event> RoomMemberEvent<E> {
+    /// Construct a new `RoomMemberEvent` around the given event.
+    pub fn new(event: E) -> Self {
+        Self(event)
+    }
+
+    /// The membership of the user.
+    pub fn membership(&self) -> Result<MembershipState, String> {
+        RoomMemberEventContent(self.content()).membership()
+    }
+
+    /// If this is a `join` event, the ID of a user on the homeserver that authorized it.
+    pub fn join_authorised_via_users_server(&self) -> Result<Option<OwnedUserId>, String> {
+        RoomMemberEventContent(self.content()).join_authorised_via_users_server()
+    }
+
+    /// If this is an `invite` event, details about the third-party invite that resulted in this
+    /// event.
+    pub(crate) fn third_party_invite(&self) -> Result<Option<ThirdPartyInvite>, String> {
+        RoomMemberEventContent(self.content()).third_party_invite()
+    }
+}
+
+impl<E: Event> Deref for RoomMemberEvent<E> {
+    type Target = E;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// Helper trait for `Option<RoomMemberEvent<E>>`.
+pub(crate) trait RoomMemberEventOptionExt {
+    /// The membership of the user.
+    ///
+    /// Defaults to `leave` if there is no `m.room.member` event.
+    fn membership(&self) -> Result<MembershipState, String>;
+}
+
+impl<E: Event> RoomMemberEventOptionExt for Option<RoomMemberEvent<E>> {
+    fn membership(&self) -> Result<MembershipState, String> {
+        match self {
+            Some(event) => event.membership(),
+            None => Ok(MembershipState::Leave),
+        }
+    }
+}
+
+/// A helper type for the raw JSON content of an event of type `m.room.member`.
+pub(crate) struct RoomMemberEventContent<'a>(&'a RawJsonValue);
+
+impl<'a> RoomMemberEventContent<'a> {
+    /// Construct a new `RoomMemberEventContent` around the given raw JSON content.
+    pub(crate) fn new(content: &'a RawJsonValue) -> Self {
+        Self(content)
+    }
+}
+
+impl RoomMemberEventContent<'_> {
+    /// The membership of the user.
+    pub(crate) fn membership(&self) -> Result<MembershipState, String> {
+        #[derive(Deserialize)]
+        struct RoomMemberContentMembership {
+            membership: MembershipState,
+        }
+
+        let content: RoomMemberContentMembership =
+            from_raw_json_value(self.0).map_err(|err: serde_json::Error| {
+                format!("missing or invalid `membership` field in `m.room.member` event: {err}")
+            })?;
+        Ok(content.membership)
+    }
+
+    /// If this is a `join` event, the ID of a user on the homeserver that authorized it.
+    pub(crate) fn join_authorised_via_users_server(&self) -> Result<Option<OwnedUserId>, String> {
+        #[derive(Deserialize)]
+        struct RoomMemberContentJoinAuthorizedViaUsersServer {
+            join_authorised_via_users_server: Option<OwnedUserId>,
+        }
+
+        let content: RoomMemberContentJoinAuthorizedViaUsersServer = from_raw_json_value(self.0)
+            .map_err(|err: serde_json::Error| {
+                format!(
+                "invalid `join_authorised_via_users_server` field in `m.room.member` event: {err}"
+            )
+            })?;
+        Ok(content.join_authorised_via_users_server)
+    }
+
+    /// If this is an `invite` event, details about the third-party invite that resulted in this
+    /// event.
+    pub(crate) fn third_party_invite(&self) -> Result<Option<ThirdPartyInvite>, String> {
+        #[derive(Deserialize)]
+        struct RoomMemberContentThirdPartyInvite {
+            third_party_invite: Option<ThirdPartyInvite>,
+        }
+
+        let content: RoomMemberContentThirdPartyInvite =
+            from_raw_json_value(self.0).map_err(|err: serde_json::Error| {
+                format!("invalid `third_party_invite` field in `m.room.member` event: {err}")
+            })?;
+        Ok(content.third_party_invite)
+    }
+}
+
+/// Details about a third-party invite.
+#[derive(Deserialize)]
+pub(crate) struct ThirdPartyInvite {
+    /// Signed details about the third-party invite.
+    signed: CanonicalJsonObject,
+}
+
+impl ThirdPartyInvite {
+    /// The unique identifier for the third-party invite.
+    pub(crate) fn token(&self) -> Result<&str, String> {
+        let Some(token_value) = self.signed.get("token") else {
+            return Err("missing `token` field in `third_party_invite.signed` \
+                        of `m.room.member` event"
+                .into());
+        };
+
+        token_value.as_str().ok_or_else(|| {
+            format!(
+                "unexpected format of `token` field in `third_party_invite.signed` \
+                 of `m.room.member` event: expected string, got {token_value:?}"
+            )
+        })
+    }
+
+    /// The Matrix ID of the user that was invited.
+    pub(crate) fn mxid(&self) -> Result<&str, String> {
+        let Some(mxid_value) = self.signed.get("mxid") else {
+            return Err("missing `mxid` field in `third_party_invite.signed` \
+                        of `m.room.member` event"
+                .into());
+        };
+
+        mxid_value.as_str().ok_or_else(|| {
+            format!(
+                "unexpected format of `mxid` field in `third_party_invite.signed` \
+                 of `m.room.member` event: expected string, got {mxid_value:?}"
+            )
+        })
+    }
+}

--- a/crates/ruma-state-res/src/lib.rs
+++ b/crates/ruma-state-res/src/lib.rs
@@ -16,7 +16,7 @@ use tracing::{debug, info, instrument, trace, warn};
 
 mod error;
 pub mod event_auth;
-mod events;
+pub mod events;
 pub mod room_version;
 #[cfg(test)]
 mod test_utils;

--- a/crates/ruma-state-res/src/test_utils.rs
+++ b/crates/ruma-state-res/src/test_utils.rs
@@ -28,7 +28,9 @@ use serde_json::{
 use tracing::info;
 
 pub(crate) use self::event::PduEvent;
-use crate::{auth_types_for_event, Error, Event, EventTypeExt, Result, StateMap};
+use crate::{
+    auth_types_for_event, events::RoomCreateEvent, Error, Event, EventTypeExt, Result, StateMap,
+};
 
 static SERVER_TIMESTAMP: AtomicU64 = AtomicU64::new(0);
 
@@ -731,8 +733,8 @@ impl TestStateMap {
     /// The `m.room.create` event contained in this map.
     ///
     /// Panics if there is no `m.room.create` event in this map.
-    pub(crate) fn room_create_event(&self) -> &Arc<PduEvent> {
-        self.get(&StateEventType::RoomCreate, "").unwrap()
+    pub(crate) fn room_create_event(&self) -> RoomCreateEvent<&Arc<PduEvent>> {
+        RoomCreateEvent::new(self.get(&StateEventType::RoomCreate, "").unwrap())
     }
 }
 

--- a/crates/ruma/CHANGELOG.md
+++ b/crates/ruma/CHANGELOG.md
@@ -8,7 +8,7 @@
 - ruma-server-util was merged into ruma-federation-api. The corresponding
   feature was removed. `XMatrix` is available in the
   `api::federation::authentication` module.
-- Bump MSRV to 1.81
+- Bump MSRV to 1.82
 
 # 0.12.1
 

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -16,7 +16,7 @@ use reexport_features::check_reexport_features;
 use spec_links::check_spec_links;
 use unused_features::check_unused_features;
 
-const MSRV: &str = "1.81";
+const MSRV: &str = "1.82";
 
 #[derive(Args)]
 pub struct CiArgs {


### PR DESCRIPTION
For `m.room.create`, `m.room.member`,  `m.room.power_levels` and `m.room.join_rules` events, to avoid errors on fields that we don't care about.

Part of #1937 (we still need `m.room.third_party_invite`, that will be handled separately, when we fix checking third-party invites).
Part of #1867  (it would still be worth it to ignore invalid join rules in ruma-events).

This can be reviewed commit by commit.