### PR TITLE
events: Don't implement `StaticEventContent` for `EventContent` types with `.*` suffix

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -39,6 +39,9 @@ Breaking changes:
 - The `BundledThread::latest_event` field is now an `AnySyncMessageLikeEvent` instead of
   `AnyMessageLikeEvent`, to reflect that it may not always include a `room_id` field (if the owning
   event came from sync, for instance), which can usually be obtained from the surrounding context.
+- The `EventContent` macro doesn't implement `StaticEventContent` anymore for account data where the
+  `type` uses the `.*` suffix, since the event type is not known at compile-time.
+  - `SecretStorageKeyEventContent` doesn't implement `StaticEventContent` anymore.
 
 Improvements:
 

--- a/crates/ruma-macros/src/lib.rs
+++ b/crates/ruma-macros/src/lib.rs
@@ -220,7 +220,7 @@ pub fn event_enum(input: TokenStream) -> TokenStream {
 /// This macro implements the following traits for the type on which it is applied:
 ///
 /// * `{kind}EventContent`
-/// * `StaticEventContent`
+/// * `StaticEventContent`, if the `type` does not use a `.*` suffix.
 /// * `StaticStateEventContent`, for the `State` kind.
 ///
 /// # Generated types


### PR DESCRIPTION
The full event type is not known at compile-time.
