### PR TITLE
[MatrixRTC] Add RTC decline event MSC4310

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -67,7 +67,7 @@ Breaking changes:
   room versions so clients should not rely on it. They can obtain it by requesting the
   `m.room.tombstone` event in the state of the predecessor.
 - The `sender_key` field of `RequestedKeyInfo` is now optional. It was deprecated in Matrix 1.3.
-- Add `m.rtc.decline` support (unstable_MSC4075).
+- Add `m.rtc.decline` support ([unstable_MSC4310](https://github.com/matrix-org/matrix-spec-proposals/pull/4310)).
 
 Improvements:
 

--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -67,7 +67,7 @@ Breaking changes:
   room versions so clients should not rely on it. They can obtain it by requesting the
   `m.room.tombstone` event in the state of the predecessor.
 - The `sender_key` field of `RequestedKeyInfo` is now optional. It was deprecated in Matrix 1.3.
-
+- Add `m.rtc.decline` support (unstable_MSC4075).
 
 Improvements:
 

--- a/crates/ruma-events/Cargo.toml
+++ b/crates/ruma-events/Cargo.toml
@@ -50,6 +50,7 @@ unstable-msc4268 = []
 unstable-msc4274 = []
 unstable-msc4278 = []
 unstable-msc4319 = []
+unstable-msc4310 = []
 
 # Allow some mandatory fields to be missing, defaulting them to an empty string
 # in deserialization.

--- a/crates/ruma-events/src/enums.rs
+++ b/crates/ruma-events/src/enums.rs
@@ -140,6 +140,9 @@ event_enum! {
         #[cfg(feature = "unstable-msc4075")]
         #[ruma_enum(alias = "m.call.notify")]
         "org.matrix.msc4075.call.notify" => super::call::notify,
+        #[cfg(feature = "unstable-msc4310")]
+        #[ruma_enum(alias = "m.rtc.decline")]
+        "org.matrix.msc4310.rtc.decline" => super::rtc::decline,
     }
 
     /// Any state event.
@@ -434,6 +437,8 @@ impl AnyMessageLikeEventContent {
             }
             #[cfg(feature = "unstable-msc4075")]
             Self::CallNotify(_) => None,
+            #[cfg(feature = "unstable-msc4310")]
+            Self::RtcDecline(ev) => Some(encrypted::Relation::Reference(ev.relates_to.clone())),
             Self::CallSdpStreamMetadataChanged(_)
             | Self::CallNegotiate(_)
             | Self::CallReject(_)

--- a/crates/ruma-events/src/lib.rs
+++ b/crates/ruma-events/src/lib.rs
@@ -182,6 +182,8 @@ pub mod room_key;
 #[cfg(feature = "unstable-msc4268")]
 pub mod room_key_bundle;
 pub mod room_key_request;
+#[cfg(feature = "unstable-msc4310")]
+pub mod rtc;
 pub mod secret;
 pub mod secret_storage;
 pub mod space;

--- a/crates/ruma-events/src/rtc.rs
+++ b/crates/ruma-events/src/rtc.rs
@@ -1,0 +1,4 @@
+//! Modules for events in the `m.rtc` namespace.
+
+#[cfg(feature = "unstable-msc4310")]
+pub mod decline;

--- a/crates/ruma-events/src/rtc/decline.rs
+++ b/crates/ruma-events/src/rtc/decline.rs
@@ -2,9 +2,7 @@
 //!
 //! Unstable: `org.matrix.msc4310.rtc.decline`
 //!
-//! This event is sent as a reference relation to an `m.rtc.notification` (or
-//! `m.call.notify` for backwards compatibility) event and can include an
-//! optional human-readable `reason`.
+//! This event is sent as a reference relation to a `m.rtc.notification` event.
 
 use ruma_events::relation::Reference;
 use ruma_macros::EventContent;
@@ -20,19 +18,12 @@ pub struct RtcDeclineEventContent {
     /// This must be an `m.reference` to the `m.rtc.notification` / `m.call.notify` event.
     #[serde(rename = "m.relates_to")]
     pub relates_to: Reference,
-
-    /// Optional human-readable reason for the decline.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub reason: Option<String>,
 }
 
 impl RtcDeclineEventContent {
     /// Creates a new `RtcDeclineEventContent` targeting the given notification event id.
-    pub fn new<E: Into<ruma_common::OwnedEventId>>(
-        notification_event_id: E,
-        reason: Option<String>,
-    ) -> Self {
-        Self { relates_to: Reference::new(notification_event_id.into()), reason }
+    pub fn new<E: Into<ruma_common::OwnedEventId>>(notification_event_id: E) -> Self {
+        Self { relates_to: Reference::new(notification_event_id.into()) }
     }
 }
 
@@ -47,10 +38,7 @@ mod tests {
 
     #[test]
     fn decline_event_serialization() {
-        let content = RtcDeclineEventContent::new(
-            owned_event_id!("$abc:example.org"),
-            Some("In a meeting".to_owned()),
-        );
+        let content = RtcDeclineEventContent::new(owned_event_id!("$abc:example.org"));
 
         let value = to_json_value(&content).unwrap();
         assert_eq!(
@@ -60,7 +48,6 @@ mod tests {
                     "rel_type": "m.reference",
                     "event_id": "$abc:example.org"
                 },
-                "reason": "In a meeting"
             })
         );
     }
@@ -70,7 +57,6 @@ mod tests {
         let json_data = json!({
             "content": {
                 "m.relates_to": {"rel_type": "m.reference", "event_id": "$abc:example.org"},
-                "reason": "Out of Office"
             },
             "event_id": "$event:notareal.hs",
             "origin_server_ts": 134_829_848,
@@ -85,7 +71,6 @@ mod tests {
             assert_eq!(ce.origin_server_ts().get(), uint!(134_829_848));
             assert_eq!(ce.room_id().to_string(), "!roomid:notareal.hs");
             assert_eq!(ce.sender().to_string(), "@user:notareal.hs");
-            assert_eq!(ce.as_original().unwrap().content.reason, Some("Out of Office".to_owned()));
             assert_eq!(
                 ce.as_original().unwrap().content.relates_to.event_id,
                 owned_event_id!("$abc:example.org")

--- a/crates/ruma-events/src/rtc/decline.rs
+++ b/crates/ruma-events/src/rtc/decline.rs
@@ -1,0 +1,95 @@
+//! Type for the MatrixRTC decline event (MSC4310).
+//!
+//! Unstable: `org.matrix.msc4310.rtc.decline`
+//!
+//! This event is sent as a reference relation to an `m.rtc.notification` (or
+//! `m.call.notify` for backwards compatibility) event and can include an
+//! optional human-readable `reason`.
+
+use ruma_events::relation::Reference;
+use ruma_macros::EventContent;
+use serde::{Deserialize, Serialize};
+
+/// The content of an `m.rtc.decline` event.
+#[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+#[ruma_event(type = "org.matrix.msc4310.rtc.decline", alias = "m.rtc.decline", kind = MessageLike)]
+pub struct RtcDeclineEventContent {
+    /// The reference to the original call notification message event.
+    ///
+    /// This must be an `m.reference` to the `m.rtc.notification` / `m.call.notify` event.
+    #[serde(rename = "m.relates_to")]
+    pub relates_to: Reference,
+
+    /// Optional human-readable reason for the decline.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+impl RtcDeclineEventContent {
+    /// Creates a new `RtcDeclineEventContent` targeting the given notification event id.
+    pub fn new<E: Into<ruma_common::OwnedEventId>>(
+        notification_event_id: E,
+        reason: Option<String>,
+    ) -> Self {
+        Self { relates_to: Reference::new(notification_event_id.into()), reason }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use js_int::uint;
+    use ruma_common::owned_event_id;
+    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+
+    use super::RtcDeclineEventContent;
+    use crate::AnyMessageLikeEvent;
+
+    #[test]
+    fn decline_event_serialization() {
+        let content = RtcDeclineEventContent::new(
+            owned_event_id!("$abc:example.org"),
+            Some("In a meeting".to_owned()),
+        );
+
+        let value = to_json_value(&content).unwrap();
+        assert_eq!(
+            value,
+            json!({
+                "m.relates_to": {
+                    "rel_type": "m.reference",
+                    "event_id": "$abc:example.org"
+                },
+                "reason": "In a meeting"
+            })
+        );
+    }
+
+    #[test]
+    fn decline_event_deserialization() {
+        let json_data = json!({
+            "content": {
+                "m.relates_to": {"rel_type": "m.reference", "event_id": "$abc:example.org"},
+                "reason": "Out of Office"
+            },
+            "event_id": "$event:notareal.hs",
+            "origin_server_ts": 134_829_848,
+            "room_id": "!roomid:notareal.hs",
+            "sender": "@user:notareal.hs",
+            "type": "m.rtc.decline"
+        });
+
+        let event = from_json_value::<AnyMessageLikeEvent>(json_data).unwrap();
+        if let AnyMessageLikeEvent::RtcDecline(ce) = event {
+            assert_eq!(ce.event_type().to_string(), "org.matrix.msc4310.rtc.decline");
+            assert_eq!(ce.origin_server_ts().get(), uint!(134_829_848));
+            assert_eq!(ce.room_id().to_string(), "!roomid:notareal.hs");
+            assert_eq!(ce.sender().to_string(), "@user:notareal.hs");
+            assert_eq!(ce.as_original().unwrap().content.reason, Some("Out of Office".to_owned()));
+            assert_eq!(
+                ce.as_original().unwrap().content.relates_to.event_id,
+                owned_event_id!("$abc:example.org")
+            );
+        }
+    }
+}

--- a/crates/ruma-events/src/rtc/decline.rs
+++ b/crates/ruma-events/src/rtc/decline.rs
@@ -1,8 +1,10 @@
-//! Type for the MatrixRTC decline event (MSC4310).
+//! Type for the MatrixRTC decline event ([MSC4310]).
 //!
 //! Unstable: `org.matrix.msc4310.rtc.decline`
 //!
 //! This event is sent as a reference relation to an `m.rtc.notification` event.
+//!
+//! [MSC4310]: https://github.com/matrix-org/matrix-spec-proposals/pull/MSC4310
 
 use ruma_events::relation::Reference;
 use ruma_macros::EventContent;

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -208,6 +208,7 @@ unstable-msc4286 = ["ruma-html?/unstable-msc4286"]
 unstable-msc4306 = ["ruma-common/unstable-msc4306", "ruma-client-api?/unstable-msc4306"]
 unstable-msc4311 = ["ruma-federation-api?/unstable-msc4311"]
 unstable-msc4319 = ["ruma-events?/unstable-msc4319"]
+unstable-msc4310 = ["ruma-events?/unstable-msc4310"]
 
 # Private features, only used in test / benchmarking code
 __unstable-mscs = [
@@ -269,6 +270,7 @@ __unstable-mscs = [
     "unstable-msc4286",
     "unstable-msc4306",
     "unstable-msc4311",
+    "unstable-msc4310",
     "unstable-msc4319",
 ]
 __ci = ["full", "compat-upload-signatures", "__unstable-mscs"]


### PR DESCRIPTION
Ruma needs to support the decline event so that ElementX is able to send a decline event when the user presses the decline button in call kit or in androids full screen notifications.

See:
https://github.com/matrix-org/matrix-spec-proposals/pull/4310

Signed-off-by: Timo K <toger5@hotmail.de>

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
