### PR TITLE
events: Replace manual `TYPE` static strings to point to macro-generated values

### DIFF
--- a/crates/ruma-events/src/poll/unstable_start.rs
+++ b/crates/ruma-events/src/poll/unstable_start.rs
@@ -138,7 +138,7 @@ impl NewUnstablePollStartEventContent {
 }
 
 impl StaticEventContent for NewUnstablePollStartEventContent {
-    const TYPE: &'static str = "org.matrix.msc3381.poll.start";
+    const TYPE: &'static str = UnstablePollStartEventContent::TYPE;
 }
 
 impl MessageLikeEventContent for NewUnstablePollStartEventContent {
@@ -221,7 +221,7 @@ impl ReplacementUnstablePollStartEventContent {
 }
 
 impl StaticEventContent for ReplacementUnstablePollStartEventContent {
-    const TYPE: &'static str = "org.matrix.msc3381.poll.start";
+    const TYPE: &'static str = UnstablePollStartEventContent::TYPE;
 }
 
 impl MessageLikeEventContent for ReplacementUnstablePollStartEventContent {
@@ -243,7 +243,7 @@ impl RedactedUnstablePollStartEventContent {
 }
 
 impl StaticEventContent for RedactedUnstablePollStartEventContent {
-    const TYPE: &'static str = "org.matrix.msc3381.poll.start";
+    const TYPE: &'static str = UnstablePollStartEventContent::TYPE;
 }
 
 impl RedactedMessageLikeEventContent for RedactedUnstablePollStartEventContent {

--- a/crates/ruma-events/src/room/power_levels.rs
+++ b/crates/ruma-events/src/room/power_levels.rs
@@ -286,7 +286,7 @@ pub struct RedactedRoomPowerLevelsEventContent {
 }
 
 impl StaticEventContent for RedactedRoomPowerLevelsEventContent {
-    const TYPE: &'static str = "m.room.power_levels";
+    const TYPE: &'static str = RoomPowerLevelsEventContent::TYPE;
 }
 
 impl RedactedStateEventContent for RedactedRoomPowerLevelsEventContent {

--- a/crates/ruma-events/src/room/redaction.rs
+++ b/crates/ruma-events/src/room/redaction.rs
@@ -232,7 +232,7 @@ pub struct RedactedRoomRedactionEventContent {
 }
 
 impl StaticEventContent for RedactedRoomRedactionEventContent {
-    const TYPE: &'static str = "m.room.redaction";
+    const TYPE: &'static str = RoomRedactionEventContent::TYPE;
 }
 
 impl RedactedMessageLikeEventContent for RedactedRoomRedactionEventContent {

--- a/crates/ruma-events/src/room/tombstone.rs
+++ b/crates/ruma-events/src/room/tombstone.rs
@@ -61,5 +61,5 @@ impl PossiblyRedactedStateEventContent for PossiblyRedactedRoomTombstoneEventCon
 }
 
 impl StaticEventContent for PossiblyRedactedRoomTombstoneEventContent {
-    const TYPE: &'static str = "m.room.tombstone";
+    const TYPE: &'static str = RoomTombstoneEventContent::TYPE;
 }


### PR DESCRIPTION
This reduces duplication of weak types and avoids possible copy-paste errors.

