### PR TITLE
serde: New Raw cast API

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -21,6 +21,11 @@ Breaking changes:
 - Update the endpoint metadata definitions to use the new syntax for variables.
 - `SpaceHierarchyRoomsChunk` is now built around `RoomSummary`, and
   `SpaceHierarchyRoomsChunkInit` was removed.
+- Add `JsonCastable` bound to `Raw::{cast, cast_ref, deserialize_as}`. When
+  a type `U` implements `JsonCastable<T>` it means that it is safe to cast from
+  `U` to `T` because `T` can be deserialized from the same JSON as `U`. It is
+  still possible to bypass that bound by using the corresponding methods of
+  `Raw` with an `_unchecked` suffix.
 
 Improvements:
 

--- a/crates/ruma-client-api/src/backup/get_backup_info.rs
+++ b/crates/ruma-client-api/src/backup/get_backup_info.rs
@@ -123,7 +123,7 @@ pub mod v3 {
         {
             let ResponseBody { algorithm, count, etag, version } = self;
             let AlgorithmWithData { algorithm, auth_data } =
-                algorithm.deserialize_as().map_err(ser::Error::custom)?;
+                algorithm.deserialize_as_unchecked().map_err(ser::Error::custom)?;
 
             let repr = RefResponseBodyRepr {
                 algorithm: &algorithm,

--- a/crates/ruma-client-api/src/backup/get_latest_backup_info.rs
+++ b/crates/ruma-client-api/src/backup/get_latest_backup_info.rs
@@ -99,7 +99,7 @@ pub mod v3 {
         {
             let ResponseBody { algorithm, count, etag, version } = self;
             let AlgorithmWithData { algorithm, auth_data } =
-                algorithm.deserialize_as().map_err(ser::Error::custom)?;
+                algorithm.deserialize_as_unchecked().map_err(ser::Error::custom)?;
 
             let repr = RefResponseBodyRepr {
                 algorithm: &algorithm,

--- a/crates/ruma-client-api/src/delayed_events/delayed_state_event.rs
+++ b/crates/ruma-client-api/src/delayed_events/delayed_state_event.rs
@@ -137,7 +137,7 @@ pub mod unstable {
                 "@userAsStateKey:example.org".to_owned(),
                 "com.example.custom_state".into(),
                 delay_parameters,
-                Raw::new(&json!({ "key": "value" })).unwrap().cast(),
+                Raw::new(&json!({ "key": "value" })).unwrap().cast_unchecked(),
             )
             .try_into_http_request(
                 "https://homeserver.tld",

--- a/crates/ruma-common/src/canonical_json.rs
+++ b/crates/ruma-common/src/canonical_json.rs
@@ -129,7 +129,7 @@ impl RedactedBecause {
     ///
     /// Fails if the raw event is not valid canonical JSON.
     pub fn from_raw_event(ev: &Raw<impl RedactionEvent>) -> serde_json::Result<Self> {
-        ev.deserialize_as().map(Self)
+        ev.deserialize_as_unchecked().map(Self)
     }
 }
 

--- a/crates/ruma-common/src/canonical_json/value.rs
+++ b/crates/ruma-common/src/canonical_json/value.rs
@@ -6,10 +6,13 @@ use serde::{de::Deserializer, ser::Serializer, Deserialize, Serialize};
 use serde_json::{to_string as to_json_string, Value as JsonValue};
 
 use super::CanonicalJsonError;
+use crate::serde::{JsonCastable, JsonObject};
 
 /// The inner type of `CanonicalJsonValue::Object`.
 #[cfg(feature = "canonical-json")]
 pub type CanonicalJsonObject = BTreeMap<String, CanonicalJsonValue>;
+
+impl<T> JsonCastable<CanonicalJsonObject> for T where T: JsonCastable<JsonObject> {}
 
 /// Represents a canonical JSON value as per the Matrix specification.
 #[cfg(feature = "canonical-json")]
@@ -211,6 +214,8 @@ impl From<CanonicalJsonValue> for JsonValue {
         }
     }
 }
+
+impl<T> JsonCastable<CanonicalJsonValue> for T {}
 
 macro_rules! variant_impls {
     ($variant:ident($ty:ty)) => {

--- a/crates/ruma-common/src/serde.rs
+++ b/crates/ruma-common/src/serde.rs
@@ -30,7 +30,7 @@ pub use self::{
     buf::{json_to_buf, slice_to_buf},
     can_be_empty::{is_empty, CanBeEmpty},
     cow::deserialize_cow_str,
-    raw::Raw,
+    raw::{JsonCastable, Raw},
     strings::{
         btreemap_deserialize_v1_powerlevel_values, deserialize_as_number_or_string,
         deserialize_as_optional_number_or_string, deserialize_v1_powerlevel, empty_string_as_none,

--- a/crates/ruma-common/src/serde/raw.rs
+++ b/crates/ruma-common/src/serde/raw.rs
@@ -9,7 +9,9 @@ use serde::{
     de::{self, Deserialize, DeserializeSeed, Deserializer, IgnoredAny, MapAccess, Visitor},
     ser::{Serialize, Serializer},
 };
-use serde_json::value::{to_raw_value as to_raw_json_value, RawValue as RawJsonValue};
+use serde_json::value::{
+    to_raw_value as to_raw_json_value, RawValue as RawJsonValue, Value as JsonValue,
+};
 
 /// A wrapper around `Box<RawValue>` with a generic parameter for the expected Rust type.
 ///
@@ -186,6 +188,15 @@ impl<T> Raw<T> {
     }
 
     /// Try to deserialize the JSON as a custom type.
+    pub fn deserialize_as<'a, U>(&'a self) -> serde_json::Result<U>
+    where
+        T: JsonCastable<U>,
+        U: Deserialize<'a>,
+    {
+        self.deserialize_as_unchecked()
+    }
+
+    /// Same as [`deserialize_as`][Self::deserialize_as], but without the trait restriction.
     pub fn deserialize_as_unchecked<'a, U>(&'a self) -> serde_json::Result<U>
     where
         U: Deserialize<'a>,
@@ -196,13 +207,29 @@ impl<T> Raw<T> {
     /// Turns `Raw<T>` into `Raw<U>` without changing the underlying JSON.
     ///
     /// This is useful for turning raw specific event types into raw event enum types.
-    pub fn cast_unchecked<U>(self) -> Raw<U> {
-        Raw::from_json(self.into_json())
+    pub fn cast<U>(self) -> Raw<U>
+    where
+        T: JsonCastable<U>,
+    {
+        self.cast_unchecked()
     }
 
     /// Turns `&Raw<T>` into `&Raw<U>` without changing the underlying JSON.
     ///
     /// This is useful for turning raw specific event types into raw event enum types.
+    pub fn cast_ref<U>(&self) -> &Raw<U>
+    where
+        T: JsonCastable<U>,
+    {
+        self.cast_ref_unchecked()
+    }
+
+    /// Same as [`cast`][Self::cast], but without the trait restriction.
+    pub fn cast_unchecked<U>(self) -> Raw<U> {
+        Raw::from_json(self.into_json())
+    }
+
+    /// Same as [`cast_ref`][Self::cast_ref], but without the trait restriction.
     pub fn cast_ref_unchecked<U>(&self) -> &Raw<U> {
         unsafe { mem::transmute(self) }
     }
@@ -238,6 +265,15 @@ impl<T> Serialize for Raw<T> {
         self.json.serialize(serializer)
     }
 }
+
+/// Marker trait for restricting the types [`Raw::deserialize_as`], [`Raw::cast`] and
+/// [`Raw::cast_ref`] can be called with.
+///
+/// Implementing this trait for a type `U` means that it is safe to cast from `U` to `T` because `T`
+/// can be deserialized from the same JSON as `U`.
+pub trait JsonCastable<T> {}
+
+impl<T> JsonCastable<JsonValue> for T {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/ruma-common/src/serde/raw.rs
+++ b/crates/ruma-common/src/serde/raw.rs
@@ -95,7 +95,7 @@ impl<T> Raw<T> {
     /// # fn foo() -> serde_json::Result<()> {
     /// # let raw_event: ruma_common::serde::Raw<()> = todo!();
     /// if raw_event.get_field::<String>("type")?.as_deref() == Some("org.custom.matrix.event") {
-    ///     let event = raw_event.deserialize_as::<CustomMatrixEvent>()?;
+    ///     let event = raw_event.deserialize_as_unchecked::<CustomMatrixEvent>()?;
     ///     // ...
     /// }
     /// # Ok(())
@@ -186,7 +186,7 @@ impl<T> Raw<T> {
     }
 
     /// Try to deserialize the JSON as a custom type.
-    pub fn deserialize_as<'a, U>(&'a self) -> serde_json::Result<U>
+    pub fn deserialize_as_unchecked<'a, U>(&'a self) -> serde_json::Result<U>
     where
         U: Deserialize<'a>,
     {
@@ -196,14 +196,14 @@ impl<T> Raw<T> {
     /// Turns `Raw<T>` into `Raw<U>` without changing the underlying JSON.
     ///
     /// This is useful for turning raw specific event types into raw event enum types.
-    pub fn cast<U>(self) -> Raw<U> {
+    pub fn cast_unchecked<U>(self) -> Raw<U> {
         Raw::from_json(self.into_json())
     }
 
     /// Turns `&Raw<T>` into `&Raw<U>` without changing the underlying JSON.
     ///
     /// This is useful for turning raw specific event types into raw event enum types.
-    pub fn cast_ref<U>(&self) -> &Raw<U> {
+    pub fn cast_ref_unchecked<U>(&self) -> &Raw<U> {
         unsafe { mem::transmute(self) }
     }
 }

--- a/crates/ruma-events/src/kinds.rs
+++ b/crates/ruma-events/src/kinds.rs
@@ -357,7 +357,7 @@ impl<C: StaticStateEventContent> InitialStateEvent<C> {
     /// `enum` with one or more variants that use the `#[serde(skip)]` attribute), this method
     /// can panic.
     pub fn to_raw_any(&self) -> Raw<AnyInitialStateEvent> {
-        self.to_raw().cast()
+        self.to_raw().cast_unchecked()
     }
 }
 

--- a/crates/ruma-events/src/room/redaction.rs
+++ b/crates/ruma-events/src/room/redaction.rs
@@ -7,8 +7,10 @@ use js_int::Int;
 #[cfg(feature = "canonical-json")]
 use ruma_common::canonical_json::RedactionEvent;
 use ruma_common::{
-    room_version_rules::RedactionRules, serde::CanBeEmpty, EventId, MilliSecondsSinceUnixEpoch,
-    OwnedEventId, OwnedRoomId, OwnedTransactionId, OwnedUserId, RoomId, UserId,
+    room_version_rules::RedactionRules,
+    serde::{CanBeEmpty, JsonCastable, JsonObject},
+    EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedTransactionId,
+    OwnedUserId, RoomId, UserId,
 };
 use ruma_macros::{Event, EventContent};
 use serde::{Deserialize, Serialize};
@@ -32,6 +34,10 @@ pub enum RoomRedactionEvent {
     Redacted(RedactedRoomRedactionEvent),
 }
 
+impl JsonCastable<SyncRoomRedactionEvent> for RoomRedactionEvent {}
+
+impl JsonCastable<JsonObject> for RoomRedactionEvent {}
+
 /// A possibly-redacted redaction event without a `room_id`.
 #[allow(clippy::exhaustive_enums)]
 #[derive(Clone, Debug)]
@@ -42,6 +48,8 @@ pub enum SyncRoomRedactionEvent {
     /// Redacted form of the event with minimal fields.
     Redacted(RedactedSyncRoomRedactionEvent),
 }
+
+impl JsonCastable<JsonObject> for SyncRoomRedactionEvent {}
 
 /// Redaction event.
 #[derive(Clone, Debug)]
@@ -87,6 +95,14 @@ impl From<OriginalRoomRedactionEvent> for OriginalSyncRoomRedactionEvent {
     }
 }
 
+impl JsonCastable<OriginalSyncRoomRedactionEvent> for OriginalRoomRedactionEvent {}
+
+impl JsonCastable<RoomRedactionEvent> for OriginalRoomRedactionEvent {}
+
+impl JsonCastable<SyncRoomRedactionEvent> for OriginalRoomRedactionEvent {}
+
+impl JsonCastable<JsonObject> for OriginalRoomRedactionEvent {}
+
 /// Redacted redaction event.
 #[derive(Clone, Debug, Event)]
 #[allow(clippy::exhaustive_structs)]
@@ -109,6 +125,14 @@ pub struct RedactedRoomRedactionEvent {
     /// Additional key-value pairs not signed by the homeserver.
     pub unsigned: RedactedUnsigned,
 }
+
+impl JsonCastable<RedactedSyncRoomRedactionEvent> for RedactedRoomRedactionEvent {}
+
+impl JsonCastable<RoomRedactionEvent> for RedactedRoomRedactionEvent {}
+
+impl JsonCastable<SyncRoomRedactionEvent> for RedactedRoomRedactionEvent {}
+
+impl JsonCastable<JsonObject> for RedactedRoomRedactionEvent {}
 
 /// Redaction event without a `room_id`.
 #[derive(Clone, Debug)]
@@ -156,6 +180,10 @@ impl OriginalSyncRoomRedactionEvent {
     }
 }
 
+impl JsonCastable<SyncRoomRedactionEvent> for OriginalSyncRoomRedactionEvent {}
+
+impl JsonCastable<JsonObject> for OriginalSyncRoomRedactionEvent {}
+
 /// Redacted redaction event without a `room_id`.
 #[derive(Clone, Debug, Event)]
 #[allow(clippy::exhaustive_structs)]
@@ -175,6 +203,10 @@ pub struct RedactedSyncRoomRedactionEvent {
     /// Additional key-value pairs not signed by the homeserver.
     pub unsigned: RedactedUnsigned,
 }
+
+impl JsonCastable<SyncRoomRedactionEvent> for RedactedSyncRoomRedactionEvent {}
+
+impl JsonCastable<JsonObject> for RedactedSyncRoomRedactionEvent {}
 
 /// A redaction of an event.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, EventContent)]

--- a/crates/ruma-events/src/space/child.rs
+++ b/crates/ruma-events/src/space/child.rs
@@ -5,6 +5,7 @@
 use std::{cmp::Ordering, ops::Deref};
 
 use ruma_common::{
+    serde::{JsonCastable, JsonObject},
     MilliSecondsSinceUnixEpoch, OwnedRoomId, OwnedServerName, OwnedSpaceChildOrder, OwnedUserId,
     RoomId, SpaceChildOrder,
 };
@@ -101,6 +102,16 @@ impl PartialOrd for HierarchySpaceChildEvent {
         Some(self.cmp(other))
     }
 }
+
+impl JsonCastable<HierarchySpaceChildEvent> for SpaceChildEvent {}
+
+impl JsonCastable<HierarchySpaceChildEvent> for OriginalSpaceChildEvent {}
+
+impl JsonCastable<HierarchySpaceChildEvent> for SyncSpaceChildEvent {}
+
+impl JsonCastable<HierarchySpaceChildEvent> for OriginalSyncSpaceChildEvent {}
+
+impl JsonCastable<JsonObject> for HierarchySpaceChildEvent {}
 
 /// Helper trait to sort `m.space.child` events using using the algorithm for [ordering children
 /// within a space].

--- a/crates/ruma-events/tests/it/ui/08-enum-invalid-path.rs
+++ b/crates/ruma-events/tests/it/ui/08-enum-invalid-path.rs
@@ -3,7 +3,7 @@
 use ruma_macros::event_enum;
 
 event_enum! {
-    enum State {
+    enum RoomAccountData {
         "m.not.a.path" => ruma_events::not::a::path,
     }
 }


### PR DESCRIPTION
Supersedes #2080.\
Closes #2061.

It tested this against Conduit and the matrix-rust-sdk to make sure that there are no outstanding `JsonCastable` implementations missing.