### PR TITLE
client-api: Replace MembershipEventFilter with MembershipState

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -37,6 +37,8 @@ Breaking changes:
   fields. The fields can be accessed with `.get()`, `.iter()` or `.into_iter()`.
   `Response::new()` takes no arguments and creates an empty response. Fields can
   be added using `.set()`, or the `FromIterator` and `Extend` implementations.
+- Replace `MembershipEventFilter` with `MembershipState` in `get_member_events`, since both enums
+  should always be identical.
 
 Improvements:
 

--- a/crates/ruma-client-api/src/membership/get_member_events.rs
+++ b/crates/ruma-client-api/src/membership/get_member_events.rs
@@ -10,12 +10,10 @@ pub mod v3 {
     use ruma_common::{
         api::{request, response, Metadata},
         metadata,
-        serde::{Raw, StringEnum},
+        serde::Raw,
         OwnedRoomId,
     };
-    use ruma_events::room::member::RoomMemberEvent;
-
-    use crate::PrivOwnedStr;
+    use ruma_events::room::member::{MembershipState, RoomMemberEvent};
 
     const METADATA: Metadata = metadata! {
         method: GET,
@@ -49,14 +47,14 @@ pub mod v3 {
         /// membership or is not the same as not_membership.
         #[serde(skip_serializing_if = "Option::is_none")]
         #[ruma_api(query)]
-        pub membership: Option<MembershipEventFilter>,
+        pub membership: Option<MembershipState>,
 
         /// The kind of memberships to *exclude* from the results.
         ///
         /// Defaults to no filtering if unspecified.
         #[serde(skip_serializing_if = "Option::is_none")]
         #[ruma_api(query)]
-        pub not_membership: Option<MembershipEventFilter>,
+        pub not_membership: Option<MembershipState>,
     }
 
     /// Response type for the `get_member_events` endpoint.
@@ -80,33 +78,11 @@ pub mod v3 {
         }
     }
 
-    /// The kind of membership events to filter for.
-    #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-    #[derive(Clone, PartialEq, Eq, StringEnum)]
-    #[ruma_enum(rename_all = "lowercase")]
-    #[non_exhaustive]
-    pub enum MembershipEventFilter {
-        /// The user has joined.
-        Join,
-
-        /// The user has been invited.
-        Invite,
-
-        /// The user has left.
-        Leave,
-
-        /// The user has been banned.
-        Ban,
-
-        #[doc(hidden)]
-        _Custom(PrivOwnedStr),
-    }
-
     #[cfg(all(test, feature = "server"))]
     mod tests {
         use ruma_common::api::IncomingRequest as _;
 
-        use super::{MembershipEventFilter, Request};
+        use super::{MembershipState, Request};
 
         #[test]
         fn deserialization() {
@@ -115,8 +91,8 @@ pub mod v3 {
                 .authority("example.org")
                 .path_and_query(
                     "/_matrix/client/r0/rooms/!dummy%3Aexample.org/members\
-                 ?not_membership=leave\
-                 &at=1026",
+                     ?not_membership=leave\
+                     &at=1026",
                 )
                 .build()
                 .unwrap();
@@ -130,7 +106,7 @@ pub mod v3 {
             assert_eq!(req.room_id, "!dummy:example.org");
             assert_eq!(req.at.as_deref(), Some("1026"));
             assert_eq!(req.membership, None);
-            assert_eq!(req.not_membership, Some(MembershipEventFilter::Leave));
+            assert_eq!(req.not_membership, Some(MembershipState::Leave));
         }
     }
 }


### PR DESCRIPTION
`MembershipEventFilter` was lacking the `Knock` variant, and both enums should always be identical, so we can just replace it.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
