### PR TITLE
events: Don't generate `AnyEphemeralRoomEvent`

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -46,6 +46,8 @@ Breaking changes:
   field is set to `None` to ignore it, as recommended in the spec.
 - `StaticEventContent` has a new associated type `IsPrefix` to identify event types where only the
   prefix is statically-known.
+- `AnyEphemeralRoomEvent` was removed. There is no reason to use it, only
+  `AnySyncEphemeralRoomEvent` can be received via `/sync`.
 
 Improvements:
 

--- a/crates/ruma-events/tests/it/enums.rs
+++ b/crates/ruma-events/tests/it/enums.rs
@@ -7,7 +7,7 @@ use ruma_events::{
         message::{MessageType, RoomMessageEventContent},
         power_levels::RoomPowerLevelsEventContent,
     },
-    AnyEphemeralRoomEvent, AnyMessageLikeEvent, AnyStateEvent, AnySyncMessageLikeEvent,
+    AnyMessageLikeEvent, AnyStateEvent, AnySyncEphemeralRoomEvent, AnySyncMessageLikeEvent,
     AnySyncStateEvent, AnySyncTimelineEvent, AnyTimelineEvent, EphemeralRoomEventType,
     GlobalAccountDataEventType, MessageLikeEvent, MessageLikeEventType, OriginalMessageLikeEvent,
     OriginalStateEvent, OriginalSyncMessageLikeEvent, OriginalSyncStateEvent,
@@ -268,15 +268,14 @@ fn ephemeral_event_deserialization() {
                 "@bob:example.com"
             ]
         },
-        "room_id": "!jEsUZKDJdhlrceRyVU:example.org",
         "type": "m.typing"
     });
 
     assert_matches!(
-        from_json_value::<AnyEphemeralRoomEvent>(json_data),
-        Ok(ephem @ AnyEphemeralRoomEvent::Typing(_))
+        from_json_value::<AnySyncEphemeralRoomEvent>(json_data),
+        Ok(AnySyncEphemeralRoomEvent::Typing(typing))
     );
-    assert_eq!(ephem.room_id(), "!jEsUZKDJdhlrceRyVU:example.org");
+    assert_eq!(typing.content.user_ids.len(), 2);
 }
 
 #[test]

--- a/crates/ruma-events/tests/it/ephemeral_event.rs
+++ b/crates/ruma-events/tests/it/ephemeral_event.rs
@@ -5,7 +5,7 @@ use ruma_common::{event_id, owned_event_id, owned_user_id, user_id, MilliSeconds
 use ruma_events::{
     receipt::{Receipt, ReceiptEventContent, ReceiptType},
     typing::TypingEventContent,
-    AnyEphemeralRoomEvent,
+    AnySyncEphemeralRoomEvent,
 };
 use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
@@ -27,17 +27,15 @@ fn deserialize_ephemeral_typing() {
         "content": {
             "user_ids": [ "@carl:example.com" ]
         },
-        "room_id": "!roomid:room.com",
         "type": "m.typing"
     });
 
     assert_matches!(
-        from_json_value::<AnyEphemeralRoomEvent>(json_data),
-        Ok(AnyEphemeralRoomEvent::Typing(typing_event))
+        from_json_value::<AnySyncEphemeralRoomEvent>(json_data),
+        Ok(AnySyncEphemeralRoomEvent::Typing(typing_event))
     );
     assert_eq!(typing_event.content.user_ids.len(), 1);
     assert_eq!(typing_event.content.user_ids[0], "@carl:example.com");
-    assert_eq!(typing_event.room_id, "!roomid:room.com");
 }
 
 #[test]
@@ -78,17 +76,15 @@ fn deserialize_ephemeral_receipt() {
                 }
             }
         },
-        "room_id": "!roomid:room.com",
         "type": "m.receipt"
     });
 
     assert_matches!(
-        from_json_value::<AnyEphemeralRoomEvent>(json_data),
-        Ok(AnyEphemeralRoomEvent::Receipt(receipt_event))
+        from_json_value::<AnySyncEphemeralRoomEvent>(json_data),
+        Ok(AnySyncEphemeralRoomEvent::Receipt(receipt_event))
     );
     let receipts = receipt_event.content.0;
     assert_eq!(receipts.len(), 1);
-    assert_eq!(receipt_event.room_id, "!roomid:room.com");
     let event_receipts = receipts.get(event_id).unwrap();
     let type_receipts = event_receipts.get(&ReceiptType::Read).unwrap();
     let user_receipt = type_receipts.get(user_id).unwrap();

--- a/crates/ruma-macros/src/events/event_enum.rs
+++ b/crates/ruma-macros/src/events/event_enum.rs
@@ -56,10 +56,13 @@ pub fn expand_event_enums(input: &EventEnumDecl) -> syn::Result<TokenStream> {
     let ruma_events = &ruma_events;
 
     res.extend(expand_content_enum(kind, events, docs, attrs, variants, ruma_events));
-    res.extend(
-        expand_event_enum(kind, V::None, events, docs, attrs, variants, ruma_events)
-            .unwrap_or_else(syn::Error::into_compile_error),
-    );
+
+    if !matches!(kind, EventKind::EphemeralRoom) {
+        res.extend(
+            expand_event_enum(kind, V::None, events, docs, attrs, variants, ruma_events)
+                .unwrap_or_else(syn::Error::into_compile_error),
+        );
+    }
 
     if matches!(kind, EventKind::MessageLike | EventKind::State) {
         res.extend(


### PR DESCRIPTION
It is not used in any API. The CS API uses `AnySyncEphemeralRoomEvent` and the Appservice API uses `EphemeralData`.
