### PR TITLE
events: Use RedactionRules to decide which `redacts` field to use for `m.room.redaction` events

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -42,6 +42,8 @@ Breaking changes:
 - The `EventContent` macro doesn't implement `StaticEventContent` anymore for account data where the
   `type` uses the `.*` suffix, since the event type is not known at compile-time.
   - `SecretStorageKeyEventContent` doesn't implement `StaticEventContent` anymore.
+- The `(Original)(Sync)RedactEvent` events take a `RedactionRules` instead of `RoomVersionId` for
+  their `redacts()` method. This avoids unexpected behavior for unknown room versions.
 
 Improvements:
 

--- a/crates/ruma-events/tests/it/redaction.rs
+++ b/crates/ruma-events/tests/it/redaction.rs
@@ -1,6 +1,9 @@
 use assert_matches2::assert_matches;
 use js_int::uint;
-use ruma_common::{owned_event_id, serde::CanBeEmpty, MilliSecondsSinceUnixEpoch, RoomVersionId};
+use ruma_common::{
+    owned_event_id, room_version_rules::RedactionRules, serde::CanBeEmpty,
+    MilliSecondsSinceUnixEpoch,
+};
 use ruma_events::{
     room::redaction::{RoomRedactionEvent, RoomRedactionEventContent},
     AnyMessageLikeEvent,
@@ -54,8 +57,8 @@ fn deserialize_redaction() {
         Ok(AnyMessageLikeEvent::RoomRedaction(RoomRedactionEvent::Original(ev)))
     );
 
-    assert_eq!(ev.redacts(&RoomVersionId::V1), "$nomorev1:example.com");
-    assert_eq!(ev.redacts(&RoomVersionId::V11), "$nomorev11:example.com");
+    assert_eq!(ev.redacts(&RedactionRules::V1), "$nomorev1:example.com");
+    assert_eq!(ev.redacts(&RedactionRules::V11), "$nomorev11:example.com");
 
     assert_eq!(ev.content.redacts.unwrap(), "$nomorev11:example.com");
     assert_eq!(ev.content.reason.as_deref(), Some("being very unfriendly"));


### PR DESCRIPTION
For consistency with the methods to redact an event, and to avoid unexpected behavior for unsupported room versions.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
