### PR TITLE
common: Refactor code around notification power levels

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -53,6 +53,10 @@ Breaking changes:
 - Make `PushConditionRoomCtx` and `PushConditionPowerLevelsCtx` non-exhaustive.
 - The `versions` field of `SupportedVersions` is now a `BTreeSet<MatrixVersion>`,
   to make sure that the versions are always deduplicated and sorted.
+- `NotificationPowerLevels` now takes a `NotificationPowerLevelsKey` for the
+  `key`, an enum that accepts any string.
+  - The `key` field of `PushCondition::SenderNotificationPermission` uses the
+    same type.
 
 Bug fix:
 

--- a/crates/ruma-common/src/power_levels.rs
+++ b/crates/ruma-common/src/power_levels.rs
@@ -3,7 +3,10 @@
 //! [power_levels]: https://spec.matrix.org/latest/client-server-api/#mroompower_levels
 
 use js_int::{int, Int};
+use ruma_macros::StringEnum;
 use serde::{Deserialize, Serialize};
+
+use crate::PrivOwnedStr;
 
 /// The power level requirements for specific notification types.
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -24,10 +27,10 @@ impl NotificationPowerLevels {
     }
 
     /// Value associated with the given `key`.
-    pub fn get(&self, key: &str) -> Option<&Int> {
+    pub fn get(&self, key: &NotificationPowerLevelsKey) -> Option<&Int> {
         match key {
-            "room" => Some(&self.room),
-            _ => None,
+            NotificationPowerLevelsKey::Room => Some(&self.room),
+            NotificationPowerLevelsKey::_Custom(_) => None,
         }
     }
 
@@ -46,4 +49,17 @@ impl Default for NotificationPowerLevels {
 /// Used to default power levels to 50 during deserialization.
 pub fn default_power_level() -> Int {
     int!(50)
+}
+
+/// The possible keys of [`NotificationPowerLevels`].
+#[derive(Clone, PartialEq, Eq, StringEnum)]
+#[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
+#[ruma_enum(rename_all = "lowercase")]
+#[non_exhaustive]
+pub enum NotificationPowerLevelsKey {
+    /// The key for `@room` notifications.
+    Room,
+
+    #[doc(hidden)]
+    _Custom(PrivOwnedStr),
 }

--- a/crates/ruma-common/src/push/condition.rs
+++ b/crates/ruma-common/src/push/condition.rs
@@ -8,7 +8,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::value::Value as JsonValue;
 use wildmatch::WildMatch;
 
-use crate::{power_levels::NotificationPowerLevels, OwnedRoomId, OwnedUserId, UserId};
+use crate::{
+    power_levels::{NotificationPowerLevels, NotificationPowerLevelsKey},
+    OwnedRoomId, OwnedUserId, UserId,
+};
 #[cfg(feature = "unstable-msc3931")]
 use crate::{PrivOwnedStr, RoomVersionId};
 
@@ -98,7 +101,7 @@ pub enum PushCondition {
         ///
         /// Fields must be specified under the `notifications` property in the power level event's
         /// `content`.
-        key: String,
+        key: NotificationPowerLevelsKey,
     },
 
     /// Apply the rule only to rooms that support a given feature.
@@ -495,7 +498,9 @@ mod tests {
         RoomMemberCountIs, StrExt,
     };
     use crate::{
-        owned_room_id, owned_user_id, power_levels::NotificationPowerLevels, serde::Raw,
+        owned_room_id, owned_user_id,
+        power_levels::{NotificationPowerLevels, NotificationPowerLevelsKey},
+        serde::Raw,
         OwnedUserId,
     };
 
@@ -596,7 +601,7 @@ mod tests {
             from_json_value::<PushCondition>(json_data).unwrap(),
             PushCondition::SenderNotificationPermission { key }
         );
-        assert_eq!(key, "room");
+        assert_eq!(key, NotificationPowerLevelsKey::Room);
     }
 
     #[test]

--- a/crates/ruma-common/src/push/condition/push_condition_serde.rs
+++ b/crates/ruma-common/src/push/condition/push_condition_serde.rs
@@ -4,7 +4,7 @@ use serde_json::value::RawValue as RawJsonValue;
 #[cfg(feature = "unstable-msc3931")]
 use super::RoomVersionFeature;
 use super::{PushCondition, RoomMemberCountIs, ScalarJsonValue};
-use crate::serde::from_raw_json_value;
+use crate::{power_levels::NotificationPowerLevelsKey, serde::from_raw_json_value};
 
 impl Serialize for PushCondition {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -84,7 +84,7 @@ enum PushConditionSerDeHelper {
         ///
         /// Fields must be specified under the `notifications` property in the power level event's
         /// `content`.
-        key: String,
+        key: NotificationPowerLevelsKey,
     },
 
     /// Apply the rule only to rooms that support a given feature.

--- a/crates/ruma-common/src/push/predefined.rs
+++ b/crates/ruma-common/src/push/predefined.rs
@@ -8,7 +8,7 @@ use super::{
     Action::*, ConditionalPushRule, PatternedPushRule, PushCondition::*, RoomMemberCountIs,
     RuleKind, Ruleset, Tweak,
 };
-use crate::{PrivOwnedStr, UserId};
+use crate::{power_levels::NotificationPowerLevelsKey, PrivOwnedStr, UserId};
 
 impl Ruleset {
     /// The list of all [predefined push rules].
@@ -256,7 +256,7 @@ impl ConditionalPushRule {
             rule_id: PredefinedOverrideRuleId::IsRoomMention.to_string(),
             conditions: vec![
                 EventPropertyIs { key: r"content.m\.mentions.room".to_owned(), value: true.into() },
-                SenderNotificationPermission { key: "room".to_owned() },
+                SenderNotificationPermission { key: NotificationPowerLevelsKey::Room },
             ],
         }
     }


### PR DESCRIPTION
Use a `StringEnum` instead of matching on a `&str` for the keys of the type, and move some logic to a method.