### PR TITLE
Client API: Add RTC Foci to the well-known discovery.

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -23,6 +23,8 @@ Improvements:
   parameter. The former was removed in Matrix 1.14.
 - The `authentication` field of `discovery::discover_homeserver::Response` has
   been removed in favour of `discovery::get_authorization_server_metadata`.
+- The `discovery::discover_homeserver::Response` well-known now includes the
+  `rtc_foci` as defined in MSC4143.
 
 # 0.20.2
 

--- a/crates/ruma-client-api/Cargo.toml
+++ b/crates/ruma-client-api/Cargo.toml
@@ -50,6 +50,7 @@ unstable-msc3983 = []
 unstable-msc4108 = []
 unstable-msc4121 = []
 unstable-msc4140 = []
+unstable-msc4143 = []
 unstable-msc4186 = []
 
 [dependencies]

--- a/crates/ruma-client-api/src/discovery/discover_homeserver.rs
+++ b/crates/ruma-client-api/src/discovery/discover_homeserver.rs
@@ -4,11 +4,20 @@
 //!
 //! Get discovery information about the domain.
 
+#[cfg(feature = "unstable-msc4143")]
+use std::borrow::Cow;
+
+#[cfg(feature = "unstable-msc4143")]
+use ruma_common::serde::JsonObject;
 use ruma_common::{
     api::{request, response, Metadata},
     metadata,
 };
+#[cfg(feature = "unstable-msc4143")]
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "unstable-msc4143")]
+use serde_json::Value as JsonValue;
 
 const METADATA: Metadata = metadata! {
     method: GET,
@@ -43,6 +52,16 @@ pub struct Response {
         skip_serializing_if = "Option::is_none"
     )]
     pub tile_server: Option<TileServerInfo>,
+
+    /// A list of the available MatrixRTC foci, ordered by priority.
+    #[cfg(feature = "unstable-msc4143")]
+    #[serde(
+        rename = "org.matrix.msc4143.rtc_foci",
+        alias = "m.rtc_foci",
+        default,
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub rtc_foci: Vec<RtcFocusInfo>,
 }
 
 impl Request {
@@ -60,6 +79,8 @@ impl Response {
             identity_server: None,
             #[cfg(feature = "unstable-msc3488")]
             tile_server: None,
+            #[cfg(feature = "unstable-msc4143")]
+            rtc_foci: Default::default(),
         }
     }
 }
@@ -110,5 +131,187 @@ impl TileServerInfo {
     /// Creates a `TileServerInfo` with the given map style URL.
     pub fn new(map_style_url: String) -> Self {
         Self { map_style_url }
+    }
+}
+
+/// Information about a specific MatrixRTC focus.
+#[cfg(feature = "unstable-msc4143")]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+#[serde(tag = "type")]
+pub enum RtcFocusInfo {
+    /// A LiveKit RTC focus.
+    #[serde(rename = "livekit")]
+    LiveKit(LiveKitRtcFocusInfo),
+
+    /// A custom RTC focus.
+    #[doc(hidden)]
+    #[serde(untagged)]
+    _Custom(CustomRtcFocusInfo),
+}
+
+#[cfg(feature = "unstable-msc4143")]
+impl RtcFocusInfo {
+    /// A constructor to create a custom RTC focus.
+    ///
+    /// Prefer to use the public variants of `RtcFocusInfo` where possible; this constructor is
+    /// meant to be used for unsupported focus types only and does not allow setting arbitrary data
+    /// for supported ones.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the `focus_type` is known and serialization of `data` to the
+    /// corresponding `RtcFocusInfo` variant fails.
+    pub fn new(focus_type: &str, data: JsonObject) -> serde_json::Result<Self> {
+        fn deserialize_variant<T: DeserializeOwned>(obj: JsonObject) -> serde_json::Result<T> {
+            serde_json::from_value(JsonValue::Object(obj))
+        }
+
+        Ok(match focus_type {
+            "livekit" => Self::LiveKit(deserialize_variant(data)?),
+            _ => Self::_Custom(CustomRtcFocusInfo { focus_type: focus_type.to_owned(), data }),
+        })
+    }
+
+    /// Creates a new `RtcFocusInfo::LiveKit`.
+    pub fn livekit(service_url: String) -> Self {
+        Self::LiveKit(LiveKitRtcFocusInfo { service_url })
+    }
+
+    /// Returns a reference to the focus type of this RTC focus.
+    pub fn focus_type(&self) -> &str {
+        match self {
+            Self::LiveKit(_) => "livekit",
+            Self::_Custom(custom) => &custom.focus_type,
+        }
+    }
+
+    /// Returns the associated data.
+    ///
+    /// The returned JSON object won't contain the `focus_type` field, please use
+    /// [`.focus_type()`][Self::focus_type] to access that.
+    ///
+    /// Prefer to use the public variants of `RtcFocusInfo` where possible; this method is meant to
+    /// be used for custom focus types only.
+    pub fn data(&self) -> Cow<'_, JsonObject> {
+        fn serialize<T: Serialize>(object: &T) -> JsonObject {
+            match serde_json::to_value(object).expect("rtc focus type serialization to succeed") {
+                JsonValue::Object(object) => object,
+                _ => panic!("all rtc focus types must serialize to objects"),
+            }
+        }
+
+        match self {
+            Self::LiveKit(info) => Cow::Owned(serialize(info)),
+            Self::_Custom(info) => Cow::Borrowed(&info.data),
+        }
+    }
+}
+
+/// Information about a LiveKit RTC focus.
+#[cfg(feature = "unstable-msc4143")]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+pub struct LiveKitRtcFocusInfo {
+    /// The URL for the LiveKit service.
+    #[serde(rename = "livekit_service_url")]
+    pub service_url: String,
+}
+
+/// Information about a custom RTC focus type.
+#[doc(hidden)]
+#[cfg(feature = "unstable-msc4143")]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct CustomRtcFocusInfo {
+    /// The type of RTC focus.
+    #[serde(rename = "type")]
+    focus_type: String,
+
+    /// Remaining RTC focus data.
+    #[serde(flatten)]
+    data: JsonObject,
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "unstable-msc4143")]
+    use assert_matches2::assert_matches;
+    #[cfg(feature = "unstable-msc4143")]
+    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+
+    #[cfg(feature = "unstable-msc4143")]
+    use super::RtcFocusInfo;
+
+    #[test]
+    #[cfg(feature = "unstable-msc4143")]
+    fn test_livekit_rtc_focus_deserialization() {
+        // Given the JSON for a LiveKit RTC focus.
+        let json = json!({
+            "type": "livekit",
+            "livekit_service_url": "https://livekit.example.com"
+        });
+
+        // When deserializing it into an RtcFocusInfo.
+        let focus: RtcFocusInfo = from_json_value(json).unwrap();
+
+        // Then it should be recognized as a LiveKit focus with the correct service URL.
+        assert_matches!(focus, RtcFocusInfo::LiveKit(info));
+        assert_eq!(info.service_url, "https://livekit.example.com");
+    }
+
+    #[test]
+    #[cfg(feature = "unstable-msc4143")]
+    fn test_livekit_rtc_focus_serialization() {
+        // Given a LiveKit RTC focus info.
+        let focus = RtcFocusInfo::livekit("https://livekit.example.com".to_owned());
+
+        // When serializing it to JSON.
+        let json = to_json_value(&focus).unwrap();
+
+        // Then it should match the expected JSON structure.
+        assert_eq!(
+            json,
+            json!({
+                "type": "livekit",
+                "livekit_service_url": "https://livekit.example.com"
+            })
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "unstable-msc4143")]
+    fn test_custom_rtc_focus_serialization() {
+        // Given the JSON for a custom RTC focus type with additional fields.
+        let json = json!({
+            "type": "some-focus-type",
+            "additional-type-specific-field": "https://my_focus.domain",
+            "another-additional-type-specific-field": ["with", "Array", "type"]
+        });
+
+        // When deserializing it into an RtcFocusInfo.
+        let focus: RtcFocusInfo = from_json_value(json.clone()).unwrap();
+
+        // Then it should be recognized as a custom focus type, with all the additional fields
+        // included.
+        assert_eq!(focus.focus_type(), "some-focus-type");
+
+        let data = &focus.data();
+        assert_eq!(data["additional-type-specific-field"], "https://my_focus.domain");
+
+        let array_values: Vec<&str> = data["another-additional-type-specific-field"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        assert_eq!(array_values, vec!["with", "Array", "type"]);
+
+        assert!(!data.contains_key("type"));
+
+        // When serializing it back to JSON.
+        let serialized = to_json_value(&focus).unwrap();
+
+        // Then it should match the original JSON.
+        assert_eq!(serialized, json);
     }
 }

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -183,6 +183,7 @@ unstable-msc4108 = ["ruma-client-api?/unstable-msc4108"]
 unstable-msc4121 = ["ruma-client-api?/unstable-msc4121"]
 unstable-msc4125 = ["ruma-federation-api?/unstable-msc4125"]
 unstable-msc4140 = ["ruma-client-api?/unstable-msc4140"]
+unstable-msc4143 = ["ruma-client-api?/unstable-msc4143"]
 unstable-msc4171 = ["ruma-events?/unstable-msc4171"]
 unstable-msc4186 = ["ruma-client-api?/unstable-msc4186"]
 unstable-msc4203 = ["ruma-appservice-api?/unstable-msc4203"]
@@ -237,6 +238,7 @@ __unstable-mscs = [
     "unstable-msc4121",
     "unstable-msc4125",
     "unstable-msc4140",
+    "unstable-msc4143",
     "unstable-msc4171",
     "unstable-msc4186",
     "unstable-msc4203",


### PR DESCRIPTION
Ah, I was going to target this against #2075 but it's a fork so I can't. Please ignore the first commit until that PR is merged.

This PR adds discovery of the MatrixRTC foci using the client well-known file. The spec is here: https://github.com/matrix-org/matrix-spec-proposals/blob/toger5/matrixRTC/proposals/4143-matrix-rtc.md#discovery-of-foci-using-well-knownmatrixclient