### PR TITLE
Make `PushConditionRoomCtx` and `PushConditionPowerLevelsCtx` non-exhaustive

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -53,6 +53,7 @@ Breaking changes:
   and includes all possible join rule kinds, due to a clarification in Matrix
   1.15.
   - It can be constructed with `JoinRule::kind()` and `JoinRuleSummary::kind()`.
+- Make `PushConditionRoomCtx` and `PushConditionPowerLevelsCtx` non-exhaustive.
 
 Improvements:
 

--- a/crates/ruma-common/src/push/condition.rs
+++ b/crates/ruma-common/src/push/condition.rs
@@ -228,7 +228,7 @@ pub struct _CustomPushCondition {
 
 /// The context of the room associated to an event to be able to test all push conditions.
 #[derive(Clone, Debug)]
-#[allow(clippy::exhaustive_structs)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct PushConditionRoomCtx {
     /// The ID of the room.
     pub room_id: OwnedRoomId,
@@ -252,9 +252,36 @@ pub struct PushConditionRoomCtx {
     pub supported_features: Vec<RoomVersionFeature>,
 }
 
+impl PushConditionRoomCtx {
+    /// Create a new `PushConditionRoomCtx`.
+    pub fn new(
+        room_id: OwnedRoomId,
+        member_count: UInt,
+        user_id: OwnedUserId,
+        user_display_name: String,
+    ) -> Self {
+        Self {
+            room_id,
+            member_count,
+            user_id,
+            user_display_name,
+            power_levels: None,
+            #[cfg(feature = "unstable-msc3931")]
+            supported_features: Vec::new(),
+        }
+    }
+
+    /// Add the given power levels context to this `PushConditionRoomCtx`.
+    pub fn with_power_levels(self, power_levels: PushConditionPowerLevelsCtx) -> Self {
+        Self { power_levels: Some(power_levels), ..self }
+    }
+}
+
 /// The room power levels context to be able to test the corresponding push conditions.
+///
+/// Should be constructed using `From<RoomPowerLevels>`.
 #[derive(Clone, Debug)]
-#[allow(clippy::exhaustive_structs)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct PushConditionPowerLevelsCtx {
     /// The power levels of the users of the room.
     pub users: BTreeMap<OwnedUserId, Int>,
@@ -264,6 +291,17 @@ pub struct PushConditionPowerLevelsCtx {
 
     /// The notification power levels of the room.
     pub notifications: NotificationPowerLevels,
+}
+
+impl PushConditionPowerLevelsCtx {
+    /// Create a new `PushConditionPowerLevelsCtx`.
+    pub fn new(
+        users: BTreeMap<OwnedUserId, Int>,
+        users_default: Int,
+        notifications: NotificationPowerLevels,
+    ) -> Self {
+        Self { users, users_default, notifications }
+    }
 }
 
 /// Additional functions for character matching.

--- a/crates/ruma-events/src/room/power_levels.rs
+++ b/crates/ruma-events/src/room/power_levels.rs
@@ -614,7 +614,7 @@ impl From<RoomPowerLevels> for RoomPowerLevelsEventContent {
 
 impl From<RoomPowerLevels> for PushConditionPowerLevelsCtx {
     fn from(c: RoomPowerLevels) -> Self {
-        Self { users: c.users, users_default: c.users_default, notifications: c.notifications }
+        Self::new(c.users, c.users_default, c.notifications)
     }
 }
 


### PR DESCRIPTION


<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
