### PR TITLE
ci: Use install-action over cache-cargo-install-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,12 +35,12 @@ jobs:
         uses: crate-ci/typos@v1.44.0
 
       - name: Install cargo-sort
-        uses: taiki-e/cache-cargo-install-action@v3
+        uses: taiki-e/install-action@v2
         with:
           tool: cargo-sort@2.1.1
 
       - name: Install cargo-machete
-        uses: taiki-e/cache-cargo-install-action@v3
+        uses: taiki-e/install-action@v2
         with:
           tool: cargo-machete@0.9.1
 


### PR DESCRIPTION
Its own readme recommends it, where possible.