### PR TITLE
events: Make fields that were deprecated by MSC3700 optional

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -66,6 +66,9 @@ Breaking changes:
 - The `event_id` field of `PreviousRoom` is now optional and deprecated. It has been removed in new
   room versions so clients should not rely on it. They can obtain it by requesting the
   `m.room.tombstone` event in the state of the predecessor.
+- The `sender_key` and `device_id` fields of `MegolmV1AesSha2Content` are now optional. They were
+  deprecated in Matrix 1.3.
+- The `sender_key` field of `RequestedKeyInfo` is now optional. It was deprecated in Matrix 1.3.
 
 Improvements:
 

--- a/crates/ruma-events/src/room/encrypted.rs
+++ b/crates/ruma-events/src/room/encrypted.rs
@@ -230,12 +230,14 @@ pub struct MegolmV1AesSha2Content {
     pub ciphertext: String,
 
     /// The Curve25519 key of the sender.
-    #[deprecated = "this field still needs to be sent but should not be used when received"]
-    pub sender_key: String,
+    #[deprecated = "Since Matrix 1.3, this field should still be sent but should not be used when received"]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sender_key: Option<String>,
 
     /// The ID of the sending device.
-    #[deprecated = "this field still needs to be sent but should not be used when received"]
-    pub device_id: OwnedDeviceId,
+    #[deprecated = "Since Matrix 1.3, this field should still be sent but should not be used when received"]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub device_id: Option<OwnedDeviceId>,
 
     /// The ID of the session used to encrypt the message.
     pub session_id: String,
@@ -266,7 +268,7 @@ impl From<MegolmV1AesSha2ContentInit> for MegolmV1AesSha2Content {
     fn from(init: MegolmV1AesSha2ContentInit) -> Self {
         let MegolmV1AesSha2ContentInit { ciphertext, sender_key, device_id, session_id } = init;
         #[allow(deprecated)]
-        Self { ciphertext, sender_key, device_id, session_id }
+        Self { ciphertext, sender_key: Some(sender_key), device_id: Some(device_id), session_id }
     }
 }
 
@@ -274,7 +276,7 @@ impl From<MegolmV1AesSha2ContentInit> for MegolmV1AesSha2Content {
 mod tests {
     use assert_matches2::assert_matches;
     use js_int::uint;
-    use ruma_common::{owned_event_id, serde::Raw};
+    use ruma_common::{device_id, owned_event_id, serde::Raw};
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     use super::{
@@ -335,8 +337,8 @@ mod tests {
 
         assert_matches!(content.scheme, EncryptedEventScheme::MegolmV1AesSha2(scheme));
         assert_eq!(scheme.ciphertext, "ciphertext");
-        assert_eq!(scheme.sender_key, "sender_key");
-        assert_eq!(scheme.device_id, "device_id");
+        assert_eq!(scheme.sender_key.as_deref(), Some("sender_key"));
+        assert_eq!(scheme.device_id.as_deref(), Some(device_id!("device_id")));
         assert_eq!(scheme.session_id, "session_id");
 
         assert_matches!(content.relates_to, Some(Relation::Reply { in_reply_to }));

--- a/crates/ruma-events/src/room/encrypted/unstable_state.rs
+++ b/crates/ruma-events/src/room/encrypted/unstable_state.rs
@@ -88,8 +88,6 @@ mod tests {
         let json_data = json!({
             "algorithm": "m.megolm.v1.aes-sha2",
             "ciphertext": "ciphertext",
-            "sender_key": "sender_key",
-            "device_id": "device_id",
             "session_id": "session_id",
         });
 
@@ -97,8 +95,8 @@ mod tests {
 
         assert_matches!(content.scheme, EncryptedEventScheme::MegolmV1AesSha2(scheme));
         assert_eq!(scheme.ciphertext, "ciphertext");
-        assert_eq!(scheme.sender_key, "sender_key");
-        assert_eq!(scheme.device_id, "device_id");
+        assert_eq!(scheme.sender_key, None);
+        assert_eq!(scheme.device_id, None);
         assert_eq!(scheme.session_id, "session_id");
     }
 
@@ -115,8 +113,6 @@ mod tests {
             "content": {
                 "algorithm": "m.megolm.v1.aes-sha2",
                 "ciphertext": "ciphertext",
-                "sender_key": "sender_key",
-                "device_id": "device_id",
                 "session_id": "session_id",
             }
         });
@@ -126,8 +122,8 @@ mod tests {
 
         assert_matches!(ev.content.scheme, EncryptedEventScheme::MegolmV1AesSha2(scheme));
         assert_eq!(scheme.ciphertext, "ciphertext");
-        assert_eq!(scheme.sender_key, "sender_key");
-        assert_eq!(scheme.device_id, "device_id");
+        assert_eq!(scheme.sender_key, None);
+        assert_eq!(scheme.device_id, None);
         assert_eq!(scheme.session_id, "session_id");
 
         assert_eq!(ev.sender, user_id!("@example:example.com"));

--- a/crates/ruma-events/src/room_key_request.rs
+++ b/crates/ruma-events/src/room_key_request.rs
@@ -74,8 +74,9 @@ pub struct RequestedKeyInfo {
     pub room_id: OwnedRoomId,
 
     /// The Curve25519 key of the device which initiated the session originally.
-    #[deprecated = "this field still needs to be sent but should not be used when received"]
-    pub sender_key: String,
+    #[deprecated = "Since Matrix 1.3, this field should still be sent but should not be used when received"]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sender_key: Option<String>,
 
     /// The ID of the session that the key is for.
     pub session_id: String,
@@ -91,6 +92,6 @@ impl RequestedKeyInfo {
         session_id: String,
     ) -> Self {
         #[allow(deprecated)]
-        Self { algorithm, room_id, sender_key, session_id }
+        Self { algorithm, room_id, sender_key: Some(sender_key), session_id }
     }
 }


### PR DESCRIPTION
Otherwise they can never be removed.

Should have been done in #1201.