### PR TITLE
appservice-api: Wrap `EphemeralData` with `Raw` in `push_events::v1::Request`

### DIFF
--- a/crates/ruma-appservice-api/CHANGELOG.md
+++ b/crates/ruma-appservice-api/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 Breaking changes:
 
-- The`thirdparty::get_protocol` response uses `AppserviceProtocolInstance`
+- The `thirdparty::get_protocol` response uses `AppserviceProtocolInstance`
   instead of `ProtocolInstance`.
 - Update the endpoint metadata definitions to use the new syntax for variables.
+- The `ephemeral` field of `push_events::v1::Request` is now a
+  `Vec<Raw<EphemeralData>>`. This avoids the entire deserialization of the
+  `Request` to fail if a single `EphemeralData` deserialization fails.
 
 # 0.12.2
 

--- a/crates/ruma-appservice-api/src/event/push_events.rs
+++ b/crates/ruma-appservice-api/src/event/push_events.rs
@@ -85,7 +85,7 @@ pub mod v1 {
 
         /// A list of ephemeral data.
         #[serde(default, skip_serializing_if = "<[_]>::is_empty")]
-        pub ephemeral: Vec<EphemeralData>,
+        pub ephemeral: Vec<Raw<EphemeralData>>,
 
         /// A list of to-device messages.
         #[cfg(feature = "unstable-msc4203")]


### PR DESCRIPTION
Avoids the entire deserialization of the `Request` to fail if a single `EphemeralData` deserialization fails.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
