### PR TITLE
state-res: Move check_pdu_format from ruma-signatures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1943,7 +1943,6 @@ dependencies = [
  "base64",
  "ed25519-dalek",
  "insta",
- "js_int",
  "pkcs8",
  "rand",
  "ruma-common",

--- a/crates/ruma-signatures/CHANGELOG.md
+++ b/crates/ruma-signatures/CHANGELOG.md
@@ -23,8 +23,6 @@ Improvements:
 
 - Add `verify_canonical_json_bytes()` as a low-level function to check the
   signature of canonical JSON bytes.
-- Add `check_pdu_format()` to check the event format and size limits of a PDU
-  according to the Matrix specification.
 
 # 0.17.1
 

--- a/crates/ruma-signatures/Cargo.toml
+++ b/crates/ruma-signatures/Cargo.toml
@@ -19,7 +19,6 @@ ring-compat = ["dep:subslice"]
 [dependencies]
 base64 = { workspace = true }
 ed25519-dalek = { version = "2.0.0", features = ["pkcs8", "rand_core"] }
-js_int = { workspace = true }
 pkcs8 = { version = "0.10.0", features = ["alloc"] }
 rand = { workspace = true }
 ruma-common = { workspace = true, features = ["canonical-json"] }

--- a/crates/ruma-signatures/src/error.rs
+++ b/crates/ruma-signatures/src/error.rs
@@ -29,23 +29,6 @@ pub enum Error {
     /// PDU was too large
     #[error("PDU is larger than maximum of 65535 bytes")]
     PduSize,
-
-    /// The size of the string value of the field was too large.
-    #[error("String value of field `{0}` is larger than maximum of 255 bytes")]
-    StringFieldSize(String),
-
-    /// The size of the string value of the field was too large.
-    #[error("Array length of field `{target}` is larger than maximum of {max}")]
-    ArrayFieldSize {
-        /// The name of the array field.
-        target: String,
-        /// The maximum length allowed.
-        max: usize,
-    },
-
-    /// The value of the `depth` field is negative.
-    #[error("Integer value of field `depth` is negative")]
-    InvalidDepth,
 }
 
 impl From<RedactionError> for Error {

--- a/crates/ruma-signatures/src/lib.rs
+++ b/crates/ruma-signatures/src/lib.rs
@@ -53,8 +53,8 @@ pub use ruma_common::{IdParseError, SigningKeyAlgorithm};
 pub use self::{
     error::{Error, JsonError, ParseError, VerificationError},
     functions::{
-        canonical_json, check_pdu_format, content_hash, hash_and_sign_event, reference_hash,
-        sign_json, verify_canonical_json_bytes, verify_event, verify_json,
+        canonical_json, content_hash, hash_and_sign_event, reference_hash, sign_json,
+        verify_canonical_json_bytes, verify_event, verify_json,
     },
     keys::{Ed25519KeyPair, KeyPair, PublicKeyMap, PublicKeySet},
     signatures::Signature,

--- a/crates/ruma-state-res/CHANGELOG.md
+++ b/crates/ruma-state-res/CHANGELOG.md
@@ -55,6 +55,8 @@ Improvements:
   - `RoomPowerLevelsEvent` for `m.room.power_levels` events
   - `RoomJoinRulesEvent` for `m.room.join_rules` events
   - `RoomThirdPartyInviteEvent` for `m.room.third_party_invite` events
+- Add `check_pdu_format()` to check the event format and size limits of a PDU
+  according to the Matrix specification.
 
 # 0.13.0
 

--- a/crates/ruma-state-res/src/event_auth.rs
+++ b/crates/ruma-state-res/src/event_auth.rs
@@ -24,17 +24,6 @@ use crate::{
     Event, StateEventType, TimelineEventType,
 };
 
-// TODO: We need methods for all checks performed on receipt of a PDU, plus the following that are
-// not listed:
-//
-// - check that the event respects the size limits,
-//
-// References:
-// - https://spec.matrix.org/latest/server-server-api/#checks-performed-on-receipt-of-a-pdu
-// - https://spec.matrix.org/latest/client-server-api/#size-limits
-// - https://github.com/element-hq/synapse/blob/9c5d08fff8d66a7cc0e2ecfeeb783f933a778c2f/synapse/event_auth.py
-// - https://github.com/matrix-org/matrix-spec/issues/365
-
 /// Get the list of [relevant auth events] required to authorize the event of the given type.
 ///
 /// Returns a list of `(event_type, state_key)` tuples.

--- a/crates/ruma-state-res/src/event_format.rs
+++ b/crates/ruma-state-res/src/event_format.rs
@@ -1,0 +1,156 @@
+use js_int::int;
+use ruma_common::{
+    room_version_rules::EventFormatRules, CanonicalJsonObject, CanonicalJsonValue, ID_MAX_BYTES,
+};
+use serde_json::to_string as to_json_string;
+
+/// The [maximum size allowed] for a PDU.
+///
+/// [maximum size allowed]: https://spec.matrix.org/latest/client-server-api/#size-limits
+const MAX_PDU_BYTES: usize = 65_535;
+
+/// The [maximum length allowed] for the `prev_events` array of a PDU.
+///
+/// [maximum length allowed]: https://spec.matrix.org/latest/rooms/v1/#event-format
+const MAX_PREV_EVENTS_LENGTH: usize = 20;
+
+/// The [maximum length allowed] for the `auth_events` array of a PDU.
+///
+/// [maximum length allowed]: https://spec.matrix.org/latest/rooms/v1/#event-format
+const MAX_AUTH_EVENTS_LENGTH: usize = 10;
+
+/// Check that the given canonicalized PDU respects the event format of the room version and the
+/// [size limits] from the Matrix specification.
+///
+/// This is part of the [checks performed on receipt of a PDU].
+///
+/// This checks the following and enforces their size limits:
+///
+/// * Full PDU
+/// * `sender`
+/// * `room_id`
+/// * `type`
+/// * `event_id`
+/// * `state_key`
+/// * `prev_events`
+/// * `auth_events`
+/// * `depth`
+///
+/// Returns an `Err(_)` if the JSON is malformed or if the PDU doesn't pass the checks.
+///
+/// [size limits]: https://spec.matrix.org/latest/client-server-api/#size-limits
+/// [checks performed on receipt of a PDU]: https://spec.matrix.org/latest/server-server-api/#checks-performed-on-receipt-of-a-pdu
+pub fn check_pdu_format(pdu: &CanonicalJsonObject, rules: &EventFormatRules) -> Result<(), String> {
+    // Check the PDU size, it must occur on the full PDU with signatures.
+    let json =
+        to_json_string(&pdu).map_err(|e| format!("Failed to serialize canonical JSON: {e}"))?;
+    if json.len() > MAX_PDU_BYTES {
+        return Err("PDU is larger than maximum of {MAX_PDU_BYTES} bytes".to_owned());
+    }
+
+    // Check the presence, type and length of the `sender`, `room_id` and `type` fields.
+    for field in &["sender", "room_id", "type"] {
+        let value = extract_string_field(pdu, field)?
+            .ok_or_else(|| format!("missing `{field}` field in PDU"))?;
+
+        if value.len() > ID_MAX_BYTES {
+            return Err(format!(
+                "invalid `{field}` field in PDU: \
+                 string length is larger than maximum of {ID_MAX_BYTES} bytes"
+            ));
+        }
+    }
+
+    // Check the presence, type and length of the `event_id` field.
+    let event_id = extract_string_field(pdu, "event_id")?;
+
+    if rules.require_event_id && event_id.is_none() {
+        return Err("missing `event_id` field in PDU".to_owned());
+    }
+
+    if event_id.is_some_and(|event_id| event_id.len() > ID_MAX_BYTES) {
+        return Err(format!(
+            "invalid `event_id` field in PDU: \
+             string length is larger than maximum of {ID_MAX_BYTES} bytes"
+        ));
+    }
+
+    // Check the type and length of the `state_key` field.
+    if extract_string_field(pdu, "state_key")?
+        .is_some_and(|state_key| state_key.len() > ID_MAX_BYTES)
+    {
+        return Err(format!(
+            "invalid `state_key` field in PDU: \
+             string length is larger than maximum of {ID_MAX_BYTES} bytes"
+        ));
+    }
+
+    // Check the presence, type and length of the `auth_events` and `prev_events` fields.
+    for (field, max_value) in
+        &[("auth_events", MAX_AUTH_EVENTS_LENGTH), ("prev_events", MAX_PREV_EVENTS_LENGTH)]
+    {
+        let value = extract_array_field(pdu, field)?
+            .ok_or_else(|| format!("missing `{field}` field in PDU"))?;
+
+        if value.len() > *max_value {
+            return Err(format!(
+                "invalid `{field}` field in PDU: \
+                 array length is larger than maximum of {max_value}"
+            ));
+        }
+    }
+
+    // Check the presence, type and value of the `depth` field.
+    match pdu.get("depth") {
+        Some(CanonicalJsonValue::Integer(value)) => {
+            if *value < int!(0) {
+                return Err("invalid `depth` field in PDU: cannot be a negative integer".to_owned());
+            }
+        }
+        Some(value) => {
+            return Err(format!(
+                "unexpected format of `depth` field in PDU: \
+                 expected integer, got {value:?}"
+            ))
+        }
+        None => return Err("missing `depth` field in PDU".to_owned()),
+    }
+
+    Ok(())
+}
+
+/// Extract the string field with the given name from the given canonical JSON object.
+///
+/// Returns `Ok(Some(value))` if the field is present and a string, `Ok(None)` if the fields is
+/// missing and an error if the field is present and not a string.
+fn extract_string_field<'a>(
+    object: &'a CanonicalJsonObject,
+    field: &'a str,
+) -> Result<Option<&'a String>, String> {
+    match object.get(field) {
+        Some(CanonicalJsonValue::String(value)) => Ok(Some(value)),
+        Some(value) => Err(format!(
+            "unexpected format of `{field}` field in PDU: \
+             expected string, got {value:?}"
+        )),
+        None => Ok(None),
+    }
+}
+
+/// Extract the array field with the given name from the given canonical JSON object.
+///
+/// Returns `Ok(Some(value))` if the field is present and an array, `Ok(None)` if the fields is
+/// missing and an error if the field is present and not a array.
+fn extract_array_field<'a>(
+    object: &'a CanonicalJsonObject,
+    field: &'a str,
+) -> Result<Option<&'a [CanonicalJsonValue]>, String> {
+    match object.get(field) {
+        Some(CanonicalJsonValue::Array(value)) => Ok(Some(value)),
+        Some(value) => Err(format!(
+            "unexpected format of `{field}` field in PDU: \
+             expected array, got {value:?}"
+        )),
+        None => Ok(None),
+    }
+}

--- a/crates/ruma-state-res/src/lib.rs
+++ b/crates/ruma-state-res/src/lib.rs
@@ -15,6 +15,7 @@ use tracing::{debug, info, instrument, trace, warn};
 
 mod error;
 mod event_auth;
+mod event_format;
 pub mod events;
 #[cfg(test)]
 mod test_utils;
@@ -28,6 +29,7 @@ pub use self::{
     event_auth::{
         auth_types_for_event, check_state_dependent_auth_rules, check_state_independent_auth_rules,
     },
+    event_format::check_pdu_format,
     events::Event,
 };
 


### PR DESCRIPTION
It actually doesn't make sense for it to be in ruma-signatures, it has no relation with signatures checks.

The initial idea was to use a crate where ruma-common's canonical-json feature was already in use, and that's the case for ruma-state-res, which is a much better location for this function.

I went with a string type for errors for simplicity, like the authorization rules checks. I don't think there is much value to copy the error types from ruma-signatures.