### PR TITLE
common: Add support for room version 12

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -35,7 +35,7 @@ Improvements:
   parameter. The former was removed in Matrix 1.14.
 - Add `additional_creators` field to `CreationContent` of `create_room` and `Request` of
   `upgrade_room`, allowing clients to specify which other users (if any) should be considered
-  additional creators from room version `org.matrix.hydra.11` onwards.
+  additional creators from room version 12 onwards.
 
 # 0.20.4
 

--- a/crates/ruma-client-api/src/room/create_room.rs
+++ b/crates/ruma-client-api/src/room/create_room.rs
@@ -129,7 +129,7 @@ pub mod v3 {
     #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
     pub struct CreationContent {
         /// A list of user IDs to consider as additional creators, and hence grant an "infinite"
-        /// immutable power level, from room version `org.matrix.hydra.11` onwards.
+        /// immutable power level, from room version 12 onwards.
         #[serde(default, skip_serializing_if = "<[_]>::is_empty")]
         pub additional_creators: Vec<OwnedUserId>,
 

--- a/crates/ruma-client-api/src/room/upgrade_room.rs
+++ b/crates/ruma-client-api/src/room/upgrade_room.rs
@@ -26,7 +26,7 @@ pub mod v3 {
     #[request(error = crate::Error)]
     pub struct Request {
         /// A list of user IDs to consider as additional creators, and hence grant an "infinite"
-        /// immutable power level, from room version `org.matrix.hydra.11` onwards.
+        /// immutable power level, from room version 12 onwards.
         #[serde(default, skip_serializing_if = "<[_]>::is_empty")]
         pub additional_creators: Vec<OwnedUserId>,
 

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -104,7 +104,7 @@ Improvements:
   `m.room.redaction` event redacts.
 - Add `SpaceChildOrder` which allows to validate the `order` of an
   `m.space.child` event.
-- Add support for room version `org.matrix.hydra.11`.
+- Add support for room version 12 and its unstable version `org.matrix.hydra.11`.
 - Add `explicitly_privilege_room_creators` and `additional_room_creators` to `AuthorizationRules`
   to indicate whether room creators are considered to have "infinite" power level and whether
   additional room creators can be specified with the `content.additional_creators` field of an

--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -24,6 +24,8 @@ api = ["dep:http", "dep:konst"]
 canonical-json = []
 js = ["dep:js-sys", "getrandom?/js", "uuid?/js"]
 rand = ["dep:rand", "dep:getrandom", "dep:uuid"]
+
+unstable-hydra = []
 unstable-msc2666 = []
 unstable-msc2870 = []
 unstable-msc3930 = []

--- a/crates/ruma-common/src/identifiers/room_version_id.rs
+++ b/crates/ruma-common/src/identifiers/room_version_id.rs
@@ -64,8 +64,11 @@ pub enum RoomVersionId {
     /// A version 11 room.
     V11,
 
-    /// `org.matrix.hydra.11`
+    /// `org.matrix.hydra.11`, the unstable version of [`V12`](Self::V12).
     Hydra,
+
+    /// A version 12 room.
+    V12,
 
     /// `org.matrix.msc2870` ([MSC2870]).
     ///
@@ -95,6 +98,7 @@ impl RoomVersionId {
             Self::V10 => "10",
             Self::V11 => "11",
             Self::Hydra => "org.matrix.hydra.11",
+            Self::V12 => "12",
             #[cfg(feature = "unstable-msc2870")]
             Self::MSC2870 => "org.matrix.msc2870",
             Self::_Custom(version) => version.as_str(),
@@ -124,6 +128,7 @@ impl RoomVersionId {
             Self::V10 => RoomVersionRules::V10,
             Self::V11 => RoomVersionRules::V11,
             Self::Hydra => RoomVersionRules::HYDRA,
+            Self::V12 => RoomVersionRules::V12,
             #[cfg(feature = "unstable-msc2870")]
             Self::MSC2870 => RoomVersionRules::MSC2870,
             Self::_Custom(_) => return None,
@@ -210,6 +215,7 @@ where
         "10" => RoomVersionId::V10,
         "11" => RoomVersionId::V11,
         "org.matrix.hydra.11" => RoomVersionId::Hydra,
+        "12" => RoomVersionId::V12,
         #[cfg(feature = "unstable-msc2870")]
         "org.matrix.msc2870" => RoomVersionId::MSC2870,
         custom => {

--- a/crates/ruma-common/src/identifiers/room_version_id.rs
+++ b/crates/ruma-common/src/identifiers/room_version_id.rs
@@ -65,7 +65,8 @@ pub enum RoomVersionId {
     V11,
 
     /// `org.matrix.hydra.11`, the unstable version of [`V12`](Self::V12).
-    Hydra,
+    #[cfg(feature = "unstable-hydra")]
+    HydraV11,
 
     /// A version 12 room.
     V12,
@@ -97,7 +98,8 @@ impl RoomVersionId {
             Self::V9 => "9",
             Self::V10 => "10",
             Self::V11 => "11",
-            Self::Hydra => "org.matrix.hydra.11",
+            #[cfg(feature = "unstable-hydra")]
+            Self::HydraV11 => "org.matrix.hydra.11",
             Self::V12 => "12",
             #[cfg(feature = "unstable-msc2870")]
             Self::MSC2870 => "org.matrix.msc2870",
@@ -127,7 +129,8 @@ impl RoomVersionId {
             Self::V9 => RoomVersionRules::V9,
             Self::V10 => RoomVersionRules::V10,
             Self::V11 => RoomVersionRules::V11,
-            Self::Hydra => RoomVersionRules::HYDRA,
+            #[cfg(feature = "unstable-hydra")]
+            Self::HydraV11 => RoomVersionRules::HYDRA_V11,
             Self::V12 => RoomVersionRules::V12,
             #[cfg(feature = "unstable-msc2870")]
             Self::MSC2870 => RoomVersionRules::MSC2870,
@@ -214,7 +217,8 @@ where
         "9" => RoomVersionId::V9,
         "10" => RoomVersionId::V10,
         "11" => RoomVersionId::V11,
-        "org.matrix.hydra.11" => RoomVersionId::Hydra,
+        #[cfg(feature = "unstable-hydra")]
+        "org.matrix.hydra.11" => RoomVersionId::HydraV11,
         "12" => RoomVersionId::V12,
         #[cfg(feature = "unstable-msc2870")]
         "org.matrix.msc2870" => RoomVersionId::MSC2870,

--- a/crates/ruma-common/src/push/condition.rs
+++ b/crates/ruma-common/src/push/condition.rs
@@ -61,6 +61,7 @@ impl RoomVersionFeature {
             | RoomVersionId::V10
             | RoomVersionId::V11
             | RoomVersionId::Hydra
+            | RoomVersionId::V12
             | RoomVersionId::_Custom(_) => vec![],
             #[cfg(feature = "unstable-msc2870")]
             RoomVersionId::MSC2870 => vec![],
@@ -1013,7 +1014,7 @@ mod tests {
             users: BTreeMap::new(),
             users_default: Int::MIN,
             notifications: NotificationPowerLevels { room: Int::MAX },
-            rules: RoomPowerLevelsRules::new(&AuthorizationRules::HYDRA, Some(sender())),
+            rules: RoomPowerLevelsRules::new(&AuthorizationRules::V12, Some(sender())),
         });
 
         let first_event = first_flattened_event();

--- a/crates/ruma-common/src/push/condition.rs
+++ b/crates/ruma-common/src/push/condition.rs
@@ -60,9 +60,10 @@ impl RoomVersionFeature {
             | RoomVersionId::V9
             | RoomVersionId::V10
             | RoomVersionId::V11
-            | RoomVersionId::Hydra
             | RoomVersionId::V12
             | RoomVersionId::_Custom(_) => vec![],
+            #[cfg(feature = "unstable-hydra")]
+            RoomVersionId::HydraV11 => vec![],
             #[cfg(feature = "unstable-msc2870")]
             RoomVersionId::MSC2870 => vec![],
         }

--- a/crates/ruma-common/src/room_version_rules.rs
+++ b/crates/ruma-common/src/room_version_rules.rs
@@ -131,7 +131,8 @@ impl RoomVersionRules {
     };
 
     /// Rules for room version `org.matrix.hydra.11`.
-    pub const HYDRA: Self = Self { disposition: RoomVersionDisposition::Unstable, ..Self::V12 };
+    #[cfg(feature = "unstable-hydra")]
+    pub const HYDRA_V11: Self = Self { disposition: RoomVersionDisposition::Unstable, ..Self::V12 };
 
     /// Rules for room version 12.
     pub const V12: Self = Self {

--- a/crates/ruma-common/src/room_version_rules.rs
+++ b/crates/ruma-common/src/room_version_rules.rs
@@ -130,11 +130,13 @@ impl RoomVersionRules {
         ..Self::V10
     };
 
-    /// Rules for room version `org.matrix.hydra.11`
-    pub const HYDRA: Self = Self {
-        disposition: RoomVersionDisposition::Unstable,
+    /// Rules for room version `org.matrix.hydra.11`.
+    pub const HYDRA: Self = Self { disposition: RoomVersionDisposition::Unstable, ..Self::V12 };
+
+    /// Rules for room version 12.
+    pub const V12: Self = Self {
         room_id_format: RoomIdFormatVersion::V2,
-        authorization: AuthorizationRules::HYDRA,
+        authorization: AuthorizationRules::V12,
         ..Self::V11
     };
 
@@ -192,7 +194,7 @@ pub enum RoomIdFormatVersion {
     V1,
 
     /// `!hash` format using the reference hash of the `m.room.create` event of the room,
-    /// introduced in room version `org.matrix.hydra.11`.
+    /// introduced in room version 12.
     V2,
 }
 
@@ -281,11 +283,11 @@ pub struct AuthorizationRules {
     pub use_room_create_sender: bool,
 
     /// Whether room creators should always be considered to have "infinite" power level,
-    /// introduced in room version `org.matrix.hydra.11`.
+    /// introduced in room version 12.
     pub explicitly_privilege_room_creators: bool,
 
     /// Whether additional room creators can be set with the `content.additional_creators` field of
-    /// an `m.room.create` event, introduced in room version `org.matrix.hydra.11`.
+    /// an `m.room.create` event, introduced in room version 12.
     pub additional_room_creators: bool,
 }
 
@@ -343,8 +345,8 @@ impl AuthorizationRules {
     /// [spec]: https://spec.matrix.org/latest/rooms/v11/#authorization-rules
     pub const V11: Self = Self { use_room_create_sender: true, ..Self::V10 };
 
-    /// Authorization rules with tweaks introduced in room version `org.matrix.hydra.11`.
-    pub const HYDRA: Self = Self {
+    /// Authorization rules with tweaks introduced in room version 12.
+    pub const V12: Self = Self {
         explicitly_privilege_room_creators: true,
         additional_room_creators: true,
         ..Self::V11
@@ -533,7 +535,7 @@ impl EventFormatRules {
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct RoomPowerLevelsRules {
     /// The creator(s) of the room which are considered to have "infinite" power level, introduced
-    /// in room version `org.matrix.hydra.11`.
+    /// in room version 12.
     #[allow(clippy::disallowed_types)]
     pub privileged_creators: Option<HashSet<OwnedUserId>>,
 }

--- a/crates/ruma-events/src/room/create.rs
+++ b/crates/ruma-events/src/room/create.rs
@@ -61,8 +61,8 @@ pub struct RoomCreateEventContent {
     #[serde(skip_serializing_if = "Option::is_none", rename = "type")]
     pub room_type: Option<RoomType>,
 
-    /// Additional room creators, considered to have "infinite" power level, in room versions
-    /// `org.matrix.hydra.11` onwards.
+    /// Additional room creators, considered to have "infinite" power level, in room version 12
+    /// onwards.
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub additional_creators: Vec<OwnedUserId>,
 }

--- a/crates/ruma-events/src/room/power_levels.rs
+++ b/crates/ruma-events/src/room/power_levels.rs
@@ -132,8 +132,8 @@ impl RoomPowerLevelsEventContent {
         };
 
         if rules.explicitly_privilege_room_creators {
-            // Since `org.matrix.hydra.11`, the default power level to send m.room.tombstone
-            // events is increased to PL150.
+            // Since v12, the default power level to send m.room.tombstone events is increased to
+            // PL150.
             pl.events.insert(TimelineEventType::RoomTombstone, int!(150));
         }
 
@@ -323,11 +323,11 @@ impl RedactedStateEventContent for RedactedRoomPowerLevelsEventContent {
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub enum UserPowerLevel {
     /// The user is considered to have "infinite" power level, due to being a room creator, from
-    /// room version `org.matrix.hydra.11` onwards.
+    /// room version 12 onwards.
     Infinite,
 
-    /// The user is either not a creator, or the room version is prior to `org.matrix.hydra.11`,
-    /// and hence has an integer power level.
+    /// The user is either not a creator, or the room version is prior to 12, and hence has an
+    /// integer power level.
     Int(Int),
 }
 
@@ -1015,12 +1015,12 @@ mod tests {
         );
         assert!(v1_power_levels.user_can_change_user_power_level(creator, creator));
 
-        let hydra_power_levels = RoomPowerLevels::new(
+        let v12_power_levels = RoomPowerLevels::new(
             RoomPowerLevelsSource::None,
-            &AuthorizationRules::HYDRA,
+            &AuthorizationRules::V12,
             vec![creator.to_owned()],
         );
-        assert!(!hydra_power_levels.user_can_change_user_power_level(creator, creator));
+        assert!(!v12_power_levels.user_can_change_user_power_level(creator, creator));
     }
 
     #[test]
@@ -1036,12 +1036,12 @@ mod tests {
         let v1_event_content = RoomPowerLevelsEventContent::try_from(v1_power_levels).unwrap();
         assert_eq!(*v1_event_content.users.get(&creator).unwrap(), int!(75));
 
-        let mut hydra_power_levels = RoomPowerLevels::new(
+        let mut v12_power_levels = RoomPowerLevels::new(
             RoomPowerLevelsSource::None,
-            &AuthorizationRules::HYDRA,
+            &AuthorizationRules::V12,
             vec![creator.to_owned()],
         );
-        hydra_power_levels.users.insert(creator.clone(), int!(75));
-        RoomPowerLevelsEventContent::try_from(hydra_power_levels).unwrap_err();
+        v12_power_levels.users.insert(creator.clone(), int!(75));
+        RoomPowerLevelsEventContent::try_from(v12_power_levels).unwrap_err();
     }
 }

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -141,6 +141,7 @@ unstable-extensible-events = [
     "unstable-msc3954",
     "unstable-msc3955",
 ]
+unstable-hydra = ["ruma-common/unstable-hydra"]
 unstable-msc1767 = ["ruma-events?/unstable-msc1767"]
 unstable-msc2448 = [
     "ruma-client-api?/unstable-msc2448",
@@ -202,6 +203,7 @@ unstable-msc4286 = ["ruma-html?/unstable-msc4286"]
 
 # Private features, only used in test / benchmarking code
 __unstable-mscs = [
+    "unstable-hydra",
     "unstable-msc1767",
     "unstable-msc2448",
     "unstable-msc2545",


### PR DESCRIPTION
The stable version of `org.matrix.hydra.11`.

Public specification for this: [Project Hydra pre-disclosure](https://matrix.org/blog/2025/07/security-predisclosure/).

