### PR TITLE
signatures: replace `subslice` with `memchr`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2081,12 +2081,12 @@ dependencies = [
  "base64",
  "ed25519-dalek",
  "insta",
+ "memchr",
  "pkcs8",
  "rand",
  "ruma-common",
  "serde_json",
  "sha2",
- "subslice",
  "thiserror",
 ]
 
@@ -2461,15 +2461,6 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "subslice"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a8e4809a3bb02de01f1f7faf1ba01a83af9e8eabcd4d31dd6e413d14d56aae"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "subtle"

--- a/crates/ruma-signatures/Cargo.toml
+++ b/crates/ruma-signatures/Cargo.toml
@@ -14,17 +14,17 @@ edition = "2021"
 all-features = true
 
 [features]
-ring-compat = ["dep:subslice"]
+ring-compat = ["dep:memchr"]
 
 [dependencies]
 base64 = { workspace = true }
 ed25519-dalek = { version = "2.0.0", features = ["pkcs8", "rand_core"] }
+memchr = { version = "2.4", optional = true }
 pkcs8 = { version = "0.10.0", features = ["alloc"] }
 rand = { workspace = true }
 ruma-common = { workspace = true, features = ["canonical-json"] }
 serde_json = { workspace = true }
 sha2 = "0.10.6"
-subslice = { version = "0.2.3", optional = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/crates/ruma-signatures/src/keys/compat.rs
+++ b/crates/ruma-signatures/src/keys/compat.rs
@@ -1,5 +1,3 @@
-use subslice::SubsliceExt as _;
-
 #[derive(Debug)]
 pub(super) enum CompatibleDocument<'a> {
     WellFormed(&'a [u8]),
@@ -38,8 +36,7 @@ fn fix_ring_doc(mut doc: Vec<u8>) -> Vec<u8> {
     // Second byte asserts the length for the rest of the document
     assert_eq!(doc[1] as usize, doc.len() - 2);
 
-    let idx = doc
-        .find(RING_TEMPLATE_CONTEXT_SPECIFIC)
+    let idx = memchr::memmem::find(&doc, RING_TEMPLATE_CONTEXT_SPECIFIC)
         .expect("Expected to find ring template in doc, but found none.");
 
     // Snip off the malformed bit.
@@ -57,5 +54,5 @@ fn fix_ring_doc(mut doc: Vec<u8>) -> Vec<u8> {
 }
 
 fn is_ring(bytes: &[u8]) -> bool {
-    bytes.find(RING_TEMPLATE_CONTEXT_SPECIFIC).is_some()
+    memchr::memmem::find(bytes, RING_TEMPLATE_CONTEXT_SPECIFIC).is_some()
 }


### PR DESCRIPTION
This replaces `subslice`, an old and unmaintained crate, with the extremely popular `memchr` crate which `subslice` already used internally anyways. This should also be more performant than the implementation approach taken by `sublice`, which predates the `memchr::memmem` module.