### PR TITLE
events: Remove the `EventContent` trait

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -30,6 +30,10 @@ Breaking changes:
 - `PresenceEventContent` doesn't implement `EventContent` and `StaticEventContent` anymore.
   They are not useful when `PresenceEvent` can only contain one type.
 - The `EventContent` macro now requires the `kind` attribute.
+- The `EventContent` trait was removed.
+  - The `event_type` method is now available on the per-kind `*EventContent` traits.
+  - For an event content type to automatically implement `EventContentFromType` it must now match
+    the bound `StaticEventContent + DeserializeOwned`.
    
 # 0.30.3
 

--- a/crates/ruma-events/src/_custom.rs
+++ b/crates/ruma-events/src/_custom.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 use serde_json::value::RawValue as RawJsonValue;
 
 use super::{
-    EphemeralRoomEventContent, EphemeralRoomEventType, EventContent, EventContentFromType,
+    EphemeralRoomEventContent, EphemeralRoomEventType, EventContentFromType,
     GlobalAccountDataEventContent, GlobalAccountDataEventType, MessageLikeEventContent,
     MessageLikeEventType, MessageLikeUnsigned, PossiblyRedactedStateEventContent, RedactContent,
     RedactedMessageLikeEventContent, RedactedStateEventContent, RoomAccountDataEventContent,
@@ -21,10 +21,6 @@ macro_rules! custom_event_content {
         pub struct $i {
             #[serde(skip)]
             event_type: Box<str>,
-        }
-
-        impl EventContent for $i {
-            type EventType = $evt;
         }
 
         impl EventContentFromType for $i {

--- a/crates/ruma-events/src/_custom.rs
+++ b/crates/ruma-events/src/_custom.rs
@@ -25,10 +25,6 @@ macro_rules! custom_event_content {
 
         impl EventContent for $i {
             type EventType = $evt;
-
-            fn event_type(&self) -> Self::EventType {
-                self.event_type[..].into()
-            }
         }
 
         impl EventContentFromType for $i {
@@ -54,21 +50,45 @@ macro_rules! custom_room_event_content {
 }
 
 custom_event_content!(CustomGlobalAccountDataEventContent, GlobalAccountDataEventType);
-impl GlobalAccountDataEventContent for CustomGlobalAccountDataEventContent {}
+impl GlobalAccountDataEventContent for CustomGlobalAccountDataEventContent {
+    fn event_type(&self) -> GlobalAccountDataEventType {
+        self.event_type[..].into()
+    }
+}
 
 custom_event_content!(CustomRoomAccountDataEventContent, RoomAccountDataEventType);
-impl RoomAccountDataEventContent for CustomRoomAccountDataEventContent {}
+impl RoomAccountDataEventContent for CustomRoomAccountDataEventContent {
+    fn event_type(&self) -> RoomAccountDataEventType {
+        self.event_type[..].into()
+    }
+}
 
 custom_event_content!(CustomEphemeralRoomEventContent, EphemeralRoomEventType);
-impl EphemeralRoomEventContent for CustomEphemeralRoomEventContent {}
+impl EphemeralRoomEventContent for CustomEphemeralRoomEventContent {
+    fn event_type(&self) -> EphemeralRoomEventType {
+        self.event_type[..].into()
+    }
+}
 
 custom_room_event_content!(CustomMessageLikeEventContent, MessageLikeEventType);
-impl MessageLikeEventContent for CustomMessageLikeEventContent {}
-impl RedactedMessageLikeEventContent for CustomMessageLikeEventContent {}
+impl MessageLikeEventContent for CustomMessageLikeEventContent {
+    fn event_type(&self) -> MessageLikeEventType {
+        self.event_type[..].into()
+    }
+}
+impl RedactedMessageLikeEventContent for CustomMessageLikeEventContent {
+    fn event_type(&self) -> MessageLikeEventType {
+        self.event_type[..].into()
+    }
+}
 
 custom_room_event_content!(CustomStateEventContent, StateEventType);
 impl StateEventContent for CustomStateEventContent {
     type StateKey = String;
+
+    fn event_type(&self) -> StateEventType {
+        self.event_type[..].into()
+    }
 }
 impl StaticStateEventContent for CustomStateEventContent {
     // Like `StateUnsigned`, but without `prev_content`.
@@ -79,10 +99,22 @@ impl StaticStateEventContent for CustomStateEventContent {
 }
 impl PossiblyRedactedStateEventContent for CustomStateEventContent {
     type StateKey = String;
+
+    fn event_type(&self) -> StateEventType {
+        self.event_type[..].into()
+    }
 }
 impl RedactedStateEventContent for CustomStateEventContent {
     type StateKey = String;
+
+    fn event_type(&self) -> StateEventType {
+        self.event_type[..].into()
+    }
 }
 
 custom_event_content!(CustomToDeviceEventContent, ToDeviceEventType);
-impl ToDeviceEventContent for CustomToDeviceEventContent {}
+impl ToDeviceEventContent for CustomToDeviceEventContent {
+    fn event_type(&self) -> ToDeviceEventType {
+        self.event_type[..].into()
+    }
+}

--- a/crates/ruma-events/src/call/member.rs
+++ b/crates/ruma-events/src/call/member.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     PossiblyRedactedStateEventContent, PrivOwnedStr, RedactContent, RedactedStateEventContent,
-    StateEventType,
+    StateEventType, StaticEventContent,
 };
 
 /// The member state event for a MatrixRTC session.
@@ -201,6 +201,10 @@ impl RedactedStateEventContent for RedactedCallMemberEventContent {
     fn event_type(&self) -> StateEventType {
         StateEventType::CallMember
     }
+}
+
+impl StaticEventContent for RedactedCallMemberEventContent {
+    const TYPE: &'static str = CallMemberEventContent::TYPE;
 }
 
 /// Legacy content with an array of memberships. See also: [`CallMemberEventContent`]

--- a/crates/ruma-events/src/call/member.rs
+++ b/crates/ruma-events/src/call/member.rs
@@ -191,10 +191,6 @@ impl PossiblyRedactedStateEventContent for PossiblyRedactedCallMemberEventConten
 #[allow(clippy::exhaustive_structs)]
 pub struct RedactedCallMemberEventContent {}
 
-impl ruma_events::content::EventContent for RedactedCallMemberEventContent {
-    type EventType = StateEventType;
-}
-
 impl RedactedStateEventContent for RedactedCallMemberEventContent {
     type StateKey = CallMemberStateKey;
 

--- a/crates/ruma-events/src/call/member.rs
+++ b/crates/ruma-events/src/call/member.rs
@@ -143,7 +143,7 @@ impl CallMemberEventContent {
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct EmptyMembershipData {
     /// An empty call member state event can optionally contain a leave reason.
-    /// If it is `None` the user has left the call ordinarily. (Intentional hangup)  
+    /// If it is `None` the user has left the call ordinarily. (Intentional hangup)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub leave_reason: Option<LeaveReason>,
 }
@@ -152,12 +152,12 @@ pub struct EmptyMembershipData {
 /// [`CallMemberEventContent::Empty`].
 ///
 /// It is used when the user disconnected and a Future ([MSC4140](https://github.com/matrix-org/matrix-spec-proposals/pull/4140))
-/// was used to update the membership after the client was not reachable anymore.  
+/// was used to update the membership after the client was not reachable anymore.
 #[derive(Clone, PartialEq, StringEnum)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 #[ruma_enum(rename_all = "m.snake_case")]
 pub enum LeaveReason {
-    /// The user left the call by losing network connection or closing  
+    /// The user left the call by losing network connection or closing
     /// the client before it was able to send the leave event.
     LostConnection,
     #[doc(hidden)]
@@ -180,6 +180,10 @@ pub type PossiblyRedactedCallMemberEventContent = CallMemberEventContent;
 
 impl PossiblyRedactedStateEventContent for PossiblyRedactedCallMemberEventContent {
     type StateKey = CallMemberStateKey;
+
+    fn event_type(&self) -> StateEventType {
+        StateEventType::CallMember
+    }
 }
 
 /// The Redacted version of [`CallMemberEventContent`].
@@ -189,13 +193,14 @@ pub struct RedactedCallMemberEventContent {}
 
 impl ruma_events::content::EventContent for RedactedCallMemberEventContent {
     type EventType = StateEventType;
-    fn event_type(&self) -> Self::EventType {
-        StateEventType::CallMember
-    }
 }
 
 impl RedactedStateEventContent for RedactedCallMemberEventContent {
     type StateKey = CallMemberStateKey;
+
+    fn event_type(&self) -> StateEventType {
+        StateEventType::CallMember
+    }
 }
 
 /// Legacy content with an array of memberships. See also: [`CallMemberEventContent`]

--- a/crates/ruma-events/src/content.rs
+++ b/crates/ruma-events/src/content.rs
@@ -123,7 +123,7 @@ pub trait EventContentFromType: EventContent {
 
 impl<T> EventContentFromType for T
 where
-    T: EventContent + DeserializeOwned,
+    T: StaticEventContent + DeserializeOwned,
 {
     fn from_parts(_event_type: &str, content: &RawJsonValue) -> serde_json::Result<Self> {
         from_json_str(content.get())

--- a/crates/ruma-events/src/content.rs
+++ b/crates/ruma-events/src/content.rs
@@ -17,9 +17,6 @@ use super::{
 pub trait EventContent: Sized + Serialize {
     /// The Rust enum for the event kind's known types.
     type EventType;
-
-    /// Get the event's type, like `m.room.message`.
-    fn event_type(&self) -> Self::EventType;
 }
 
 /// Extension trait for [`Raw<T>`].
@@ -48,24 +45,41 @@ pub trait StaticEventContent: EventContent {
 pub trait GlobalAccountDataEventContent:
     EventContent<EventType = GlobalAccountDataEventType>
 {
+    /// Get the event's type, like `m.push_rules`.
+    fn event_type(&self) -> GlobalAccountDataEventType;
 }
 
 /// Content of a room-specific account-data event.
-pub trait RoomAccountDataEventContent: EventContent<EventType = RoomAccountDataEventType> {}
+pub trait RoomAccountDataEventContent: EventContent<EventType = RoomAccountDataEventType> {
+    /// Get the event's type, like `m.tag`.
+    fn event_type(&self) -> RoomAccountDataEventType;
+}
 
 /// Content of an ephemeral room event.
-pub trait EphemeralRoomEventContent: EventContent<EventType = EphemeralRoomEventType> {}
+pub trait EphemeralRoomEventContent: EventContent<EventType = EphemeralRoomEventType> {
+    /// Get the event's type, like `m.receipt`.
+    fn event_type(&self) -> EphemeralRoomEventType;
+}
 
 /// Content of a non-redacted message-like event.
-pub trait MessageLikeEventContent: EventContent<EventType = MessageLikeEventType> {}
+pub trait MessageLikeEventContent: EventContent<EventType = MessageLikeEventType> {
+    /// Get the event's type, like `m.room.message`.
+    fn event_type(&self) -> MessageLikeEventType;
+}
 
 /// Content of a redacted message-like event.
-pub trait RedactedMessageLikeEventContent: EventContent<EventType = MessageLikeEventType> {}
+pub trait RedactedMessageLikeEventContent: EventContent<EventType = MessageLikeEventType> {
+    /// Get the event's type, like `m.room.message`.
+    fn event_type(&self) -> MessageLikeEventType;
+}
 
 /// Content of a non-redacted state event.
 pub trait StateEventContent: EventContent<EventType = StateEventType> {
     /// The type of the event's `state_key` field.
     type StateKey: AsRef<str> + Clone + fmt::Debug + DeserializeOwned + Serialize;
+
+    /// Get the event's type, like `m.room.name`.
+    fn event_type(&self) -> StateEventType;
 }
 
 /// Content of a non-redacted state event with a corresponding possibly-redacted type.
@@ -81,16 +95,25 @@ pub trait StaticStateEventContent: StateEventContent {
 pub trait RedactedStateEventContent: EventContent<EventType = StateEventType> {
     /// The type of the event's `state_key` field.
     type StateKey: AsRef<str> + Clone + fmt::Debug + DeserializeOwned + Serialize;
+
+    /// Get the event's type, like `m.room.name`.
+    fn event_type(&self) -> StateEventType;
 }
 
 /// Content of a state event.
 pub trait PossiblyRedactedStateEventContent: EventContent<EventType = StateEventType> {
     /// The type of the event's `state_key` field.
     type StateKey: AsRef<str> + Clone + fmt::Debug + DeserializeOwned + Serialize;
+
+    /// Get the event's type, like `m.room.name`.
+    fn event_type(&self) -> StateEventType;
 }
 
 /// Content of a to-device event.
-pub trait ToDeviceEventContent: EventContent<EventType = ToDeviceEventType> {}
+pub trait ToDeviceEventContent: EventContent<EventType = ToDeviceEventType> {
+    /// Get the event's type, like `m.room_key`.
+    fn event_type(&self) -> ToDeviceEventType;
+}
 
 /// Event content that can be deserialized with its event type.
 pub trait EventContentFromType: EventContent {

--- a/crates/ruma-events/src/content.rs
+++ b/crates/ruma-events/src/content.rs
@@ -9,72 +9,59 @@ use super::{
     RoomAccountDataEventType, StateEventType, ToDeviceEventType,
 };
 
-/// The base trait that all event content types implement.
-///
-/// Use [`macros::EventContent`] to derive this traits. It is not meant to be implemented manually.
-///
-/// [`macros::EventContent`]: super::macros::EventContent
-pub trait EventContent: Sized + Serialize {
-    /// The Rust enum for the event kind's known types.
-    type EventType;
-}
-
 /// Extension trait for [`Raw<T>`].
 pub trait RawExt<T: EventContentFromType> {
     /// Try to deserialize the JSON as an event's content with the given event type.
-    fn deserialize_with_type(&self, event_type: T::EventType) -> serde_json::Result<T>;
+    fn deserialize_with_type(&self, event_type: &str) -> serde_json::Result<T>;
 }
 
 impl<T> RawExt<T> for Raw<T>
 where
     T: EventContentFromType,
-    T::EventType: fmt::Display,
 {
-    fn deserialize_with_type(&self, event_type: T::EventType) -> serde_json::Result<T> {
-        T::from_parts(&event_type.to_string(), self.json())
+    fn deserialize_with_type(&self, event_type: &str) -> serde_json::Result<T> {
+        T::from_parts(event_type, self.json())
     }
 }
 
 /// An event content type with a statically-known event `type` value.
-pub trait StaticEventContent: EventContent {
+pub trait StaticEventContent: Sized {
     /// The event type.
     const TYPE: &'static str;
 }
 
 /// Content of a global account-data event.
-pub trait GlobalAccountDataEventContent:
-    EventContent<EventType = GlobalAccountDataEventType>
-{
+pub trait GlobalAccountDataEventContent: Sized + Serialize {
     /// Get the event's type, like `m.push_rules`.
     fn event_type(&self) -> GlobalAccountDataEventType;
 }
 
 /// Content of a room-specific account-data event.
-pub trait RoomAccountDataEventContent: EventContent<EventType = RoomAccountDataEventType> {
+pub trait RoomAccountDataEventContent: Sized + Serialize {
     /// Get the event's type, like `m.tag`.
     fn event_type(&self) -> RoomAccountDataEventType;
 }
 
 /// Content of an ephemeral room event.
-pub trait EphemeralRoomEventContent: EventContent<EventType = EphemeralRoomEventType> {
+pub trait EphemeralRoomEventContent: Sized + Serialize {
     /// Get the event's type, like `m.receipt`.
     fn event_type(&self) -> EphemeralRoomEventType;
 }
 
 /// Content of a non-redacted message-like event.
-pub trait MessageLikeEventContent: EventContent<EventType = MessageLikeEventType> {
+pub trait MessageLikeEventContent: Sized + Serialize {
     /// Get the event's type, like `m.room.message`.
     fn event_type(&self) -> MessageLikeEventType;
 }
 
 /// Content of a redacted message-like event.
-pub trait RedactedMessageLikeEventContent: EventContent<EventType = MessageLikeEventType> {
+pub trait RedactedMessageLikeEventContent: Sized + Serialize {
     /// Get the event's type, like `m.room.message`.
     fn event_type(&self) -> MessageLikeEventType;
 }
 
 /// Content of a non-redacted state event.
-pub trait StateEventContent: EventContent<EventType = StateEventType> {
+pub trait StateEventContent: Sized + Serialize {
     /// The type of the event's `state_key` field.
     type StateKey: AsRef<str> + Clone + fmt::Debug + DeserializeOwned + Serialize;
 
@@ -92,7 +79,7 @@ pub trait StaticStateEventContent: StateEventContent {
 }
 
 /// Content of a redacted state event.
-pub trait RedactedStateEventContent: EventContent<EventType = StateEventType> {
+pub trait RedactedStateEventContent: Sized + Serialize {
     /// The type of the event's `state_key` field.
     type StateKey: AsRef<str> + Clone + fmt::Debug + DeserializeOwned + Serialize;
 
@@ -101,7 +88,7 @@ pub trait RedactedStateEventContent: EventContent<EventType = StateEventType> {
 }
 
 /// Content of a state event.
-pub trait PossiblyRedactedStateEventContent: EventContent<EventType = StateEventType> {
+pub trait PossiblyRedactedStateEventContent: Sized + Serialize {
     /// The type of the event's `state_key` field.
     type StateKey: AsRef<str> + Clone + fmt::Debug + DeserializeOwned + Serialize;
 
@@ -110,13 +97,13 @@ pub trait PossiblyRedactedStateEventContent: EventContent<EventType = StateEvent
 }
 
 /// Content of a to-device event.
-pub trait ToDeviceEventContent: EventContent<EventType = ToDeviceEventType> {
+pub trait ToDeviceEventContent: Sized + Serialize {
     /// Get the event's type, like `m.room_key`.
     fn event_type(&self) -> ToDeviceEventType;
 }
 
 /// Event content that can be deserialized with its event type.
-pub trait EventContentFromType: EventContent {
+pub trait EventContentFromType: Sized {
     /// Constructs this event content from the given event type and JSON.
     fn from_parts(event_type: &str, content: &RawJsonValue) -> serde_json::Result<Self>;
 }

--- a/crates/ruma-events/src/kinds.rs
+++ b/crates/ruma-events/src/kinds.rs
@@ -12,9 +12,9 @@ use serde::{ser::SerializeStruct, Deserialize, Deserializer, Serialize};
 use serde_json::value::RawValue as RawJsonValue;
 
 use super::{
-    AnyInitialStateEvent, EmptyStateKey, EphemeralRoomEventContent, EventContent,
-    EventContentFromType, GlobalAccountDataEventContent, MessageLikeEventContent,
-    MessageLikeEventType, MessageLikeUnsigned, PossiblyRedactedStateEventContent, RedactContent,
+    AnyInitialStateEvent, EmptyStateKey, EphemeralRoomEventContent, EventContentFromType,
+    GlobalAccountDataEventContent, MessageLikeEventContent, MessageLikeEventType,
+    MessageLikeUnsigned, PossiblyRedactedStateEventContent, RedactContent,
     RedactedMessageLikeEventContent, RedactedStateEventContent, RedactedUnsigned,
     RedactionDeHelper, RoomAccountDataEventContent, StateEventType, StaticStateEventContent,
     ToDeviceEventContent,

--- a/crates/ruma-events/src/policy/rule/room.rs
+++ b/crates/ruma-events/src/policy/rule/room.rs
@@ -25,14 +25,14 @@ pub struct PossiblyRedactedPolicyRuleRoomEventContent(pub PossiblyRedactedPolicy
 
 impl EventContent for PossiblyRedactedPolicyRuleRoomEventContent {
     type EventType = StateEventType;
-
-    fn event_type(&self) -> Self::EventType {
-        StateEventType::PolicyRuleRoom
-    }
 }
 
 impl PossiblyRedactedStateEventContent for PossiblyRedactedPolicyRuleRoomEventContent {
     type StateKey = String;
+
+    fn event_type(&self) -> StateEventType {
+        StateEventType::PolicyRuleRoom
+    }
 }
 
 #[cfg(test)]

--- a/crates/ruma-events/src/policy/rule/room.rs
+++ b/crates/ruma-events/src/policy/rule/room.rs
@@ -6,7 +6,7 @@ use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
 use super::{PolicyRuleEventContent, PossiblyRedactedPolicyRuleEventContent};
-use crate::{EventContent, PossiblyRedactedStateEventContent, StateEventType};
+use crate::{EventContent, PossiblyRedactedStateEventContent, StateEventType, StaticEventContent};
 
 /// The content of an `m.policy.rule.room` event.
 ///
@@ -33,6 +33,10 @@ impl PossiblyRedactedStateEventContent for PossiblyRedactedPolicyRuleRoomEventCo
     fn event_type(&self) -> StateEventType {
         StateEventType::PolicyRuleRoom
     }
+}
+
+impl StaticEventContent for PossiblyRedactedPolicyRuleRoomEventContent {
+    const TYPE: &'static str = PolicyRuleRoomEventContent::TYPE;
 }
 
 #[cfg(test)]

--- a/crates/ruma-events/src/policy/rule/room.rs
+++ b/crates/ruma-events/src/policy/rule/room.rs
@@ -6,7 +6,7 @@ use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
 use super::{PolicyRuleEventContent, PossiblyRedactedPolicyRuleEventContent};
-use crate::{EventContent, PossiblyRedactedStateEventContent, StateEventType, StaticEventContent};
+use crate::{PossiblyRedactedStateEventContent, StateEventType, StaticEventContent};
 
 /// The content of an `m.policy.rule.room` event.
 ///
@@ -22,10 +22,6 @@ pub struct PolicyRuleRoomEventContent(pub PolicyRuleEventContent);
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[allow(clippy::exhaustive_structs)]
 pub struct PossiblyRedactedPolicyRuleRoomEventContent(pub PossiblyRedactedPolicyRuleEventContent);
-
-impl EventContent for PossiblyRedactedPolicyRuleRoomEventContent {
-    type EventType = StateEventType;
-}
 
 impl PossiblyRedactedStateEventContent for PossiblyRedactedPolicyRuleRoomEventContent {
     type StateKey = String;

--- a/crates/ruma-events/src/policy/rule/server.rs
+++ b/crates/ruma-events/src/policy/rule/server.rs
@@ -25,12 +25,12 @@ pub struct PossiblyRedactedPolicyRuleServerEventContent(pub PossiblyRedactedPoli
 
 impl EventContent for PossiblyRedactedPolicyRuleServerEventContent {
     type EventType = StateEventType;
-
-    fn event_type(&self) -> Self::EventType {
-        StateEventType::PolicyRuleServer
-    }
 }
 
 impl PossiblyRedactedStateEventContent for PossiblyRedactedPolicyRuleServerEventContent {
     type StateKey = String;
+
+    fn event_type(&self) -> StateEventType {
+        StateEventType::PolicyRuleServer
+    }
 }

--- a/crates/ruma-events/src/policy/rule/server.rs
+++ b/crates/ruma-events/src/policy/rule/server.rs
@@ -6,7 +6,7 @@ use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
 use super::{PolicyRuleEventContent, PossiblyRedactedPolicyRuleEventContent};
-use crate::{EventContent, PossiblyRedactedStateEventContent, StateEventType, StaticEventContent};
+use crate::{PossiblyRedactedStateEventContent, StateEventType, StaticEventContent};
 
 /// The content of an `m.policy.rule.server` event.
 ///
@@ -22,10 +22,6 @@ pub struct PolicyRuleServerEventContent(pub PolicyRuleEventContent);
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[allow(clippy::exhaustive_structs)]
 pub struct PossiblyRedactedPolicyRuleServerEventContent(pub PossiblyRedactedPolicyRuleEventContent);
-
-impl EventContent for PossiblyRedactedPolicyRuleServerEventContent {
-    type EventType = StateEventType;
-}
 
 impl PossiblyRedactedStateEventContent for PossiblyRedactedPolicyRuleServerEventContent {
     type StateKey = String;

--- a/crates/ruma-events/src/policy/rule/server.rs
+++ b/crates/ruma-events/src/policy/rule/server.rs
@@ -6,7 +6,7 @@ use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
 use super::{PolicyRuleEventContent, PossiblyRedactedPolicyRuleEventContent};
-use crate::{EventContent, PossiblyRedactedStateEventContent, StateEventType};
+use crate::{EventContent, PossiblyRedactedStateEventContent, StateEventType, StaticEventContent};
 
 /// The content of an `m.policy.rule.server` event.
 ///
@@ -33,4 +33,8 @@ impl PossiblyRedactedStateEventContent for PossiblyRedactedPolicyRuleServerEvent
     fn event_type(&self) -> StateEventType {
         StateEventType::PolicyRuleServer
     }
+}
+
+impl StaticEventContent for PossiblyRedactedPolicyRuleServerEventContent {
+    const TYPE: &'static str = PolicyRuleServerEventContent::TYPE;
 }

--- a/crates/ruma-events/src/policy/rule/user.rs
+++ b/crates/ruma-events/src/policy/rule/user.rs
@@ -25,12 +25,12 @@ pub struct PossiblyRedactedPolicyRuleUserEventContent(pub PossiblyRedactedPolicy
 
 impl EventContent for PossiblyRedactedPolicyRuleUserEventContent {
     type EventType = StateEventType;
-
-    fn event_type(&self) -> Self::EventType {
-        StateEventType::PolicyRuleUser
-    }
 }
 
 impl PossiblyRedactedStateEventContent for PossiblyRedactedPolicyRuleUserEventContent {
     type StateKey = String;
+
+    fn event_type(&self) -> StateEventType {
+        StateEventType::PolicyRuleUser
+    }
 }

--- a/crates/ruma-events/src/policy/rule/user.rs
+++ b/crates/ruma-events/src/policy/rule/user.rs
@@ -6,7 +6,7 @@ use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
 use super::{PolicyRuleEventContent, PossiblyRedactedPolicyRuleEventContent};
-use crate::{EventContent, PossiblyRedactedStateEventContent, StateEventType};
+use crate::{EventContent, PossiblyRedactedStateEventContent, StateEventType, StaticEventContent};
 
 /// The content of an `m.policy.rule.user` event.
 ///
@@ -33,4 +33,8 @@ impl PossiblyRedactedStateEventContent for PossiblyRedactedPolicyRuleUserEventCo
     fn event_type(&self) -> StateEventType {
         StateEventType::PolicyRuleUser
     }
+}
+
+impl StaticEventContent for PossiblyRedactedPolicyRuleUserEventContent {
+    const TYPE: &'static str = PolicyRuleUserEventContent::TYPE;
 }

--- a/crates/ruma-events/src/policy/rule/user.rs
+++ b/crates/ruma-events/src/policy/rule/user.rs
@@ -6,7 +6,7 @@ use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
 use super::{PolicyRuleEventContent, PossiblyRedactedPolicyRuleEventContent};
-use crate::{EventContent, PossiblyRedactedStateEventContent, StateEventType, StaticEventContent};
+use crate::{PossiblyRedactedStateEventContent, StateEventType, StaticEventContent};
 
 /// The content of an `m.policy.rule.user` event.
 ///
@@ -22,10 +22,6 @@ pub struct PolicyRuleUserEventContent(pub PolicyRuleEventContent);
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[allow(clippy::exhaustive_structs)]
 pub struct PossiblyRedactedPolicyRuleUserEventContent(pub PossiblyRedactedPolicyRuleEventContent);
-
-impl EventContent for PossiblyRedactedPolicyRuleUserEventContent {
-    type EventType = StateEventType;
-}
 
 impl PossiblyRedactedStateEventContent for PossiblyRedactedPolicyRuleUserEventContent {
     type StateKey = String;

--- a/crates/ruma-events/src/poll/unstable_start.rs
+++ b/crates/ruma-events/src/poll/unstable_start.rs
@@ -20,9 +20,8 @@ use super::{
     PollResponseData,
 };
 use crate::{
-    relation::Replacement, room::message::RelationWithoutReplacement, EventContent,
-    MessageLikeEventContent, MessageLikeEventType, RedactContent, RedactedMessageLikeEventContent,
-    StaticEventContent,
+    relation::Replacement, room::message::RelationWithoutReplacement, MessageLikeEventContent,
+    MessageLikeEventType, RedactContent, RedactedMessageLikeEventContent, StaticEventContent,
 };
 
 /// The payload for an unstable poll start event.
@@ -138,10 +137,6 @@ impl NewUnstablePollStartEventContent {
     }
 }
 
-impl EventContent for NewUnstablePollStartEventContent {
-    type EventType = MessageLikeEventType;
-}
-
 impl StaticEventContent for NewUnstablePollStartEventContent {
     const TYPE: &'static str = "org.matrix.msc3381.poll.start";
 }
@@ -225,10 +220,6 @@ impl ReplacementUnstablePollStartEventContent {
     }
 }
 
-impl EventContent for ReplacementUnstablePollStartEventContent {
-    type EventType = MessageLikeEventType;
-}
-
 impl StaticEventContent for ReplacementUnstablePollStartEventContent {
     const TYPE: &'static str = "org.matrix.msc3381.poll.start";
 }
@@ -249,10 +240,6 @@ impl RedactedUnstablePollStartEventContent {
     pub fn new() -> RedactedUnstablePollStartEventContent {
         Self::default()
     }
-}
-
-impl EventContent for RedactedUnstablePollStartEventContent {
-    type EventType = MessageLikeEventType;
 }
 
 impl StaticEventContent for RedactedUnstablePollStartEventContent {

--- a/crates/ruma-events/src/poll/unstable_start.rs
+++ b/crates/ruma-events/src/poll/unstable_start.rs
@@ -140,17 +140,17 @@ impl NewUnstablePollStartEventContent {
 
 impl EventContent for NewUnstablePollStartEventContent {
     type EventType = MessageLikeEventType;
-
-    fn event_type(&self) -> Self::EventType {
-        MessageLikeEventType::UnstablePollStart
-    }
 }
 
 impl StaticEventContent for NewUnstablePollStartEventContent {
     const TYPE: &'static str = "org.matrix.msc3381.poll.start";
 }
 
-impl MessageLikeEventContent for NewUnstablePollStartEventContent {}
+impl MessageLikeEventContent for NewUnstablePollStartEventContent {
+    fn event_type(&self) -> MessageLikeEventType {
+        MessageLikeEventType::UnstablePollStart
+    }
+}
 
 /// Form of [`NewUnstablePollStartEventContent`] without relation.
 ///
@@ -227,17 +227,17 @@ impl ReplacementUnstablePollStartEventContent {
 
 impl EventContent for ReplacementUnstablePollStartEventContent {
     type EventType = MessageLikeEventType;
-
-    fn event_type(&self) -> Self::EventType {
-        MessageLikeEventType::UnstablePollStart
-    }
 }
 
 impl StaticEventContent for ReplacementUnstablePollStartEventContent {
     const TYPE: &'static str = "org.matrix.msc3381.poll.start";
 }
 
-impl MessageLikeEventContent for ReplacementUnstablePollStartEventContent {}
+impl MessageLikeEventContent for ReplacementUnstablePollStartEventContent {
+    fn event_type(&self) -> MessageLikeEventType {
+        MessageLikeEventType::UnstablePollStart
+    }
+}
 
 /// Redacted form of UnstablePollStartEventContent
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
@@ -253,17 +253,17 @@ impl RedactedUnstablePollStartEventContent {
 
 impl EventContent for RedactedUnstablePollStartEventContent {
     type EventType = MessageLikeEventType;
-
-    fn event_type(&self) -> Self::EventType {
-        MessageLikeEventType::UnstablePollStart
-    }
 }
 
 impl StaticEventContent for RedactedUnstablePollStartEventContent {
     const TYPE: &'static str = "org.matrix.msc3381.poll.start";
 }
 
-impl RedactedMessageLikeEventContent for RedactedUnstablePollStartEventContent {}
+impl RedactedMessageLikeEventContent for RedactedUnstablePollStartEventContent {
+    fn event_type(&self) -> MessageLikeEventType {
+        MessageLikeEventType::UnstablePollStart
+    }
+}
 
 /// An unstable block for poll start content.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/ruma-events/src/room/aliases.rs
+++ b/crates/ruma-events/src/room/aliases.rs
@@ -4,9 +4,7 @@ use ruma_common::{room_version_rules::RedactionRules, OwnedRoomAliasId, OwnedSer
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    EventContent, RedactContent, RedactedStateEventContent, StateEventType, StaticEventContent,
-};
+use crate::{RedactContent, RedactedStateEventContent, StateEventType, StaticEventContent};
 
 /// The content of an `m.room.aliases` event.
 ///
@@ -61,10 +59,6 @@ impl RedactedRoomAliasesEventContent {
     pub fn new_v6() -> Self {
         Self::default()
     }
-}
-
-impl EventContent for RedactedRoomAliasesEventContent {
-    type EventType = StateEventType;
 }
 
 impl RedactedStateEventContent for RedactedRoomAliasesEventContent {

--- a/crates/ruma-events/src/room/aliases.rs
+++ b/crates/ruma-events/src/room/aliases.rs
@@ -63,12 +63,12 @@ impl RedactedRoomAliasesEventContent {
 
 impl EventContent for RedactedRoomAliasesEventContent {
     type EventType = StateEventType;
-
-    fn event_type(&self) -> StateEventType {
-        StateEventType::RoomAliases
-    }
 }
 
 impl RedactedStateEventContent for RedactedRoomAliasesEventContent {
     type StateKey = OwnedServerName;
+
+    fn event_type(&self) -> StateEventType {
+        StateEventType::RoomAliases
+    }
 }

--- a/crates/ruma-events/src/room/aliases.rs
+++ b/crates/ruma-events/src/room/aliases.rs
@@ -4,7 +4,9 @@ use ruma_common::{room_version_rules::RedactionRules, OwnedRoomAliasId, OwnedSer
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
-use crate::{EventContent, RedactContent, RedactedStateEventContent, StateEventType};
+use crate::{
+    EventContent, RedactContent, RedactedStateEventContent, StateEventType, StaticEventContent,
+};
 
 /// The content of an `m.room.aliases` event.
 ///
@@ -71,4 +73,8 @@ impl RedactedStateEventContent for RedactedRoomAliasesEventContent {
     fn event_type(&self) -> StateEventType {
         StateEventType::RoomAliases
     }
+}
+
+impl StaticEventContent for RedactedRoomAliasesEventContent {
+    const TYPE: &'static str = RoomAliasesEventContent::TYPE;
 }

--- a/crates/ruma-events/src/room/create.rs
+++ b/crates/ruma-events/src/room/create.rs
@@ -9,7 +9,7 @@ use ruma_common::{
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
-use crate::{EmptyStateKey, RedactContent, RedactedStateEventContent};
+use crate::{EmptyStateKey, RedactContent, RedactedStateEventContent, StateEventType};
 
 /// The content of an `m.room.create` event.
 ///
@@ -137,6 +137,10 @@ pub type RedactedRoomCreateEventContent = RoomCreateEventContent;
 
 impl RedactedStateEventContent for RedactedRoomCreateEventContent {
     type StateKey = EmptyStateKey;
+
+    fn event_type(&self) -> StateEventType {
+        StateEventType::RoomCreate
+    }
 }
 
 #[cfg(test)]

--- a/crates/ruma-events/src/room/member.rs
+++ b/crates/ruma-events/src/room/member.rs
@@ -179,6 +179,10 @@ pub type PossiblyRedactedRoomMemberEventContent = RoomMemberEventContent;
 
 impl PossiblyRedactedStateEventContent for RoomMemberEventContent {
     type StateKey = OwnedUserId;
+
+    fn event_type(&self) -> StateEventType {
+        StateEventType::RoomMember
+    }
 }
 
 /// A member event that has been redacted.
@@ -241,14 +245,14 @@ impl RedactedRoomMemberEventContent {
 
 impl EventContent for RedactedRoomMemberEventContent {
     type EventType = StateEventType;
-
-    fn event_type(&self) -> StateEventType {
-        StateEventType::RoomMember
-    }
 }
 
 impl RedactedStateEventContent for RedactedRoomMemberEventContent {
     type StateKey = OwnedUserId;
+
+    fn event_type(&self) -> StateEventType {
+        StateEventType::RoomMember
+    }
 }
 
 impl RoomMemberEvent {

--- a/crates/ruma-events/src/room/member.rs
+++ b/crates/ruma-events/src/room/member.rs
@@ -12,8 +12,8 @@ use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    AnyStrippedStateEvent, BundledStateRelations, EventContent, PossiblyRedactedStateEventContent,
-    PrivOwnedStr, RedactContent, RedactedStateEventContent, StateEventType, StaticEventContent,
+    AnyStrippedStateEvent, BundledStateRelations, PossiblyRedactedStateEventContent, PrivOwnedStr,
+    RedactContent, RedactedStateEventContent, StateEventType, StaticEventContent,
 };
 
 mod change;
@@ -241,10 +241,6 @@ impl RedactedRoomMemberEventContent {
     ) -> MembershipChange<'a> {
         membership_change(self.details(), prev_details, sender, state_key)
     }
-}
-
-impl EventContent for RedactedRoomMemberEventContent {
-    type EventType = StateEventType;
 }
 
 impl RedactedStateEventContent for RedactedRoomMemberEventContent {

--- a/crates/ruma-events/src/room/member.rs
+++ b/crates/ruma-events/src/room/member.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     AnyStrippedStateEvent, BundledStateRelations, EventContent, PossiblyRedactedStateEventContent,
-    PrivOwnedStr, RedactContent, RedactedStateEventContent, StateEventType,
+    PrivOwnedStr, RedactContent, RedactedStateEventContent, StateEventType, StaticEventContent,
 };
 
 mod change;
@@ -253,6 +253,10 @@ impl RedactedStateEventContent for RedactedRoomMemberEventContent {
     fn event_type(&self) -> StateEventType {
         StateEventType::RoomMember
     }
+}
+
+impl StaticEventContent for RedactedRoomMemberEventContent {
+    const TYPE: &'static str = RoomMemberEventContent::TYPE;
 }
 
 impl RoomMemberEvent {

--- a/crates/ruma-events/src/room/power_levels.rs
+++ b/crates/ruma-events/src/room/power_levels.rs
@@ -287,10 +287,6 @@ pub struct RedactedRoomPowerLevelsEventContent {
 
 impl EventContent for RedactedRoomPowerLevelsEventContent {
     type EventType = StateEventType;
-
-    fn event_type(&self) -> Self::EventType {
-        StateEventType::RoomPowerLevels
-    }
 }
 
 impl StaticEventContent for RedactedRoomPowerLevelsEventContent {
@@ -299,6 +295,10 @@ impl StaticEventContent for RedactedRoomPowerLevelsEventContent {
 
 impl RedactedStateEventContent for RedactedRoomPowerLevelsEventContent {
     type StateKey = EmptyStateKey;
+
+    fn event_type(&self) -> StateEventType {
+        StateEventType::RoomPowerLevels
+    }
 }
 
 /// The effective power levels of a room.

--- a/crates/ruma-events/src/room/power_levels.rs
+++ b/crates/ruma-events/src/room/power_levels.rs
@@ -15,8 +15,8 @@ use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    EmptyStateKey, EventContent, MessageLikeEventType, RedactContent, RedactedStateEventContent,
-    StateEventType, StaticEventContent, TimelineEventType,
+    EmptyStateKey, MessageLikeEventType, RedactContent, RedactedStateEventContent, StateEventType,
+    StaticEventContent, TimelineEventType,
 };
 
 /// The content of an `m.room.power_levels` event.
@@ -283,10 +283,6 @@ pub struct RedactedRoomPowerLevelsEventContent {
         deserialize_with = "ruma_common::serde::deserialize_v1_powerlevel"
     )]
     pub users_default: Int,
-}
-
-impl EventContent for RedactedRoomPowerLevelsEventContent {
-    type EventType = StateEventType;
 }
 
 impl StaticEventContent for RedactedRoomPowerLevelsEventContent {

--- a/crates/ruma-events/src/room/redaction.rs
+++ b/crates/ruma-events/src/room/redaction.rs
@@ -15,8 +15,8 @@ use serde::{Deserialize, Serialize};
 use tracing::error;
 
 use crate::{
-    BundledMessageLikeRelations, EventContent, MessageLikeEventType, RedactContent,
-    RedactedMessageLikeEventContent, RedactedUnsigned, StaticEventContent,
+    BundledMessageLikeRelations, EventContent, MessageLikeEventContent, MessageLikeEventType,
+    RedactContent, RedactedMessageLikeEventContent, RedactedUnsigned, StaticEventContent,
 };
 
 mod event_serde;
@@ -233,17 +233,17 @@ pub struct RedactedRoomRedactionEventContent {
 
 impl EventContent for RedactedRoomRedactionEventContent {
     type EventType = MessageLikeEventType;
-
-    fn event_type(&self) -> Self::EventType {
-        MessageLikeEventType::RoomRedaction
-    }
 }
 
 impl StaticEventContent for RedactedRoomRedactionEventContent {
     const TYPE: &'static str = "m.room.redaction";
 }
 
-impl RedactedMessageLikeEventContent for RedactedRoomRedactionEventContent {}
+impl RedactedMessageLikeEventContent for RedactedRoomRedactionEventContent {
+    fn event_type(&self) -> MessageLikeEventType {
+        MessageLikeEventType::RoomRedaction
+    }
+}
 
 impl RoomRedactionEvent {
     /// Returns the `type` of this event.

--- a/crates/ruma-events/src/room/redaction.rs
+++ b/crates/ruma-events/src/room/redaction.rs
@@ -15,8 +15,8 @@ use serde::{Deserialize, Serialize};
 use tracing::error;
 
 use crate::{
-    BundledMessageLikeRelations, EventContent, MessageLikeEventContent, MessageLikeEventType,
-    RedactContent, RedactedMessageLikeEventContent, RedactedUnsigned, StaticEventContent,
+    BundledMessageLikeRelations, MessageLikeEventContent, MessageLikeEventType, RedactContent,
+    RedactedMessageLikeEventContent, RedactedUnsigned, StaticEventContent,
 };
 
 mod event_serde;
@@ -229,10 +229,6 @@ pub struct RedactedRoomRedactionEventContent {
     /// This field is required starting from room version 11.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub redacts: Option<OwnedEventId>,
-}
-
-impl EventContent for RedactedRoomRedactionEventContent {
-    type EventType = MessageLikeEventType;
 }
 
 impl StaticEventContent for RedactedRoomRedactionEventContent {

--- a/crates/ruma-events/src/room/tombstone.rs
+++ b/crates/ruma-events/src/room/tombstone.rs
@@ -6,10 +6,7 @@ use ruma_common::OwnedRoomId;
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    EmptyStateKey, EventContent, PossiblyRedactedStateEventContent, StateEventType,
-    StaticEventContent,
-};
+use crate::{EmptyStateKey, PossiblyRedactedStateEventContent, StateEventType, StaticEventContent};
 
 /// The content of an `m.room.tombstone` event.
 ///
@@ -53,10 +50,6 @@ pub struct PossiblyRedactedRoomTombstoneEventContent {
 
     /// The new room the client should be visiting.
     pub replacement_room: Option<OwnedRoomId>,
-}
-
-impl EventContent for PossiblyRedactedRoomTombstoneEventContent {
-    type EventType = StateEventType;
 }
 
 impl PossiblyRedactedStateEventContent for PossiblyRedactedRoomTombstoneEventContent {

--- a/crates/ruma-events/src/room/tombstone.rs
+++ b/crates/ruma-events/src/room/tombstone.rs
@@ -57,14 +57,14 @@ pub struct PossiblyRedactedRoomTombstoneEventContent {
 
 impl EventContent for PossiblyRedactedRoomTombstoneEventContent {
     type EventType = StateEventType;
-
-    fn event_type(&self) -> Self::EventType {
-        StateEventType::RoomTombstone
-    }
 }
 
 impl PossiblyRedactedStateEventContent for PossiblyRedactedRoomTombstoneEventContent {
     type StateKey = EmptyStateKey;
+
+    fn event_type(&self) -> StateEventType {
+        StateEventType::RoomTombstone
+    }
 }
 
 impl StaticEventContent for PossiblyRedactedRoomTombstoneEventContent {

--- a/crates/ruma-events/tests/it/event_enums.rs
+++ b/crates/ruma-events/tests/it/event_enums.rs
@@ -64,7 +64,7 @@ fn text_msgtype_plain_text_deserialization_as_any() {
     let raw_event: Raw<AnyMessageLikeEventContent> =
         Raw::from_json_string(serialized.to_string()).unwrap();
 
-    let event = raw_event.deserialize_with_type("m.room.message".into()).unwrap();
+    let event = raw_event.deserialize_with_type("m.room.message").unwrap();
 
     assert_matches!(event, AnyMessageLikeEventContent::RoomMessage(content));
     assert_eq!(content.body(), "Hello world!");
@@ -83,7 +83,7 @@ fn secret_storage_key_deserialization_as_any() {
     let raw_event: Raw<AnyGlobalAccountDataEventContent> =
         Raw::from_json_string(serialized.to_string()).unwrap();
 
-    let event = raw_event.deserialize_with_type("m.secret_storage.key.test".into()).unwrap();
+    let event = raw_event.deserialize_with_type("m.secret_storage.key.test").unwrap();
 
     assert_matches!(event, AnyGlobalAccountDataEventContent::SecretStorageKey(content));
 

--- a/crates/ruma-events/tests/it/room_message.rs
+++ b/crates/ruma-events/tests/it/room_message.rs
@@ -21,7 +21,7 @@ use ruma_events::{
         },
         EncryptedFileInit, JsonWebKeyInit, MediaSource,
     },
-    Mentions, MessageLikeEventContent, MessageLikeUnsigned, RawExt,
+    Mentions, MessageLikeUnsigned,
 };
 use serde_json::{
     from_value as from_json_value, json, to_value as to_json_value, Value as JsonValue,
@@ -371,8 +371,7 @@ fn reply_thread_serialization_roundtrip() {
 
     let as_raw = Raw::new(&reply_as_thread_fallback).unwrap();
 
-    let reply_as_thread_fallback =
-        as_raw.deserialize_with_type(reply_as_thread_fallback.event_type()).unwrap();
+    let reply_as_thread_fallback = as_raw.deserialize().unwrap();
 
     let relation = reply_as_thread_fallback.relates_to.unwrap();
     assert_matches!(relation, Relation::Thread(thread_info));

--- a/crates/ruma-events/tests/it/room_message.rs
+++ b/crates/ruma-events/tests/it/room_message.rs
@@ -21,7 +21,7 @@ use ruma_events::{
         },
         EncryptedFileInit, JsonWebKeyInit, MediaSource,
     },
-    EventContent, Mentions, MessageLikeUnsigned, RawExt,
+    Mentions, MessageLikeEventContent, MessageLikeUnsigned, RawExt,
 };
 use serde_json::{
     from_value as from_json_value, json, to_value as to_json_value, Value as JsonValue,

--- a/crates/ruma-events/tests/it/ui/10-content-wildcard.rs
+++ b/crates/ruma-events/tests/it/ui/10-content-wildcard.rs
@@ -11,7 +11,7 @@ pub struct MacroTestContent {
 }
 
 fn main() {
-    use ruma_events::EventContent;
+    use ruma_events::GlobalAccountDataEventContent;
 
     assert_eq!(
         MacroTestContent { frag: "foo".to_owned() }.event_type().to_string(),

--- a/crates/ruma-macros/src/events/event_content.rs
+++ b/crates/ruma-macros/src/events/event_content.rs
@@ -846,8 +846,6 @@ fn generate_event_content_impl<'a>(
     let serde = quote! { #ruma_events::exports::serde };
     let serde_json = quote! { #ruma_events::exports::serde_json };
 
-    let event_type_enum = event_kind.to_event_type_enum();
-
     let event_content_kind_trait_impl = generate_event_content_kind_trait_impl(
         ident,
         event_type,
@@ -939,11 +937,6 @@ fn generate_event_content_impl<'a>(
     });
 
     Ok(quote! {
-        #[automatically_derived]
-        impl #ruma_events::EventContent for #ident {
-            type EventType = #ruma_events::#event_type_enum;
-        }
-
         #event_content_from_type_impl
         #event_content_kind_trait_impl
         #static_state_event_content_impl

--- a/crates/ruma-macros/src/events/event_enum.rs
+++ b/crates/ruma-macros/src/events/event_enum.rs
@@ -410,11 +410,6 @@ fn expand_content_enum(
         }
 
         #[automatically_derived]
-        impl #ruma_events::EventContent for #ident {
-            type EventType = #ruma_events::#event_type_enum;
-        }
-
-        #[automatically_derived]
         impl #ruma_events::EventContentFromType for #ident {
             fn from_parts(event_type: &str, json: &#serde_json::value::RawValue) -> serde_json::Result<Self> {
                 match event_type {

--- a/crates/ruma-macros/src/events/event_parse.rs
+++ b/crates/ruma-macros/src/events/event_parse.rs
@@ -11,6 +11,8 @@ use syn::{
     Attribute, Ident, LitStr, Path, Token,
 };
 
+use super::event_content::EventKindContentVariation;
+
 /// Custom keywords for the `event_enum!` macro
 mod kw {
     syn::custom_keyword!(kind);
@@ -150,6 +152,11 @@ impl EventKind {
     /// `AnyFull[kind]EventContent`
     pub fn to_full_content_enum(self) -> Ident {
         format_ident!("AnyFull{}Content", self)
+    }
+
+    /// `[variation][kind]Content`
+    pub fn to_content_kind_trait(self, variation: EventKindContentVariation) -> Ident {
+        format_ident!("{variation}{self}Content")
     }
 }
 


### PR DESCRIPTION
Prerequisite for #2066.

This can be reviewed commit by commit.