### PR TITLE
federation-api: Stabilize sending full PDUs for stripped state

### DIFF
--- a/crates/ruma-federation-api/CHANGELOG.md
+++ b/crates/ruma-federation-api/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [unreleased]
 
+Improvements:
+
+- `RawStrippedState::Stripped` is deprecated in favor of the `Pdu` variant,
+  according to Matrix 1.16.
+
 # 0.12.0
 
 Breaking changes:

--- a/crates/ruma-federation-api/Cargo.toml
+++ b/crates/ruma-federation-api/Cargo.toml
@@ -30,7 +30,6 @@ unstable-msc3618 = []
 unstable-msc3723 = []
 unstable-msc3843 = []
 unstable-msc4125 = []
-unstable-msc4311 = []
 
 [dependencies]
 bytes = { workspace = true, optional = true }

--- a/crates/ruma-federation-api/src/membership.rs
+++ b/crates/ruma-federation-api/src/membership.rs
@@ -1,8 +1,8 @@
 //! Room membership endpoints.
 
-use ruma_common::serde::Raw;
+use ruma_common::serde::{from_raw_json_value, Raw};
 use ruma_events::AnyStrippedStateEvent;
-use serde::{Deserialize, Serialize};
+use serde::{de, Deserialize, Serialize};
 use serde_json::value::RawValue as RawJsonValue;
 
 pub mod create_invite;
@@ -19,10 +19,11 @@ pub mod prepare_leave_event;
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub enum RawStrippedState {
     /// A stripped state event.
+    #[deprecated = "Since Matrix 1.16, stripped state events are required to be sent over federation as full PDUs.\
+                    It is still possible to receive this variant for backwards compatibility."]
     Stripped(Raw<AnyStrippedStateEvent>),
 
     /// A full federation PDU.
-    #[cfg(feature = "unstable-msc4311")]
     Pdu(Box<RawJsonValue>),
 }
 
@@ -31,39 +32,35 @@ impl<'de> Deserialize<'de> for RawStrippedState {
     where
         D: ::serde::Deserializer<'de>,
     {
-        let json = Box::<RawJsonValue>::deserialize(deserializer)?;
-
-        #[cfg(feature = "unstable-msc4311")]
-        {
-            use ruma_common::serde::from_raw_json_value;
-            use serde::de;
-
-            #[derive(Deserialize)]
-            struct PotentialPduDeHelper {
-                auth_events: Option<de::IgnoredAny>,
-                prev_events: Option<de::IgnoredAny>,
-                signatures: Option<de::IgnoredAny>,
-                hashes: Option<de::IgnoredAny>,
-            }
-
-            let PotentialPduDeHelper { auth_events, prev_events, signatures, hashes } =
-                from_raw_json_value(&json)?;
-
-            if auth_events.is_some()
-                && prev_events.is_some()
-                && signatures.is_some()
-                && hashes.is_some()
-            {
-                return Ok(Self::Pdu(json));
-            }
+        #[derive(Deserialize)]
+        struct PotentialPduDeHelper {
+            auth_events: Option<de::IgnoredAny>,
+            prev_events: Option<de::IgnoredAny>,
+            signatures: Option<de::IgnoredAny>,
+            hashes: Option<de::IgnoredAny>,
         }
 
-        Ok(Raw::from_json(json).into())
+        let json = Box::<RawJsonValue>::deserialize(deserializer)?;
+
+        let PotentialPduDeHelper { auth_events, prev_events, signatures, hashes } =
+            from_raw_json_value(&json)?;
+
+        if auth_events.is_some()
+            && prev_events.is_some()
+            && signatures.is_some()
+            && hashes.is_some()
+        {
+            Ok(Self::Pdu(json))
+        } else {
+            #[allow(deprecated)]
+            Ok(Self::Stripped(Raw::from_json(json)))
+        }
     }
 }
 
 impl From<Raw<AnyStrippedStateEvent>> for RawStrippedState {
     fn from(value: Raw<AnyStrippedStateEvent>) -> Self {
+        #[allow(deprecated)]
         Self::Stripped(value)
     }
 }
@@ -78,6 +75,7 @@ mod tests {
     use super::RawStrippedState;
 
     #[test]
+    #[allow(deprecated)]
     fn deserialize_stripped_state() {
         let user_id = user_id!("@patrick:localhost");
         let content = json!({
@@ -103,41 +101,38 @@ mod tests {
         assert_eq!(stripped_member_event.state_key, user_id);
         assert_eq!(stripped_member_event.content.membership, MembershipState::Join);
 
-        #[cfg(feature = "unstable-msc4311")]
-        {
-            // PDU format
-            let pdu_event_json = json!({
-                "auth_events": [
-                    "$one",
-                    "$two",
-                    "$three"
-                ],
-                "content": content,
-                "depth": 10,
-                "hashes": {
-                    "sha256": "thisisahash"
-                },
-                "origin_server_ts": 1_000_000,
-                "prev_events": [
-                    "$one",
-                    "$two",
-                    "$three"
-                ],
-                "room_id": "!room:localhost",
-                "sender": user_id,
-                "signatures": {
-                    "localhost": {
-                        "ed25519:1": "thisisakey"
-                    }
-                },
-                "state_key": user_id,
-                "type": "m.room.member",
-            });
-            assert_matches!(
-                from_json_value::<RawStrippedState>(pdu_event_json).unwrap(),
-                RawStrippedState::Pdu(_pdu_member_event)
-            );
-        }
+        // PDU format
+        let pdu_event_json = json!({
+            "auth_events": [
+                "$one",
+                "$two",
+                "$three"
+            ],
+            "content": content,
+            "depth": 10,
+            "hashes": {
+                "sha256": "thisisahash"
+            },
+            "origin_server_ts": 1_000_000,
+            "prev_events": [
+                "$one",
+                "$two",
+                "$three"
+            ],
+            "room_id": "!room:localhost",
+            "sender": user_id,
+            "signatures": {
+                "localhost": {
+                    "ed25519:1": "thisisakey"
+                }
+            },
+            "state_key": user_id,
+            "type": "m.room.member",
+        });
+        assert_matches!(
+            from_json_value::<RawStrippedState>(pdu_event_json).unwrap(),
+            RawStrippedState::Pdu(_pdu_member_event)
+        );
     }
 
     #[test]

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -206,7 +206,6 @@ unstable-msc4286 = ["ruma-html?/unstable-msc4286"]
 # Thread subscription support.
 unstable-msc4306 = ["ruma-common/unstable-msc4306", "ruma-client-api?/unstable-msc4306"]
 unstable-msc4308 = ["ruma-client-api?/unstable-msc4308"]
-unstable-msc4311 = ["ruma-federation-api?/unstable-msc4311"]
 unstable-msc4319 = ["ruma-events?/unstable-msc4319"]
 unstable-msc4310 = ["ruma-events?/unstable-msc4310"]
 unstable-msc4334 = ["ruma-events?/unstable-msc4334", "dep:language-tags"]


### PR DESCRIPTION
According to Matrix 1.16 ([Spec PR](https://github.com/matrix-org/matrix-spec/issues/2207)).

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
