### PR TITLE
events: Add `IsPrefix` associated type to `StaticEventContent`

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -39,14 +39,13 @@ Breaking changes:
 - The `BundledThread::latest_event` field is now an `AnySyncMessageLikeEvent` instead of
   `AnyMessageLikeEvent`, to reflect that it may not always include a `room_id` field (if the owning
   event came from sync, for instance), which can usually be obtained from the surrounding context.
-- The `EventContent` macro doesn't implement `StaticEventContent` anymore for account data where the
-  `type` uses the `.*` suffix, since the event type is not known at compile-time.
-  - `SecretStorageKeyEventContent` doesn't implement `StaticEventContent` anymore.
 - The `(Original)(Sync)RedactEvent` events take a `RedactionRules` instead of `RoomVersionId` for
   their `redacts()` method. This avoids unexpected behavior for unknown room versions.
 - `SpaceChildEventContent` now uses `OwnedSpaceChildOrder` for the `order` field. This is a type
   with strong validation according to the rules of the spec. If its deserialization fails, this
   field is set to `None` to ignore it, as recommended in the spec.
+- `StaticEventContent` has a new associated type `IsPrefix` to identify event types where only the
+  prefix is statically-known.
 
 Improvements:
 

--- a/crates/ruma-events/src/call/member.rs
+++ b/crates/ruma-events/src/call/member.rs
@@ -201,6 +201,7 @@ impl RedactedStateEventContent for RedactedCallMemberEventContent {
 
 impl StaticEventContent for RedactedCallMemberEventContent {
     const TYPE: &'static str = CallMemberEventContent::TYPE;
+    type IsPrefix = <CallMemberEventContent as StaticEventContent>::IsPrefix;
 }
 
 /// Legacy content with an array of memberships. See also: [`CallMemberEventContent`]

--- a/crates/ruma-events/src/content.rs
+++ b/crates/ruma-events/src/content.rs
@@ -25,9 +25,55 @@ where
 }
 
 /// An event content type with a statically-known event `type` value.
+///
+/// Note that the `TYPE` might not be the full event type. If `IsPrefix` is set to `True`, it only
+/// contains the statically-known prefix of the event type.
+///
+/// To only support full event types, the bound `StaticEventContent<IsPrefix = False>` can be used.
 pub trait StaticEventContent: Sized {
-    /// The event type.
+    /// The statically-known part of the event type.
+    ///
+    /// If this is only the prefix of the event type, it should end with `.`, which is usually used
+    /// a separator in Matrix event types.
     const TYPE: &'static str;
+    /// Whether the statically-known part of the event type is the prefix.
+    ///
+    /// Should be set to the [`True`] or [`False`] types.
+    ///
+    /// Ideally this should be a boolean associated constant, but [associated constant equality is
+    /// unstable], so this field could not be used as a bound. Instead we use an associated type so
+    /// we can rely on associated type equality.
+    ///
+    /// If this is set to [`False`], the `TYPE` is the full event type.
+    ///
+    /// [associated constant equality is unstable]: https://github.com/rust-lang/rust/issues/92827
+    type IsPrefix: BooleanType;
+}
+
+/// A trait for types representing a boolean value.
+pub trait BooleanType {
+    /// The boolean representation of this type.
+    fn as_bool() -> bool;
+}
+
+/// The equivalent of the `true` boolean.
+#[non_exhaustive]
+pub struct True;
+
+impl BooleanType for True {
+    fn as_bool() -> bool {
+        true
+    }
+}
+
+/// The equivalent of the `false` boolean.
+#[non_exhaustive]
+pub struct False;
+
+impl BooleanType for False {
+    fn as_bool() -> bool {
+        false
+    }
 }
 
 /// Content of a global account-data event.

--- a/crates/ruma-events/src/policy/rule/room.rs
+++ b/crates/ruma-events/src/policy/rule/room.rs
@@ -33,6 +33,7 @@ impl PossiblyRedactedStateEventContent for PossiblyRedactedPolicyRuleRoomEventCo
 
 impl StaticEventContent for PossiblyRedactedPolicyRuleRoomEventContent {
     const TYPE: &'static str = PolicyRuleRoomEventContent::TYPE;
+    type IsPrefix = <PolicyRuleRoomEventContent as StaticEventContent>::IsPrefix;
 }
 
 #[cfg(test)]

--- a/crates/ruma-events/src/policy/rule/server.rs
+++ b/crates/ruma-events/src/policy/rule/server.rs
@@ -33,4 +33,5 @@ impl PossiblyRedactedStateEventContent for PossiblyRedactedPolicyRuleServerEvent
 
 impl StaticEventContent for PossiblyRedactedPolicyRuleServerEventContent {
     const TYPE: &'static str = PolicyRuleServerEventContent::TYPE;
+    type IsPrefix = <PolicyRuleServerEventContent as StaticEventContent>::IsPrefix;
 }

--- a/crates/ruma-events/src/policy/rule/user.rs
+++ b/crates/ruma-events/src/policy/rule/user.rs
@@ -33,4 +33,5 @@ impl PossiblyRedactedStateEventContent for PossiblyRedactedPolicyRuleUserEventCo
 
 impl StaticEventContent for PossiblyRedactedPolicyRuleUserEventContent {
     const TYPE: &'static str = PolicyRuleUserEventContent::TYPE;
+    type IsPrefix = <PolicyRuleUserEventContent as StaticEventContent>::IsPrefix;
 }

--- a/crates/ruma-events/src/poll/unstable_start.rs
+++ b/crates/ruma-events/src/poll/unstable_start.rs
@@ -139,6 +139,7 @@ impl NewUnstablePollStartEventContent {
 
 impl StaticEventContent for NewUnstablePollStartEventContent {
     const TYPE: &'static str = UnstablePollStartEventContent::TYPE;
+    type IsPrefix = <UnstablePollStartEventContent as StaticEventContent>::IsPrefix;
 }
 
 impl MessageLikeEventContent for NewUnstablePollStartEventContent {
@@ -222,6 +223,7 @@ impl ReplacementUnstablePollStartEventContent {
 
 impl StaticEventContent for ReplacementUnstablePollStartEventContent {
     const TYPE: &'static str = UnstablePollStartEventContent::TYPE;
+    type IsPrefix = <UnstablePollStartEventContent as StaticEventContent>::IsPrefix;
 }
 
 impl MessageLikeEventContent for ReplacementUnstablePollStartEventContent {
@@ -244,6 +246,7 @@ impl RedactedUnstablePollStartEventContent {
 
 impl StaticEventContent for RedactedUnstablePollStartEventContent {
     const TYPE: &'static str = UnstablePollStartEventContent::TYPE;
+    type IsPrefix = <UnstablePollStartEventContent as StaticEventContent>::IsPrefix;
 }
 
 impl RedactedMessageLikeEventContent for RedactedUnstablePollStartEventContent {

--- a/crates/ruma-events/src/room/aliases.rs
+++ b/crates/ruma-events/src/room/aliases.rs
@@ -71,4 +71,5 @@ impl RedactedStateEventContent for RedactedRoomAliasesEventContent {
 
 impl StaticEventContent for RedactedRoomAliasesEventContent {
     const TYPE: &'static str = RoomAliasesEventContent::TYPE;
+    type IsPrefix = <RoomAliasesEventContent as StaticEventContent>::IsPrefix;
 }

--- a/crates/ruma-events/src/room/member.rs
+++ b/crates/ruma-events/src/room/member.rs
@@ -253,6 +253,7 @@ impl RedactedStateEventContent for RedactedRoomMemberEventContent {
 
 impl StaticEventContent for RedactedRoomMemberEventContent {
     const TYPE: &'static str = RoomMemberEventContent::TYPE;
+    type IsPrefix = <RoomMemberEventContent as StaticEventContent>::IsPrefix;
 }
 
 impl RoomMemberEvent {

--- a/crates/ruma-events/src/room/power_levels.rs
+++ b/crates/ruma-events/src/room/power_levels.rs
@@ -287,6 +287,7 @@ pub struct RedactedRoomPowerLevelsEventContent {
 
 impl StaticEventContent for RedactedRoomPowerLevelsEventContent {
     const TYPE: &'static str = RoomPowerLevelsEventContent::TYPE;
+    type IsPrefix = <RoomPowerLevelsEventContent as StaticEventContent>::IsPrefix;
 }
 
 impl RedactedStateEventContent for RedactedRoomPowerLevelsEventContent {

--- a/crates/ruma-events/src/room/redaction.rs
+++ b/crates/ruma-events/src/room/redaction.rs
@@ -233,6 +233,7 @@ pub struct RedactedRoomRedactionEventContent {
 
 impl StaticEventContent for RedactedRoomRedactionEventContent {
     const TYPE: &'static str = RoomRedactionEventContent::TYPE;
+    type IsPrefix = <RoomRedactionEventContent as StaticEventContent>::IsPrefix;
 }
 
 impl RedactedMessageLikeEventContent for RedactedRoomRedactionEventContent {

--- a/crates/ruma-events/src/room/tombstone.rs
+++ b/crates/ruma-events/src/room/tombstone.rs
@@ -62,4 +62,5 @@ impl PossiblyRedactedStateEventContent for PossiblyRedactedRoomTombstoneEventCon
 
 impl StaticEventContent for PossiblyRedactedRoomTombstoneEventContent {
     const TYPE: &'static str = RoomTombstoneEventContent::TYPE;
+    type IsPrefix = <RoomTombstoneEventContent as StaticEventContent>::IsPrefix;
 }

--- a/crates/ruma-events/tests/it/ui/01-content-sanity-check.rs
+++ b/crates/ruma-events/tests/it/ui/01-content-sanity-check.rs
@@ -9,4 +9,10 @@ pub struct MacroTestContent {
     pub url: String,
 }
 
-fn main() {}
+fn main() {
+    use ruma_events::{BooleanType, StateEventContent, StaticEventContent};
+
+    assert_eq!(MacroTestContent::TYPE, "m.macro.test");
+    assert!(!<MacroTestContent as StaticEventContent>::IsPrefix::as_bool());
+    assert_eq!(MacroTestContent { url: "foo".to_owned() }.event_type().to_string(), "m.macro.test");
+}

--- a/crates/ruma-events/tests/it/ui/10-content-wildcard.rs
+++ b/crates/ruma-events/tests/it/ui/10-content-wildcard.rs
@@ -11,8 +11,10 @@ pub struct MacroTestContent {
 }
 
 fn main() {
-    use ruma_events::GlobalAccountDataEventContent;
+    use ruma_events::{BooleanType, GlobalAccountDataEventContent, StaticEventContent};
 
+    assert_eq!(MacroTestContent::TYPE, "m.macro.test.");
+    assert!(<MacroTestContent as StaticEventContent>::IsPrefix::as_bool());
     assert_eq!(
         MacroTestContent { frag: "foo".to_owned() }.event_type().to_string(),
         "m.macro.test.foo"

--- a/crates/ruma-macros/src/lib.rs
+++ b/crates/ruma-macros/src/lib.rs
@@ -220,7 +220,7 @@ pub fn event_enum(input: TokenStream) -> TokenStream {
 /// This macro implements the following traits for the type on which it is applied:
 ///
 /// * `{kind}EventContent`
-/// * `StaticEventContent`, if the `type` does not use a `.*` suffix.
+/// * `StaticEventContent`
 /// * `StaticStateEventContent`, for the `State` kind.
 ///
 /// # Generated types
@@ -333,7 +333,8 @@ pub fn event_enum(input: TokenStream) -> TokenStream {
 ///
 /// Types with an account data kind can also use the `.*` suffix, if the end of the type changes
 /// dynamically. It must be associated with a field that has the `#[ruma_event(type_fragment)]`
-/// attribute that will store the end of the event type.
+/// attribute that will store the end of the event type. Those types have the
+/// `StaticEventContent::IsPrefix` type set to `True`.
 ///
 /// ### `kind = Kind`
 ///


### PR DESCRIPTION
To identify when the statically-known part of the event type is a prefix.

Alternative to #2136.

~~Marking this as a draft for now, to check if this works for the SDK.~~
