### PR TITLE
serde: Fix default_on_error

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -57,6 +57,10 @@ Breaking changes:
 Bug fix:
 
 - Set the `disposition` of `RoomVersionRules::MSC2870` as unstable.
+- Fix `serde::default_on_error` deserialization helper. It was working with
+  `serde_json::from_value` but not other functions like
+  `serde_json::from_(str/slice)`. It now works with all 3 methods but is limited
+  to deserializing JSON.
 
 Improvements:
 

--- a/crates/ruma-events/src/room/create.rs
+++ b/crates/ruma-events/src/room/create.rs
@@ -235,6 +235,33 @@ mod tests {
     }
 
     #[test]
+    fn deserialize_valid_predecessor() {
+        let json = json!({
+            "m.federate": true,
+            "room_version": "11",
+            "predecessor": {
+                "room_id": "!room:localhost",
+                "event_id": "$eokpnkpn",
+            },
+        });
+
+        let content = from_json_value::<RoomCreateEventContent>(json).unwrap();
+        assert!(content.federate);
+        assert_eq!(content.room_version, RoomVersionId::V11);
+        assert_matches!(content.predecessor, Some(_));
+        assert_eq!(content.room_type, None);
+
+        let content = serde_json::from_str::<RoomCreateEventContent>(
+            r#"{"m.federate":true,"room_version":"11","predecessor":{"room_id":"!room:localhost","event_id":"$eokpnkpn"}}"#,
+        )
+        .unwrap();
+        assert!(content.federate);
+        assert_eq!(content.room_version, RoomVersionId::V11);
+        assert_matches!(content.predecessor, Some(_));
+        assert_eq!(content.room_type, None);
+    }
+
+    #[test]
     #[cfg(feature = "compat-lax-room-create-deser")]
     fn deserialize_invalid_predecessor() {
         let json = json!({
@@ -244,6 +271,15 @@ mod tests {
         });
 
         let content = from_json_value::<RoomCreateEventContent>(json).unwrap();
+        assert!(content.federate);
+        assert_eq!(content.room_version, RoomVersionId::V11);
+        assert_matches!(content.predecessor, None);
+        assert_eq!(content.room_type, None);
+
+        let content = serde_json::from_str::<RoomCreateEventContent>(
+            r#"{"m.federate":true,"room_version":"11","predecessor":"!room:localhost"}"#,
+        )
+        .unwrap();
         assert!(content.federate);
         assert_eq!(content.room_version, RoomVersionId::V11);
         assert_matches!(content.predecessor, None);

--- a/crates/ruma-events/src/room/topic.rs
+++ b/crates/ruma-events/src/room/topic.rs
@@ -163,6 +163,36 @@ mod tests {
         assert_eq!(content.topic, "Hot Topic");
         assert_eq!(content.topic_block.text.find_html(), Some("<strong>Hot</strong> Topic"));
         assert_eq!(content.topic_block.text.find_plain(), Some("Hot Topic"));
+
+        let content = serde_json::from_str::<RoomTopicEventContent>(
+            r#"{"topic":"Hot Topic","m.topic":{"m.text":[{"body":"Hot Topic"}]}}"#,
+        )
+        .unwrap();
+        assert_eq!(content.topic, "Hot Topic");
+        assert_eq!(content.topic_block.text.find_html(), None);
+        assert_eq!(content.topic_block.text.find_plain(), Some("Hot Topic"));
+    }
+
+    #[test]
+    fn deserialize_event() {
+        let json = json!({
+            "content": {
+                "topic": "Hot Topic",
+                "m.topic": {
+                    "m.text": [
+                        { "body": "<strong>Hot</strong> Topic", "mimetype": "text/html" },
+                        { "body": "Hot Topic" },
+                    ],
+                },
+            },
+            "type": "m.room.topic",
+            "state_key": "",
+            "event_id": "$lkioKdioukshnlDDz",
+            "sender": "@alice:localhost",
+            "origin_server_ts": 309_998_934,
+        });
+
+        from_json_value::<super::SyncRoomTopicEvent>(json).unwrap();
     }
 
     #[test]
@@ -180,5 +210,34 @@ mod tests {
         assert_eq!(content.topic, "Hot Topic");
         assert_eq!(content.topic_block.text.find_html(), None);
         assert_eq!(content.topic_block.text.find_plain(), None);
+
+        let content = serde_json::from_str::<RoomTopicEventContent>(
+            r#"{"topic":"Hot Topic","m.topic":[{"body":"Hot Topic"}]}"#,
+        )
+        .unwrap();
+        assert_eq!(content.topic, "Hot Topic");
+        assert_eq!(content.topic_block.text.find_html(), None);
+        assert_eq!(content.topic_block.text.find_plain(), None);
+    }
+
+    #[test]
+    #[cfg(feature = "compat-lax-room-topic-deser")]
+    fn deserialize_invalid_event() {
+        let json = json!({
+            "content": {
+                "topic": "Hot Topic",
+                "m.topic": [
+                    { "body": "<strong>Hot</strong> Topic", "mimetype": "text/html" },
+                    { "body": "Hot Topic" },
+                ],
+            },
+            "type": "m.room.topic",
+            "state_key": "",
+            "event_id": "$lkioKdioukshnlDDz",
+            "sender": "@alice:localhost",
+            "origin_server_ts": 309_998_934,
+        });
+
+        from_json_value::<super::SyncRoomTopicEvent>(json).unwrap();
     }
 }


### PR DESCRIPTION
It was working with `serde_json::from_value` but not other functions like `serde_json::from_(str/slice)`. This is due to the fact that the serde_json deserializers parse the JSON lazily and were expecting the end of a map after ignoring the erroneous content (due to the expected type being a struct), instead of expecting the end of the value matching the beginning that was found.

To work around that, we first parse the full value as a `Box<RawJsonValue>`, then try to deserialize the expected type from that value. It now works will all 3 methods but is limited to deserializing JSON.

This matches the behavior of serde_with for their `DefaultOnError` helper (except that they use a deserializer-agnostic type to store the content in the first step): https://github.com/jonasbb/serde_with/blob/16ea265e501c6c0655de727fb8aa3a1c8d5d0880/serde_with/src/de/impls.rs#L1041-L1066.