### PR TITLE
Add support for MSC3230 - Top level space order

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -6,6 +6,8 @@ Breaking changes:
 
 Improvements:
 
+- Add support for the room account data `m.space_order` event which powers top 
+  level space ordering as per [MSC3230](https://github.com/matrix-org/matrix-spec-proposals/pull/3230).
 - Add `m.rtc.notification` event support and deprecate the (non MSC conformant)
   `m.call.notify` event.
 - Add `dm.filament.do_not_disturb` account data event as per MSC4359.

--- a/crates/ruma-events/Cargo.toml
+++ b/crates/ruma-events/Cargo.toml
@@ -53,6 +53,7 @@ unstable-msc4319 = []
 unstable-msc4310 = []
 unstable-msc4334 = ["dep:language-tags"]
 unstable-msc4359 = []
+unstable-msc3230 = []
 
 # Allow some mandatory fields to be missing, defaulting them to an empty string
 # in deserialization.

--- a/crates/ruma-events/src/enums.rs
+++ b/crates/ruma-events/src/enums.rs
@@ -65,6 +65,9 @@ event_enum! {
         #[cfg(feature = "unstable-msc4278")]
         #[ruma_enum(ident = UnstableMediaPreviewConfig)]
         "io.element.msc4278.media_preview_config" => super::media_preview_config,
+        #[cfg(feature = "unstable-msc3230")]
+        #[ruma_enum(alias = "m.space_order")]
+        "org.matrix.msc3230.space_order" => super::space_order,
     }
 
     /// Any ephemeral room event.

--- a/crates/ruma-events/src/lib.rs
+++ b/crates/ruma-events/src/lib.rs
@@ -189,6 +189,8 @@ pub mod rtc;
 pub mod secret;
 pub mod secret_storage;
 pub mod space;
+#[cfg(feature = "unstable-msc3230")]
+pub mod space_order;
 pub mod sticker;
 pub mod tag;
 pub mod typing;

--- a/crates/ruma-events/src/space_order.rs
+++ b/crates/ruma-events/src/space_order.rs
@@ -1,0 +1,81 @@
+//! Types for the [`m.space_order`] event.
+//!
+//! [`m.space_order`]: https://github.com/matrix-org/matrix-spec-proposals/pull/3230
+
+use ruma_common::OwnedSpaceChildOrder;
+use ruma_macros::EventContent;
+use serde::{Deserialize, Serialize};
+
+/// The content of an `m.space_order` event.
+///
+/// Whether the space has been explicitly ordered.
+///
+/// This event appears in the user's room account data for the space room in
+/// question.
+#[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+#[ruma_event(type = "org.matrix.msc3230.space_order", alias = "m.space_order", kind = RoomAccountData)]
+pub struct SpaceOrderEventContent {
+    /// The current space order.
+    pub order: OwnedSpaceChildOrder,
+}
+
+impl SpaceOrderEventContent {
+    /// Creates a new `SpaceOrderEventContent` with the given order.
+    pub fn new(order: OwnedSpaceChildOrder) -> Self {
+        Self { order }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_matches2::assert_matches;
+    use ruma_common::SpaceChildOrder;
+    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+
+    use super::SpaceOrderEventContent;
+    use crate::{AnyRoomAccountDataEvent, RoomAccountDataEvent};
+
+    #[test]
+    fn deserialize() {
+        let raw_unstable_space_order = json!({
+            "type": "org.matrix.msc3230.space_order",
+            "content": {
+                "order": "a",
+            },
+        });
+        let unstable_space_order_account_data =
+            from_json_value::<AnyRoomAccountDataEvent>(raw_unstable_space_order).unwrap();
+        assert_matches!(
+            unstable_space_order_account_data,
+            AnyRoomAccountDataEvent::SpaceOrder(unstable_space_order)
+        );
+        assert_eq!(unstable_space_order.content.order, SpaceChildOrder::parse("a").unwrap());
+
+        let raw_space_order = json!({
+            "type": "m.space_order",
+            "content": {
+                "order": "b",
+            },
+        });
+        let space_order_account_data =
+            from_json_value::<AnyRoomAccountDataEvent>(raw_space_order).unwrap();
+        assert_matches!(space_order_account_data, AnyRoomAccountDataEvent::SpaceOrder(space_order));
+        assert_eq!(space_order.content.order, SpaceChildOrder::parse("b").unwrap());
+    }
+
+    #[test]
+    fn serialize() {
+        let space_order = SpaceOrderEventContent::new(SpaceChildOrder::parse("a").unwrap());
+        let space_order_account_data = RoomAccountDataEvent { content: space_order.clone() };
+        assert_eq!(
+            to_json_value(space_order_account_data).unwrap(),
+            json!({
+                "type": "org.matrix.msc3230.space_order",
+                "content": {
+                    "order": "a",
+                },
+            })
+        );
+    }
+}

--- a/crates/ruma-events/src/space_order.rs
+++ b/crates/ruma-events/src/space_order.rs
@@ -67,7 +67,7 @@ mod tests {
     #[test]
     fn serialize() {
         let space_order = SpaceOrderEventContent::new(SpaceChildOrder::parse("a").unwrap());
-        let space_order_account_data = RoomAccountDataEvent { content: space_order.clone() };
+        let space_order_account_data = RoomAccountDataEvent { content: space_order };
         assert_eq!(
             to_json_value(space_order_account_data).unwrap(),
             json!({

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -211,6 +211,7 @@ unstable-msc4319 = ["ruma-events?/unstable-msc4319"]
 unstable-msc4310 = ["ruma-events?/unstable-msc4310"]
 unstable-msc4334 = ["ruma-events?/unstable-msc4334", "dep:language-tags"]
 unstable-msc4359 = ["ruma-events?/unstable-msc4359"]
+unstable-msc3230 = ["ruma-events?/unstable-msc3230"]
 
 # Private features, only used in test / benchmarking code
 __unstable-mscs = [
@@ -276,6 +277,7 @@ __unstable-mscs = [
     "unstable-msc4319",
     "unstable-msc4334",
     "unstable-msc4359",
+    "unstable-msc3230",
 ]
 __ci = ["full", "compat-upload-signatures", "__unstable-mscs"]
 __compat = [


### PR DESCRIPTION
Add a new `SpaceOrderEventContent` account data structure holding string `order` field as defined in https://github.com/matrix-org/matrix-spec-proposals/pull/3230

Not entirely sure what to do about that `there is a expected value with a similar name: "unstable-msc4230"`, not entirely sure about anything here really so please be gentle 😁 