### PR TITLE
events: relax requirement for `BundledThread::latest_event` to include a `room_id`

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -37,6 +37,9 @@ Breaking changes:
   - The `event_type` method is now available on the per-kind `*EventContent` traits.
   - For an event content type to automatically implement `EventContentFromType` it must now match
     the bound `StaticEventContent + DeserializeOwned`.
+- The `BundledThread::latest_event` field is now an `AnySyncMessageLikeEvent` instead of
+  `AnyMessageLikeEvent`, to reflect that it may not always include a `room_id` field (if the owning
+  event came from sync, for instance), which can usually be obtained from the surrounding context.
 
 Improvements:
 

--- a/crates/ruma-events/src/relation.rs
+++ b/crates/ruma-events/src/relation.rs
@@ -11,8 +11,7 @@ use ruma_common::{
 };
 use serde::{Deserialize, Serialize};
 
-use super::AnyMessageLikeEvent;
-use crate::PrivOwnedStr;
+use crate::{AnySyncMessageLikeEvent, PrivOwnedStr};
 
 mod rel_serde;
 
@@ -135,7 +134,7 @@ impl Thread {
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct BundledThread {
     /// The latest event in the thread.
-    pub latest_event: Raw<AnyMessageLikeEvent>,
+    pub latest_event: Raw<AnySyncMessageLikeEvent>,
 
     /// The number of events in the thread.
     pub count: UInt,
@@ -147,7 +146,7 @@ pub struct BundledThread {
 impl BundledThread {
     /// Creates a new `BundledThread` with the given event, count and user participated flag.
     pub fn new(
-        latest_event: Raw<AnyMessageLikeEvent>,
+        latest_event: Raw<AnySyncMessageLikeEvent>,
         count: UInt,
         current_user_participated: bool,
     ) -> Self {


### PR DESCRIPTION
The [spec](https://spec.matrix.org/latest/client-server-api/#server-side-aggregation-of-mthread-relationships) is a bit unclear about whether the included latest event always has a room id or not. Based on discussions with Synapse developers, it seems the event is included as in the same context of the owning event; if both come from sync, then they'll follow the sync format (thus won't have a room id).

It's better to relax the format here; usually the room id should always be available from the surrounding context anyways.
