### PR TITLE
events: Update MSC4319 implementation

### DIFF
--- a/crates/ruma-events/src/kinds.rs
+++ b/crates/ruma-events/src/kinds.rs
@@ -453,19 +453,16 @@ pub struct StrippedStateEvent<C: PossiblyRedactedStateEventContent> {
     /// the same tuple replaces the previous one.
     pub state_key: C::StateKey,
 
-    /// The globally unique identifier for the event.
-    ///
-    /// This field is usually stripped, but some events might include it.
-    #[cfg(feature = "unstable-msc4319")]
-    #[ruma_event(default)]
-    pub event_id: Option<OwnedEventId>,
-
     /// Timestamp on the originating homeserver when this event was sent.
     ///
     /// This field is usually stripped, but some events might include it.
     #[cfg(feature = "unstable-msc4319")]
     #[ruma_event(default)]
     pub origin_server_ts: Option<MilliSecondsSinceUnixEpoch>,
+
+    /// Additional key-value pairs not signed by the homeserver.
+    #[cfg(feature = "unstable-msc4319")]
+    pub unsigned: Option<Raw<crate::StateUnsigned<C>>>,
 }
 
 impl<C: PossiblyRedactedStateEventContent> JsonCastable<JsonObject> for StrippedStateEvent<C> {}


### PR DESCRIPTION
[MSC4319](https://github.com/matrix-org/matrix-spec-proposals/pull/4319)

To match the latest version. Instead of potentially sending a full `m.room.member` event in the stripped state, now all stripped state can have the `origin_server_ts` and `unsigned` fields.

