### PR TITLE
client-api: Update outdated docs using the Raw API

### DIFF
--- a/crates/ruma-client-api/src/config/get_global_account_data.rs
+++ b/crates/ruma-client-api/src/config/get_global_account_data.rs
@@ -43,9 +43,9 @@ pub mod v3 {
         /// Account data content for the given type.
         ///
         /// Since the inner type of the `Raw` does not implement `Deserialize`, you need to use
-        /// `.deserialize_as::<T>()` or `.cast_ref::<T>().deserialize_with_type()` for event
-        /// types with a variable suffix (like [`SecretStorageKeyEventContent`]) to
-        /// deserialize it.
+        /// `.deserialize_as_unchecked::<T>()` or
+        /// `.cast_ref_unchecked::<T>().deserialize_with_type()` for event types with a
+        /// variable suffix (like [`SecretStorageKeyEventContent`]) to deserialize it.
         ///
         /// [`SecretStorageKeyEventContent`]: ruma_events::secret_storage::key::SecretStorageKeyEventContent
         #[ruma_api(body)]


### PR DESCRIPTION
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
