### PR TITLE
Fixes around third-party invites

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -25,6 +25,8 @@ Breaking changes:
   for unknown room versions.
 - Add the `sender_device_keys` field to `DecryptedOlmV1Event`, according to
   MSC4147.
+- `signed` in `ThirdPartyInvite` is now wrapped inside a `Raw` because it is
+  signed so we need the full raw JSON to verify the signature.
    
 # 0.30.3
 

--- a/crates/ruma-events/src/room/member.rs
+++ b/crates/ruma-events/src/room/member.rs
@@ -307,12 +307,12 @@ pub struct ThirdPartyInvite {
     /// A block of content which has been signed, which servers can use to verify the event.
     ///
     /// Clients should ignore this.
-    pub signed: SignedContent,
+    pub signed: Raw<SignedContent>,
 }
 
 impl ThirdPartyInvite {
     /// Creates a new `ThirdPartyInvite` with the given display name and signed content.
-    pub fn new(display_name: String, signed: SignedContent) -> Self {
+    pub fn new(display_name: String, signed: Raw<SignedContent>) -> Self {
         Self { display_name, signed }
     }
 
@@ -334,7 +334,7 @@ pub struct RedactedThirdPartyInvite {
     /// A block of content which has been signed, which servers can use to verify the event.
     ///
     /// Clients should ignore this.
-    pub signed: SignedContent,
+    pub signed: Raw<SignedContent>,
 }
 
 /// A block of content which has been signed, which servers can use to verify a third party
@@ -681,10 +681,10 @@ mod tests {
 
         let third_party_invite = ev.content.third_party_invite.unwrap();
         assert_eq!(third_party_invite.display_name, "alice");
-        assert_eq!(third_party_invite.signed.mxid, "@alice:example.org");
-        assert_eq!(third_party_invite.signed.signatures.len(), 1);
-        let server_signatures =
-            third_party_invite.signed.signatures.get(server_name!("magic.forest")).unwrap();
+        let signed = third_party_invite.signed.deserialize().unwrap();
+        assert_eq!(signed.mxid, "@alice:example.org");
+        assert_eq!(signed.signatures.len(), 1);
+        let server_signatures = signed.signatures.get(server_name!("magic.forest")).unwrap();
         assert_eq!(
             *server_signatures,
             btreemap! {
@@ -694,7 +694,7 @@ mod tests {
                 ) => "foobar".to_owned()
             }
         );
-        assert_eq!(third_party_invite.signed.token, "abc123");
+        assert_eq!(signed.token, "abc123");
     }
 
     #[test]
@@ -755,10 +755,10 @@ mod tests {
 
         let third_party_invite = prev_content.third_party_invite.unwrap();
         assert_eq!(third_party_invite.display_name, "alice");
-        assert_eq!(third_party_invite.signed.mxid, "@alice:example.org");
-        assert_eq!(third_party_invite.signed.signatures.len(), 1);
-        let server_signatures =
-            third_party_invite.signed.signatures.get(server_name!("magic.forest")).unwrap();
+        let signed = third_party_invite.signed.deserialize().unwrap();
+        assert_eq!(signed.mxid, "@alice:example.org");
+        assert_eq!(signed.signatures.len(), 1);
+        let server_signatures = signed.signatures.get(server_name!("magic.forest")).unwrap();
         assert_eq!(
             *server_signatures,
             btreemap! {
@@ -768,7 +768,7 @@ mod tests {
                 ) => "foobar".to_owned()
             }
         );
-        assert_eq!(third_party_invite.signed.token, "abc123");
+        assert_eq!(signed.token, "abc123");
     }
 
     #[test]

--- a/crates/ruma-federation-api/CHANGELOG.md
+++ b/crates/ruma-federation-api/CHANGELOG.md
@@ -4,6 +4,8 @@ Breaking changes:
 
 - Remove the `origin` field in `create_join_event::{v1/v2}::RoomState` due to a
   clarification in the spec.
+- The type of `signed` in `thirdparty::bind_callback::v1::Request` was fixed. It
+  uses `SignedContent` from `RoomMemberEventContent`.
 
 Improvements:
 

--- a/crates/ruma-federation-api/CHANGELOG.md
+++ b/crates/ruma-federation-api/CHANGELOG.md
@@ -6,6 +6,10 @@ Breaking changes:
   clarification in the spec.
 - The type of `signed` in `thirdparty::bind_callback::v1::Request` was fixed. It
   uses `SignedContent` from `RoomMemberEventContent`.
+- The type of `content` in `thirdparty::exchange_invite::v1::Request` was fixed.
+  It is a `RoomMemberEventContent`. A new constructor was added,
+  `with_third_party_invite()` that constructs the event content from a
+  `ThirdPartyInvite`.
 
 Bug fixes:
 

--- a/crates/ruma-federation-api/CHANGELOG.md
+++ b/crates/ruma-federation-api/CHANGELOG.md
@@ -19,6 +19,9 @@ Improvements:
 
 - ruma-server-util was merged into this crate. `XMatrix` is available in the
   `authentication` module.
+- Add a method to construct a `thirdparty::exchange_invite::v1::Request` from a
+  `thirdparty::bind_callback::v1::ThirdPartyInvite` and a
+  `RoomThirdPartyInviteEventContent`.
 
 # 0.11.1
 

--- a/crates/ruma-federation-api/CHANGELOG.md
+++ b/crates/ruma-federation-api/CHANGELOG.md
@@ -7,6 +7,10 @@ Breaking changes:
 - The type of `signed` in `thirdparty::bind_callback::v1::Request` was fixed. It
   uses `SignedContent` from `RoomMemberEventContent`.
 
+Bug fixes:
+
+- Add constructor for `thirdparty::bind_callback::v1::Response`.
+
 Improvements:
 
 - ruma-server-util was merged into this crate. `XMatrix` is available in the

--- a/crates/ruma-federation-api/CHANGELOG.md
+++ b/crates/ruma-federation-api/CHANGELOG.md
@@ -5,7 +5,7 @@ Breaking changes:
 - Remove the `origin` field in `create_join_event::{v1/v2}::RoomState` due to a
   clarification in the spec.
 - The type of `signed` in `thirdparty::bind_callback::v1::Request` was fixed. It
-  uses `SignedContent` from `RoomMemberEventContent`.
+  uses `Raw<SignedContent>` from `RoomMemberEventContent`.
 - The type of `content` in `thirdparty::exchange_invite::v1::Request` was fixed.
   It is a `RoomMemberEventContent`. A new constructor was added,
   `with_third_party_invite()` that constructs the event content from a

--- a/crates/ruma-federation-api/src/thirdparty/bind_callback.rs
+++ b/crates/ruma-federation-api/src/thirdparty/bind_callback.rs
@@ -49,6 +49,7 @@ pub mod v1 {
 
     /// Response type for the `bind_callback` endpoint.
     #[response]
+    #[derive(Default)]
     pub struct Response {}
 
     impl Request {
@@ -104,6 +105,13 @@ pub mod v1 {
             signed: SignedContent,
         ) -> Self {
             Self { medium: Medium::Email, address, mxid, room_id, sender, signed }
+        }
+    }
+
+    impl Response {
+        /// Construct an empty response.
+        pub fn new() -> Self {
+            Self {}
         }
     }
 }

--- a/crates/ruma-federation-api/src/thirdparty/bind_callback.rs
+++ b/crates/ruma-federation-api/src/thirdparty/bind_callback.rs
@@ -9,14 +9,13 @@ pub mod v1 {
     //!
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv13pidonbind
 
-    use std::collections::BTreeMap;
-
     use ruma_common::{
         api::{request, response, Metadata},
         metadata,
         thirdparty::Medium,
-        OwnedRoomId, OwnedServerName, OwnedServerSigningKeyId, OwnedUserId,
+        OwnedRoomId, OwnedUserId,
     };
+    use ruma_events::room::member::SignedContent;
     use serde::{Deserialize, Serialize};
 
     const METADATA: Metadata = metadata! {
@@ -90,8 +89,9 @@ pub mod v1 {
         /// The user ID that sent the invite.
         pub sender: OwnedUserId,
 
-        /// Signature from the identity server using a long-term private key.
-        pub signed: BTreeMap<OwnedServerName, BTreeMap<OwnedServerSigningKeyId, String>>,
+        /// A block of content which has been signed, which servers can use to verify the
+        /// third-party invite.
+        pub signed: SignedContent,
     }
 
     impl ThirdPartyInvite {
@@ -101,7 +101,7 @@ pub mod v1 {
             mxid: OwnedUserId,
             room_id: OwnedRoomId,
             sender: OwnedUserId,
-            signed: BTreeMap<OwnedServerName, BTreeMap<OwnedServerSigningKeyId, String>>,
+            signed: SignedContent,
         ) -> Self {
             Self { medium: Medium::Email, address, mxid, room_id, sender, signed }
         }

--- a/crates/ruma-federation-api/src/thirdparty/bind_callback.rs
+++ b/crates/ruma-federation-api/src/thirdparty/bind_callback.rs
@@ -12,6 +12,7 @@ pub mod v1 {
     use ruma_common::{
         api::{request, response, Metadata},
         metadata,
+        serde::Raw,
         thirdparty::Medium,
         OwnedRoomId, OwnedUserId,
     };
@@ -92,7 +93,7 @@ pub mod v1 {
 
         /// A block of content which has been signed, which servers can use to verify the
         /// third-party invite.
-        pub signed: SignedContent,
+        pub signed: Raw<SignedContent>,
     }
 
     impl ThirdPartyInvite {
@@ -102,7 +103,7 @@ pub mod v1 {
             mxid: OwnedUserId,
             room_id: OwnedRoomId,
             sender: OwnedUserId,
-            signed: SignedContent,
+            signed: Raw<SignedContent>,
         ) -> Self {
             Self { medium: Medium::Email, address, mxid, room_id, sender, signed }
         }

--- a/crates/ruma-federation-api/src/thirdparty/exchange_invite.rs
+++ b/crates/ruma-federation-api/src/thirdparty/exchange_invite.rs
@@ -13,9 +13,14 @@ pub mod v1 {
 
     use ruma_common::{
         api::{request, response, Metadata},
-        metadata, OwnedRoomId, OwnedUserId,
+        metadata,
+        serde::Raw,
+        OwnedRoomId, OwnedUserId,
     };
-    use ruma_events::{room::member::ThirdPartyInvite, StateEventType};
+    use ruma_events::{
+        room::member::{MembershipState, RoomMemberEventContent, ThirdPartyInvite},
+        StateEventType,
+    };
 
     const METADATA: Metadata = metadata! {
         method: PUT,
@@ -29,13 +34,13 @@ pub mod v1 {
     /// Request type for the `exchange_invite` endpoint.
     #[request]
     pub struct Request {
-        /// The room ID to exchange a third party invite in.
+        /// The room ID to exchange the third-party invite in.
         #[ruma_api(path)]
         pub room_id: OwnedRoomId,
 
         /// The event type.
         ///
-        /// Must be `StateEventType::RoomMember`.
+        /// Must be [`StateEventType::RoomMember`].
         #[serde(rename = "type")]
         pub kind: StateEventType,
 
@@ -46,7 +51,9 @@ pub mod v1 {
         pub state_key: OwnedUserId,
 
         /// The content of the invite event.
-        pub content: ThirdPartyInvite,
+        ///
+        /// It must have a `membership` of `invite` and the `third_party_invite` field must be set.
+        pub content: Raw<RoomMemberEventContent>,
     }
 
     /// Response type for the `exchange_invite` endpoint.
@@ -55,14 +62,30 @@ pub mod v1 {
     pub struct Response {}
 
     impl Request {
-        /// Creates a new `Request` for a third party invite exchange
+        /// Creates a new `Request` for a third-party invite exchange.
         pub fn new(
             room_id: OwnedRoomId,
             sender: OwnedUserId,
             state_key: OwnedUserId,
-            content: ThirdPartyInvite,
+            content: Raw<RoomMemberEventContent>,
         ) -> Self {
             Self { room_id, kind: StateEventType::RoomMember, sender, state_key, content }
+        }
+
+        /// Creates a new `Request` for a third-party invite exchange from a `ThirdPartyInvite`.
+        ///
+        /// Returns an error if the serialization of the event content fails.
+        pub fn with_third_party_invite(
+            room_id: OwnedRoomId,
+            sender: OwnedUserId,
+            state_key: OwnedUserId,
+            third_party_invite: ThirdPartyInvite,
+        ) -> Result<Self, serde_json::Error> {
+            let mut content = RoomMemberEventContent::new(MembershipState::Invite);
+            content.third_party_invite = Some(third_party_invite);
+            let content = Raw::new(&content)?;
+
+            Ok(Self::new(room_id, sender, state_key, content))
         }
     }
 

--- a/crates/ruma-federation-api/src/thirdparty/exchange_invite.rs
+++ b/crates/ruma-federation-api/src/thirdparty/exchange_invite.rs
@@ -18,9 +18,14 @@ pub mod v1 {
         OwnedRoomId, OwnedUserId,
     };
     use ruma_events::{
-        room::member::{MembershipState, RoomMemberEventContent, ThirdPartyInvite},
+        room::{
+            member::{MembershipState, RoomMemberEventContent, ThirdPartyInvite},
+            third_party_invite::RoomThirdPartyInviteEventContent,
+        },
         StateEventType,
     };
+
+    use crate::thirdparty::bind_callback;
 
     const METADATA: Metadata = metadata! {
         method: PUT,
@@ -86,6 +91,28 @@ pub mod v1 {
             let content = Raw::new(&content)?;
 
             Ok(Self::new(room_id, sender, state_key, content))
+        }
+
+        /// Creates a new `Request` for a third-party invite exchange from a `ThirdPartyInvite` in
+        /// the [`bind_callback::v1::Request`] and the matching
+        /// [`RoomThirdPartyInviteEventContent`].
+        ///
+        /// Returns an error if the serialization of the event content fails.
+        pub fn with_bind_callback_request_and_event(
+            bind_callback_invite: bind_callback::v1::ThirdPartyInvite,
+            room_third_party_invite_event: &RoomThirdPartyInviteEventContent,
+        ) -> Result<Self, serde_json::Error> {
+            let third_party_invite = ThirdPartyInvite::new(
+                room_third_party_invite_event.display_name.clone(),
+                bind_callback_invite.signed,
+            );
+
+            Self::with_third_party_invite(
+                bind_callback_invite.room_id,
+                bind_callback_invite.sender,
+                bind_callback_invite.mxid,
+                third_party_invite,
+            )
         }
     }
 

--- a/crates/ruma-identity-service-api/CHANGELOG.md
+++ b/crates/ruma-identity-service-api/CHANGELOG.md
@@ -9,6 +9,11 @@ Breaking changes:
 - `get_supported_versions::Response::known_versions()` was replaced by
   `as_supported_versions()` which returns a `SupportedVersions`.
 
+Improvements:
+
+- Implement `From<store_invitation::v2::Response>` for
+  `RoomThirdPartyEventContent`.
+
 # 0.11.0
 
 Improvements:

--- a/crates/ruma-identity-service-api/Cargo.toml
+++ b/crates/ruma-identity-service-api/Cargo.toml
@@ -20,6 +20,7 @@ server = []
 [dependencies]
 js_int = { workspace = true, features = ["serde"] }
 ruma-common = { workspace = true, features = ["api"] }
+ruma-events = { workspace = true }
 serde = { workspace = true }
 
 [dev-dependencies]

--- a/crates/ruma-identity-service-api/src/invitation/store_invitation.rs
+++ b/crates/ruma-identity-service-api/src/invitation/store_invitation.rs
@@ -15,6 +15,7 @@ pub mod v2 {
         thirdparty::Medium,
         OwnedMxcUri, OwnedRoomAliasId, OwnedRoomId, OwnedUserId,
     };
+    use ruma_events::room::third_party_invite::RoomThirdPartyInviteEventContent;
     use serde::{ser::SerializeSeq, Deserialize, Serialize};
 
     const METADATA: Metadata = metadata! {
@@ -188,6 +189,29 @@ pub mod v2 {
         /// Constructs a new `PublicKey` with the given encoded public key and key validity URL.
         pub fn new(public_key: IdentityServerBase64PublicKey, key_validity_url: String) -> Self {
             Self { public_key, key_validity_url }
+        }
+    }
+
+    impl From<PublicKey> for ruma_events::room::third_party_invite::PublicKey {
+        fn from(key: PublicKey) -> Self {
+            let mut new_key = Self::new(key.public_key);
+            new_key.key_validity_url = Some(key.key_validity_url);
+            new_key
+        }
+    }
+
+    impl From<Response> for RoomThirdPartyInviteEventContent {
+        fn from(response: Response) -> Self {
+            let mut content = RoomThirdPartyInviteEventContent::new(
+                response.display_name,
+                response.public_keys.server_key.key_validity_url.clone(),
+                response.public_keys.server_key.public_key.clone(),
+            );
+            content.public_keys = Some(vec![
+                response.public_keys.server_key.into(),
+                response.public_keys.ephemeral_key.into(),
+            ]);
+            content
         }
     }
 }

--- a/crates/ruma-state-res/src/event_auth/room_member/tests.rs
+++ b/crates/ruma-state-res/src/event_auth/room_member/tests.rs
@@ -1,6 +1,6 @@
 use ruma_common::{
-    room_version_rules::AuthorizationRules, third_party_invite::IdentityServerBase64PublicKey,
-    Signatures,
+    room_version_rules::AuthorizationRules, serde::Raw,
+    third_party_invite::IdentityServerBase64PublicKey, Signatures,
 };
 use ruma_events::{
     room::{
@@ -854,7 +854,12 @@ fn invite_via_third_party_invite_banned() {
     let mut content = RoomMemberEventContent::new(MembershipState::Invite);
     content.third_party_invite = Some(ThirdPartyInvite::new(
         "e..@p..".to_owned(),
-        SignedContent::new(Signatures::new(), ella().to_owned(), "somerandomtoken".to_owned()),
+        Raw::new(&SignedContent::new(
+            Signatures::new(),
+            ella().to_owned(),
+            "somerandomtoken".to_owned(),
+        ))
+        .unwrap(),
     ));
 
     let incoming_event = to_pdu_event(
@@ -1016,7 +1021,12 @@ fn invite_via_third_party_invite_mxid_mismatch() {
     let mut content = RoomMemberEventContent::new(MembershipState::Invite);
     content.third_party_invite = Some(ThirdPartyInvite::new(
         "z..@p..".to_owned(),
-        SignedContent::new(Signatures::new(), zara().to_owned(), "somerandomtoken".to_owned()),
+        Raw::new(&SignedContent::new(
+            Signatures::new(),
+            zara().to_owned(),
+            "somerandomtoken".to_owned(),
+        ))
+        .unwrap(),
     ));
 
     let incoming_event = to_pdu_event(
@@ -1051,7 +1061,12 @@ fn invite_via_third_party_invite_missing_room_third_party_invite() {
     let mut content = RoomMemberEventContent::new(MembershipState::Invite);
     content.third_party_invite = Some(ThirdPartyInvite::new(
         "e..@p..".to_owned(),
-        SignedContent::new(Signatures::new(), ella().to_owned(), "somerandomtoken".to_owned()),
+        Raw::new(&SignedContent::new(
+            Signatures::new(),
+            ella().to_owned(),
+            "somerandomtoken".to_owned(),
+        ))
+        .unwrap(),
     ));
 
     let incoming_event = to_pdu_event(
@@ -1104,7 +1119,12 @@ fn invite_via_third_party_invite_room_third_party_invite_sender_mismatch() {
     let mut content = RoomMemberEventContent::new(MembershipState::Invite);
     content.third_party_invite = Some(ThirdPartyInvite::new(
         "e..@p..".to_owned(),
-        SignedContent::new(Signatures::new(), ella().to_owned(), "somerandomtoken".to_owned()),
+        Raw::new(&SignedContent::new(
+            Signatures::new(),
+            ella().to_owned(),
+            "somerandomtoken".to_owned(),
+        ))
+        .unwrap(),
     ));
 
     let incoming_event = to_pdu_event(


### PR DESCRIPTION
Fixes types and adds conversions in the federation-api and identity-service-api. I believe that these are all the conversions that we can make around third-party invites.

Closes #272.