### PR TITLE
events: add gallery msgtype for MSC4274

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -15,6 +15,11 @@ Breaking changes:
 - `RoomThirdPartyInviteEventContent` uses `IdentityServerBase64PublicKey`
   instead of `Base64` for the `public_key` fields, to avoid deserialization
   errors when public keys encoded using URL-safe base64 are encountered.
+- The `msgtype` is no longer serialized in `AudioMessageEventContent`, `EmoteMessageEventContent`,
+  `FileMessageEventContent`, `ImageMessageEventContent`, `LocationMessageEventContent`,
+  `NoticeMessageEventContent`, `ServerNoticeMessageEventContent`, `TextMessageEventContent`,
+  `VideoMessageEventContent` and `KeyVerificationRequestEventContent`. Instead the `msgtype`
+  is now serialized on the variants of `MessageType`.
 
 Improvements:
 

--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -20,6 +20,7 @@ Improvements:
 
 - Add `RECOMMENDED_STRIPPED_STATE_EVENT_TYPES` constant for servers to filter/get recommended
   stripped state events.
+- Add unstable support for gallery `msgtype` as per MSC4274.
 
 # 0.30.1
 

--- a/crates/ruma-events/Cargo.toml
+++ b/crates/ruma-events/Cargo.toml
@@ -45,6 +45,7 @@ unstable-msc4075 = ["unstable-msc3401"]
 unstable-msc4095 = []
 unstable-msc4171 = []
 unstable-msc4230 = []
+unstable-msc4274 = []
 unstable-pdu = []
 
 # Allow some mandatory fields to be missing, defaulting them to an empty string

--- a/crates/ruma-events/src/room/message.rs
+++ b/crates/ruma-events/src/room/message.rs
@@ -392,45 +392,57 @@ pub enum ReplyWithinThread {
 
 /// The content that is specific to each message type variant.
 #[derive(Clone, Debug, Serialize)]
-#[serde(untagged)]
+#[serde(tag = "msgtype")]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub enum MessageType {
     /// An audio message.
+    #[serde(rename = "m.audio")]
     Audio(AudioMessageEventContent),
 
     /// An emote message.
+    #[serde(rename = "m.emote")]
     Emote(EmoteMessageEventContent),
 
     /// A file message.
+    #[serde(rename = "m.file")]
     File(FileMessageEventContent),
 
     /// A media gallery message.
     #[cfg(feature = "unstable-msc4274")]
+    #[serde(rename = "dm.filament.gallery")]
     Gallery(GalleryMessageEventContent),
 
     /// An image message.
+    #[serde(rename = "m.image")]
     Image(ImageMessageEventContent),
 
     /// A location message.
+    #[serde(rename = "m.location")]
     Location(LocationMessageEventContent),
 
     /// A notice message.
+    #[serde(rename = "m.notice")]
     Notice(NoticeMessageEventContent),
 
     /// A server notice message.
+    #[serde(rename = "m.server_notice")]
     ServerNotice(ServerNoticeMessageEventContent),
 
     /// A text message.
+    #[serde(rename = "m.text")]
     Text(TextMessageEventContent),
 
     /// A video message.
+    #[serde(rename = "m.video")]
     Video(VideoMessageEventContent),
 
     /// A request to initiate a key verification.
+    #[serde(rename = "m.key.verification.request")]
     VerificationRequest(KeyVerificationRequestEventContent),
 
     /// A custom message.
     #[doc(hidden)]
+    #[serde(untagged)]
     _Custom(CustomEventContent),
 }
 

--- a/crates/ruma-events/src/room/message.rs
+++ b/crates/ruma-events/src/room/message.rs
@@ -27,6 +27,7 @@ mod audio;
 mod content_serde;
 mod emote;
 mod file;
+mod gallery;
 mod image;
 mod key_verification_request;
 mod location;
@@ -52,6 +53,7 @@ pub use self::{
     audio::{AudioInfo, AudioMessageEventContent},
     emote::EmoteMessageEventContent,
     file::{FileInfo, FileMessageEventContent},
+    gallery::{GalleryItemType, GalleryMessageEventContent},
     image::ImageMessageEventContent,
     key_verification_request::KeyVerificationRequestEventContent,
     location::{LocationInfo, LocationMessageEventContent},
@@ -400,6 +402,9 @@ pub enum MessageType {
     /// A file message.
     File(FileMessageEventContent),
 
+    /// A media gallery message.
+    Gallery(GalleryMessageEventContent),
+
     /// An image message.
     Image(ImageMessageEventContent),
 
@@ -454,6 +459,7 @@ impl MessageType {
             "m.audio" => Self::Audio(deserialize_variant(body, data)?),
             "m.emote" => Self::Emote(deserialize_variant(body, data)?),
             "m.file" => Self::File(deserialize_variant(body, data)?),
+            "dm.filament.gallery" => Self::Gallery(deserialize_variant(body, data)?),
             "m.image" => Self::Image(deserialize_variant(body, data)?),
             "m.location" => Self::Location(deserialize_variant(body, data)?),
             "m.notice" => Self::Notice(deserialize_variant(body, data)?),
@@ -521,6 +527,7 @@ impl MessageType {
             Self::Audio(_) => "m.audio",
             Self::Emote(_) => "m.emote",
             Self::File(_) => "m.file",
+            Self::Gallery(_) => "dm.filament.gallery",
             Self::Image(_) => "m.image",
             Self::Location(_) => "m.location",
             Self::Notice(_) => "m.notice",
@@ -538,6 +545,7 @@ impl MessageType {
             MessageType::Audio(m) => &m.body,
             MessageType::Emote(m) => &m.body,
             MessageType::File(m) => &m.body,
+            MessageType::Gallery(m) => &m.body,
             MessageType::Image(m) => &m.body,
             MessageType::Location(m) => &m.body,
             MessageType::Notice(m) => &m.body,
@@ -571,6 +579,7 @@ impl MessageType {
             Self::Audio(d) => Cow::Owned(serialize(d)),
             Self::Emote(d) => Cow::Owned(serialize(d)),
             Self::File(d) => Cow::Owned(serialize(d)),
+            Self::Gallery(d) => Cow::Owned(serialize(d)),
             Self::Image(d) => Cow::Owned(serialize(d)),
             Self::Location(d) => Cow::Owned(serialize(d)),
             Self::Notice(d) => Cow::Owned(serialize(d)),
@@ -630,6 +639,7 @@ impl MessageType {
                 }
                 MessageType::Audio(m) => (&mut m.body, None),
                 MessageType::File(m) => (&mut m.body, None),
+                MessageType::Gallery(m) => (&mut m.body, None),
                 MessageType::Image(m) => (&mut m.body, None),
                 MessageType::Location(m) => (&mut m.body, None),
                 MessageType::ServerNotice(m) => (&mut m.body, None),

--- a/crates/ruma-events/src/room/message.rs
+++ b/crates/ruma-events/src/room/message.rs
@@ -27,6 +27,7 @@ mod audio;
 mod content_serde;
 mod emote;
 mod file;
+#[cfg(feature = "unstable-msc4274")]
 mod gallery;
 mod image;
 mod key_verification_request;
@@ -47,13 +48,14 @@ mod without_relation;
 pub use self::audio::{
     UnstableAmplitude, UnstableAudioDetailsContentBlock, UnstableVoiceContentBlock,
 };
+#[cfg(feature = "unstable-msc4274")]
+pub use self::gallery::{GalleryItemType, GalleryMessageEventContent};
 #[cfg(feature = "unstable-msc4095")]
 pub use self::url_preview::{PreviewImage, PreviewImageSource, UrlPreview};
 pub use self::{
     audio::{AudioInfo, AudioMessageEventContent},
     emote::EmoteMessageEventContent,
     file::{FileInfo, FileMessageEventContent},
-    gallery::{GalleryItemType, GalleryMessageEventContent},
     image::ImageMessageEventContent,
     key_verification_request::KeyVerificationRequestEventContent,
     location::{LocationInfo, LocationMessageEventContent},
@@ -403,6 +405,7 @@ pub enum MessageType {
     File(FileMessageEventContent),
 
     /// A media gallery message.
+    #[cfg(feature = "unstable-msc4274")]
     Gallery(GalleryMessageEventContent),
 
     /// An image message.
@@ -459,6 +462,7 @@ impl MessageType {
             "m.audio" => Self::Audio(deserialize_variant(body, data)?),
             "m.emote" => Self::Emote(deserialize_variant(body, data)?),
             "m.file" => Self::File(deserialize_variant(body, data)?),
+            #[cfg(feature = "unstable-msc4274")]
             "dm.filament.gallery" => Self::Gallery(deserialize_variant(body, data)?),
             "m.image" => Self::Image(deserialize_variant(body, data)?),
             "m.location" => Self::Location(deserialize_variant(body, data)?),
@@ -527,6 +531,7 @@ impl MessageType {
             Self::Audio(_) => "m.audio",
             Self::Emote(_) => "m.emote",
             Self::File(_) => "m.file",
+            #[cfg(feature = "unstable-msc4274")]
             Self::Gallery(_) => "dm.filament.gallery",
             Self::Image(_) => "m.image",
             Self::Location(_) => "m.location",
@@ -545,6 +550,7 @@ impl MessageType {
             MessageType::Audio(m) => &m.body,
             MessageType::Emote(m) => &m.body,
             MessageType::File(m) => &m.body,
+            #[cfg(feature = "unstable-msc4274")]
             MessageType::Gallery(m) => &m.body,
             MessageType::Image(m) => &m.body,
             MessageType::Location(m) => &m.body,
@@ -579,6 +585,7 @@ impl MessageType {
             Self::Audio(d) => Cow::Owned(serialize(d)),
             Self::Emote(d) => Cow::Owned(serialize(d)),
             Self::File(d) => Cow::Owned(serialize(d)),
+            #[cfg(feature = "unstable-msc4274")]
             Self::Gallery(d) => Cow::Owned(serialize(d)),
             Self::Image(d) => Cow::Owned(serialize(d)),
             Self::Location(d) => Cow::Owned(serialize(d)),
@@ -639,6 +646,7 @@ impl MessageType {
                 }
                 MessageType::Audio(m) => (&mut m.body, None),
                 MessageType::File(m) => (&mut m.body, None),
+                #[cfg(feature = "unstable-msc4274")]
                 MessageType::Gallery(m) => (&mut m.body, None),
                 MessageType::Image(m) => (&mut m.body, None),
                 MessageType::Location(m) => (&mut m.body, None),

--- a/crates/ruma-events/src/room/message/audio.rs
+++ b/crates/ruma-events/src/room/message/audio.rs
@@ -13,7 +13,6 @@ use crate::room::{
 /// The payload for an audio message.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
-#[serde(tag = "msgtype", rename = "m.audio")]
 pub struct AudioMessageEventContent {
     /// The textual representation of this message.
     ///

--- a/crates/ruma-events/src/room/message/content_serde.rs
+++ b/crates/ruma-events/src/room/message/content_serde.rs
@@ -1,12 +1,8 @@
 //! `Deserialize` implementation for RoomMessageEventContent and MessageType.
 
 use ruma_common::serde::from_raw_json_value;
-#[cfg(feature = "unstable-msc4274")]
-use serde::Serialize;
 use serde::{de, Deserialize};
 use serde_json::value::RawValue as RawJsonValue;
-#[cfg(feature = "unstable-msc4274")]
-use serde_json::Value as JsonValue;
 
 #[cfg(feature = "unstable-msc4274")]
 use super::gallery::GalleryItemType;
@@ -108,40 +104,6 @@ impl<'de> Deserialize<'de> for GalleryItemType {
             "m.video" => Self::Video(from_raw_json_value(&json)?),
             _ => Self::_Custom(from_raw_json_value(&json)?),
         })
-    }
-}
-
-#[cfg(feature = "unstable-msc4274")]
-impl Serialize for GalleryItemType {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let mut map = match self {
-            GalleryItemType::Audio(content) => {
-                serde_json::to_value(content).map_err(serde::ser::Error::custom)?
-            }
-            GalleryItemType::File(content) => {
-                serde_json::to_value(content).map_err(serde::ser::Error::custom)?
-            }
-            GalleryItemType::Image(content) => {
-                serde_json::to_value(content).map_err(serde::ser::Error::custom)?
-            }
-            GalleryItemType::Video(content) => {
-                serde_json::to_value(content).map_err(serde::ser::Error::custom)?
-            }
-            GalleryItemType::_Custom(content) => {
-                serde_json::to_value(content).map_err(serde::ser::Error::custom)?
-            }
-        }
-        .as_object()
-        .cloned()
-        .unwrap_or_default();
-
-        map.insert("itemtype".to_owned(), JsonValue::String(self.itemtype().to_owned()));
-        map.remove("msgtype");
-
-        map.serialize(serializer)
     }
 }
 

--- a/crates/ruma-events/src/room/message/content_serde.rs
+++ b/crates/ruma-events/src/room/message/content_serde.rs
@@ -2,7 +2,7 @@
 
 use ruma_common::serde::from_raw_json_value;
 use serde::{de, Deserialize, Serialize};
-use serde_json::{value::RawValue as RawJsonValue, Value};
+use serde_json::{value::RawValue as RawJsonValue, Value as JsonValue};
 
 use super::{
     gallery::GalleryItemType, relation_serde::deserialize_relation, MessageType,
@@ -128,7 +128,7 @@ impl Serialize for GalleryItemType {
         .cloned()
         .unwrap_or_default();
 
-        map.insert("itemtype".to_string(), Value::String(self.itemtype().to_string()));
+        map.insert("itemtype".to_owned(), JsonValue::String(self.itemtype().to_owned()));
         map.remove("msgtype");
 
         map.serialize(serializer)

--- a/crates/ruma-events/src/room/message/content_serde.rs
+++ b/crates/ruma-events/src/room/message/content_serde.rs
@@ -1,12 +1,18 @@
 //! `Deserialize` implementation for RoomMessageEventContent and MessageType.
 
 use ruma_common::serde::from_raw_json_value;
-use serde::{de, Deserialize, Serialize};
-use serde_json::{value::RawValue as RawJsonValue, Value as JsonValue};
+#[cfg(feature = "unstable-msc4274")]
+use serde::Serialize;
+use serde::{de, Deserialize};
+use serde_json::value::RawValue as RawJsonValue;
+#[cfg(feature = "unstable-msc4274")]
+use serde_json::Value as JsonValue;
 
+#[cfg(feature = "unstable-msc4274")]
+use super::gallery::GalleryItemType;
 use super::{
-    gallery::GalleryItemType, relation_serde::deserialize_relation, MessageType,
-    RoomMessageEventContent, RoomMessageEventContentWithoutRelation,
+    relation_serde::deserialize_relation, MessageType, RoomMessageEventContent,
+    RoomMessageEventContentWithoutRelation,
 };
 use crate::Mentions;
 
@@ -64,6 +70,7 @@ impl<'de> Deserialize<'de> for MessageType {
             "m.audio" => Self::Audio(from_raw_json_value(&json)?),
             "m.emote" => Self::Emote(from_raw_json_value(&json)?),
             "m.file" => Self::File(from_raw_json_value(&json)?),
+            #[cfg(feature = "unstable-msc4274")]
             "dm.filament.gallery" => Self::Gallery(from_raw_json_value(&json)?),
             "m.image" => Self::Image(from_raw_json_value(&json)?),
             "m.location" => Self::Location(from_raw_json_value(&json)?),
@@ -79,11 +86,13 @@ impl<'de> Deserialize<'de> for MessageType {
 
 /// Helper struct to determine the itemtype from a `serde_json::value::RawValue`
 #[derive(Debug, Deserialize)]
+#[cfg(feature = "unstable-msc4274")]
 struct ItemTypeDeHelper {
     /// The item type field
     itemtype: String,
 }
 
+#[cfg(feature = "unstable-msc4274")]
 impl<'de> Deserialize<'de> for GalleryItemType {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -102,6 +111,7 @@ impl<'de> Deserialize<'de> for GalleryItemType {
     }
 }
 
+#[cfg(feature = "unstable-msc4274")]
 impl Serialize for GalleryItemType {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/crates/ruma-events/src/room/message/content_serde.rs
+++ b/crates/ruma-events/src/room/message/content_serde.rs
@@ -5,8 +5,8 @@ use serde::{de, Deserialize};
 use serde_json::value::RawValue as RawJsonValue;
 
 use super::{
-    relation_serde::deserialize_relation, MessageType, RoomMessageEventContent,
-    RoomMessageEventContentWithoutRelation,
+    gallery::GalleryItemType, relation_serde::deserialize_relation, MessageType,
+    RoomMessageEventContent, RoomMessageEventContentWithoutRelation,
 };
 use crate::Mentions;
 
@@ -64,6 +64,7 @@ impl<'de> Deserialize<'de> for MessageType {
             "m.audio" => Self::Audio(from_raw_json_value(&json)?),
             "m.emote" => Self::Emote(from_raw_json_value(&json)?),
             "m.file" => Self::File(from_raw_json_value(&json)?),
+            "dm.filament.gallery" => Self::Gallery(from_raw_json_value(&json)?),
             "m.image" => Self::Image(from_raw_json_value(&json)?),
             "m.location" => Self::Location(from_raw_json_value(&json)?),
             "m.notice" => Self::Notice(from_raw_json_value(&json)?),
@@ -71,6 +72,24 @@ impl<'de> Deserialize<'de> for MessageType {
             "m.text" => Self::Text(from_raw_json_value(&json)?),
             "m.video" => Self::Video(from_raw_json_value(&json)?),
             "m.key.verification.request" => Self::VerificationRequest(from_raw_json_value(&json)?),
+            _ => Self::_Custom(from_raw_json_value(&json)?),
+        })
+    }
+}
+
+impl<'de> Deserialize<'de> for GalleryItemType {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        let json = Box::<RawJsonValue>::deserialize(deserializer)?;
+        let MessageTypeDeHelper { msgtype } = from_raw_json_value(&json)?;
+
+        Ok(match msgtype.as_ref() {
+            "m.audio" => Self::Audio(from_raw_json_value(&json)?),
+            "m.file" => Self::File(from_raw_json_value(&json)?),
+            "m.image" => Self::Image(from_raw_json_value(&json)?),
+            "m.video" => Self::Video(from_raw_json_value(&json)?),
             _ => Self::_Custom(from_raw_json_value(&json)?),
         })
     }

--- a/crates/ruma-events/src/room/message/emote.rs
+++ b/crates/ruma-events/src/room/message/emote.rs
@@ -5,7 +5,6 @@ use super::FormattedBody;
 /// The payload for an emote message.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
-#[serde(tag = "msgtype", rename = "m.emote")]
 pub struct EmoteMessageEventContent {
     /// The emote action to perform.
     pub body: String,

--- a/crates/ruma-events/src/room/message/file.rs
+++ b/crates/ruma-events/src/room/message/file.rs
@@ -11,7 +11,6 @@ use crate::room::{
 /// The payload for a file message.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
-#[serde(tag = "msgtype", rename = "m.file")]
 pub struct FileMessageEventContent {
     /// A human-readable description of the file.
     ///

--- a/crates/ruma-events/src/room/message/gallery.rs
+++ b/crates/ruma-events/src/room/message/gallery.rs
@@ -1,0 +1,128 @@
+use ruma_common::serde::JsonObject;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+
+use super::{
+    AudioMessageEventContent, FileMessageEventContent, FormattedBody, ImageMessageEventContent,
+    VideoMessageEventContent,
+};
+
+/// The payload for a gallery message.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+#[serde(tag = "msgtype", rename = "dm.filament.gallery")]
+pub struct GalleryMessageEventContent {
+    /// A human-readable description of the gallery.
+    pub body: String,
+
+    /// Formatted form of the message `body`.
+    #[serde(flatten)]
+    pub formatted: Option<FormattedBody>,
+
+    /// Item types for the media in the gallery.
+    pub itemtypes: Vec<GalleryItemType>,
+}
+
+impl GalleryMessageEventContent {
+    /// Creates a new `GalleryMessageEventContent`.
+    pub fn new(
+        body: String,
+        formatted: Option<FormattedBody>,
+        itemtypes: Vec<GalleryItemType>,
+    ) -> Self {
+        Self { body, formatted, itemtypes }
+    }
+}
+
+/// The content that is specific to each gallery item type variant.
+#[derive(Clone, Debug, Serialize)]
+#[serde(untagged)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+pub enum GalleryItemType {
+    /// An audio item.
+    Audio(AudioMessageEventContent),
+
+    /// A file item.
+    File(FileMessageEventContent),
+
+    /// An image item.
+    Image(ImageMessageEventContent),
+
+    /// A video item.
+    Video(VideoMessageEventContent),
+
+    /// A custom item.
+    #[doc(hidden)]
+    _Custom(CustomEventContent),
+}
+
+impl GalleryItemType {
+    /// Creates a new `GalleryItemType`.
+    ///
+    /// The `itemtype` and `body` are required fields.
+    /// Additionally it's possible to add arbitrary key/value pairs to the event content for custom
+    /// item types through the `data` map.
+    ///
+    /// Prefer to use the public variants of `GalleryItemType` where possible; this constructor is
+    /// meant be used for unsupported item types only and does not allow setting arbitrary data
+    /// for supported ones.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the `itemtype` is known and serialization of `data` to the corresponding
+    /// `GalleryItemType` variant fails.
+    pub fn new(itemtype: &str, body: String, data: JsonObject) -> serde_json::Result<Self> {
+        fn deserialize_variant<T: DeserializeOwned>(
+            body: String,
+            mut obj: JsonObject,
+        ) -> serde_json::Result<T> {
+            obj.insert("body".into(), body.into());
+            serde_json::from_value(JsonValue::Object(obj))
+        }
+
+        Ok(match itemtype {
+            "m.audio" => Self::Audio(deserialize_variant(body, data)?),
+            "m.file" => Self::File(deserialize_variant(body, data)?),
+            "m.image" => Self::Image(deserialize_variant(body, data)?),
+            "m.video" => Self::Video(deserialize_variant(body, data)?),
+            _ => Self::_Custom(CustomEventContent { itemtype: itemtype.to_owned(), body, data }),
+        })
+    }
+
+    /// Returns a reference to the `itemtype` string.
+    pub fn itemtype(&self) -> &str {
+        match self {
+            Self::Audio(_) => "m.audio",
+            Self::File(_) => "m.file",
+            Self::Image(_) => "m.image",
+            Self::Video(_) => "m.video",
+            Self::_Custom(c) => &c.itemtype,
+        }
+    }
+
+    /// Return a reference to the itemtype body.
+    pub fn body(&self) -> &str {
+        match self {
+            GalleryItemType::Audio(m) => &m.body,
+            GalleryItemType::File(m) => &m.body,
+            GalleryItemType::Image(m) => &m.body,
+            GalleryItemType::Video(m) => &m.body,
+            GalleryItemType::_Custom(m) => &m.body,
+        }
+    }
+}
+
+/// The payload for a custom gallery item.
+#[doc(hidden)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct CustomEventContent {
+    /// A custom itemtype.
+    itemtype: String,
+
+    /// The message body.
+    body: String,
+
+    /// Remaining event content.
+    #[serde(flatten)]
+    data: JsonObject,
+}

--- a/crates/ruma-events/src/room/message/image.rs
+++ b/crates/ruma-events/src/room/message/image.rs
@@ -10,7 +10,6 @@ use crate::room::{
 /// The payload for an image message.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
-#[serde(tag = "msgtype", rename = "m.image")]
 pub struct ImageMessageEventContent {
     /// A textual representation of the image.
     ///

--- a/crates/ruma-events/src/room/message/key_verification_request.rs
+++ b/crates/ruma-events/src/room/message/key_verification_request.rs
@@ -7,7 +7,6 @@ use crate::key::verification::VerificationMethod;
 /// The payload for a key verification request message.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
-#[serde(tag = "msgtype", rename = "m.key.verification.request")]
 pub struct KeyVerificationRequestEventContent {
     /// A fallback message to alert users that their client does not support the key verification
     /// framework.

--- a/crates/ruma-events/src/room/message/location.rs
+++ b/crates/ruma-events/src/room/message/location.rs
@@ -12,7 +12,6 @@ use crate::{
 /// The payload for a location message.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
-#[serde(tag = "msgtype", rename = "m.location")]
 #[cfg_attr(
     feature = "unstable-msc3488",
     serde(

--- a/crates/ruma-events/src/room/message/notice.rs
+++ b/crates/ruma-events/src/room/message/notice.rs
@@ -5,7 +5,6 @@ use super::FormattedBody;
 /// The payload for a notice message.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
-#[serde(tag = "msgtype", rename = "m.notice")]
 pub struct NoticeMessageEventContent {
     /// The notice text.
     pub body: String,

--- a/crates/ruma-events/src/room/message/server_notice.rs
+++ b/crates/ruma-events/src/room/message/server_notice.rs
@@ -6,7 +6,6 @@ use crate::PrivOwnedStr;
 /// The payload for a server notice message.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
-#[serde(tag = "msgtype", rename = "m.server_notice")]
 pub struct ServerNoticeMessageEventContent {
     /// A human-readable description of the notice.
     pub body: String,

--- a/crates/ruma-events/src/room/message/text.rs
+++ b/crates/ruma-events/src/room/message/text.rs
@@ -7,7 +7,6 @@ use super::FormattedBody;
 /// The payload for a text message.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
-#[serde(tag = "msgtype", rename = "m.text")]
 pub struct TextMessageEventContent {
     /// The body of the message.
     pub body: String,

--- a/crates/ruma-events/src/room/message/video.rs
+++ b/crates/ruma-events/src/room/message/video.rs
@@ -13,7 +13,6 @@ use crate::room::{
 /// The payload for a video message.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
-#[serde(tag = "msgtype", rename = "m.video")]
 pub struct VideoMessageEventContent {
     /// A description of the video.
     ///

--- a/crates/ruma-events/tests/it/room_message.rs
+++ b/crates/ruma-events/tests/it/room_message.rs
@@ -7,13 +7,14 @@ use ruma_common::{
     serde::{Base64, Raw},
     user_id, MilliSecondsSinceUnixEpoch, OwnedDeviceId,
 };
+#[cfg(feature = "unstable-msc4274")]
+use ruma_events::room::message::{GalleryItemType, GalleryMessageEventContent};
 use ruma_events::{
     key::verification::VerificationMethod,
     room::{
         message::{
             AddMentions, AudioMessageEventContent, EmoteMessageEventContent,
-            FileMessageEventContent, FormattedBody, ForwardThread, GalleryItemType,
-            GalleryMessageEventContent, ImageMessageEventContent,
+            FileMessageEventContent, FormattedBody, ForwardThread, ImageMessageEventContent,
             KeyVerificationRequestEventContent, MessageType, OriginalRoomMessageEvent,
             OriginalSyncRoomMessageEvent, Relation, ReplyWithinThread, RoomMessageEventContent,
             TextMessageEventContent, VideoMessageEventContent,
@@ -601,6 +602,7 @@ fn file_msgtype_encrypted_content_deserialization() {
 }
 
 #[test]
+#[cfg(feature = "unstable-msc4274")]
 fn gallery_msgtype_serialization() {
     let message_event_content =
         RoomMessageEventContent::new(MessageType::Gallery(GalleryMessageEventContent::new(
@@ -631,6 +633,7 @@ fn gallery_msgtype_serialization() {
 }
 
 #[test]
+#[cfg(feature = "unstable-msc4274")]
 fn gallery_msgtype_deserialization() {
     let json_data = json!({
         "body": "My photos from [FOSDEM 2025](https://fosdem.org/2025/)",

--- a/crates/ruma-events/tests/it/room_message.rs
+++ b/crates/ruma-events/tests/it/room_message.rs
@@ -652,7 +652,7 @@ fn gallery_msgtype_deserialization() {
         "My photos from <a href=\"https://fosdem.org/2025/\">FOSDEM 2025</a>"
     );
     assert_matches!(&content.itemtypes.len(), 1);
-    assert_matches!(&content.itemtypes.get(0).unwrap(), GalleryItemType::Image(content));
+    assert_matches!(&content.itemtypes.first().unwrap(), GalleryItemType::Image(content));
     assert_eq!(content.body, "my_image.jpg");
     assert_matches!(&content.source, MediaSource::Plain(url));
     assert_eq!(url, "mxc://notareal.hs/file");

--- a/crates/ruma-events/tests/it/room_message.rs
+++ b/crates/ruma-events/tests/it/room_message.rs
@@ -12,7 +12,8 @@ use ruma_events::{
     room::{
         message::{
             AddMentions, AudioMessageEventContent, EmoteMessageEventContent,
-            FileMessageEventContent, FormattedBody, ForwardThread, ImageMessageEventContent,
+            FileMessageEventContent, FormattedBody, ForwardThread, GalleryItemType,
+            GalleryMessageEventContent, ImageMessageEventContent,
             KeyVerificationRequestEventContent, MessageType, OriginalRoomMessageEvent,
             OriginalSyncRoomMessageEvent, Relation, ReplyWithinThread, RoomMessageEventContent,
             TextMessageEventContent, VideoMessageEventContent,
@@ -597,6 +598,65 @@ fn file_msgtype_encrypted_content_deserialization() {
     assert_eq!(content.body, "Upload: my_file.txt");
     assert_matches!(content.source, MediaSource::Encrypted(encrypted_file));
     assert_eq!(encrypted_file.url, "mxc://notareal.hs/file");
+}
+
+#[test]
+fn gallery_msgtype_serialization() {
+    let message_event_content =
+        RoomMessageEventContent::new(MessageType::Gallery(GalleryMessageEventContent::new(
+            "My photos from [FOSDEM 2025](https://fosdem.org/2025/)".to_owned(),
+            Some(FormattedBody::html(
+                "My photos from <a href=\"https://fosdem.org/2025/\">FOSDEM 2025</a>",
+            )),
+            vec![GalleryItemType::Image(ImageMessageEventContent::plain(
+                "my_image.jpg".to_owned(),
+                mxc_uri!("mxc://notareal.hs/file").to_owned(),
+            ))],
+        )));
+
+    assert_eq!(
+        to_json_value(&message_event_content).unwrap(),
+        json!({
+            "body": "My photos from [FOSDEM 2025](https://fosdem.org/2025/)",
+            "formatted_body": "My photos from <a href=\"https://fosdem.org/2025/\">FOSDEM 2025</a>",
+            "format": "org.matrix.custom.html",
+            "itemtypes": [{
+                "body": "my_image.jpg",
+                "url": "mxc://notareal.hs/file",
+                "itemtype": "m.image",
+            }],
+            "msgtype": "dm.filament.gallery",
+        })
+    );
+}
+
+#[test]
+fn gallery_msgtype_deserialization() {
+    let json_data = json!({
+        "body": "My photos from [FOSDEM 2025](https://fosdem.org/2025/)",
+        "formatted_body": "My photos from <a href=\"https://fosdem.org/2025/\">FOSDEM 2025</a>",
+        "format": "org.matrix.custom.html",
+        "itemtypes": [{
+            "body": "my_image.jpg",
+            "url": "mxc://notareal.hs/file",
+            "itemtype": "m.image",
+        }],
+        "msgtype": "dm.filament.gallery",
+    });
+
+    let event_content = from_json_value::<RoomMessageEventContent>(json_data).unwrap();
+    assert_matches!(event_content.msgtype, MessageType::Gallery(content));
+    assert_eq!(content.body, "My photos from [FOSDEM 2025](https://fosdem.org/2025/)");
+    assert_eq!(
+        content.formatted.unwrap().body,
+        "My photos from <a href=\"https://fosdem.org/2025/\">FOSDEM 2025</a>"
+    );
+    assert_matches!(&content.itemtypes.len(), 1);
+    assert_matches!(&content.itemtypes.get(0).unwrap(), GalleryItemType::Image(content));
+    assert_eq!(content.body, "my_image.jpg");
+    assert_matches!(&content.source, MediaSource::Plain(url));
+    assert_eq!(url, "mxc://notareal.hs/file");
+    assert!(content.caption().is_none());
 }
 
 #[test]

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -244,6 +244,7 @@ __unstable-mscs = [
     "unstable-msc4186",
     "unstable-msc4203",
     "unstable-msc4230",
+    "unstable-msc4274",
 ]
 __ci = [
     "full",

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -191,6 +191,7 @@ unstable-msc4171 = ["ruma-events?/unstable-msc4171"]
 unstable-msc4186 = ["ruma-client-api?/unstable-msc4186"]
 unstable-msc4203 = ["ruma-appservice-api?/unstable-msc4203"]
 unstable-msc4230 = ["ruma-events?/unstable-msc4230"]
+unstable-msc4274 = ["ruma-events?/unstable-msc4274"]
 unstable-pdu = ["ruma-events?/unstable-pdu"]
 
 # Private features, only used in test / benchmarking code


### PR DESCRIPTION
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->

This adds the gallery `msgtype` from [MSC4274](https://github.com/matrix-org/matrix-spec-proposals/pull/4274).
