### PR TITLE
third-party-invite: Add IdentityServerBase64PublicKey

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -42,6 +42,8 @@ Improvements:
 - Add `AnyKeyName` as a helper type to use `KeyId` APIs without validating the
   key name.
 - `DeviceId::new()` generates a string with 10 chars instead of 8.
+- Add `IdentityServerBase64PublicKey` as a helper type to decode identity server
+  public keys encoded using standard or URL-safe base64.
 
 # 0.15.1
 

--- a/crates/ruma-common/src/lib.rs
+++ b/crates/ruma-common/src/lib.rs
@@ -34,6 +34,7 @@ pub mod push;
 pub mod room;
 pub mod serde;
 pub mod space;
+pub mod third_party_invite;
 pub mod thirdparty;
 mod time;
 pub mod to_device;

--- a/crates/ruma-common/src/third_party_invite.rs
+++ b/crates/ruma-common/src/third_party_invite.rs
@@ -1,0 +1,109 @@
+//! Common types for [third-party invites].
+//!
+//! [third-party invites]: https://spec.matrix.org/latest/client-server-api/#third-party-invites
+
+use std::ops::Deref;
+
+use serde::{Deserialize, Serialize};
+
+use crate::serde::{
+    base64::{Standard, UrlSafe},
+    Base64, Base64DecodeError,
+};
+
+/// A base64-encoded public key from an [identity server].
+///
+/// This type supports both standard and URL-safe base64, for [compatibility with Sydent].
+///
+/// No validation is done on the inner string during deserialization, this type is used for its
+/// semantic value and for providing a helper to decode it.
+///
+/// The key can be decoded by calling [`IdentityServerBase64PublicKey::decode()`].
+///
+/// [identity server]: https://spec.matrix.org/latest/identity-service-api/
+/// [compatibility with Sydent]: https://github.com/matrix-org/sydent/issues/593
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[allow(clippy::exhaustive_structs)]
+pub struct IdentityServerBase64PublicKey(pub String);
+
+impl IdentityServerBase64PublicKey {
+    /// Construct a new `IdentityServerBase64PublicKey` by encoding the given key using unpadded
+    /// standard base64.
+    pub fn new(bytes: &[u8]) -> Self {
+        Self(Base64::<Standard, &[u8]>::new(bytes).encode())
+    }
+
+    /// Try to decode this base64-encoded string.
+    ///
+    /// This will try to detect the proper alphabet to use for decoding, between
+    /// the standard and the URL-safe alphabet.
+    pub fn decode(&self) -> Result<Vec<u8>, Base64DecodeError> {
+        let is_url_safe_alphabet = self.0.contains(['-', '_']);
+
+        if is_url_safe_alphabet {
+            Ok(Base64::<UrlSafe>::parse(&self.0)?.into_inner())
+        } else {
+            Ok(Base64::<Standard>::parse(&self.0)?.into_inner())
+        }
+    }
+}
+
+impl From<String> for IdentityServerBase64PublicKey {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl AsRef<str> for IdentityServerBase64PublicKey {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Deref for IdentityServerBase64PublicKey {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_ref()
+    }
+}
+
+impl PartialEq<String> for IdentityServerBase64PublicKey {
+    fn eq(&self, other: &String) -> bool {
+        self.0.eq(other)
+    }
+}
+
+impl<'a> PartialEq<&'a str> for IdentityServerBase64PublicKey {
+    fn eq(&self, other: &&'a str) -> bool {
+        self.0.eq(other)
+    }
+}
+
+impl PartialEq<str> for IdentityServerBase64PublicKey {
+    fn eq(&self, other: &str) -> bool {
+        self.0.eq(other)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::IdentityServerBase64PublicKey;
+
+    #[test]
+    fn identity_server_base64_public_key_encode_then_decode() {
+        let original = b"foobar";
+        let encoded = IdentityServerBase64PublicKey::new(original);
+        assert_eq!(encoded, "Zm9vYmFy");
+        assert_eq!(encoded.decode().unwrap(), original);
+    }
+
+    #[test]
+    fn identity_server_base64_public_key_decode_standard_and_url_safe() {
+        let original = &[60, 98, 62, 77, 68, 78, 60, 47, 98, 62];
+        let standard_base64 = IdentityServerBase64PublicKey("PGI+TUROPC9iPg".to_owned());
+        assert_eq!(standard_base64.decode().unwrap(), original);
+        let urlsafe_base64 = IdentityServerBase64PublicKey("PGI-TUROPC9iPg".to_owned());
+        assert_eq!(urlsafe_base64.decode().unwrap(), original);
+    }
+}

--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -12,6 +12,9 @@ Breaking changes:
   - `make_for_thread` also takes a `ReplyMetadata` instead of a room message
     event.
   - `make_replacement` does not take the replied-to message anymore.
+- `RoomThirdPartyInviteEventContent` uses `IdentityServerBase64PublicKey`
+  instead of `Base64` for the `public_key` fields, to avoid deserialization
+  errors when public keys encoded using URL-safe base64 are encountered.
 
 Improvements:
 

--- a/crates/ruma-events/src/room/third_party_invite.rs
+++ b/crates/ruma-events/src/room/third_party_invite.rs
@@ -2,7 +2,7 @@
 //!
 //! [`m.room.third_party_invite`]: https://spec.matrix.org/latest/client-server-api/#mroomthird_party_invite
 
-use ruma_common::serde::Base64;
+use ruma_common::third_party_invite::IdentityServerBase64PublicKey;
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
@@ -35,8 +35,11 @@ pub struct RoomThirdPartyInviteEventContent {
     ///
     /// If the `compat-optional` feature is enabled, this field being absent in JSON will result
     /// in an empty string instead of an error when deserializing.
-    #[cfg_attr(feature = "compat-optional", serde(default = "Base64::empty"))]
-    pub public_key: Base64,
+    #[cfg_attr(
+        feature = "compat-optional",
+        serde(default = "empty_identity_server_base64_public_key")
+    )]
+    pub public_key: IdentityServerBase64PublicKey,
 
     /// Keys with which the token may be signed.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -46,7 +49,11 @@ pub struct RoomThirdPartyInviteEventContent {
 impl RoomThirdPartyInviteEventContent {
     /// Creates a new `RoomThirdPartyInviteEventContent` with the given display name, key validity
     /// url and public key.
-    pub fn new(display_name: String, key_validity_url: String, public_key: Base64) -> Self {
+    pub fn new(
+        display_name: String,
+        key_validity_url: String,
+        public_key: IdentityServerBase64PublicKey,
+    ) -> Self {
         Self { display_name, key_validity_url, public_key, public_keys: None }
     }
 }
@@ -63,12 +70,18 @@ pub struct PublicKey {
     pub key_validity_url: Option<String>,
 
     /// A base64-encoded Ed25519 key with which the token must be signed.
-    pub public_key: Base64,
+    pub public_key: IdentityServerBase64PublicKey,
 }
 
 impl PublicKey {
     /// Creates a new `PublicKey` with the given base64-encoded ed25519 key.
-    pub fn new(public_key: Base64) -> Self {
+    pub fn new(public_key: IdentityServerBase64PublicKey) -> Self {
         Self { key_validity_url: None, public_key }
     }
+}
+
+/// Generate an empty [`IdentityServerBase64PublicKey`].
+#[cfg(feature = "compat-optional")]
+fn empty_identity_server_base64_public_key() -> IdentityServerBase64PublicKey {
+    IdentityServerBase64PublicKey(String::new())
 }

--- a/crates/ruma-identity-service-api/CHANGELOG.md
+++ b/crates/ruma-identity-service-api/CHANGELOG.md
@@ -4,6 +4,10 @@ Breaking changes:
 
 - `get_supported_versions::Response::known_versions()` returns a
   `BTreeSet<MatrixVersion>` instead of a `DoubleEndedIterator`.
+- The `store_invitation`, `check_public_key_validity`, `get_public_key` and
+  `validate_ephemeral_key` endpoints use `IdentityServerBase64PublicKey` instead
+  of `Base64` for the public keys, to avoid deserialization errors when public
+  keys encoded using URL-safe base64 is encountered.
 
 # 0.11.0
 

--- a/crates/ruma-identity-service-api/src/invitation/store_invitation.rs
+++ b/crates/ruma-identity-service-api/src/invitation/store_invitation.rs
@@ -11,6 +11,7 @@ pub mod v2 {
         api::{request, response, Metadata},
         metadata,
         room::RoomType,
+        third_party_invite::IdentityServerBase64PublicKey,
         thirdparty::Medium,
         OwnedMxcUri, OwnedRoomAliasId, OwnedRoomId, OwnedUserId,
     };
@@ -175,8 +176,8 @@ pub mod v2 {
     #[derive(Clone, Debug, Serialize, Deserialize)]
     #[non_exhaustive]
     pub struct PublicKey {
-        /// The public key, encoded using [unpadded Base64](https://spec.matrix.org/latest/appendices/#unpadded-base64).
-        pub public_key: String,
+        /// The public key, encoded using unpadded base64.
+        pub public_key: IdentityServerBase64PublicKey,
 
         /// The URI of an endpoint where the validity of this key can be checked by passing it as a
         /// `public_key` query parameter.
@@ -185,7 +186,7 @@ pub mod v2 {
 
     impl PublicKey {
         /// Constructs a new `PublicKey` with the given encoded public key and key validity URL.
-        pub fn new(public_key: String, key_validity_url: String) -> Self {
+        pub fn new(public_key: IdentityServerBase64PublicKey, key_validity_url: String) -> Self {
             Self { public_key, key_validity_url }
         }
     }

--- a/crates/ruma-identity-service-api/src/keys/check_public_key_validity.rs
+++ b/crates/ruma-identity-service-api/src/keys/check_public_key_validity.rs
@@ -11,7 +11,7 @@ pub mod v2 {
     use ruma_common::{
         api::{request, response, Metadata},
         metadata,
-        serde::Base64,
+        third_party_invite::IdentityServerBase64PublicKey,
     };
 
     const METADATA: Metadata = metadata! {
@@ -28,7 +28,7 @@ pub mod v2 {
     pub struct Request {
         /// Base64-encoded (no padding) public key to check for validity.
         #[ruma_api(query)]
-        pub public_key: Base64,
+        pub public_key: IdentityServerBase64PublicKey,
     }
 
     /// Response type for the `check_public_key_validity` endpoint.
@@ -40,7 +40,7 @@ pub mod v2 {
 
     impl Request {
         /// Create a `Request` with the given base64-encoded (unpadded) public key.
-        pub fn new(public_key: Base64) -> Self {
+        pub fn new(public_key: IdentityServerBase64PublicKey) -> Self {
             Self { public_key }
         }
     }

--- a/crates/ruma-identity-service-api/src/keys/get_public_key.rs
+++ b/crates/ruma-identity-service-api/src/keys/get_public_key.rs
@@ -10,7 +10,7 @@ pub mod v2 {
     use ruma_common::{
         api::{request, response, Metadata},
         metadata,
-        serde::Base64,
+        third_party_invite::IdentityServerBase64PublicKey,
         OwnedServerSigningKeyId,
     };
 
@@ -35,7 +35,7 @@ pub mod v2 {
     #[response]
     pub struct Response {
         /// Unpadded base64-encoded public key.
-        pub public_key: Base64,
+        pub public_key: IdentityServerBase64PublicKey,
     }
 
     impl Request {
@@ -47,7 +47,7 @@ pub mod v2 {
 
     impl Response {
         /// Create a `Response` with the given base64-encoded (unpadded) public key.
-        pub fn new(public_key: Base64) -> Self {
+        pub fn new(public_key: IdentityServerBase64PublicKey) -> Self {
             Self { public_key }
         }
     }

--- a/crates/ruma-identity-service-api/src/keys/validate_ephemeral_key.rs
+++ b/crates/ruma-identity-service-api/src/keys/validate_ephemeral_key.rs
@@ -10,7 +10,7 @@ pub mod v2 {
     use ruma_common::{
         api::{request, response, Metadata},
         metadata,
-        serde::Base64,
+        third_party_invite::IdentityServerBase64PublicKey,
     };
 
     const METADATA: Metadata = metadata! {
@@ -27,7 +27,7 @@ pub mod v2 {
     pub struct Request {
         /// The unpadded base64-encoded short-term public key to check.
         #[ruma_api(query)]
-        pub public_key: Base64,
+        pub public_key: IdentityServerBase64PublicKey,
     }
 
     /// Response type for the `validate_ephemeral_key` endpoint.
@@ -39,7 +39,7 @@ pub mod v2 {
 
     impl Request {
         /// Create a `Request` with the given base64-encoded (unpadded) short-term public key.
-        pub fn new(public_key: Base64) -> Self {
+        pub fn new(public_key: IdentityServerBase64PublicKey) -> Self {
             Self { public_key }
         }
     }

--- a/crates/ruma-state-res/src/event_auth/room_member/tests.rs
+++ b/crates/ruma-state-res/src/event_auth/room_member/tests.rs
@@ -1,4 +1,4 @@
-use ruma_common::{serde::Base64, Signatures};
+use ruma_common::{third_party_invite::IdentityServerBase64PublicKey, Signatures};
 use ruma_events::{
     room::{
         join_rules::{JoinRule, Restricted, RoomJoinRulesEventContent},
@@ -922,7 +922,7 @@ fn invite_via_third_party_invite_missing_room_third_party_invite() {
             to_raw_json_value(&RoomThirdPartyInviteEventContent::new(
                 "e..@p..".to_owned(),
                 "http://host.local/check/public_key".to_owned(),
-                Base64::new(b"public_key".to_vec()),
+                IdentityServerBase64PublicKey::new(b"public_key"),
             ))
             .unwrap(),
             &["CREATE", "IJR", "IPOWER"],

--- a/crates/ruma-state-res/src/test_utils.rs
+++ b/crates/ruma-state-res/src/test_utils.rs
@@ -9,8 +9,8 @@ use std::{
 
 use js_int::{int, uint};
 use ruma_common::{
-    event_id, room_id, serde::Base64, user_id, EventId, MilliSecondsSinceUnixEpoch, OwnedEventId,
-    RoomId, RoomVersionId, ServerSignatures, UserId,
+    event_id, room_id, third_party_invite::IdentityServerBase64PublicKey, user_id, EventId,
+    MilliSecondsSinceUnixEpoch, OwnedEventId, RoomId, RoomVersionId, ServerSignatures, UserId,
 };
 use ruma_events::{
     pdu::{EventHash, Pdu, RoomV3Pdu},
@@ -719,7 +719,7 @@ pub(crate) fn room_third_party_invite(sender: &UserId) -> Arc<PduEvent> {
         to_raw_json_value(&RoomThirdPartyInviteEventContent::new(
             "e..@p..".to_owned(),
             "http://host.local/check/public_key".to_owned(),
-            Base64::new(b"public_key".to_vec()),
+            IdentityServerBase64PublicKey::new(b"public_key"),
         ))
         .unwrap(),
         &["CREATE", "IJR", "IPOWER"],


### PR DESCRIPTION
This is as a helper type to decode identity server public keys encoded using standard or URL-safe base64, for compatibility with Sydent.

This is useful both for clients and homeservers, and will be necessary for fixing the authorization rules.

Fixes #1999.