### PR TITLE
events: Don't generate `PossiblyRedacted` type alias with `EventContent` derive macro

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -69,6 +69,8 @@ Breaking changes:
 - The `sender_key` and `device_id` fields of `MegolmV1AesSha2Content` are now optional. They were
   deprecated in Matrix 1.3.
 - The `sender_key` field of `RequestedKeyInfo` is now optional. It was deprecated in Matrix 1.3.
+- The `EventContent` derive macro doesn't generate a type alias anymore if the
+  `PossiblyRedacted*EventContent` type is identical to the original type.
 
 Improvements:
 

--- a/crates/ruma-events/src/room/power_levels.rs
+++ b/crates/ruma-events/src/room/power_levels.rs
@@ -18,8 +18,9 @@ use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    EmptyStateKey, MessageLikeEventType, RedactContent, RedactedStateEventContent, StateEventType,
-    StaticEventContent, TimelineEventType,
+    EmptyStateKey, MessageLikeEventType, PossiblyRedactedStateEventContent, RedactContent,
+    RedactedStateEventContent, StateEventContent, StateEventType, StaticEventContent,
+    TimelineEventType,
 };
 
 /// The content of an `m.room.power_levels` event.
@@ -27,7 +28,7 @@ use crate::{
 /// Defines the power levels (privileges) of users in the room.
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
-#[ruma_event(type = "m.room.power_levels", kind = State, state_key_type = EmptyStateKey, custom_redacted)]
+#[ruma_event(type = "m.room.power_levels", kind = State, state_key_type = EmptyStateKey, custom_redacted, custom_possibly_redacted)]
 pub struct RoomPowerLevelsEventContent {
     /// The level required to ban a user.
     #[serde(
@@ -171,6 +172,19 @@ impl RedactContent for RoomPowerLevelsEventContent {
             users,
             users_default,
         }
+    }
+}
+
+/// The possibly redacted form of [`RoomPowerLevelsEventContent`].
+///
+/// This type is used when it’s not obvious whether the content is redacted or not.
+pub type PossiblyRedactedRoomPowerLevelsEventContent = RoomPowerLevelsEventContent;
+
+impl PossiblyRedactedStateEventContent for PossiblyRedactedRoomPowerLevelsEventContent {
+    type StateKey = <RoomPowerLevelsEventContent as StateEventContent>::StateKey;
+
+    fn event_type(&self) -> StateEventType {
+        StateEventType::RoomPowerLevels
     }
 }
 


### PR DESCRIPTION
Originated from https://github.com/ruma/ruma/pull/2177#issuecomment-3154212172.

It might cause issues if fields are added because of the redaction rules, so users have to be mindful about that. A type alias can still be created with `custom_possibly_redacted` if wanted.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
