### PR TITLE
events: Add knock_room_state to RoomMemberUnsigned

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -9,6 +9,8 @@ Improvements:
 - Add `m.rtc.notification` event support and deprecate the (non MSC conformant)
   `m.call.notify` event.
 - Add `dm.filament.do_not_disturb` account data event as per MSC4359.
+- `RoomMemberUnsigned` has a `knock_room_state` field. This is the equivalent to
+  `invite_room_state` but after a knock rather than an invite.
 
 # 0.31.0
 

--- a/crates/ruma-events/src/room/member.rs
+++ b/crates/ruma-events/src/room/member.rs
@@ -523,9 +523,14 @@ pub struct RoomMemberUnsigned {
     /// Optional previous content of the event.
     pub prev_content: Option<PossiblyRedactedRoomMemberEventContent>,
 
-    /// State events to assist the receiver in identifying the room.
+    /// Stripped state events to assist the receiver in identifying the room when receiving an
+    /// invite.
     #[serde(default)]
     pub invite_room_state: Vec<Raw<AnyStrippedStateEvent>>,
+
+    /// Stripped state events to assist the receiver in identifying the room after knocking.
+    #[serde(default)]
+    pub knock_room_state: Vec<Raw<AnyStrippedStateEvent>>,
 
     /// [Bundled aggregations] of related child events.
     ///


### PR DESCRIPTION
Although it is not properly defined in the CS spec, it is mentioned in one place: https://spec.matrix.org/v1.16/client-server-api/#stripped-state.

Note that it comes from the SS spec, like `invite_room_state`.
