### PR TITLE
events: Add support for including devices keys with Olm-encrypted events

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -23,6 +23,8 @@ Breaking changes:
 - `RedactContent::redact()` and `FullStateEventContent::redact()` take a
   `RedactionRules` instead of `RoomVersionId`. This avoids undefined behavior
   for unknown room versions.
+- Add the `sender_device_keys` field to `DecryptedOlmV1Event`, according to
+  MSC4147.
    
 # 0.30.3
 

--- a/crates/ruma-events/src/kinds.rs
+++ b/crates/ruma-events/src/kinds.rs
@@ -2,6 +2,7 @@
 
 use as_variant::as_variant;
 use ruma_common::{
+    encryption::DeviceKeys,
     room_version_rules::RedactionRules,
     serde::{from_raw_json_value, Raw},
     EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedUserId, RoomId, UserId,
@@ -515,6 +516,9 @@ pub struct DecryptedOlmV1Event<C: MessageLikeEventContent> {
 
     /// The sender's ed25519 key.
     pub keys: OlmV1Keys,
+
+    /// The sender's device keys.
+    pub sender_device_keys: Option<Raw<DeviceKeys>>,
 }
 
 /// Public keys used for an `m.olm.v1.curve25519-aes-sha2` event.


### PR DESCRIPTION
According to [MSC4147](https://github.com/matrix-org/matrix-spec-proposals/pull/4147) / [Spec PR](https://github.com/matrix-org/matrix-spec/pull/2122).

Because the struct is exhaustive, we cannot put the field behind an unstable cargo feature, and this is a breaking change.
