### PR TITLE
events: Add more field attributes to the Event derive macro

### DIFF
--- a/crates/ruma-events/tests/it/event.rs
+++ b/crates/ruma-events/tests/it/event.rs
@@ -1,3 +1,16 @@
+use ruma_events::GlobalAccountDataEventContent;
+use ruma_macros::{Event, EventContent};
+use serde::{Deserialize, Serialize};
+use serde_json::{from_value as from_json_value, json};
+
+const TAG: &str = "you're it!";
+
+#[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
+#[ruma_event(type = "m.macro.test", kind = GlobalAccountData)]
+struct MacroTestContent {
+    tag: String,
+}
+
 #[test]
 fn ui() {
     let t = trybuild::TestCases::new();
@@ -7,4 +20,59 @@ fn ui() {
     t.pass("tests/it/ui/04-event-sanity-check.rs");
     t.compile_fail("tests/it/ui/05-named-fields.rs");
     t.compile_fail("tests/it/ui/06-no-content-field.rs");
+}
+
+#[test]
+fn default_attribute() {
+    let json_with_flag = json!({
+        "content": {
+            "tag": TAG,
+        },
+        "type": "m.macro.test",
+        "flag": true,
+    });
+    let json_without_flag = json!({
+        "content": {
+            "tag": TAG,
+        },
+        "type": "m.macro.test",
+    });
+
+    // Event that requires the flag.
+    {
+        #[derive(Clone, Debug, Event)]
+        struct GlobalAccountDataEvent<C: GlobalAccountDataEventContent> {
+            content: C,
+            flag: bool,
+        }
+
+        let event =
+            from_json_value::<GlobalAccountDataEvent<MacroTestContent>>(json_with_flag.clone())
+                .unwrap();
+        assert_eq!(event.content.tag, TAG);
+        assert!(event.flag);
+
+        from_json_value::<GlobalAccountDataEvent<MacroTestContent>>(json_without_flag.clone())
+            .unwrap_err();
+    }
+
+    // Event that doesn't require the flag.
+    {
+        #[derive(Clone, Debug, Event)]
+        struct GlobalAccountDataEvent<C: GlobalAccountDataEventContent> {
+            content: C,
+            #[ruma_event(default)]
+            flag: bool,
+        }
+
+        let event =
+            from_json_value::<GlobalAccountDataEvent<MacroTestContent>>(json_with_flag).unwrap();
+        assert_eq!(event.content.tag, TAG);
+        assert!(event.flag);
+
+        let event =
+            from_json_value::<GlobalAccountDataEvent<MacroTestContent>>(json_without_flag).unwrap();
+        assert_eq!(event.content.tag, TAG);
+        assert!(!event.flag);
+    }
 }

--- a/crates/ruma-events/tests/it/event.rs
+++ b/crates/ruma-events/tests/it/event.rs
@@ -132,3 +132,103 @@ fn rename_attribute() {
         assert!(event.flag);
     }
 }
+
+#[test]
+fn alias_attribute() {
+    let json_with_flag = json!({
+        "content": {
+            "tag": TAG,
+        },
+        "type": "m.macro.test",
+        "flag": true,
+    });
+    let json_with_unstable_flag = json!({
+        "content": {
+            "tag": TAG,
+        },
+        "type": "m.macro.test",
+        "unstable_flag": true,
+    });
+    let json_with_alt_flag = json!({
+        "content": {
+            "tag": TAG,
+        },
+        "type": "m.macro.test",
+        "alt_flag": true,
+    });
+
+    // Event with field not renamed and no alias.
+    {
+        #[derive(Clone, Debug, Event)]
+        struct GlobalAccountDataEvent<C: GlobalAccountDataEventContent> {
+            content: C,
+            flag: bool,
+        }
+
+        let event =
+            from_json_value::<GlobalAccountDataEvent<MacroTestContent>>(json_with_flag.clone())
+                .unwrap();
+        assert_eq!(event.content.tag, TAG);
+        assert!(event.flag);
+
+        from_json_value::<GlobalAccountDataEvent<MacroTestContent>>(
+            json_with_unstable_flag.clone(),
+        )
+        .unwrap_err();
+
+        from_json_value::<GlobalAccountDataEvent<MacroTestContent>>(json_with_alt_flag.clone())
+            .unwrap_err();
+    }
+
+    // Event with field not renamed and aliases.
+    {
+        #[derive(Clone, Debug, Event)]
+        struct GlobalAccountDataEvent<C: GlobalAccountDataEventContent> {
+            content: C,
+            #[ruma_event(alias = "unstable_flag", alias = "alt_flag")]
+            flag: bool,
+        }
+
+        let event =
+            from_json_value::<GlobalAccountDataEvent<MacroTestContent>>(json_with_flag.clone())
+                .unwrap();
+        assert_eq!(event.content.tag, TAG);
+        assert!(event.flag);
+
+        let event = from_json_value::<GlobalAccountDataEvent<MacroTestContent>>(
+            json_with_unstable_flag.clone(),
+        )
+        .unwrap();
+        assert_eq!(event.content.tag, TAG);
+        assert!(event.flag);
+
+        let event =
+            from_json_value::<GlobalAccountDataEvent<MacroTestContent>>(json_with_alt_flag.clone())
+                .unwrap();
+        assert_eq!(event.content.tag, TAG);
+        assert!(event.flag);
+    }
+
+    // Event with field renamed and alias.
+    {
+        #[derive(Clone, Debug, Event)]
+        struct GlobalAccountDataEvent<C: GlobalAccountDataEventContent> {
+            content: C,
+            #[ruma_event(rename = "unstable_flag", alias = "alt_flag")]
+            flag: bool,
+        }
+
+        from_json_value::<GlobalAccountDataEvent<MacroTestContent>>(json_with_flag).unwrap_err();
+
+        let event =
+            from_json_value::<GlobalAccountDataEvent<MacroTestContent>>(json_with_unstable_flag)
+                .unwrap();
+        assert_eq!(event.content.tag, TAG);
+        assert!(event.flag);
+
+        let event = from_json_value::<GlobalAccountDataEvent<MacroTestContent>>(json_with_alt_flag)
+            .unwrap();
+        assert_eq!(event.content.tag, TAG);
+        assert!(event.flag);
+    }
+}

--- a/crates/ruma-events/tests/it/ui/04-event-sanity-check.rs
+++ b/crates/ruma-events/tests/it/ui/04-event-sanity-check.rs
@@ -14,6 +14,8 @@ pub struct OriginalStateEvent<C: StaticStateEventContent> {
     pub unsigned: C::Unsigned,
     #[ruma_event(default)]
     pub custom_flag: bool,
+    #[ruma_event(rename = "unstable_name")]
+    pub renamed_field: String,
 }
 
 fn main() {}

--- a/crates/ruma-events/tests/it/ui/04-event-sanity-check.rs
+++ b/crates/ruma-events/tests/it/ui/04-event-sanity-check.rs
@@ -12,7 +12,7 @@ pub struct OriginalStateEvent<C: StaticStateEventContent> {
     pub room_id: OwnedRoomId,
     pub state_key: C::StateKey,
     pub unsigned: C::Unsigned,
-    #[ruma_event(default)]
+    #[ruma_event(default, default_on_error)]
     pub custom_flag: bool,
     #[ruma_event(rename = "unstable_name", alias = "stable_name")]
     pub renamed_field: String,

--- a/crates/ruma-events/tests/it/ui/04-event-sanity-check.rs
+++ b/crates/ruma-events/tests/it/ui/04-event-sanity-check.rs
@@ -12,6 +12,8 @@ pub struct OriginalStateEvent<C: StaticStateEventContent> {
     pub room_id: OwnedRoomId,
     pub state_key: C::StateKey,
     pub unsigned: C::Unsigned,
+    #[ruma_event(default)]
+    pub custom_flag: bool,
 }
 
 fn main() {}

--- a/crates/ruma-events/tests/it/ui/04-event-sanity-check.rs
+++ b/crates/ruma-events/tests/it/ui/04-event-sanity-check.rs
@@ -14,7 +14,7 @@ pub struct OriginalStateEvent<C: StaticStateEventContent> {
     pub unsigned: C::Unsigned,
     #[ruma_event(default)]
     pub custom_flag: bool,
-    #[ruma_event(rename = "unstable_name")]
+    #[ruma_event(rename = "unstable_name", alias = "stable_name")]
     pub renamed_field: String,
 }
 

--- a/crates/ruma-macros/src/events/event.rs
+++ b/crates/ruma-macros/src/events/event.rs
@@ -83,8 +83,18 @@ fn expand_deserialize_event(
     let enum_variants_serde_attributes = fields
         .iter()
         .map(|field| {
-            field.rename.as_ref().map(|rename| {
-                quote! { #[serde(rename = #rename)]}
+            let mut attrs = Vec::new();
+
+            if let Some(rename) = &field.rename {
+                attrs.push(quote! { rename = #rename });
+            }
+
+            attrs.extend(field.aliases.iter().map(|alias| {
+                quote! { alias = #alias }
+            }));
+
+            (!attrs.is_empty()).then(|| {
+                quote! { #[serde(#( #attrs, )*)] }
             })
         })
         .collect::<Vec<_>>();

--- a/crates/ruma-macros/src/events/event/parse.rs
+++ b/crates/ruma-macros/src/events/event/parse.rs
@@ -62,6 +62,9 @@ pub(super) struct ParsedEventField {
     ///
     /// If this is not set, the name of the field will be used.
     pub(super) rename: Option<LitStr>,
+
+    /// The alternate names to recognize when deserializing this field.
+    pub(super) aliases: Vec<LitStr>,
 }
 
 impl ParsedEventField {
@@ -70,7 +73,7 @@ impl ParsedEventField {
     /// Returns an error if an unknown `ruma_event` attribute is encountered, or if an attribute
     /// that accepts a single value appears several times.
     pub(super) fn parse(inner: Field) -> Result<Self, syn::Error> {
-        let mut parsed = Self { inner, default: false, rename: None };
+        let mut parsed = Self { inner, default: false, rename: None, aliases: Vec::new() };
 
         for attr in &parsed.inner.attrs {
             if !attr.path().is_ident("ruma_event") {
@@ -93,6 +96,10 @@ impl ParsedEventField {
                         parsed.rename = Some(value.parse()?);
                         Ok(())
                     }
+                } else if meta.path.is_ident("alias") {
+                    let value = meta.value()?;
+                    parsed.aliases.push(value.parse()?);
+                    Ok(())
                 } else {
                     Err(meta.error("unsupported attribute, only `default` is supported"))
                 }

--- a/crates/ruma-macros/src/lib.rs
+++ b/crates/ruma-macros/src/lib.rs
@@ -418,6 +418,11 @@ pub fn derive_event_content(input: TokenStream) -> TokenStream {
 /// Use a different name when the field is serialized. The name is used both during serialization
 /// and deserialization.
 ///
+/// ### `alias = "alt_name"`
+///
+/// Allow a different name for the field during deserialization. This can be used several times for
+/// different aliases.
+///
 /// You can use `cargo doc` to find out more details, its `--document-private-items` flag also lets
 /// you generate documentation for binaries or private parts of a library.
 #[proc_macro_derive(Event, attributes(ruma_event))]

--- a/crates/ruma-macros/src/lib.rs
+++ b/crates/ruma-macros/src/lib.rs
@@ -413,6 +413,11 @@ pub fn derive_event_content(input: TokenStream) -> TokenStream {
 ///
 /// If the field is missing, its `Default` implementation is used.
 ///
+/// ### `rename = "serialized_name"`
+///
+/// Use a different name when the field is serialized. The name is used both during serialization
+/// and deserialization.
+///
 /// You can use `cargo doc` to find out more details, its `--document-private-items` flag also lets
 /// you generate documentation for binaries or private parts of a library.
 #[proc_macro_derive(Event, attributes(ruma_event))]

--- a/crates/ruma-macros/src/lib.rs
+++ b/crates/ruma-macros/src/lib.rs
@@ -413,6 +413,12 @@ pub fn derive_event_content(input: TokenStream) -> TokenStream {
 ///
 /// If the field is missing, its `Default` implementation is used.
 ///
+/// ### `default_on_error`
+///
+/// If an error occurs during deserialization of the value of this field, its `Default`
+/// implementation is used. The error is logged with the [tracing] crate at the debug level, which
+/// means that it must be a dependency of the crate where the macro is used.
+///
 /// ### `rename = "serialized_name"`
 ///
 /// Use a different name when the field is serialized. The name is used both during serialization
@@ -425,6 +431,8 @@ pub fn derive_event_content(input: TokenStream) -> TokenStream {
 ///
 /// You can use `cargo doc` to find out more details, its `--document-private-items` flag also lets
 /// you generate documentation for binaries or private parts of a library.
+///
+/// [tracing]: https://crates.io/crates/tracing
 #[proc_macro_derive(Event, attributes(ruma_event))]
 pub fn derive_event(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);


### PR DESCRIPTION
These attributes have the same behavior as the ones of the same name from the serde crate, or the ruma_common::serde module:

- `rename`
- `alias`
- `default_on_error`

These should be all the attributes needed for #2230.