### PR TITLE
signatures: Add function to check PDU size limits

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -74,6 +74,7 @@ Improvements:
   version defined in MSC2870.
 - Add `OutgoingRequest::is_supported()` and `VersionHistory::is_supported()` to
   be able to know if a server advertises support for an endpoint.
+- Re-export `ID_MAX_BYTES` from `ruma-identifiers-validation`.
 
 # 0.15.2
 

--- a/crates/ruma-common/src/identifiers.rs
+++ b/crates/ruma-common/src/identifiers.rs
@@ -10,7 +10,7 @@ pub use ruma_identifiers_validation::{
         Error as IdParseError, MatrixIdError, MatrixToError, MatrixUriError, MxcUriError,
         VoipVersionIdError,
     },
-    KeyName,
+    KeyName, ID_MAX_BYTES,
 };
 use serde::de::{self, Deserializer, Unexpected};
 

--- a/crates/ruma-signatures/CHANGELOG.md
+++ b/crates/ruma-signatures/CHANGELOG.md
@@ -22,7 +22,9 @@ Breaking changes:
 Improvements:
 
 - Add `verify_canonical_json_bytes()` as a low-level function to check the
-  signature of canonical JSON bytes
+  signature of canonical JSON bytes.
+- Add `check_pdu_sizes()` to check the size limits of a PDU according to the
+  Matrix specification.
 
 # 0.17.1
 

--- a/crates/ruma-signatures/src/error.rs
+++ b/crates/ruma-signatures/src/error.rs
@@ -29,6 +29,10 @@ pub enum Error {
     /// PDU was too large
     #[error("PDU is larger than maximum of 65535 bytes")]
     PduSize,
+
+    /// The size of the string value of the field was too large.
+    #[error("String value of field `{0}` is larger than maximum of 255 bytes")]
+    StringFieldSize(String),
 }
 
 impl From<RedactionError> for Error {

--- a/crates/ruma-signatures/src/lib.rs
+++ b/crates/ruma-signatures/src/lib.rs
@@ -53,8 +53,8 @@ pub use ruma_common::{IdParseError, SigningKeyAlgorithm};
 pub use self::{
     error::{Error, JsonError, ParseError, VerificationError},
     functions::{
-        canonical_json, content_hash, hash_and_sign_event, reference_hash, sign_json,
-        verify_canonical_json_bytes, verify_event, verify_json,
+        canonical_json, check_pdu_sizes, content_hash, hash_and_sign_event, reference_hash,
+        sign_json, verify_canonical_json_bytes, verify_event, verify_json,
     },
     keys::{Ed25519KeyPair, KeyPair, PublicKeyMap, PublicKeySet},
     signatures::Signature,


### PR DESCRIPTION
According to the [size limits](https://spec.matrix.org/latest/client-server-api/#size-limits) of the specification.

I made this in `ruma-signatures` instead of `ruma-state-res` because we need the canonical JSON to check the PDU size.

Note that here Synapse checks the sizes differently depending on the room version, for backwards compatibility with itself, when it checked string sizes as codepoints instead of bytes: https://github.com/element-hq/synapse/blob/9c5d08fff8d66a7cc0e2ecfeeb783f933a778c2f/synapse/event_auth.py#L395. I am not sure whether homeserver implementations would also be interested in this behavior.

Closes #164.