### PR TITLE
Html5ever 0.29.1 is presenting compilation issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,14 +743,16 @@ checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
 
 [[package]]
 name = "html5ever"
-version = "0.29.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b7410cae13cbc75623c98ac4cbfd1f0bedddf3227afc24f370cf0f50a44a11c"
+checksum = "2e15626aaf9c351bc696217cbe29cb9b5e86c43f8a46b5e2f5c6c5cf7cb904ce"
 dependencies = [
  "log",
  "mac",
  "markup5ever",
- "match_token",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1191,17 +1193,6 @@ dependencies = [
  "string_cache",
  "string_cache_codegen",
  "tendril",
-]
-
-[[package]]
-name = "match_token"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/crates/ruma-html/Cargo.toml
+++ b/crates/ruma-html/Cargo.toml
@@ -19,7 +19,7 @@ unstable-msc4286 = []
 
 [dependencies]
 as_variant = { workspace = true }
-html5ever = "0.29.0"
+html5ever = "=0.29.0"
 ruma-common = { workspace = true, optional = true }
 tracing = { workspace = true, features = ["attributes"] }
 wildmatch = "2.0.0"


### PR DESCRIPTION
Started getting errors when compiling ruma in another project related to html5ever accidentally moving to 0.29.1. 

It seems like this dependency needs to be pinned to 0.29.0 exactly to avoid this.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
