### PR TITLE
Client API: Remove the authentication issuer field from the well-known request.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ target
 Cargo.lock
 .DS_Store
 .idea
+.nova
 *.snap.new

--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -21,6 +21,8 @@ Improvements:
   endpoints, the `server_name` query parameter is only serialized if the server
   doesn't advertise at least one version that supports the `via` query
   parameter. The former was removed in Matrix 1.14.
+- The `authentication` field of `discovery::discover_homeserver::Response` has
+  been removed in favour of `discovery::get_authorization_server_metadata`.
 
 # 0.20.2
 

--- a/crates/ruma-client-api/src/discovery/discover_homeserver.rs
+++ b/crates/ruma-client-api/src/discovery/discover_homeserver.rs
@@ -43,15 +43,6 @@ pub struct Response {
         skip_serializing_if = "Option::is_none"
     )]
     pub tile_server: Option<TileServerInfo>,
-
-    /// Information about the authentication server to connect to when using OpenID Connect.
-    #[cfg(feature = "unstable-msc2965")]
-    #[serde(
-        rename = "org.matrix.msc2965.authentication",
-        alias = "m.authentication",
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub authentication: Option<AuthenticationServerInfo>,
 }
 
 impl Request {
@@ -69,8 +60,6 @@ impl Response {
             identity_server: None,
             #[cfg(feature = "unstable-msc3488")]
             tile_server: None,
-            #[cfg(feature = "unstable-msc2965")]
-            authentication: None,
         }
     }
 }
@@ -121,27 +110,5 @@ impl TileServerInfo {
     /// Creates a `TileServerInfo` with the given map style URL.
     pub fn new(map_style_url: String) -> Self {
         Self { map_style_url }
-    }
-}
-
-/// Information about a discovered authentication server.
-#[cfg(feature = "unstable-msc2965")]
-#[derive(Clone, Debug, Deserialize, Hash, Serialize)]
-#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
-pub struct AuthenticationServerInfo {
-    /// The OIDC Provider that is trusted by the homeserver.
-    pub issuer: String,
-
-    /// The URL where the user is able to access the account management
-    /// capabilities of the OIDC Provider.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub account: Option<String>,
-}
-
-#[cfg(feature = "unstable-msc2965")]
-impl AuthenticationServerInfo {
-    /// Creates an `AuthenticationServerInfo` with the given `issuer` and an optional `account`.
-    pub fn new(issuer: String, account: Option<String>) -> Self {
-        Self { issuer, account }
     }
 }


### PR DESCRIPTION
It seems like it is time to remove this old implementation added in #1193. It was replaced by a CS-API request (GET `/auth_metadata`) a long time ago and wasn't part of the accepted [MSC](https://github.com/sandhose/matrix-doc/blob/msc/sandhose/oidc-discovery/proposals/2965-auth-metadata.md).
