### PR TITLE
events: Mark base event structs as non-exhaustive

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -3,6 +3,15 @@
 Breaking changes:
 
 - Upgrade `js_option` to v0.2.0
+- The following structs are now marked as non-exhaustive:
+  `GlobalAccountDataEvent`, `RoomAccountDataEvent`, `(Sync)EphemeralRoomEvent`,
+  `Original(Sync)MessageLikeEvent`, `Redacted(Sync)MessageLikeEvent`,
+  `Original(Sync)StateEvent`, `Redacted(Sync)StateEvent`, `StrippedStateEvent`,
+  `Original(Sync)RoomRedactionEvent`, `Redacted(Sync)RoomRedactionEvent`,
+  `InitialStateEvent`, `ToDeviceEvent`,  `DecryptedMegolmV1Event`, `OlmV1Keys`.
+   Some of them can only be constructed through deserialization.
+   - `InitialStateEvent::new()` takes a `state_key`. For events with an empty
+     state key, `InitialStateEvent::with_empty_state_key()` can be used instead.
 
 Improvements:
 

--- a/crates/ruma-events/src/kinds.rs
+++ b/crates/ruma-events/src/kinds.rs
@@ -89,7 +89,7 @@ pub struct EphemeralRoomEvent<C: EphemeralRoomEventContent> {
 
 impl<C: EphemeralRoomEventContent> EphemeralRoomEvent<C> {
     /// Construct a new `EphemeralRoomEvent` with the given content and room ID.
-    pub fn new(content: C, room_id: OwnedRoomId) -> Self {
+    pub fn new(room_id: OwnedRoomId, content: C) -> Self {
         Self { content, room_id }
     }
 }
@@ -530,7 +530,7 @@ impl<C: StaticStateEventContent> InitialStateEvent<C> {
     ///
     /// For cases where the state key is empty,
     /// [`with_empty_state_key()`](Self::with_empty_state_key) can be used instead.
-    pub fn new(content: C, state_key: C::StateKey) -> Self {
+    pub fn new(state_key: C::StateKey, content: C) -> Self {
         Self { content, state_key }
     }
 
@@ -541,7 +541,7 @@ impl<C: StaticStateEventContent> InitialStateEvent<C> {
     where
         C: StaticStateEventContent<StateKey = EmptyStateKey>,
     {
-        Self::new(content, EmptyStateKey)
+        Self::new(EmptyStateKey, content)
     }
 
     /// Shorthand for `Raw::new(self).unwrap()`.
@@ -764,7 +764,7 @@ pub struct ToDeviceEvent<C: ToDeviceEventContent> {
 
 impl<C: ToDeviceEventContent> ToDeviceEvent<C> {
     /// Construct a new `ToDeviceEvent` with the given content and sender.
-    pub fn new(content: C, sender: OwnedUserId) -> Self {
+    pub fn new(sender: OwnedUserId, content: C) -> Self {
         Self { content, sender }
     }
 }

--- a/crates/ruma-events/src/kinds.rs
+++ b/crates/ruma-events/src/kinds.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::exhaustive_structs)]
-
 use as_variant::as_variant;
 use ruma_common::{
     encryption::DeviceKeys,
@@ -22,9 +20,17 @@ use super::{
 
 /// A global account data event.
 #[derive(Clone, Debug, Event)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct GlobalAccountDataEvent<C: GlobalAccountDataEventContent> {
     /// Data specific to the event type.
     pub content: C,
+}
+
+impl<C: GlobalAccountDataEventContent> GlobalAccountDataEvent<C> {
+    /// Construct a new `GlobalAccountDataEvent` with the given content.
+    pub fn new(content: C) -> Self {
+        Self { content }
+    }
 }
 
 impl<C: GlobalAccountDataEventContent> Serialize for GlobalAccountDataEvent<C> {
@@ -43,9 +49,17 @@ impl<C: GlobalAccountDataEventContent> JsonCastable<JsonObject> for GlobalAccoun
 
 /// A room account data event.
 #[derive(Clone, Debug, Event)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct RoomAccountDataEvent<C: RoomAccountDataEventContent> {
     /// Data specific to the event type.
     pub content: C,
+}
+
+impl<C: RoomAccountDataEventContent> RoomAccountDataEvent<C> {
+    /// Construct a new `RoomAccountDataEvent` with the given content.
+    pub fn new(content: C) -> Self {
+        Self { content }
+    }
 }
 
 impl<C: RoomAccountDataEventContent> Serialize for RoomAccountDataEvent<C> {
@@ -64,12 +78,20 @@ impl<C: RoomAccountDataEventContent> JsonCastable<JsonObject> for RoomAccountDat
 
 /// An ephemeral room event.
 #[derive(Clone, Debug, Event)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct EphemeralRoomEvent<C: EphemeralRoomEventContent> {
     /// Data specific to the event type.
     pub content: C,
 
     /// The ID of the room associated with this event.
     pub room_id: OwnedRoomId,
+}
+
+impl<C: EphemeralRoomEventContent> EphemeralRoomEvent<C> {
+    /// Construct a new `EphemeralRoomEvent` with the given content and room ID.
+    pub fn new(content: C, room_id: OwnedRoomId) -> Self {
+        Self { content, room_id }
+    }
 }
 
 impl<C: EphemeralRoomEventContent> Serialize for EphemeralRoomEvent<C> {
@@ -94,9 +116,17 @@ impl<C: EphemeralRoomEventContent> JsonCastable<JsonObject> for EphemeralRoomEve
 
 /// An ephemeral room event without a `room_id`.
 #[derive(Clone, Debug, Event)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct SyncEphemeralRoomEvent<C: EphemeralRoomEventContent> {
     /// Data specific to the event type.
     pub content: C,
+}
+
+impl<C: EphemeralRoomEventContent> SyncEphemeralRoomEvent<C> {
+    /// Construct a new `SyncEphemeralRoomEvent` with the given content and room ID.
+    pub fn new(content: C) -> Self {
+        Self { content }
+    }
 }
 
 impl<C: EphemeralRoomEventContent> Serialize for SyncEphemeralRoomEvent<C> {
@@ -118,6 +148,7 @@ impl<C: EphemeralRoomEventContent> JsonCastable<JsonObject> for SyncEphemeralRoo
 /// `OriginalMessageLikeEvent` implements the comparison traits using only the `event_id` field, a
 /// sorted list would be sorted lexicographically based on the event's `EventId`.
 #[derive(Clone, Debug, Event)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct OriginalMessageLikeEvent<C: MessageLikeEventContent> {
     /// Data specific to the event type.
     pub content: C,
@@ -164,6 +195,7 @@ impl<C: MessageLikeEventContent> JsonCastable<JsonObject> for OriginalMessageLik
 /// `OriginalSyncMessageLikeEvent` implements the comparison traits using only the `event_id` field,
 /// a sorted list would be sorted lexicographically based on the event's `EventId`.
 #[derive(Clone, Debug, Event)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct OriginalSyncMessageLikeEvent<C: MessageLikeEventContent> {
     /// Data specific to the event type.
     pub content: C,
@@ -204,6 +236,7 @@ impl<C: MessageLikeEventContent> JsonCastable<JsonObject> for OriginalSyncMessag
 /// `RedactedMessageLikeEvent` implements the comparison traits using only the `event_id` field, a
 /// sorted list would be sorted lexicographically based on the event's `EventId`.
 #[derive(Clone, Debug, Event)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct RedactedMessageLikeEvent<C: RedactedMessageLikeEventContent> {
     /// Data specific to the event type.
     pub content: C,
@@ -250,6 +283,7 @@ impl<C: RedactedMessageLikeEventContent> JsonCastable<JsonObject> for RedactedMe
 /// `RedactedSyncMessageLikeEvent` implements the comparison traits using only the `event_id` field,
 /// a sorted list would be sorted lexicographically based on the event's `EventId`.
 #[derive(Clone, Debug, Event)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct RedactedSyncMessageLikeEvent<C: RedactedMessageLikeEventContent> {
     /// Data specific to the event type.
     pub content: C,
@@ -337,6 +371,7 @@ where
 /// `OriginalStateEvent` implements the comparison traits using only the `event_id` field, a sorted
 /// list would be sorted lexicographically based on the event's `EventId`.
 #[derive(Clone, Debug, Event)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct OriginalStateEvent<C: StaticStateEventContent> {
     /// Data specific to the event type.
     pub content: C,
@@ -395,6 +430,7 @@ impl<C: StaticStateEventContent> JsonCastable<JsonObject> for OriginalStateEvent
 /// `OriginalSyncStateEvent` implements the comparison traits using only the `event_id` field, a
 /// sorted list would be sorted lexicographically based on the event's `EventId`.
 #[derive(Clone, Debug, Event)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct OriginalSyncStateEvent<C: StaticStateEventContent> {
     /// Data specific to the event type.
     pub content: C,
@@ -438,6 +474,7 @@ impl<C: StaticStateEventContent> JsonCastable<JsonObject> for OriginalSyncStateE
 
 /// A stripped-down state event, used for previews of rooms the user has been invited to.
 #[derive(Clone, Debug, Event)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct StrippedStateEvent<C: PossiblyRedactedStateEventContent> {
     /// Data specific to the event type.
     pub content: C,
@@ -472,6 +509,7 @@ impl<C: PossiblyRedactedStateEventContent> JsonCastable<JsonObject> for Stripped
 
 /// A minimal state event, used for creating a new room.
 #[derive(Clone, Debug, Event)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct InitialStateEvent<C: StaticStateEventContent> {
     /// Data specific to the event type.
     pub content: C,
@@ -488,14 +526,22 @@ pub struct InitialStateEvent<C: StaticStateEventContent> {
 }
 
 impl<C: StaticStateEventContent> InitialStateEvent<C> {
+    /// Create a new `InitialStateEvent` for an event type with the given state key.
+    ///
+    /// For cases where the state key is empty,
+    /// [`with_empty_state_key()`](Self::with_empty_state_key) can be used instead.
+    pub fn new(content: C, state_key: C::StateKey) -> Self {
+        Self { content, state_key }
+    }
+
     /// Create a new `InitialStateEvent` for an event type with an empty state key.
     ///
-    /// For cases where the state key is not empty, use a struct literal to create the event.
-    pub fn new(content: C) -> Self
+    /// For cases where the state key is not empty, use [`new()`](Self::new).
+    pub fn with_empty_state_key(content: C) -> Self
     where
         C: StaticStateEventContent<StateKey = EmptyStateKey>,
     {
-        Self { content, state_key: EmptyStateKey }
+        Self::new(content, EmptyStateKey)
     }
 
     /// Shorthand for `Raw::new(self).unwrap()`.
@@ -550,6 +596,7 @@ impl<C: StaticStateEventContent> JsonCastable<JsonObject> for InitialStateEvent<
 /// `RedactedStateEvent` implements the comparison traits using only the `event_id` field, a sorted
 /// list would be sorted lexicographically based on the event's `EventId`.
 #[derive(Clone, Debug, Event)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct RedactedStateEvent<C: RedactedStateEventContent> {
     /// Data specific to the event type.
     pub content: C,
@@ -604,6 +651,7 @@ impl<C: RedactedStateEventContent> JsonCastable<JsonObject> for RedactedStateEve
 /// `RedactedSyncStateEvent` implements the comparison traits using only the `event_id` field, a
 /// sorted list would be sorted lexicographically based on the event's `EventId`.
 #[derive(Clone, Debug, Event)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct RedactedSyncStateEvent<C: RedactedStateEventContent> {
     /// Data specific to the event type.
     pub content: C,
@@ -705,12 +753,20 @@ impl<C: StaticStateEventContent + RedactContent> JsonCastable<JsonObject> for Sy
 
 /// An event sent using send-to-device messaging.
 #[derive(Clone, Debug, Event)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct ToDeviceEvent<C: ToDeviceEventContent> {
     /// Data specific to the event type.
     pub content: C,
 
     /// The fully-qualified ID of the user who sent this event.
     pub sender: OwnedUserId,
+}
+
+impl<C: ToDeviceEventContent> ToDeviceEvent<C> {
+    /// Construct a new `ToDeviceEvent` with the given content and sender.
+    pub fn new(content: C, sender: OwnedUserId) -> Self {
+        Self { content, sender }
+    }
 }
 
 impl<C: ToDeviceEventContent> Serialize for ToDeviceEvent<C> {
@@ -730,6 +786,7 @@ impl<C: ToDeviceEventContent> JsonCastable<JsonObject> for ToDeviceEvent<C> {}
 
 /// The decrypted payload of an `m.olm.v1.curve25519-aes-sha2` event.
 #[derive(Clone, Debug, Event)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct DecryptedOlmV1Event<C: MessageLikeEventContent> {
     /// Data specific to the event type.
     pub content: C,
@@ -752,13 +809,22 @@ pub struct DecryptedOlmV1Event<C: MessageLikeEventContent> {
 
 /// Public keys used for an `m.olm.v1.curve25519-aes-sha2` event.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct OlmV1Keys {
     /// An ed25519 key.
     pub ed25519: String,
 }
 
+impl OlmV1Keys {
+    /// Construct a new `OlmV1Keys` with the given ed25519 key.
+    pub fn new(ed25519: String) -> Self {
+        Self { ed25519 }
+    }
+}
+
 /// The decrypted payload of an `m.megolm.v1.aes-sha2` event.
 #[derive(Clone, Debug, Event)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct DecryptedMegolmV1Event<C: MessageLikeEventContent> {
     /// Data specific to the event type.
     pub content: C,

--- a/crates/ruma-events/src/room/redaction.rs
+++ b/crates/ruma-events/src/room/redaction.rs
@@ -53,7 +53,7 @@ impl JsonCastable<JsonObject> for SyncRoomRedactionEvent {}
 
 /// Redaction event.
 #[derive(Clone, Debug)]
-#[allow(clippy::exhaustive_structs)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct OriginalRoomRedactionEvent {
     /// Data specific to the event type.
     pub content: RoomRedactionEventContent,
@@ -105,7 +105,7 @@ impl JsonCastable<JsonObject> for OriginalRoomRedactionEvent {}
 
 /// Redacted redaction event.
 #[derive(Clone, Debug, Event)]
-#[allow(clippy::exhaustive_structs)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct RedactedRoomRedactionEvent {
     /// Data specific to the event type.
     pub content: RedactedRoomRedactionEventContent,
@@ -136,7 +136,7 @@ impl JsonCastable<JsonObject> for RedactedRoomRedactionEvent {}
 
 /// Redaction event without a `room_id`.
 #[derive(Clone, Debug)]
-#[allow(clippy::exhaustive_structs)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct OriginalSyncRoomRedactionEvent {
     /// Data specific to the event type.
     pub content: RoomRedactionEventContent,
@@ -186,7 +186,7 @@ impl JsonCastable<JsonObject> for OriginalSyncRoomRedactionEvent {}
 
 /// Redacted redaction event without a `room_id`.
 #[derive(Clone, Debug, Event)]
-#[allow(clippy::exhaustive_structs)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct RedactedSyncRoomRedactionEvent {
     /// Data specific to the event type.
     pub content: RedactedRoomRedactionEventContent,

--- a/crates/ruma-events/tests/it/ui/14-enum-content-double-kind.rs
+++ b/crates/ruma-events/tests/it/ui/14-enum-content-double-kind.rs
@@ -39,10 +39,8 @@ fn main() {
     );
 
     // Both event type aliases are created, and they work with the enum variants.
-    let _ = AnyGlobalAccountDataEvent::MacroTest(event::GlobalMacroTestEvent {
-        content: content.clone(),
-    });
-    let _ = AnyRoomAccountDataEvent::MacroTest(event::RoomMacroTestEvent { content });
+    let _ = AnyGlobalAccountDataEvent::MacroTest(event::GlobalMacroTestEvent::new(content.clone()));
+    let _ = AnyRoomAccountDataEvent::MacroTest(event::RoomMacroTestEvent::new(content));
 
     // Both event type enums variants are created.
     assert_eq!(GlobalAccountDataEventType::MacroTest.to_string(), "m.macro.test");


### PR DESCRIPTION
We need this to be able to add fields without it being a breaking change. This fixes the `unstable-msc4319` cargo feature that was non-additive. This is also necessary for #2230.

~~Marking this is a draft for now, because some types can only be constructed through deserialization now, and I want to check if it creates issues in the SDK.~~ There are only a few tests in the SDK that need to be changed for this, so this should be fine.
