### PR TITLE
events: Declare `MediaPreviewConfigEventContent` as room account data too

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -43,6 +43,11 @@ Improvements:
 - The `EventContent` and `event_enum!` macros support declaring the same type for both global and
   room account data. The syntax to use for the `EventContent` macro is `kind = GlobalAccountData +
   RoomAccountData`.
+- The `(Unstable)MediaPreviewConfigEventContent` types are also declared as room account data: they
+  implement `RoomAccountDataEventContent` and have variants in the `AnyRoomAccountDataEvent*` and
+  `RoomAccountDataEventType` enums. The `MediaPreviewConfigEvent` and
+  `UnstableMediaPreviewConfigEvent` type aliases are renamed to `GlobalMediaPreviewConfigEvent` and
+  `GlobalUnstableMediaPreviewConfigEvent`, respectively.
    
 # 0.30.3
 

--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -48,6 +48,14 @@ Improvements:
   `RoomAccountDataEventType` enums. The `MediaPreviewConfigEvent` and
   `UnstableMediaPreviewConfigEvent` type aliases are renamed to `GlobalMediaPreviewConfigEvent` and
   `GlobalUnstableMediaPreviewConfigEvent`, respectively.
+- The fields of `MediaPreviewConfigEventContent` are now optional. It allows to differentiate
+  whether the room account data is unset or explicitly set to the default value. This allows in
+  turn to know whether the room account data should override the global account data or not.
+  - `MediaPreviewConfigEventContent::new()` doesn't take any arguments and creates an empty config.
+    The fields can be set with a builder pattern, e.g.
+    `MediaPreviewConfigEventContent::new().media_previews(Some(MediaPreviews::Off))`.
+  - `MediaPreviewConfigEventContent::merge_global_and_room_config()` can be used to get the current
+    config for a room.
    
 # 0.30.3
 

--- a/crates/ruma-events/src/enums.rs
+++ b/crates/ruma-events/src/enums.rs
@@ -52,6 +52,11 @@ event_enum! {
         #[cfg(feature = "unstable-msc2867")]
         #[ruma_enum(ident = UnstableMarkedUnread)]
         "com.famedly.marked_unread" => super::marked_unread,
+        #[cfg(feature = "unstable-msc4278")]
+        "m.media_preview_config" => super::media_preview_config,
+        #[cfg(feature = "unstable-msc4278")]
+        #[ruma_enum(ident = UnstableMediaPreviewConfig)]
+        "io.element.msc4278.media_preview_config" => super::media_preview_config,
     }
 
     /// Any ephemeral room event.

--- a/crates/ruma-events/src/media_preview_config.rs
+++ b/crates/ruma-events/src/media_preview_config.rs
@@ -10,7 +10,7 @@ use crate::{macros::EventContent, PrivOwnedStr};
 /// The content of an `m.media_preview_config` event.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
-#[ruma_event(type = "m.media_preview_config", kind = GlobalAccountData)]
+#[ruma_event(type = "m.media_preview_config", kind = GlobalAccountData + RoomAccountData)]
 pub struct MediaPreviewConfigEventContent {
     /// The media previews configuration.
     #[serde(default)]
@@ -25,7 +25,7 @@ pub struct MediaPreviewConfigEventContent {
 /// the unstable version of `m.media_preview_config` in global account data.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
-#[ruma_event(type = "io.element.msc4278.media_preview_config", kind = GlobalAccountData)]
+#[ruma_event(type = "io.element.msc4278.media_preview_config", kind = GlobalAccountData + RoomAccountData)]
 #[serde(transparent)]
 pub struct UnstableMediaPreviewConfigEventContent(pub MediaPreviewConfigEventContent);
 

--- a/crates/ruma-events/src/media_preview_config.rs
+++ b/crates/ruma-events/src/media_preview_config.rs
@@ -13,12 +13,12 @@ use crate::{macros::EventContent, PrivOwnedStr};
 #[ruma_event(type = "m.media_preview_config", kind = GlobalAccountData + RoomAccountData)]
 pub struct MediaPreviewConfigEventContent {
     /// The media previews configuration.
-    #[serde(default)]
-    pub media_previews: MediaPreviews,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub media_previews: Option<MediaPreviews>,
 
     /// The invite avatars configuration.
-    #[serde(default)]
-    pub invite_avatars: InviteAvatars,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub invite_avatars: Option<InviteAvatars>,
 }
 
 /// The content of an `io.element.msc4278.media_preview_config` event,
@@ -65,9 +65,32 @@ pub enum InviteAvatars {
 }
 
 impl MediaPreviewConfigEventContent {
-    /// Create a new [`MediaPreviewConfigEventContent`] with the given values.
-    pub fn new(media_previews: MediaPreviews, invite_avatars: InviteAvatars) -> Self {
-        Self { media_previews, invite_avatars }
+    /// Create a new empty [`MediaPreviewConfigEventContent`].
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the value of the setting for the media previews.
+    pub fn media_previews(mut self, media_previews: Option<MediaPreviews>) -> Self {
+        self.media_previews = media_previews;
+        self
+    }
+
+    /// Set the value of the setting for the media previews.
+    pub fn invite_avatars(mut self, invite_avatars: Option<InviteAvatars>) -> Self {
+        self.invite_avatars = invite_avatars;
+        self
+    }
+
+    /// Merge the config from the global account data with the config from the room account data.
+    ///
+    /// The values that are set in the room account data take precedence over the values in the
+    /// global account data.
+    pub fn merge_global_and_room_config(global_config: Self, room_config: Self) -> Self {
+        Self {
+            media_previews: room_config.media_previews.or(global_config.media_previews),
+            invite_avatars: room_config.invite_avatars.or(global_config.invite_avatars),
+        }
     }
 }
 
@@ -118,8 +141,11 @@ mod tests {
             unstable_media_preview_config_data,
             AnyGlobalAccountDataEvent::UnstableMediaPreviewConfig(unstable_media_preview_config)
         );
-        assert_eq!(unstable_media_preview_config.content.media_previews, MediaPreviews::Private);
-        assert_eq!(unstable_media_preview_config.content.invite_avatars, InviteAvatars::Off);
+        assert_eq!(
+            unstable_media_preview_config.content.media_previews,
+            Some(MediaPreviews::Private)
+        );
+        assert_eq!(unstable_media_preview_config.content.invite_avatars, Some(InviteAvatars::Off));
 
         let raw_media_preview_config = json!({
             "type": "m.media_preview_config",
@@ -134,14 +160,16 @@ mod tests {
             media_preview_config_data,
             AnyGlobalAccountDataEvent::MediaPreviewConfig(media_preview_config)
         );
-        assert_eq!(media_preview_config.content.media_previews, MediaPreviews::On);
-        assert_eq!(media_preview_config.content.invite_avatars, InviteAvatars::On);
+        assert_eq!(media_preview_config.content.media_previews, Some(MediaPreviews::On));
+        assert_eq!(media_preview_config.content.invite_avatars, Some(InviteAvatars::On));
     }
 
     #[test]
     fn serialize() {
         let unstable_media_preview_config = UnstableMediaPreviewConfigEventContent(
-            MediaPreviewConfigEventContent::new(MediaPreviews::Off, InviteAvatars::On),
+            MediaPreviewConfigEventContent::new()
+                .media_previews(Some(MediaPreviews::Off))
+                .invite_avatars(Some(InviteAvatars::On)),
         );
         let unstable_media_preview_config_account_data =
             GlobalAccountDataEvent { content: unstable_media_preview_config };
@@ -156,8 +184,9 @@ mod tests {
             })
         );
 
-        let media_preview_config =
-            MediaPreviewConfigEventContent::new(MediaPreviews::On, InviteAvatars::Off);
+        let media_preview_config = MediaPreviewConfigEventContent::new()
+            .media_previews(Some(MediaPreviews::On))
+            .invite_avatars(Some(InviteAvatars::Off));
         let media_preview_config_account_data =
             GlobalAccountDataEvent { content: media_preview_config };
         assert_eq!(


### PR DESCRIPTION
Based on #2092.

Requires to set the fields as optional to know whether a room setting overrides a global setting or not.
