### PR TITLE
client-api: use room config type for all MSC4186 extensions

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -25,6 +25,8 @@ Improvements:
   been removed in favour of `discovery::get_authorization_server_metadata`.
 - The `discovery::discover_homeserver::Response` well-known now includes the
   `rtc_foci` as defined in MSC4143.
+- Use specialized room ID type (`ExtensionRoomConfig`) for all MSC4186
+  extension requests, not just the Receipts extension.
 
 # 0.20.2
 

--- a/crates/ruma-client-api/src/sync/sync_events/v5.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v5.rs
@@ -231,21 +231,6 @@ pub mod request {
         /// Give messages since this token only.
         #[serde(skip_serializing_if = "Option::is_none")]
         pub since: Option<String>,
-
-        /// List of list names for which to-device events should be enabled.
-        ///
-        /// If not defined, will be enabled for *all* the lists appearing in the
-        /// request. If defined and empty, will be disabled for all the lists.
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub lists: Option<Vec<String>>,
-
-        /// List of room names for which to-device events should be enabled.
-        ///
-        /// If not defined, will be enabled for *all* the rooms appearing in the
-        /// room subscriptions. If defined and empty, will be disabled for all
-        /// the rooms.
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub rooms: Option<Vec<OwnedRoomId>>,
     }
 
     impl ToDevice {


### PR DESCRIPTION
This was previously only implemented for the Receipts extension, but it applies equally to all extensions - [MSC4186][1] (currently) defers to [MSC3575][2], which describes the special handling of "*".

[1]: https://github.com/matrix-org/matrix-spec-proposals/blob/4c47844771bb160a4efefe4bd063efd33902df73/proposals/4186-simplified-sliding-sync.md#extensions
[2]: https://github.com/matrix-org/matrix-spec-proposals/blob/7036c29db2b0ea40dccb0c505d6ef4b6085bf192/proposals/3575-sync.md#extensions