### PR TITLE
fix changelog for `RawStrippedState` introduction

### DIFF
--- a/crates/ruma-federation-api/CHANGELOG.md
+++ b/crates/ruma-federation-api/CHANGELOG.md
@@ -18,7 +18,7 @@ Breaking changes:
     `SpaceHierarchyChildSummaryInit` was removed.
 - Merge the `knock` module into `membership`, and rename `create_knock_event_template` and
   `send_knock` to `prepare_knock_event` and `create_knock_event` respectively for consistency.
-- Use `StrippedState` instead of `Raw<AnyStrippedStateEvent>`, to allow non-stripped events to be
+- Use `RawStrippedState` instead of `Raw<AnyStrippedStateEvent>`, to allow non-stripped events to be
   represented for `create_invite` and `create_knock_event`.
 
 Bug fixes:


### PR DESCRIPTION
Forgot to update the changelog to match the rename in #2171 

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
