### PR TITLE
signatures: Perform more event format checks in check_pdu_size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1943,6 +1943,7 @@ dependencies = [
  "base64",
  "ed25519-dalek",
  "insta",
+ "js_int",
  "pkcs8",
  "rand",
  "ruma-common",

--- a/crates/ruma-common/src/room_version_rules.rs
+++ b/crates/ruma-common/src/room_version_rules.rs
@@ -35,6 +35,9 @@ pub struct RoomVersionRules {
 
     /// The tweaks for verifying signatures.
     pub signatures: SignaturesRules,
+
+    /// The tweaks for verifying the event format.
+    pub event_format: EventFormatRules,
 }
 
 impl RoomVersionRules {
@@ -49,6 +52,7 @@ impl RoomVersionRules {
         authorization: AuthorizationRules::V1,
         redaction: RedactionRules::V1,
         signatures: SignaturesRules::V1,
+        event_format: EventFormatRules::V1,
     };
 
     /// Rules for [room version 2].
@@ -63,6 +67,7 @@ impl RoomVersionRules {
         event_id_format: EventIdFormatVersion::V2,
         authorization: AuthorizationRules::V3,
         signatures: SignaturesRules::V3,
+        event_format: EventFormatRules::V3,
         ..Self::V2
     };
 
@@ -441,4 +446,23 @@ impl SignaturesRules {
 
     /// Signatures verification rules with tweaks introduced in room version 8.
     pub const V8: Self = Self { check_join_authorised_via_users_server: true, ..Self::V3 };
+}
+
+/// The tweaks for verifying the event format for a room version.
+///
+/// This type can be constructed from one of its constants (like [`EventFormatRules::V1`]), or by
+/// constructing a [`RoomVersionRules`] first and using the `event_format` field.
+#[derive(Debug, Clone)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+pub struct EventFormatRules {
+    /// Whether the `event_id` field is required, disabled since room version 3.
+    pub require_event_id: bool,
+}
+
+impl EventFormatRules {
+    /// Event format rules as introduced in room version 1.
+    pub const V1: Self = Self { require_event_id: true };
+
+    /// Event format rules with tweaks introduced in room version 3.
+    pub const V3: Self = Self { require_event_id: false };
 }

--- a/crates/ruma-signatures/CHANGELOG.md
+++ b/crates/ruma-signatures/CHANGELOG.md
@@ -23,8 +23,8 @@ Improvements:
 
 - Add `verify_canonical_json_bytes()` as a low-level function to check the
   signature of canonical JSON bytes.
-- Add `check_pdu_sizes()` to check the size limits of a PDU according to the
-  Matrix specification.
+- Add `check_pdu_format()` to check the event format and size limits of a PDU
+  according to the Matrix specification.
 
 # 0.17.1
 

--- a/crates/ruma-signatures/Cargo.toml
+++ b/crates/ruma-signatures/Cargo.toml
@@ -19,6 +19,7 @@ ring-compat = ["dep:subslice"]
 [dependencies]
 base64 = { workspace = true }
 ed25519-dalek = { version = "2.0.0", features = ["pkcs8", "rand_core"] }
+js_int = { workspace = true }
 pkcs8 = { version = "0.10.0", features = ["alloc"] }
 rand = { workspace = true }
 ruma-common = { workspace = true, features = ["canonical-json"] }

--- a/crates/ruma-signatures/src/error.rs
+++ b/crates/ruma-signatures/src/error.rs
@@ -33,6 +33,19 @@ pub enum Error {
     /// The size of the string value of the field was too large.
     #[error("String value of field `{0}` is larger than maximum of 255 bytes")]
     StringFieldSize(String),
+
+    /// The size of the string value of the field was too large.
+    #[error("Array length of field `{target}` is larger than maximum of {max}")]
+    ArrayFieldSize {
+        /// The name of the array field.
+        target: String,
+        /// The maximum length allowed.
+        max: usize,
+    },
+
+    /// The value of the `depth` field is negative.
+    #[error("Integer value of field `depth` is negative")]
+    InvalidDepth,
 }
 
 impl From<RedactionError> for Error {

--- a/crates/ruma-signatures/src/functions.rs
+++ b/crates/ruma-signatures/src/functions.rs
@@ -7,9 +7,12 @@ use std::{
 };
 
 use base64::{alphabet, Engine};
+use js_int::int;
 use ruma_common::{
     canonical_json::{redact, JsonType},
-    room_version_rules::{EventIdFormatVersion, RedactionRules, RoomVersionRules, SignaturesRules},
+    room_version_rules::{
+        EventFormatRules, EventIdFormatVersion, RedactionRules, RoomVersionRules, SignaturesRules,
+    },
     serde::{base64::Standard, Base64},
     AnyKeyName, CanonicalJsonObject, CanonicalJsonValue, OwnedEventId, OwnedServerName,
     SigningKeyAlgorithm, SigningKeyId, UserId, ID_MAX_BYTES,
@@ -26,7 +29,20 @@ use crate::{
     Error, JsonError, ParseError, VerificationError,
 };
 
+/// The [maximum size allowed] for a PDU.
+///
+/// [maximum size allowed]: https://spec.matrix.org/latest/client-server-api/#size-limits
 const MAX_PDU_BYTES: usize = 65_535;
+
+/// The [maximum length allowed] for the `prev_events` array of a PDU.
+///
+/// [maximum length allowed]: https://spec.matrix.org/latest/rooms/v1/#event-format
+const MAX_PREV_EVENTS_LENGTH: usize = 20;
+
+/// The [maximum length allowed] for the `auth_events` array of a PDU.
+///
+/// [maximum length allowed]: https://spec.matrix.org/latest/rooms/v1/#event-format
+const MAX_AUTH_EVENTS_LENGTH: usize = 10;
 
 /// The fields to remove from a JSON object when converting JSON into the "canonical" form.
 static CANONICAL_JSON_FIELDS_TO_REMOVE: &[&str] = &["signatures", "unsigned"];
@@ -814,19 +830,33 @@ fn is_invite_via_third_party_id(object: &CanonicalJsonObject) -> Result<bool, Er
     }
 }
 
-/// Check that the given canonicalized PDU respects the [size limits] from the Matrix specification.
+/// Check that the given canonicalized PDU respects the event format of the room version and the
+/// [size limits] from the Matrix specification.
+///
+/// This checks the following and enforces their size limits:
+///
+/// * Full PDU
+/// * `sender`
+/// * `room_id`
+/// * `type`
+/// * `event_id`
+/// * `state_key`
+/// * `prev_events`
+/// * `auth_events`
+/// * `depth`
 ///
 /// Returns an error if the JSON is malformed or if the PDU doesn't pass the checks.
 ///
 /// [size limits]: https://spec.matrix.org/latest/client-server-api/#size-limits
-pub fn check_pdu_sizes(pdu: &CanonicalJsonObject) -> Result<(), Error> {
-    // The PDU size check must occur on the full PDU with signatures.
+pub fn check_pdu_format(pdu: &CanonicalJsonObject, rules: &EventFormatRules) -> Result<(), Error> {
+    // Check the PDU size, it must occur on the full PDU with signatures.
     let json = to_json_string(&pdu).map_err(|e| Error::Json(e.into()))?;
     if json.len() > MAX_PDU_BYTES {
         return Err(Error::PduSize);
     }
 
-    for field in &["sender", "room_id", "type", "event_id"] {
+    // Check the presence, type and length of the `sender`, `room_id` and `type` fields.
+    for field in &["sender", "room_id", "type"] {
         let value = extract_string_field(pdu, field)?
             .ok_or_else(|| JsonError::field_missing_from_object(*field))?;
 
@@ -835,16 +865,51 @@ pub fn check_pdu_sizes(pdu: &CanonicalJsonObject) -> Result<(), Error> {
         }
     }
 
+    // Check the presence, type and length of the `event_id` field.
+    let event_id = extract_string_field(pdu, "event_id")?;
+
+    if rules.require_event_id && event_id.is_none() {
+        return Err(JsonError::field_missing_from_object("event_id"));
+    }
+
+    if event_id.is_some_and(|event_id| event_id.len() > ID_MAX_BYTES) {
+        return Err(Error::StringFieldSize(("event_id").to_owned()));
+    }
+
+    // Check the type and length of the `state_key` field.
     if extract_string_field(pdu, "state_key")?
         .is_some_and(|state_key| state_key.len() > ID_MAX_BYTES)
     {
         return Err(Error::StringFieldSize("state_key".to_owned()));
     }
 
+    // Check the presence, type and length of the `auth_events` and `prev_events` fields.
+    for (field, max_value) in
+        &[("auth_events", MAX_AUTH_EVENTS_LENGTH), ("prev_events", MAX_PREV_EVENTS_LENGTH)]
+    {
+        let value = extract_array_field(pdu, field)?
+            .ok_or_else(|| JsonError::field_missing_from_object(*field))?;
+
+        if value.len() > *max_value {
+            return Err(Error::ArrayFieldSize { target: (*field).to_owned(), max: *max_value });
+        }
+    }
+
+    // Check the presence, type and value of the `depth` field.
+    match pdu.get("depth") {
+        Some(CanonicalJsonValue::Integer(value)) => {
+            if *value < int!(0) {
+                return Err(Error::InvalidDepth);
+            }
+        }
+        Some(_) => return Err(JsonError::not_of_type("depth", JsonType::Integer)),
+        None => return Err(JsonError::field_missing_from_object("depth")),
+    }
+
     Ok(())
 }
 
-/// Extract the field with the given name from the given canonical JSON object.
+/// Extract the string field with the given name from the given canonical JSON object.
 ///
 /// Returns `Ok(Some(value))` if the field is present and a string, `Ok(None)` if the fields is
 /// missing and an error if the field is present and not a string.
@@ -857,6 +922,21 @@ fn extract_string_field<'a>(
         Some(_) => {
             Err(JsonError::NotOfType { target: field.to_owned(), of_type: JsonType::String })
         }
+        None => Ok(None),
+    }
+}
+
+/// Extract the array field with the given name from the given canonical JSON object.
+///
+/// Returns `Ok(Some(value))` if the field is present and an array, `Ok(None)` if the fields is
+/// missing and an error if the field is present and not a array.
+fn extract_array_field<'a>(
+    object: &'a CanonicalJsonObject,
+    field: &'a str,
+) -> Result<Option<&'a [CanonicalJsonValue]>, JsonError> {
+    match object.get(field) {
+        Some(CanonicalJsonValue::Array(value)) => Ok(Some(value)),
+        Some(_) => Err(JsonError::NotOfType { target: field.to_owned(), of_type: JsonType::Array }),
         None => Ok(None),
     }
 }

--- a/crates/ruma-signatures/src/lib.rs
+++ b/crates/ruma-signatures/src/lib.rs
@@ -53,7 +53,7 @@ pub use ruma_common::{IdParseError, SigningKeyAlgorithm};
 pub use self::{
     error::{Error, JsonError, ParseError, VerificationError},
     functions::{
-        canonical_json, check_pdu_sizes, content_hash, hash_and_sign_event, reference_hash,
+        canonical_json, check_pdu_format, content_hash, hash_and_sign_event, reference_hash,
         sign_json, verify_canonical_json_bytes, verify_event, verify_json,
     },
     keys::{Ed25519KeyPair, KeyPair, PublicKeyMap, PublicKeySet},


### PR DESCRIPTION
And rename it to `check_pdu_format`.

It now checks the length of `prev_events` and `auth_events`, as well as that `depth` is a positive integer. It also fixes the check on `event_id` which is not in PDUs since room v3.
