### PR TITLE
html: Remove dependency on phf

### DIFF
--- a/crates/ruma-html/Cargo.toml
+++ b/crates/ruma-html/Cargo.toml
@@ -20,7 +20,6 @@ unstable-msc4286 = []
 [dependencies]
 as_variant = { workspace = true }
 html5ever = "0.29.0"
-phf = { version = "0.11.1", features = ["macros"] }
 ruma-common = { workspace = true, optional = true }
 tracing = { workspace = true, features = ["attributes"] }
 wildmatch = "2.0.0"

--- a/crates/ruma-html/src/html/matrix.rs
+++ b/crates/ruma-html/src/html/matrix.rs
@@ -9,9 +9,7 @@ use ruma_common::{
     IdParseError, MatrixToError, MatrixToUri, MatrixUri, MatrixUriError, MxcUri, OwnedMxcUri,
 };
 
-use crate::sanitizer_config::clean::{
-    ALLOWED_SCHEMES_A_HREF_COMPAT, ALLOWED_SCHEMES_A_HREF_STRICT,
-};
+use crate::sanitizer_config::clean::{compat, spec};
 
 const CLASS_LANGUAGE_PREFIX: &str = "language-";
 
@@ -416,8 +414,10 @@ impl AnchorUri {
         let s = value.as_ref();
 
         // Check if it starts with a supported scheme.
-        let mut allowed_schemes =
-            ALLOWED_SCHEMES_A_HREF_STRICT.iter().chain(ALLOWED_SCHEMES_A_HREF_COMPAT.iter());
+        let mut allowed_schemes = spec::allowed_schemes("a", "href")
+            .into_iter()
+            .chain(compat::allowed_schemes("a", "href"))
+            .flatten();
         if !allowed_schemes.any(|scheme| s.starts_with(&format!("{scheme}:"))) {
             return None;
         }


### PR DESCRIPTION
Allows to put some entries behind a cargo feature, instead of having to duplicate the list for each feature.

The APIs are really different so some significant refactoring was necessary, but in my opinion it makes the spec rules definitions easier to read.
