### PR TITLE
events: Add feature for ignoring deserialization error of `m.topic` in `RoomTopicEventContent`

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -75,6 +75,9 @@ Improvements:
   now implements `Ord` using the aforementioned trait.
 - With the `compat-lax-room-create-deser` cargo feature, the `predecessor` field of
   `RoomCreateEventContent` is ignored during deserialization if it has an invalid format.
+- With the `compat-lax-room-topic-deser` cargo feature, the `topic_block` field of
+  `RoomTopicEventContent` (named `m.topic` in the JSON source) is ignored during deserialization if
+  it has an invalid format.
    
 # 0.30.3
 

--- a/crates/ruma-events/Cargo.toml
+++ b/crates/ruma-events/Cargo.toml
@@ -68,6 +68,10 @@ compat-encrypted-stickers = []
 # deserialization fails.
 compat-lax-room-create-deser = []
 
+# The topic_block (`m.topic`) field of RoomTopicEventContent is ignored if its
+# deserialization fails.
+compat-lax-room-topic-deser = []
+
 [dependencies]
 as_variant = { workspace = true }
 indexmap = { version = "2.0.0", features = ["serde"] }

--- a/crates/ruma-events/src/room/create.rs
+++ b/crates/ruma-events/src/room/create.rs
@@ -46,7 +46,7 @@ pub struct RoomCreateEventContent {
 
     /// A reference to the room this room replaces, if the previous room was upgraded.
     ///
-    /// With the `compat-lax-room-create-deser` cargo feature, this field is ignored it its
+    /// With the `compat-lax-room-create-deser` cargo feature, this field is ignored if its
     /// deserialization fails.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg_attr(

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -125,6 +125,10 @@ compat-optional-txn-pdus = ["ruma-federation-api?/compat-optional-txn-pdus"]
 # deserialization fails.
 compat-lax-room-create-deser = ["ruma-events?/compat-lax-room-create-deser"]
 
+# The topic_block (`m.topic`) field of RoomTopicEventContent is ignored if its
+# deserialization fails.
+compat-lax-room-topic-deser = ["ruma-events?/compat-lax-room-topic-deser"]
+
 # Specific compatibility for past ring public/private key documents.
 ring-compat = ["dep:ruma-signatures", "ruma-signatures?/ring-compat"]
 
@@ -264,6 +268,7 @@ __compat = [
     "compat-encrypted-stickers",
     "compat-optional-txn-pdus",
     "compat-lax-room-create-deser",
+    "compat-lax-room-topic-deser",
 ]
 
 [dependencies]


### PR DESCRIPTION
Invalid format of the content has been found in the wild. At least the matrix-js-sdk sends that invalid format: https://github.com/matrix-org/matrix-js-sdk/issues/4902.
