### PR TITLE
client-api: Support sync events in stripped state

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -45,6 +45,8 @@ Improvements:
   additional creators from room version 12 onwards.
 - Add unstable support for `AnyStateEvent` formatted events in `sync_events`, alongside stripped
   events from MSC4311 behind the `unstable-msc4311` feature.
+- Add unstable support for `AnySyncStateEvent` formatted events in `sync_events`, alongside stripped
+  events, according to MSC4319.
 
 # 0.20.4
 

--- a/crates/ruma-client-api/Cargo.toml
+++ b/crates/ruma-client-api/Cargo.toml
@@ -54,6 +54,7 @@ unstable-msc4191 = []
 # Thread subscription support.
 unstable-msc4306 = []
 unstable-msc4311 = []
+unstable-msc4319 = []
 
 [dependencies]
 as_variant = { workspace = true }

--- a/crates/ruma-client-api/src/sync/sync_events.rs
+++ b/crates/ruma-client-api/src/sync/sync_events.rs
@@ -5,7 +5,7 @@
 use js_int::UInt;
 use ruma_common::{
     serde::{from_raw_json_value, JsonCastable, JsonObject},
-    OwnedUserId, UserId,
+    EventId, MilliSecondsSinceUnixEpoch, OwnedUserId, UserId,
 };
 use ruma_events::{
     AnyStateEvent, AnyStrippedStateEvent, AnySyncStateEvent, OriginalStateEvent,
@@ -121,6 +121,28 @@ impl StrippedState {
             Self::Sync(event) => event.state_key(),
             #[cfg(feature = "unstable-msc4311")]
             Self::Full(event) => event.state_key(),
+        }
+    }
+
+    /// Returns this event's `event_id` field, if there is one.
+    pub fn event_id(&self) -> Option<&EventId> {
+        match self {
+            Self::Stripped(_) => None,
+            #[cfg(feature = "unstable-msc4319")]
+            Self::Sync(event) => Some(event.event_id()),
+            #[cfg(feature = "unstable-msc4311")]
+            Self::Full(event) => Some(event.event_id()),
+        }
+    }
+
+    /// Returns this event's `origin_server_ts` field, if there is one.
+    pub fn origin_server_ts(&self) -> Option<MilliSecondsSinceUnixEpoch> {
+        match self {
+            Self::Stripped(_) => None,
+            #[cfg(feature = "unstable-msc4319")]
+            Self::Sync(event) => Some(event.origin_server_ts()),
+            #[cfg(feature = "unstable-msc4311")]
+            Self::Full(event) => Some(event.origin_server_ts()),
         }
     }
 }

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -205,6 +205,7 @@ unstable-msc4286 = ["ruma-html?/unstable-msc4286"]
 # Thread subscription support.
 unstable-msc4306 = ["ruma-client-api?/unstable-msc4306"]
 unstable-msc4311 = ["ruma-client-api?/unstable-msc4311", "ruma-federation-api?/unstable-msc4311"]
+unstable-msc4319 = ["ruma-client-api?/unstable-msc4319"]
 
 # Private features, only used in test / benchmarking code
 __unstable-mscs = [
@@ -264,6 +265,7 @@ __unstable-mscs = [
     "unstable-msc4286",
     "unstable-msc4306",
     "unstable-msc4311",
+    "unstable-msc4319",
 ]
 __ci = ["full", "compat-upload-signatures", "__unstable-mscs"]
 __compat = [


### PR DESCRIPTION
The `m.room.member` event of the user is sent by homeservers in the sync format rather than the stripped state format.

Spec PR for the clarification: https://github.com/matrix-org/matrix-spec/pull/2181.
