### PR TITLE
Client API: Derive (de)serialisation traits on discover_homeserver::Response.

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -21,6 +21,8 @@ Improvements:
   endpoints, the `server_name` query parameter is only serialized if the server
   doesn't advertise at least one version that supports the `via` query
   parameter. The former was removed in Matrix 1.14.
+- `discovery::discover_homeserver::Response` can now be (de)serialised to 
+  cache the value for re-use.
 - The `authentication` field of `discovery::discover_homeserver::Response` has
   been removed in favour of `discovery::get_authorization_server_metadata`.
 

--- a/crates/ruma-client-api/src/discovery/discover_homeserver.rs
+++ b/crates/ruma-client-api/src/discovery/discover_homeserver.rs
@@ -26,6 +26,7 @@ pub struct Request {}
 
 /// Response type for the `client_well_known` endpoint.
 #[response(error = crate::Error)]
+#[derive(Deserialize, Serialize)]
 pub struct Response {
     /// Information about the homeserver to connect to.
     #[serde(rename = "m.homeserver")]


### PR DESCRIPTION
Small change to allow the .well-known configuration to be stored in a cache and therefore reduce the need to request it each time you e.g. make a MatrixRTC call.