### PR TITLE
events: added the msc4278 implementation to handle media previews configuration

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -23,6 +23,10 @@ Breaking changes:
 - `RedactContent::redact()` and `FullStateEventContent::redact()` take a
   `RedactionRules` instead of `RoomVersionId`. This avoids undefined behavior
   for unknown room versions.
+- Add implementation of [MSC 4278](https://github.com/matrix-org/matrix-spec-proposals/pull/4278)
+  using `MediaPreviewConfigEventContent` for the stable version and `MediaPreviewConfigEventContent`
+  for the unstable one, both are only implemented as `GlobalAccountData` events as of right now.
+   
 
 Improvements:
 

--- a/crates/ruma-events/Cargo.toml
+++ b/crates/ruma-events/Cargo.toml
@@ -46,6 +46,7 @@ unstable-msc4095 = []
 unstable-msc4171 = []
 unstable-msc4230 = []
 unstable-msc4274 = []
+unstable-msc4278 = []
 unstable-pdu = []
 
 # Allow some mandatory fields to be missing, defaulting them to an empty string

--- a/crates/ruma-events/src/enums.rs
+++ b/crates/ruma-events/src/enums.rs
@@ -31,6 +31,11 @@ event_enum! {
         "m.push_rules" => super::push_rules,
         "m.secret_storage.default_key" => super::secret_storage::default_key,
         "m.secret_storage.key.*" => super::secret_storage::key,
+        #[cfg(feature = "unstable-msc4278")]
+        "m.media_preview_config" => super::media_preview_config,
+        #[cfg(feature = "unstable-msc4278")]
+        #[ruma_enum(ident = UnstableMediaPreviewConfig)]
+        "io.element.msc4278.media_preview_config" => super::media_preview_config,
         #[cfg(feature = "unstable-msc2545")]
         #[ruma_enum(ident = AccountImagePack, alias = "m.image_pack")]
         "im.ponies.user_emotes" => super::image_pack,

--- a/crates/ruma-events/src/lib.rs
+++ b/crates/ruma-events/src/lib.rs
@@ -164,6 +164,8 @@ pub mod key;
 #[cfg(feature = "unstable-msc3488")]
 pub mod location;
 pub mod marked_unread;
+#[cfg(feature = "unstable-msc4278")]
+pub mod media_preview_config;
 #[cfg(feature = "unstable-msc4171")]
 pub mod member_hints;
 #[cfg(feature = "unstable-msc1767")]

--- a/crates/ruma-events/src/media_preview_config.rs
+++ b/crates/ruma-events/src/media_preview_config.rs
@@ -1,0 +1,172 @@
+//! Types for the [`m.media_preview_config`] event.
+//!
+//! [`m.media_preview_config`]: https://github.com/matrix-org/matrix-spec-proposals/pull/4278
+
+use ruma_macros::StringEnum;
+use serde::{Deserialize, Serialize};
+
+use crate::{macros::EventContent, PrivOwnedStr};
+
+/// The content of an `m.media_preview_config` event.
+#[cfg(feature = "unstable-msc4278")]
+#[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+#[ruma_event(type = "m.media_preview_config", kind = GlobalAccountData)]
+pub struct MediaPreviewConfigEventContent {
+    /// The media previews configuration.
+    #[serde(default)]
+    pub media_previews: MediaPreviews,
+
+    /// The invite avatars configuration.
+    #[serde(default)]
+    pub invite_avatars: InviteAvatars,
+}
+
+/// The content of an `io.element.msc4278.media_preview_config` event,
+/// the unstable version of `m.media_preview_config` in global account data.
+#[cfg(feature = "unstable-msc4278")]
+#[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+#[ruma_event(type = "io.element.msc4278.media_preview_config", kind = GlobalAccountData)]
+pub struct UnstableMediaPreviewConfigEventContent {
+    /// The media previews configuration.
+    #[serde(default)]
+    pub media_previews: MediaPreviews,
+
+    /// The invite avatars configuration.
+    #[serde(default)]
+    pub invite_avatars: InviteAvatars,
+}
+
+/// The configuration that handles if media previews should be shown in the timeline.
+#[cfg(feature = "unstable-msc4278")]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, StringEnum, Default)]
+#[ruma_enum(rename_all = "lowercase")]
+#[non_exhaustive]
+pub enum MediaPreviews {
+    /// Media previews should be hidden.
+    Off,
+
+    /// Media previews should be only shown in private rooms.
+    Private,
+
+    /// Media previews should always be shown.
+    #[default]
+    On,
+
+    #[doc(hidden)]
+    _Custom(PrivOwnedStr),
+}
+
+/// The configuration to handle if avatars should be shown in invites.
+#[cfg(feature = "unstable-msc4278")]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, StringEnum, Default)]
+#[ruma_enum(rename_all = "lowercase")]
+#[non_exhaustive]
+pub enum InviteAvatars {
+    /// Avatars in invites should be hidden.
+    Off,
+
+    /// Avatars in invites should be shown.
+    #[default]
+    On,
+
+    #[doc(hidden)]
+    _Custom(PrivOwnedStr),
+}
+
+impl MediaPreviewConfigEventContent {
+    /// Create a new [`MediaPreviewConfigEventContent`] with the given values.
+    pub fn new(media_previews: MediaPreviews, invite_avatars: InviteAvatars) -> Self {
+        Self { media_previews, invite_avatars }
+    }
+}
+
+#[cfg(feature = "unstable-msc4278")]
+impl UnstableMediaPreviewConfigEventContent {
+    /// Create a new [`UnstableMediaPreviewConfigEventContent`] with the given values.
+    pub fn new(media_previews: MediaPreviews, invite_avatars: InviteAvatars) -> Self {
+        Self { media_previews, invite_avatars }
+    }
+}
+
+#[cfg(all(test, feature = "unstable-msc4278"))]
+mod tests {
+    use assert_matches2::assert_matches;
+    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+
+    use super::{MediaPreviewConfigEventContent, UnstableMediaPreviewConfigEventContent};
+    use crate::{
+        media_preview_config::{InviteAvatars, MediaPreviews},
+        AnyGlobalAccountDataEvent, GlobalAccountDataEvent,
+    };
+
+    #[test]
+    fn deserialize() {
+        let raw_unstable_media_preview_config = json!({
+            "type": "io.element.msc4278.media_preview_config",
+            "content": {
+                "media_previews": "private",
+                "invite_avatars": "off",
+            },
+        });
+        let unstable_media_preview_config_data =
+            from_json_value::<AnyGlobalAccountDataEvent>(raw_unstable_media_preview_config)
+                .unwrap();
+        assert_matches!(
+            unstable_media_preview_config_data,
+            AnyGlobalAccountDataEvent::UnstableMediaPreviewConfig(unstable_media_preview_config)
+        );
+        assert_eq!(unstable_media_preview_config.content.media_previews, MediaPreviews::Private);
+        assert_eq!(unstable_media_preview_config.content.invite_avatars, InviteAvatars::Off);
+
+        let raw_media_preview_config = json!({
+            "type": "m.media_preview_config",
+            "content": {
+                "media_previews": "on",
+                "invite_avatars": "on",
+            },
+        });
+        let media_preview_config_data =
+            from_json_value::<AnyGlobalAccountDataEvent>(raw_media_preview_config).unwrap();
+        assert_matches!(
+            media_preview_config_data,
+            AnyGlobalAccountDataEvent::MediaPreviewConfig(media_preview_config)
+        );
+        assert_eq!(media_preview_config.content.media_previews, MediaPreviews::On);
+        assert_eq!(media_preview_config.content.invite_avatars, InviteAvatars::On);
+    }
+
+    #[test]
+    fn serialize() {
+        let unstable_media_preview_config =
+            UnstableMediaPreviewConfigEventContent::new(MediaPreviews::Off, InviteAvatars::On);
+        let unstable_media_preview_config_account_data =
+            GlobalAccountDataEvent { content: unstable_media_preview_config };
+        assert_eq!(
+            to_json_value(unstable_media_preview_config_account_data).unwrap(),
+            json!({
+                "type": "io.element.msc4278.media_preview_config",
+                "content": {
+                    "media_previews": "off",
+                    "invite_avatars": "on",
+                },
+            })
+        );
+
+        let media_preview_config =
+            MediaPreviewConfigEventContent::new(MediaPreviews::On, InviteAvatars::Off);
+        let media_preview_config_account_data =
+            GlobalAccountDataEvent { content: media_preview_config };
+        assert_eq!(
+            to_json_value(media_preview_config_account_data).unwrap(),
+            json!({
+                "type": "m.media_preview_config",
+                "content": {
+                    "media_previews": "on",
+                    "invite_avatars": "off",
+                },
+            })
+        );
+    }
+}

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -191,6 +191,7 @@ unstable-msc4186 = ["ruma-client-api?/unstable-msc4186"]
 unstable-msc4203 = ["ruma-appservice-api?/unstable-msc4203"]
 unstable-msc4230 = ["ruma-events?/unstable-msc4230"]
 unstable-msc4274 = ["ruma-events?/unstable-msc4274"]
+unstable-msc4278 = ["ruma-events?/unstable-msc4278"]
 unstable-pdu = ["ruma-events?/unstable-pdu"]
 
 # Private features, only used in test / benchmarking code
@@ -243,6 +244,7 @@ __unstable-mscs = [
     "unstable-msc4203",
     "unstable-msc4230",
     "unstable-msc4274",
+    "unstable-msc4278",
 ]
 __ci = [
     "full",


### PR DESCRIPTION
This PR adds the unstable-msc4278 and its implementation.

This new global account data event, will be used to allow homeservers to comunicate to their users account data, what policy should be enforced by default by the clients regarding showing media previews in the timeline, and avatars in invites for safety reasons.

More details on the MSC can be found here: https://github.com/matrix-org/matrix-spec-proposals/pull/4278