### PR TITLE
events: Add support for specifying two account data kinds for the `EventContent` macro

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -40,6 +40,9 @@ Improvements:
 - Add support for the `m.room_key.withheld` to-device event, which was introduced in Matrix 1.1.
 - Remove the `pdu` module and the corresponding `unstable-pdu` cargo feature. As far as we know, it
   was not used anywhere outside of the tests of ruma-state-res.
+- The `EventContent` and `event_enum!` macros support declaring the same type for both global and
+  room account data. The syntax to use for the `EventContent` macro is `kind = GlobalAccountData +
+  RoomAccountData`.
    
 # 0.30.3
 

--- a/crates/ruma-events/tests/it/event_content.rs
+++ b/crates/ruma-events/tests/it/event_content.rs
@@ -8,4 +8,6 @@ fn ui() {
     t.pass("tests/it/ui/11-content-without-relation-sanity-check.rs");
     t.compile_fail("tests/it/ui/12-no-relates_to.rs");
     t.pass("tests/it/ui/13-private-event-content-type.rs");
+    t.pass("tests/it/ui/14-enum-content-double-kind.rs");
+    t.compile_fail("tests/it/ui/15-content-invalid-double-kind.rs");
 }

--- a/crates/ruma-events/tests/it/ui/14-enum-content-double-kind.rs
+++ b/crates/ruma-events/tests/it/ui/14-enum-content-double-kind.rs
@@ -1,0 +1,54 @@
+#![allow(unexpected_cfgs)]
+
+use ruma_macros::event_enum;
+
+mod event {
+    use ruma_macros::EventContent;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
+    #[ruma_event(type = "m.macro.test", kind = RoomAccountData + GlobalAccountData)]
+    pub struct MacroTestEventContent {
+        pub url: String,
+    }
+}
+
+event_enum! {
+    /// Any global account data event.
+    enum GlobalAccountData {
+        "m.macro.test" => event,
+    }
+
+    /// Any room account data event.
+    enum RoomAccountData {
+        "m.macro.test" => event,
+    }
+}
+
+fn main() {
+    let content = event::MacroTestEventContent { url: "http://localhost".to_owned() };
+
+    // Both traits are implemented for the content.
+    assert_eq!(
+        ruma_events::GlobalAccountDataEventContent::event_type(&content).to_string(),
+        "m.macro.test"
+    );
+    assert_eq!(
+        ruma_events::RoomAccountDataEventContent::event_type(&content).to_string(),
+        "m.macro.test"
+    );
+
+    // Both event type aliases are created, and they work with the enum variants.
+    let _ = AnyGlobalAccountDataEvent::MacroTest(event::GlobalMacroTestEvent {
+        content: content.clone(),
+    });
+    let _ = AnyRoomAccountDataEvent::MacroTest(event::RoomMacroTestEvent { content });
+
+    // Both event type enums variants are created.
+    assert_eq!(GlobalAccountDataEventType::MacroTest.to_string(), "m.macro.test");
+    assert_eq!(RoomAccountDataEventType::MacroTest.to_string(), "m.macro.test");
+}
+
+#[doc(hidden)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PrivOwnedStr(Box<str>);

--- a/crates/ruma-events/tests/it/ui/15-content-invalid-double-kind.rs
+++ b/crates/ruma-events/tests/it/ui/15-content-invalid-double-kind.rs
@@ -1,0 +1,12 @@
+#![allow(unexpected_cfgs)]
+
+use ruma_macros::EventContent;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
+#[ruma_event(type = "m.macro.test", kind = MessageLike + GlobalAccountData)]
+pub struct MacroTestEventContent {
+    pub url: String,
+}
+
+fn main() {}

--- a/crates/ruma-events/tests/it/ui/15-content-invalid-double-kind.stderr
+++ b/crates/ruma-events/tests/it/ui/15-content-invalid-double-kind.stderr
@@ -1,0 +1,7 @@
+error: only account data can have two kinds
+ --> tests/it/ui/15-content-invalid-double-kind.rs:6:48
+  |
+6 | #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
+  |                                                ^^^^^^^^^^^^
+  |
+  = note: this error originates in the derive macro `EventContent` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/ruma-macros/src/events/event_enum.rs
+++ b/crates/ruma-macros/src/events/event_enum.rs
@@ -851,7 +851,13 @@ impl EventEnumEntry {
             assert_eq!(var, EventEnumVariation::None);
             format_ident!("ToDevice{ident}Event")
         } else {
-            format_ident!("{}{ident}Event", var)
+            let type_prefix = match kind {
+                EventKind::GlobalAccountData if self.both_account_data => "Global",
+                EventKind::RoomAccountData if self.both_account_data => "Room",
+                _ => "",
+            };
+
+            format_ident!("{}{type_prefix}{ident}Event", var)
         };
         quote! { #path::#event_name }
     }

--- a/crates/ruma-macros/src/events/event_type.rs
+++ b/crates/ruma-macros/src/events/event_type.rs
@@ -1,6 +1,6 @@
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
-use syn::{parse_quote, Ident, LitStr};
+use syn::Ident;
 
 use super::event_parse::{EventEnumEntry, EventEnumInput, EventKind};
 
@@ -32,15 +32,6 @@ pub fn expand_event_type_enum(
             EventKind::RoomRedaction | EventKind::Decrypted | EventKind::HierarchySpaceChild => {}
         }
     }
-    let presence = vec![EventEnumEntry {
-        attrs: vec![],
-        aliases: vec![],
-        ev_type: LitStr::new("m.presence", Span::call_site()),
-        ev_path: parse_quote! { #ruma_events::presence },
-        ident: None,
-    }];
-    let mut all = input.enums.iter().map(|e| &e.events).collect::<Vec<_>>();
-    all.push(&presence);
 
     let mut res = TokenStream::new();
 


### PR DESCRIPTION
Uses the syntax `kind = GlobalAccountData + RoomAccountData`.

This also requires changes to the `event_enum!` macro because we now generate two event type aliases for one event content: `Global*Event` and `Room*Event`.

Closes #2066.