### PR TITLE
client-api: Update some docs to not recommend `deserialize_as`

### DIFF
--- a/crates/ruma-client-api/src/config/get_room_account_data.rs
+++ b/crates/ruma-client-api/src/config/get_room_account_data.rs
@@ -47,7 +47,8 @@ pub mod v3 {
         /// Account data content for the given type.
         ///
         /// Since the inner type of the `Raw` does not implement `Deserialize`, you need to use
-        /// [`Raw::deserialize_as`] to deserialize it.
+        /// `.deserialize_as_unchecked::<T>()` or
+        /// `.cast_ref_unchecked::<T>().deserialize_with_type()` to deserialize it.
         #[ruma_api(body)]
         pub account_data: Raw<AnyRoomAccountDataEventContent>,
     }

--- a/crates/ruma-client-api/src/state/get_state_events_for_key.rs
+++ b/crates/ruma-client-api/src/state/get_state_events_for_key.rs
@@ -52,7 +52,8 @@ pub mod v3 {
         /// The content of the state event.
         ///
         /// Since the inner type of the `Raw` does not implement `Deserialize`, you need to use
-        /// [`Raw::deserialize_as`] to deserialize it.
+        /// `.deserialize_as_unchecked::<T>()` or
+        /// `.cast_ref_unchecked::<T>().deserialize_with_type()` to deserialize it.
         #[ruma_api(body)]
         pub content: Raw<AnyStateEventContent>,
     }


### PR DESCRIPTION
because there is no type they can do that safely with

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
