### PR TITLE
events: Use type alias in EventContent macro when redaction doesn't change any field

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -69,6 +69,10 @@ Breaking changes:
 - The `sender_key` and `device_id` fields of `MegolmV1AesSha2Content` are now optional. They were
   deprecated in Matrix 1.3.
 - The `sender_key` field of `RequestedKeyInfo` is now optional. It was deprecated in Matrix 1.3.
+- `RedactedRoomJoinRulesEventContent` is now a type alias of `RoomJoinRulesEventContent`, since they
+  were identical. This also solves a deserialization error for `RedactedRoomJoinRulesEventContent`.
+- `RedactedRoomHistoryVisibilityEventContent` is now a type alias of
+  `RoomHistoryVisibilityEventContent`, since they were identical.
 
 Improvements:
 


### PR DESCRIPTION
I noticed this because of a bug report in Fractal, which turned out to be `RedactedRoomJoinRulesEventContent` that failed to deserialize.

The thing is that `RoomJoinRulesEventContent` has a custom `Deserialize` implementation, but `RedactedRoomJoinRulesEventContent` did not and of course the `#[serde(flatten)]` was problematic. In this case, we can solve the issue because we can just use a type alias.
