### PR TITLE
Handle clippy warnings in macros

### DIFF
--- a/crates/ruma-macros/src/api/response/incoming.rs
+++ b/crates/ruma-macros/src/api/response/incoming.rs
@@ -119,6 +119,7 @@ impl Response {
         quote! {
             #[automatically_derived]
             #[cfg(feature = "client")]
+            #[allow(deprecated)]
             impl #ruma_common::api::IncomingResponse for Response {
                 type EndpointError = #error_ty;
 

--- a/crates/ruma-macros/src/api/response/outgoing.rs
+++ b/crates/ruma-macros/src/api/response/outgoing.rs
@@ -64,6 +64,7 @@ impl Response {
         quote! {
             #[automatically_derived]
             #[cfg(feature = "server")]
+            #[allow(deprecated)]
             impl #ruma_common::api::OutgoingResponse for Response {
                 fn try_into_http_response<T: ::std::default::Default + #bytes::BufMut>(
                     self,

--- a/crates/ruma-macros/src/util.rs
+++ b/crates/ruma-macros/src/util.rs
@@ -123,7 +123,7 @@ pub fn cfg_expand_struct(item: &mut syn::ItemStruct) {
     struct CfgAttrExpand;
 
     impl VisitMut for CfgAttrExpand {
-        fn visit_attribute_mut(&mut self, attr: &mut syn::Attribute) {
+        fn visit_attribute_mut(&mut self, attr: &mut Attribute) {
             if attr.meta.path().is_ident("cfg_attr") {
                 // Ignore invalid cfg attributes
                 let Meta::List(list) = &attr.meta else { return };


### PR DESCRIPTION
These warnings would show up when running `cargo clippy --all-targets --all-features`, or enable all features with rust-analyzer.