### PR TITLE
events: Add support for ThumbHashes for MSC2448

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -22,7 +22,12 @@ Breaking changes:
   is now serialized on the variants of `MessageType`.
 - `RedactContent::redact()` and `FullStateEventContent::redact()` take a
   `RedactionRules` instead of `RoomVersionId`. This avoids undefined behavior
-  for unknown room versions. 
+  for unknown room versions.
+
+Improvements:
+
+- Add support for ThumbHash as an alternative to BlurHash for MSC2448 in 
+  `ImageInfo` and `VideoInfo`.
 
 # 0.30.2
 

--- a/crates/ruma-events/src/room.rs
+++ b/crates/ruma-events/src/room.rs
@@ -105,6 +105,14 @@ pub struct ImageInfo {
     #[serde(rename = "xyz.amorgan.blurhash", skip_serializing_if = "Option::is_none")]
     pub blurhash: Option<String>,
 
+    /// The [ThumbHash](https://evanw.github.io/thumbhash/) for this image.
+    ///
+    /// This uses the unstable prefix in
+    /// [MSC2448](https://github.com/matrix-org/matrix-spec-proposals/pull/2448).
+    #[cfg(feature = "unstable-msc2448")]
+    #[serde(rename = "xyz.amorgan.thumbhash", skip_serializing_if = "Option::is_none")]
+    pub thumbhash: Option<Base64>,
+
     /// Whether the image is animated.
     ///
     /// This uses the unstable prefix in [MSC4230].

--- a/crates/ruma-events/src/room/avatar.rs
+++ b/crates/ruma-events/src/room/avatar.rs
@@ -3,6 +3,8 @@
 //! [`m.room.avatar`]: https://spec.matrix.org/latest/client-server-api/#mroomavatar
 
 use js_int::UInt;
+#[cfg(feature = "unstable-msc2448")]
+use ruma_common::serde::Base64;
 use ruma_common::OwnedMxcUri;
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
@@ -69,6 +71,14 @@ pub struct ImageInfo {
     #[cfg(feature = "unstable-msc2448")]
     #[serde(rename = "xyz.amorgan.blurhash", skip_serializing_if = "Option::is_none")]
     pub blurhash: Option<String>,
+
+    /// The [ThumbHash](https://evanw.github.io/thumbhash/) for this image.
+    ///
+    /// This uses the unstable prefix in
+    /// [MSC2448](https://github.com/matrix-org/matrix-spec-proposals/pull/2448).
+    #[cfg(feature = "unstable-msc2448")]
+    #[serde(rename = "xyz.amorgan.thumbhash", skip_serializing_if = "Option::is_none")]
+    pub thumbhash: Option<Base64>,
 }
 
 impl ImageInfo {

--- a/crates/ruma-events/src/room/message/video.rs
+++ b/crates/ruma-events/src/room/message/video.rs
@@ -1,6 +1,8 @@
 use std::time::Duration;
 
 use js_int::UInt;
+#[cfg(feature = "unstable-msc2448")]
+use ruma_common::serde::Base64;
 use ruma_common::OwnedMxcUri;
 use serde::{Deserialize, Serialize};
 
@@ -139,6 +141,14 @@ pub struct VideoInfo {
     #[cfg(feature = "unstable-msc2448")]
     #[serde(rename = "xyz.amorgan.blurhash", skip_serializing_if = "Option::is_none")]
     pub blurhash: Option<String>,
+
+    /// The [ThumbHash](https://evanw.github.io/thumbhash/) for this video.
+    ///
+    /// This uses the unstable prefix in
+    /// [MSC2448](https://github.com/matrix-org/matrix-spec-proposals/pull/2448).
+    #[cfg(feature = "unstable-msc2448")]
+    #[serde(rename = "xyz.amorgan.thumbhash", skip_serializing_if = "Option::is_none")]
+    pub thumbhash: Option<Base64>,
 }
 
 impl VideoInfo {


### PR DESCRIPTION
It is technically not defined in the MSC but was mentioned as an alternative in https://github.com/matrix-org/matrix-spec-proposals/pull/2448#discussion_r1145925335. We would prefer to support ThumbHash rather than BlurHash in Fractal.