### PR TITLE
events: Improvements for `m.space.child` events

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -94,6 +94,8 @@ Improvements:
 - Add `MatrixVersion::V1_15`.
 - Add `content_field_redacts` field to `RedactionRules`, which is used to determine whether the
   `content` or top-level `redacts` field should be used to determine what event an event redacts.
+- Add `serde::default_on_error()` as a helper to ignore errors during
+  deserialization.
 
 # 0.15.2
 

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -96,6 +96,8 @@ Improvements:
   `content` or top-level `redacts` field should be used to determine what event an event redacts.
 - Add `serde::default_on_error()` as a helper to ignore errors during
   deserialization.
+- Add `SpaceChildOrder` which allows to validate the `order` of an
+  `m.space.child` event.
 
 # 0.15.2
 

--- a/crates/ruma-common/src/identifiers.rs
+++ b/crates/ruma-common/src/identifiers.rs
@@ -46,6 +46,7 @@ pub use self::{
         CrossSigningOrDeviceSignatures, DeviceSignatures, EntitySignatures, ServerSignatures,
         Signatures,
     },
+    space_child_order::{OwnedSpaceChildOrder, SpaceChildOrder},
     transaction_id::{OwnedTransactionId, TransactionId},
     user_id::{OwnedUserId, UserId},
     voip_id::{OwnedVoipId, VoipId},
@@ -72,6 +73,7 @@ mod server_name;
 mod server_signing_key_version;
 mod session_id;
 mod signatures;
+mod space_child_order;
 mod transaction_id;
 mod voip_id;
 mod voip_version_id;

--- a/crates/ruma-common/src/identifiers/space_child_order.rs
+++ b/crates/ruma-common/src/identifiers/space_child_order.rs
@@ -1,0 +1,37 @@
+//! `m.space.child` order.
+
+use ruma_macros::IdZst;
+
+/// The order of an [`m.space.child`] event.
+///
+/// Space child orders in Matrix are opaque character sequences consisting of ASCII characters
+/// within the range `\x20` (space) and `\x7E` (~), inclusive. Their length must must not exceed 50
+/// characters.
+///
+/// [`m.space.child`]: https://spec.matrix.org/latest/client-server-api/#mspacechild
+#[repr(transparent)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdZst)]
+#[ruma_id(validate = ruma_identifiers_validation::space_child_order::validate)]
+pub struct SpaceChildOrder(str);
+
+#[cfg(test)]
+mod tests {
+    use std::iter::repeat_n;
+
+    use ruma_identifiers_validation::Error;
+
+    use super::SpaceChildOrder;
+
+    #[test]
+    fn validate_space_child_order() {
+        // Valid string.
+        SpaceChildOrder::parse("aaa").unwrap();
+
+        // String too long.
+        let order = repeat_n('a', 60).collect::<String>();
+        assert_eq!(SpaceChildOrder::parse(&order), Err(Error::MaximumLengthExceeded));
+
+        // Invalid character.
+        assert_eq!(SpaceChildOrder::parse("🔝"), Err(Error::InvalidCharacters));
+    }
+}

--- a/crates/ruma-common/src/serde.rs
+++ b/crates/ruma-common/src/serde.rs
@@ -12,6 +12,7 @@ use serde::{
     Deserialize, Deserializer,
 };
 use serde_json::{value::RawValue as RawJsonValue, Value as JsonValue};
+use tracing::debug;
 
 pub mod base64;
 mod buf;
@@ -76,6 +77,20 @@ where
     E: de::Error,
 {
     serde_json::from_str(val.get()).map_err(E::custom)
+}
+
+/// Helper function for returning a default value if deserialization of the type fails.
+///
+/// Used as `#[serde(deserialize_with = "default_on_error")]`.
+pub fn default_on_error<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de> + Default,
+{
+    Ok(T::deserialize(deserializer).unwrap_or_else(|error| {
+        debug!("deserialization error, using default value: {error}");
+        T::default()
+    }))
 }
 
 /// Helper function for ignoring invalid items in a `Vec`, instead letting them cause the entire

--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -71,6 +71,9 @@ Improvements:
   - `MediaPreviewConfigEventContent::merge_global_and_room_config()` can be used to get the current
     config for a room.
 - Fix and stabilize support for rich text in room topics, according to Matrix 1.15.
+- `m.space.child` events can be sorted with the algorithm defined in the spec by using the new
+  `SpaceChildOrd` trait and `SpaceChildOrdHelper` type, and `HierarchySpaceChildEvent` specifically
+  now implements `Ord` using the aforementioned trait.
    
 # 0.30.3
 

--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -44,6 +44,9 @@ Breaking changes:
   - `SecretStorageKeyEventContent` doesn't implement `StaticEventContent` anymore.
 - The `(Original)(Sync)RedactEvent` events take a `RedactionRules` instead of `RoomVersionId` for
   their `redacts()` method. This avoids unexpected behavior for unknown room versions.
+- `SpaceChildEventContent` now uses `OwnedSpaceChildOrder` for the `order` field. This is a type
+  with strong validation according to the rules of the spec. If its deserialization fails, this
+  field is set to `None` to ignore it, as recommended in the spec.
 
 Improvements:
 

--- a/crates/ruma-identifiers-validation/CHANGELOG.md
+++ b/crates/ruma-identifiers-validation/CHANGELOG.md
@@ -26,6 +26,7 @@ Improvements:
   spec.
 - `room_alias_id::validate` disallows the `NUL` byte for the localpart, due to a
   clarification in the spec.
+- Add `space_child_order::validate`.
 
 # 0.10.1
 

--- a/crates/ruma-identifiers-validation/src/lib.rs
+++ b/crates/ruma-identifiers-validation/src/lib.rs
@@ -13,6 +13,7 @@ pub mod room_id_or_alias_id;
 pub mod room_version_id;
 pub mod server_name;
 pub mod server_signing_key_version;
+pub mod space_child_order;
 pub mod user_id;
 pub mod voip_version_id;
 

--- a/crates/ruma-identifiers-validation/src/space_child_order.rs
+++ b/crates/ruma-identifiers-validation/src/space_child_order.rs
@@ -1,0 +1,24 @@
+use crate::Error;
+
+/// Validate the `order` of an [`m.space.child`] event.
+///
+/// According to the specification, the order:
+///
+/// > Must consist of ASCII characters within the range `\x20` (space) and `\x7E` (~),
+/// > inclusive. Must not exceed 50 characters.
+///
+/// Returns `Ok(())` if the order passes validation, or an error if the order doesn't respect
+/// the rules from the spec, as it cannot be used for ordering.
+///
+/// [`m.space.child`]: https://spec.matrix.org/latest/client-server-api/#mspacechild
+pub fn validate(s: &str) -> Result<(), Error> {
+    if s.len() > 50 {
+        return Err(Error::MaximumLengthExceeded);
+    }
+
+    if !s.bytes().all(|byte| (b'\x20'..=b'\x7E').contains(&byte)) {
+        return Err(Error::InvalidCharacters);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
1. Validate the `order` during deserialization, using the rules from the spec. We just ignore invalid values, like recommended in the spec.
2. Add `SpaceChildOrd` and `SpaceChildOrdHelper` to sort space child events with the algorithm from the spec.