### PR TITLE
events: Wrap `redacted_because` field of `RedactedUnsigned` into `Raw`

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -48,6 +48,9 @@ Breaking changes:
   prefix is statically-known.
 - `AnyEphemeralRoomEvent` was removed. There is no reason to use it, only
   `AnySyncEphemeralRoomEvent` can be received via `/sync`.
+- The `redacted_because` field of `RedactedUnsigned` is wrapped in `Raw`. It avoids to fail
+  deserialization of the whole event if only deserialization of this field fails. It is also more
+  forward-compatible in case events other than `m.room.redaction` are used here in the future.
 
 Improvements:
 

--- a/crates/ruma-events/src/unsigned.rs
+++ b/crates/ruma-events/src/unsigned.rs
@@ -1,6 +1,7 @@
 use js_int::Int;
 use ruma_common::{
-    serde::CanBeEmpty, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, OwnedUserId,
+    serde::{CanBeEmpty, Raw},
+    MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, OwnedUserId,
 };
 use serde::{de::DeserializeOwned, Deserialize};
 
@@ -114,12 +115,12 @@ impl<C: PossiblyRedactedStateEventContent> Default for StateUnsigned<C> {
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct RedactedUnsigned {
     /// The event that redacted this event, if any.
-    pub redacted_because: UnsignedRoomRedactionEvent,
+    pub redacted_because: Raw<UnsignedRoomRedactionEvent>,
 }
 
 impl RedactedUnsigned {
     /// Create a new `RedactedUnsigned` with the given redaction event.
-    pub fn new(redacted_because: UnsignedRoomRedactionEvent) -> Self {
+    pub fn new(redacted_because: Raw<UnsignedRoomRedactionEvent>) -> Self {
         Self { redacted_because }
     }
 }


### PR DESCRIPTION
It avoids to fail deserialization of the whole event if only deserialization of this field fails. It is also more forward-compatible in case events other than `m.room.redaction` are used here in the future like [MSC4293](https://github.com/matrix-org/matrix-spec-proposals/pull/4293).

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
