### PR TITLE
Fix missing `Send` for `StaticProfileField::Value` (9ede1ac950)

### DIFF
--- a/crates/ruma-client-api/src/profile.rs
+++ b/crates/ruma-client-api/src/profile.rs
@@ -32,7 +32,7 @@ pub mod set_profile_field;
 #[cfg(feature = "unstable-msc4133")]
 pub trait StaticProfileField {
     /// The type for the value of the field.
-    type Value: Sized + Serialize + DeserializeOwned;
+    type Value: DeserializeOwned + Send + Serialize + Sized;
 
     /// The string representation of this field.
     const NAME: &str;

--- a/crates/ruma-common/src/api.rs
+++ b/crates/ruma-common/src/api.rs
@@ -356,7 +356,7 @@ pub trait OutgoingRequest: Sized + Clone {
 }
 
 /// A response type for a Matrix API endpoint, used for receiving responses.
-pub trait IncomingResponse: Sized {
+pub trait IncomingResponse: Sized + Send {
     /// A type capturing the expected error conditions the server can return.
     type EndpointError: EndpointError;
 


### PR DESCRIPTION
```
pub trait IncomingResponse: Sized + Send {                                                                                                               
                                     ^^^^ required by this bound
```