### PR TITLE
events: relay existing relationships for poll start events

### DIFF
--- a/crates/ruma-events/src/room/encrypted.rs
+++ b/crates/ruma-events/src/room/encrypted.rs
@@ -10,8 +10,10 @@ use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
 use super::message;
-use crate::relation::{Annotation, CustomRelation, InReplyTo, Reference, RelationType, Thread};
-use crate::room::message::RelationWithoutReplacement;
+use crate::{
+    relation::{Annotation, CustomRelation, InReplyTo, Reference, RelationType, Thread},
+    room::message::RelationWithoutReplacement,
+};
 
 mod relation_serde;
 #[cfg(feature = "unstable-msc3414")]

--- a/crates/ruma-events/src/room/encrypted.rs
+++ b/crates/ruma-events/src/room/encrypted.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 
 use super::message;
 use crate::relation::{Annotation, CustomRelation, InReplyTo, Reference, RelationType, Thread};
+use crate::room::message::RelationWithoutReplacement;
 
 mod relation_serde;
 #[cfg(feature = "unstable-msc3414")]
@@ -154,6 +155,16 @@ impl<C> From<message::Relation<C>> for Relation {
                 is_falling_back: t.is_falling_back,
             }),
             message::Relation::_Custom(c) => Self::_Custom(c),
+        }
+    }
+}
+
+impl From<RelationWithoutReplacement> for Relation {
+    fn from(value: RelationWithoutReplacement) -> Self {
+        match value {
+            RelationWithoutReplacement::Thread(t) => Self::Thread(t),
+            RelationWithoutReplacement::_Custom(c) => Self::_Custom(c),
+            RelationWithoutReplacement::Reply { in_reply_to } => Self::Reply { in_reply_to },
         }
     }
 }

--- a/crates/ruma-events/tests/it/relations.rs
+++ b/crates/ruma-events/tests/it/relations.rs
@@ -1,21 +1,27 @@
-use assert_matches2::{assert_let, assert_matches};
+#[cfg(feature = "unstable-msc3381")]
+use assert_matches2::assert_let;
+use assert_matches2::assert_matches;
 use assign::assign;
-use ruma_common::{event_id, owned_event_id, serde::Raw};
+#[cfg(feature = "unstable-msc3381")]
+use ruma_common::event_id;
+use ruma_common::{owned_event_id, serde::Raw};
+#[cfg(feature = "unstable-msc3381")]
+use ruma_events::poll::{
+    start::{PollAnswer, PollContentBlock, PollStartEventContent},
+    unstable_start::{
+        NewUnstablePollStartEventContent, UnstablePollAnswer, UnstablePollStartContentBlock,
+        UnstablePollStartEventContent,
+    },
+};
+#[cfg(feature = "unstable-msc3381")]
 use ruma_events::{
     message::TextContentBlock,
-    poll::{
-        start::{PollAnswer, PollContentBlock, PollStartEventContent},
-        unstable_start::{
-            NewUnstablePollStartEventContent, UnstablePollAnswer, UnstablePollStartContentBlock,
-            UnstablePollStartEventContent,
-        },
-    },
-    relation::{CustomRelation, InReplyTo, Replacement, Thread},
-    room::{
-        encrypted,
-        message::{MessageType, Relation, RelationWithoutReplacement, RoomMessageEventContent},
-    },
+    room::{encrypted, message::RelationWithoutReplacement},
     AnyMessageLikeEventContent,
+};
+use ruma_events::{
+    relation::{CustomRelation, InReplyTo, Replacement, Thread},
+    room::message::{MessageType, Relation, RoomMessageEventContent},
 };
 use serde_json::{
     from_value as from_json_value, json, to_value as to_json_value, Value as JsonValue,


### PR DESCRIPTION
Poll response and end events already did this in `AnyMessageLikeEventContent::relation`, but it was missing for the start events.

Fixes https://github.com/ruma/ruma/issues/2191 (I hope).

On one side, this seems to be the right thing to do intuitively and fixes the associated issue in the Matrix Rust SDK. On the other side, I have no idea what I'm doing, so please let me know if I broke something with these changes.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
