### PR TITLE
client-api: Add endpoints for peeking

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -14,6 +14,7 @@ Improvements:
   latest draft of MSC2965.
 - Add the `guest_access_token` field to `account::register::v3::Request` to
   allow a guest user to upgrade to a regular account.
+- Add the endpoints for peeking: `get_current_state` and `listen_to_new_events`.
 
 # 0.20.1
 

--- a/crates/ruma-client-api/src/lib.rs
+++ b/crates/ruma-client-api/src/lib.rs
@@ -31,6 +31,7 @@ pub mod knock;
 pub mod media;
 pub mod membership;
 pub mod message;
+pub mod peeking;
 pub mod presence;
 pub mod profile;
 pub mod push;

--- a/crates/ruma-client-api/src/peeking.rs
+++ b/crates/ruma-client-api/src/peeking.rs
@@ -1,0 +1,6 @@
+//! Endpoints for [previewing a room] without joining it, aka peeking.
+//!
+//! [previewing a room]: https://spec.matrix.org/latest/client-server-api/#room-previews
+
+pub mod get_current_state;
+pub mod listen_to_new_events;

--- a/crates/ruma-client-api/src/peeking/get_current_state.rs
+++ b/crates/ruma-client-api/src/peeking/get_current_state.rs
@@ -1,0 +1,131 @@
+//! `GET /_matrix/client/*/rooms/{roomId}/initialSync`
+//!
+//! Get a copy of the current state and the most recent messages in a room.
+
+pub mod v3 {
+    //! `/v3/` ([spec])
+    //!
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3roomsroomidinitialsync
+
+    use ruma_common::{
+        api::{request, response, Metadata},
+        metadata,
+        serde::Raw,
+        OwnedRoomId,
+    };
+    use ruma_events::{
+        room::member::MembershipState, AnyRoomAccountDataEvent, AnyStateEvent, AnyTimelineEvent,
+    };
+    use serde::{Deserialize, Serialize};
+
+    use crate::room::Visibility;
+
+    const METADATA: Metadata = metadata! {
+        method: GET,
+        rate_limited: false,
+        authentication: AccessToken,
+        history: {
+            1.0 => "/_matrix/client/r0/rooms/:room_id/initialSync",
+            1.1 => "/_matrix/client/v3/rooms/:room_id/initialSync",
+        }
+    };
+
+    /// Request type for the `get_current_state` endpoint.
+    #[request(error = crate::Error)]
+    pub struct Request {
+        /// The room to get the data of.
+        #[ruma_api(path)]
+        pub room_id: OwnedRoomId,
+    }
+
+    impl Request {
+        /// Creates a `Request` for the given room.
+        pub fn new(room_id: OwnedRoomId) -> Self {
+            Self { room_id }
+        }
+    }
+
+    /// Response type for the `get_current_state` endpoint.
+    #[response(error = crate::Error)]
+    pub struct Response {
+        /// The private data that this user has attached to this room.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        pub account_data: Vec<Raw<AnyRoomAccountDataEvent>>,
+
+        /// The user’s membership state in this room.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub membership: Option<MembershipState>,
+
+        /// The pagination chunk for this room.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub messages: Option<PaginationChunk>,
+
+        /// The room ID for this room.
+        pub room_id: OwnedRoomId,
+
+        /// The state of the room.
+        ///
+        /// If the user is a member of the room this will be the current state of the room as a
+        /// list of events.
+        ///
+        /// If the user has left the room this will be the state of the room when they left it.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        pub state: Vec<Raw<AnyStateEvent>>,
+
+        /// Whether this room is visible to the `/publicRooms` API or not.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub visibility: Option<Visibility>,
+    }
+
+    impl Response {
+        /// Creates a `Response` for the given room.
+        pub fn new(room_id: OwnedRoomId) -> Self {
+            Self {
+                room_id,
+                account_data: Vec::new(),
+                membership: None,
+                messages: None,
+                state: Vec::new(),
+                visibility: None,
+            }
+        }
+    }
+
+    /// A paginated chunk of messages from the room's timeline.
+    #[derive(Debug, Clone, Deserialize, Serialize)]
+    #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+    pub struct PaginationChunk {
+        /// An array of events.
+        ///
+        /// If the user is a member of the room this will be a list of the most recent messages for
+        /// this room.
+        ///
+        /// If the user has left the room this will be the messages that preceded them leaving.
+        pub chunk: Vec<Raw<AnyTimelineEvent>>,
+
+        ///  A token which correlates to the end of chunk.
+        ///
+        /// Can be passed to [`listen_to_new_events`] to listen to new events and to
+        /// [`get_message_events`] to retrieve later events.
+        ///
+        /// [`listen_to_new_events`]: crate::peeking::listen_to_new_events
+        /// [`get_message_events`]: crate::message::get_message_events
+        pub end: String,
+
+        /// A token which correlates to the start of chunk. Can be passed to [`get_message_events`]
+        /// to retrieve earlier events.
+        ///
+        /// If no earlier events are available, this property may be omitted from the response.
+        ///
+        /// [`get_message_events`]: crate::message::get_message_events
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub start: Option<String>,
+    }
+
+    impl PaginationChunk {
+        /// Construct a new `PaginationChunk` with the given events and end token.
+        pub fn new(chunk: Vec<Raw<AnyTimelineEvent>>, end: String) -> Self {
+            Self { chunk, end, start: None }
+        }
+    }
+}

--- a/crates/ruma-client-api/src/peeking/listen_to_new_events.rs
+++ b/crates/ruma-client-api/src/peeking/listen_to_new_events.rs
@@ -1,0 +1,95 @@
+//! `GET /_matrix/client/*/events`
+//!
+//! Listen for new events related to a particular room.
+
+pub mod v3 {
+    //! `/v3/` ([spec])
+    //!
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#peeking_get_matrixclientv3events
+
+    use std::time::Duration;
+
+    use ruma_common::{
+        api::{request, response, Metadata},
+        metadata,
+        serde::Raw,
+        OwnedRoomId,
+    };
+    use ruma_events::AnyTimelineEvent;
+
+    const METADATA: Metadata = metadata! {
+        method: GET,
+        rate_limited: false,
+        authentication: AccessToken,
+        history: {
+            1.0 => "/_matrix/client/r0/events",
+            1.1 => "/_matrix/client/v3/events",
+        }
+    };
+
+    /// Request type for the `listen_to_new_events` endpoint.
+    #[request(error = crate::Error)]
+    #[derive(Default)]
+    pub struct Request {
+        /// The token to stream from.
+        ///
+        /// This token is either from a previous request to this API or from the initial sync API.
+        #[ruma_api(query)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub from: Option<String>,
+
+        /// The room ID for which events should be returned.
+        ///
+        /// This field [should be required], but the spec marks it as optional so it is an
+        /// `Option`.
+        ///
+        /// [should be required]: https://github.com/matrix-org/matrix-spec/issues/2098
+        #[ruma_api(query)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub room_id: Option<OwnedRoomId>,
+
+        /// The maximum time to wait for an event.
+        #[ruma_api(query)]
+        #[serde(
+            with = "ruma_common::serde::duration::opt_ms",
+            default,
+            skip_serializing_if = "Option::is_none"
+        )]
+        pub timeout: Option<Duration>,
+    }
+
+    impl Request {
+        /// Creates a `Request` for the given room.
+        pub fn new(room_id: OwnedRoomId) -> Self {
+            Self { room_id: Some(room_id), ..Default::default() }
+        }
+    }
+
+    /// Response type for the `listen_to_new_events` endpoint.
+    #[response(error = crate::Error)]
+    #[derive(Default)]
+    pub struct Response {
+        /// An array of new events.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        pub chunk: Vec<Raw<AnyTimelineEvent>>,
+
+        /// A token which correlates to the last value in `chunk`.
+        ///
+        /// This token should be used in the next request to this endpoint.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub end: Option<String>,
+
+        /// A token which correlates to the first value in `chunk`.
+        ///
+        /// This is usually the same token supplied to `from` in the request.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub start: Option<String>,
+    }
+
+    impl Response {
+        /// Creates an empty `Response`.
+        pub fn new() -> Self {
+            Self::default()
+        }
+    }
+}


### PR DESCRIPTION
As defined in [the spec](https://spec.matrix.org/v1.13/client-server-api/#room-previews).

Fixes #2010.