### PR TITLE
events: fix rtc decline doc broken link

### DIFF
--- a/crates/ruma-events/src/rtc/decline.rs
+++ b/crates/ruma-events/src/rtc/decline.rs
@@ -4,7 +4,7 @@
 //!
 //! This event is sent as a reference relation to an `m.rtc.notification` event.
 //!
-//! [MSC4310]: https://github.com/matrix-org/matrix-spec-proposals/pull/MSC4310
+//! [MSC4310]: https://github.com/matrix-org/matrix-spec-proposals/pull/4310
 
 use ruma_events::relation::Reference;
 use ruma_macros::EventContent;


### PR DESCRIPTION
quick fix for a broken link in doc
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
