### PR TITLE
events: Remove deprecated method RoomMessageEventContent::set_mentions

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -12,6 +12,7 @@ Breaking changes:
    Some of them can only be constructed through deserialization.
    - `InitialStateEvent::new()` takes a `state_key`. For events with an empty
      state key, `InitialStateEvent::with_empty_state_key()` can be used instead.
+- Remove the deprecated `RoomMessageEventContent::set_mentions()`.
 
 Improvements:
 

--- a/crates/ruma-events/src/room/message.rs
+++ b/crates/ruma-events/src/room/message.rs
@@ -94,7 +94,7 @@ pub struct RoomMessageEventContent {
     /// This should always be set to avoid triggering the legacy mention push rules. It is
     /// recommended to modify this field only before calling a method that adds a relation. For
     /// example, [`make_replacement()`](Self::make_replacement) needs to know all the mentions
-    /// beforehand to avoid re-triggering notifications for users that were already mentionned in
+    /// beforehand to avoid re-triggering notifications for users that were already mentioned in
     /// the original event.
     ///
     /// [mentions]: https://spec.matrix.org/latest/client-server-api/#user-and-room-mentions

--- a/crates/ruma-events/src/room/message.rs
+++ b/crates/ruma-events/src/room/message.rs
@@ -92,8 +92,10 @@ pub struct RoomMessageEventContent {
     /// The [mentions] of this event.
     ///
     /// This should always be set to avoid triggering the legacy mention push rules. It is
-    /// recommended to set this field before calling a method that adds a relation, as they
-    /// take care of setting the mentions correctly.
+    /// recommended to modify this field only before calling a method that adds a relation. For
+    /// example, [`make_replacement()`](Self::make_replacement) needs to know all the mentions
+    /// beforehand to avoid re-triggering notifications for users that were already mentionned in
+    /// the original event.
     ///
     /// [mentions]: https://spec.matrix.org/latest/client-server-api/#user-and-room-mentions
     #[serde(rename = "m.mentions", skip_serializing_if = "Option::is_none")]

--- a/crates/ruma-events/tests/it/room_message.rs
+++ b/crates/ruma-events/tests/it/room_message.rs
@@ -954,19 +954,6 @@ fn video_msgtype_deserialization() {
 }
 
 #[test]
-#[allow(deprecated)]
-fn set_mentions() {
-    let mut content = RoomMessageEventContent::text_plain("you!");
-    let mentions = content.mentions.take();
-    assert_matches!(mentions, None);
-
-    let user_id = owned_user_id!("@you:localhost");
-    content = content.set_mentions(Mentions::with_user_ids(vec![user_id.clone()]));
-    let mentions = content.mentions.unwrap();
-    assert_eq!(mentions.user_ids, [user_id].into());
-}
-
-#[test]
 fn add_mentions_then_make_replacement() {
     let alice = owned_user_id!("@alice:localhost");
     let bob = owned_user_id!("@bob:localhost");


### PR DESCRIPTION
It has been deprecated for over a year and is prone to error, `add_mentions` provides a nicer API.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
