### PR TITLE
Rename derive macro IdZst => IdDst

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ zeroize = "1.8.1"
 rust_2018_idioms = { level = "warn", priority = -1 }
 semicolon_in_expressions_from_macros = "warn"
 unexpected_cfgs = { level = "warn", check-cfg = [
-    'cfg(ruma_identifiers_storage, values("Arc"))', # used by the IdZst macro
+    'cfg(ruma_identifiers_storage, values("Arc"))', # used by the IdDst macro
     'cfg(ruma_unstable_exhaustive_types)', # set all types as exhaustive
 ] }
 unreachable_pub = "warn"

--- a/crates/ruma-common/src/identifiers/base64_public_key.rs
+++ b/crates/ruma-common/src/identifiers/base64_public_key.rs
@@ -1,4 +1,4 @@
-use ruma_macros::IdZst;
+use ruma_macros::IdDst;
 
 use super::{IdParseError, KeyName};
 use crate::serde::{base64::Standard, Base64, Base64DecodeError};
@@ -10,7 +10,7 @@ use crate::serde::{base64::Standard, Base64, Base64DecodeError};
 ///
 /// [cross-signing]: https://spec.matrix.org/latest/client-server-api/#cross-signing
 #[repr(transparent)]
-#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdZst)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
 #[ruma_id(validate = ruma_identifiers_validation::base64_public_key::validate)]
 pub struct Base64PublicKey(str);
 

--- a/crates/ruma-common/src/identifiers/base64_public_key_or_device_id.rs
+++ b/crates/ruma-common/src/identifiers/base64_public_key_or_device_id.rs
@@ -1,4 +1,4 @@
-use ruma_macros::IdZst;
+use ruma_macros::IdDst;
 
 use super::{
     Base64PublicKey, DeviceId, IdParseError, KeyName, OwnedBase64PublicKey, OwnedDeviceId,
@@ -25,7 +25,7 @@ use super::{
 /// assert_eq!(owned_id.as_str(), "ijklmnop");
 /// ```
 #[repr(transparent)]
-#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdZst)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
 pub struct Base64PublicKeyOrDeviceId(str);
 
 impl KeyName for Base64PublicKeyOrDeviceId {

--- a/crates/ruma-common/src/identifiers/client_secret.rs
+++ b/crates/ruma-common/src/identifiers/client_secret.rs
@@ -1,6 +1,6 @@
 //! Client secret identifier.
 
-use ruma_macros::IdZst;
+use ruma_macros::IdDst;
 
 /// A client secret.
 ///
@@ -11,7 +11,7 @@ use ruma_macros::IdZst;
 /// use `ClientSecret::new()` to generate a random one. If that function is not available for you,
 /// you need to activate this crate's `rand` Cargo feature.
 #[repr(transparent)]
-#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdZst)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
 #[ruma_id(validate = ruma_identifiers_validation::client_secret::validate)]
 pub struct ClientSecret(str);
 

--- a/crates/ruma-common/src/identifiers/device_id.rs
+++ b/crates/ruma-common/src/identifiers/device_id.rs
@@ -1,4 +1,4 @@
-use ruma_macros::IdZst;
+use ruma_macros::IdDst;
 
 #[cfg(feature = "rand")]
 use super::generate_localpart;
@@ -29,7 +29,7 @@ use super::{IdParseError, KeyName};
 /// assert_eq!(owned_id.as_str(), "ijklmnop");
 /// ```
 #[repr(transparent)]
-#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdZst)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
 pub struct DeviceId(str);
 
 impl DeviceId {

--- a/crates/ruma-common/src/identifiers/event_id.rs
+++ b/crates/ruma-common/src/identifiers/event_id.rs
@@ -1,6 +1,6 @@
 //! Matrix event identifiers.
 
-use ruma_macros::IdZst;
+use ruma_macros::IdDst;
 
 use super::ServerName;
 
@@ -36,7 +36,7 @@ use super::ServerName;
 /// [event ID]: https://spec.matrix.org/latest/appendices/#event-ids
 /// [room versions]: https://spec.matrix.org/latest/rooms/#complete-list-of-room-versions
 #[repr(transparent)]
-#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdZst)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
 #[ruma_id(validate = ruma_identifiers_validation::event_id::validate)]
 pub struct EventId(str);
 

--- a/crates/ruma-common/src/identifiers/key_id.rs
+++ b/crates/ruma-common/src/identifiers/key_id.rs
@@ -4,7 +4,7 @@ use std::{
     marker::PhantomData,
 };
 
-use ruma_macros::IdZst;
+use ruma_macros::IdDst;
 
 use super::{
     crypto_algorithms::SigningKeyAlgorithm, Base64PublicKey, Base64PublicKeyOrDeviceId, DeviceId,
@@ -46,7 +46,7 @@ use super::{
 /// assert_eq!(k.as_str(), "curve25519:MYDEVICE");
 /// ```
 #[repr(transparent)]
-#[derive(IdZst)]
+#[derive(IdDst)]
 #[ruma_id(
     validate = ruma_identifiers_validation::key_id::validate::<K>,
 )]
@@ -208,7 +208,7 @@ impl KeyAlgorithm for OneTimeKeyAlgorithm {}
 ///
 /// This type has no semantic value and no validation is done. It is meant to be able to use the
 /// [`KeyId`] API without validating the key name.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdZst)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
 pub struct AnyKeyName(str);
 
 impl KeyName for AnyKeyName {

--- a/crates/ruma-common/src/identifiers/mxc_uri.rs
+++ b/crates/ruma-common/src/identifiers/mxc_uri.rs
@@ -5,7 +5,7 @@
 use std::num::NonZeroU8;
 
 use ruma_identifiers_validation::{error::MxcUriError, mxc_uri::validate};
-use ruma_macros::IdZst;
+use ruma_macros::IdDst;
 
 use super::ServerName;
 
@@ -15,7 +15,7 @@ type Result<T, E = MxcUriError> = std::result::Result<T, E>;
 ///
 /// [MXC URI]: https://spec.matrix.org/latest/client-server-api/#matrix-content-mxc-uris
 #[repr(transparent)]
-#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdZst)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
 pub struct MxcUri(str);
 
 impl MxcUri {

--- a/crates/ruma-common/src/identifiers/one_time_key_name.rs
+++ b/crates/ruma-common/src/identifiers/one_time_key_name.rs
@@ -1,4 +1,4 @@
-use ruma_macros::IdZst;
+use ruma_macros::IdDst;
 
 use super::{IdParseError, KeyName};
 
@@ -9,7 +9,7 @@ use super::{IdParseError, KeyName};
 ///
 /// [one-time or fallback key]: https://spec.matrix.org/latest/client-server-api/#one-time-and-fallback-keys
 #[repr(transparent)]
-#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdZst)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
 pub struct OneTimeKeyName(str);
 
 impl KeyName for OneTimeKeyName {

--- a/crates/ruma-common/src/identifiers/room_alias_id.rs
+++ b/crates/ruma-common/src/identifiers/room_alias_id.rs
@@ -1,6 +1,6 @@
 //! Matrix room alias identifiers.
 
-use ruma_macros::IdZst;
+use ruma_macros::IdDst;
 
 use super::{matrix_uri::UriAction, server_name::ServerName, MatrixToUri, MatrixUri, OwnedEventId};
 
@@ -16,7 +16,7 @@ use super::{matrix_uri::UriAction, server_name::ServerName, MatrixToUri, MatrixU
 ///
 /// [room alias ID]: https://spec.matrix.org/latest/appendices/#room-aliases
 #[repr(transparent)]
-#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdZst)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
 #[ruma_id(validate = ruma_identifiers_validation::room_alias_id::validate)]
 pub struct RoomAliasId(str);
 

--- a/crates/ruma-common/src/identifiers/room_id.rs
+++ b/crates/ruma-common/src/identifiers/room_id.rs
@@ -1,6 +1,6 @@
 //! Matrix room identifiers.
 
-use ruma_macros::IdZst;
+use ruma_macros::IdDst;
 
 use super::{
     matrix_uri::UriAction, MatrixToUri, MatrixUri, OwnedEventId, OwnedServerName, ServerName,
@@ -19,7 +19,7 @@ use crate::RoomOrAliasId;
 ///
 /// [room ID]: https://spec.matrix.org/latest/appendices/#room-ids
 #[repr(transparent)]
-#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdZst)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
 #[ruma_id(validate = ruma_identifiers_validation::room_id::validate)]
 pub struct RoomId(str);
 

--- a/crates/ruma-common/src/identifiers/room_or_alias_id.rs
+++ b/crates/ruma-common/src/identifiers/room_or_alias_id.rs
@@ -2,7 +2,7 @@
 
 use std::hint::unreachable_unchecked;
 
-use ruma_macros::IdZst;
+use ruma_macros::IdDst;
 use tracing::warn;
 
 use super::{server_name::ServerName, OwnedRoomAliasId, OwnedRoomId, RoomAliasId, RoomId};
@@ -30,7 +30,7 @@ use super::{server_name::ServerName, OwnedRoomAliasId, OwnedRoomId, RoomAliasId,
 /// [room ID]: https://spec.matrix.org/latest/appendices/#room-ids
 /// [room alias ID]: https://spec.matrix.org/latest/appendices/#room-aliases
 #[repr(transparent)]
-#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdZst)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
 #[ruma_id(validate = ruma_identifiers_validation::room_id_or_alias_id::validate)]
 pub struct RoomOrAliasId(str);
 

--- a/crates/ruma-common/src/identifiers/server_name.rs
+++ b/crates/ruma-common/src/identifiers/server_name.rs
@@ -2,7 +2,7 @@
 
 use std::net::Ipv4Addr;
 
-use ruma_macros::IdZst;
+use ruma_macros::IdDst;
 
 /// A Matrix-spec compliant [server name].
 ///
@@ -10,7 +10,7 @@ use ruma_macros::IdZst;
 ///
 /// [server name]: https://spec.matrix.org/latest/appendices/#server-name
 #[repr(transparent)]
-#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdZst)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
 #[ruma_id(validate = ruma_identifiers_validation::server_name::validate)]
 pub struct ServerName(str);
 

--- a/crates/ruma-common/src/identifiers/server_signing_key_version.rs
+++ b/crates/ruma-common/src/identifiers/server_signing_key_version.rs
@@ -1,4 +1,4 @@
-use ruma_macros::IdZst;
+use ruma_macros::IdDst;
 
 use super::{IdParseError, KeyName};
 
@@ -12,7 +12,7 @@ use super::{IdParseError, KeyName};
 ///
 /// [homeserver signing key]: https://spec.matrix.org/latest/server-server-api/#retrieving-server-keys
 #[repr(transparent)]
-#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdZst)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
 #[ruma_id(
     validate = ruma_identifiers_validation::server_signing_key_version::validate,
 )]

--- a/crates/ruma-common/src/identifiers/session_id.rs
+++ b/crates/ruma-common/src/identifiers/session_id.rs
@@ -1,6 +1,6 @@
 //! Matrix session ID.
 
-use ruma_macros::IdZst;
+use ruma_macros::IdDst;
 
 use super::IdParseError;
 
@@ -9,7 +9,7 @@ use super::IdParseError;
 /// Session IDs in Matrix are opaque character sequences of `[0-9a-zA-Z.=_-]`. Their length must
 /// must not exceed 255 characters.
 #[repr(transparent)]
-#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdZst)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
 #[ruma_id(validate = validate_session_id)]
 pub struct SessionId(str);
 

--- a/crates/ruma-common/src/identifiers/space_child_order.rs
+++ b/crates/ruma-common/src/identifiers/space_child_order.rs
@@ -1,6 +1,6 @@
 //! `m.space.child` order.
 
-use ruma_macros::IdZst;
+use ruma_macros::IdDst;
 
 /// The order of an [`m.space.child`] event.
 ///
@@ -10,7 +10,7 @@ use ruma_macros::IdZst;
 ///
 /// [`m.space.child`]: https://spec.matrix.org/latest/client-server-api/#mspacechild
 #[repr(transparent)]
-#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdZst)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
 #[ruma_id(validate = ruma_identifiers_validation::space_child_order::validate)]
 pub struct SpaceChildOrder(str);
 

--- a/crates/ruma-common/src/identifiers/transaction_id.rs
+++ b/crates/ruma-common/src/identifiers/transaction_id.rs
@@ -1,4 +1,4 @@
-use ruma_macros::IdZst;
+use ruma_macros::IdDst;
 
 /// A Matrix transaction ID.
 ///
@@ -9,7 +9,7 @@ use ruma_macros::IdZst;
 /// `TransactionId::new()` to generate a random one. If that function is not available for you, you
 /// need to activate this crate's `rand` Cargo feature.
 #[repr(transparent)]
-#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdZst)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
 pub struct TransactionId(str);
 
 impl TransactionId {

--- a/crates/ruma-common/src/identifiers/user_id.rs
+++ b/crates/ruma-common/src/identifiers/user_id.rs
@@ -4,7 +4,7 @@ use std::{rc::Rc, sync::Arc};
 
 pub use ruma_identifiers_validation::user_id::localpart_is_fully_conforming;
 use ruma_identifiers_validation::{localpart_is_backwards_compatible, ID_MAX_BYTES};
-use ruma_macros::IdZst;
+use ruma_macros::IdDst;
 
 use super::{matrix_uri::UriAction, IdParseError, MatrixToUri, MatrixUri, ServerName};
 
@@ -20,7 +20,7 @@ use super::{matrix_uri::UriAction, IdParseError, MatrixToUri, MatrixUri, ServerN
 ///
 /// [user ID]: https://spec.matrix.org/latest/appendices/#user-identifiers
 #[repr(transparent)]
-#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdZst)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
 #[ruma_id(validate = ruma_identifiers_validation::user_id::validate)]
 pub struct UserId(str);
 

--- a/crates/ruma-common/src/identifiers/voip_id.rs
+++ b/crates/ruma-common/src/identifiers/voip_id.rs
@@ -1,6 +1,6 @@
 //! VoIP identifier.
 
-use ruma_macros::IdZst;
+use ruma_macros::IdDst;
 
 /// A VoIP identifier.
 ///
@@ -11,7 +11,7 @@ use ruma_macros::IdZst;
 /// use `VoipId::new()` to generate a random one. If that function is not available for you,
 /// you need to activate this crate's `rand` Cargo feature.
 #[repr(transparent)]
-#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdZst)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
 pub struct VoipId(str);
 
 impl VoipId {

--- a/crates/ruma-events/src/direct.rs
+++ b/crates/ruma-events/src/direct.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use ruma_common::{IdParseError, OwnedRoomId, OwnedUserId, UserId};
-use ruma_macros::{EventContent, IdZst};
+use ruma_macros::{EventContent, IdDst};
 use serde::{Deserialize, Serialize};
 
 /// An user identifier, it can be a [`UserId`] or a third-party identifier
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 /// There is no validation on this type, any string is allowed,
 /// but you can use `as_user_id` or `into_user_id` to try to get an [`UserId`].
 #[repr(transparent)]
-#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdZst)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
 pub struct DirectUserIdentifier(str);
 
 impl DirectUserIdentifier {

--- a/crates/ruma-macros/src/identifiers.rs
+++ b/crates/ruma-macros/src/identifiers.rs
@@ -23,19 +23,19 @@ impl Parse for IdentifierInput {
     }
 }
 
-pub fn expand_id_zst(input: ItemStruct) -> syn::Result<TokenStream> {
+pub fn expand_id_dst(input: ItemStruct) -> syn::Result<TokenStream> {
     let id = &input.ident;
     let owned = format_ident!("Owned{id}");
 
     let owned_decl = expand_owned_id(&input);
 
     let meta = input.attrs.iter().filter(|attr| attr.path().is_ident("ruma_id")).try_fold(
-        IdZstMeta::default(),
+        IdDstMeta::default(),
         |meta, attr| {
-            let list: Punctuated<IdZstMeta, Token![,]> =
+            let list: Punctuated<IdDstMeta, Token![,]> =
                 attr.parse_args_with(Punctuated::parse_terminated)?;
 
-            list.into_iter().try_fold(meta, IdZstMeta::merge)
+            list.into_iter().try_fold(meta, IdDstMeta::merge)
         },
     )?;
 
@@ -769,12 +769,12 @@ mod kw {
 }
 
 #[derive(Default)]
-struct IdZstMeta {
+struct IdDstMeta {
     validate: Option<Path>,
 }
 
-impl IdZstMeta {
-    fn merge(self, other: IdZstMeta) -> syn::Result<Self> {
+impl IdDstMeta {
+    fn merge(self, other: IdDstMeta) -> syn::Result<Self> {
         let validate = match (self.validate, other.validate) {
             (None, None) => None,
             (Some(val), None) | (None, Some(val)) => Some(val),
@@ -789,7 +789,7 @@ impl IdZstMeta {
     }
 }
 
-impl Parse for IdZstMeta {
+impl Parse for IdDstMeta {
     fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
         let _: kw::validate = input.parse()?;
         let _: Token![=] = input.parse()?;

--- a/crates/ruma-macros/src/lib.rs
+++ b/crates/ruma-macros/src/lib.rs
@@ -10,7 +10,7 @@
 // https://github.com/rust-lang/rust-clippy/issues/9029
 #![allow(clippy::derive_partial_eq_without_eq)]
 
-use identifiers::expand_id_zst;
+use identifiers::expand_id_dst;
 use proc_macro::TokenStream;
 use proc_macro2 as pm2;
 use quote::quote;
@@ -360,7 +360,7 @@ pub fn event_enum(input: TokenStream) -> TokenStream {
 ///
 /// The type of the state key of the event, required and only supported if the kind is `State`. This
 /// type should be a string type like `String`, `EmptyStateKey` or an identifier type generated with
-/// the `IdZst` macro.
+/// the `IdDst` macro.
 ///
 /// ### `unsigned_type = UnsignedType`
 ///
@@ -442,7 +442,7 @@ pub fn derive_from_event_to_enum(input: TokenStream) -> TokenStream {
     expand_from_impls_derived(input).into()
 }
 
-/// Generate methods and trait impl's for ZST identifier type.
+/// Generate methods and trait impl's for DST identifier type.
 ///
 /// This macro generates an `Owned*` wrapper type for the identifier type. This wrapper type is
 /// variable, by default it'll use [`Box`], but it can be changed at compile time
@@ -470,16 +470,16 @@ pub fn derive_from_event_to_enum(input: TokenStream) -> TokenStream {
 ///
 /// ```ignore
 /// # // HACK: This is "ignore" because of cyclical dependency drama.
-/// use ruma_macros::IdZst;
+/// use ruma_macros::IdDst;
 ///
-/// #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdZst)]
+/// #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
 /// #[ruma_id(validate = ruma_identifiers_validation::user_id::validate)]
 /// pub struct UserId(str);
 /// ```
-#[proc_macro_derive(IdZst, attributes(ruma_id))]
-pub fn derive_id_zst(input: TokenStream) -> TokenStream {
+#[proc_macro_derive(IdDst, attributes(ruma_id))]
+pub fn derive_id_dst(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as ItemStruct);
-    expand_id_zst(input).unwrap_or_else(syn::Error::into_compile_error).into()
+    expand_id_dst(input).unwrap_or_else(syn::Error::into_compile_error).into()
 }
 
 /// Compile-time checked `EventId` construction.


### PR DESCRIPTION
The previous name was simply wrong.

This is a breaking change for `ruma-macros`, but not for any of the other crates since we never re-export this derive macro. Since `ruma-macros` doesn't have a changelog (it's only meant to be used _by Ruma_), I didn't write a changelog entry at all. Should I?