### PR TITLE
Add initial support for Matrix 1.14

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -67,7 +67,9 @@ Improvements:
   - `SignaturesRules` was added under the `signatures` field.
 - `RoomVersionId` has an `MSC2870` variant for the `org.matrix.msc2870` room
   version defined in MSC2870.
-- Add `ignore_invalid_vec_items`, to assist deserialization of `Vec`s, where invalid items should
+- Add `ignore_invalid_vec_items`, to assist deserialization of `Vec`s, where
+  invalid items should
+- Add `MatrixVersion::V1_14`.
 
 # 0.15.1
 

--- a/crates/ruma-common/src/api/metadata.rs
+++ b/crates/ruma-common/src/api/metadata.rs
@@ -579,6 +579,11 @@ pub enum MatrixVersion {
     ///
     /// See <https://spec.matrix.org/v1.13/>.
     V1_13,
+
+    /// Version 1.14 of the Matrix specification, released in Q1 2025.
+    ///
+    /// See <https://spec.matrix.org/v1.14/>.
+    V1_14,
 }
 
 impl TryFrom<&str> for MatrixVersion {
@@ -606,6 +611,7 @@ impl TryFrom<&str> for MatrixVersion {
             "v1.11" => V1_11,
             "v1.12" => V1_12,
             "v1.13" => V1_13,
+            "v1.14" => V1_14,
             _ => return Err(UnknownVersionError),
         })
     }
@@ -655,6 +661,7 @@ impl MatrixVersion {
             MatrixVersion::V1_11 => "v1.11",
             MatrixVersion::V1_12 => "v1.12",
             MatrixVersion::V1_13 => "v1.13",
+            MatrixVersion::V1_14 => "v1.14",
         };
 
         Some(string)
@@ -677,6 +684,7 @@ impl MatrixVersion {
             MatrixVersion::V1_11 => (1, 11),
             MatrixVersion::V1_12 => (1, 12),
             MatrixVersion::V1_13 => (1, 13),
+            MatrixVersion::V1_14 => (1, 14),
         }
     }
 
@@ -697,6 +705,7 @@ impl MatrixVersion {
             (1, 11) => Ok(MatrixVersion::V1_11),
             (1, 12) => Ok(MatrixVersion::V1_12),
             (1, 13) => Ok(MatrixVersion::V1_13),
+            (1, 14) => Ok(MatrixVersion::V1_14),
             _ => Err(UnknownVersionError),
         }
     }
@@ -798,6 +807,8 @@ impl MatrixVersion {
             | MatrixVersion::V1_12
             // <https://spec.matrix.org/v1.13/rooms/#complete-list-of-room-versions>
             | MatrixVersion::V1_13 => RoomVersionId::V10,
+            // <https://spec.matrix.org/v1.14/rooms/#complete-list-of-room-versions>
+            | MatrixVersion::V1_14 => RoomVersionId::V11,
         }
     }
 }

--- a/crates/ruma-common/src/push/condition.rs
+++ b/crates/ruma-common/src/push/condition.rs
@@ -604,7 +604,7 @@ mod tests {
         assert!(!"m".matches_word("[[:alpha:]]?"));
         assert!("[[:alpha:]]!".matches_word("[[:alpha:]]?"));
 
-        // From the spec: <https://spec.matrix.org/v1.13/client-server-api/#conditions-1>
+        // From the spec: <https://spec.matrix.org/v1.14/client-server-api/#conditions-1>
         assert!("An example event.".matches_word("ex*ple"));
         assert!("exple".matches_word("ex*ple"));
         assert!("An exciting triple-whammy".matches_word("ex*ple"));
@@ -653,7 +653,7 @@ mod tests {
         assert!("".matches_pattern("*", false));
         assert!(!"foo".matches_pattern("", false));
 
-        // From the spec: <https://spec.matrix.org/v1.13/client-server-api/#conditions-1>
+        // From the spec: <https://spec.matrix.org/v1.14/client-server-api/#conditions-1>
         assert!("Lunch plans".matches_pattern("lunc?*", false));
         assert!("LUNCH".matches_pattern("lunc?*", false));
         assert!(!" lunch".matches_pattern("lunc?*", false));

--- a/crates/ruma-common/src/room_version_rules.rs
+++ b/crates/ruma-common/src/room_version_rules.rs
@@ -233,7 +233,7 @@ pub struct AuthorizationRules {
     /// Whether the room creator should be determined using the `m.room.create` event's `sender`,
     /// instead of the event content's `creator` field ([spec]), introduced in room version 11.
     ///
-    /// [spec]: https://spec.matrix.org/v1.13/rooms/v11/#event-format
+    /// [spec]: https://spec.matrix.org/v1.14/rooms/v11/#event-format
     pub use_room_create_sender: bool,
 }
 
@@ -302,49 +302,49 @@ pub struct RedactionRules {
     /// Whether to keep the `aliases` field in the `content` of `m.room.aliases` events ([spec]),
     /// disabled since room version 6.
     ///
-    /// [spec]: https://spec.matrix.org/v1.13/rooms/v6/#redactions
+    /// [spec]: https://spec.matrix.org/v1.14/rooms/v6/#redactions
     pub keep_room_aliases_aliases: bool,
 
     /// Whether to keep the `allow` field in the `content` of `m.room.join_rules` events ([spec]),
     /// introduced in room version 8.
     ///
-    /// [spec]: https://spec.matrix.org/v1.13/rooms/v8/#redactions
+    /// [spec]: https://spec.matrix.org/v1.14/rooms/v8/#redactions
     pub keep_room_join_rules_allow: bool,
 
     /// Whether to keep the `join_authorised_via_users_server` field in the `content` of
     /// `m.room.member` events ([spec]), introduced in room version 9.
     ///
-    /// [spec]: https://spec.matrix.org/v1.13/rooms/v9/#redactions
+    /// [spec]: https://spec.matrix.org/v1.14/rooms/v9/#redactions
     pub keep_room_member_join_authorised_via_users_server: bool,
 
     /// Whether to keep the `origin`, `membership` and `prev_state` fields a the top-level of all
     /// events ([spec]), disabled since room version 11.
     ///
-    /// [spec]: https://spec.matrix.org/v1.13/rooms/v11/#redactions
+    /// [spec]: https://spec.matrix.org/v1.14/rooms/v11/#redactions
     pub keep_origin_membership_prev_state: bool,
 
     /// Whether to keep the entire `content` of `m.room.create` events ([spec]), introduced in room
     /// version 11.
     ///
-    /// [spec]: https://spec.matrix.org/v1.13/rooms/v11/#redactions
+    /// [spec]: https://spec.matrix.org/v1.14/rooms/v11/#redactions
     pub keep_room_create_content: bool,
 
     /// Whether to keep the `redacts` field in the `content` of `m.room.redaction` events ([spec]),
     /// introduced in room version 11.
     ///
-    /// [spec]: https://spec.matrix.org/v1.13/rooms/v11/#redactions
+    /// [spec]: https://spec.matrix.org/v1.14/rooms/v11/#redactions
     pub keep_room_redaction_redacts: bool,
 
     /// Whether to keep the `invite` field in the `content` of `m.room.power_levels` events
     /// ([spec]), introduced in room version 11.
     ///
-    /// [spec]: https://spec.matrix.org/v1.13/rooms/v11/#redactions
+    /// [spec]: https://spec.matrix.org/v1.14/rooms/v11/#redactions
     pub keep_room_power_levels_invite: bool,
 
     /// Whether to keep the `signed` field in `third_party_invite` of the `content` of
     /// `m.room.member` events ([spec]), introduced in room version 11.
     ///
-    /// [spec]: https://spec.matrix.org/v1.13/rooms/v11/#redactions
+    /// [spec]: https://spec.matrix.org/v1.14/rooms/v11/#redactions
     pub keep_room_member_third_party_invite_signed: bool,
 
     /// Whether to keep the `allow`, `deny` and `allow_ip_literals` in the `content` of
@@ -358,7 +358,7 @@ pub struct RedactionRules {
 impl RedactionRules {
     /// Redaction rules as introduced in room version 1 ([spec]).
     ///
-    /// [spec]: https://spec.matrix.org/v1.13/rooms/v1/#redactions
+    /// [spec]: https://spec.matrix.org/v1.14/rooms/v1/#redactions
     pub const V1: Self = Self {
         keep_room_aliases_aliases: true,
         keep_room_join_rules_allow: false,
@@ -374,23 +374,23 @@ impl RedactionRules {
 
     /// Redaction rules with tweaks introduced in room version 6 ([spec]).
     ///
-    /// [spec]: https://spec.matrix.org/v1.13/rooms/v6/#redactions
+    /// [spec]: https://spec.matrix.org/v1.14/rooms/v6/#redactions
     pub const V6: Self = Self { keep_room_aliases_aliases: false, ..Self::V1 };
 
     /// Redaction rules with tweaks introduced in room version 8 ([spec]).
     ///
-    /// [spec]: https://spec.matrix.org/v1.13/rooms/v8/#redactions
+    /// [spec]: https://spec.matrix.org/v1.14/rooms/v8/#redactions
     pub const V8: Self = Self { keep_room_join_rules_allow: true, ..Self::V6 };
 
     /// Redaction rules with tweaks introduced in room version 9 ([spec]).
     ///
-    /// [spec]: https://spec.matrix.org/v1.13/rooms/v9/#redactions
+    /// [spec]: https://spec.matrix.org/v1.14/rooms/v9/#redactions
     pub const V9: Self =
         Self { keep_room_member_join_authorised_via_users_server: true, ..Self::V8 };
 
     /// Redaction rules with tweaks introduced in room version 11 ([spec]).
     ///
-    /// [spec]: https://spec.matrix.org/v1.13/rooms/v11/#redactions
+    /// [spec]: https://spec.matrix.org/v1.14/rooms/v11/#redactions
     pub const V11: Self = Self {
         keep_origin_membership_prev_state: false,
         keep_room_create_content: true,

--- a/crates/ruma-events/src/secret_storage/key.rs
+++ b/crates/ruma-events/src/secret_storage/key.rs
@@ -57,7 +57,7 @@ fn is_default_bits(val: &UInt) -> bool {
 ///
 /// The only algorithm currently specified is `m.secret_storage.v1.aes-hmac-sha2`, so this
 /// essentially represents `AesHmacSha2KeyDescription` in the
-/// [spec](https://spec.matrix.org/v1.13/client-server-api/#msecret_storagev1aes-hmac-sha2).
+/// [spec](https://spec.matrix.org/v1.14/client-server-api/#msecret_storagev1aes-hmac-sha2).
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 #[derive(Clone, Debug, Serialize, EventContent)]
 #[ruma_event(type = "m.secret_storage.key.*", kind = GlobalAccountData)]
@@ -137,7 +137,7 @@ impl SecretStorageEncryptionAlgorithm {
 /// The key properties for the `m.secret_storage.v1.aes-hmac-sha2` algorithm.
 ///
 /// Corresponds to the AES-specific properties of `AesHmacSha2KeyDescription` in the
-/// [spec](https://spec.matrix.org/v1.13/client-server-api/#msecret_storagev1aes-hmac-sha2).
+/// [spec](https://spec.matrix.org/v1.14/client-server-api/#msecret_storagev1aes-hmac-sha2).
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct SecretStorageV1AesHmacSha2Properties {

--- a/crates/ruma-identifiers-validation/src/error.rs
+++ b/crates/ruma-identifiers-validation/src/error.rs
@@ -77,7 +77,7 @@ pub enum MxcUriError {
     /// Media identifier malformed due to invalid characters detected.
     ///
     /// Valid characters are (in regex notation) `[A-Za-z0-9_-]+`.
-    /// See [here](https://spec.matrix.org/v1.13/client-server-api/#security-considerations-5) for more details.
+    /// See [here](https://spec.matrix.org/v1.14/client-server-api/#security-considerations-5) for more details.
     #[error("Media Identifier malformed, invalid characters")]
     MediaIdMalformed,
 

--- a/crates/ruma-identifiers-validation/src/mxc_uri.rs
+++ b/crates/ruma-identifiers-validation/src/mxc_uri.rs
@@ -17,7 +17,7 @@ pub fn validate(uri: &str) -> Result<NonZeroU8, MxcUriError> {
 
     let server_name = &uri[..index];
     let media_id = &uri[index + 1..];
-    // See: https://spec.matrix.org/v1.13/client-server-api/#security-considerations-5
+    // See: https://spec.matrix.org/v1.14/client-server-api/#security-considerations-5
     let media_id_is_valid = media_id
         .bytes()
         .all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'z' | b'A'..=b'Z' | b'-' | b'_' ));

--- a/xtask/src/ci/spec_links.rs
+++ b/xtask/src/ci/spec_links.rs
@@ -18,7 +18,7 @@ const OLD_URL_WHITELIST: &[&str] =
 /// Authorized versions in URLs pointing to the new specs.
 const NEW_VERSION_WHITELIST: &[&str] = &[
     "v1.1", "v1.2", "v1.3", "v1.4", "v1.5", "v1.6", "v1.7", "v1.8", "v1.9", "v1.10", "v1.11",
-    "v1.12", "v1.13",
+    "v1.12", "v1.13", "v1.14",
     "latest",
     // This should only be enabled if a legitimate use case is found.
     // "unstable",


### PR DESCRIPTION
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
