### PR TITLE
client-api: add support for msc4308 accompanying endpoint

### DIFF
--- a/crates/ruma-client-api/Cargo.toml
+++ b/crates/ruma-client-api/Cargo.toml
@@ -55,6 +55,7 @@ unstable-msc4191 = []
 unstable-msc4222 = []
 # Thread subscription support.
 unstable-msc4306 = []
+unstable-msc4308 = []
 
 [dependencies]
 as_variant = { workspace = true }

--- a/crates/ruma-client-api/src/threads.rs
+++ b/crates/ruma-client-api/src/threads.rs
@@ -2,6 +2,8 @@
 
 #[cfg(feature = "unstable-msc4306")]
 pub mod get_thread_subscription;
+#[cfg(feature = "unstable-msc4308")]
+pub mod get_thread_subscriptions_changes;
 pub mod get_threads;
 #[cfg(feature = "unstable-msc4306")]
 pub mod subscribe_thread;

--- a/crates/ruma-client-api/src/threads/get_thread_subscriptions_changes.rs
+++ b/crates/ruma-client-api/src/threads/get_thread_subscriptions_changes.rs
@@ -1,0 +1,116 @@
+//! `GET /_matrix/client/*/thread_subscriptions`
+//!
+//! Retrieve a paginated range of thread subscriptions across all rooms.
+
+pub mod unstable {
+    //! `/unstable/` ([spec])
+    //!
+    //! [spec]: https://github.com/matrix-org/matrix-spec-proposals/pull/4308
+
+    use std::collections::BTreeMap;
+
+    use js_int::UInt;
+    use ruma_common::{
+        api::{request, response, Direction, Metadata},
+        metadata, OwnedEventId, OwnedRoomId,
+    };
+    use serde::{Deserialize, Serialize};
+
+    const METADATA: Metadata = metadata! {
+        method: GET,
+        rate_limited: true,
+        authentication: AccessToken,
+        history: {
+            unstable("org.matrix.msc4308") => "/_matrix/client/unstable/io.element.msc4308/thread_subscriptions",
+        }
+    };
+
+    /// Request type for the `get_thread_subscriptions_changes` endpoint.
+    #[request(error = crate::Error)]
+    pub struct Request {
+        /// The direction to use for pagination.
+        ///
+        /// Always `b`ackwards at the time of implementation (2025-08-21).
+        #[ruma_api(query)]
+        dir: Direction,
+
+        /// A token to continue pagination from.
+        ///
+        /// This token can be acquired from a previous `/thread_subscriptions` response, or the
+        /// `prev_batch` in a sliding sync response's `thread_subscriptions` field.
+        ///
+        /// The token is opaque and has no client-discernible meaning.
+        ///
+        /// If not provided, then the pagination starts from the "end".
+        #[ruma_api(query)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub from: Option<String>,
+
+        /// A token used to limit the pagination.
+        ///
+        /// The token can be set to the value of a sliding sync `pos` field used in a request that
+        /// returned new thread subscriptions with a `prev_batch` token.
+        #[ruma_api(query)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub to: Option<String>,
+
+        /// A maximum number of thread subscriptions to fetch in one response.
+        ///
+        /// Defaults to 100, if not provided. Servers may impose a smaller limit than requested.
+        #[ruma_api(query)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub limit: Option<UInt>,
+    }
+
+    /// A thread has been subscribed to at some point.
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+    pub struct ThreadSubscription {
+        /// Whether the subscription was made automatically by a client, not by manual user choice.
+        pub automatic: bool,
+
+        /// The bump stamp of the thread subscription, to be used to compare with other changes
+        /// related to the same thread.
+        pub bump_stamp: UInt,
+    }
+
+    /// A thread has been unsubscribed to at some point.
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+    pub struct ThreadUnsubscription {
+        /// The bump stamp of the thread subscription, to be used to compare with other changes
+        /// related to the same thread.
+        pub bump_stamp: UInt,
+    }
+
+    /// Response type for the `get_thread_subscriptions_changes` endpoint.
+    #[response(error = crate::Error)]
+    pub struct Response {
+        /// New thread subscriptions.
+        #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+        pub subscribed: BTreeMap<OwnedRoomId, BTreeMap<OwnedEventId, ThreadSubscription>>,
+
+        /// New thread unsubscriptions.
+        #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+        pub unsubscribed: BTreeMap<OwnedRoomId, BTreeMap<OwnedEventId, ThreadUnsubscription>>,
+
+        /// If there are still more results to fetch, this is the token to use as the next `from`
+        /// value.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub end: Option<String>,
+    }
+
+    impl Request {
+        /// Creates a new empty `Request`.
+        pub fn new() -> Self {
+            Self { dir: Direction::Backward, from: None, to: None, limit: None }
+        }
+    }
+
+    impl Response {
+        /// Creates a new empty `Response`.
+        pub fn new() -> Self {
+            Self { subscribed: BTreeMap::new(), unsubscribed: BTreeMap::new(), end: None }
+        }
+    }
+}

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -206,6 +206,7 @@ unstable-msc4278 = ["ruma-events?/unstable-msc4278"]
 unstable-msc4286 = ["ruma-html?/unstable-msc4286"]
 # Thread subscription support.
 unstable-msc4306 = ["ruma-common/unstable-msc4306", "ruma-client-api?/unstable-msc4306"]
+unstable-msc4308 = ["ruma-client-api?/unstable-msc4308"]
 unstable-msc4311 = ["ruma-federation-api?/unstable-msc4311"]
 unstable-msc4319 = ["ruma-events?/unstable-msc4319"]
 
@@ -268,6 +269,7 @@ __unstable-mscs = [
     "unstable-msc4278",
     "unstable-msc4286",
     "unstable-msc4306",
+    "unstable-msc4308",
     "unstable-msc4311",
     "unstable-msc4319",
 ]


### PR DESCRIPTION
Implements the accompanying endpoint for [MSC4308](https://github.com/matrix-org/matrix-spec-proposals/pull/4308), that allows fetching all thread subscriptions across all rooms.