### PR TITLE
MSC4357 Add support for custom fields in RoomMessageEventContent

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -8,6 +8,11 @@ Improvements:
 
 - Add `m.rtc.notification` event support and deprecate the (non MSC conformant)
   `m.call.notify` event.
+- Add `additional_fields` BTreeMap to `RoomMessageEventContent` and `RoomMessageEventContentWithoutRelation`
+  to support custom protocol extensions and MSCs without SDK modifications. The field is transparently
+  handled during serialization/deserialization and doesn't break existing code.
+- Add methods to manage custom fields in message content: `add_custom_field`, `get_custom_field`,
+  `remove_custom_field`, `has_custom_field`, and `clear_custom_fields`.
 
 # 0.31.0
 

--- a/crates/ruma-events/src/relation.rs
+++ b/crates/ruma-events/src/relation.rs
@@ -61,7 +61,7 @@ impl Annotation {
 /// The content of a [replacement] relation.
 ///
 /// [replacement]: https://spec.matrix.org/latest/client-server-api/#event-replacements
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct Replacement<C> {
     /// The ID of the event being replaced.


### PR DESCRIPTION
This PR adds support for arbitrary custom fields in RoomMessageEventContent and RoomMessageEventContentWithoutRelation, enabling Matrix clients to use experimental features and MSC extensions without requiring SDK modifications.

The primary motivation is to support https://github.com/matrix-org/matrix-spec-proposals/pull/4357 which introduces "live messages" - messages that can be updated in real-time as the user types. However, this implementation is generic and will benefit any future MSCs that need to add custom fields to messages.

## Problem

Currently, the SDK's RoomMessageEventContent struct has a fixed set of fields. When new MSCs are proposed that require additional fields (like org.matrix.msc4357.live for live messages), clients cannot use these features without forking the SDK or waiting for official support to be added.

  This creates friction for:
  - MSC authors who want to experiment with new features
  - Client developers who want to implement experimental features
  - The ecosystem's ability to iterate quickly on new ideas

## Solution

  This PR introduces an additional_fields: BTreeMap<String, JsonValue> field with #[serde(flatten)] to both RoomMessageEventContent and RoomMessageEventContentWithoutRelation.
