### PR TITLE
client-api: Make params field of UiaaInfo optional

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -7,6 +7,9 @@ Breaking changes:
   `BTreeSet<MatrixVersion>` instead of a `DoubleEndedIterator`.
 - Only allow appservices to call `appservice::request_ping::v1` and
   `appservice::set_room_visibility::v1`
+- The `params` field of `UiaaInfo` is now optional. It was never required in the
+  specification. Servers are encouraged to keep sending it for compatibility with
+  clients that required it.
 
 Improvements:
 

--- a/crates/ruma-client-api/src/uiaa.rs
+++ b/crates/ruma-client-api/src/uiaa.rs
@@ -630,7 +630,8 @@ pub struct UiaaInfo {
     /// Authentication parameters required for the client to complete authentication.
     ///
     /// To create a `Box<RawJsonValue>`, use `serde_json::value::to_raw_value`.
-    pub params: Box<RawJsonValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub params: Option<Box<RawJsonValue>>,
 
     /// Session key for client to use to complete authentication.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -642,9 +643,9 @@ pub struct UiaaInfo {
 }
 
 impl UiaaInfo {
-    /// Creates a new `UiaaInfo` with the given flows and parameters.
-    pub fn new(flows: Vec<AuthFlow>, params: Box<RawJsonValue>) -> Self {
-        Self { flows, completed: Vec::new(), params, session: None, auth_error: None }
+    /// Creates a new `UiaaInfo` with the given flows.
+    pub fn new(flows: Vec<AuthFlow>) -> Self {
+        Self { flows, completed: Vec::new(), params: None, session: None, auth_error: None }
     }
 }
 

--- a/crates/ruma-client-api/tests/uiaa.rs
+++ b/crates/ruma-client-api/tests/uiaa.rs
@@ -80,7 +80,8 @@ fn serialize_uiaa_info() {
         }
     }))
     .unwrap();
-    let uiaa_info = assign!(UiaaInfo::new(flows, params), {
+    let uiaa_info = assign!(UiaaInfo::new(flows), {
+        params: Some(params),
         completed: vec!["m.login.password".into()],
     });
 
@@ -128,7 +129,7 @@ fn deserialize_uiaa_info() {
     assert_matches!(auth_error.kind, ErrorKind::Forbidden { .. });
     assert_eq!(auth_error.message, "Invalid password");
     assert_eq!(
-        from_json_str::<JsonValue>(info.params.get()).unwrap(),
+        from_json_str::<JsonValue>(info.params.unwrap().get()).unwrap(),
         json!({
             "example.type.baz": {
                 "example_key": "foobar"
@@ -146,7 +147,8 @@ fn try_uiaa_response_into_http_response() {
         }
     }))
     .unwrap();
-    let uiaa_info = assign!(UiaaInfo::new(flows, params), {
+    let uiaa_info = assign!(UiaaInfo::new(flows), {
+        params: Some(params),
         completed: vec![AuthType::ReCaptcha],
     });
     let uiaa_response =
@@ -159,7 +161,7 @@ fn try_uiaa_response_into_http_response() {
     assert_eq!(info.session, None);
     assert_matches!(info.auth_error, None);
     assert_eq!(
-        from_json_str::<JsonValue>(info.params.get()).unwrap(),
+        from_json_str::<JsonValue>(info.params.unwrap().get()).unwrap(),
         json!({
             "example.type.baz": {
                 "example_key": "foobar"
@@ -210,7 +212,7 @@ fn try_uiaa_response_from_http_response() {
     assert_matches!(auth_error.kind, ErrorKind::Forbidden { .. });
     assert_eq!(auth_error.message, "Invalid password");
     assert_eq!(
-        from_json_str::<JsonValue>(info.params.get()).unwrap(),
+        from_json_str::<JsonValue>(info.params.unwrap().get()).unwrap(),
         json!({
             "example.type.baz": {
                 "example_key": "foobar"


### PR DESCRIPTION
As seen in the spec. For example, in the [401 response of POST /account/deactivate](https://spec.matrix.org/v1.13/client-server-api/#post_matrixclientv3accountdeactivate_response-401_authentication-response).