### PR TITLE
ruma-state-res: use `BTree{Map,Set}` in place of `Hash{Map,Set}` when computing auth chains

### DIFF
--- a/crates/ruma-state-res/src/event_auth.rs
+++ b/crates/ruma-state-res/src/event_auth.rs
@@ -1,6 +1,6 @@
 use std::{
     borrow::Borrow,
-    collections::{BTreeMap, BTreeSet, HashSet},
+    collections::{BTreeMap, BTreeSet},
 };
 
 use js_int::Int;
@@ -164,14 +164,13 @@ pub fn check_state_independent_auth_rules<E: Event>(
     )?
     .into_iter()
     .map(|(event_type, state_key)| (TimelineEventType::from(event_type), state_key))
-    .collect::<HashSet<_>>();
+    .collect::<BTreeSet<_>>();
 
     let Some(room_id) = incoming_event.room_id() else {
         return Err("missing `room_id` field for event".to_owned());
     };
 
-    let mut seen_auth_types: HashSet<(TimelineEventType, String)> =
-        HashSet::with_capacity(expected_auth_types.len());
+    let mut seen_auth_types: BTreeSet<(TimelineEventType, String)> = BTreeSet::new();
 
     // Since v1, considering auth_events:
     for auth_event_id in incoming_event.auth_events() {
@@ -460,7 +459,7 @@ fn check_room_power_levels(
     current_room_power_levels_event: Option<RoomPowerLevelsEvent<impl Event>>,
     rules: &AuthorizationRules,
     sender_power_level: UserPowerLevel,
-    room_creators: &HashSet<OwnedUserId>,
+    room_creators: &BTreeSet<OwnedUserId>,
 ) -> Result<(), String> {
     debug!("starting m.room.power_levels check");
 

--- a/crates/ruma-state-res/src/event_auth/tests/room_power_levels.rs
+++ b/crates/ruma-state-res/src/event_auth/tests/room_power_levels.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, sync::Arc};
+use std::{collections::BTreeSet, sync::Arc};
 
 use as_variant::as_variant;
 use js_int::int;
@@ -77,7 +77,7 @@ fn not_int_or_string_int_in_content() {
                 current_room_power_levels_event.clone(),
                 &AuthorizationRules::V6,
                 int!(100).into(),
-                &HashSet::new(),
+                &BTreeSet::new(),
             );
 
             if *is_int {
@@ -92,7 +92,7 @@ fn not_int_or_string_int_in_content() {
                 current_room_power_levels_event.clone(),
                 &AuthorizationRules::V10,
                 int!(100).into(),
-                &HashSet::new(),
+                &BTreeSet::new(),
             );
 
             if *is_string {
@@ -149,7 +149,7 @@ fn not_int_or_string_int_in_events() {
             current_room_power_levels_event.clone(),
             &AuthorizationRules::V6,
             int!(100).into(),
-            &HashSet::new(),
+            &BTreeSet::new(),
         );
 
         if *is_int {
@@ -164,7 +164,7 @@ fn not_int_or_string_int_in_events() {
             current_room_power_levels_event.clone(),
             &AuthorizationRules::V10,
             int!(100).into(),
-            &HashSet::new(),
+            &BTreeSet::new(),
         );
 
         if *is_string {
@@ -220,7 +220,7 @@ fn not_int_or_string_int_in_notifications() {
             current_room_power_levels_event.clone(),
             &AuthorizationRules::V6,
             int!(100).into(),
-            &HashSet::new(),
+            &BTreeSet::new(),
         );
 
         if *is_int {
@@ -235,7 +235,7 @@ fn not_int_or_string_int_in_notifications() {
             current_room_power_levels_event.clone(),
             &AuthorizationRules::V10,
             int!(100).into(),
-            &HashSet::new(),
+            &BTreeSet::new(),
         );
 
         if *is_string {
@@ -274,7 +274,7 @@ fn not_user_id_in_users() {
         current_room_power_levels_event,
         &AuthorizationRules::V6,
         int!(100).into(),
-        &HashSet::new(),
+        &BTreeSet::new(),
     )
     .unwrap_err();
 }
@@ -325,7 +325,7 @@ fn not_int_or_string_int_in_users() {
             current_room_power_levels_event.clone(),
             &AuthorizationRules::V6,
             int!(100).into(),
-            &HashSet::new(),
+            &BTreeSet::new(),
         );
 
         if *is_int {
@@ -340,7 +340,7 @@ fn not_int_or_string_int_in_users() {
             current_room_power_levels_event.clone(),
             &AuthorizationRules::V10,
             int!(100).into(),
-            &HashSet::new(),
+            &BTreeSet::new(),
         );
 
         if *is_string {
@@ -378,7 +378,7 @@ fn first_power_levels_event() {
         current_room_power_levels_event,
         &AuthorizationRules::V6,
         int!(100).into(),
-        &HashSet::new(),
+        &BTreeSet::new(),
     )
     .unwrap();
 }
@@ -435,7 +435,7 @@ fn change_content_level_with_current_higher_power_level() {
             Some(RoomPowerLevelsEvent::new(current_room_power_levels_event)),
             &AuthorizationRules::V6,
             int!(40).into(),
-            &HashSet::new(),
+            &BTreeSet::new(),
         )
         .unwrap_err();
     }
@@ -493,7 +493,7 @@ fn change_content_level_with_new_higher_power_level() {
             Some(RoomPowerLevelsEvent::new(current_room_power_levels_event)),
             &AuthorizationRules::V6,
             int!(40).into(),
-            &HashSet::new(),
+            &BTreeSet::new(),
         )
         .unwrap_err();
     }
@@ -551,7 +551,7 @@ fn change_content_level_with_same_power_level() {
             Some(RoomPowerLevelsEvent::new(current_room_power_levels_event)),
             &AuthorizationRules::V6,
             int!(40).into(),
-            &HashSet::new(),
+            &BTreeSet::new(),
         )
         .unwrap();
     }
@@ -605,7 +605,7 @@ fn change_events_level_with_current_higher_power_level() {
         Some(RoomPowerLevelsEvent::new(current_room_power_levels_event)),
         &AuthorizationRules::V6,
         int!(40).into(),
-        &HashSet::new(),
+        &BTreeSet::new(),
     )
     .unwrap_err();
 }
@@ -658,7 +658,7 @@ fn change_events_level_with_new_higher_power_level() {
         Some(RoomPowerLevelsEvent::new(current_room_power_levels_event)),
         &AuthorizationRules::V6,
         int!(40).into(),
-        &HashSet::new(),
+        &BTreeSet::new(),
     )
     .unwrap_err();
 }
@@ -711,7 +711,7 @@ fn change_events_level_with_same_power_level() {
         Some(RoomPowerLevelsEvent::new(current_room_power_levels_event)),
         &AuthorizationRules::V6,
         int!(40).into(),
-        &HashSet::new(),
+        &BTreeSet::new(),
     )
     .unwrap();
 }
@@ -764,7 +764,7 @@ fn change_notifications_level_with_current_higher_power_level() {
         Some(RoomPowerLevelsEvent::new(&current_room_power_levels_event)),
         &AuthorizationRules::V3,
         int!(40).into(),
-        &HashSet::new(),
+        &BTreeSet::new(),
     )
     .unwrap();
 
@@ -774,7 +774,7 @@ fn change_notifications_level_with_current_higher_power_level() {
         Some(RoomPowerLevelsEvent::new(&current_room_power_levels_event)),
         &AuthorizationRules::V6,
         int!(40).into(),
-        &HashSet::new(),
+        &BTreeSet::new(),
     )
     .unwrap_err();
 }
@@ -827,7 +827,7 @@ fn change_notifications_level_with_new_higher_power_level() {
         Some(RoomPowerLevelsEvent::new(&current_room_power_levels_event)),
         &AuthorizationRules::V3,
         int!(40).into(),
-        &HashSet::new(),
+        &BTreeSet::new(),
     )
     .unwrap();
 
@@ -837,7 +837,7 @@ fn change_notifications_level_with_new_higher_power_level() {
         Some(RoomPowerLevelsEvent::new(&current_room_power_levels_event)),
         &AuthorizationRules::V6,
         int!(40).into(),
-        &HashSet::new(),
+        &BTreeSet::new(),
     )
     .unwrap_err();
 }
@@ -890,7 +890,7 @@ fn change_notifications_level_with_same_power_level() {
         Some(RoomPowerLevelsEvent::new(&current_room_power_levels_event)),
         &AuthorizationRules::V3,
         int!(40).into(),
-        &HashSet::new(),
+        &BTreeSet::new(),
     )
     .unwrap();
 
@@ -900,7 +900,7 @@ fn change_notifications_level_with_same_power_level() {
         Some(RoomPowerLevelsEvent::new(&current_room_power_levels_event)),
         &AuthorizationRules::V6,
         int!(40).into(),
-        &HashSet::new(),
+        &BTreeSet::new(),
     )
     .unwrap();
 }
@@ -948,7 +948,7 @@ fn change_other_user_level_with_current_higher_power_level() {
         Some(RoomPowerLevelsEvent::new(&current_room_power_levels_event)),
         &AuthorizationRules::V6,
         int!(40).into(),
-        &HashSet::new(),
+        &BTreeSet::new(),
     )
     .unwrap_err();
 }
@@ -997,7 +997,7 @@ fn change_other_user_level_with_new_higher_power_level() {
         Some(RoomPowerLevelsEvent::new(&current_room_power_levels_event)),
         &AuthorizationRules::V6,
         int!(40).into(),
-        &HashSet::new(),
+        &BTreeSet::new(),
     )
     .unwrap_err();
 }
@@ -1046,7 +1046,7 @@ fn change_other_user_level_with_same_power_level() {
         Some(RoomPowerLevelsEvent::new(&current_room_power_levels_event)),
         &AuthorizationRules::V6,
         int!(40).into(),
-        &HashSet::new(),
+        &BTreeSet::new(),
     )
     .unwrap();
 }
@@ -1093,7 +1093,7 @@ fn change_own_user_level_to_new_higher_power_level() {
         Some(RoomPowerLevelsEvent::new(&current_room_power_levels_event)),
         &AuthorizationRules::V6,
         int!(40).into(),
-        &HashSet::new(),
+        &BTreeSet::new(),
     )
     .unwrap_err();
 }
@@ -1140,7 +1140,7 @@ fn change_own_user_level_to_lower_power_level() {
         Some(RoomPowerLevelsEvent::new(&current_room_power_levels_event)),
         &AuthorizationRules::V6,
         int!(40).into(),
-        &HashSet::new(),
+        &BTreeSet::new(),
     )
     .unwrap();
 }
@@ -1186,7 +1186,7 @@ fn creator_has_infinite_power() {
         Some(RoomPowerLevelsEvent::new(&current_room_power_levels_event)),
         &AuthorizationRules::V12,
         UserPowerLevel::Infinite,
-        &HashSet::new(),
+        &BTreeSet::new(),
     )
     .unwrap();
 }
@@ -1232,7 +1232,7 @@ fn dont_allow_creator_in_users_field() {
         Some(RoomPowerLevelsEvent::new(&current_room_power_levels_event)),
         &AuthorizationRules::V12,
         UserPowerLevel::Infinite,
-        &HashSet::from_iter([alice().to_owned()]),
+        &BTreeSet::from_iter([alice().to_owned()]),
     )
     .unwrap_err();
 }

--- a/crates/ruma-state-res/src/events/create.rs
+++ b/crates/ruma-state-res/src/events/create.rs
@@ -1,6 +1,6 @@
 //! Types to deserialize `m.room.create` events.
 
-use std::{borrow::Cow, collections::HashSet, ops::Deref};
+use std::{borrow::Cow, collections::BTreeSet, ops::Deref};
 
 use ruma_common::{
     room_version_rules::AuthorizationRules, serde::from_raw_json_value, OwnedUserId, RoomVersionId,
@@ -88,11 +88,11 @@ impl<E: Event> RoomCreateEvent<E> {
     pub(crate) fn additional_creators(
         &self,
         rules: &AuthorizationRules,
-    ) -> Result<HashSet<OwnedUserId>, String> {
+    ) -> Result<BTreeSet<OwnedUserId>, String> {
         #[derive(Deserialize)]
         struct RoomCreateContentAdditionalCreators {
             #[serde(default)]
-            additional_creators: HashSet<OwnedUserId>,
+            additional_creators: BTreeSet<OwnedUserId>,
         }
 
         Ok(if rules.additional_room_creators {
@@ -103,7 +103,7 @@ impl<E: Event> RoomCreateEvent<E> {
 
             content.additional_creators
         } else {
-            HashSet::new()
+            BTreeSet::new()
         })
     }
 
@@ -114,7 +114,7 @@ impl<E: Event> RoomCreateEvent<E> {
     /// field of this event's content. Additionally if the `explicitly_privilege_room_creators`
     /// field of `AuthorizationRules` is set, any additional user IDs in `additional_creators`, if
     /// present, will also be considered creators.
-    pub fn creators(&self, rules: &AuthorizationRules) -> Result<HashSet<OwnedUserId>, String> {
+    pub fn creators(&self, rules: &AuthorizationRules) -> Result<BTreeSet<OwnedUserId>, String> {
         let mut creators = self.additional_creators(rules)?;
 
         creators.insert(self.creator(rules)?.into_owned());

--- a/crates/ruma-state-res/src/events/power_levels.rs
+++ b/crates/ruma-state-res/src/events/power_levels.rs
@@ -1,7 +1,7 @@
 //! Types to deserialize `m.room.power_levels` events.
 
 use std::{
-    collections::{BTreeMap, HashSet},
+    collections::{BTreeMap, BTreeSet},
     ops::Deref,
     sync::{Arc, Mutex, OnceLock},
 };
@@ -253,7 +253,7 @@ pub(crate) trait RoomPowerLevelsEventOptionExt {
     fn user_power_level(
         &self,
         user_id: &UserId,
-        creators: &HashSet<OwnedUserId>,
+        creators: &BTreeSet<OwnedUserId>,
         rules: &AuthorizationRules,
     ) -> Result<UserPowerLevel, String>;
 
@@ -278,7 +278,7 @@ impl<E: Event> RoomPowerLevelsEventOptionExt for Option<RoomPowerLevelsEvent<E>>
     fn user_power_level(
         &self,
         user_id: &UserId,
-        creators: &HashSet<OwnedUserId>,
+        creators: &BTreeSet<OwnedUserId>,
         rules: &AuthorizationRules,
     ) -> Result<UserPowerLevel, String> {
         if rules.explicitly_privilege_room_creators && creators.contains(user_id) {

--- a/crates/ruma-state-res/src/state_res/tests.rs
+++ b/crates/ruma-state-res/src/state_res/tests.rs
@@ -1,10 +1,10 @@
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashMap},
     sync::Arc,
 };
 
 use js_int::{int, uint};
-use maplit::{hashmap, hashset};
+use maplit::{btreemap, btreeset};
 use rand::seq::SliceRandom;
 use ruma_common::{
     room_version_rules::{AuthorizationRules, StateResolutionV2Rules},
@@ -35,7 +35,7 @@ fn test_event_sort() {
         .map(|ev| (ev.event_type().with_state_key(ev.state_key().unwrap()), ev.clone()))
         .collect::<StateMap<_>>();
 
-    let auth_chain: HashSet<OwnedEventId> = HashSet::new();
+    let auth_chain: BTreeSet<OwnedEventId> = BTreeSet::new();
 
     let power_events = event_map
         .values()
@@ -52,7 +52,7 @@ fn test_event_sort() {
     let resolved_power = super::iterative_auth_checks(
         &AuthorizationRules::V6,
         &sorted_power_events,
-        HashMap::new(), // unconflicted events
+        BTreeMap::new(), // unconflicted events
         |id| events.get(id).cloned(),
     )
     .expect("iterative auth check failed on resolved events");
@@ -393,7 +393,7 @@ fn topic_setting() {
 fn test_event_map_none() {
     let _ = tracing::subscriber::set_default(tracing_subscriber::fmt().with_test_writer().finish());
 
-    let mut store = TestStore::<PduEvent>(hashmap! {});
+    let mut store = TestStore::<PduEvent>(BTreeMap::new());
 
     // build up the DAG
     let (state_at_bob, state_at_charlie, expected) = store.set_up();
@@ -422,12 +422,12 @@ fn test_event_map_none() {
 fn test_reverse_topological_power_sort() {
     let _ = tracing::subscriber::set_default(tracing_subscriber::fmt().with_test_writer().finish());
 
-    let graph = hashmap! {
-        event_id("l") => hashset![event_id("o")],
-        event_id("m") => hashset![event_id("n"), event_id("o")],
-        event_id("n") => hashset![event_id("o")],
-        event_id("o") => hashset![], // "o" has zero outgoing edges but 4 incoming edges
-        event_id("p") => hashset![event_id("o")],
+    let graph = btreemap! {
+        event_id("l") => btreeset![event_id("o")],
+        event_id("m") => btreeset![event_id("n"), event_id("o")],
+        event_id("n") => btreeset![event_id("o")],
+        event_id("o") => btreeset![], // "o" has zero outgoing edges but 4 incoming edges
+        event_id("p") => btreeset![event_id("o")],
     };
 
     let res = crate::reverse_topological_power_sort(&graph, |_id| {

--- a/crates/ruma-state-res/tests/it/resolve.rs
+++ b/crates/ruma-state-res/tests/it/resolve.rs
@@ -378,7 +378,7 @@ fn test_contrived_states(pdus_paths: &[&str], state_sets_paths: &[&str]) -> Snap
 
     let mut auth_chain_sets = Vec::new();
     for state_map in &state_sets {
-        let mut auth_chain = HashSet::new();
+        let mut auth_chain = BTreeSet::new();
 
         for event_id in state_map.values() {
             let pdu = pdus_by_id
@@ -517,7 +517,7 @@ where
 
     let auth_chain_from_state_map =
         |state_map: &StateMap<OwnedEventId>| -> Result<_, Box<dyn Error>> {
-            let mut auth_chain_sets = HashSet::new();
+            let mut auth_chain_sets = BTreeSet::new();
 
             for event_id in state_map.values() {
                 let pdu = pdus_by_id.get(event_id).expect("every pdu should be available");
@@ -628,8 +628,8 @@ where
 fn auth_events_dfs(
     pdus_by_id: &HashMap<OwnedEventId, Pdu>,
     pdu: &Pdu,
-) -> Result<HashSet<OwnedEventId>, Box<dyn Error>> {
-    let mut out = HashSet::new();
+) -> Result<BTreeSet<OwnedEventId>, Box<dyn Error>> {
+    let mut out = BTreeSet::new();
     let mut stack = pdu.auth_events().cloned().collect::<Vec<_>>();
 
     while let Some(event_id) = stack.pop() {
@@ -656,10 +656,10 @@ fn auth_events_dfs(
 fn conflicted_state_subgraph_dfs(
     conflicted_state_set: &StateMap<Vec<OwnedEventId>>,
     pdus_by_id: &HashMap<OwnedEventId, Pdu>,
-) -> Option<HashSet<OwnedEventId>> {
+) -> Option<BTreeSet<OwnedEventId>> {
     let conflicted_event_ids: HashSet<_> =
         conflicted_state_set.values().flatten().cloned().collect();
-    let mut conflicted_state_subgraph = HashSet::new();
+    let mut conflicted_state_subgraph = BTreeSet::new();
 
     let mut stack = vec![conflicted_event_ids.iter().cloned().collect::<Vec<_>>()];
     let mut path = Vec::new();


### PR DESCRIPTION
Using `HashSet` / `HashMap` is forbidden in Ruma's CI. This fixes running the command `cargo xtask ci clippy-wasm` when all CI features are enabled (viz. `default = ["__ci"]` in the Ruma's crate Cargo.toml).

Semantically no changes, although this adds a few `Ord` bounds on the key's type in one or two places, so it's technically a breaking change.