### PR TITLE
client-api: Add set_presence to simplified sliding sync v5 request.

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -45,6 +45,8 @@ Breaking changes:
   be added using `.set()`, or the `FromIterator` and `Extend` implementations.
 - Replace `MembershipEventFilter` with `MembershipState` in `get_member_events`, since both enums
   should always be identical.
+- Add `set_presence` field to `sync_events::v5::Request` as per MSC4186; specified identically
+  to the field appearing in prior sync versions.
 
 Improvements:
 

--- a/crates/ruma-client-api/src/sync/sync_events/v5.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v5.rs
@@ -14,6 +14,7 @@ use js_option::JsOption;
 use ruma_common::{
     api::{request, response, Metadata},
     metadata,
+    presence::PresenceState,
     serde::{duration::opt_ms, Raw},
     OwnedMxcUri, OwnedRoomId, OwnedUserId,
 };
@@ -69,6 +70,13 @@ pub struct Request {
     #[serde(with = "opt_ms", default, skip_serializing_if = "Option::is_none")]
     #[ruma_api(query)]
     pub timeout: Option<Duration>,
+
+    /// Controls whether the client is automatically marked as online by polling this API.
+    ///
+    /// Defaults to `PresenceState::Online`.
+    #[serde(default, skip_serializing_if = "ruma_common::serde::is_default")]
+    #[ruma_api(query)]
+    pub set_presence: PresenceState,
 
     /// Lists of rooms we are interested by, represented by ranges.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]


### PR DESCRIPTION
MSC4186 spec: https://github.com/matrix-org/matrix-spec-proposals/blob/erikj/sss/proposals/4186-simplified-sliding-sync.md#top-level

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
