### PR TITLE
Move to target_family = "wasm" instead of target_arch = "wasm32"

### DIFF
--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -73,7 +73,7 @@ uuid = { version = "1.0.0", optional = true, features = ["v4"] }
 web-time = { workspace = true }
 wildmatch = "2.0.0"
 
-[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+[target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
 js-sys = { version = "0.3", optional = true }
 
 [dev-dependencies]

--- a/crates/ruma-common/src/time.rs
+++ b/crates/ruma-common/src/time.rs
@@ -22,10 +22,10 @@ impl MilliSecondsSinceUnixEpoch {
 
     /// The current system time in milliseconds since the unix epoch.
     pub fn now() -> Self {
-        #[cfg(not(all(target_arch = "wasm32", target_os = "unknown", feature = "js")))]
+        #[cfg(not(all(target_family = "wasm", target_os = "unknown", feature = "js")))]
         return Self::from_system_time(SystemTime::now()).expect("date out of range");
 
-        #[cfg(all(target_arch = "wasm32", target_os = "unknown", feature = "js"))]
+        #[cfg(all(target_family = "wasm", target_os = "unknown", feature = "js"))]
         return Self(f64_to_uint(js_sys::Date::now()));
     }
 
@@ -89,10 +89,10 @@ impl SecondsSinceUnixEpoch {
 
     /// The current system-time as seconds since the unix epoch.
     pub fn now() -> Self {
-        #[cfg(not(all(target_arch = "wasm32", target_os = "unknown", feature = "js")))]
+        #[cfg(not(all(target_family = "wasm", target_os = "unknown", feature = "js")))]
         return Self::from_system_time(SystemTime::now()).expect("date out of range");
 
-        #[cfg(all(target_arch = "wasm32", target_os = "unknown", feature = "js"))]
+        #[cfg(all(target_family = "wasm", target_os = "unknown", feature = "js"))]
         return Self(f64_to_uint(js_sys::Date::now() / 1000.0));
     }
 
@@ -132,7 +132,7 @@ impl fmt::Debug for SecondsSinceUnixEpoch {
     }
 }
 
-#[cfg(all(target_arch = "wasm32", target_os = "unknown", feature = "js"))]
+#[cfg(all(target_family = "wasm", target_os = "unknown", feature = "js"))]
 fn f64_to_uint(val: f64) -> UInt {
     // UInt::MAX milliseconds is ~285 616 years, we do not account for that
     // (or for dates before the unix epoch which would have to be negative)


### PR DESCRIPTION
Adjust cfg guards to use `target_family = "wasm"` instead of the more limiting `target_arch = "wasm32"`

This mirrors recent changes made in the matrix-rust-sdk, and should be functionally equivalent until wasm64 becomes official.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
