### PR TITLE
client-api: Allow guest user to upgrade to a regular account

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -12,6 +12,8 @@ Improvements:
 
 - Add support for the authorization server metadata endpoint, according to the
   latest draft of MSC2965.
+- Add the `guest_access_token` field to `account::register::v3::Request` to
+  allow a guest user to upgrade to a regular account.
 
 # 0.20.1
 

--- a/crates/ruma-client-api/src/account/register.rs
+++ b/crates/ruma-client-api/src/account/register.rs
@@ -94,6 +94,14 @@ pub mod v3 {
         /// [refresh tokens]: https://spec.matrix.org/latest/client-server-api/#refreshing-access-tokens
         #[serde(default, skip_serializing_if = "ruma_common::serde::is_default")]
         pub refresh_token: bool,
+
+        /// A [guest user]'s access token, to upgrade to a regular account.
+        ///
+        /// If this is set, the `username` field is also required.
+        ///
+        /// [guest user]: https://spec.matrix.org/latest/client-server-api/#guest-access
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub guest_access_token: Option<String>,
     }
 
     /// Response type for the `register` endpoint.


### PR DESCRIPTION
As defined in [the spec](https://spec.matrix.org/v1.13/client-server-api/#guest-access).

Fixes #1983.