### PR TITLE
events: Use `EphemeralRoom` name for event kind consistently

### DIFF
--- a/crates/ruma-macros/src/events/event_enum.rs
+++ b/crates/ruma-macros/src/events/event_enum.rs
@@ -26,7 +26,7 @@ type EventKindFn = fn(EventKind, EventEnumVariation) -> bool;
 const EVENT_FIELDS: &[(&str, EventKindFn)] = &[
     ("origin_server_ts", is_non_stripped_room_event),
     ("room_id", |kind, var| {
-        matches!(kind, EventKind::MessageLike | EventKind::State | EventKind::Ephemeral)
+        matches!(kind, EventKind::MessageLike | EventKind::State | EventKind::EphemeralRoom)
             && matches!(var, EventEnumVariation::None)
     }),
     ("event_id", is_non_stripped_room_event),
@@ -76,7 +76,7 @@ pub fn expand_event_enums(input: &EventEnumDecl) -> syn::Result<TokenStream> {
         );
     }
 
-    if matches!(kind, EventKind::Ephemeral) {
+    if matches!(kind, EventKind::EphemeralRoom) {
         res.extend(
             expand_event_enum(kind, V::Sync, events, docs, attrs, variants, ruma_events)
                 .unwrap_or_else(syn::Error::into_compile_error),

--- a/crates/ruma-macros/src/events/event_parse.rs
+++ b/crates/ruma-macros/src/events/event_parse.rs
@@ -70,7 +70,7 @@ impl EventKindVariation {
 pub enum EventKind {
     GlobalAccountData,
     RoomAccountData,
-    Ephemeral,
+    EphemeralRoom,
     MessageLike,
     State,
     ToDevice,
@@ -84,7 +84,7 @@ impl fmt::Display for EventKind {
         match self {
             EventKind::GlobalAccountData => write!(f, "GlobalAccountDataEvent"),
             EventKind::RoomAccountData => write!(f, "RoomAccountDataEvent"),
-            EventKind::Ephemeral => write!(f, "EphemeralRoomEvent"),
+            EventKind::EphemeralRoom => write!(f, "EphemeralRoomEvent"),
             EventKind::MessageLike => write!(f, "MessageLikeEvent"),
             EventKind::State => write!(f, "StateEvent"),
             EventKind::ToDevice => write!(f, "ToDeviceEvent"),
@@ -121,7 +121,7 @@ impl EventKind {
 
         match (self, var) {
             (_, V::None)
-            | (Self::Ephemeral | Self::MessageLike | Self::State, V::Sync)
+            | (Self::EphemeralRoom | Self::MessageLike | Self::State, V::Sync)
             | (
                 Self::MessageLike | Self::RoomRedaction | Self::State,
                 V::Original | V::OriginalSync | V::Redacted | V::RedactedSync,
@@ -164,7 +164,7 @@ impl Parse for EventKind {
         Ok(match ident.to_string().as_str() {
             "GlobalAccountData" => EventKind::GlobalAccountData,
             "RoomAccountData" => EventKind::RoomAccountData,
-            "EphemeralRoom" => EventKind::Ephemeral,
+            "EphemeralRoom" => EventKind::EphemeralRoom,
             "MessageLike" => EventKind::MessageLike,
             "State" => EventKind::State,
             "ToDevice" => EventKind::ToDevice,
@@ -189,8 +189,8 @@ pub fn to_kind_variation(ident: &Ident) -> Option<(EventKind, EventKindVariation
     match ident_str.as_str() {
         "GlobalAccountDataEvent" => Some((EventKind::GlobalAccountData, EventKindVariation::None)),
         "RoomAccountDataEvent" => Some((EventKind::RoomAccountData, EventKindVariation::None)),
-        "EphemeralRoomEvent" => Some((EventKind::Ephemeral, EventKindVariation::None)),
-        "SyncEphemeralRoomEvent" => Some((EventKind::Ephemeral, EventKindVariation::Sync)),
+        "EphemeralRoomEvent" => Some((EventKind::EphemeralRoom, EventKindVariation::None)),
+        "SyncEphemeralRoomEvent" => Some((EventKind::EphemeralRoom, EventKindVariation::Sync)),
         "OriginalMessageLikeEvent" => Some((EventKind::MessageLike, EventKindVariation::Original)),
         "OriginalSyncMessageLikeEvent" => {
             Some((EventKind::MessageLike, EventKindVariation::OriginalSync))

--- a/crates/ruma-macros/src/events/event_type.rs
+++ b/crates/ruma-macros/src/events/event_type.rs
@@ -19,7 +19,7 @@ pub fn expand_event_type_enum(
         match event.kind {
             EventKind::GlobalAccountData => global_account.push(&event.events),
             EventKind::RoomAccountData => room_account.push(&event.events),
-            EventKind::Ephemeral => ephemeral.push(&event.events),
+            EventKind::EphemeralRoom => ephemeral.push(&event.events),
             EventKind::MessageLike => {
                 message.push(&event.events);
                 timeline.push(&event.events);

--- a/crates/ruma-macros/src/lib.rs
+++ b/crates/ruma-macros/src/lib.rs
@@ -63,12 +63,10 @@ use self::{
 /// * `Any{Kind}Event`
 /// * `{Kind}EventType`
 ///
-/// _Note that the `Ephemeral` kind generates types named `*EphemeralRoom*`._
-///
 /// It also generates the following enums:
 ///
 /// * `AnySync{Kind}Event` for the kinds that have a different format in the `/sync` API:
-///   `Ephemeral`, `MessageLike` and `State`.
+///   `EphemeralRoom`, `MessageLike` and `State`.
 /// * `TimelineEventType` which includes the variants from `MessageLikeEventType` and
 ///   `StateEventType`
 /// * And extra enums for the `State` kind:
@@ -117,7 +115,7 @@ use self::{
 /// * `GlobalAccountData` - Global config event
 /// * `RoomAccountData` - Per-room config event
 /// * `ToDevice` - Event sent directly to a device
-/// * `Ephemeral` - Event that is not persistent in the room
+/// * `EphemeralRoom` - Event that is not persistent in the room
 ///
 /// ## Event types
 ///
@@ -294,7 +292,7 @@ pub fn event_enum(input: TokenStream) -> TokenStream {
 /// Some kinds generate more type aliases:
 ///
 /// * `type SyncFooEvent = Sync{Kind}Event<FooEventContent>`: an event received via the `/sync` API,
-///   for the `MessageLike`, `State` and `Ephemeral` kinds
+///   for the `MessageLike`, `State` and `EphemeralRoom` kinds
 /// * `type OriginalFooEvent = Original{Kind}Event<FooEventContent>`, a non-redacted event, for the
 ///   `MessageLike` and `State` kinds
 /// * `type OriginalSyncFooEvent = OriginalSync{Kind}Event<FooEventContent>`, a non-redacted event
@@ -347,7 +345,7 @@ pub fn event_enum(input: TokenStream) -> TokenStream {
 /// * `GlobalAccountData` - Global config event
 /// * `RoomAccountData` - Per-room config event
 /// * `ToDevice` - Event sent directly to a device
-/// * `Ephemeral` - Event that is not persistent in the room
+/// * `EphemeralRoom` - Event that is not persistent in the room
 ///
 /// It is possible to implement both account data kinds for the same type by using the syntax `kind
 /// = GlobalAccountData + RoomAccountData`.


### PR DESCRIPTION
To avoid confusions like #2094.
