### PR TITLE
ruma-events: Add `org.matrix.msc4334.room.language` state event.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,6 +1224,9 @@ name = "language-tags"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "lazy_static"
@@ -1882,6 +1885,7 @@ dependencies = [
  "assign",
  "js_int",
  "js_option",
+ "language-tags",
  "ruma-appservice-api",
  "ruma-client-api",
  "ruma-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,6 +1220,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "language-tags"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1976,6 +1982,7 @@ dependencies = [
  "indexmap",
  "js_int",
  "js_option",
+ "language-tags",
  "maplit",
  "percent-encoding",
  "pulldown-cmark",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ criterion = "0.5.0"
 http = "1.1.0"
 insta = { version = "1.41.1", features = ["json"] }
 js_int = "0.2.2"
+language-tags = { version = "0.3.2", features = ["serde"], optional = true }
 maplit = "1.0.2"
 rand = "0.8.5"
 ruma-appservice-api = { version = "0.12.2", path = "crates/ruma-appservice-api" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ criterion = "0.5.0"
 http = "1.1.0"
 insta = { version = "1.41.1", features = ["json"] }
 js_int = "0.2.2"
-language-tags = { version = "0.3.2", features = ["serde"], optional = true }
+language-tags = { version = "0.3.2", features = ["serde"] }
 maplit = "1.0.2"
 rand = "0.8.5"
 ruma-appservice-api = { version = "0.12.2", path = "crates/ruma-appservice-api" }

--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -71,6 +71,7 @@ Breaking changes:
 
 Improvements:
 
+- Add `RoomLanguageEventContent` and derived state events to specify language of a room.
 - Don't print out the secret key contained in JsonWebKey and JsonWebKeyInit in
   their `Debug` implementations.
 - Remove the `pdu` module and the corresponding `unstable-pdu` cargo feature. As far as we know, it

--- a/crates/ruma-events/Cargo.toml
+++ b/crates/ruma-events/Cargo.toml
@@ -51,7 +51,7 @@ unstable-msc4274 = []
 unstable-msc4278 = []
 unstable-msc4319 = []
 unstable-msc4310 = []
-unstable-msc4334 = ["language-tags"]
+unstable-msc4334 = ["dep:language-tags"]
 
 # Allow some mandatory fields to be missing, defaulting them to an empty string
 # in deserialization.
@@ -81,7 +81,7 @@ as_variant = { workspace = true }
 indexmap = { version = "2.0.0", features = ["serde"] }
 js_int = { workspace = true, features = ["serde"] }
 js_option = "0.1.0"
-language-tags = { version = "0.3.2", features = ["serde"], optional = true }
+language-tags = { workspace = true }
 percent-encoding = "2.1.0"
 pulldown-cmark = { version = "0.13.0", optional = true, default-features = false, features = ["html"] }
 regex = { version = "1.5.6", default-features = false, features = ["std", "perf"] }

--- a/crates/ruma-events/Cargo.toml
+++ b/crates/ruma-events/Cargo.toml
@@ -51,6 +51,7 @@ unstable-msc4274 = []
 unstable-msc4278 = []
 unstable-msc4319 = []
 unstable-msc4310 = []
+unstable-msc4334 = []
 
 # Allow some mandatory fields to be missing, defaulting them to an empty string
 # in deserialization.

--- a/crates/ruma-events/Cargo.toml
+++ b/crates/ruma-events/Cargo.toml
@@ -81,7 +81,7 @@ as_variant = { workspace = true }
 indexmap = { version = "2.0.0", features = ["serde"] }
 js_int = { workspace = true, features = ["serde"] }
 js_option = "0.1.0"
-language-tags = { workspace = true }
+language-tags = { workspace = true, optional = true }
 percent-encoding = "2.1.0"
 pulldown-cmark = { version = "0.13.0", optional = true, default-features = false, features = ["html"] }
 regex = { version = "1.5.6", default-features = false, features = ["std", "perf"] }

--- a/crates/ruma-events/Cargo.toml
+++ b/crates/ruma-events/Cargo.toml
@@ -51,7 +51,7 @@ unstable-msc4274 = []
 unstable-msc4278 = []
 unstable-msc4319 = []
 unstable-msc4310 = []
-unstable-msc4334 = []
+unstable-msc4334 = ["language-tags"]
 
 # Allow some mandatory fields to be missing, defaulting them to an empty string
 # in deserialization.
@@ -81,7 +81,7 @@ as_variant = { workspace = true }
 indexmap = { version = "2.0.0", features = ["serde"] }
 js_int = { workspace = true, features = ["serde"] }
 js_option = "0.1.0"
-language-tags = "0.3.2"
+language-tags = { version = "0.3.2", features = ["serde"], optional = true }
 percent-encoding = "2.1.0"
 pulldown-cmark = { version = "0.13.0", optional = true, default-features = false, features = ["html"] }
 regex = { version = "1.5.6", default-features = false, features = ["std", "perf"] }

--- a/crates/ruma-events/Cargo.toml
+++ b/crates/ruma-events/Cargo.toml
@@ -81,6 +81,7 @@ as_variant = { workspace = true }
 indexmap = { version = "2.0.0", features = ["serde"] }
 js_int = { workspace = true, features = ["serde"] }
 js_option = "0.1.0"
+language-tags = "0.3.2"
 percent-encoding = "2.1.0"
 pulldown-cmark = { version = "0.13.0", optional = true, default-features = false, features = ["html"] }
 regex = { version = "1.5.6", default-features = false, features = ["std", "perf"] }

--- a/crates/ruma-events/src/enums.rs
+++ b/crates/ruma-events/src/enums.rs
@@ -160,6 +160,8 @@ event_enum! {
         "m.room.guest_access" => super::room::guest_access,
         "m.room.history_visibility" => super::room::history_visibility,
         "m.room.join_rules" => super::room::join_rules,
+        #[cfg(feature = "unstable-msc4334")]
+        "m.room.language" => super::room::language,
         "m.room.member" => super::room::member,
         "m.room.name" => super::room::name,
         "m.room.pinned_events" => super::room::pinned_events,

--- a/crates/ruma-events/src/enums.rs
+++ b/crates/ruma-events/src/enums.rs
@@ -161,7 +161,8 @@ event_enum! {
         "m.room.history_visibility" => super::room::history_visibility,
         "m.room.join_rules" => super::room::join_rules,
         #[cfg(feature = "unstable-msc4334")]
-        "m.room.language" => super::room::language,
+        #[ruma_enum(alias = "m.room.language")]
+        "org.matrix.msc4334.room.language" => super::room::language,
         "m.room.member" => super::room::member,
         "m.room.name" => super::room::name,
         "m.room.pinned_events" => super::room::pinned_events,

--- a/crates/ruma-events/src/lib.rs
+++ b/crates/ruma-events/src/lib.rs
@@ -107,7 +107,7 @@
 use std::{collections::BTreeSet, fmt};
 
 use ruma_common::{room_version_rules::RedactionRules, EventEncryptionAlgorithm, OwnedUserId};
-use serde::{de::IgnoredAny, Deserialize, Deserializer, Serialize, Serializer};
+use serde::{de::IgnoredAny, Deserialize, Serialize, Serializer};
 
 // Needs to be public for trybuild tests
 #[doc(hidden)]
@@ -303,52 +303,5 @@ pub struct PrivOwnedStr(Box<str>);
 impl fmt::Debug for PrivOwnedStr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
-    }
-}
-
-/// A wrapper for [`language_tags::LanguageTag`] that implements [`serde::Serialize`]
-/// and [`serde::Deserialize`].
-#[derive(Clone, Debug, PartialEq)]
-pub struct RumaLanguageTag {
-    inner: language_tags::LanguageTag,
-}
-
-impl RumaLanguageTag {
-    /// Create a new [`RumaLanguageTag`] from a [`language_tags::LanguageTag`].
-    pub fn new(lang: language_tags::LanguageTag) -> Self {
-        Self { inner: lang }
-    }
-}
-
-impl TryFrom<&str> for RumaLanguageTag {
-    type Error = language_tags::ParseError;
-
-    /// Create a new [`RumaLanguageTag`] from a `&str`. Returns a
-    /// [`language_tags::ParseError`] if the `lang` is not a valid
-    /// BCP-47 language tag.
-    fn try_from(lang: &str) -> Result<Self, Self::Error> {
-        let lang = language_tags::LanguageTag::parse(lang)?;
-        Ok(Self { inner: lang })
-    }
-}
-
-impl Serialize for RumaLanguageTag {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_str(self.inner.as_str())
-    }
-}
-
-impl<'de> Deserialize<'de> for RumaLanguageTag {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let s = String::deserialize(deserializer)?;
-        language_tags::LanguageTag::parse(&s)
-            .map_err(serde::de::Error::custom)
-            .map(RumaLanguageTag::new)
     }
 }

--- a/crates/ruma-events/src/room.rs
+++ b/crates/ruma-events/src/room.rs
@@ -21,6 +21,8 @@ pub mod encryption;
 pub mod guest_access;
 pub mod history_visibility;
 pub mod join_rules;
+#[cfg(feature = "unstable-msc4334")]
+pub mod language;
 pub mod member;
 pub mod message;
 pub mod name;

--- a/crates/ruma-events/src/room/language.rs
+++ b/crates/ruma-events/src/room/language.rs
@@ -12,7 +12,7 @@ use crate::EmptyStateKey;
 /// The room language is a [IETF BCP 47](https://developer.mozilla.org/en-US/docs/Glossary/BCP_47_language_tag) language code.
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
-#[ruma_event(type = "m.room.language", kind = State, state_key_type = EmptyStateKey)]
+#[ruma_event(type = "org.matrix.msc4334.room.language", kind = State, state_key_type = EmptyStateKey)]
 pub struct RoomLanguageEventContent {
     /// The language of the room.
     pub language: String,
@@ -61,14 +61,14 @@ mod tests {
             "room_id": "!n8f893n9:example.com",
             "sender": "@carl:example.com",
             "state_key": "",
-            "type": "m.room.name"
+            "type": "org.matrix.msc4334.room.language"
         });
 
         assert_eq!(
             from_json_value::<OriginalStateEvent<RoomLanguageEventContent>>(json_data)
                 .unwrap()
                 .content
-                .name,
+                .language,
             "fr"
         );
     }

--- a/crates/ruma-events/src/room/language.rs
+++ b/crates/ruma-events/src/room/language.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::EmptyStateKey;
 
-/// The content of an `m.room.language` event.
+/// The content of an `org.matrix.msc4334.room.language` event.
 ///
 /// The room language is a [IETF BCP 47](https://datatracker.ietf.org/doc/bcp47/) language code.
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]

--- a/crates/ruma-events/src/room/language.rs
+++ b/crates/ruma-events/src/room/language.rs
@@ -1,0 +1,75 @@
+//! Types for the [`m.room.language`] event.
+//!
+//! [`m.room.language`]: https://github.com/matrix-org/matrix-spec-proposals/pull/4334
+
+use ruma_macros::EventContent;
+use serde::{Deserialize, Serialize};
+
+use crate::EmptyStateKey;
+
+/// The content of an `m.room.language` event.
+///
+/// The room language is a [IETF BCP 47](https://developer.mozilla.org/en-US/docs/Glossary/BCP_47_language_tag) language code.
+#[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+#[ruma_event(type = "m.room.language", kind = State, state_key_type = EmptyStateKey)]
+pub struct RoomLanguageEventContent {
+    /// The language of the room.
+    pub language: String,
+}
+
+impl RoomLanguageEventContent {
+    /// Create a new `RoomLanguageEventContent` with the given language.
+    pub fn new(language: String) -> Self {
+        Self { language }
+    }
+}
+
+impl Default for RoomLanguageEventContent {
+    fn default() -> Self {
+        Self { language: String::from("en-US") }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+
+    use super::RoomLanguageEventContent;
+    use crate::OriginalStateEvent;
+
+    #[test]
+    fn serialization() {
+        let content = RoomLanguageEventContent { language: "fr".to_owned() };
+
+        let actual = to_json_value(content).unwrap();
+        let expected = json!({
+            "language": "fr",
+        });
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn deserialization() {
+        let json_data = json!({
+            "content": {
+                "language": "fr"
+            },
+            "event_id": "$h29iv0s8:example.com",
+            "origin_server_ts": 1,
+            "room_id": "!n8f893n9:example.com",
+            "sender": "@carl:example.com",
+            "state_key": "",
+            "type": "m.room.name"
+        });
+
+        assert_eq!(
+            from_json_value::<OriginalStateEvent<RoomLanguageEventContent>>(json_data)
+                .unwrap()
+                .content
+                .name,
+            "fr"
+        );
+    }
+}

--- a/crates/ruma-events/src/room/language.rs
+++ b/crates/ruma-events/src/room/language.rs
@@ -2,10 +2,11 @@
 //!
 //! [`m.room.language`]: https://github.com/matrix-org/matrix-spec-proposals/pull/4334
 
+use language_tags::LanguageTag;
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
-use crate::{EmptyStateKey, RumaLanguageTag};
+use crate::EmptyStateKey;
 
 /// The content of an `m.room.language` event.
 ///
@@ -15,12 +16,12 @@ use crate::{EmptyStateKey, RumaLanguageTag};
 #[ruma_event(type = "org.matrix.msc4334.room.language", kind = State, state_key_type = EmptyStateKey)]
 pub struct RoomLanguageEventContent {
     /// The language of the room.
-    pub language: RumaLanguageTag,
+    pub language: LanguageTag,
 }
 
 impl RoomLanguageEventContent {
     /// Create a new `RoomLanguageEventContent` with the given language.
-    pub fn new(language: RumaLanguageTag) -> Self {
+    pub fn new(language: LanguageTag) -> Self {
         Self { language }
     }
 }
@@ -30,12 +31,11 @@ mod tests {
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     use super::RoomLanguageEventContent;
-    use crate::{OriginalStateEvent, RumaLanguageTag};
+    use crate::{room::language::LanguageTag, OriginalStateEvent};
 
     #[test]
     fn serialization() {
-        let content =
-            RoomLanguageEventContent { language: RumaLanguageTag::try_from("fr").unwrap() };
+        let content = RoomLanguageEventContent { language: LanguageTag::parse("fr").unwrap() };
 
         let actual = to_json_value(content).unwrap();
         let expected = json!({
@@ -64,7 +64,7 @@ mod tests {
                 .unwrap()
                 .content
                 .language,
-            RumaLanguageTag::try_from("fr").unwrap()
+            LanguageTag::parse("fr").unwrap()
         );
     }
 }

--- a/crates/ruma-events/src/room/language.rs
+++ b/crates/ruma-events/src/room/language.rs
@@ -25,12 +25,6 @@ impl RoomLanguageEventContent {
     }
 }
 
-impl Default for RoomLanguageEventContent {
-    fn default() -> Self {
-        Self { language: String::from("en-US") }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};

--- a/crates/ruma-events/src/room/language.rs
+++ b/crates/ruma-events/src/room/language.rs
@@ -5,22 +5,22 @@
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
-use crate::EmptyStateKey;
+use crate::{EmptyStateKey, RumaLanguageTag};
 
 /// The content of an `m.room.language` event.
 ///
-/// The room language is a [IETF BCP 47](https://developer.mozilla.org/en-US/docs/Glossary/BCP_47_language_tag) language code.
+/// The room language is a [IETF BCP 47](https://datatracker.ietf.org/doc/bcp47/) language code.
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 #[ruma_event(type = "org.matrix.msc4334.room.language", kind = State, state_key_type = EmptyStateKey)]
 pub struct RoomLanguageEventContent {
     /// The language of the room.
-    pub language: String,
+    pub language: RumaLanguageTag,
 }
 
 impl RoomLanguageEventContent {
     /// Create a new `RoomLanguageEventContent` with the given language.
-    pub fn new(language: String) -> Self {
+    pub fn new(language: RumaLanguageTag) -> Self {
         Self { language }
     }
 }
@@ -30,11 +30,12 @@ mod tests {
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     use super::RoomLanguageEventContent;
-    use crate::OriginalStateEvent;
+    use crate::{OriginalStateEvent, RumaLanguageTag};
 
     #[test]
     fn serialization() {
-        let content = RoomLanguageEventContent { language: "fr".to_owned() };
+        let content =
+            RoomLanguageEventContent { language: RumaLanguageTag::try_from("fr").unwrap() };
 
         let actual = to_json_value(content).unwrap();
         let expected = json!({
@@ -63,7 +64,7 @@ mod tests {
                 .unwrap()
                 .content
                 .language,
-            "fr"
+            RumaLanguageTag::try_from("fr").unwrap()
         );
     }
 }

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -275,6 +275,7 @@ __unstable-mscs = [
     "unstable-msc4311",
     "unstable-msc4310",
     "unstable-msc4319",
+    "unstable-msc4334",
 ]
 __ci = ["full", "compat-upload-signatures", "__unstable-mscs"]
 __compat = [

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -298,7 +298,7 @@ __compat = [
 assign = { workspace = true }
 js_int = { workspace = true }
 js_option = "0.1.1"
-language-tags = { workspace = true }
+language-tags = { workspace = true, optional = true }
 web-time = { workspace = true }
 
 ruma-common = { workspace = true }

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -210,7 +210,7 @@ unstable-msc4308 = ["ruma-client-api?/unstable-msc4308"]
 unstable-msc4311 = ["ruma-federation-api?/unstable-msc4311"]
 unstable-msc4319 = ["ruma-events?/unstable-msc4319"]
 unstable-msc4310 = ["ruma-events?/unstable-msc4310"]
-unstable-msc4334 = ["ruma-events?/unstable-msc4334", "language-tags"]
+unstable-msc4334 = ["ruma-events?/unstable-msc4334", "dep:language-tags"]
 
 # Private features, only used in test / benchmarking code
 __unstable-mscs = [
@@ -298,7 +298,7 @@ __compat = [
 assign = { workspace = true }
 js_int = { workspace = true }
 js_option = "0.1.1"
-language-tags = { version = "0.3.2", features = ["serde"], optional = true }
+language-tags = { workspace = true }
 web-time = { workspace = true }
 
 ruma-common = { workspace = true }

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -210,6 +210,7 @@ unstable-msc4308 = ["ruma-client-api?/unstable-msc4308"]
 unstable-msc4311 = ["ruma-federation-api?/unstable-msc4311"]
 unstable-msc4319 = ["ruma-events?/unstable-msc4319"]
 unstable-msc4310 = ["ruma-events?/unstable-msc4310"]
+unstable-msc4334 = ["ruma-events?/unstable-msc4334"]
 
 # Private features, only used in test / benchmarking code
 __unstable-mscs = [

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -210,7 +210,7 @@ unstable-msc4308 = ["ruma-client-api?/unstable-msc4308"]
 unstable-msc4311 = ["ruma-federation-api?/unstable-msc4311"]
 unstable-msc4319 = ["ruma-events?/unstable-msc4319"]
 unstable-msc4310 = ["ruma-events?/unstable-msc4310"]
-unstable-msc4334 = ["ruma-events?/unstable-msc4334"]
+unstable-msc4334 = ["ruma-events?/unstable-msc4334", "language-tags"]
 
 # Private features, only used in test / benchmarking code
 __unstable-mscs = [
@@ -298,6 +298,7 @@ __compat = [
 assign = { workspace = true }
 js_int = { workspace = true }
 js_option = "0.1.1"
+language-tags = { version = "0.3.2", features = ["serde"], optional = true }
 web-time = { workspace = true }
 
 ruma-common = { workspace = true }

--- a/crates/ruma/src/lib.rs
+++ b/crates/ruma/src/lib.rs
@@ -138,6 +138,9 @@ pub use assign::assign;
 pub use js_int::{int, uint, Int, UInt};
 #[doc(no_inline)]
 pub use js_option::JsOption;
+#[cfg(all(feature = "events", feature = "unstable-msc4334"))]
+#[doc(no_inline)]
+pub use language_tags::LanguageTag;
 pub use ruma_common::*;
 #[cfg(feature = "canonical-json")]
 pub use ruma_common::{


### PR DESCRIPTION
According to unstable [MSC4334](https://github.com/matrix-org/matrix-spec-proposals/pull/4334).

- Added an `unstable-msc4334` feature flag.
- Added a new `RoomLanguageEventContent` and derived events.
- Run `cargo xtask ci` before posting the PR

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
