### PR TITLE
client-api/common: update to latest semantics of MSC4306

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -9,6 +9,9 @@ exclude = [
 
 [advisories]
 version = 2
+ignore = [
+    "RUSTSEC-2024-0436" # in paste, used transitively by `smol_macros`, which is test-only.
+]
 
 [licenses]
 version = 2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f093eed78becd229346bf859eec0aa4dd7ddde0757287b2b4107a1f09c80002"
 
 [[package]]
+name = "async-executor"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb812ffb58524bdd10860d7d974e2f01cc0950c2438a74ee5ec2e2280c6c4ffa"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19634d6336019ef220f09fd31168ce5c184b295cbf80345437cc36094ef223ca"
+dependencies = [
+ "async-lock",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,7 +173,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -259,6 +308,15 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "console"
@@ -522,6 +580,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -594,6 +673,19 @@ name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-sink"
@@ -1174,6 +1266,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
+name = "macro_rules_attribute"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65049d7923698040cd0b1ddcced9b0eb14dd22c5f86ae59c3740eab64a676520"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+ "paste",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
+
+[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1371,6 +1479,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1390,8 +1504,14 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -1491,6 +1611,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "polling"
+version = "3.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5bd19146350fe804f7cb2669c851c03d69da628803dab0d98018142aaa5d829"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1808,6 +1942,7 @@ dependencies = [
  "js-sys",
  "js_int",
  "konst",
+ "macro_rules_attribute",
  "maplit",
  "percent-encoding",
  "rand",
@@ -1817,9 +1952,9 @@ dependencies = [
  "serde",
  "serde_html_form",
  "serde_json",
+ "smol-macros",
  "thiserror",
  "time",
- "tokio",
  "tracing",
  "trybuild",
  "url",
@@ -2258,6 +2393,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
+name = "smol-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfcaedb62e0475a6898988138995ec7b1e5d116167a72bb12c7b59d0649fbbc2"
+dependencies = [
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "event-listener",
+ "futures-lite",
+]
+
+[[package]]
 name = "socket2"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2501,19 +2649,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
- "tokio-macros",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2985,9 +3121,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-registry"
@@ -3024,7 +3160,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3033,7 +3169,16 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -3042,14 +3187,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -3059,10 +3221,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3071,10 +3245,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3083,10 +3269,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3095,10 +3293,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1819,6 +1819,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "time",
+ "tokio",
  "tracing",
  "trybuild",
  "url",
@@ -2500,7 +2501,19 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/crates/ruma-client-api/src/error.rs
+++ b/crates/ruma-client-api/src/error.rs
@@ -90,6 +90,15 @@ pub enum ErrorKind {
     /// A Captcha is required to complete the request.
     CaptchaNeeded,
 
+    /// `M_CONFLICTING_UNSUBSCRIPTION`
+    ///
+    /// Part of [MSC4306]: an automatic thread subscription has been skipped by the server, because
+    /// the user unsubsubscribed after the indicated subscribed-to event.
+    ///
+    /// [MSC4306]: https://github.com/matrix-org/matrix-spec-proposals/pull/4306
+    #[cfg(feature = "unstable-msc4306")]
+    ConflictingUnsubscription,
+
     /// `M_CONNECTION_FAILED`
     ///
     /// The connection to the application service failed.
@@ -184,6 +193,15 @@ pub enum ErrorKind {
     ///
     /// No resource was found for this request.
     NotFound,
+
+    /// `M_NOT_IN_THREAD`
+    ///
+    /// Part of [MSC4306]: an automatic thread subscription was set to an event ID that isn't part
+    /// of the subscribed-to thread.
+    ///
+    /// [MSC4306]: https://github.com/matrix-org/matrix-spec-proposals/pull/4306
+    #[cfg(feature = "unstable-msc4306")]
+    NotInThread,
 
     /// `M_NOT_JSON`
     ///
@@ -430,11 +448,15 @@ impl ErrorKind {
             ErrorKind::MissingParam => ErrorCode::MissingParam,
             ErrorKind::MissingToken => ErrorCode::MissingToken,
             ErrorKind::NotFound => ErrorCode::NotFound,
+            #[cfg(feature = "unstable-msc4306")]
+            ErrorKind::NotInThread => ErrorCode::NotInThread,
             ErrorKind::NotJson => ErrorCode::NotJson,
             ErrorKind::NotYetUploaded => ErrorCode::NotYetUploaded,
             ErrorKind::ResourceLimitExceeded { .. } => ErrorCode::ResourceLimitExceeded,
             ErrorKind::RoomInUse => ErrorCode::RoomInUse,
             ErrorKind::ServerNotTrusted => ErrorCode::ServerNotTrusted,
+            #[cfg(feature = "unstable-msc4306")]
+            ErrorKind::ConflictingUnsubscription => ErrorCode::ConflictingUnsubscription,
             ErrorKind::ThreepidAuthFailed => ErrorCode::ThreepidAuthFailed,
             ErrorKind::ThreepidDenied => ErrorCode::ThreepidDenied,
             ErrorKind::ThreepidInUse => ErrorCode::ThreepidInUse,
@@ -525,6 +547,16 @@ pub enum ErrorCode {
     /// A Captcha is required to complete the request.
     CaptchaNeeded,
 
+    /// `M_CONFLICTING_UNSUBSCRIPTION`
+    ///
+    /// Part of [MSC4306]: an automatic thread subscription has been skipped by the server, because
+    /// the user unsubsubscribed after the indicated subscribed-to event.
+    ///
+    /// [MSC4306]: https://github.com/matrix-org/matrix-spec-proposals/pull/4306
+    #[cfg(feature = "unstable-msc4306")]
+    #[ruma_enum(rename = "IO.ELEMENT.MSC4306.M_CONFLICTING_UNSUBSCRIPTION")]
+    ConflictingUnsubscription,
+
     /// `M_CONNECTION_FAILED`
     ///
     /// The connection to the application service failed.
@@ -608,6 +640,16 @@ pub enum ErrorCode {
     ///
     /// No resource was found for this request.
     NotFound,
+
+    /// `M_NOT_IN_THREAD`
+    ///
+    /// Part of [MSC4306]: an automatic thread subscription was set to an event ID that isn't part
+    /// of the subscribed-to thread.
+    ///
+    /// [MSC4306]: https://github.com/matrix-org/matrix-spec-proposals/pull/4306
+    #[cfg(feature = "unstable-msc4306")]
+    #[ruma_enum(rename = "IO.ELEMENT.MSC4306.M_NOT_IN_THREAD")]
+    NotInThread,
 
     /// `M_NOT_JSON`
     ///

--- a/crates/ruma-client-api/src/error.rs
+++ b/crates/ruma-client-api/src/error.rs
@@ -434,6 +434,8 @@ impl ErrorKind {
             ErrorKind::CannotOverwriteMedia => ErrorCode::CannotOverwriteMedia,
             ErrorKind::CaptchaInvalid => ErrorCode::CaptchaInvalid,
             ErrorKind::CaptchaNeeded => ErrorCode::CaptchaNeeded,
+            #[cfg(feature = "unstable-msc4306")]
+            ErrorKind::ConflictingUnsubscription => ErrorCode::ConflictingUnsubscription,
             ErrorKind::ConnectionFailed => ErrorCode::ConnectionFailed,
             ErrorKind::ConnectionTimeout => ErrorCode::ConnectionTimeout,
             ErrorKind::DuplicateAnnotation => ErrorCode::DuplicateAnnotation,
@@ -455,8 +457,6 @@ impl ErrorKind {
             ErrorKind::ResourceLimitExceeded { .. } => ErrorCode::ResourceLimitExceeded,
             ErrorKind::RoomInUse => ErrorCode::RoomInUse,
             ErrorKind::ServerNotTrusted => ErrorCode::ServerNotTrusted,
-            #[cfg(feature = "unstable-msc4306")]
-            ErrorKind::ConflictingUnsubscription => ErrorCode::ConflictingUnsubscription,
             ErrorKind::ThreepidAuthFailed => ErrorCode::ThreepidAuthFailed,
             ErrorKind::ThreepidDenied => ErrorCode::ThreepidDenied,
             ErrorKind::ThreepidInUse => ErrorCode::ThreepidInUse,

--- a/crates/ruma-client-api/src/error/kind_serde.rs
+++ b/crates/ruma-client-api/src/error/kind_serde.rs
@@ -181,6 +181,8 @@ impl<'de> Visitor<'de> for ErrorKindVisitor {
             ErrorCode::CannotOverwriteMedia => ErrorKind::CannotOverwriteMedia,
             ErrorCode::CaptchaInvalid => ErrorKind::CaptchaInvalid,
             ErrorCode::CaptchaNeeded => ErrorKind::CaptchaNeeded,
+            #[cfg(feature = "unstable-msc4306")]
+            ErrorCode::ConflictingUnsubscription => ErrorKind::ConflictingUnsubscription,
             ErrorCode::ConnectionFailed => ErrorKind::ConnectionFailed,
             ErrorCode::ConnectionTimeout => ErrorKind::ConnectionTimeout,
             ErrorCode::DuplicateAnnotation => ErrorKind::DuplicateAnnotation,
@@ -208,6 +210,8 @@ impl<'de> Visitor<'de> for ErrorKindVisitor {
             ErrorCode::MissingParam => ErrorKind::MissingParam,
             ErrorCode::MissingToken => ErrorKind::MissingToken,
             ErrorCode::NotFound => ErrorKind::NotFound,
+            #[cfg(feature = "unstable-msc4306")]
+            ErrorCode::NotInThread => ErrorKind::NotInThread,
             ErrorCode::NotJson => ErrorKind::NotJson,
             ErrorCode::NotYetUploaded => ErrorKind::NotYetUploaded,
             ErrorCode::ResourceLimitExceeded => ErrorKind::ResourceLimitExceeded {

--- a/crates/ruma-client-api/src/threads/subscribe_thread.rs
+++ b/crates/ruma-client-api/src/threads/subscribe_thread.rs
@@ -32,8 +32,10 @@ pub mod unstable {
         #[ruma_api(path)]
         pub thread_root: OwnedEventId,
 
-        /// Whether the subscription was made automatically by a client, not by manual user choice.
-        pub automatic: bool,
+        /// Whether the subscription was made automatically by a client, not by manual user choice,
+        /// and up to which event.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub automatic: Option<OwnedEventId>,
     }
 
     /// Response type for the `subscribe_thread` endpoint.
@@ -42,7 +44,14 @@ pub mod unstable {
 
     impl Request {
         /// Creates a new `Request` for the given room and thread IDs.
-        pub fn new(room_id: OwnedRoomId, thread_root: OwnedEventId, automatic: bool) -> Self {
+        ///
+        /// If `automatic` is set, it must be the ID of the last thread event causing an automatic
+        /// update, which is not necessarily the latest thread event. See the MSC for more details.
+        pub fn new(
+            room_id: OwnedRoomId,
+            thread_root: OwnedEventId,
+            automatic: Option<OwnedEventId>,
+        ) -> Self {
             Self { room_id, thread_root, automatic }
         }
     }

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Breaking changes:
 
+- `PushCondition::applies`, `ConditionalPushRule::applies`, `AnyPushRuleRef::applies`,
+  `AnyPushRule::applies`, `Ruleset::applies`, `Ruleset::get_actions` all became async,
+  to allow for lazy evaluation of push rules.
 - `UserId` parsing and deserialization are now compatible with all non-compliant
   user IDs in the wild by default, due to a clarification in the spec.
   - The `compat-user-id` cargo feature was removed.

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -3,8 +3,8 @@
 Breaking changes:
 
 - `PushCondition::applies`, `ConditionalPushRule::applies`, `AnyPushRuleRef::applies`,
-  `AnyPushRule::applies`, `Ruleset::applies`, `Ruleset::get_actions` all became async,
-  to allow for lazy evaluation of push rules.
+  `AnyPushRule::applies`, `Ruleset::applies`, `Ruleset::get_actions`, `Ruleset::get_match` all
+  became async, to allow for lazy evaluation of push rules.
 - `UserId` parsing and deserialization are now compatible with all non-compliant
   user IDs in the wild by default, due to a clarification in the spec.
   - The `compat-user-id` cargo feature was removed.

--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -90,6 +90,7 @@ js-sys = { version = "0.3", optional = true }
 assert_matches2 = { workspace = true }
 assign = { workspace = true }
 maplit = { workspace = true }
+tokio = { version = "1.45.0", features = ["macros", "rt"] }
 trybuild = "1.0.71"
 
 [lints]

--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -35,6 +35,8 @@ unstable-msc3932 = ["unstable-msc3931"]
 unstable-msc4108 = []
 unstable-msc4140 = []
 unstable-msc4186 = []
+# Thread subscriptions.
+unstable-msc4306 = []
 
 # Allow IDs to exceed 255 bytes.
 compat-arbitrary-length-ids = ["ruma-identifiers-validation/compat-arbitrary-length-ids"]

--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -89,8 +89,9 @@ js-sys = { version = "0.3", optional = true }
 [dev-dependencies]
 assert_matches2 = { workspace = true }
 assign = { workspace = true }
+macro_rules_attribute = "0.2.2"
 maplit = { workspace = true }
-tokio = { version = "1.45.0", features = ["macros", "rt"] }
+smol-macros = "0.1.1"
 trybuild = "1.0.71"
 
 [lints]

--- a/crates/ruma-common/src/push.rs
+++ b/crates/ruma-common/src/push.rs
@@ -1434,6 +1434,8 @@ mod tests {
             power_levels: Some(power_levels()),
             #[cfg(feature = "unstable-msc3931")]
             supported_features: Default::default(),
+            #[cfg(feature = "unstable-msc4306")]
+            thread_subscriptions: Default::default(),
         };
 
         let context_public_room = &PushConditionRoomCtx {
@@ -1444,6 +1446,8 @@ mod tests {
             power_levels: Some(power_levels()),
             #[cfg(feature = "unstable-msc3931")]
             supported_features: Default::default(),
+            #[cfg(feature = "unstable-msc4306")]
+            thread_subscriptions: Default::default(),
         };
 
         let message = serde_json::from_str::<Raw<JsonValue>>(
@@ -1535,6 +1539,8 @@ mod tests {
             power_levels: Some(power_levels()),
             #[cfg(feature = "unstable-msc3931")]
             supported_features: Default::default(),
+            #[cfg(feature = "unstable-msc4306")]
+            thread_subscriptions: Default::default(),
         };
 
         let message = serde_json::from_str::<Raw<JsonValue>>(
@@ -1674,6 +1680,8 @@ mod tests {
             power_levels: Some(power_levels()),
             #[cfg(feature = "unstable-msc3931")]
             supported_features: Default::default(),
+            #[cfg(feature = "unstable-msc4306")]
+            thread_subscriptions: Default::default(),
         };
 
         let message = serde_json::from_str::<Raw<JsonValue>>(
@@ -1784,6 +1792,8 @@ mod tests {
             power_levels: Some(power_levels()),
             #[cfg(feature = "unstable-msc3931")]
             supported_features: Default::default(),
+            #[cfg(feature = "unstable-msc4306")]
+            thread_subscriptions: Default::default(),
         };
 
         let message = serde_json::from_str::<Raw<JsonValue>>(
@@ -1838,6 +1848,8 @@ mod tests {
             power_levels: None,
             #[cfg(feature = "unstable-msc3931")]
             supported_features: Default::default(),
+            #[cfg(feature = "unstable-msc4306")]
+            thread_subscriptions: Default::default(),
         };
 
         let message = serde_json::from_str::<Raw<JsonValue>>(

--- a/crates/ruma-common/src/push.rs
+++ b/crates/ruma-common/src/push.rs
@@ -299,7 +299,7 @@ impl Ruleset {
             return None;
         }
 
-        for rule in self.iter() {
+        for rule in self {
             if rule.applies(&event, context).await {
                 return Some(rule);
             }
@@ -527,7 +527,7 @@ impl ConditionalPushRule {
             return false;
         }
 
-        for cond in self.conditions.iter() {
+        for cond in &self.conditions {
             if !cond.applies(event, context).await {
                 return false;
             }

--- a/crates/ruma-common/src/push.rs
+++ b/crates/ruma-common/src/push.rs
@@ -987,10 +987,12 @@ mod tests {
 
     use assert_matches2::assert_matches;
     use js_int::{int, uint};
+    use macro_rules_attribute::apply;
     use serde_json::{
         from_value as from_json_value, json, to_value as to_json_value,
         value::RawValue as RawJsonValue, Value as JsonValue,
     };
+    use smol_macros::test;
 
     use super::{
         action::{Action, Tweak},
@@ -1437,7 +1439,7 @@ mod tests {
         assert_matches!(iter.next(), None);
     }
 
-    #[tokio::test]
+    #[apply(test!)]
     async fn default_ruleset_applies() {
         let set = Ruleset::server_default(user_id!("@jolly_jumper:server.name"));
 
@@ -1544,7 +1546,7 @@ mod tests {
         assert_matches!(set.get_actions(&empty, context_one_to_one).await, []);
     }
 
-    #[tokio::test]
+    #[apply(test!)]
     async fn custom_ruleset_applies() {
         let context_one_to_one = &PushConditionRoomCtx {
             room_id: owned_room_id!("!dm:server.name"),
@@ -1682,7 +1684,7 @@ mod tests {
         assert_eq!(sound, "three");
     }
 
-    #[tokio::test]
+    #[apply(test!)]
     #[allow(deprecated)]
     async fn old_mentions_apply() {
         let set = Ruleset::server_default(user_id!("@jolly_jumper:server.name"));
@@ -1795,7 +1797,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[apply(test!)]
     async fn intentional_mentions_apply() {
         let set = Ruleset::server_default(user_id!("@jolly_jumper:server.name"));
 
@@ -1850,7 +1852,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[apply(test!)]
     async fn invite_for_me_applies() {
         let set = Ruleset::server_default(user_id!("@jolly_jumper:server.name"));
 

--- a/crates/ruma-common/src/push/condition.rs
+++ b/crates/ruma-common/src/push/condition.rs
@@ -611,9 +611,11 @@ mod tests {
 
     use assert_matches2::assert_matches;
     use js_int::{int, uint, Int};
+    use macro_rules_attribute::apply;
     use serde_json::{
         from_value as from_json_value, json, to_value as to_json_value, Value as JsonValue,
     };
+    use smol_macros::test;
 
     use super::{
         FlattenedJson, PushCondition, PushConditionPowerLevelsCtx, PushConditionRoomCtx,
@@ -870,7 +872,7 @@ mod tests {
         FlattenedJson::from_raw(&raw)
     }
 
-    #[tokio::test]
+    #[apply(test!)]
     async fn event_match_applies() {
         let context = push_context();
         let first_event = first_flattened_event();
@@ -901,7 +903,7 @@ mod tests {
         assert!(msgtype.applies(&second_event, &context).await);
     }
 
-    #[tokio::test]
+    #[apply(test!)]
     async fn room_member_count_is_applies() {
         let context = push_context();
         let event = first_flattened_event();
@@ -918,7 +920,7 @@ mod tests {
         assert!(!member_count_lt.applies(&event, &context).await);
     }
 
-    #[tokio::test]
+    #[apply(test!)]
     async fn contains_display_name_applies() {
         let context = push_context();
         let first_event = first_flattened_event();
@@ -930,7 +932,7 @@ mod tests {
         assert!(!contains_display_name.applies(&second_event, &context).await);
     }
 
-    #[tokio::test]
+    #[apply(test!)]
     async fn sender_notification_permission_applies() {
         let context = push_context();
         let first_event = first_flattened_event();
@@ -944,7 +946,7 @@ mod tests {
     }
 
     #[cfg(feature = "unstable-msc3932")]
-    #[tokio::test]
+    #[apply(test!)]
     async fn room_version_supports_applies() {
         let context_not_matching = push_context();
 
@@ -979,7 +981,7 @@ mod tests {
         assert!(!room_version_condition.applies(&simple_event, &context_not_matching).await);
     }
 
-    #[tokio::test]
+    #[apply(test!)]
     async fn event_property_is_applies() {
         use crate::push::condition::ScalarJsonValue;
 
@@ -1044,7 +1046,7 @@ mod tests {
         assert!(null_match.applies(&event, &context).await);
     }
 
-    #[tokio::test]
+    #[apply(test!)]
     async fn event_property_contains_applies() {
         use crate::push::condition::ScalarJsonValue;
 
@@ -1107,7 +1109,7 @@ mod tests {
         assert!(null_match.applies(&event, &context).await);
     }
 
-    #[tokio::test]
+    #[apply(test!)]
     async fn room_creators_always_have_notification_permission() {
         let mut context = push_context();
         context.power_levels = Some(PushConditionPowerLevelsCtx {
@@ -1126,7 +1128,7 @@ mod tests {
     }
 
     #[cfg(feature = "unstable-msc4306")]
-    #[tokio::test]
+    #[apply(test!)]
     async fn thread_subscriptions_match() {
         use crate::{event_id, EventId};
 

--- a/crates/ruma-common/src/push/iter.rs
+++ b/crates/ruma-common/src/push/iter.rs
@@ -86,8 +86,8 @@ impl AnyPushRule {
     ///
     /// * `event` - The flattened JSON representation of a room message event.
     /// * `context` - The context of the room at the time of the event.
-    pub fn applies(&self, event: &FlattenedJson, context: &PushConditionRoomCtx) -> bool {
-        self.as_ref().applies(event, context)
+    pub async fn applies(&self, event: &FlattenedJson, context: &PushConditionRoomCtx) -> bool {
+        self.as_ref().applies(event, context).await
     }
 }
 
@@ -234,14 +234,14 @@ impl<'a> AnyPushRuleRef<'a> {
     ///
     /// * `event` - The flattened JSON representation of a room message event.
     /// * `context` - The context of the room at the time of the event.
-    pub fn applies(self, event: &FlattenedJson, context: &PushConditionRoomCtx) -> bool {
+    pub async fn applies(self, event: &FlattenedJson, context: &PushConditionRoomCtx) -> bool {
         if event.get_str("sender").is_some_and(|sender| sender == context.user_id) {
             return false;
         }
 
         match self {
-            Self::Override(rule) => rule.applies(event, context),
-            Self::Underride(rule) => rule.applies(event, context),
+            Self::Override(rule) => rule.applies(event, context).await,
+            Self::Underride(rule) => rule.applies(event, context).await,
             Self::Content(rule) => rule.applies_to("content.body", event, context),
             Self::Room(rule) => {
                 rule.enabled

--- a/crates/ruma-common/src/push/predefined.rs
+++ b/crates/ruma-common/src/push/predefined.rs
@@ -46,6 +46,10 @@ impl Ruleset {
             ]
             .into(),
             underride: [
+                #[cfg(feature = "unstable-msc4306")]
+                ConditionalPushRule::unsubscribed_thread(),
+                #[cfg(feature = "unstable-msc4306")]
+                ConditionalPushRule::subscribed_thread(),
                 ConditionalPushRule::call(),
                 ConditionalPushRule::encrypted_room_one_to_one(),
                 ConditionalPushRule::room_one_to_one(),
@@ -539,6 +543,38 @@ impl ConditionalPushRule {
             actions: vec![Notify],
         }
     }
+
+    /// Matches an event that's part of a thread, that is *not* subscribed to, by the current user.
+    ///
+    /// Thread subscriptions are defined in [MSC4306].
+    ///
+    /// [MSC4306]: https://github.com/matrix-org/matrix-spec-proposals/pull/4306
+    #[cfg(feature = "unstable-msc4306")]
+    pub fn unsubscribed_thread() -> Self {
+        Self {
+            rule_id: PredefinedUnderrideRuleId::UnsubscribedThread.to_string(),
+            default: true,
+            enabled: true,
+            conditions: vec![ThreadSubscription { subscribed: false }],
+            actions: vec![],
+        }
+    }
+
+    /// Matches an event that's part of a thread, that *is* subscribed to, by the current user.
+    ///
+    /// Thread subscriptions are defined in [MSC4306].
+    ///
+    /// [MSC4306]: https://github.com/matrix-org/matrix-spec-proposals/pull/4306
+    #[cfg(feature = "unstable-msc4306")]
+    pub fn subscribed_thread() -> Self {
+        Self {
+            rule_id: PredefinedUnderrideRuleId::SubscribedThread.to_string(),
+            default: true,
+            enabled: true,
+            conditions: vec![ThreadSubscription { subscribed: true }],
+            actions: vec![Notify, SetTweak(Tweak::Sound("default".into()))],
+        }
+    }
 }
 
 /// The rule IDs of the predefined server push rules.
@@ -703,6 +739,24 @@ pub enum PredefinedUnderrideRuleId {
     #[cfg(feature = "unstable-msc3930")]
     #[ruma_enum(rename = ".org.matrix.msc3930.rule.poll_end")]
     PollEnd,
+
+    /// `.m.rule.unsubscribed_thread`
+    ///
+    /// This uses the unstable prefix defined in [MSC4306].
+    ///
+    /// [MSC4306]: https://github.com/matrix-org/matrix-spec-proposals/pull/4306
+    #[cfg(feature = "unstable-msc4306")]
+    #[ruma_enum(rename = ".io.element.msc4306.rule.unsubscribed_thread")]
+    UnsubscribedThread,
+
+    /// `.m.rule.subscribed_thread`
+    ///
+    /// This uses the unstable prefix defined in [MSC4306].
+    ///
+    /// [MSC4306]: https://github.com/matrix-org/matrix-spec-proposals/pull/4306
+    #[cfg(feature = "unstable-msc4306")]
+    #[ruma_enum(rename = ".io.element.msc4306.rule.subscribed_thread")]
+    SubscribedThread,
 
     #[doc(hidden)]
     _Custom(PrivOwnedStr),

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -204,7 +204,7 @@ unstable-msc4274 = ["ruma-events?/unstable-msc4274"]
 unstable-msc4278 = ["ruma-events?/unstable-msc4278"]
 unstable-msc4286 = ["ruma-html?/unstable-msc4286"]
 # Thread subscription support.
-unstable-msc4306 = ["ruma-client-api?/unstable-msc4306"]
+unstable-msc4306 = ["ruma-common/unstable-msc4306", "ruma-client-api?/unstable-msc4306"]
 unstable-msc4311 = ["ruma-client-api?/unstable-msc4311", "ruma-federation-api?/unstable-msc4311"]
 unstable-msc4319 = ["ruma-client-api?/unstable-msc4319"]
 


### PR DESCRIPTION
This:

- updates to the new unstable prefixes
- adds the optional event id that needs to be passed for an automatic thread subscription ("subscribe up to this event")
- adds support for the new push rules. In the first commit implementing this, it uses a plain hashset of the known thread subscriptions, but since this is too likely to be inefficient/incorrect, the second commit makes evaluation of push rules async, and adds a new arc closure that allows to lazily fetch the thread subscription status.

Making the evaluation of push rules async is a big breaking change, but overall it should be a good thing, as it also paves the way for more async in those evaluation. For what it's worth, callers in the Matrix Rust SDK were not too impacted by this change.