### PR TITLE
events: make `JoinRule` no longer fail to deserialize when encountering invalid allow conditions

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -67,6 +67,7 @@ Improvements:
   - `SignaturesRules` was added under the `signatures` field.
 - `RoomVersionId` has an `MSC2870` variant for the `org.matrix.msc2870` room
   version defined in MSC2870.
+- Add `ignore_invalid_vec_items`, to assist deserialization of `Vec`s, where invalid items should
 
 # 0.15.1
 

--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -29,6 +29,8 @@ Improvements:
 - Add `RECOMMENDED_STRIPPED_STATE_EVENT_TYPES` constant for servers to filter/get recommended
   stripped state events.
 - Add unstable support for gallery `msgtype` as per MSC4274.
+- Invalid Objects inside the `allow` array of `Restricted` are now ignored, meaning that
+  `JoinRules` will not fail to deserialize if there are invalid restricted join conditions
 
 # 0.30.1
 


### PR DESCRIPTION
Supersedes #1871
Closes #1867
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
