### PR TITLE
client-api: Only serialize `server_name` if `via` is not supported

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -17,6 +17,10 @@ Improvements:
 
 - Remove the unstable support for MSC3575 as it was closed. MSC4186 should be
   used instead.
+- For the `membership::join_room_by_id_or_alias` and `knock::knock_room`
+  endpoints, the `server_name` query parameter is only serialized if the server
+  doesn't advertise at least one version that supports the `via` query
+  parameter. The former was removed in Matrix 1.14.
 
 # 0.20.2
 

--- a/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
+++ b/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
@@ -94,10 +94,20 @@ pub mod v3 {
         ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
             use http::header::{self, HeaderValue};
 
-            let query_string = serde_html_form::to_string(RequestQuery {
-                server_name: self.via.clone(),
-                via: self.via,
-            })?;
+            // Only send `server_name` if the `via` parameter is not supported by the server.
+            // `via` was introduced in Matrix 1.12.
+            let server_name = if considering_versions
+                .iter()
+                .rev()
+                .any(|version| version.is_superset_of(ruma_common::api::MatrixVersion::V1_12))
+            {
+                vec![]
+            } else {
+                self.via.clone()
+            };
+
+            let query_string =
+                serde_html_form::to_string(RequestQuery { server_name, via: self.via })?;
 
             let http_request = http::Request::builder()
                 .method(METADATA.method)
@@ -207,7 +217,7 @@ pub mod v3 {
 
         #[cfg(feature = "client")]
         #[test]
-        fn serialize_request() {
+        fn serialize_request_via_and_server_name() {
             let mut req = Request::new(owned_room_id!("!foo:b.ar").into());
             req.via = vec![owned_server_name!("f.oo")];
             let req = req
@@ -218,6 +228,21 @@ pub mod v3 {
                 )
                 .unwrap();
             assert_eq!(req.uri().query(), Some("via=f.oo&server_name=f.oo"));
+        }
+
+        #[cfg(feature = "client")]
+        #[test]
+        fn serialize_request_only_via() {
+            let mut req = Request::new(owned_room_id!("!foo:b.ar").into());
+            req.via = vec![owned_server_name!("f.oo")];
+            let req = req
+                .try_into_http_request::<Vec<u8>>(
+                    "https://matrix.org",
+                    SendAccessToken::IfRequired("tok"),
+                    &[MatrixVersion::V1_13],
+                )
+                .unwrap();
+            assert_eq!(req.uri().query(), Some("via=f.oo"));
         }
 
         #[cfg(feature = "server")]


### PR DESCRIPTION
According to [MSC4213](https://github.com/matrix-org/matrix-spec-proposals/pull/4213) / [Matrix 1.14](https://github.com/matrix-org/matrix-spec/issues/2059).

