### PR TITLE
events: Add dm.filament.do_not_disturb account data event as per MSC4359

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -8,6 +8,7 @@ Improvements:
 
 - Add `m.rtc.notification` event support and deprecate the (non MSC conformant)
   `m.call.notify` event.
+- Add `dm.filament.do_not_disturb` account data event as per MSC4359.
 
 # 0.31.0
 

--- a/crates/ruma-events/Cargo.toml
+++ b/crates/ruma-events/Cargo.toml
@@ -52,6 +52,7 @@ unstable-msc4278 = []
 unstable-msc4319 = []
 unstable-msc4310 = []
 unstable-msc4334 = ["dep:language-tags"]
+unstable-msc4359 = []
 
 # Allow some mandatory fields to be missing, defaulting them to an empty string
 # in deserialization.

--- a/crates/ruma-events/src/do_not_disturb.rs
+++ b/crates/ruma-events/src/do_not_disturb.rs
@@ -62,6 +62,7 @@ pub enum DoNotDisturbRoomKey {
     /// Match any room.
     #[serde(rename = "*")]
     AllRooms,
+
     /// Match a single room based on its room ID.
     #[serde(untagged)]
     SingleRoom(OwnedRoomId),

--- a/crates/ruma-events/src/do_not_disturb.rs
+++ b/crates/ruma-events/src/do_not_disturb.rs
@@ -1,0 +1,152 @@
+//! Types for the [`dm.filament.do_not_disturb`] event.
+//!
+//! [`dm.filament.do_not_disturb`]: https://github.com/matrix-org/matrix-spec-proposals/pull/4359
+
+use std::collections::BTreeMap;
+
+use ruma_common::OwnedRoomId;
+use ruma_macros::EventContent;
+use serde::{Deserialize, Serialize};
+
+/// The content of a `dm.filament.do_not_disturb` event.
+///
+/// A list of rooms in "Do not Disturb" mode.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, EventContent)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+#[ruma_event(type = "dm.filament.do_not_disturb", kind = GlobalAccountData)]
+pub struct DoNotDisturbEventContent {
+    /// A map of rooms in which to inhibit notifications.
+    ///
+    /// As [`DoNotDisturbRoom`] is currently empty, only the room IDs are useful and
+    /// can be accessed with the `.keys()` and `into_keys()` iterators.
+    pub rooms: BTreeMap<DoNotDisturbRoomIds, DoNotDisturbRoom>,
+}
+
+impl DoNotDisturbEventContent {
+    /// Creates a new `DoNotDisturbEventContent` from the given map of [`DoNotDisturbRoom`]s.
+    pub fn new(rooms: BTreeMap<DoNotDisturbRoomIds, DoNotDisturbRoom>) -> Self {
+        Self { rooms }
+    }
+
+    /// Creates a new `DoNotDisturbEventContent` from the given list of room IDs.
+    pub fn rooms(rooms: impl IntoIterator<Item = OwnedRoomId>) -> Self {
+        Self::new(
+            rooms
+                .into_iter()
+                .map(|id| (DoNotDisturbRoomIds::SingleRoom(id), DoNotDisturbRoom {}))
+                .collect(),
+        )
+    }
+}
+
+/// The key for a "Do not Disturb" setting.
+///
+/// This either matches a single room or all rooms.
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+pub enum DoNotDisturbRoomIds {
+    /// Match any room.
+    #[serde(rename = "*")]
+    AllRooms,
+    /// Match a single room based on its room ID.
+    #[serde(untagged)]
+    SingleRoom(OwnedRoomId),
+}
+
+/// Details about a room in "Do not Disturb" mode.
+///
+/// This is currently empty.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+pub struct DoNotDisturbRoom {}
+
+impl DoNotDisturbRoom {
+    /// Creates an empty `DoNotDisturbRoom`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use assert_matches2::assert_matches;
+    use ruma_common::owned_room_id;
+    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+
+    use super::DoNotDisturbEventContent;
+    use crate::{do_not_disturb::DoNotDisturbRoomIds, AnyGlobalAccountDataEvent};
+
+    #[test]
+    fn serialization_with_single_room() {
+        let do_not_disturb_room_list =
+            DoNotDisturbEventContent::rooms(vec![owned_room_id!("!foo:bar.baz")]);
+
+        let json = json!({
+            "rooms": {
+                "!foo:bar.baz": {}
+            },
+        });
+
+        assert_eq!(to_json_value(do_not_disturb_room_list).unwrap(), json);
+    }
+
+    #[test]
+    fn serialization_with_all_rooms() {
+        let do_not_disturb_room_list = DoNotDisturbEventContent::new(BTreeMap::from([(
+            DoNotDisturbRoomIds::AllRooms,
+            Default::default(),
+        )]));
+
+        let json = json!({
+            "rooms": {
+                "*": {}
+            },
+        });
+
+        assert_eq!(to_json_value(do_not_disturb_room_list).unwrap(), json);
+    }
+
+    #[test]
+    fn deserialization_with_single_room() {
+        let json = json!({
+            "content": {
+                "rooms": {
+                    "!foo:bar.baz": {}
+                }
+            },
+            "type": "dm.filament.do_not_disturb"
+        });
+
+        assert_matches!(
+            from_json_value::<AnyGlobalAccountDataEvent>(json),
+            Ok(AnyGlobalAccountDataEvent::DoNotDisturb(ev))
+        );
+        assert_eq!(
+            ev.content.rooms.keys().collect::<Vec<_>>(),
+            vec![&DoNotDisturbRoomIds::SingleRoom(owned_room_id!("!foo:bar.baz"))]
+        );
+    }
+
+    #[test]
+    fn deserialization_with_all_room() {
+        let json = json!({
+            "content": {
+                "rooms": {
+                    "*": {}
+                }
+            },
+            "type": "dm.filament.do_not_disturb"
+        });
+
+        assert_matches!(
+            from_json_value::<AnyGlobalAccountDataEvent>(json),
+            Ok(AnyGlobalAccountDataEvent::DoNotDisturb(ev))
+        );
+        assert_eq!(
+            ev.content.rooms.keys().collect::<Vec<_>>(),
+            vec![&DoNotDisturbRoomIds::AllRooms]
+        );
+    }
+}

--- a/crates/ruma-events/src/do_not_disturb.rs
+++ b/crates/ruma-events/src/do_not_disturb.rs
@@ -19,37 +19,37 @@ pub struct DoNotDisturbEventContent {
     ///
     /// As [`DoNotDisturbRoom`] is currently empty, only the room IDs are useful and
     /// can be accessed with the `.keys()` and `into_keys()` iterators.
-    pub rooms: BTreeMap<DoNotDisturbRoomIds, DoNotDisturbRoom>,
+    pub rooms: BTreeMap<DoNotDisturbRoomKey, DoNotDisturbRoom>,
 }
 
 impl DoNotDisturbEventContent {
     /// Creates a new `DoNotDisturbEventContent` from the given map of [`DoNotDisturbRoom`]s.
-    pub fn new(rooms: BTreeMap<DoNotDisturbRoomIds, DoNotDisturbRoom>) -> Self {
+    pub fn new(rooms: BTreeMap<DoNotDisturbRoomKey, DoNotDisturbRoom>) -> Self {
         Self { rooms }
     }
 }
 
-impl FromIterator<DoNotDisturbRoomIds> for DoNotDisturbEventContent {
-    fn from_iter<T: IntoIterator<Item = DoNotDisturbRoomIds>>(iter: T) -> Self {
-        Self::new(iter.into_iter().map(|ids| (ids, DoNotDisturbRoom {})).collect())
+impl FromIterator<DoNotDisturbRoomKey> for DoNotDisturbEventContent {
+    fn from_iter<T: IntoIterator<Item = DoNotDisturbRoomKey>>(iter: T) -> Self {
+        Self::new(iter.into_iter().map(|key| (key, DoNotDisturbRoom {})).collect())
     }
 }
 
 impl FromIterator<OwnedRoomId> for DoNotDisturbEventContent {
     fn from_iter<T: IntoIterator<Item = OwnedRoomId>>(iter: T) -> Self {
-        iter.into_iter().map(DoNotDisturbRoomIds::SingleRoom).collect()
+        iter.into_iter().map(DoNotDisturbRoomKey::SingleRoom).collect()
     }
 }
 
-impl Extend<DoNotDisturbRoomIds> for DoNotDisturbEventContent {
-    fn extend<T: IntoIterator<Item = DoNotDisturbRoomIds>>(&mut self, iter: T) {
-        self.rooms.extend(iter.into_iter().map(|ids| (ids, DoNotDisturbRoom {})));
+impl Extend<DoNotDisturbRoomKey> for DoNotDisturbEventContent {
+    fn extend<T: IntoIterator<Item = DoNotDisturbRoomKey>>(&mut self, iter: T) {
+        self.rooms.extend(iter.into_iter().map(|key| (key, DoNotDisturbRoom {})));
     }
 }
 
 impl Extend<OwnedRoomId> for DoNotDisturbEventContent {
     fn extend<T: IntoIterator<Item = OwnedRoomId>>(&mut self, iter: T) {
-        self.extend(iter.into_iter().map(DoNotDisturbRoomIds::SingleRoom));
+        self.extend(iter.into_iter().map(DoNotDisturbRoomKey::SingleRoom));
     }
 }
 
@@ -58,7 +58,7 @@ impl Extend<OwnedRoomId> for DoNotDisturbEventContent {
 /// This either matches a single room or all rooms.
 #[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
-pub enum DoNotDisturbRoomIds {
+pub enum DoNotDisturbRoomKey {
     /// Match any room.
     #[serde(rename = "*")]
     AllRooms,
@@ -90,7 +90,7 @@ mod tests {
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     use super::DoNotDisturbEventContent;
-    use crate::{do_not_disturb::DoNotDisturbRoomIds, AnyGlobalAccountDataEvent};
+    use crate::{do_not_disturb::DoNotDisturbRoomKey, AnyGlobalAccountDataEvent};
 
     #[test]
     fn serialization_with_single_room() {
@@ -109,7 +109,7 @@ mod tests {
     #[test]
     fn serialization_with_all_rooms() {
         let do_not_disturb_room_list = DoNotDisturbEventContent::new(BTreeMap::from([(
-            DoNotDisturbRoomIds::AllRooms,
+            DoNotDisturbRoomKey::AllRooms,
             Default::default(),
         )]));
 
@@ -139,7 +139,7 @@ mod tests {
         );
         assert_eq!(
             ev.content.rooms.keys().collect::<Vec<_>>(),
-            vec![&DoNotDisturbRoomIds::SingleRoom(owned_room_id!("!foo:bar.baz"))]
+            vec![&DoNotDisturbRoomKey::SingleRoom(owned_room_id!("!foo:bar.baz"))]
         );
     }
 
@@ -160,7 +160,7 @@ mod tests {
         );
         assert_eq!(
             ev.content.rooms.keys().collect::<Vec<_>>(),
-            vec![&DoNotDisturbRoomIds::AllRooms]
+            vec![&DoNotDisturbRoomKey::AllRooms]
         );
     }
 }

--- a/crates/ruma-events/src/enums.rs
+++ b/crates/ruma-events/src/enums.rs
@@ -31,6 +31,9 @@ event_enum! {
     /// Any global account data event.
     enum GlobalAccountData {
         "m.direct" => super::direct,
+        #[cfg(feature = "unstable-msc4359")]
+        #[ruma_enum(ident = DoNotDisturb, alias = "m.do_not_disturb")]
+        "dm.filament.do_not_disturb" => super::do_not_disturb,
         "m.identity_server" => super::identity_server,
         "m.ignored_user_list" => super::ignored_user_list,
         "m.push_rules" => super::push_rules,

--- a/crates/ruma-events/src/lib.rs
+++ b/crates/ruma-events/src/lib.rs
@@ -145,6 +145,8 @@ pub mod beacon;
 pub mod beacon_info;
 pub mod call;
 pub mod direct;
+#[cfg(feature = "unstable-msc4359")]
+pub mod do_not_disturb;
 pub mod dummy;
 #[cfg(feature = "unstable-msc3954")]
 pub mod emote;

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -211,6 +211,7 @@ unstable-msc4311 = ["ruma-federation-api?/unstable-msc4311"]
 unstable-msc4319 = ["ruma-events?/unstable-msc4319"]
 unstable-msc4310 = ["ruma-events?/unstable-msc4310"]
 unstable-msc4334 = ["ruma-events?/unstable-msc4334", "dep:language-tags"]
+unstable-msc4359 = ["ruma-events?/unstable-msc4359"]
 
 # Private features, only used in test / benchmarking code
 __unstable-mscs = [
@@ -276,6 +277,7 @@ __unstable-mscs = [
     "unstable-msc4310",
     "unstable-msc4319",
     "unstable-msc4334",
+    "unstable-msc4359",
 ]
 __ci = ["full", "compat-upload-signatures", "__unstable-mscs"]
 __compat = [


### PR DESCRIPTION
As per https://github.com/matrix-org/matrix-spec-proposals/pull/4359.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
