### PR TITLE
api: Allow to specify unstable and stable features in metadata macro

### DIFF
--- a/crates/ruma-appservice-api/src/event/push_events.rs
+++ b/crates/ruma-appservice-api/src/event/push_events.rs
@@ -266,7 +266,9 @@ pub mod v1 {
         #[cfg(feature = "client")]
         #[test]
         fn request_contains_events_field() {
-            use ruma_common::api::{OutgoingRequest, SendAccessToken};
+            use ruma_common::api::{
+                MatrixVersion, OutgoingRequest, SendAccessToken, SupportedVersions,
+            };
 
             let dummy_event_json = json!({
                 "type": "m.room.message",
@@ -281,12 +283,14 @@ pub mod v1 {
             });
             let dummy_event = from_json_value(dummy_event_json.clone()).unwrap();
             let events = vec![dummy_event];
+            let supported =
+                SupportedVersions { versions: [MatrixVersion::V1_1].into(), features: Vec::new() };
 
             let req = super::Request::new("any_txn_id".into(), events)
                 .try_into_http_request::<Vec<u8>>(
                     "https://homeserver.tld",
                     SendAccessToken::IfRequired("auth_tok"),
-                    &[ruma_common::api::MatrixVersion::V1_1],
+                    &supported,
                 )
                 .unwrap();
             let json_body: serde_json::Value = serde_json::from_slice(req.body()).unwrap();

--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -3,8 +3,6 @@
 Breaking changes:
 
 - Use `AuthType` for the `auth_type` of `get_uiaa_fallback_page`'s Request.
-- `get_supported_versions::Response::known_versions()` returns a
-  `BTreeSet<MatrixVersion>` instead of a `DoubleEndedIterator`.
 - Only allow appservices to call `appservice::request_ping::v1` and
   `appservice::set_room_visibility::v1`
 - The `params` field of `UiaaInfo` is now optional. It was never required in the
@@ -18,6 +16,8 @@ Breaking changes:
   burden and potential issues in the future.
 - Move `Capabilities` and associated types into the
   `discovery::get_capabilities::v3` module, for consistency with other endpoints.
+- `get_supported_versions::Response::known_versions()` was replaced by
+  `as_supported_versions()` which returns a `SupportedVersions`.
 
 Improvements:
 

--- a/crates/ruma-client-api/src/appservice/request_ping.rs
+++ b/crates/ruma-client-api/src/appservice/request_ping.rs
@@ -19,8 +19,8 @@ pub mod v1 {
         rate_limited: false,
         authentication: AppserviceToken,
         history: {
-            unstable => "/_matrix/client/unstable/fi.mau.msc2659/appservice/:appservice_id/ping",
-            1.7 => "/_matrix/client/v1/appservice/:appservice_id/ping",
+            unstable("fi.mau.msc2659") => "/_matrix/client/unstable/fi.mau.msc2659/appservice/:appservice_id/ping",
+            1.7 | stable("fi.mau.msc2659.stable") => "/_matrix/client/v1/appservice/:appservice_id/ping",
         }
     };
 

--- a/crates/ruma-client-api/src/authenticated_media/get_content.rs
+++ b/crates/ruma-client-api/src/authenticated_media/get_content.rs
@@ -21,8 +21,8 @@ pub mod v1 {
         rate_limited: true,
         authentication: AccessToken,
         history: {
-            unstable => "/_matrix/client/unstable/org.matrix.msc3916/media/download/:server_name/:media_id",
-            1.11 => "/_matrix/client/v1/media/download/:server_name/:media_id",
+            unstable("org.matrix.msc3916") => "/_matrix/client/unstable/org.matrix.msc3916/media/download/:server_name/:media_id",
+            1.11 | stable("org.matrix.msc3916.stable") => "/_matrix/client/v1/media/download/:server_name/:media_id",
         }
     };
 

--- a/crates/ruma-client-api/src/authenticated_media/get_content_as_filename.rs
+++ b/crates/ruma-client-api/src/authenticated_media/get_content_as_filename.rs
@@ -21,8 +21,8 @@ pub mod v1 {
         rate_limited: true,
         authentication: AccessToken,
         history: {
-            unstable => "/_matrix/client/unstable/org.matrix.msc3916/media/download/:server_name/:media_id/:filename",
-            1.11 => "/_matrix/client/v1/media/download/:server_name/:media_id/:filename",
+            unstable("org.matrix.msc3916") => "/_matrix/client/unstable/org.matrix.msc3916/media/download/:server_name/:media_id/:filename",
+            1.11 | stable("org.matrix.msc3916.stable") => "/_matrix/client/v1/media/download/:server_name/:media_id/:filename",
         }
     };
 

--- a/crates/ruma-client-api/src/authenticated_media/get_content_thumbnail.rs
+++ b/crates/ruma-client-api/src/authenticated_media/get_content_thumbnail.rs
@@ -23,8 +23,8 @@ pub mod v1 {
         rate_limited: true,
         authentication: AccessToken,
         history: {
-            unstable => "/_matrix/client/unstable/org.matrix.msc3916/media/thumbnail/:server_name/:media_id",
-            1.11 => "/_matrix/client/v1/media/thumbnail/:server_name/:media_id",
+            unstable("org.matrix.msc3916") => "/_matrix/client/unstable/org.matrix.msc3916/media/thumbnail/:server_name/:media_id",
+            1.11 | stable("org.matrix.msc3916.stable") => "/_matrix/client/v1/media/thumbnail/:server_name/:media_id",
         }
     };
 

--- a/crates/ruma-client-api/src/authenticated_media/get_media_config.rs
+++ b/crates/ruma-client-api/src/authenticated_media/get_media_config.rs
@@ -18,8 +18,8 @@ pub mod v1 {
         rate_limited: true,
         authentication: AccessToken,
         history: {
-            unstable => "/_matrix/client/unstable/org.matrix.msc3916/media/config",
-            1.11 => "/_matrix/client/v1/media/config",
+            unstable("org.matrix.msc3916") => "/_matrix/client/unstable/org.matrix.msc3916/media/config",
+            1.11 | stable("org.matrix.msc3916.stable") => "/_matrix/client/v1/media/config",
         }
     };
 

--- a/crates/ruma-client-api/src/authenticated_media/get_media_preview.rs
+++ b/crates/ruma-client-api/src/authenticated_media/get_media_preview.rs
@@ -19,8 +19,8 @@ pub mod v1 {
         rate_limited: true,
         authentication: AccessToken,
         history: {
-            unstable => "/_matrix/client/unstable/org.matrix.msc3916/media/preview_url",
-            1.11 => "/_matrix/client/v1/media/preview_url",
+            unstable("org.matrix.msc3916") => "/_matrix/client/unstable/org.matrix.msc3916/media/preview_url",
+            1.11 | stable("org.matrix.msc3916.stable") => "/_matrix/client/v1/media/preview_url",
         }
     };
 

--- a/crates/ruma-client-api/src/delayed_events/delayed_message_event.rs
+++ b/crates/ruma-client-api/src/delayed_events/delayed_message_event.rs
@@ -118,7 +118,7 @@ pub mod unstable {
     #[cfg(all(test, feature = "client"))]
     mod tests {
         use ruma_common::{
-            api::{MatrixVersion, OutgoingRequest, SendAccessToken},
+            api::{MatrixVersion, OutgoingRequest, SendAccessToken, SupportedVersions},
             owned_room_id,
         };
         use ruma_events::room::message::RoomMessageEventContent;
@@ -131,6 +131,8 @@ pub mod unstable {
         #[test]
         fn serialize_delayed_message_request() {
             let room_id = owned_room_id!("!roomid:example.org");
+            let supported =
+                SupportedVersions { versions: [MatrixVersion::V1_1].into(), features: Vec::new() };
 
             let req = Request::new(
                 room_id,
@@ -143,7 +145,7 @@ pub mod unstable {
                 .try_into_http_request(
                     "https://homeserver.tld",
                     SendAccessToken::IfRequired("auth_tok"),
-                    &[MatrixVersion::V1_1],
+                    &supported,
                 )
                 .unwrap();
             let (parts, body) = request.into_parts();

--- a/crates/ruma-client-api/src/delayed_events/delayed_state_event.rs
+++ b/crates/ruma-client-api/src/delayed_events/delayed_state_event.rs
@@ -114,7 +114,7 @@ pub mod unstable {
     #[cfg(all(test, feature = "client"))]
     mod tests {
         use ruma_common::{
-            api::{MatrixVersion, OutgoingRequest, SendAccessToken},
+            api::{MatrixVersion, OutgoingRequest, SendAccessToken, SupportedVersions},
             owned_room_id,
             serde::Raw,
         };
@@ -127,6 +127,9 @@ pub mod unstable {
         fn create_delayed_event_request(
             delay_parameters: DelayParameters,
         ) -> (http::request::Parts, Vec<u8>) {
+            let supported =
+                SupportedVersions { versions: [MatrixVersion::V1_1].into(), features: Vec::new() };
+
             Request::new_raw(
                 owned_room_id!("!roomid:example.org"),
                 "@userAsStateKey:example.org".to_owned(),
@@ -137,7 +140,7 @@ pub mod unstable {
             .try_into_http_request(
                 "https://homeserver.tld",
                 SendAccessToken::IfRequired("auth_tok"),
-                &[MatrixVersion::V1_1],
+                &supported,
             )
             .unwrap()
             .into_parts()

--- a/crates/ruma-client-api/src/delayed_events/update_delayed_event.rs
+++ b/crates/ruma-client-api/src/delayed_events/update_delayed_event.rs
@@ -21,7 +21,7 @@ pub mod unstable {
         rate_limited: true,
         authentication: AccessToken,
         history: {
-            unstable => "/_matrix/client/unstable/org.matrix.msc4140/delayed_events/:delay_id",
+            unstable("org.matrix.msc4140") => "/_matrix/client/unstable/org.matrix.msc4140/delayed_events/:delay_id",
         }
     };
 

--- a/crates/ruma-client-api/src/delayed_events/update_delayed_event.rs
+++ b/crates/ruma-client-api/src/delayed_events/update_delayed_event.rs
@@ -73,18 +73,22 @@ pub mod unstable {
 
     #[cfg(all(test, feature = "client"))]
     mod tests {
-        use ruma_common::api::{MatrixVersion, OutgoingRequest, SendAccessToken};
+        use ruma_common::api::{
+            MatrixVersion, OutgoingRequest, SendAccessToken, SupportedVersions,
+        };
         use serde_json::{json, Value as JsonValue};
 
         use super::{Request, UpdateAction};
         #[test]
         fn serialize_update_delayed_event_request() {
+            let supported =
+                SupportedVersions { versions: [MatrixVersion::V1_1].into(), features: Vec::new() };
             let request: http::Request<Vec<u8>> =
                 Request::new("1234".to_owned(), UpdateAction::Cancel)
                     .try_into_http_request(
                         "https://homeserver.tld",
                         SendAccessToken::IfRequired("auth_tok"),
-                        &[MatrixVersion::V1_1],
+                        &supported,
                     )
                     .unwrap();
 

--- a/crates/ruma-client-api/src/directory/get_public_rooms.rs
+++ b/crates/ruma-client-api/src/directory/get_public_rooms.rs
@@ -87,9 +87,12 @@ pub mod v3 {
         #[test]
         fn construct_request_from_refs() {
             use ruma_common::{
-                api::{MatrixVersion, OutgoingRequest as _, SendAccessToken},
+                api::{MatrixVersion, OutgoingRequest as _, SendAccessToken, SupportedVersions},
                 server_name,
             };
+
+            let supported =
+                SupportedVersions { versions: [MatrixVersion::V1_1].into(), features: Vec::new() };
 
             let req = super::Request {
                 limit: Some(uint!(10)),
@@ -99,7 +102,7 @@ pub mod v3 {
             .try_into_http_request::<Vec<u8>>(
                 "https://homeserver.tld",
                 SendAccessToken::IfRequired("auth_tok"),
-                &[MatrixVersion::V1_1],
+                &supported,
             )
             .unwrap();
 

--- a/crates/ruma-client-api/src/discovery/get_supported_versions.rs
+++ b/crates/ruma-client-api/src/discovery/get_supported_versions.rs
@@ -4,10 +4,10 @@
 //!
 //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientversions
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 
 use ruma_common::{
-    api::{request, response, MatrixVersion, Metadata},
+    api::{request, response, Metadata, SupportedVersions},
     metadata,
 };
 
@@ -52,82 +52,12 @@ impl Response {
         Self { versions, unstable_features: BTreeMap::new() }
     }
 
-    /// Extracts known Matrix versions from this response.
+    /// Convert this `Response` into a [`SupportedVersions`] that can be used with
+    /// `OutgoingRequest::try_into_http_request()`.
     ///
-    /// Matrix versions that Ruma cannot parse, or does not know about, are discarded.
-    ///
-    /// The versions returned will be sorted from oldest to latest. Use [`.find()`][Iterator::find]
-    /// or [`.rfind()`][DoubleEndedIterator::rfind] to look for a minimum or maximum version to use
-    /// given some constraint.
-    pub fn known_versions(&self) -> BTreeSet<MatrixVersion> {
-        self.versions
-            .iter()
-            // Parse, discard unknown versions
-            .flat_map(|s| s.parse::<MatrixVersion>())
-            // Collect to BTreeSet
-            .collect()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::collections::BTreeSet;
-
-    use ruma_common::api::MatrixVersion;
-
-    use super::Response;
-
-    #[test]
-    fn known_versions() {
-        let none = Response::new(vec![]);
-        assert_eq!(none.known_versions(), BTreeSet::new());
-
-        let single_known = Response::new(vec!["r0.6.0".to_owned()]);
-        assert_eq!(single_known.known_versions(), BTreeSet::from([MatrixVersion::V1_0]));
-
-        let single_unknown = Response::new(vec!["v0.0".to_owned()]);
-        assert_eq!(single_unknown.known_versions(), BTreeSet::new());
-    }
-
-    #[test]
-    fn known_versions_order() {
-        let sorted = Response::new(vec![
-            "r0.0.1".to_owned(),
-            "r0.5.0".to_owned(),
-            "r0.6.0".to_owned(),
-            "r0.6.1".to_owned(),
-            "v1.1".to_owned(),
-            "v1.2".to_owned(),
-        ]);
-        assert_eq!(
-            sorted.known_versions(),
-            BTreeSet::from([MatrixVersion::V1_0, MatrixVersion::V1_1, MatrixVersion::V1_2])
-        );
-
-        let sorted_reverse = Response::new(vec![
-            "v1.2".to_owned(),
-            "v1.1".to_owned(),
-            "r0.6.1".to_owned(),
-            "r0.6.0".to_owned(),
-            "r0.5.0".to_owned(),
-            "r0.0.1".to_owned(),
-        ]);
-        assert_eq!(
-            sorted_reverse.known_versions(),
-            BTreeSet::from([MatrixVersion::V1_0, MatrixVersion::V1_1, MatrixVersion::V1_2])
-        );
-
-        let random_order = Response::new(vec![
-            "v1.1".to_owned(),
-            "r0.6.1".to_owned(),
-            "r0.5.0".to_owned(),
-            "r0.6.0".to_owned(),
-            "r0.0.1".to_owned(),
-            "v1.2".to_owned(),
-        ]);
-        assert_eq!(
-            random_order.known_versions(),
-            BTreeSet::from([MatrixVersion::V1_0, MatrixVersion::V1_1, MatrixVersion::V1_2])
-        );
+    /// Matrix versions that can't be parsed to a `MatrixVersion`, and features with the boolean
+    /// value set to `false` are discarded.
+    pub fn as_supported_versions(&self) -> SupportedVersions {
+        SupportedVersions::from_parts(&self.versions, &self.unstable_features)
     }
 }

--- a/crates/ruma-client-api/src/filter/create_filter.rs
+++ b/crates/ruma-client-api/src/filter/create_filter.rs
@@ -86,18 +86,21 @@ pub mod v3 {
         #[test]
         fn serialize_request() {
             use ruma_common::{
-                api::{MatrixVersion, OutgoingRequest, SendAccessToken},
+                api::{MatrixVersion, OutgoingRequest, SendAccessToken, SupportedVersions},
                 owned_user_id,
             };
 
             use crate::filter::FilterDefinition;
+
+            let supported =
+                SupportedVersions { versions: [MatrixVersion::V1_1].into(), features: Vec::new() };
 
             let req =
                 super::Request::new(owned_user_id!("@foo:bar.com"), FilterDefinition::default())
                     .try_into_http_request::<Vec<u8>>(
                         "https://matrix.org",
                         SendAccessToken::IfRequired("tok"),
-                        &[MatrixVersion::V1_1],
+                        &supported,
                     )
                     .unwrap();
             assert_eq!(req.body(), b"{}");

--- a/crates/ruma-client-api/src/knock/knock_room.rs
+++ b/crates/ruma-client-api/src/knock/knock_room.rs
@@ -79,13 +79,14 @@ pub mod v3 {
             self,
             base_url: &str,
             access_token: ruma_common::api::SendAccessToken<'_>,
-            considering_versions: &'_ [ruma_common::api::MatrixVersion],
+            considering: &'_ ruma_common::api::SupportedVersions,
         ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
             use http::header::{self, HeaderValue};
 
             // Only send `server_name` if the `via` parameter is not supported by the server.
             // `via` was introduced in Matrix 1.12.
-            let server_name = if considering_versions
+            let server_name = if considering
+                .versions
                 .iter()
                 .rev()
                 .any(|version| version.is_superset_of(ruma_common::api::MatrixVersion::V1_12))
@@ -101,7 +102,7 @@ pub mod v3 {
             let http_request = http::Request::builder()
                 .method(METADATA.method)
                 .uri(METADATA.make_endpoint_url(
-                    considering_versions,
+                    considering,
                     base_url,
                     &[&self.room_id_or_alias],
                     &query_string,
@@ -190,7 +191,10 @@ pub mod v3 {
     #[cfg(all(test, any(feature = "client", feature = "server")))]
     mod tests {
         use ruma_common::{
-            api::{IncomingRequest as _, MatrixVersion, OutgoingRequest, SendAccessToken},
+            api::{
+                IncomingRequest as _, MatrixVersion, OutgoingRequest, SendAccessToken,
+                SupportedVersions,
+            },
             owned_room_id, owned_server_name,
         };
 
@@ -201,11 +205,14 @@ pub mod v3 {
         fn serialize_request_via_and_server_name() {
             let mut req = Request::new(owned_room_id!("!foo:b.ar").into());
             req.via = vec![owned_server_name!("f.oo")];
+            let supported =
+                SupportedVersions { versions: [MatrixVersion::V1_1].into(), features: Vec::new() };
+
             let req = req
                 .try_into_http_request::<Vec<u8>>(
                     "https://matrix.org",
                     SendAccessToken::IfRequired("tok"),
-                    &[MatrixVersion::V1_1],
+                    &supported,
                 )
                 .unwrap();
             assert_eq!(req.uri().query(), Some("via=f.oo&server_name=f.oo"));
@@ -216,11 +223,14 @@ pub mod v3 {
         fn serialize_request_only_via() {
             let mut req = Request::new(owned_room_id!("!foo:b.ar").into());
             req.via = vec![owned_server_name!("f.oo")];
+            let supported =
+                SupportedVersions { versions: [MatrixVersion::V1_12].into(), features: Vec::new() };
+
             let req = req
                 .try_into_http_request::<Vec<u8>>(
                     "https://matrix.org",
                     SendAccessToken::IfRequired("tok"),
-                    &[MatrixVersion::V1_12],
+                    &supported,
                 )
                 .unwrap();
             assert_eq!(req.uri().query(), Some("via=f.oo"));

--- a/crates/ruma-client-api/src/media/create_content_async.rs
+++ b/crates/ruma-client-api/src/media/create_content_async.rs
@@ -18,7 +18,7 @@ pub mod v3 {
         rate_limited: true,
         authentication: AccessToken,
         history: {
-            unstable => "/_matrix/media/unstable/fi.mau.msc2246/upload/:server_name/:media_id",
+            unstable("fi.mau.msc2246") => "/_matrix/media/unstable/fi.mau.msc2246/upload/:server_name/:media_id",
             1.7 => "/_matrix/media/v3/upload/:server_name/:media_id",
         }
     };

--- a/crates/ruma-client-api/src/media/create_mxc_uri.rs
+++ b/crates/ruma-client-api/src/media/create_mxc_uri.rs
@@ -17,7 +17,7 @@ pub mod v1 {
         rate_limited: true,
         authentication: AccessToken,
         history: {
-            unstable => "/_matrix/media/unstable/fi.mau.msc2246/create",
+            unstable("fi.mau.msc2246") => "/_matrix/media/unstable/fi.mau.msc2246/create",
             1.7 => "/_matrix/media/v1/create",
         }
     };

--- a/crates/ruma-client-api/src/membership/mutual_rooms.rs
+++ b/crates/ruma-client-api/src/membership/mutual_rooms.rs
@@ -17,7 +17,7 @@ pub mod unstable {
         rate_limited: true,
         authentication: AccessToken,
         history: {
-            unstable => "/_matrix/client/unstable/uk.half-shot.msc2666/user/mutual_rooms",
+            unstable("uk.half-shot.msc2666.query_mutual_rooms") => "/_matrix/client/unstable/uk.half-shot.msc2666/user/mutual_rooms",
         }
     };
 

--- a/crates/ruma-client-api/src/message/get_message_events.rs
+++ b/crates/ruma-client-api/src/message/get_message_events.rs
@@ -174,7 +174,7 @@ pub mod v3 {
     mod tests {
         use js_int::uint;
         use ruma_common::{
-            api::{Direction, MatrixVersion, OutgoingRequest, SendAccessToken},
+            api::{Direction, MatrixVersion, OutgoingRequest, SendAccessToken, SupportedVersions},
             owned_room_id,
         };
 
@@ -204,12 +204,14 @@ pub mod v3 {
                 limit: uint!(0),
                 filter,
             };
+            let supported =
+                SupportedVersions { versions: [MatrixVersion::V1_1].into(), features: Vec::new() };
 
             let request: http::Request<Vec<u8>> = req
                 .try_into_http_request(
                     "https://homeserver.tld",
                     SendAccessToken::IfRequired("auth_tok"),
-                    &[MatrixVersion::V1_1],
+                    &supported,
                 )
                 .unwrap();
             assert_eq!(
@@ -233,12 +235,14 @@ pub mod v3 {
                 limit: uint!(0),
                 filter: RoomEventFilter::default(),
             };
+            let supported =
+                SupportedVersions { versions: [MatrixVersion::V1_1].into(), features: Vec::new() };
 
             let request = req
                 .try_into_http_request::<Vec<u8>>(
                     "https://homeserver.tld",
                     SendAccessToken::IfRequired("auth_tok"),
-                    &[MatrixVersion::V1_1],
+                    &supported,
                 )
                 .unwrap();
             assert_eq!("from=token&to=token2&dir=b&limit=0", request.uri().query().unwrap(),);

--- a/crates/ruma-client-api/src/push/set_pushrule.rs
+++ b/crates/ruma-client-api/src/push/set_pushrule.rs
@@ -70,7 +70,7 @@ pub mod v3 {
             self,
             base_url: &str,
             access_token: ruma_common::api::SendAccessToken<'_>,
-            considering_versions: &[ruma_common::api::MatrixVersion],
+            considering: &ruma_common::api::SupportedVersions,
         ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
             use http::header;
 
@@ -80,7 +80,7 @@ pub mod v3 {
             })?;
 
             let url = METADATA.make_endpoint_url(
-                considering_versions,
+                considering,
                 base_url,
                 &[&self.rule.kind(), &self.rule.rule_id()],
                 &query_string,

--- a/crates/ruma-client-api/src/rendezvous/create_rendezvous_session.rs
+++ b/crates/ruma-client-api/src/rendezvous/create_rendezvous_session.rs
@@ -48,9 +48,9 @@ pub mod unstable {
             self,
             base_url: &str,
             _: ruma_common::api::SendAccessToken<'_>,
-            considering_versions: &'_ [ruma_common::api::MatrixVersion],
+            considering: &'_ ruma_common::api::SupportedVersions,
         ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
-            let url = METADATA.make_endpoint_url(considering_versions, base_url, &[], "")?;
+            let url = METADATA.make_endpoint_url(considering, base_url, &[], "")?;
             let body = self.content.as_bytes();
             let content_length = body.len();
 

--- a/crates/ruma-client-api/src/rendezvous/create_rendezvous_session.rs
+++ b/crates/ruma-client-api/src/rendezvous/create_rendezvous_session.rs
@@ -26,7 +26,7 @@ pub mod unstable {
         rate_limited: true,
         authentication: None,
         history: {
-            unstable => "/_matrix/client/unstable/org.matrix.msc4108/rendezvous",
+            unstable("org.matrix.msc4108") => "/_matrix/client/unstable/org.matrix.msc4108/rendezvous",
         }
     };
 

--- a/crates/ruma-client-api/src/room/aliases.rs
+++ b/crates/ruma-client-api/src/room/aliases.rs
@@ -17,7 +17,7 @@ pub mod v3 {
         rate_limited: true,
         authentication: AccessToken,
         history: {
-            unstable => "/_matrix/client/unstable/org.matrix.msc2432/rooms/:room_id/aliases",
+            unstable("org.matrix.msc2432") => "/_matrix/client/unstable/org.matrix.msc2432/rooms/:room_id/aliases",
             1.0 => "/_matrix/client/r0/rooms/:room_id/aliases",
             1.1 => "/_matrix/client/v3/rooms/:room_id/aliases",
         }

--- a/crates/ruma-client-api/src/room/get_event_by_timestamp.rs
+++ b/crates/ruma-client-api/src/room/get_event_by_timestamp.rs
@@ -17,7 +17,7 @@ pub mod v1 {
         rate_limited: true,
         authentication: AccessToken,
         history: {
-            unstable => "/_matrix/client/unstable/org.matrix.msc3030/rooms/:room_id/timestamp_to_event",
+            unstable("org.matrix.msc3030") => "/_matrix/client/unstable/org.matrix.msc3030/rooms/:room_id/timestamp_to_event",
             1.6 => "/_matrix/client/v1/rooms/:room_id/timestamp_to_event",
         }
     };

--- a/crates/ruma-client-api/src/session/get_login_token.rs
+++ b/crates/ruma-client-api/src/session/get_login_token.rs
@@ -21,7 +21,7 @@ pub mod v1 {
         rate_limited: true,
         authentication: AccessToken,
         history: {
-            unstable => "/_matrix/client/unstable/org.matrix.msc3882/login/get_token",
+            unstable("org.matrix.msc3882") => "/_matrix/client/unstable/org.matrix.msc3882/login/get_token",
             1.7 => "/_matrix/client/v1/login/get_token",
         }
     };

--- a/crates/ruma-client-api/src/session/login.rs
+++ b/crates/ruma-client-api/src/session/login.rs
@@ -435,11 +435,16 @@ pub mod v3 {
         #[test]
         #[cfg(feature = "client")]
         fn serialize_login_request_body() {
-            use ruma_common::api::{MatrixVersion, OutgoingRequest, SendAccessToken};
+            use ruma_common::api::{
+                MatrixVersion, OutgoingRequest, SendAccessToken, SupportedVersions,
+            };
             use serde_json::Value as JsonValue;
 
             use super::{LoginInfo, Password, Request, Token};
             use crate::uiaa::UserIdentifier;
+
+            let supported =
+                SupportedVersions { versions: [MatrixVersion::V1_1].into(), features: Vec::new() };
 
             let req: http::Request<Vec<u8>> = Request {
                 login_info: LoginInfo::Token(Token { token: "0xdeadbeef".to_owned() }),
@@ -447,11 +452,7 @@ pub mod v3 {
                 initial_device_display_name: Some("test".to_owned()),
                 refresh_token: false,
             }
-            .try_into_http_request(
-                "https://homeserver.tld",
-                SendAccessToken::None,
-                &[MatrixVersion::V1_1],
-            )
+            .try_into_http_request("https://homeserver.tld", SendAccessToken::None, &supported)
             .unwrap();
 
             let req_body_value: JsonValue = serde_json::from_slice(req.body()).unwrap();
@@ -479,11 +480,7 @@ pub mod v3 {
                 initial_device_display_name: Some("test".to_owned()),
                 refresh_token: false,
             }
-            .try_into_http_request(
-                "https://homeserver.tld",
-                SendAccessToken::None,
-                &[MatrixVersion::V1_1],
-            )
+            .try_into_http_request("https://homeserver.tld", SendAccessToken::None, &supported)
             .unwrap();
 
             let req_body_value: JsonValue = serde_json::from_slice(req.body()).unwrap();

--- a/crates/ruma-client-api/src/session/logout.rs
+++ b/crates/ruma-client-api/src/session/logout.rs
@@ -45,9 +45,9 @@ pub mod v3 {
             self,
             base_url: &str,
             access_token: ruma_common::api::SendAccessToken<'_>,
-            considering_versions: &'_ [ruma_common::api::MatrixVersion],
+            considering: &'_ ruma_common::api::SupportedVersions,
         ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
-            let url = METADATA.make_endpoint_url(considering_versions, base_url, &[], "")?;
+            let url = METADATA.make_endpoint_url(considering, base_url, &[], "")?;
 
             http::Request::builder()
                 .method(METADATA.method)

--- a/crates/ruma-client-api/src/session/logout_all.rs
+++ b/crates/ruma-client-api/src/session/logout_all.rs
@@ -45,9 +45,9 @@ pub mod v3 {
             self,
             base_url: &str,
             access_token: ruma_common::api::SendAccessToken<'_>,
-            considering_versions: &'_ [ruma_common::api::MatrixVersion],
+            considering: &'_ ruma_common::api::SupportedVersions,
         ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
-            let url = METADATA.make_endpoint_url(considering_versions, base_url, &[], "")?;
+            let url = METADATA.make_endpoint_url(considering, base_url, &[], "")?;
 
             http::Request::builder()
                 .method(METADATA.method)

--- a/crates/ruma-client-api/src/session/sso_login.rs
+++ b/crates/ruma-client-api/src/session/sso_login.rs
@@ -76,18 +76,18 @@ pub mod v3 {
 
     #[cfg(all(test, feature = "client"))]
     mod tests {
-        use ruma_common::api::{MatrixVersion, OutgoingRequest, SendAccessToken};
+        use ruma_common::api::{
+            MatrixVersion, OutgoingRequest, SendAccessToken, SupportedVersions,
+        };
 
         use super::Request;
 
         #[test]
         fn serialize_sso_login_request_uri() {
+            let supported =
+                SupportedVersions { versions: [MatrixVersion::V1_1].into(), features: Vec::new() };
             let req: http::Request<Vec<u8>> = Request::new("https://example.com/sso".to_owned())
-                .try_into_http_request(
-                    "https://homeserver.tld",
-                    SendAccessToken::None,
-                    &[MatrixVersion::V1_1],
-                )
+                .try_into_http_request("https://homeserver.tld", SendAccessToken::None, &supported)
                 .unwrap();
 
             assert_eq!(

--- a/crates/ruma-client-api/src/session/sso_login_with_provider.rs
+++ b/crates/ruma-client-api/src/session/sso_login_with_provider.rs
@@ -83,17 +83,21 @@ pub mod v3 {
 
     #[cfg(all(test, feature = "client"))]
     mod tests {
-        use ruma_common::api::{MatrixVersion, OutgoingRequest as _, SendAccessToken};
+        use ruma_common::api::{
+            MatrixVersion, OutgoingRequest as _, SendAccessToken, SupportedVersions,
+        };
 
         use super::Request;
 
         #[test]
         fn serialize_sso_login_with_provider_request_uri() {
+            let supported =
+                SupportedVersions { versions: [MatrixVersion::V1_1].into(), features: Vec::new() };
             let req = Request::new("provider".to_owned(), "https://example.com/sso".to_owned())
                 .try_into_http_request::<Vec<u8>>(
                     "https://homeserver.tld",
                     SendAccessToken::None,
-                    &[MatrixVersion::V1_1],
+                    &supported,
                 )
                 .unwrap();
 

--- a/crates/ruma-client-api/src/state/get_state_events_for_key.rs
+++ b/crates/ruma-client-api/src/state/get_state_events_for_key.rs
@@ -75,14 +75,14 @@ pub mod v3 {
             self,
             base_url: &str,
             access_token: ruma_common::api::SendAccessToken<'_>,
-            considering_versions: &'_ [ruma_common::api::MatrixVersion],
+            considering: &'_ ruma_common::api::SupportedVersions,
         ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
             use http::header;
 
             http::Request::builder()
                 .method(http::Method::GET)
                 .uri(METADATA.make_endpoint_url(
-                    considering_versions,
+                    considering,
                     base_url,
                     &[&self.room_id, &self.event_type, &self.state_key],
                     "",

--- a/crates/ruma-client-api/src/state/send_state_event.rs
+++ b/crates/ruma-client-api/src/state/send_state_event.rs
@@ -117,7 +117,7 @@ pub mod v3 {
             self,
             base_url: &str,
             access_token: ruma_common::api::SendAccessToken<'_>,
-            considering_versions: &'_ [ruma_common::api::MatrixVersion],
+            considering: &'_ ruma_common::api::SupportedVersions,
         ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
             use http::header::{self, HeaderValue};
 
@@ -127,7 +127,7 @@ pub mod v3 {
             let http_request = http::Request::builder()
                 .method(http::Method::PUT)
                 .uri(METADATA.make_endpoint_url(
-                    considering_versions,
+                    considering,
                     base_url,
                     &[&self.room_id, &self.event_type, &self.state_key],
                     &query_string,
@@ -208,10 +208,13 @@ pub mod v3 {
     #[test]
     fn serialize() {
         use ruma_common::{
-            api::{MatrixVersion, OutgoingRequest as _, SendAccessToken},
+            api::{MatrixVersion, OutgoingRequest as _, SendAccessToken, SupportedVersions},
             owned_room_id,
         };
         use ruma_events::{room::name::RoomNameEventContent, EmptyStateKey};
+
+        let supported =
+            SupportedVersions { versions: [MatrixVersion::V1_1].into(), features: Vec::new() };
 
         // This used to panic in make_endpoint_url because of a mismatch in the path parameter count
         let req = Request::new(
@@ -223,7 +226,7 @@ pub mod v3 {
         .try_into_http_request::<Vec<u8>>(
             "https://server.tld",
             SendAccessToken::IfRequired("access_token"),
-            &[MatrixVersion::V1_1],
+            &supported,
         )
         .unwrap();
 

--- a/crates/ruma-client-api/src/sync/sync_events/v3.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v3.rs
@@ -655,12 +655,16 @@ mod tests {
 mod client_tests {
     use std::time::Duration;
 
-    use ruma_common::api::{MatrixVersion, OutgoingRequest as _, SendAccessToken};
+    use ruma_common::api::{
+        MatrixVersion, OutgoingRequest as _, SendAccessToken, SupportedVersions,
+    };
 
     use super::{Filter, PresenceState, Request};
 
     #[test]
     fn serialize_all_params() {
+        let supported =
+            SupportedVersions { versions: [MatrixVersion::V1_1].into(), features: Vec::new() };
         let req: http::Request<Vec<u8>> = Request {
             filter: Some(Filter::FilterId("66696p746572".to_owned())),
             since: Some("s72594_4483_1934".to_owned()),
@@ -671,7 +675,7 @@ mod client_tests {
         .try_into_http_request(
             "https://homeserver.tld",
             SendAccessToken::IfRequired("auth_tok"),
-            &[MatrixVersion::V1_1],
+            &supported,
         )
         .unwrap();
 

--- a/crates/ruma-client-api/src/sync/sync_events/v5.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v5.rs
@@ -27,7 +27,7 @@ const METADATA: Metadata = metadata! {
     rate_limited: false,
     authentication: AccessToken,
     history: {
-        unstable => "/_matrix/client/unstable/org.matrix.simplified_msc3575/sync",
+        unstable("org.matrix.simplified_msc3575") => "/_matrix/client/unstable/org.matrix.simplified_msc3575/sync",
         // 1.4 => "/_matrix/client/v5/sync",
     }
 };

--- a/crates/ruma-client-api/tests/headers.rs
+++ b/crates/ruma-client-api/tests/headers.rs
@@ -2,16 +2,14 @@
 
 use http::HeaderMap;
 use ruma_client_api::discovery::discover_homeserver;
-use ruma_common::api::{MatrixVersion, OutgoingRequest as _, SendAccessToken};
+use ruma_common::api::{MatrixVersion, OutgoingRequest as _, SendAccessToken, SupportedVersions};
 
 #[test]
 fn get_request_headers() {
+    let supported =
+        SupportedVersions { versions: [MatrixVersion::V1_1].into(), features: Vec::new() };
     let req: http::Request<Vec<u8>> = discover_homeserver::Request::new()
-        .try_into_http_request(
-            "https://homeserver.tld",
-            SendAccessToken::None,
-            &[MatrixVersion::V1_1],
-        )
+        .try_into_http_request("https://homeserver.tld", SendAccessToken::None, &supported)
         .unwrap();
 
     assert_eq!(*req.headers(), HeaderMap::default());

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -72,6 +72,8 @@ Improvements:
   - `SignaturesRules` was added under the `signatures` field.
 - `RoomVersionId` has an `MSC2870` variant for the `org.matrix.msc2870` room
   version defined in MSC2870.
+- Add `OutgoingRequest::is_supported()` and `VersionHistory::is_supported()` to
+  be able to know if a server advertises support for an endpoint.
 
 # 0.15.2
 

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -29,6 +29,18 @@ Breaking changes:
   `OutgoingRequestAppserviceExt::try_into_http_request_with_user_id()` and
   `Metadata::make_endpoint_url()` take a `SupportedVersions` instead of a
   `&[MatrixVersion]`.
+- The `metadata` macro allows to specify stable and unstable feature flags for
+  the paths in `history`.
+  - `VersionHistory::new()` takes a
+    `&'static [(Option<&'static str>, &'static str)]` for the unstable paths and
+    a `&'static [(StablePathSelector, &'static str)]` for the stable paths.
+  - `VersionHistory::unstable_paths()` returns an
+    `impl Iterator<Item = (Option<&'static str>, &'static str)>`.
+  - `VersionHistory::stable_paths()` returns an
+    `impl Iterator<Item = (StablePathSelector, &'static str)>`.
+  - `VersionHistory::stable_endpoint_for()` was renamed to `version_path()`.
+  - `VersioningDecision`'s `Stable` variant was renamed to `Version` and
+    `Unstable` was renamed to `Feature`.
 
 Improvements:
 

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -25,6 +25,10 @@ Breaking changes:
   `AppserviceToken`'s place.
 - The `redact*` functions in `canonical_json` take `RedactionRules` instead of
   `RoomVersionId`. This avoids undefined behavior for unknown room versions.
+- `OutgoingRequest::try_into_http_request()`,
+  `OutgoingRequestAppserviceExt::try_into_http_request_with_user_id()` and
+  `Metadata::make_endpoint_url()` take a `SupportedVersions` instead of a
+  `&[MatrixVersion]`.
 
 Improvements:
 

--- a/crates/ruma-common/src/api.rs
+++ b/crates/ruma-common/src/api.rs
@@ -23,21 +23,68 @@ use crate::UserId;
 
 /// Convenient constructor for [`Metadata`] constants.
 ///
-/// Usage:
+/// ## Definition
+///
+/// The definition of the macro is made to look like a struct, with the following fields:
+///
+/// * `method` - The HTTP method to use for the endpoint. Its value must be one of the associated
+///   constants of [`http::Method`]. In most cases it should be one of `GET`, `POST`, `PUT` or
+///   `DELETE`.
+/// * `rate_limited` - Whether the endpoint should be rate-limited, according to the specification.
+///   Its value must be a `bool`.
+/// * `authentication` - The type of authentication that is required for the endpoint, according to
+///   the specification. Its value must be one of the variants of [`AuthScheme`].
+/// * `history` - The history of the paths of the endpoint. Its definition is made to look like
+///   match arms and must include at least one arm.
+///
+///   The match arms accept the following syntax:
+///
+///   * `unstable => "unstable/endpoint/path/:variable"` - An unstable version of the endpoint as
+///     defined in the MSC that adds it, if the MSC does **NOT** define an unstable feature in the
+///     `unstable_features` field of the client-server API's `/versions` endpoint.
+///   * `unstable("org.bar.unstable_feature") => "unstable/endpoint/path/:variable"` - An unstable
+///     version of the endpoint as defined in the MSC that adds it, if the MSC defines an unstable
+///     feature in the `unstable_features` field of the client-server API's `/versions` endpoint.
+///   * `1.0 | stable("org.bar.feature.stable") => "stable/endpoint/path/:variable"` - A stable
+///     version of the endpoint as defined in an MSC or the Matrix specification. The match arm can
+///     be a Matrix version, a stable feature, or both separated by `|`.
+///
+///     A stable feature can be defined in an MSC alongside an unstable feature, and can be found in
+///     the `unstable_features` field of the client-server API's `/versions` endpoint. It is meant
+///     to be used by homeservers if they want to declare stable support for a feature before they
+///     can declare support for a whole Matrix version that supports it.
+///
+///   * `1.2 => deprecated` - The Matrix version that deprecated the endpoint, if any. It must be
+///     preceded by a match arm with a stable path and a different Matrix version.
+///   * `1.3 => removed` - The Matrix version that removed the endpoint, if any. It must be preceded
+///     by a match arm with a deprecation and a different Matrix version.
+///
+///   A Matrix version is a `float` representation of the version that looks like `major.minor`.
+///   It must match one of the variants of [`MatrixVersion`]. For example `1.0` matches
+///   [`MatrixVersion::V1_0`], `1.1` matches [`MatrixVersion::V1_1`], etc.
+///
+///   It is expected that the match arms are ordered by descending age. Usually the older unstable
+///   paths would be before the newer unstable paths, then we would find the stable paths, and
+///   finally the deprecation and removal.
+///
+///   The following checks occur at compile time:
+///
+///   * All unstable and stable paths contain the same variables (or lack thereof).
+///   * Matrix versions in match arms are all different and in ascending order.
+///
+/// ## Example
 ///
 /// ```
-/// # use ruma_common::{metadata, api::Metadata};
-/// const _: Metadata = metadata! {
-///     method: GET, // one of the associated constants of http::Method
+/// use ruma_common::{api::Metadata, metadata};
+/// const METADATA: Metadata = metadata! {
+///     method: GET,
 ///     rate_limited: true,
-///     authentication: AccessToken, // one of the variants of api::AuthScheme
+///     authentication: AccessToken,
 ///
-///     // history of endpoint paths
-///     // there must be at least one path but otherwise everything is optional
 ///     history: {
-///         unstable => "/_matrix/foo/org.bar.msc9000/baz",
-///         unstable => "/_matrix/foo/org.bar.msc9000/qux",
-///         1.0 => "/_matrix/media/r0/qux",
+///         unstable => "/_matrix/unstable/org.bar.msc9000/baz",
+///         unstable("org.bar.msc9000.v1") => "/_matrix/unstable/org.bar.msc9000.v1/qux",
+///         1.0 | stable("org.bar.msc9000.stable") => "/_matrix/media/r0/qux",
 ///         1.1 => "/_matrix/media/v3/qux",
 ///         1.2 => deprecated,
 ///         1.3 => removed,
@@ -57,14 +104,16 @@ macro_rules! metadata {
     ( @field authentication: $scheme:ident ) => { $crate::api::AuthScheme::$scheme };
 
     ( @field history: {
-        $( unstable => $unstable_path:literal, )*
-        $( $( $version:literal => $rhs:tt, )+ )?
+        $( unstable $(($unstable_feature:literal))? => $unstable_path:literal, )*
+        $( stable ($stable_feature_only:literal) => $stable_feature_path:literal, )?
+        $( $( $version:literal $(| stable ($stable_feature:literal))? => $rhs:tt, )+ )?
     } ) => {
         $crate::metadata! {
             @history_impl
-            [ $($unstable_path),* ]
+            [ $( $unstable_path $(= $unstable_feature)? ),* ]
+            $( stable ($stable_feature_only) => $stable_feature_path, )?
             // Flip left and right to avoid macro parsing ambiguities
-            $( $( $rhs = $version ),+ )?
+            $( $( $rhs = $version $(| stable ($stable_feature))? ),+ )?
         }
     };
 
@@ -72,9 +121,10 @@ macro_rules! metadata {
     ( @field $_field:ident: $rhs:expr ) => { $rhs };
 
     ( @history_impl
-        [ $($unstable_path:literal),* ]
+        [ $( $unstable_path:literal $(= $unstable_feature:literal)? ),* ]
+        $( stable ($stable_feature_only:literal) => $stable_feature_path:literal, )?
         $(
-            $( $stable_path:literal = $version:literal ),+
+            $( $stable_path:literal = $version:literal $(| stable ($stable_feature:literal))? ),+
             $(,
                 deprecated = $deprecated_version:literal
                 $(, removed = $removed_version:literal )?
@@ -82,15 +132,32 @@ macro_rules! metadata {
         )?
     ) => {
         $crate::api::VersionHistory::new(
-            &[ $( $unstable_path ),* ],
-            &[ $($(
-                ($crate::api::MatrixVersion::from_lit(stringify!($version)), $stable_path)
-            ),+)? ],
+            &[ $(($crate::metadata!(@optional_feature $($unstable_feature)?), $unstable_path)),* ],
+            &[
+                $((
+                    $crate::metadata!(@stable_path_selector stable($stable_feature_only)),
+                    $stable_feature_path
+                ),)?
+                $($((
+                    $crate::metadata!(@stable_path_selector $version $(| stable($stable_feature))?),
+                    $stable_path
+                )),+)?
+            ],
             $crate::metadata!(@optional_version $($( $deprecated_version )?)?),
             $crate::metadata!(@optional_version $($($( $removed_version )?)?)?),
         )
     };
 
+    ( @optional_feature ) => { None };
+    ( @optional_feature $feature:literal ) => { Some($feature) };
+    ( @stable_path_selector stable($feature:literal)) => { $crate::api::StablePathSelector::Feature($feature) };
+    ( @stable_path_selector $version:literal | stable($feature:literal)) => {
+        $crate::api::StablePathSelector::FeatureAndVersion {
+            feature: $feature,
+            version: $crate::api::MatrixVersion::from_lit(stringify!($version)),
+        }
+    };
+    ( @stable_path_selector $version:literal) => { $crate::api::StablePathSelector::Version($crate::api::MatrixVersion::from_lit(stringify!($version))) };
     ( @optional_version ) => { None };
     ( @optional_version $version:literal ) => { Some($crate::api::MatrixVersion::from_lit(stringify!($version))) }
 }
@@ -330,7 +397,8 @@ pub mod error;
 mod metadata;
 
 pub use self::metadata::{
-    MatrixVersion, Metadata, SupportedVersions, VersionHistory, VersioningDecision,
+    MatrixVersion, Metadata, StablePathSelector, SupportedVersions, VersionHistory,
+    VersioningDecision,
 };
 
 /// An enum to control whether an access token should be added to outgoing requests

--- a/crates/ruma-common/src/api.rs
+++ b/crates/ruma-common/src/api.rs
@@ -481,6 +481,18 @@ pub trait OutgoingRequest: Sized + Clone {
         access_token: SendAccessToken<'_>,
         considering: &'_ SupportedVersions,
     ) -> Result<http::Request<T>, IntoHttpError>;
+
+    /// Whether the homeserver advertises support for this endpoint.
+    ///
+    /// Returns `true` if any version or feature in the given [`SupportedVersions`] matches a path
+    /// in the history of this endpoint, unless the endpoint was removed.
+    ///
+    /// Note that this is likely to return false negatives, since some endpoints don't specify a
+    /// stable or unstable feature, and homeservers should not advertise support for a Matrix
+    /// version unless they support all of its features.
+    fn is_supported(considering_versions: &SupportedVersions) -> bool {
+        Self::METADATA.history.is_supported(considering_versions)
+    }
 }
 
 /// A response type for a Matrix API endpoint, used for receiving responses.

--- a/crates/ruma-common/tests/it/api/conversions.rs
+++ b/crates/ruma-common/tests/it/api/conversions.rs
@@ -4,7 +4,7 @@ use http::header::CONTENT_TYPE;
 use ruma_common::{
     api::{
         request, response, IncomingRequest as _, MatrixVersion, Metadata, OutgoingRequest as _,
-        OutgoingRequestAppserviceExt, SendAccessToken,
+        OutgoingRequestAppserviceExt, SendAccessToken, SupportedVersions,
     },
     metadata, owned_user_id, user_id, OwnedUserId,
 };
@@ -61,13 +61,15 @@ fn request_serde() {
         bar: "barVal".to_owned(),
         user: owned_user_id!("@bazme:ruma.io"),
     };
+    let supported =
+        SupportedVersions { versions: [MatrixVersion::V1_1].into(), features: Vec::new() };
 
     let http_req = req
         .clone()
         .try_into_http_request::<Vec<u8>>(
             "https://homeserver.tld",
             SendAccessToken::None,
-            &[MatrixVersion::V1_1],
+            &supported,
         )
         .unwrap();
     let req2 = Request::try_from_http_request(http_req, &["barVal", "@bazme:ruma.io"]).unwrap();
@@ -90,12 +92,11 @@ fn invalid_uri_should_not_panic() {
         bar: "barVal".to_owned(),
         user: owned_user_id!("@bazme:ruma.io"),
     };
+    let supported =
+        SupportedVersions { versions: [MatrixVersion::V1_1].into(), features: Vec::new() };
 
-    let result = req.try_into_http_request::<Vec<u8>>(
-        "invalid uri",
-        SendAccessToken::None,
-        &[MatrixVersion::V1_1],
-    );
+    let result =
+        req.try_into_http_request::<Vec<u8>>("invalid uri", SendAccessToken::None, &supported);
     result.unwrap_err();
 }
 
@@ -109,6 +110,8 @@ fn request_with_user_id_serde() {
         bar: "barVal".to_owned(),
         user: owned_user_id!("@bazme:ruma.io"),
     };
+    let supported =
+        SupportedVersions { versions: [MatrixVersion::V1_1].into(), features: Vec::new() };
 
     let user_id = user_id!("@_virtual_:ruma.io");
     let http_req = req
@@ -116,7 +119,7 @@ fn request_with_user_id_serde() {
             "https://homeserver.tld",
             SendAccessToken::None,
             user_id,
-            &[MatrixVersion::V1_1],
+            &supported,
         )
         .unwrap();
 
@@ -133,7 +136,7 @@ mod without_query {
     use ruma_common::{
         api::{
             request, response, MatrixVersion, Metadata, OutgoingRequestAppserviceExt,
-            SendAccessToken,
+            SendAccessToken, SupportedVersions,
         },
         metadata, owned_user_id, user_id, OwnedUserId,
     };
@@ -182,6 +185,8 @@ mod without_query {
             bar: "barVal".to_owned(),
             user: owned_user_id!("@bazme:ruma.io"),
         };
+        let supported =
+            SupportedVersions { versions: [MatrixVersion::V1_1].into(), features: Vec::new() };
 
         let user_id = user_id!("@_virtual_:ruma.io");
         let http_req = req
@@ -189,7 +194,7 @@ mod without_query {
                 "https://homeserver.tld",
                 SendAccessToken::None,
                 user_id,
-                &[MatrixVersion::V1_1],
+                &supported,
             )
             .unwrap();
 

--- a/crates/ruma-common/tests/it/api/header_override.rs
+++ b/crates/ruma-common/tests/it/api/header_override.rs
@@ -4,7 +4,7 @@ use http::header::{Entry, CONTENT_TYPE, LOCATION};
 use ruma_common::{
     api::{
         request, response, MatrixVersion, Metadata, OutgoingRequest as _, OutgoingResponse as _,
-        SendAccessToken,
+        SendAccessToken, SupportedVersions,
     },
     metadata,
 };
@@ -55,11 +55,14 @@ fn response_content_type_override() {
 #[test]
 fn request_content_type_override() {
     let req = Request { location: None, stuff: "magic".into() };
+    let supported =
+        SupportedVersions { versions: [MatrixVersion::V1_1].into(), features: Vec::new() };
+
     let mut http_req = req
         .try_into_http_request::<Vec<u8>>(
             "https://homeserver.tld",
             SendAccessToken::None,
-            &[MatrixVersion::V1_1],
+            &supported,
         )
         .unwrap();
 

--- a/crates/ruma-common/tests/it/api/manual_endpoint_impl.rs
+++ b/crates/ruma-common/tests/it/api/manual_endpoint_impl.rs
@@ -8,7 +8,7 @@ use ruma_common::{
     api::{
         error::{FromHttpRequestError, FromHttpResponseError, IntoHttpError, MatrixError},
         AuthScheme, EndpointError, IncomingRequest, IncomingResponse, MatrixVersion, Metadata,
-        OutgoingRequest, OutgoingResponse, SendAccessToken, VersionHistory,
+        OutgoingRequest, OutgoingResponse, SendAccessToken, SupportedVersions, VersionHistory,
     },
     OwnedRoomAliasId, OwnedRoomId,
 };
@@ -46,10 +46,9 @@ impl OutgoingRequest for Request {
         self,
         base_url: &str,
         _access_token: SendAccessToken<'_>,
-        considering_versions: &'_ [MatrixVersion],
+        considering: &'_ SupportedVersions,
     ) -> Result<http::Request<T>, IntoHttpError> {
-        let url =
-            METADATA.make_endpoint_url(considering_versions, base_url, &[&self.room_alias], "")?;
+        let url = METADATA.make_endpoint_url(considering, base_url, &[&self.room_alias], "")?;
 
         let request_body = RequestBody { room_id: self.room_id };
 

--- a/crates/ruma-common/tests/it/api/manual_endpoint_impl.rs
+++ b/crates/ruma-common/tests/it/api/manual_endpoint_impl.rs
@@ -8,7 +8,8 @@ use ruma_common::{
     api::{
         error::{FromHttpRequestError, FromHttpResponseError, IntoHttpError, MatrixError},
         AuthScheme, EndpointError, IncomingRequest, IncomingResponse, MatrixVersion, Metadata,
-        OutgoingRequest, OutgoingResponse, SendAccessToken, SupportedVersions, VersionHistory,
+        OutgoingRequest, OutgoingResponse, SendAccessToken, StablePathSelector, SupportedVersions,
+        VersionHistory,
     },
     OwnedRoomAliasId, OwnedRoomId,
 };
@@ -26,10 +27,25 @@ const METADATA: Metadata = Metadata {
     rate_limited: false,
     authentication: AuthScheme::None,
     history: VersionHistory::new(
-        &["/_matrix/client/unstable/directory/room/:room_alias"],
         &[
-            (MatrixVersion::V1_0, "/_matrix/client/r0/directory/room/:room_alias"),
-            (MatrixVersion::V1_1, "/_matrix/client/v3/directory/room/:room_alias"),
+            (None, "/_matrix/client/unstable/directory/room/:room_alias"),
+            (
+                Some("org.bar.directory"),
+                "/_matrix/client/unstable/org.bar.directory/room/:room_alias",
+            ),
+        ],
+        &[
+            (
+                StablePathSelector::FeatureAndVersion {
+                    feature: "org.bar.directory.stable",
+                    version: MatrixVersion::V1_0,
+                },
+                "/_matrix/client/r0/directory/room/:room_alias",
+            ),
+            (
+                StablePathSelector::Version(MatrixVersion::V1_1),
+                "/_matrix/client/v3/directory/room/:room_alias",
+            ),
         ],
         Some(MatrixVersion::V1_2),
         Some(MatrixVersion::V1_3),

--- a/crates/ruma-common/tests/it/api/no_fields.rs
+++ b/crates/ruma-common/tests/it/api/no_fields.rs
@@ -1,5 +1,5 @@
 use ruma_common::api::{
-    MatrixVersion, OutgoingRequest as _, OutgoingResponse as _, SendAccessToken,
+    MatrixVersion, OutgoingRequest as _, OutgoingResponse as _, SendAccessToken, SupportedVersions,
 };
 
 mod get {
@@ -53,11 +53,14 @@ mod post {
 #[test]
 fn empty_post_request_http_repr() {
     let req = post::Request {};
+    let supported =
+        SupportedVersions { versions: [MatrixVersion::V1_1].into(), features: Vec::new() };
+
     let http_req = req
         .try_into_http_request::<Vec<u8>>(
             "https://homeserver.tld",
             SendAccessToken::None,
-            &[MatrixVersion::V1_1],
+            &supported,
         )
         .unwrap();
 
@@ -67,11 +70,14 @@ fn empty_post_request_http_repr() {
 #[test]
 fn empty_get_request_http_repr() {
     let req = get::Request {};
+    let supported =
+        SupportedVersions { versions: [MatrixVersion::V1_1].into(), features: Vec::new() };
+
     let http_req = req
         .try_into_http_request::<Vec<u8>>(
             "https://homeserver.tld",
             SendAccessToken::None,
-            &[MatrixVersion::V1_1],
+            &supported,
         )
         .unwrap();
 

--- a/crates/ruma-common/tests/it/api/optional_headers.rs
+++ b/crates/ruma-common/tests/it/api/optional_headers.rs
@@ -3,7 +3,7 @@ use http::header::{CONTENT_DISPOSITION, LOCATION};
 use ruma_common::{
     api::{
         request, response, IncomingRequest, IncomingResponse, MatrixVersion, Metadata,
-        OutgoingRequest, OutgoingResponse, SendAccessToken,
+        OutgoingRequest, OutgoingResponse, SendAccessToken, SupportedVersions,
     },
     http_headers::{ContentDisposition, ContentDispositionType},
     metadata,
@@ -39,13 +39,15 @@ pub struct Response {
 #[test]
 fn request_serde_no_header() {
     let req = Request { location: None, content_disposition: None };
+    let supported =
+        SupportedVersions { versions: [MatrixVersion::V1_1].into(), features: Vec::new() };
 
     let http_req = req
         .clone()
         .try_into_http_request::<Vec<u8>>(
             "https://homeserver.tld",
             SendAccessToken::None,
-            &[MatrixVersion::V1_1],
+            &supported,
         )
         .unwrap();
     assert_matches!(http_req.headers().get(LOCATION), None);
@@ -65,13 +67,15 @@ fn request_serde_with_header() {
         location: Some(location.to_owned()),
         content_disposition: Some(content_disposition.clone()),
     };
+    let supported =
+        SupportedVersions { versions: [MatrixVersion::V1_1].into(), features: Vec::new() };
 
     let mut http_req = req
         .clone()
         .try_into_http_request::<Vec<u8>>(
             "https://homeserver.tld",
             SendAccessToken::None,
-            &[MatrixVersion::V1_1],
+            &supported,
         )
         .unwrap();
     assert_matches!(http_req.headers().get(LOCATION), Some(_));

--- a/crates/ruma-common/tests/it/api/required_headers.rs
+++ b/crates/ruma-common/tests/it/api/required_headers.rs
@@ -7,7 +7,7 @@ use ruma_common::{
             HeaderDeserializationError,
         },
         request, response, IncomingRequest, IncomingResponse, MatrixVersion, Metadata,
-        OutgoingRequest, OutgoingResponse, SendAccessToken,
+        OutgoingRequest, OutgoingResponse, SendAccessToken, SupportedVersions,
     },
     http_headers::{ContentDisposition, ContentDispositionType},
     metadata,
@@ -47,13 +47,15 @@ fn request_serde() {
         .with_filename(Some("my_file".to_owned()));
     let req =
         Request { location: location.to_owned(), content_disposition: content_disposition.clone() };
+    let supported =
+        SupportedVersions { versions: [MatrixVersion::V1_1].into(), features: Vec::new() };
 
     let mut http_req = req
         .clone()
         .try_into_http_request::<Vec<u8>>(
             "https://homeserver.tld",
             SendAccessToken::None,
-            &[MatrixVersion::V1_1],
+            &supported,
         )
         .unwrap();
     assert_matches!(http_req.headers().get(LOCATION), Some(_));

--- a/crates/ruma-identity-service-api/CHANGELOG.md
+++ b/crates/ruma-identity-service-api/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 Breaking changes:
 
-- `get_supported_versions::Response::known_versions()` returns a
-  `BTreeSet<MatrixVersion>` instead of a `DoubleEndedIterator`.
 - The `store_invitation`, `check_public_key_validity`, `get_public_key` and
   `validate_ephemeral_key` endpoints use `IdentityServerBase64PublicKey` instead
   of `Base64` for the public keys, to avoid deserialization errors when public
   keys encoded using URL-safe base64 is encountered.
+- `get_supported_versions::Response::known_versions()` was replaced by
+  `as_supported_versions()` which returns a `SupportedVersions`.
 
 # 0.11.0
 

--- a/crates/ruma-identity-service-api/src/discovery/get_supported_versions.rs
+++ b/crates/ruma-identity-service-api/src/discovery/get_supported_versions.rs
@@ -10,10 +10,10 @@
 //!
 //! [spec]: https://spec.matrix.org/latest/identity-service-api/#get_matrixidentityversions
 
-use std::collections::BTreeSet;
+use std::collections::BTreeMap;
 
 use ruma_common::{
-    api::{request, response, MatrixVersion, Metadata},
+    api::{request, response, Metadata, SupportedVersions},
     metadata,
 };
 
@@ -51,19 +51,12 @@ impl Response {
         Self { versions }
     }
 
-    /// Extracts known Matrix versions from this response.
+    /// Convert this `Response` into a [`SupportedVersions`] that can be used with
+    /// `OutgoingRequest::try_into_http_request()`.
     ///
-    /// Matrix versions that Ruma cannot parse, or does not know about, are discarded.
-    ///
-    /// The versions returned will be sorted from oldest to latest. Use [`.find()`][Iterator::find]
-    /// or [`.rfind()`][DoubleEndedIterator::rfind] to look for a minimum or maximum version to use
-    /// given some constraint.
-    pub fn known_versions(&self) -> BTreeSet<MatrixVersion> {
-        self.versions
-            .iter()
-            // Parse, discard unknown versions
-            .flat_map(|s| s.parse::<MatrixVersion>())
-            // Collect to BTreeSet
-            .collect()
+    /// Matrix versions that can't be parsed to a `MatrixVersion`, and features with the boolean
+    /// value set to `false` are discarded.
+    pub fn as_supported_versions(&self) -> SupportedVersions {
+        SupportedVersions::from_parts(&self.versions, &BTreeMap::new())
     }
 }

--- a/crates/ruma-macros/src/api/request/outgoing.rs
+++ b/crates/ruma-macros/src/api/request/outgoing.rs
@@ -112,12 +112,12 @@ impl Request {
                     self,
                     base_url: &::std::primitive::str,
                     access_token: #ruma_common::api::SendAccessToken<'_>,
-                    considering_versions: &'_ [#ruma_common::api::MatrixVersion],
+                    considering: &'_ #ruma_common::api::SupportedVersions,
                 ) -> ::std::result::Result<#http::Request<T>, #ruma_common::api::error::IntoHttpError> {
                     let mut req_builder = #http::Request::builder()
                         .method(METADATA.method)
                         .uri(METADATA.make_endpoint_url(
-                            considering_versions,
+                            considering,
                             base_url,
                             &[ #( &self.#path_fields ),* ],
                             #request_query_string,


### PR DESCRIPTION
`Metadata` now selects the appropriate path according to the supported features as well as the supported Matrix versions of the homeserver.

This is particularly important for stable features (like for authenticated media), even if they are rare.

This also adds `OutgoingRequest::is_supported()` to know if the homeserver advertises support for an endpoint before making a request.

This is kind of my take on #1546, although I am not sure what the enum proposed in that issue would bring on top of this.