### PR TITLE
canonical-json: Remove unnecessary `cfg` attributes

### DIFF
--- a/crates/ruma-common/src/canonical_json.rs
+++ b/crates/ruma-common/src/canonical_json.rs
@@ -11,7 +11,6 @@ pub use self::value::{CanonicalJsonObject, CanonicalJsonValue};
 use crate::{room_version_rules::RedactionRules, serde::Raw};
 
 /// The set of possible errors when serializing to canonical JSON.
-#[cfg(feature = "canonical-json")]
 #[derive(Debug)]
 #[allow(clippy::exhaustive_enums)]
 pub enum CanonicalJsonError {
@@ -36,7 +35,6 @@ impl fmt::Display for CanonicalJsonError {
 impl std::error::Error for CanonicalJsonError {}
 
 /// Errors that can happen in redaction.
-#[cfg(feature = "canonical-json")]
 #[derive(Debug)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub enum RedactionError {

--- a/crates/ruma-common/src/canonical_json/value.rs
+++ b/crates/ruma-common/src/canonical_json/value.rs
@@ -9,13 +9,11 @@ use super::CanonicalJsonError;
 use crate::serde::{JsonCastable, JsonObject};
 
 /// The inner type of `CanonicalJsonValue::Object`.
-#[cfg(feature = "canonical-json")]
 pub type CanonicalJsonObject = BTreeMap<String, CanonicalJsonValue>;
 
 impl<T> JsonCastable<CanonicalJsonObject> for T where T: JsonCastable<JsonObject> {}
 
 /// Represents a canonical JSON value as per the Matrix specification.
-#[cfg(feature = "canonical-json")]
 #[derive(Clone, Default, Eq, PartialEq)]
 #[allow(clippy::exhaustive_enums)]
 pub enum CanonicalJsonValue {

--- a/crates/ruma/src/lib.rs
+++ b/crates/ruma/src/lib.rs
@@ -139,4 +139,8 @@ pub use js_int::{int, uint, Int, UInt};
 #[doc(no_inline)]
 pub use js_option::JsOption;
 pub use ruma_common::*;
+#[cfg(feature = "canonical-json")]
+pub use ruma_common::{
+    canonical_json, CanonicalJsonError, CanonicalJsonObject, CanonicalJsonValue,
+};
 pub use web_time as time;


### PR DESCRIPTION
The whole module is behind the `canonical-json` feature so those types don't need the attribute too.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
