### PR TITLE
common: add `content_field_redacts` field to `RedactionRules`

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -92,6 +92,8 @@ Improvements:
   - Implement `From<RoomSummary>` for `PublicRoomsChunk` and
     `From<PublicRoomsChunk>` for `RoomSummary`.
 - Add `MatrixVersion::V1_15`.
+- Add `content_field_redacts` field to `RedactionRules`, which is used to determine whether the
+  `content` or top-level `redacts` field should be used to determine what event an event redacts.
 
 # 0.15.2
 

--- a/crates/ruma-common/src/room_version_rules.rs
+++ b/crates/ruma-common/src/room_version_rules.rs
@@ -356,6 +356,13 @@ pub struct RedactionRules {
     /// [spec]: https://spec.matrix.org/v1.15/rooms/v11/#redactions
     pub keep_room_member_third_party_invite_signed: bool,
 
+    /// Whether the `content.redacts` field should be used to determine the event an event
+    /// redacts, as opposed to the top-level `redacts` field ([spec]), introduced in room version
+    /// 11.
+    ///
+    /// [spec]: https://spec.matrix.org/v1.15/rooms/v11/#redactions
+    pub content_field_redacts: bool,
+
     /// Whether to keep the `allow`, `deny` and `allow_ip_literals` in the `content` of
     /// `m.room.server_acl` events ([MSC2870]).
     ///
@@ -377,6 +384,7 @@ impl RedactionRules {
         keep_room_redaction_redacts: false,
         keep_room_power_levels_invite: false,
         keep_room_member_third_party_invite_signed: false,
+        content_field_redacts: false,
         #[cfg(feature = "unstable-msc2870")]
         keep_room_server_acl_allow_deny_allow_ip_literals: false,
     };
@@ -406,6 +414,7 @@ impl RedactionRules {
         keep_room_redaction_redacts: true,
         keep_room_power_levels_invite: true,
         keep_room_member_third_party_invite_signed: true,
+        content_field_redacts: true,
         ..Self::V9
     };
 

--- a/crates/ruma-events/src/room/redaction.rs
+++ b/crates/ruma-events/src/room/redaction.rs
@@ -470,7 +470,7 @@ fn redacts<'a>(
     redacts: Option<&'a EventId>,
     content_redacts: Option<&'a EventId>,
 ) -> &'a EventId {
-    if rules.keep_room_redaction_redacts {
+    if rules.content_field_redacts {
         content_redacts.or_else(|| {
             error!(
                 "Redacts field inside content not available, \


### PR DESCRIPTION
While not used inside Ruma itself, it's useful for severs, to know where to try find the event an event redacts.
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
