### PR TITLE
state-res: add iteratively resolved snapshot tests

### DIFF
--- a/crates/ruma-state-res/tests/it/fixtures/bootstrap-private-chat.json
+++ b/crates/ruma-state-res/tests/it/fixtures/bootstrap-private-chat.json
@@ -43,7 +43,9 @@
     },
     "state_key": "",
     "origin_server_ts": 2,
-    "prev_events": [],
+    "prev_events": [
+      "$00-m-room-member-join-alice"
+    ],
     "auth_events": [
       "$00-m-room-create",
       "$00-m-room-member-join-alice"
@@ -59,7 +61,9 @@
     },
     "state_key": "",
     "origin_server_ts": 3,
-    "prev_events": [],
+    "prev_events": [
+      "$00-m-room-power_levels"
+    ],
     "auth_events": [
       "$00-m-room-create",
       "$00-m-room-member-join-alice",
@@ -76,7 +80,9 @@
     },
     "state_key": "",
     "origin_server_ts": 4,
-    "prev_events": [],
+    "prev_events": [
+      "$00-m-room-join_rules"
+    ],
     "auth_events": [
       "$00-m-room-create",
       "$00-m-room-member-join-alice",
@@ -93,7 +99,9 @@
     },
     "state_key": "",
     "origin_server_ts": 5,
-    "prev_events": [],
+    "prev_events": [
+      "$00-m-room-history_visibility"
+    ],
     "auth_events": [
       "$00-m-room-create",
       "$00-m-room-member-join-alice",

--- a/crates/ruma-state-res/tests/it/fixtures/origin-server-ts-tiebreak.json
+++ b/crates/ruma-state-res/tests/it/fixtures/origin-server-ts-tiebreak.json
@@ -21,7 +21,9 @@
     },
     "state_key": "",
     "origin_server_ts": 6,
-    "prev_events": [],
+    "prev_events": [
+      "$00-m-room-guest_access"
+    ],
     "auth_events": [
       "$00-m-room-create",
       "$00-m-room-member-join-alice",
@@ -44,7 +46,9 @@
     },
     "state_key": "",
     "origin_server_ts": 7,
-    "prev_events": [],
+    "prev_events": [
+      "$00-m-room-guest_access"
+    ],
     "auth_events": [
       "$00-m-room-create",
       "$00-m-room-member-join-alice",


### PR DESCRIPTION
More closely simulates what happens within servers, since most of the time, events come in one-by-one, and events are resolved against the state before them.
