### PR TITLE
Bump getrandom to 0.2.15

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -68,6 +68,7 @@ Improvements:
 - `RoomVersionId` has an `MSC2870` variant for the `org.matrix.msc2870` room
   version defined in MSC2870.
 - Add `ignore_invalid_vec_items`, to assist deserialization of `Vec`s, where invalid items should
+- Move `getrandom` dependency to version 0.2.15
 
 # 0.15.1
 

--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -52,7 +52,7 @@ as_variant = { workspace = true }
 base64 = { workspace = true }
 bytes = { workspace = true }
 form_urlencoded = "1.0.0"
-getrandom = { version = "0.2.6", optional = true }
+getrandom = { version = "0.2.15", optional = true }
 http = { workspace = true, optional = true }
 indexmap = { version = "2.0.0", features = ["serde"] }
 js_int = { workspace = true, features = ["serde"] }


### PR DESCRIPTION
Helps resolve an issue when targeting a wasm32-unknown-unknown target with the matrix-rust-sdk by aligning the dependency with what is used in that project.  