### PR TITLE
state-res: Perform authorization rules checks on `auth_events`

### DIFF
--- a/crates/ruma-state-res/CHANGELOG.md
+++ b/crates/ruma-state-res/CHANGELOG.md
@@ -25,6 +25,10 @@ Breaking:
   with other changes. Check the changelog of ruma-common for more details.
 - The `event_auth` module is no longer public. Everything public inside of it
   is already exposed at the root of the crate.
+- `auth_check` was split into 2 functions: `check_state_independent_auth_rules`
+  and `check_state_dependent_auth_rules`. The former should be called once when
+  the incoming event is received, while the latter should be called for every
+  state that should be checked.
 
 Bug fixes:
 

--- a/crates/ruma-state-res/CHANGELOG.md
+++ b/crates/ruma-state-res/CHANGELOG.md
@@ -41,6 +41,8 @@ Bug fixes:
 - Fix `auth_check` for `m.room.member` with an `invite` membership and a
   `third_party_invite`. The `signed` object in the content is now verified
   against the public keys in the matching `m.room.third_party_invite` event.
+- `check_state_independent_auth_rules` now performs the authorization rules
+  checks on `auth_events`.
 
 Improvements:
 

--- a/crates/ruma-state-res/CHANGELOG.md
+++ b/crates/ruma-state-res/CHANGELOG.md
@@ -23,6 +23,8 @@ Breaking:
   to provide an `AuthorizationRules` for their custom `RoomVersionId`.
 - `RoomVersion` was moved to ruma-common and renamed `RoomVersionRules`, along
   with other changes. Check the changelog of ruma-common for more details.
+- The `event_auth` module is no longer public. Everything public inside of it
+  is already exposed at the root of the crate.
 
 Bug fixes:
 

--- a/crates/ruma-state-res/benches/state_res_bench.rs
+++ b/crates/ruma-state-res/benches/state_res_bench.rs
@@ -622,6 +622,10 @@ mod event {
                 _ => unreachable!("new PDU version"),
             }
         }
+
+        fn rejected(&self) {
+            false
+        }
     }
 
     #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/ruma-state-res/src/event_auth.rs
+++ b/crates/ruma-state-res/src/event_auth.rs
@@ -36,7 +36,7 @@ use crate::{
 // - https://github.com/element-hq/synapse/blob/9c5d08fff8d66a7cc0e2ecfeeb783f933a778c2f/synapse/event_auth.py
 // - https://github.com/matrix-org/matrix-spec/issues/365
 
-/// Get the list of [relevant auth event types] required to authorize the event of the given type.
+/// Get the list of [relevant auth events] required to authorize the event of the given type.
 ///
 /// Returns a list of `(event_type, state_key)` tuples.
 ///

--- a/crates/ruma-state-res/src/event_auth.rs
+++ b/crates/ruma-state-res/src/event_auth.rs
@@ -206,10 +206,11 @@ pub fn check_state_independent_auth_rules<E: Event>(
             ));
         };
 
-        // TODO:
-        //
         // Since v1, if there are entries which were themselves rejected under the checks performed
         // on receipt of a PDU, reject.
+        if auth_event.rejected() {
+            return Err(format!("rejected auth event {event_id}"));
+        }
 
         seen_auth_types.insert(key);
     }

--- a/crates/ruma-state-res/src/events/traits.rs
+++ b/crates/ruma-state-res/src/events/traits.rs
@@ -44,6 +44,9 @@ pub trait Event {
 
     /// If this event is a redaction event this is the event it redacts.
     fn redacts(&self) -> Option<&Self::Id>;
+
+    /// Whether this event was rejected for not passing the checks on reception of a PDU.
+    fn rejected(&self) -> bool;
 }
 
 impl<T: Event> Event for &T {
@@ -88,6 +91,10 @@ impl<T: Event> Event for &T {
     fn redacts(&self) -> Option<&Self::Id> {
         (*self).redacts()
     }
+
+    fn rejected(&self) -> bool {
+        (*self).rejected()
+    }
 }
 
 impl<T: Event> Event for Arc<T> {
@@ -131,5 +138,9 @@ impl<T: Event> Event for Arc<T> {
 
     fn redacts(&self) -> Option<&Self::Id> {
         (**self).redacts()
+    }
+
+    fn rejected(&self) -> bool {
+        (**self).rejected()
     }
 }

--- a/crates/ruma-state-res/src/lib.rs
+++ b/crates/ruma-state-res/src/lib.rs
@@ -14,7 +14,7 @@ use ruma_events::{room::member::MembershipState, StateEventType, TimelineEventTy
 use tracing::{debug, info, instrument, trace, warn};
 
 mod error;
-pub mod event_auth;
+mod event_auth;
 pub mod events;
 #[cfg(test)]
 mod test_utils;

--- a/crates/ruma-state-res/src/lib.rs
+++ b/crates/ruma-state-res/src/lib.rs
@@ -25,7 +25,9 @@ use self::events::{
 };
 pub use self::{
     error::{Error, Result},
-    event_auth::{auth_check, auth_types_for_event},
+    event_auth::{
+        auth_types_for_event, check_state_dependent_auth_rules, check_state_independent_auth_rules,
+    },
     events::Event,
 };
 
@@ -494,7 +496,9 @@ fn iterative_auth_check<E: Event + Clone>(
             }
         }
 
-        match auth_check(rules, &event, |ty, key| auth_events.get(&ty.with_state_key(key))) {
+        match check_state_dependent_auth_rules(rules, &event, |ty, key| {
+            auth_events.get(&ty.with_state_key(key))
+        }) {
             Ok(()) => {
                 // Add event to resolved state.
                 resolved_state

--- a/crates/ruma-state-res/src/test_utils.rs
+++ b/crates/ruma-state-res/src/test_utils.rs
@@ -398,6 +398,7 @@ pub(crate) fn to_init_pdu_event(
             hashes: EventHash::new("".to_owned()),
             signatures: ServerSignatures::default(),
         }),
+        rejected: false,
     })
 }
 
@@ -436,6 +437,7 @@ where
             hashes: EventHash::new("".to_owned()),
             signatures: ServerSignatures::default(),
         }),
+        rejected: false,
     })
 }
 
@@ -472,6 +474,7 @@ where
             hashes: EventHash::new("".to_owned()),
             signatures: ServerSignatures::default(),
         }),
+        rejected: false,
     })
 }
 
@@ -677,6 +680,10 @@ pub(crate) mod event {
                 _ => unreachable!("new PDU version"),
             }
         }
+
+        fn rejected(&self) -> bool {
+            self.rejected
+        }
     }
 
     #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -685,6 +692,7 @@ pub(crate) mod event {
         pub(crate) event_id: OwnedEventId,
         #[serde(flatten)]
         pub(crate) rest: Pdu,
+        pub(crate) rejected: bool,
     }
 }
 

--- a/crates/ruma-state-res/tests/it/resolve.rs
+++ b/crates/ruma-state-res/tests/it/resolve.rs
@@ -65,6 +65,8 @@ struct Pdu {
     prev_events: Vec<OwnedEventId>,
     auth_events: Vec<OwnedEventId>,
     redacts: Option<OwnedEventId>,
+    #[serde(default)]
+    rejected: bool,
 }
 
 impl Event for Pdu {
@@ -108,6 +110,10 @@ impl Event for Pdu {
 
     fn redacts(&self) -> Option<&Self::Id> {
         self.redacts.as_ref()
+    }
+
+    fn rejected(&self) -> bool {
+        self.rejected
     }
 }
 


### PR DESCRIPTION
This is mostly copying the [behavior of Synapse](https://github.com/element-hq/synapse/blob/fe8bb620de8e5830328c6d23127657560f449af0/synapse/event_auth.py), while checking that it makes sense according to the spec.

I recommend to review this commit by commit. 