### PR TITLE
client-api: Add unstable support for `state_after` in `sync_events::v3`

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -32,6 +32,9 @@ Breaking changes:
   in the request.
 - Use `StrippedState` instead of `AnyStrippedStateEvent`, to allow non-stripped events to be
   represented for `sync_events`.
+- `sync_events::v3::State` is now an enum, to prepare for the stabilization of MSC4222. The state
+  before the timeline, corresponding to the `state` field in the Matrix specification, is available
+  in the `Before` variant, and the struct representing its content was renamed to `StateEvents`. 
 
 Improvements:
 
@@ -47,6 +50,9 @@ Improvements:
   events from MSC4311 behind the `unstable-msc4311` feature.
 - Add unstable support for `AnySyncStateEvent` formatted events in `sync_events`, alongside stripped
   events, according to MSC4319.
+- Add unstable support for the `use_state_after` query parameter in `sync_events::v3::Request`, and
+  the corresponding `State::After` variant in the response (`state_after` in the spec), according to
+  MSC4222.
 
 # 0.20.4
 

--- a/crates/ruma-client-api/Cargo.toml
+++ b/crates/ruma-client-api/Cargo.toml
@@ -51,6 +51,7 @@ unstable-msc4140 = ["ruma-common/unstable-msc4140"]
 unstable-msc4143 = []
 unstable-msc4186 = ["ruma-common/unstable-msc4186"]
 unstable-msc4191 = []
+unstable-msc4222 = []
 # Thread subscription support.
 unstable-msc4306 = []
 unstable-msc4311 = []

--- a/crates/ruma-client-api/src/sync/sync_events/v3.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v3.rs
@@ -107,6 +107,7 @@ pub struct Response {
     ///
     /// The presence of this field indicates that the server supports
     /// fallback keys.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub device_unused_fallback_key_types: Option<Vec<OneTimeKeyAlgorithm>>,
 }
 

--- a/crates/ruma-client-api/src/sync/sync_events/v3/response_serde.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v3/response_serde.rs
@@ -1,0 +1,114 @@
+use std::collections::BTreeMap;
+
+#[cfg(feature = "unstable-msc2654")]
+use js_int::UInt;
+use ruma_common::{serde::from_raw_json_value, OwnedEventId};
+use serde::{Deserialize, Deserializer};
+use serde_json::value::RawValue as RawJsonValue;
+
+use super::{
+    Ephemeral, JoinedRoom, LeftRoom, RoomAccountData, RoomSummary, State, StateEvents, Timeline,
+    UnreadNotificationsCount,
+};
+
+#[derive(Debug, Deserialize)]
+struct StateDeHelper {
+    state: Option<StateEvents>,
+    #[cfg(feature = "unstable-msc4222")]
+    #[serde(rename = "org.matrix.msc4222.state_after")]
+    state_after: Option<StateEvents>,
+}
+
+impl<'de> Deserialize<'de> for State {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let StateDeHelper {
+            state,
+            #[cfg(feature = "unstable-msc4222")]
+            state_after,
+        } = StateDeHelper::deserialize(deserializer)?;
+
+        #[cfg(feature = "unstable-msc4222")]
+        if let Some(state) = state_after {
+            return Ok(Self::After(state));
+        }
+
+        Ok(state.map(Self::Before).unwrap_or_default())
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct LeftRoomDeHelper {
+    #[serde(default)]
+    timeline: Timeline,
+    #[serde(default)]
+    account_data: RoomAccountData,
+}
+
+impl<'de> Deserialize<'de> for LeftRoom {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let json = Box::<RawJsonValue>::deserialize(deserializer)?;
+
+        let state = from_raw_json_value(&json)?;
+        let LeftRoomDeHelper { timeline, account_data } = from_raw_json_value(&json)?;
+
+        Ok(Self { timeline, state, account_data })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct JoinedRoomDeHelper {
+    #[serde(default)]
+    summary: RoomSummary,
+    #[serde(default)]
+    unread_notifications: UnreadNotificationsCount,
+    #[serde(default)]
+    unread_thread_notifications: BTreeMap<OwnedEventId, UnreadNotificationsCount>,
+    #[serde(default)]
+    timeline: Timeline,
+    #[serde(default)]
+    account_data: RoomAccountData,
+    #[serde(default)]
+    ephemeral: Ephemeral,
+    #[cfg(feature = "unstable-msc2654")]
+    #[serde(rename = "org.matrix.msc2654.unread_count")]
+    unread_count: Option<UInt>,
+}
+
+impl<'de> Deserialize<'de> for JoinedRoom {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let json = Box::<RawJsonValue>::deserialize(deserializer)?;
+
+        let state = from_raw_json_value(&json)?;
+        let JoinedRoomDeHelper {
+            summary,
+            unread_notifications,
+            unread_thread_notifications,
+            timeline,
+            account_data,
+            ephemeral,
+            #[cfg(feature = "unstable-msc2654")]
+            unread_count,
+        } = from_raw_json_value(&json)?;
+
+        Ok(Self {
+            summary,
+            unread_notifications,
+            unread_thread_notifications,
+            timeline,
+            state,
+            account_data,
+            ephemeral,
+            #[cfg(feature = "unstable-msc2654")]
+            unread_count,
+        })
+    }
+}

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -197,6 +197,7 @@ unstable-msc4171 = ["ruma-events?/unstable-msc4171"]
 unstable-msc4186 = ["ruma-common/unstable-msc4186", "ruma-client-api?/unstable-msc4186"]
 unstable-msc4191 = ["ruma-client-api?/unstable-msc4191"]
 unstable-msc4203 = ["ruma-appservice-api?/unstable-msc4203"]
+unstable-msc4222 = ["ruma-client-api?/unstable-msc4222"]
 unstable-msc4230 = ["ruma-events?/unstable-msc4230"]
 unstable-msc4268 = ["ruma-events?/unstable-msc4268"]
 unstable-msc4274 = ["ruma-events?/unstable-msc4274"]
@@ -258,6 +259,7 @@ __unstable-mscs = [
     "unstable-msc4186",
     "unstable-msc4191",
     "unstable-msc4203",
+    "unstable-msc4222",
     "unstable-msc4230",
     "unstable-msc4268",
     "unstable-msc4274",


### PR DESCRIPTION
[MSC4222](https://github.com/matrix-org/matrix-spec-proposals/pull/4222) / [Spec PR](https://github.com/matrix-org/matrix-spec/pull/2187).
