### PR TITLE
client-api: Make `reason` of `report_room` required

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -10,6 +10,8 @@ Breaking changes:
 - The `params` field of `UiaaInfo` is now optional. It was never required in the
   specification. Servers are encouraged to keep sending it for compatibility with
   clients that required it.
+- The `reason` field of `report_room::v3::Request` is now required, due to a
+  clarification in the spec.
 
 Improvements:
 

--- a/crates/ruma-client-api/src/room/report_room.rs
+++ b/crates/ruma-client-api/src/room/report_room.rs
@@ -29,9 +29,13 @@ pub mod v3 {
         #[ruma_api(path)]
         pub room_id: OwnedRoomId,
 
-        /// The reason to report the room.
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub reason: Option<String>,
+        /// The reason to report the room, may be empty.
+        // We deserialize a missing field as an empty string for backwards compatibility. The field
+        // was initially specified as optional in Matrix 1.13 and then clarified as being required
+        // in Matrix 1.14 to align with its initial definition in MSC4151.
+        // See: https://github.com/matrix-org/matrix-spec/pull/2093#discussion_r1993171166
+        #[serde(default)]
+        pub reason: String,
     }
 
     /// Response type for the `report_room` endpoint.
@@ -40,9 +44,9 @@ pub mod v3 {
     pub struct Response {}
 
     impl Request {
-        /// Creates a new `Request` with the given room ID.
-        pub fn new(room_id: OwnedRoomId) -> Self {
-            Self { room_id, reason: None }
+        /// Creates a new `Request` with the given room ID and reason.
+        pub fn new(room_id: OwnedRoomId, reason: String) -> Self {
+            Self { room_id, reason }
         }
     }
 


### PR DESCRIPTION
Due to a [clarification in the spec](https://github.com/matrix-org/matrix-spec/pull/2093#discussion_r1993171166).
