### PR TITLE
identifiers: Fix changed trybuild output

### DIFF
--- a/crates/ruma-common/tests/it/identifiers/ui/03-invalid-new-id-macros.stderr
+++ b/crates/ruma-common/tests/it/identifiers/ui/03-invalid-new-id-macros.stderr
@@ -2,7 +2,7 @@ error[E0080]: evaluation of constant value failed
  --> tests/it/identifiers/ui/03-invalid-new-id-macros.rs:2:13
   |
 2 |     let _ = ruma_common::session_id!("invalid~");
-  |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'Invalid Session ID: contains invalid characters', $DIR/tests/it/identifiers/ui/03-invalid-new-id-macros.rs:2:13
+  |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation panicked: Invalid Session ID: contains invalid characters
   |
   = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `ruma_common::session_id` (in Nightly builds, run with -Z macro-backtrace for more info)
 


### PR DESCRIPTION
It must be due to the new Rust stable version.
