### PR TITLE
events: Ignore errors for `predecessor` of `RoomCreateEventContent` during deserialization

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -74,6 +74,8 @@ Improvements:
 - `m.space.child` events can be sorted with the algorithm defined in the spec by using the new
   `SpaceChildOrd` trait and `SpaceChildOrdHelper` type, and `HierarchySpaceChildEvent` specifically
   now implements `Ord` using the aforementioned trait.
+- With the `compat-lax-room-create-deser` cargo feature, the `predecessor` field of
+  `RoomCreateEventContent` is ignored during deserialization if it has an invalid format.
    
 # 0.30.3
 

--- a/crates/ruma-events/Cargo.toml
+++ b/crates/ruma-events/Cargo.toml
@@ -64,6 +64,10 @@ compat-tag-info = []
 # https://github.com/matrix-org/matrix-spec/issues/1667
 compat-encrypted-stickers = []
 
+# The predecessor field of RoomCreateEventContent is ignored if its
+# deserialization fails.
+compat-lax-room-create-deser = []
+
 [dependencies]
 as_variant = { workspace = true }
 indexmap = { version = "2.0.0", features = ["serde"] }

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -121,6 +121,10 @@ compat-encrypted-stickers = ["ruma-events?/compat-encrypted-stickers"]
 # defaulting to an empty `Vec` in deserialization.
 compat-optional-txn-pdus = ["ruma-federation-api?/compat-optional-txn-pdus"]
 
+# The predecessor field of RoomCreateEventContent is ignored if its
+# deserialization fails.
+compat-lax-room-create-deser = ["ruma-events?/compat-lax-room-create-deser"]
+
 # Specific compatibility for past ring public/private key documents.
 ring-compat = ["dep:ruma-signatures", "ruma-signatures?/ring-compat"]
 
@@ -259,6 +263,7 @@ __compat = [
     "compat-tag-info",
     "compat-encrypted-stickers",
     "compat-optional-txn-pdus",
+    "compat-lax-room-create-deser",
 ]
 
 [dependencies]


### PR DESCRIPTION
Finishes #1927.

I am not sure if we should apply this to other fields of `m.room.create`, this is likely the only one that is problematic currently.