### PR TITLE
identifiers: Don't allow alphanumeric characters outside of the ASCII…

### DIFF
--- a/crates/ruma-identifiers-validation/CHANGELOG.md
+++ b/crates/ruma-identifiers-validation/CHANGELOG.md
@@ -13,6 +13,12 @@ Breaking changes:
   - `user_id::validate_strict` allows to validate strictly a user ID against the
     strict grammar, regardless of the compat features that are enabled.
 
+Bug fixes:
+
+- Don't allow alphanumeric characters outside of the ASCII range in
+  `room_version_id::validate()`. It used to allow any Unicode alphanumeric
+  character.
+
 Improvements:
 
 - The maximum allowed length of Matrix identifiers is exposed as `ID_MAX_BYTES`.

--- a/crates/ruma-identifiers-validation/src/room_version_id.rs
+++ b/crates/ruma-identifiers-validation/src/room_version_id.rs
@@ -8,7 +8,7 @@ pub fn validate(s: &str) -> Result<(), Error> {
         Err(Error::Empty)
     } else if s.chars().count() > MAX_CODE_POINTS {
         Err(Error::MaximumLengthExceeded)
-    } else if !s.chars().all(|c| c.is_alphanumeric() || ".-".contains(c)) {
+    } else if !s.chars().all(|c| c.is_ascii_alphanumeric() || ".-".contains(c)) {
         Err(Error::InvalidCharacters)
     } else {
         Ok(())


### PR DESCRIPTION
… range for `RoomVersionId`

The [spec text](https://spec.matrix.org/v1.13/rooms/#room-version-grammar) is clear:

> Room versions MUST NOT be empty and MUST contain only the characters a-z, 0-9, ., and -.
