### PR TITLE
html: support for unstable MSC4286

### DIFF
--- a/crates/ruma-html/CHANGELOG.md
+++ b/crates/ruma-html/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [unreleased]
 
+Improvements:
+
+- Add unstable support for the `data-mx-external-payment-details` attribute for spans, according to MSC4286.
+
 # 0.4.0
 
 Upgrade `ruma-common` to 0.15.0.

--- a/crates/ruma-html/Cargo.toml
+++ b/crates/ruma-html/Cargo.toml
@@ -15,6 +15,7 @@ all-features = true
 
 [features]
 matrix = ["dep:ruma-common"]
+unstable-msc4286 = []
 
 [dependencies]
 as_variant = { workspace = true }

--- a/crates/ruma-html/src/html/matrix.rs
+++ b/crates/ruma-html/src/html/matrix.rs
@@ -607,12 +607,27 @@ pub struct SpanData {
     /// [mathematical message]: https://spec.matrix.org/latest/client-server-api/#mathematical-messages
     /// [LaTeX]: https://www.latex-project.org/
     pub maths: Option<StrTendril>,
+
+    /// `data-mx-external-payment-details`, unstable feature from MSC4186.
+    ///
+    /// This uses the unstable prefix in [MSC4286].
+    ///
+    /// [MSC4286]: https://github.com/matrix-org/matrix-spec-proposals/pull/4286
+    #[cfg(feature = "unstable-msc4286")]
+    pub external_payment_details: Option<StrTendril>,
 }
 
 impl SpanData {
     /// Construct an empty `SpanData`.
     fn new() -> Self {
-        Self { bg_color: None, color: None, spoiler: None, maths: None }
+        Self {
+            bg_color: None,
+            color: None,
+            spoiler: None,
+            maths: None,
+            #[cfg(feature = "unstable-msc4286")]
+            external_payment_details: None,
+        }
     }
 
     /// Parse the given attributes to construct a new `SpanData`.
@@ -639,6 +654,10 @@ impl SpanData {
                 }
                 b"data-mx-maths" => {
                     data.maths = Some(attr.value.clone());
+                }
+                #[cfg(feature = "unstable-msc4286")]
+                b"data-msc4286-external-payment-details" => {
+                    data.external_payment_details = Some(attr.value.clone());
                 }
                 _ => {
                     remaining_attrs.insert(attr.clone());

--- a/crates/ruma-html/src/sanitizer_config/clean.rs
+++ b/crates/ruma-html/src/sanitizer_config/clean.rs
@@ -30,8 +30,14 @@ static ALLOWED_ATTRIBUTES_STRICT: Map<&str, &Set<&str>> = phf_map! {
     "code" => &ALLOWED_ATTRIBUTES_CODE_STRICT,
     "div" => &ALLOWED_ATTRIBUTES_DIV_STRICT,
 };
+
+#[cfg(not(feature = "unstable-msc4286"))]
 static ALLOWED_ATTRIBUTES_SPAN_STRICT: Set<&str> =
     phf_set! { "data-mx-bg-color", "data-mx-color", "data-mx-spoiler", "data-mx-maths" };
+
+#[cfg(feature = "unstable-msc4286")]
+static ALLOWED_ATTRIBUTES_SPAN_STRICT: Set<&str> = phf_set! { "data-mx-bg-color", "data-mx-color", "data-mx-spoiler", "data-mx-maths", "data-msc4286-external-payment-details" };
+
 static ALLOWED_ATTRIBUTES_A_STRICT: Set<&str> = phf_set! { "target", "href" };
 static ALLOWED_ATTRIBUTES_IMG_STRICT: Set<&str> =
     phf_set! { "width", "height", "alt", "title", "src" };

--- a/crates/ruma-html/tests/it/html/matrix.rs
+++ b/crates/ruma-html/tests/it/html/matrix.rs
@@ -61,6 +61,7 @@ fn span_attributes() {
             data-mx-bg-color=\"#ff0000\" \
             data-mx-spoiler \
             data-mx-spoiler=\"This is a spoiler\"\
+            data-msc4286-external-payment-details=\"foo\"\
         >\
             Hidden and colored\
         </span>\
@@ -78,7 +79,15 @@ fn span_attributes() {
     // Uses the first spoiler attribute, the second is dropped.
     assert!(span.spoiler.unwrap().is_empty());
 
-    assert!(span_element.attrs.is_empty());
+    #[cfg(feature = "unstable-msc4286")]
+    {
+        assert_eq!(span.external_payment_details.unwrap().as_ref(), "foo");
+        assert!(span_element.attrs.is_empty());
+    }
+
+    // "data-msc4286-external-payment-details" should remain in the attributes
+    #[cfg(not(feature = "unstable-msc4286"))]
+    assert_eq!(span_element.attrs.len(), 1);
 }
 
 #[test]

--- a/crates/ruma-html/tests/it/html/sanitize.rs
+++ b/crates/ruma-html/tests/it/html/sanitize.rs
@@ -846,3 +846,32 @@ fn remove_classes() {
         "
     );
 }
+
+#[cfg(feature = "unstable-msc4286")]
+#[test]
+fn strict_mode_external_payment_details() {
+    let config = SanitizerConfig::strict().remove_reply_fallback();
+    let html = Html::parse(
+        "\
+        <p>\
+        some text here\
+        <span data-msc4286-external-payment-details=\"foo\">\
+        <a href=\"https://example.com\">link</a>\
+        </span>\
+        </p>\
+        ",
+    );
+    html.sanitize_with(&config);
+
+    assert_eq!(
+        html.to_string(),
+        "\
+        <p>\
+        some text here\
+        <span data-msc4286-external-payment-details=\"foo\">\
+        <a href=\"https://example.com\">link</a>\
+        </span>\
+        </p>\
+        ",
+    );
+}

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -189,6 +189,7 @@ unstable-msc4203 = ["ruma-appservice-api?/unstable-msc4203"]
 unstable-msc4230 = ["ruma-events?/unstable-msc4230"]
 unstable-msc4274 = ["ruma-events?/unstable-msc4274"]
 unstable-msc4278 = ["ruma-events?/unstable-msc4278"]
+unstable-msc4286 = ["ruma-html?/unstable-msc4286"]
 unstable-pdu = ["ruma-events?/unstable-pdu"]
 
 # Private features, only used in test / benchmarking code
@@ -242,6 +243,7 @@ __unstable-mscs = [
     "unstable-msc4230",
     "unstable-msc4274",
     "unstable-msc4278",
+    "unstable-msc4286",
 ]
 __ci = ["full", "compat-upload-signatures", "__unstable-mscs"]
 __compat = [


### PR DESCRIPTION
See: https://github.com/matrix-org/matrix-spec-proposals/pull/4286

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
