### PR TITLE
events: add convenience function to get the room version from the create event

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -40,6 +40,8 @@ Improvements:
 - Add support for the `m.room_key.withheld` to-device event, which was introduced in Matrix 1.1.
 - Remove the `pdu` module and the corresponding `unstable-pdu` cargo feature. As far as we know, it
   was not used anywhere outside of the tests of ruma-state-res.
+- Add convenience function to get the room version from both `RoomCreateEvent` and
+  `SyncRoomCreateEvent`.
    
 # 0.30.3
 

--- a/crates/ruma-events/src/room/create.rs
+++ b/crates/ruma-events/src/room/create.rs
@@ -102,6 +102,26 @@ impl RedactContent for RoomCreateEventContent {
     }
 }
 
+impl RoomCreateEvent {
+    /// Obtain the room version, regardless of whether this event is redacted.
+    pub fn room_version(&self) -> &RoomVersionId {
+        match self {
+            Self::Original(ev) => &ev.content.room_version,
+            Self::Redacted(ev) => &ev.content.room_version,
+        }
+    }
+}
+
+impl SyncRoomCreateEvent {
+    /// Obtain the room version, regardless of whether this event is redacted.
+    pub fn room_version(&self) -> &RoomVersionId {
+        match self {
+            Self::Original(ev) => &ev.content.room_version,
+            Self::Redacted(ev) => &ev.content.room_version,
+        }
+    }
+}
+
 /// A reference to an old room replaced during a room version upgrade.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]


### PR DESCRIPTION
Like #1068

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
