### PR TITLE
appservice-api: Require `url` field in `Registration` during deserialization

### DIFF
--- a/crates/ruma-appservice-api/CHANGELOG.md
+++ b/crates/ruma-appservice-api/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [unreleased]
 
+Bug fixes:
+
+- `Registration` deserialization fails if `url` is missing. The value must be
+  set or `null`.
+
 Breaking changes:
 
 - The`thirdparty::get_protocol` response uses `AppserviceProtocolInstance`

--- a/crates/ruma-appservice-api/src/lib.rs
+++ b/crates/ruma-appservice-api/src/lib.rs
@@ -76,6 +76,7 @@ pub struct Registration {
     /// The URL for the application service.
     ///
     /// Optionally set to `null` if no traffic is required.
+    #[serde(deserialize_with = "Option::deserialize")]
     pub url: Option<String>,
 
     /// A unique token for application services to use to authenticate requests to Homeservers.

--- a/crates/ruma-appservice-api/tests/appservice_registration.rs
+++ b/crates/ruma-appservice-api/tests/appservice_registration.rs
@@ -46,7 +46,7 @@ fn registration_deserialization() {
 }
 
 #[test]
-fn config_with_optional_url() {
+fn registration_with_optional_url() {
     let registration_config = r#"
         id: "IRC Bridge"
         url: null
@@ -60,4 +60,19 @@ fn config_with_optional_url() {
         "#;
     assert_matches!(serde_yaml::from_str(registration_config).unwrap(), Registration { url, .. });
     assert_eq!(url, None);
+}
+
+#[test]
+fn registration_with_missing_url() {
+    let registration_config = r#"
+        id: "IRC Bridge"
+        as_token: "30c05ae90a248a4188e620216fa72e349803310ec83e2a77b34fe90be6081f46"
+        hs_token: "312df522183efd404ec1cd22d2ffa4bbc76a8c1ccf541dd692eef281356bb74e"
+        sender_localpart: "_irc_bot"
+        namespaces:
+          users: []
+          aliases: []
+          rooms: []
+        "#;
+    serde_yaml::from_str::<Registration>(registration_config).unwrap_err();
 }


### PR DESCRIPTION
According to the spec, the field is required so the value must be set or `null`.

Fixes #2074.