### PR TITLE
events: Don't print the secret key in the Debug implementation of JsonWebKey

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -72,6 +72,8 @@ Breaking changes:
 
 Improvements:
 
+- Don't print out the secret key contained in JsonWebKey and JsonWebKeyInit in
+  their `Debug` implementations.
 - Remove the `pdu` module and the corresponding `unstable-pdu` cargo feature. As far as we know, it
   was not used anywhere outside of the tests of ruma-state-res.
 - The `EventContent` and `event_enum!` macros support declaring the same type for both global and

--- a/crates/ruma-events/src/room.rs
+++ b/crates/ruma-events/src/room.rs
@@ -224,7 +224,7 @@ impl From<EncryptedFileInit> for EncryptedFile {
 ///
 /// To create an instance of this type, first create a `JsonWebKeyInit` and convert it via
 /// `JsonWebKey::from` / `.into()`.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct JsonWebKey {
     /// Key type.
@@ -252,6 +252,17 @@ pub struct JsonWebKey {
     pub ext: bool,
 }
 
+impl std::fmt::Debug for JsonWebKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("JsonWebKey")
+            .field("kty", &self.kty)
+            .field("key_ops", &self.key_ops)
+            .field("alg", &self.alg)
+            .field("ext", &self.ext)
+            .finish_non_exhaustive()
+    }
+}
+
 impl Drop for JsonWebKey {
     fn drop(&mut self) {
         self.k.zeroize();
@@ -262,7 +273,6 @@ impl Drop for JsonWebKey {
 ///
 /// This struct will not be updated even if additional fields are added to `JsonWebKey` in a new
 /// (non-breaking) release of the Matrix specification.
-#[derive(Debug)]
 #[allow(clippy::exhaustive_structs)]
 pub struct JsonWebKeyInit {
     /// Key type.
@@ -288,6 +298,17 @@ pub struct JsonWebKeyInit {
     /// Must be `true`. This is a
     /// [W3C extension](https://w3c.github.io/webcrypto/#iana-section-jwk).
     pub ext: bool,
+}
+
+impl std::fmt::Debug for JsonWebKeyInit {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("JsonWebKeyInit")
+            .field("kty", &self.kty)
+            .field("key_ops", &self.key_ops)
+            .field("alg", &self.alg)
+            .field("ext", &self.ext)
+            .finish_non_exhaustive()
+    }
 }
 
 impl From<JsonWebKeyInit> for JsonWebKey {


### PR DESCRIPTION
This should avoid having secret key material accidentally leak into logs.