### PR TITLE
common: Remove support for org.matrix.hydra.11 room version

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -3,6 +3,9 @@
 Improvements:
 
 - Add `MatrixVersion::V1_16`
+- Remove support for the `org.matrix.hydra.11` room version and the
+  corresponding `unstable-hydra` cargo feature. It should only have been used
+  for development, and room version 12 should be used instead.
 
 # 0.16.0
 

--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -25,7 +25,6 @@ canonical-json = []
 js = ["dep:js-sys", "getrandom?/js", "uuid?/js"]
 rand = ["dep:rand", "dep:getrandom", "dep:uuid"]
 
-unstable-hydra = []
 unstable-msc2666 = []
 unstable-msc2870 = []
 unstable-msc3768 = []

--- a/crates/ruma-common/src/identifiers/room_version_id.rs
+++ b/crates/ruma-common/src/identifiers/room_version_id.rs
@@ -64,10 +64,6 @@ pub enum RoomVersionId {
     /// A version 11 room.
     V11,
 
-    /// `org.matrix.hydra.11`, the unstable version of [`V12`](Self::V12).
-    #[cfg(feature = "unstable-hydra")]
-    HydraV11,
-
     /// A version 12 room.
     V12,
 
@@ -98,8 +94,6 @@ impl RoomVersionId {
             Self::V9 => "9",
             Self::V10 => "10",
             Self::V11 => "11",
-            #[cfg(feature = "unstable-hydra")]
-            Self::HydraV11 => "org.matrix.hydra.11",
             Self::V12 => "12",
             #[cfg(feature = "unstable-msc2870")]
             Self::MSC2870 => "org.matrix.msc2870",
@@ -129,8 +123,6 @@ impl RoomVersionId {
             Self::V9 => RoomVersionRules::V9,
             Self::V10 => RoomVersionRules::V10,
             Self::V11 => RoomVersionRules::V11,
-            #[cfg(feature = "unstable-hydra")]
-            Self::HydraV11 => RoomVersionRules::HYDRA_V11,
             Self::V12 => RoomVersionRules::V12,
             #[cfg(feature = "unstable-msc2870")]
             Self::MSC2870 => RoomVersionRules::MSC2870,
@@ -217,8 +209,6 @@ where
         "9" => RoomVersionId::V9,
         "10" => RoomVersionId::V10,
         "11" => RoomVersionId::V11,
-        #[cfg(feature = "unstable-hydra")]
-        "org.matrix.hydra.11" => RoomVersionId::HydraV11,
         "12" => RoomVersionId::V12,
         #[cfg(feature = "unstable-msc2870")]
         "org.matrix.msc2870" => RoomVersionId::MSC2870,

--- a/crates/ruma-common/src/push/condition.rs
+++ b/crates/ruma-common/src/push/condition.rs
@@ -66,8 +66,6 @@ impl RoomVersionFeature {
             | RoomVersionId::V11
             | RoomVersionId::V12
             | RoomVersionId::_Custom(_) => vec![],
-            #[cfg(feature = "unstable-hydra")]
-            RoomVersionId::HydraV11 => vec![],
             #[cfg(feature = "unstable-msc2870")]
             RoomVersionId::MSC2870 => vec![],
         }

--- a/crates/ruma-common/src/room_version_rules.rs
+++ b/crates/ruma-common/src/room_version_rules.rs
@@ -138,10 +138,6 @@ impl RoomVersionRules {
         ..Self::V10
     };
 
-    /// Rules for room version `org.matrix.hydra.11`.
-    #[cfg(feature = "unstable-hydra")]
-    pub const HYDRA_V11: Self = Self { disposition: RoomVersionDisposition::Unstable, ..Self::V12 };
-
     /// Rules for room version 12.
     pub const V12: Self = Self {
         room_id_format: RoomIdFormatVersion::V2,

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -141,7 +141,6 @@ unstable-extensible-events = [
     "unstable-msc3954",
     "unstable-msc3955",
 ]
-unstable-hydra = ["ruma-common/unstable-hydra"]
 unstable-msc1767 = ["ruma-events?/unstable-msc1767"]
 unstable-msc2448 = [
     "ruma-client-api?/unstable-msc2448",
@@ -215,7 +214,6 @@ unstable-msc4359 = ["ruma-events?/unstable-msc4359"]
 
 # Private features, only used in test / benchmarking code
 __unstable-mscs = [
-    "unstable-hydra",
     "unstable-msc1767",
     "unstable-msc2448",
     "unstable-msc2545",


### PR DESCRIPTION
It should only have been used for development, room version 12 should be used instead now.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
