### PR TITLE
client-api: Allow to cast `StrippedState` to `AnyStrippedStateEvent`

### DIFF
--- a/crates/ruma-client-api/src/sync/sync_events.rs
+++ b/crates/ruma-client-api/src/sync/sync_events.rs
@@ -149,6 +149,8 @@ impl JsonCastable<StrippedState> for AnySyncStateEvent {}
 
 impl JsonCastable<StrippedState> for AnyStrippedStateEvent {}
 
+impl JsonCastable<AnyStrippedStateEvent> for StrippedState {}
+
 impl JsonCastable<StrippedState> for AnyStateEvent {}
 
 impl<C> JsonCastable<StrippedState> for OriginalStateEvent<C> where C: StaticStateEventContent {}


### PR DESCRIPTION
Since any event format in it should be deserializable as stripped state.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
