### PR TITLE
MatrixRTC: Add updated `m.rtc.notification` event (depreceate `m.call.notify`)

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [unreleased]
 
+Improvements:
+
+- Add `m.rtc.notification` event support and deprecate the (non MSC conformant)
+  `m.call.notify` event.
+
 # 0.31.0
 
 Breaking changes:

--- a/crates/ruma-events/src/call.rs
+++ b/crates/ruma-events/src/call.rs
@@ -10,6 +10,7 @@ pub mod invite;
 pub mod member;
 pub mod negotiate;
 #[cfg(feature = "unstable-msc4075")]
+#[allow(deprecated)]
 pub mod notify;
 pub mod reject;
 pub mod sdp_stream_metadata_changed;

--- a/crates/ruma-events/src/call/notify.rs
+++ b/crates/ruma-events/src/call/notify.rs
@@ -6,12 +6,13 @@ use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
 use super::member::Application;
-use crate::Mentions;
+use crate::{rtc, Mentions};
 
 /// The content of an `m.call.notify` event.
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 #[ruma_event(type = "m.call.notify", kind = MessageLike)]
+#[deprecated = "Use the m.rtc.notification event instead."]
 pub struct CallNotifyEventContent {
     /// A unique identifier for the call.
     pub call_id: String,
@@ -20,7 +21,7 @@ pub struct CallNotifyEventContent {
     pub application: ApplicationType,
 
     /// How this notify event should notify the receiver.
-    pub notify_type: NotifyType,
+    pub notify_type: rtc::notification::NotificationType,
 
     /// The users that are notified by this event (See [MSC3952] (Intentional Mentions)).
     ///
@@ -28,30 +29,16 @@ pub struct CallNotifyEventContent {
     #[serde(rename = "m.mentions")]
     pub mentions: Mentions,
 }
-
 impl CallNotifyEventContent {
     /// Creates a new `CallNotifyEventContent` with the given configuration.
     pub fn new(
         call_id: String,
         application: ApplicationType,
-        notify_type: NotifyType,
+        notify_type: rtc::notification::NotificationType,
         mentions: Mentions,
     ) -> Self {
         Self { call_id, application, notify_type, mentions }
     }
-}
-
-/// How this notify event should notify the receiver.
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
-pub enum NotifyType {
-    /// The receiving client should ring with an audible sound.
-    #[serde(rename = "ring")]
-    Ring,
-
-    /// The receiving client should display a visual notification.
-    #[serde(rename = "notify")]
-    Notify,
 }
 
 /// The type of matrix RTC application.
@@ -62,6 +49,7 @@ pub enum NotifyType {
 /// An `Application` can be converted into an `ApplicationType` using `.into()`.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+#[deprecated = "Part of the deprecated CallNotifyEventContent."]
 pub enum ApplicationType {
     /// A VoIP call.
     #[serde(rename = "m.call")]
@@ -81,8 +69,8 @@ mod tests {
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     use crate::{
-        call::notify::{ApplicationType, CallNotifyEventContent, NotifyType},
-        Mentions,
+        call::notify::{ApplicationType, CallNotifyEventContent},
+        rtc, Mentions,
     };
 
     #[test]
@@ -92,7 +80,7 @@ mod tests {
         let content_user_mention = CallNotifyEventContent::new(
             "abcdef".into(),
             ApplicationType::Call,
-            NotifyType::Ring,
+            rtc::notification::NotificationType::Ring,
             Mentions::with_user_ids(vec![
                 owned_user_id!("@user:example.com"),
                 owned_user_id!("@user2:example.com"),
@@ -102,7 +90,7 @@ mod tests {
         let content_room_mention = CallNotifyEventContent::new(
             "abcdef".into(),
             ApplicationType::Call,
-            NotifyType::Ring,
+            rtc::notification::NotificationType::Ring,
             Mentions::with_room_mention(),
         );
 

--- a/crates/ruma-events/src/enums.rs
+++ b/crates/ruma-events/src/enums.rs
@@ -139,7 +139,11 @@ event_enum! {
         "org.matrix.msc3245.voice.v2" => super::voice,
         #[cfg(feature = "unstable-msc4075")]
         #[ruma_enum(alias = "m.call.notify")]
+        #[allow(deprecated)]
         "org.matrix.msc4075.call.notify" => super::call::notify,
+        #[cfg(feature = "unstable-msc4075")]
+        #[ruma_enum(alias = "m.rtc.notification")]
+        "org.matrix.msc4075.rtc.notification" => super::rtc::notification,
         #[cfg(feature = "unstable-msc4310")]
         #[ruma_enum(alias = "m.rtc.decline")]
         "org.matrix.msc4310.rtc.decline" => super::rtc::decline,
@@ -440,6 +444,8 @@ impl AnyMessageLikeEventContent {
             }
             #[cfg(feature = "unstable-msc4075")]
             Self::CallNotify(_) => None,
+            #[cfg(feature = "unstable-msc4075")]
+            Self::RtcNotification(ev) => ev.relates_to.clone().map(encrypted::Relation::Reference),
             #[cfg(feature = "unstable-msc4310")]
             Self::RtcDecline(ev) => Some(encrypted::Relation::Reference(ev.relates_to.clone())),
             Self::CallSdpStreamMetadataChanged(_)

--- a/crates/ruma-events/src/rtc.rs
+++ b/crates/ruma-events/src/rtc.rs
@@ -2,3 +2,5 @@
 
 #[cfg(feature = "unstable-msc4310")]
 pub mod decline;
+#[cfg(feature = "unstable-msc4075")]
+pub mod notification;

--- a/crates/ruma-events/src/rtc/notification.rs
+++ b/crates/ruma-events/src/rtc/notification.rs
@@ -1,0 +1,216 @@
+//! Type for the MatrixRTC notification event ([MSC4075]).
+//!
+//! Stable: `m.rtc.notification`
+//! Unstable: `org.matrix.msc4075.rtc.notification`
+//!
+//! [MSC4075]: https://github.com/matrix-org/matrix-spec-proposals/pull/4075
+
+use std::time::Duration;
+
+use js_int::UInt;
+use ruma_common::MilliSecondsSinceUnixEpoch;
+use ruma_events::{relation::Reference, Mentions};
+use ruma_macros::{EventContent, StringEnum};
+use serde::{Deserialize, Serialize};
+
+use crate::PrivOwnedStr;
+
+/// The content of an `m.rtc.notification` event.
+#[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+#[ruma_event(
+    type = "m.rtc.notification",
+    kind = MessageLike
+)]
+pub struct RtcNotificationEventContent {
+    /// Local timestamp observed by the sender device.
+    ///
+    /// Used with `lifetime` to determine validity; receivers SHOULD compare with
+    /// `origin_server_ts` and prefer it if the difference is large.
+    pub sender_ts: MilliSecondsSinceUnixEpoch,
+
+    /// Relative time from `sender_ts` during which the notification is considered valid.
+    #[serde(with = "ruma_common::serde::duration::ms")]
+    pub lifetime: Duration,
+
+    /// Intentional mentions determining who should be notified.
+    #[serde(rename = "m.mentions", default, skip_serializing_if = "Option::is_none")]
+    pub mentions: Option<Mentions>,
+
+    /// Optional reference to the related `m.rtc.member` event.
+    #[serde(rename = "m.relates_to", skip_serializing_if = "Option::is_none")]
+    pub relates_to: Option<Reference>,
+
+    /// How this notification should notify the receiver.
+    pub notification_type: NotificationType,
+}
+
+impl RtcNotificationEventContent {
+    /// Creates a new `RtcNotificationEventContent` with the given configuration.
+    pub fn new(
+        sender_ts: MilliSecondsSinceUnixEpoch,
+        lifetime: Duration,
+        notification_type: NotificationType,
+    ) -> Self {
+        Self { sender_ts, lifetime, mentions: None, relates_to: None, notification_type }
+    }
+
+    /// Calculates the timestamp at which this notification is considered invalid.
+    /// This calculation is based on MSC4075 and tries to use the `sender_ts` as the starting point
+    /// and the `lifetime` as the duration for which the notification is valid.
+    ///
+    /// The `sender_ts` cannot be trusted since it is a generated value by the sending client.
+    /// To mitigate issue because of misconfigured client clocks, the MSC requires
+    /// that the `origin_server_ts` is used as the starting point if the difference is large.
+    ///
+    /// # Arguments:
+    ///
+    /// - `max_sender_ts_offset` is the maximum allowed offset between the two timestamps. (default
+    ///   20s)
+    /// - `origin_server_ts` has to be set to the origin_server_ts from the event containing this
+    ///   event content.
+    ///
+    /// # Examples
+    /// To start a timer until this client should stop ringing for this notification:
+    /// `let duration_ring =
+    /// MilliSecondsSinceUnixEpoch::now().saturated_sub(content.expiration_ts(event.
+    /// origin_server_ts(), None));`
+    pub fn expiration_ts(
+        &self,
+        origin_server_ts: MilliSecondsSinceUnixEpoch,
+        max_sender_ts_offset: Option<u32>,
+    ) -> MilliSecondsSinceUnixEpoch {
+        let (larger, smaller) = if self.sender_ts.get() > origin_server_ts.get() {
+            (self.sender_ts.get(), origin_server_ts.get())
+        } else {
+            (origin_server_ts.get(), self.sender_ts.get())
+        };
+        let use_origin_server_ts =
+            larger.saturating_sub(smaller) > max_sender_ts_offset.unwrap_or(20_000).into();
+        let start_ts =
+            if use_origin_server_ts { origin_server_ts.get() } else { self.sender_ts.get() };
+        MilliSecondsSinceUnixEpoch(
+            start_ts.saturating_add(UInt::from(self.lifetime.as_millis() as u32)),
+        )
+    }
+}
+
+/// How this notification should notify the receiver.
+#[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
+#[derive(Clone, PartialEq, Eq, StringEnum)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+#[ruma_enum(rename_all = "snake_case")]
+pub enum NotificationType {
+    /// The receiving client should ring with an audible sound.
+    Ring,
+
+    /// The receiving client should display a visual notification.
+    Notification,
+
+    #[doc(hidden)]
+    _Custom(PrivOwnedStr),
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use assert_matches2::assert_matches;
+    use js_int::UInt;
+    use ruma_common::{owned_event_id, MilliSecondsSinceUnixEpoch};
+    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+
+    use super::{NotificationType, RtcNotificationEventContent};
+    use crate::{AnyMessageLikeEvent, Mentions, MessageLikeEvent};
+
+    #[test]
+    fn notification_event_serialization() {
+        let mut content = RtcNotificationEventContent::new(
+            MilliSecondsSinceUnixEpoch(UInt::new(1_752_583_130_365).unwrap()),
+            Duration::from_millis(30_000),
+            NotificationType::Ring,
+        );
+        content.mentions = Some(Mentions::with_room_mention());
+        content.relates_to = Some(ruma_events::relation::Reference::new(owned_event_id!("$m:ex")));
+
+        assert_eq!(
+            to_json_value(&content).unwrap(),
+            json!({
+                "sender_ts": 1_752_583_130_365_u64,
+                "lifetime": 30_000_u32,
+                "m.mentions": {"room": true},
+                "m.relates_to": {"rel_type": "m.reference", "event_id": "$m:ex"},
+                "notification_type": "ring"
+            })
+        );
+    }
+
+    #[test]
+    fn notification_event_deserialization() {
+        let json_data = json!({
+            "content": {
+                "sender_ts": 1_752_583_130_365_u64,
+                "lifetime": 30_000_u32,
+                "m.mentions": {"room": true},
+                "m.relates_to": {"rel_type": "m.reference", "event_id": "$m:ex"},
+                "notification_type": "notification"
+            },
+            "event_id": "$event:notareal.hs",
+            "origin_server_ts": 134_829_848,
+            "room_id": "!roomid:notareal.hs",
+            "sender": "@user:notareal.hs",
+            "type": "m.rtc.notification"
+        });
+
+        let event = from_json_value::<AnyMessageLikeEvent>(json_data).unwrap();
+        assert_matches!(
+            event,
+            AnyMessageLikeEvent::RtcNotification(MessageLikeEvent::Original(ev))
+        );
+        assert_eq!(ev.content.lifetime, Duration::from_millis(30_000));
+    }
+
+    #[test]
+    fn expiration_ts_computation() {
+        let content = RtcNotificationEventContent::new(
+            MilliSecondsSinceUnixEpoch(UInt::new(100_365).unwrap()),
+            Duration::from_millis(30_000),
+            NotificationType::Ring,
+        );
+
+        // sender_ts is trustworthy
+        let origin_server_ts = MilliSecondsSinceUnixEpoch(UInt::new(120_000).unwrap());
+        assert_eq!(
+            content.expiration_ts(origin_server_ts, None),
+            MilliSecondsSinceUnixEpoch(UInt::new(130_365).unwrap())
+        );
+
+        // sender_ts is not trustworthy (sender_ts too small), origin_server_ts is used instead
+        let origin_server_ts = MilliSecondsSinceUnixEpoch(UInt::new(200_000).unwrap());
+        assert_eq!(
+            content.expiration_ts(origin_server_ts, None),
+            MilliSecondsSinceUnixEpoch(UInt::new(230_000).unwrap())
+        );
+
+        // sender_ts is not trustworthy (sender_ts too large), origin_server_ts is used instead
+        let origin_server_ts = MilliSecondsSinceUnixEpoch(UInt::new(50_000).unwrap());
+        assert_eq!(
+            content.expiration_ts(origin_server_ts, None),
+            MilliSecondsSinceUnixEpoch(UInt::new(80_000).unwrap())
+        );
+
+        // using a custom max offset (result in origin_server_ts)
+        let origin_server_ts = MilliSecondsSinceUnixEpoch(UInt::new(130_200).unwrap());
+        assert_eq!(
+            content.expiration_ts(origin_server_ts, Some(100)),
+            MilliSecondsSinceUnixEpoch(UInt::new(160_200).unwrap())
+        );
+
+        // using a custom max offset (result in sender_ts)
+        let origin_server_ts = MilliSecondsSinceUnixEpoch(UInt::new(100_300).unwrap());
+        assert_eq!(
+            content.expiration_ts(origin_server_ts, Some(100)),
+            MilliSecondsSinceUnixEpoch(UInt::new(130_365).unwrap())
+        );
+    }
+}


### PR DESCRIPTION
This addresses changes done in MSC4075 and moves the notification event into the rtc namespace.
https://github.com/matrix-org/matrix-spec-proposals/pull/4075
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
