### PR TITLE
client-api: Add endpoint for reporting users

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -20,6 +20,8 @@ Improvements:
 - Add the endpoints for peeking: `get_current_state` and `listen_to_new_events`.
 - Remove the unstable support for MSC3575 as it was closed. MSC4186 should be
   used instead.
+- Add the `reporting::report_user` endpoint to report users, according to Matrix
+  1.14.
 
 # 0.20.1
 

--- a/crates/ruma-client-api/src/lib.rs
+++ b/crates/ruma-client-api/src/lib.rs
@@ -41,6 +41,7 @@ pub mod redact;
 pub mod relations;
 #[cfg(feature = "unstable-msc4108")]
 pub mod rendezvous;
+pub mod reporting;
 pub mod room;
 pub mod search;
 pub mod server;

--- a/crates/ruma-client-api/src/reporting.rs
+++ b/crates/ruma-client-api/src/reporting.rs
@@ -1,0 +1,3 @@
+//! Endpoints for reporting content outside of rooms.
+
+pub mod report_user;

--- a/crates/ruma-client-api/src/reporting/report_user.rs
+++ b/crates/ruma-client-api/src/reporting/report_user.rs
@@ -1,0 +1,54 @@
+//! `POST /_matrix/client/*/users/{userId}/report`
+//!
+//! Report a user as inappropriate.
+
+pub mod v3 {
+    //! `/v3/` ([spec])
+    //!
+    //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3usersuseridreport
+
+    use ruma_common::{
+        api::{request, response, Metadata},
+        metadata, OwnedUserId,
+    };
+
+    const METADATA: Metadata = metadata! {
+        method: POST,
+        rate_limited: true,
+        authentication: AccessToken,
+        history: {
+            unstable => "/_matrix/client/unstable/org.matrix.msc4260/users/:user_id/report",
+            1.14 => "/_matrix/client/v3/users/:user_id/report",
+        }
+    };
+
+    /// Request type for the `report_user` endpoint.
+    #[request(error = crate::Error)]
+    pub struct Request {
+        /// The ID of the user to report.
+        #[ruma_api(path)]
+        pub user_id: OwnedUserId,
+
+        /// The reason to report the user, may be empty.
+        pub reason: String,
+    }
+
+    /// Response type for the `report_user` endpoint.
+    #[response(error = crate::Error)]
+    #[derive(Default)]
+    pub struct Response {}
+
+    impl Request {
+        /// Creates a new `Request` with the given user ID and reason.
+        pub fn new(user_id: OwnedUserId, reason: String) -> Self {
+            Self { user_id, reason }
+        }
+    }
+
+    impl Response {
+        /// Creates an empty `Response`.
+        pub fn new() -> Self {
+            Self {}
+        }
+    }
+}


### PR DESCRIPTION
According to [MSC4260](https://github.com/matrix-org/matrix-spec-proposals/pull/4260) / [Matrix 1.14](https://github.com/matrix-org/matrix-spec/pull/2093).

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
