### PR TITLE
events: update state key format for `m.call.member` event to be less strict to make it compatible with MSC4143 updates

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -66,9 +66,8 @@ Breaking changes:
 - The `event_id` field of `PreviousRoom` is now optional and deprecated. It has been removed in new
   room versions so clients should not rely on it. They can obtain it by requesting the
   `m.room.tombstone` event in the state of the predecessor.
-- The `sender_key` and `device_id` fields of `MegolmV1AesSha2Content` are now optional. They were
-  deprecated in Matrix 1.3.
 - The `sender_key` field of `RequestedKeyInfo` is now optional. It was deprecated in Matrix 1.3.
+
 
 Improvements:
 
@@ -96,6 +95,8 @@ Improvements:
 - Implement types for encrypted state events, according to MSC3414.
 - Add `additional_creators` field to `RoomCreateEventContent`, used to optionally specify
   additional creators of a room.
+- The state key type `CallMemberStateKey` for `m.call.member` state events changed to allow any postfix
+  for state keys. The `device_id()` method is not available anymore. Use the event content instead.
 
 # 0.30.4
 

--- a/crates/ruma-events/src/call/member/member_state_key.rs
+++ b/crates/ruma-events/src/call/member/member_state_key.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use ruma_common::{DeviceId, OwnedDeviceId, OwnedUserId, UserId};
+use ruma_common::{OwnedUserId, UserId};
 use serde::{
     de::{self, Deserialize, Deserializer, Unexpected},
     Serialize, Serializer,
@@ -16,37 +16,31 @@ pub struct CallMemberStateKey {
 
 impl CallMemberStateKey {
     /// Constructs a new CallMemberStateKey there are three possible formats:
-    /// - `_{UserId}_{DeviceId}` example: `_@test:user.org_DEVICE`. `device_id: Some`, `underscore:
-    ///   true`
-    /// - `{UserId}_{DeviceId}` example: `@test:user.org_DEVICE`. `device_id: Some`, `underscore:
-    ///   false`
-    /// - `{UserId}` example: `@test:user.org`. `device_id: None`, underscore is ignored:
+    /// - `_{UserId}_{MemberId}` example: `_@test:user.org_DEVICE_m.call`. `member_id:
+    ///   Some(DEVICE_m.call)`, `underscore: true`
+    /// - `{UserId}_{MemberId}` example: `@test:user.org_DEVICE_m.call`. `member_id:
+    ///   Some(DEVICE_m.call)`, `underscore: false`
+    /// - `{UserId}` example: `@test:user.org`. `member_id: None`, underscore is ignored:
     ///   `underscore: false|true`
     ///
-    /// Dependent on the parameters the correct CallMemberStateKey will be constructed.
-    pub fn new(user_id: OwnedUserId, device_id: Option<OwnedDeviceId>, underscore: bool) -> Self {
-        CallMemberStateKeyEnum::new(user_id, device_id, underscore).into()
+    /// The MemberId is a combination of the UserId and the session information
+    /// (session.application and session.id).
+    /// The session information is an opaque string that should not be parsed after creation.
+    pub fn new(user_id: OwnedUserId, member_id: Option<String>, underscore: bool) -> Self {
+        CallMemberStateKeyEnum::new(user_id, member_id, underscore).into()
     }
 
     /// Returns the user id in this state key.
     /// (This is a cheap operations. The id is already type checked on initialization. And does
     /// only returns a reference to an existing OwnedUserId.)
+    ///
+    /// It is recommended to not use the state key to get the user id, but rather use the `sender`
+    /// field.
     pub fn user_id(&self) -> &UserId {
         match &self.key {
-            CallMemberStateKeyEnum::UnderscoreUserDevice(u, _) => u,
-            CallMemberStateKeyEnum::UserDevice(u, _) => u,
+            CallMemberStateKeyEnum::UnderscoreMemberId(u, _) => u,
+            CallMemberStateKeyEnum::MemberId(u, _) => u,
             CallMemberStateKeyEnum::User(u) => u,
-        }
-    }
-
-    /// Returns the device id in this state key (if available)
-    /// (This is a cheap operations. The id is already type checked on initialization. And does
-    /// only returns a reference to an existing OwnedDeviceId.)
-    pub fn device_id(&self) -> Option<&DeviceId> {
-        match &self.key {
-            CallMemberStateKeyEnum::UnderscoreUserDevice(_, d) => Some(d),
-            CallMemberStateKeyEnum::UserDevice(_, d) => Some(d),
-            CallMemberStateKeyEnum::User(_) => None,
         }
     }
 }
@@ -96,18 +90,18 @@ impl Serialize for CallMemberStateKey {
 /// This enum represents all possible formats for a call member event state key.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 enum CallMemberStateKeyEnum {
-    UnderscoreUserDevice(OwnedUserId, OwnedDeviceId),
-    UserDevice(OwnedUserId, OwnedDeviceId),
+    UnderscoreMemberId(OwnedUserId, String),
+    MemberId(OwnedUserId, String),
     User(OwnedUserId),
 }
 
 impl CallMemberStateKeyEnum {
-    fn new(user_id: OwnedUserId, device_id: Option<OwnedDeviceId>, underscore: bool) -> Self {
-        match (device_id, underscore) {
-            (Some(device_id), true) => {
-                CallMemberStateKeyEnum::UnderscoreUserDevice(user_id, device_id)
+    fn new(user_id: OwnedUserId, unique_member_id: Option<String>, underscore: bool) -> Self {
+        match (unique_member_id, underscore) {
+            (Some(member_id), true) => {
+                CallMemberStateKeyEnum::UnderscoreMemberId(user_id, member_id)
             }
-            (Some(device_id), false) => CallMemberStateKeyEnum::UserDevice(user_id, device_id),
+            (Some(member_id), false) => CallMemberStateKeyEnum::MemberId(user_id, member_id),
             (None, _) => CallMemberStateKeyEnum::User(user_id),
         }
     }
@@ -116,8 +110,8 @@ impl CallMemberStateKeyEnum {
 impl std::fmt::Display for CallMemberStateKeyEnum {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self {
-            CallMemberStateKeyEnum::UnderscoreUserDevice(u, d) => write!(f, "_{u}_{d}"),
-            CallMemberStateKeyEnum::UserDevice(u, d) => write!(f, "{u}_{d}"),
+            CallMemberStateKeyEnum::UnderscoreMemberId(u, d) => write!(f, "_{u}_{d}"),
+            CallMemberStateKeyEnum::MemberId(u, d) => write!(f, "{u}_{d}"),
             CallMemberStateKeyEnum::User(u) => f.write_str(u.as_str()),
         }
     }
@@ -129,7 +123,7 @@ impl FromStr for CallMemberStateKeyEnum {
     fn from_str(state_key: &str) -> Result<Self, Self::Err> {
         // Ignore leading underscore if present
         // (used for avoiding auth rules on @-prefixed state keys)
-        let (state_key, underscore) = match state_key.strip_prefix('_') {
+        let (state_key, has_underscore) = match state_key.strip_prefix('_') {
             Some(s) => (s, true),
             None => (state_key, false),
         };
@@ -142,14 +136,14 @@ impl FromStr for CallMemberStateKeyEnum {
             });
         };
 
-        let (user_id, device_id) = match state_key[colon_idx + 1..].find('_') {
+        let (user_id, member_id) = match state_key[colon_idx + 1..].find('_') {
             None => {
                 return match UserId::parse(state_key) {
                     Ok(user_id) => {
-                        if underscore {
-                            Err(KeyParseError::LeadingUnderscoreNoDevice)
+                        if has_underscore {
+                            Err(KeyParseError::LeadingUnderscoreNoMemberId)
                         } else {
-                            Ok(CallMemberStateKeyEnum::new(user_id, None, underscore))
+                            Ok(CallMemberStateKeyEnum::new(user_id, None, has_underscore))
                         }
                     }
                     Err(err) => Err(KeyParseError::InvalidUser {
@@ -163,16 +157,14 @@ impl FromStr for CallMemberStateKeyEnum {
             }
         };
 
-        match (UserId::parse(user_id), OwnedDeviceId::from(device_id)) {
-            (Ok(user_id), device_id) => {
-                if device_id.as_str().is_empty() {
-                    return Err(KeyParseError::EmptyDevice);
+        match UserId::parse(user_id) {
+            Ok(user_id) => {
+                if member_id.is_empty() {
+                    return Err(KeyParseError::EmptyMemberId);
                 }
-                Ok(CallMemberStateKeyEnum::new(user_id, Some(device_id), underscore))
+                Ok(CallMemberStateKeyEnum::new(user_id, Some(member_id.to_owned()), has_underscore))
             }
-            (Err(err), _) => {
-                Err(KeyParseError::InvalidUser { user_id: user_id.to_owned(), error: err })
-            }
+            Err(err) => Err(KeyParseError::InvalidUser { user_id: user_id.to_owned(), error: err }),
         }
     }
 }
@@ -194,10 +186,10 @@ pub enum KeyParseError {
     #[error(
         "uses a leading underscore but no trailing device id. The part after the underscore is a valid user id."
     )]
-    LeadingUnderscoreNoDevice,
-    /// Uses an empty device id. (UserId with trailing underscore)
-    #[error("uses an empty device id. (UserId with trailing underscore)")]
-    EmptyDevice,
+    LeadingUnderscoreNoMemberId,
+    /// Uses an empty memberId. (UserId with trailing underscore)
+    #[error("uses an empty memberId. (UserId with trailing underscore)")]
+    EmptyMemberId,
 }
 
 impl de::Expected for KeyParseError {
@@ -210,18 +202,56 @@ impl de::Expected for KeyParseError {
 mod tests {
     use std::str::FromStr;
 
+    use ruma_common::user_id;
+
     use crate::call::member::{member_state_key::CallMemberStateKeyEnum, CallMemberStateKey};
 
     #[test]
     fn convert_state_key_enum_to_state_key() {
-        let key = "_@user:domain.org_DEVICE";
+        let key = "_@user:domain.org_ABC";
         let state_key_enum = CallMemberStateKeyEnum::from_str(key).unwrap();
         // This generates state_key.raw from the enum
         let state_key: CallMemberStateKey = state_key_enum.into();
         // This compares state_key.raw (generated) with key (original)
         assert_eq!(state_key.as_ref(), key);
         // Compare to the from string without `CallMemberStateKeyEnum` step.
-        let state_key_direct = CallMemberStateKey::from_str(state_key.as_ref()).unwrap();
+        let state_key_direct = CallMemberStateKey::new(
+            user_id!("@user:domain.org").to_owned(),
+            Some("ABC".to_owned()),
+            true,
+        );
+        assert_eq!(state_key, state_key_direct);
+    }
+
+    #[test]
+    fn convert_no_underscore_state_key_without_member_id() {
+        let key = "@user:domain.org";
+        let state_key_enum = CallMemberStateKeyEnum::from_str(key).unwrap();
+        // This generates state_key.raw from the enum
+        let state_key: CallMemberStateKey = state_key_enum.into();
+        // This compares state_key.raw (generated) with key (original)
+        assert_eq!(state_key.as_ref(), key);
+        // Compare to the from string without `CallMemberStateKeyEnum` step.
+        let state_key_direct =
+            CallMemberStateKey::new(user_id!("@user:domain.org").to_owned(), None, false);
+        assert_eq!(state_key, state_key_direct);
+    }
+
+    #[test]
+    fn convert_no_underscore_state_key_with_member_id() {
+        let key = "@user:domain.org_ABC_m.callTestId";
+        let state_key_enum = CallMemberStateKeyEnum::from_str(key).unwrap();
+        // This generates state_key.raw from the enum
+        let state_key: CallMemberStateKey = state_key_enum.into();
+        // This compares state_key.raw (generated) with key (original)
+        assert_eq!(state_key.as_ref(), key);
+        // Compare to the from string without `CallMemberStateKeyEnum` step.
+        let state_key_direct = CallMemberStateKey::new(
+            user_id!("@user:domain.org").to_owned(),
+            Some("ABC_m.callTestId".to_owned()),
+            false,
+        );
+
         assert_eq!(state_key, state_key_direct);
     }
 }


### PR DESCRIPTION
The current MatrixRTC spec allows member events to contain application information in the state key. The ruma state key format was not allowing this spec change.

Signed-off-by: Timo K <toger5@hotmail.de>

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
