### PR TITLE
client-api: implement MSC4306 endpoints

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -29,6 +29,7 @@ Breaking changes:
 
 Improvements:
 
+- Added support for the experiment MSC4036 thread subscription endpoints.
 - For the `membership::join_room_by_id_or_alias` and `knock::knock_room`
   endpoints, the `server_name` query parameter is only serialized if the server
   doesn't advertise at least one version that supports the `via` query

--- a/crates/ruma-client-api/Cargo.toml
+++ b/crates/ruma-client-api/Cargo.toml
@@ -52,6 +52,9 @@ unstable-msc4143 = []
 unstable-msc4186 = ["ruma-common/unstable-msc4186"]
 unstable-msc4191 = []
 
+# Thread subscription support.
+unstable-msc4306 = []
+
 [dependencies]
 as_variant = { workspace = true }
 assign = { workspace = true }

--- a/crates/ruma-client-api/Cargo.toml
+++ b/crates/ruma-client-api/Cargo.toml
@@ -51,7 +51,6 @@ unstable-msc4140 = ["ruma-common/unstable-msc4140"]
 unstable-msc4143 = []
 unstable-msc4186 = ["ruma-common/unstable-msc4186"]
 unstable-msc4191 = []
-
 # Thread subscription support.
 unstable-msc4306 = []
 

--- a/crates/ruma-client-api/src/threads.rs
+++ b/crates/ruma-client-api/src/threads.rs
@@ -1,9 +1,8 @@
 //! Endpoints for querying threads in a room.
 
-pub mod get_threads;
-
 #[cfg(feature = "unstable-msc4306")]
 pub mod get_thread_subscription;
+pub mod get_threads;
 #[cfg(feature = "unstable-msc4306")]
 pub mod subscribe_thread;
 #[cfg(feature = "unstable-msc4306")]

--- a/crates/ruma-client-api/src/threads.rs
+++ b/crates/ruma-client-api/src/threads.rs
@@ -1,3 +1,10 @@
 //! Endpoints for querying threads in a room.
 
 pub mod get_threads;
+
+#[cfg(feature = "unstable-msc4306")]
+pub mod get_thread_subscription;
+#[cfg(feature = "unstable-msc4306")]
+pub mod subscribe_thread;
+#[cfg(feature = "unstable-msc4306")]
+pub mod unsubscribe_thread;

--- a/crates/ruma-client-api/src/threads/get_thread_subscription.rs
+++ b/crates/ruma-client-api/src/threads/get_thread_subscription.rs
@@ -1,0 +1,56 @@
+//! `GET /_matrix/client/*/rooms/{roomId}/thread/{eventId}/subscription`
+//!
+//! Gets the subscription state of the current user to a thread in a room.
+
+pub mod unstable {
+    //! `/unstable/` ([spec])
+    //!
+    //! [spec]: https://github.com/matrix-org/matrix-spec-proposals/blob/rei/msc_thread_subscriptions/proposals/4306-thread-subscriptions.md
+
+    use ruma_common::{
+        api::{request, response, Metadata},
+        metadata, OwnedEventId, OwnedRoomId,
+    };
+
+    const METADATA: Metadata = metadata! {
+        method: GET,
+        rate_limited: true,
+        authentication: AccessToken,
+        history: {
+            unstable("org.matrix.msc4306") => "/_matrix/client/unstable/io.element.msc4306/rooms/{room_id}/thread/{event_id}/subscription",
+        }
+    };
+
+    /// Request type for the `get_thread_subscription` endpoint.
+    #[request(error = crate::Error)]
+    pub struct Request {
+        /// The room ID where the thread is located.
+        #[ruma_api(path)]
+        pub room_id: OwnedRoomId,
+
+        /// The event ID of the thread root to get the status for.
+        #[ruma_api(path)]
+        pub event_id: OwnedEventId,
+    }
+
+    /// Response type for the `get_thread_subscription` endpoint.
+    #[response(error = crate::Error)]
+    pub struct Response {
+        /// Whether the subscription was made automatically by a client, not by manual user choice.
+        pub automatic: bool,
+    }
+
+    impl Request {
+        /// Creates a new `Request` for the given room and thread IDs.
+        pub fn new(room_id: OwnedRoomId, thread_root: OwnedEventId) -> Self {
+            Self { room_id, event_id: thread_root }
+        }
+    }
+
+    impl Response {
+        /// Creates a new `Response`.
+        pub fn new(automatic: bool) -> Self {
+            Self { automatic }
+        }
+    }
+}

--- a/crates/ruma-client-api/src/threads/get_thread_subscription.rs
+++ b/crates/ruma-client-api/src/threads/get_thread_subscription.rs
@@ -17,7 +17,7 @@ pub mod unstable {
         rate_limited: true,
         authentication: AccessToken,
         history: {
-            unstable("org.matrix.msc4306") => "/_matrix/client/unstable/io.element.msc4306/rooms/{room_id}/thread/{event_id}/subscription",
+            unstable("org.matrix.msc4306") => "/_matrix/client/unstable/io.element.msc4306/rooms/{room_id}/thread/{thread_root}/subscription",
         }
     };
 
@@ -30,7 +30,7 @@ pub mod unstable {
 
         /// The event ID of the thread root to get the status for.
         #[ruma_api(path)]
-        pub event_id: OwnedEventId,
+        pub thread_root: OwnedEventId,
     }
 
     /// Response type for the `get_thread_subscription` endpoint.
@@ -43,7 +43,7 @@ pub mod unstable {
     impl Request {
         /// Creates a new `Request` for the given room and thread IDs.
         pub fn new(room_id: OwnedRoomId, thread_root: OwnedEventId) -> Self {
-            Self { room_id, event_id: thread_root }
+            Self { room_id, thread_root }
         }
     }
 

--- a/crates/ruma-client-api/src/threads/get_thread_subscription.rs
+++ b/crates/ruma-client-api/src/threads/get_thread_subscription.rs
@@ -5,7 +5,7 @@
 pub mod unstable {
     //! `/unstable/` ([spec])
     //!
-    //! [spec]: https://github.com/matrix-org/matrix-spec-proposals/blob/rei/msc_thread_subscriptions/proposals/4306-thread-subscriptions.md
+    //! [spec]: https://github.com/matrix-org/matrix-spec-proposals/pull/4306
 
     use ruma_common::{
         api::{request, response, Metadata},

--- a/crates/ruma-client-api/src/threads/subscribe_thread.rs
+++ b/crates/ruma-client-api/src/threads/subscribe_thread.rs
@@ -1,0 +1,56 @@
+//! `PUT /_matrix/client/*/rooms/{roomId}/thread/{eventId}/subscription`
+//!
+//! Updates the subscription state of the current user to a thread in a room.
+
+pub mod unstable {
+    //! `/unstable/` ([spec])
+    //!
+    //! [spec]: https://github.com/matrix-org/matrix-spec-proposals/blob/rei/msc_thread_subscriptions/proposals/4306-thread-subscriptions.md
+
+    use ruma_common::{
+        api::{request, response, Metadata},
+        metadata, OwnedEventId, OwnedRoomId,
+    };
+
+    const METADATA: Metadata = metadata! {
+        method: PUT,
+        rate_limited: true,
+        authentication: AccessToken,
+        history: {
+            unstable("org.matrix.msc4306") => "/_matrix/client/unstable/io.element.msc4306/rooms/{room_id}/thread/{event_id}/subscription",
+        }
+    };
+
+    /// Request type for the `subscribe_thread` endpoint.
+    #[request(error = crate::Error)]
+    pub struct Request {
+        /// The room ID where the thread is located.
+        #[ruma_api(path)]
+        pub room_id: OwnedRoomId,
+
+        /// The event ID of the thread root to subscribe to.
+        #[ruma_api(path)]
+        pub event_id: OwnedEventId,
+
+        /// Whether the subscription was made automatically by a client, not by manual user choice.
+        automatic: bool,
+    }
+
+    /// Response type for the `subscribe_thread` endpoint.
+    #[response(error = crate::Error)]
+    pub struct Response {}
+
+    impl Request {
+        /// Creates a new `Request` for the given room and thread IDs.
+        pub fn new(room_id: OwnedRoomId, thread_root: OwnedEventId, automatic: bool) -> Self {
+            Self { room_id, event_id: thread_root, automatic }
+        }
+    }
+
+    impl Response {
+        /// Creates a new `Response`.
+        pub fn new() -> Self {
+            Self {}
+        }
+    }
+}

--- a/crates/ruma-client-api/src/threads/subscribe_thread.rs
+++ b/crates/ruma-client-api/src/threads/subscribe_thread.rs
@@ -5,7 +5,7 @@
 pub mod unstable {
     //! `/unstable/` ([spec])
     //!
-    //! [spec]: https://github.com/matrix-org/matrix-spec-proposals/blob/rei/msc_thread_subscriptions/proposals/4306-thread-subscriptions.md
+    //! [spec]: https://github.com/matrix-org/matrix-spec-proposals/pull/4306
 
     use ruma_common::{
         api::{request, response, Metadata},
@@ -17,7 +17,7 @@ pub mod unstable {
         rate_limited: true,
         authentication: AccessToken,
         history: {
-            unstable("org.matrix.msc4306") => "/_matrix/client/unstable/io.element.msc4306/rooms/{room_id}/thread/{event_id}/subscription",
+            unstable("org.matrix.msc4306") => "/_matrix/client/unstable/io.element.msc4306/rooms/{room_id}/thread/{thread_root}/subscription",
         }
     };
 
@@ -30,10 +30,10 @@ pub mod unstable {
 
         /// The event ID of the thread root to subscribe to.
         #[ruma_api(path)]
-        pub event_id: OwnedEventId,
+        pub thread_root: OwnedEventId,
 
         /// Whether the subscription was made automatically by a client, not by manual user choice.
-        automatic: bool,
+        pub automatic: bool,
     }
 
     /// Response type for the `subscribe_thread` endpoint.
@@ -43,7 +43,7 @@ pub mod unstable {
     impl Request {
         /// Creates a new `Request` for the given room and thread IDs.
         pub fn new(room_id: OwnedRoomId, thread_root: OwnedEventId, automatic: bool) -> Self {
-            Self { room_id, event_id: thread_root, automatic }
+            Self { room_id, thread_root, automatic }
         }
     }
 

--- a/crates/ruma-client-api/src/threads/unsubscribe_thread.rs
+++ b/crates/ruma-client-api/src/threads/unsubscribe_thread.rs
@@ -1,0 +1,53 @@
+//! `DELETE /_matrix/client/*/rooms/{roomId}/thread/{eventId}/subscription`
+//!
+//! Removes the subscription state of the current user to a thread in a room.
+
+pub mod unstable {
+    //! `/unstable/` ([spec])
+    //!
+    //! [spec]: https://github.com/matrix-org/matrix-spec-proposals/blob/rei/msc_thread_subscriptions/proposals/4306-thread-subscriptions.md
+
+    use ruma_common::{
+        api::{request, response, Metadata},
+        metadata, OwnedEventId, OwnedRoomId,
+    };
+
+    const METADATA: Metadata = metadata! {
+        method: DELETE,
+        rate_limited: true,
+        authentication: AccessToken,
+        history: {
+            unstable("org.matrix.msc4306") => "/_matrix/client/unstable/io.element.msc4306/rooms/{room_id}/thread/{event_id}/subscription",
+        }
+    };
+
+    /// Request type for the `unsubscribe_thread` endpoint.
+    #[request(error = crate::Error)]
+    pub struct Request {
+        /// The room ID where the thread is located.
+        #[ruma_api(path)]
+        pub room_id: OwnedRoomId,
+
+        /// The event ID of the thread root to unsubscribe to.
+        #[ruma_api(path)]
+        pub event_id: OwnedEventId,
+    }
+
+    /// Response type for the `unsubscribe_thread` endpoint.
+    #[response(error = crate::Error)]
+    pub struct Response {}
+
+    impl Request {
+        /// Creates a new `Request` for the given room and thread IDs.
+        pub fn new(room_id: OwnedRoomId, thread_root: OwnedEventId) -> Self {
+            Self { room_id, event_id: thread_root }
+        }
+    }
+
+    impl Response {
+        /// Creates a new `Response`.
+        pub fn new() -> Self {
+            Self {}
+        }
+    }
+}

--- a/crates/ruma-client-api/src/threads/unsubscribe_thread.rs
+++ b/crates/ruma-client-api/src/threads/unsubscribe_thread.rs
@@ -5,7 +5,7 @@
 pub mod unstable {
     //! `/unstable/` ([spec])
     //!
-    //! [spec]: https://github.com/matrix-org/matrix-spec-proposals/blob/rei/msc_thread_subscriptions/proposals/4306-thread-subscriptions.md
+    //! [spec]: https://github.com/matrix-org/matrix-spec-proposals/pull/4306
 
     use ruma_common::{
         api::{request, response, Metadata},
@@ -17,7 +17,7 @@ pub mod unstable {
         rate_limited: true,
         authentication: AccessToken,
         history: {
-            unstable("org.matrix.msc4306") => "/_matrix/client/unstable/io.element.msc4306/rooms/{room_id}/thread/{event_id}/subscription",
+            unstable("org.matrix.msc4306") => "/_matrix/client/unstable/io.element.msc4306/rooms/{room_id}/thread/{thread_root}/subscription",
         }
     };
 
@@ -30,7 +30,7 @@ pub mod unstable {
 
         /// The event ID of the thread root to unsubscribe to.
         #[ruma_api(path)]
-        pub event_id: OwnedEventId,
+        pub thread_root: OwnedEventId,
     }
 
     /// Response type for the `unsubscribe_thread` endpoint.
@@ -40,7 +40,7 @@ pub mod unstable {
     impl Request {
         /// Creates a new `Request` for the given room and thread IDs.
         pub fn new(room_id: OwnedRoomId, thread_root: OwnedEventId) -> Self {
-            Self { room_id, event_id: thread_root }
+            Self { room_id, thread_root }
         }
     }
 

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -201,6 +201,9 @@ unstable-msc4274 = ["ruma-events?/unstable-msc4274"]
 unstable-msc4278 = ["ruma-events?/unstable-msc4278"]
 unstable-msc4286 = ["ruma-html?/unstable-msc4286"]
 
+# Thread subscription support.
+unstable-msc4306 = ["ruma-client-api?/unstable-msc4306"]
+
 # Private features, only used in test / benchmarking code
 __unstable-mscs = [
     "unstable-hydra",

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -200,7 +200,6 @@ unstable-msc4268 = ["ruma-events?/unstable-msc4268"]
 unstable-msc4274 = ["ruma-events?/unstable-msc4274"]
 unstable-msc4278 = ["ruma-events?/unstable-msc4278"]
 unstable-msc4286 = ["ruma-html?/unstable-msc4286"]
-
 # Thread subscription support.
 unstable-msc4306 = ["ruma-client-api?/unstable-msc4306"]
 
@@ -258,6 +257,7 @@ __unstable-mscs = [
     "unstable-msc4274",
     "unstable-msc4278",
     "unstable-msc4286",
+    "unstable-msc4306",
 ]
 __ci = ["full", "compat-upload-signatures", "__unstable-mscs"]
 __compat = [


### PR DESCRIPTION
This adds support for [MSC4306](https://github.com/matrix-org/matrix-spec-proposals/pull/4306) endpoints, with a new Cargo feature for both.

This has been tested against a `develop` synapse server with [this fix](https://github.com/element-hq/synapse/pull/18722), and it works great.