### PR TITLE
events: Use string representation for Ord implementation of `*EventType` enums

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -13,6 +13,9 @@ Breaking changes:
    - `InitialStateEvent::new()` takes a `state_key`. For events with an empty
      state key, `InitialStateEvent::with_empty_state_key()` can be used instead.
 - Remove the deprecated `RoomMessageEventContent::set_mentions()`.
+- The `Ord` and `PartialOrd` implementations of the `*EventType` enums are now
+  ordered using the string representations of the variants. It used to be
+  ordered using the variants declaration order.
 
 Improvements:
 


### PR DESCRIPTION
It is considered to be a breaking change to change the `Ord` and `PartialOrd` order when adding variants, and this is what occurs currently when an unsupported event type becomes supported. This makes cargo features adding new event types non-additive.

So instead we rely on the string representation of the event types, which means that the same event type will always be ordered the same compared to others. This is not straightforward because of "dynamic" event types, so we compare the event type first, and then the type fragment if needed. This implementation doesn't support being able to construct the same event type from 2 different variants, but it should already cause an issue during deserialization.

The simpler alternative would be to use `to_cow_str` and just compare the strings, at the cost of having to allocate a string for "dynamic" event types.