### PR TITLE
events: Require `kind` attribute for `EventContent` macro 

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -29,6 +29,7 @@ Breaking changes:
   signed so we need the full raw JSON to verify the signature.
 - `PresenceEventContent` doesn't implement `EventContent` and `StaticEventContent` anymore.
   They are not useful when `PresenceEvent` can only contain one type.
+- The `EventContent` macro now requires the `kind` attribute.
    
 # 0.30.3
 

--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -27,6 +27,8 @@ Breaking changes:
   MSC4147.
 - `signed` in `ThirdPartyInvite` is now wrapped inside a `Raw` because it is
   signed so we need the full raw JSON to verify the signature.
+- `PresenceEventContent` doesn't implement `EventContent` and `StaticEventContent` anymore.
+  They are not useful when `PresenceEvent` can only contain one type.
    
 # 0.30.3
 

--- a/crates/ruma-events/src/presence.rs
+++ b/crates/ruma-events/src/presence.rs
@@ -4,14 +4,12 @@
 
 use js_int::UInt;
 use ruma_common::{presence::PresenceState, OwnedMxcUri, OwnedUserId};
-use ruma_macros::{Event, EventContent};
-use serde::{ser::SerializeStruct, Deserialize, Serialize};
-
-use super::EventContent;
+use serde::{Deserialize, Serialize};
 
 /// Presence event.
-#[derive(Clone, Debug, Event)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[allow(clippy::exhaustive_structs)]
+#[serde(tag = "type", rename = "m.presence")]
 pub struct PresenceEvent {
     /// Data specific to the event type.
     pub content: PresenceEventContent,
@@ -20,25 +18,11 @@ pub struct PresenceEvent {
     pub sender: OwnedUserId,
 }
 
-impl Serialize for PresenceEvent {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let mut state = serializer.serialize_struct("PresenceEvent", 3)?;
-        state.serialize_field("type", &self.content.event_type())?;
-        state.serialize_field("content", &self.content)?;
-        state.serialize_field("sender", &self.sender)?;
-        state.end()
-    }
-}
-
 /// Informs the room of members presence.
 ///
 /// This is the only type a `PresenceEvent` can contain as its `content` field.
-#[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
-#[ruma_event(type = "m.presence")]
 pub struct PresenceEventContent {
     /// The current avatar URL for this user.
     ///

--- a/crates/ruma-macros/src/events/event_parse.rs
+++ b/crates/ruma-macros/src/events/event_parse.rs
@@ -75,7 +75,6 @@ pub enum EventKind {
     State,
     ToDevice,
     RoomRedaction,
-    Presence,
     HierarchySpaceChild,
     Decrypted,
 }
@@ -90,7 +89,6 @@ impl fmt::Display for EventKind {
             EventKind::State => write!(f, "StateEvent"),
             EventKind::ToDevice => write!(f, "ToDeviceEvent"),
             EventKind::RoomRedaction => write!(f, "RoomRedactionEvent"),
-            EventKind::Presence => write!(f, "PresenceEvent"),
             EventKind::HierarchySpaceChild => write!(f, "HierarchySpaceChildEvent"),
             EventKind::Decrypted => unreachable!(),
         }
@@ -203,7 +201,6 @@ pub fn to_kind_variation(ident: &Ident) -> Option<(EventKind, EventKindVariation
         "RedactedStateEvent" => Some((EventKind::State, EventKindVariation::Redacted)),
         "RedactedSyncStateEvent" => Some((EventKind::State, EventKindVariation::RedactedSync)),
         "ToDeviceEvent" => Some((EventKind::ToDevice, EventKindVariation::None)),
-        "PresenceEvent" => Some((EventKind::Presence, EventKindVariation::None)),
         "HierarchySpaceChildEvent" => {
             Some((EventKind::HierarchySpaceChild, EventKindVariation::Stripped))
         }

--- a/crates/ruma-macros/src/events/event_type.rs
+++ b/crates/ruma-macros/src/events/event_type.rs
@@ -29,10 +29,7 @@ pub fn expand_event_type_enum(
                 timeline.push(&event.events);
             }
             EventKind::ToDevice => to_device.push(&event.events),
-            EventKind::RoomRedaction
-            | EventKind::Presence
-            | EventKind::Decrypted
-            | EventKind::HierarchySpaceChild => {}
+            EventKind::RoomRedaction | EventKind::Decrypted | EventKind::HierarchySpaceChild => {}
         }
     }
     let presence = vec![EventEnumEntry {


### PR DESCRIPTION
It was only missing for PresenceEventContent and is a potential
footgun.