### PR TITLE
common: Allow any join rule kind in `PublicRoomsChunk`

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -47,6 +47,10 @@ Breaking changes:
   syntax and the new syntax supported by axum 0.8.
 - `JoinRule` and its associated types where imported from `ruma-events` into the
   `room` module.
+- `directory::PublicRoomJoinRule` was moved and renamed to `room::JoinRuleKind`
+  and includes all possible join rule kinds, due to a clarification in Matrix
+  1.15.
+  - It can be constructed with `JoinRule::kind()` and `JoinRuleSummary::kind()`.
 
 Improvements:
 

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -47,6 +47,8 @@ Breaking changes:
   syntax and the new syntax supported by axum 0.8.
 - `JoinRule` and its associated types where imported from `ruma-events` into the
   `room` module.
+- `space::SpaceRoomJoinRule` was moved and renamed as `room::JoinRuleSummary`.
+  It now includes a `RestrictedSummary` for the restricted join rules variants.
 - `directory::PublicRoomJoinRule` was moved and renamed to `room::JoinRuleKind`
   and includes all possible join rule kinds, due to a clarification in Matrix
   1.15.
@@ -89,8 +91,6 @@ Improvements:
 - Add `RoomSummary` that represents the summary of a room's state.
   - Implement `From<RoomSummary>` for `PublicRoomsChunk` and
     `From<PublicRoomsChunk>` for `RoomSummary`.
-- `space::SpaceRoomJoinRule` was moved and renamed as `room::JoinRuleSummary`.
-  It now includes a `RestrictedSummary` for the restricted join rules variants.
 - Add `MatrixVersion::V1_15`.
 
 # 0.15.2

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -87,7 +87,8 @@ Improvements:
   be able to know if a server advertises support for an endpoint.
 - Re-export `ID_MAX_BYTES` from `ruma-identifiers-validation`.
 - Add `RoomSummary` that represents the summary of a room's state.
-  - Implement `From<RoomSummary>` for `PublicRoomsChunk`
+  - Implement `From<RoomSummary>` for `PublicRoomsChunk` and
+    `From<PublicRoomsChunk>` for `RoomSummary`.
 - `space::SpaceRoomJoinRule` was moved and renamed as `room::JoinRuleSummary`.
   It now includes a `RestrictedSummary` for the restricted join rules variants.
 - Add `MatrixVersion::V1_15`.

--- a/crates/ruma-common/src/directory.rs
+++ b/crates/ruma-common/src/directory.rs
@@ -7,8 +7,7 @@ mod filter_room_type_serde;
 mod room_network_serde;
 
 use crate::{
-    room::{RoomSummary, RoomType},
-    serde::StringEnum,
+    room::{JoinRuleKind, RoomSummary, RoomType},
     OwnedMxcUri, OwnedRoomAliasId, OwnedRoomId, PrivOwnedStr,
 };
 
@@ -63,7 +62,7 @@ pub struct PublicRoomsChunk {
 
     /// The join rule of the room.
     #[serde(default, skip_serializing_if = "crate::serde::is_default")]
-    pub join_rule: PublicRoomJoinRule,
+    pub join_rule: JoinRuleKind,
 
     /// The type of room from `m.room.create`, if any.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -106,7 +105,7 @@ impl From<PublicRoomsChunkInit> for PublicRoomsChunk {
             world_readable,
             guest_can_join,
             avatar_url: None,
-            join_rule: PublicRoomJoinRule::default(),
+            join_rule: JoinRuleKind::default(),
             room_type: None,
         }
     }
@@ -188,23 +187,6 @@ pub enum RoomNetwork {
 
     /// Return rooms from a specific third party network/protocol.
     ThirdParty(String),
-}
-
-/// The rule used for users wishing to join a public room.
-#[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, Default, PartialEq, Eq, StringEnum)]
-#[ruma_enum(rename_all = "snake_case")]
-#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
-pub enum PublicRoomJoinRule {
-    /// Users can request an invite to the room.
-    Knock,
-
-    /// Anyone can join the room without any prior action.
-    #[default]
-    Public,
-
-    #[doc(hidden)]
-    _Custom(PrivOwnedStr),
 }
 
 /// An enum of possible room types to filter.

--- a/crates/ruma-common/src/directory.rs
+++ b/crates/ruma-common/src/directory.rs
@@ -14,8 +14,8 @@ use crate::{
 /// A chunk of a room list response, describing one room.
 ///
 /// To create an instance of this type, first create a [`PublicRoomsChunkInit`] and convert it via
-/// `PublicRoomsChunk::from` / `.into()`. It is also possible to construct this type from a
-/// [`RoomSummary`].
+/// `PublicRoomsChunk::from` / `.into()`. It is also possible to construct this type from or convert
+/// it to a [`RoomSummary`].
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct PublicRoomsChunk {
@@ -138,6 +138,38 @@ impl From<RoomSummary> for PublicRoomsChunk {
             avatar_url,
             join_rule: join_rule.as_str().into(),
             room_type,
+        }
+    }
+}
+
+impl From<PublicRoomsChunk> for RoomSummary {
+    fn from(value: PublicRoomsChunk) -> Self {
+        let PublicRoomsChunk {
+            room_id,
+            canonical_alias,
+            name,
+            topic,
+            avatar_url,
+            room_type,
+            num_joined_members,
+            join_rule,
+            world_readable,
+            guest_can_join,
+        } = value;
+
+        Self {
+            canonical_alias,
+            name,
+            num_joined_members,
+            room_id,
+            topic,
+            world_readable,
+            guest_can_join,
+            avatar_url,
+            join_rule: join_rule.into(),
+            room_type,
+            encryption: None,
+            room_version: None,
         }
     }
 }

--- a/crates/ruma-common/src/room.rs
+++ b/crates/ruma-common/src/room.rs
@@ -246,13 +246,13 @@ pub enum JoinRuleKind {
 impl From<JoinRuleKind> for JoinRuleSummary {
     fn from(value: JoinRuleKind) -> Self {
         match value {
-            JoinRuleKind::Invite => JoinRuleSummary::Invite,
-            JoinRuleKind::Knock => JoinRuleSummary::Knock,
-            JoinRuleKind::Private => JoinRuleSummary::Private,
-            JoinRuleKind::Restricted => JoinRuleSummary::Restricted(Default::default()),
-            JoinRuleKind::KnockRestricted => JoinRuleSummary::KnockRestricted(Default::default()),
-            JoinRuleKind::Public => JoinRuleSummary::Public,
-            JoinRuleKind::_Custom(s) => JoinRuleSummary::_Custom(s),
+            JoinRuleKind::Invite => Self::Invite,
+            JoinRuleKind::Knock => Self::Knock,
+            JoinRuleKind::Private => Self::Private,
+            JoinRuleKind::Restricted => Self::Restricted(Default::default()),
+            JoinRuleKind::KnockRestricted => Self::KnockRestricted(Default::default()),
+            JoinRuleKind::Public => Self::Public,
+            JoinRuleKind::_Custom(s) => Self::_Custom(s),
         }
     }
 }

--- a/crates/ruma-common/src/room.rs
+++ b/crates/ruma-common/src/room.rs
@@ -67,13 +67,13 @@ impl JoinRule {
     /// Returns the kind of this `JoinRule`.
     pub fn kind(&self) -> JoinRuleKind {
         match self {
-            JoinRule::Invite => JoinRuleKind::Invite,
-            JoinRule::Knock => JoinRuleKind::Knock,
-            JoinRule::Private => JoinRuleKind::Private,
-            JoinRule::Restricted(_) => JoinRuleKind::Restricted,
-            JoinRule::KnockRestricted(_) => JoinRuleKind::KnockRestricted,
-            JoinRule::Public => JoinRuleKind::Public,
-            JoinRule::_Custom(rule) => JoinRuleKind::_Custom(rule.clone()),
+            Self::Invite => JoinRuleKind::Invite,
+            Self::Knock => JoinRuleKind::Knock,
+            Self::Private => JoinRuleKind::Private,
+            Self::Restricted(_) => JoinRuleKind::Restricted,
+            Self::KnockRestricted(_) => JoinRuleKind::KnockRestricted,
+            Self::Public => JoinRuleKind::Public,
+            Self::_Custom(rule) => JoinRuleKind::_Custom(rule.clone()),
         }
     }
 

--- a/crates/ruma-common/src/room.rs
+++ b/crates/ruma-common/src/room.rs
@@ -64,6 +64,19 @@ pub enum JoinRule {
 }
 
 impl JoinRule {
+    /// Returns the kind of this `JoinRule`.
+    pub fn kind(&self) -> JoinRuleKind {
+        match self {
+            JoinRule::Invite => JoinRuleKind::Invite,
+            JoinRule::Knock => JoinRuleKind::Knock,
+            JoinRule::Private => JoinRuleKind::Private,
+            JoinRule::Restricted(_) => JoinRuleKind::Restricted,
+            JoinRule::KnockRestricted(_) => JoinRuleKind::KnockRestricted,
+            JoinRule::Public => JoinRuleKind::Public,
+            JoinRule::_Custom(rule) => JoinRuleKind::_Custom(rule.clone()),
+        }
+    }
+
     /// Returns the string name of this `JoinRule`
     pub fn as_str(&self) -> &str {
         match self {
@@ -194,6 +207,40 @@ impl<'de> Deserialize<'de> for AllowRule {
             None => Err(de::Error::missing_field("type")),
         }
     }
+}
+
+/// The kind of rule used for users wishing to join this room.
+#[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
+#[derive(Clone, Default, PartialEq, Eq, StringEnum)]
+#[ruma_enum(rename_all = "snake_case")]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+pub enum JoinRuleKind {
+    /// A user who wishes to join the room must first receive an invite to the room from someone
+    /// already inside of the room.
+    Invite,
+
+    /// Users can join the room if they are invited, or they can request an invite to the room.
+    ///
+    /// They can be allowed (invited) or denied (kicked/banned) access.
+    Knock,
+
+    /// Reserved but not yet implemented by the Matrix specification.
+    Private,
+
+    /// Users can join the room if they are invited, or if they meet any of the conditions
+    /// described in a set of rules.
+    Restricted,
+
+    /// Users can join the room if they are invited, or if they meet any of the conditions
+    /// described in a set of rules, or they can request an invite to the room.
+    KnockRestricted,
+
+    /// Anyone can join the room without any prior action.
+    #[default]
+    Public,
+
+    #[doc(hidden)]
+    _Custom(PrivOwnedStr),
 }
 
 /// The summary of a room's state.
@@ -344,7 +391,7 @@ impl<'de> Deserialize<'de> for RoomSummary {
 
 /// The rule used for users wishing to join a room.
 ///
-/// In contrast to the regular `JoinRule` in `ruma_events`, this enum does holds only simplified
+/// In contrast to the regular `JoinRule` in `ruma_events`, this enum holds only simplified
 /// conditions for joining restricted rooms.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
@@ -380,7 +427,20 @@ pub enum JoinRuleSummary {
 }
 
 impl JoinRuleSummary {
-    /// Returns the string name of this `JoinRule`.
+    /// Returns the kind of this `JoinRuleSummary`.
+    pub fn kind(&self) -> JoinRuleKind {
+        match self {
+            Self::Invite => JoinRuleKind::Invite,
+            Self::Knock => JoinRuleKind::Knock,
+            Self::Private => JoinRuleKind::Private,
+            Self::Restricted(_) => JoinRuleKind::Restricted,
+            Self::KnockRestricted(_) => JoinRuleKind::KnockRestricted,
+            Self::Public => JoinRuleKind::Public,
+            Self::_Custom(rule) => JoinRuleKind::_Custom(rule.clone()),
+        }
+    }
+
+    /// Returns the string name of this `JoinRuleSummary`.
     pub fn as_str(&self) -> &str {
         match self {
             Self::Invite => "invite",

--- a/crates/ruma-common/src/room.rs
+++ b/crates/ruma-common/src/room.rs
@@ -243,6 +243,20 @@ pub enum JoinRuleKind {
     _Custom(PrivOwnedStr),
 }
 
+impl From<JoinRuleKind> for JoinRuleSummary {
+    fn from(value: JoinRuleKind) -> Self {
+        match value {
+            JoinRuleKind::Invite => JoinRuleSummary::Invite,
+            JoinRuleKind::Knock => JoinRuleSummary::Knock,
+            JoinRuleKind::Private => JoinRuleSummary::Private,
+            JoinRuleKind::Restricted => JoinRuleSummary::Restricted(Default::default()),
+            JoinRuleKind::KnockRestricted => JoinRuleSummary::KnockRestricted(Default::default()),
+            JoinRuleKind::Public => JoinRuleSummary::Public,
+            JoinRuleKind::_Custom(s) => JoinRuleSummary::_Custom(s),
+        }
+    }
+}
+
 /// The summary of a room's state.
 #[derive(Debug, Clone, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]

--- a/crates/ruma-state-res/src/event_auth.rs
+++ b/crates/ruma-state-res/src/event_auth.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use js_int::Int;
-use ruma_common::{room_version_rules::AuthorizationRules, EventId, UserId};
+use ruma_common::{room::JoinRuleKind, room_version_rules::AuthorizationRules, EventId, UserId};
 use ruma_events::{room::member::MembershipState, StateEventType, TimelineEventType};
 use serde_json::value::RawValue as RawJsonValue;
 use tracing::{debug, info, instrument, warn};
@@ -18,7 +18,7 @@ use crate::{
     events::{
         member::{RoomMemberEventContent, RoomMemberEventOptionExt},
         power_levels::{RoomPowerLevelsEventOptionExt, RoomPowerLevelsIntField},
-        JoinRule, RoomCreateEvent, RoomJoinRulesEvent, RoomMemberEvent, RoomPowerLevelsEvent,
+        RoomCreateEvent, RoomJoinRulesEvent, RoomMemberEvent, RoomPowerLevelsEvent,
         RoomThirdPartyInviteEvent,
     },
     Event,
@@ -619,7 +619,7 @@ trait FetchStateExt<E: Event> {
 
     fn room_power_levels_event(&self) -> Option<RoomPowerLevelsEvent<E>>;
 
-    fn join_rule(&self) -> Result<JoinRule, String>;
+    fn join_rule(&self) -> Result<JoinRuleKind, String>;
 
     fn room_third_party_invite_event(&self, token: &str) -> Option<RoomThirdPartyInviteEvent<E>>;
 }
@@ -643,7 +643,7 @@ where
         self(&StateEventType::RoomPowerLevels, "").map(RoomPowerLevelsEvent::new)
     }
 
-    fn join_rule(&self) -> Result<JoinRule, String> {
+    fn join_rule(&self) -> Result<JoinRuleKind, String> {
         self(&StateEventType::RoomJoinRules, "")
             .map(RoomJoinRulesEvent::new)
             .ok_or_else(|| "no `m.room.join_rules` event in current state".to_owned())?

--- a/crates/ruma-state-res/src/event_auth/room_member.rs
+++ b/crates/ruma-state-res/src/event_auth/room_member.rs
@@ -1,6 +1,7 @@
 use std::borrow::Borrow;
 
 use ruma_common::{
+    room::JoinRuleKind,
     room_version_rules::AuthorizationRules,
     serde::{base64::Standard, Base64},
     AnyKeyName, SigningKeyId, UserId,
@@ -15,8 +16,8 @@ mod tests;
 use super::FetchStateExt;
 use crate::{
     events::{
-        member::ThirdPartyInvite, power_levels::RoomPowerLevelsEventOptionExt, JoinRule,
-        RoomCreateEvent, RoomMemberEvent, RoomPowerLevelsIntField,
+        member::ThirdPartyInvite, power_levels::RoomPowerLevelsEventOptionExt, RoomCreateEvent,
+        RoomMemberEvent, RoomPowerLevelsIntField,
     },
     Event,
 };
@@ -136,7 +137,7 @@ fn check_room_member_join<E: Event>(
     // join.
     // Since v7, if the join_rule is invite or knock then allow if membership state is
     // invite or join.
-    if (join_rule == JoinRule::Invite || rules.knocking && join_rule == JoinRule::Knock)
+    if (join_rule == JoinRuleKind::Invite || rules.knocking && join_rule == JoinRuleKind::Knock)
         && matches!(current_membership, MembershipState::Invite | MembershipState::Join)
     {
         return Ok(());
@@ -144,8 +145,8 @@ fn check_room_member_join<E: Event>(
 
     // v8-v9, if the join_rule is restricted:
     // Since v10, if the join_rule is restricted or knock_restricted:
-    if rules.restricted_join_rule && matches!(join_rule, JoinRule::Restricted)
-        || rules.knock_restricted_join_rule && matches!(join_rule, JoinRule::KnockRestricted)
+    if rules.restricted_join_rule && matches!(join_rule, JoinRuleKind::Restricted)
+        || rules.knock_restricted_join_rule && matches!(join_rule, JoinRuleKind::KnockRestricted)
     {
         // Since v8, if membership state is join or invite, allow.
         if matches!(current_membership, MembershipState::Join | MembershipState::Invite) {
@@ -188,7 +189,7 @@ fn check_room_member_join<E: Event>(
 
     // Since v1, if the join_rule is public, allow.
     // Otherwise, reject.
-    if join_rule == JoinRule::Public {
+    if join_rule == JoinRuleKind::Public {
         Ok(())
     } else {
         Err("cannot join a room that is not `public`".to_owned())
@@ -462,8 +463,8 @@ fn check_room_member_knock<E: Event>(
     // v7-v9, if the join_rule is anything other than knock, reject.
     // Since v10, if the join_rule is anything other than knock or knock_restricted,
     // reject.
-    if join_rule != JoinRule::Knock
-        && (rules.knock_restricted_join_rule && !matches!(join_rule, JoinRule::KnockRestricted))
+    if join_rule != JoinRuleKind::Knock
+        && (rules.knock_restricted_join_rule && !matches!(join_rule, JoinRuleKind::KnockRestricted))
     {
         return Err(
             "join rule is not set to knock or knock_restricted, knocking is not allowed".to_owned()

--- a/crates/ruma-state-res/src/events.rs
+++ b/crates/ruma-state-res/src/events.rs
@@ -9,7 +9,7 @@ mod traits;
 
 pub use self::{
     create::RoomCreateEvent,
-    join_rules::{JoinRule, RoomJoinRulesEvent},
+    join_rules::RoomJoinRulesEvent,
     member::RoomMemberEvent,
     power_levels::{RoomPowerLevelsEvent, RoomPowerLevelsIntField},
     third_party_invite::RoomThirdPartyInviteEvent,

--- a/crates/ruma-state-res/src/events/join_rules.rs
+++ b/crates/ruma-state-res/src/events/join_rules.rs
@@ -2,7 +2,7 @@
 
 use std::ops::Deref;
 
-use ruma_common::serde::{from_raw_json_value, PartialEqAsRefStr, StringEnum};
+use ruma_common::{room::JoinRuleKind, serde::from_raw_json_value};
 use serde::Deserialize;
 
 use super::Event;
@@ -20,10 +20,10 @@ impl<E: Event> RoomJoinRulesEvent<E> {
     }
 
     /// The join rule of the room.
-    pub fn join_rule(&self) -> Result<JoinRule, String> {
+    pub fn join_rule(&self) -> Result<JoinRuleKind, String> {
         #[derive(Deserialize)]
         struct RoomJoinRulesContentJoinRule {
-            join_rule: JoinRule,
+            join_rule: JoinRuleKind,
         }
 
         let content: RoomJoinRulesContentJoinRule =
@@ -41,35 +41,3 @@ impl<E: Event> Deref for RoomJoinRulesEvent<E> {
         &self.0
     }
 }
-
-/// The possible values for the join rule of a room.
-#[derive(Clone, StringEnum, PartialEqAsRefStr)]
-#[ruma_enum(rename_all = "snake_case")]
-#[non_exhaustive]
-pub enum JoinRule {
-    /// `public`
-    Public,
-
-    /// `invite`
-    Invite,
-
-    /// `knock`
-    Knock,
-
-    /// `restricted`
-    Restricted,
-
-    /// `KnockRestricted`
-    KnockRestricted,
-
-    #[doc(hidden)]
-    _Custom(PrivOwnedStr),
-}
-
-impl Eq for JoinRule {}
-
-// Wrapper around `Box<str>` that cannot be used in a meaningful way outside of
-// this crate. Used for string enums because their `_Custom` variant can't be
-// truly private (only `#[doc(hidden)]`).
-#[derive(Debug, Clone)]
-pub struct PrivOwnedStr(Box<str>);


### PR DESCRIPTION
Due to a clarification Matrix 1.15 ([spec PR](https://github.com/matrix-org/matrix-spec/issues/2104)):

> Rooms published in `/publicRooms` don’t necessarily have `public` join rules or `world_readable` history visibility. 

Merges `PublicRoomJoinRule` with `ruma_state_res::events::JoinRule` as `JoinRuleKind` since they are now identical.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
