### PR TITLE
client-api: allow non-stripped events to be represented in `sync_events`, unstable support for MSC4311

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -30,6 +30,8 @@ Breaking changes:
 - Allow specifying the event format for `state::get_state_event_for_key`, meaning the response may
   either be `Raw<AnyStateEvent>` or `Raw<AnyStateEventContent>`, depending on the format specified
   in the request.
+- Use `StrippedState` instead of `AnyStrippedStateEvent`, to allow non-stripped events to be
+  represented for `sync_events`.
 
 Improvements:
 

--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -43,6 +43,8 @@ Improvements:
 - Add `additional_creators` field to `CreationContent` of `create_room` and `Request` of
   `upgrade_room`, allowing clients to specify which other users (if any) should be considered
   additional creators from room version 12 onwards.
+- Add unstable support for `AnyStateEvent` formatted events in `sync_events`, alongside stripped
+  events from MSC4311 behind the `unstable-msc4311` feature.
 
 # 0.20.4
 

--- a/crates/ruma-client-api/Cargo.toml
+++ b/crates/ruma-client-api/Cargo.toml
@@ -53,6 +53,7 @@ unstable-msc4186 = ["ruma-common/unstable-msc4186"]
 unstable-msc4191 = []
 # Thread subscription support.
 unstable-msc4306 = []
+unstable-msc4311 = []
 
 [dependencies]
 as_variant = { workspace = true }

--- a/crates/ruma-client-api/src/sync/sync_events.rs
+++ b/crates/ruma-client-api/src/sync/sync_events.rs
@@ -76,9 +76,14 @@ impl DeviceLists {
 /// Possible event formats that may appear in stripped state.
 #[derive(Debug, Clone)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+#[allow(clippy::large_enum_variant)]
 pub enum StrippedState {
     /// A stripped state event.
     Stripped(AnyStrippedStateEvent),
+
+    /// A full state event.
+    #[cfg(feature = "unstable-msc4311")]
+    Full(AnyStateEvent),
 }
 
 impl StrippedState {
@@ -86,6 +91,8 @@ impl StrippedState {
     pub fn event_type(&self) -> StateEventType {
         match self {
             Self::Stripped(event) => event.event_type(),
+            #[cfg(feature = "unstable-msc4311")]
+            Self::Full(event) => event.event_type(),
         }
     }
 
@@ -93,6 +100,8 @@ impl StrippedState {
     pub fn sender(&self) -> &UserId {
         match self {
             Self::Stripped(event) => event.sender(),
+            #[cfg(feature = "unstable-msc4311")]
+            Self::Full(event) => event.sender(),
         }
     }
 
@@ -100,6 +109,8 @@ impl StrippedState {
     pub fn state_key(&self) -> &str {
         match self {
             Self::Stripped(event) => event.state_key(),
+            #[cfg(feature = "unstable-msc4311")]
+            Self::Full(event) => event.state_key(),
         }
     }
 }
@@ -111,13 +122,26 @@ impl<'de> Deserialize<'de> for StrippedState {
     {
         let json = Box::<RawJsonValue>::deserialize(deserializer)?;
 
-        from_raw_json_value(&json).map(Self::Stripped)
-    }
-}
+        #[cfg(feature = "unstable-msc4311")]
+        {
+            use serde::de;
 
-impl From<AnyStrippedStateEvent> for StrippedState {
-    fn from(value: AnyStrippedStateEvent) -> Self {
-        Self::Stripped(value)
+            #[derive(Deserialize)]
+            struct PotentialFullEventDeHelper {
+                event_id: Option<de::IgnoredAny>,
+                origin_server_ts: Option<de::IgnoredAny>,
+                room_id: Option<de::IgnoredAny>,
+            }
+
+            let PotentialFullEventDeHelper { event_id, origin_server_ts, room_id } =
+                from_raw_json_value(&json)?;
+
+            if event_id.is_some() && origin_server_ts.is_some() && room_id.is_some() {
+                return from_raw_json_value(&json).map(Self::Full);
+            }
+        }
+
+        from_raw_json_value(&json).map(Self::Stripped)
     }
 }
 
@@ -186,5 +210,38 @@ mod tests {
         assert_eq!(stripped_member_event.sender, user_id);
         assert_eq!(stripped_member_event.state_key, user_id);
         assert_eq!(stripped_member_event.content.membership, MembershipState::Join);
+
+        #[cfg(feature = "unstable-msc4311")]
+        {
+            use js_int::uint;
+            use ruma_common::{event_id, room_id};
+            use ruma_events::{AnyStateEvent, StateEvent};
+
+            let event_id = event_id!("$abcdefgh");
+            let room_id = room_id!("!room:localhost");
+
+            // Timeline format.
+            let timeline_event_json = json!({
+                "content": content,
+                "event_id": event_id,
+                "origin_server_ts": 1_000_000,
+                "room_id": room_id,
+                "sender": user_id,
+                "state_key": user_id,
+                "type": "m.room.member",
+            });
+            assert_matches!(
+                from_json_value::<StrippedState>(timeline_event_json).unwrap(),
+                StrippedState::Full(AnyStateEvent::RoomMember(StateEvent::Original(
+                    timeline_member_event
+                )))
+            );
+            assert_eq!(timeline_member_event.content.membership, MembershipState::Join);
+            assert_eq!(timeline_member_event.event_id, event_id);
+            assert_eq!(timeline_member_event.origin_server_ts.0, uint!(1_000_000));
+            assert_eq!(timeline_member_event.room_id, room_id);
+            assert_eq!(timeline_member_event.sender, user_id);
+            assert_eq!(timeline_member_event.state_key, user_id);
+        }
     }
 }

--- a/crates/ruma-client-api/src/sync/sync_events/v3.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v3.rs
@@ -14,12 +14,11 @@ use ruma_common::{
 };
 use ruma_events::{
     presence::PresenceEvent, AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent,
-    AnyStrippedStateEvent, AnySyncEphemeralRoomEvent, AnySyncStateEvent, AnySyncTimelineEvent,
-    AnyToDeviceEvent,
+    AnySyncEphemeralRoomEvent, AnySyncStateEvent, AnySyncTimelineEvent, AnyToDeviceEvent,
 };
 use serde::{Deserialize, Serialize};
 
-use super::{DeviceLists, UnreadNotificationsCount};
+use super::{DeviceLists, StrippedState, UnreadNotificationsCount};
 use crate::filter::FilterDefinition;
 
 const METADATA: Metadata = metadata! {
@@ -349,7 +348,7 @@ impl From<KnockState> for KnockedRoom {
 pub struct KnockState {
     /// The stripped state of a room that the user has knocked upon.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub events: Vec<Raw<AnyStrippedStateEvent>>,
+    pub events: Vec<Raw<StrippedState>>,
 }
 
 impl KnockState {
@@ -563,7 +562,7 @@ impl From<InviteState> for InvitedRoom {
 pub struct InviteState {
     /// A list of state events.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub events: Vec<Raw<AnyStrippedStateEvent>>,
+    pub events: Vec<Raw<StrippedState>>,
 }
 
 impl InviteState {
@@ -578,8 +577,8 @@ impl InviteState {
     }
 }
 
-impl From<Vec<Raw<AnyStrippedStateEvent>>> for InviteState {
-    fn from(events: Vec<Raw<AnyStrippedStateEvent>>) -> Self {
+impl From<Vec<Raw<StrippedState>>> for InviteState {
+    fn from(events: Vec<Raw<StrippedState>>) -> Self {
         InviteState { events, ..Default::default() }
     }
 }

--- a/crates/ruma-client-api/src/sync/sync_events/v5.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v5.rs
@@ -17,10 +17,10 @@ use ruma_common::{
     serde::{duration::opt_ms, Raw},
     OwnedMxcUri, OwnedRoomId, OwnedUserId,
 };
-use ruma_events::{AnyStrippedStateEvent, AnySyncStateEvent, AnySyncTimelineEvent, StateEventType};
+use ruma_events::{AnySyncStateEvent, AnySyncTimelineEvent, StateEventType};
 use serde::{Deserialize, Serialize};
 
-use super::UnreadNotificationsCount;
+use super::{StrippedState, UnreadNotificationsCount};
 
 const METADATA: Metadata = metadata! {
     method: POST,
@@ -449,9 +449,9 @@ pub mod response {
     };
 
     use super::{
-        super::DeviceLists, AnyStrippedStateEvent, AnySyncStateEvent, AnySyncTimelineEvent,
-        BTreeMap, Deserialize, JsOption, OwnedMxcUri, OwnedRoomId, OwnedUserId, Raw, Serialize,
-        UInt, UnreadNotificationsCount,
+        super::DeviceLists, AnySyncStateEvent, AnySyncTimelineEvent, BTreeMap, Deserialize,
+        JsOption, OwnedMxcUri, OwnedRoomId, OwnedUserId, Raw, Serialize, StrippedState, UInt,
+        UnreadNotificationsCount,
     };
 
     /// A sliding sync response updates to joiend rooms (see
@@ -486,7 +486,7 @@ pub mod response {
         /// If this is `Some(_)`, this is a not-yet-accepted invite containing
         /// the given stripped state events.
         #[serde(skip_serializing_if = "Option::is_none")]
-        pub invite_state: Option<Vec<Raw<AnyStrippedStateEvent>>>,
+        pub invite_state: Option<Vec<Raw<StrippedState>>>,
 
         /// Number of unread notifications.
         #[serde(flatten, default, skip_serializing_if = "UnreadNotificationsCount::is_empty")]

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -203,7 +203,7 @@ unstable-msc4278 = ["ruma-events?/unstable-msc4278"]
 unstable-msc4286 = ["ruma-html?/unstable-msc4286"]
 # Thread subscription support.
 unstable-msc4306 = ["ruma-client-api?/unstable-msc4306"]
-unstable-msc4311 = ["ruma-federation-api?/unstable-msc4311"]
+unstable-msc4311 = ["ruma-client-api?/unstable-msc4311", "ruma-federation-api?/unstable-msc4311"]
 
 # Private features, only used in test / benchmarking code
 __unstable-mscs = [


### PR DESCRIPTION
Like #2171, but for the client-api

[MSC4311](https://github.com/matrix-org/matrix-spec-proposals/pull/4311)

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
