### PR TITLE
common: Fix disposition of RoomVersionRules::MSC2870

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -54,6 +54,10 @@ Breaking changes:
   1.15.
   - It can be constructed with `JoinRule::kind()` and `JoinRuleSummary::kind()`.
 
+Bug fix:
+
+- Set the `disposition` of `RoomVersionRules::MSC2870` as unstable.
+
 Improvements:
 
 - Implement the `Zeroize` trait for the `Base64` type.

--- a/crates/ruma-common/src/room_version_rules.rs
+++ b/crates/ruma-common/src/room_version_rules.rs
@@ -125,7 +125,11 @@ impl RoomVersionRules {
     ///
     /// [MSC2870]: https://github.com/matrix-org/matrix-spec-proposals/pull/2870
     #[cfg(feature = "unstable-msc2870")]
-    pub const MSC2870: Self = Self { redaction: RedactionRules::MSC2870, ..Self::V11 };
+    pub const MSC2870: Self = Self {
+        disposition: RoomVersionDisposition::Unstable,
+        redaction: RedactionRules::MSC2870,
+        ..Self::V11
+    };
 }
 
 /// The stability of a room version.


### PR DESCRIPTION
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
