### PR TITLE
state-res: Use macro to initialize tracing for tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1392,15 +1392,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
-name = "nu-ansi-term"
-version = "0.50.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
-dependencies = [
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2099,9 +2090,9 @@ dependencies = [
  "serde",
  "serde_json",
  "similar",
+ "test-log",
  "thiserror",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -2562,6 +2553,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-log"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e33b98a582ea0be1168eba097538ee8dd4bbe0f2b01b22ac92ea30054e5be7b"
+dependencies = [
+ "test-log-macros",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "test-log-macros"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451b374529930d7601b1eef8d32bc79ae870b6079b069401709c2a8bf9e75f36"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2805,18 +2817,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
 ]
 
 [[package]]
@@ -2826,15 +2826,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "matchers",
- "nu-ansi-term",
  "once_cell",
  "regex-automata",
  "sharded-slab",
- "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log",
 ]
 
 [[package]]
@@ -2943,12 +2940,6 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "valuable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/crates/ruma-state-res/Cargo.toml
+++ b/crates/ruma-state-res/Cargo.toml
@@ -33,7 +33,7 @@ insta = { workspace = true }
 maplit = { workspace = true }
 rand = { workspace = true }
 similar = { workspace = true }
-tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
+test-log = { version = "0.2", default-features = false, features = ["trace"] }
 
 [[bench]]
 name = "state_res_bench"

--- a/crates/ruma-state-res/src/event_auth/room_member/tests.rs
+++ b/crates/ruma-state-res/src/event_auth/room_member/tests.rs
@@ -11,21 +11,20 @@ use ruma_events::{
     TimelineEventType,
 };
 use serde_json::{json, value::to_raw_value as to_raw_json_value};
+use test_log::test;
 
 use super::check_room_member;
 use crate::{
     events::RoomMemberEvent,
     test_utils::{
-        alice, bob, charlie, ella, event_id, init_subscriber, member_content_ban,
-        member_content_join, room_third_party_invite, to_pdu_event, zara, TestStateMap,
-        INITIAL_EVENTS, INITIAL_EVENTS_CREATE_ROOM,
+        alice, bob, charlie, ella, event_id, member_content_ban, member_content_join,
+        room_third_party_invite, to_pdu_event, zara, TestStateMap, INITIAL_EVENTS,
+        INITIAL_EVENTS_CREATE_ROOM,
     },
 };
 
 #[test]
 fn missing_state_key() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         charlie(),
@@ -53,8 +52,6 @@ fn missing_state_key() {
 
 #[test]
 fn missing_membership() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         charlie(),
@@ -82,8 +79,6 @@ fn missing_membership() {
 
 #[test]
 fn join_after_create_creator_match() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         alice(),
@@ -111,8 +106,6 @@ fn join_after_create_creator_match() {
 
 #[test]
 fn join_after_create_creator_mismatch() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         charlie(),
@@ -140,8 +133,6 @@ fn join_after_create_creator_mismatch() {
 
 #[test]
 fn join_after_create_sender_match() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         alice(),
@@ -169,8 +160,6 @@ fn join_after_create_sender_match() {
 
 #[test]
 fn join_after_create_sender_mismatch() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         charlie(),
@@ -198,8 +187,6 @@ fn join_after_create_sender_mismatch() {
 
 #[test]
 fn join_sender_state_key_mismatch() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         charlie(),
@@ -227,8 +214,6 @@ fn join_sender_state_key_mismatch() {
 
 #[test]
 fn join_banned() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         charlie(),
@@ -266,8 +251,6 @@ fn join_banned() {
 
 #[test]
 fn join_invite_join_rule_already_joined() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         charlie(),
@@ -305,8 +288,6 @@ fn join_invite_join_rule_already_joined() {
 
 #[test]
 fn join_knock_join_rule_already_invited() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         charlie(),
@@ -354,8 +335,6 @@ fn join_knock_join_rule_already_invited() {
 
 #[test]
 fn join_knock_join_rule_not_supported() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         charlie(),
@@ -395,8 +374,6 @@ fn join_knock_join_rule_not_supported() {
 
 #[test]
 fn join_restricted_join_rule_not_supported() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         charlie(),
@@ -439,8 +416,6 @@ fn join_restricted_join_rule_not_supported() {
 
 #[test]
 fn join_knock_restricted_join_rule_not_supported() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         charlie(),
@@ -483,8 +458,6 @@ fn join_knock_restricted_join_rule_not_supported() {
 
 #[test]
 fn join_restricted_join_rule_already_joined() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         charlie(),
@@ -526,8 +499,6 @@ fn join_restricted_join_rule_already_joined() {
 
 #[test]
 fn join_knock_restricted_join_rule_already_invited() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         charlie(),
@@ -578,8 +549,6 @@ fn join_knock_restricted_join_rule_already_invited() {
 
 #[test]
 fn join_restricted_join_rule_missing_join_authorised_via_users_server() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         ella(),
@@ -621,8 +590,6 @@ fn join_restricted_join_rule_missing_join_authorised_via_users_server() {
 
 #[test]
 fn join_restricted_join_rule_authorised_via_user_not_in_room() {
-    let _guard = init_subscriber();
-
     let mut content = RoomMemberEventContent::new(MembershipState::Join);
     content.join_authorized_via_users_server = Some(zara().to_owned());
 
@@ -667,8 +634,6 @@ fn join_restricted_join_rule_authorised_via_user_not_in_room() {
 
 #[test]
 fn join_restricted_join_rule_authorised_via_user_with_not_enough_power() {
-    let _guard = init_subscriber();
-
     let mut content = RoomMemberEventContent::new(MembershipState::Join);
     content.join_authorized_via_users_server = Some(charlie().to_owned());
 
@@ -722,8 +687,6 @@ fn join_restricted_join_rule_authorised_via_user_with_not_enough_power() {
 
 #[test]
 fn join_restricted_join_rule_authorised_via_user() {
-    let _guard = init_subscriber();
-
     // Check various contents that might not match the definition of `m.room.join_rules` in the
     // spec, to ensure that we only care about the `join_rule` field.
     let join_rules_to_check = [
@@ -799,8 +762,6 @@ fn join_restricted_join_rule_authorised_via_user() {
 
 #[test]
 fn join_public_join_rule() {
-    let _guard = init_subscriber();
-
     // Check various contents that might not match the definition of `m.room.member` in the
     // spec, to ensure that we only care about a few fields.
     let contents_to_check = [
@@ -849,8 +810,6 @@ fn join_public_join_rule() {
 
 #[test]
 fn invite_via_third_party_invite_banned() {
-    let _guard = init_subscriber();
-
     let mut content = RoomMemberEventContent::new(MembershipState::Invite);
     content.third_party_invite = Some(ThirdPartyInvite::new(
         "e..@p..".to_owned(),
@@ -902,8 +861,6 @@ fn invite_via_third_party_invite_banned() {
 
 #[test]
 fn invite_via_third_party_invite_missing_signed() {
-    let _guard = init_subscriber();
-
     let content = json!({
         "membership": "invite",
         "third_party_invite": {
@@ -938,8 +895,6 @@ fn invite_via_third_party_invite_missing_signed() {
 
 #[test]
 fn invite_via_third_party_invite_missing_mxid() {
-    let _guard = init_subscriber();
-
     let content = json!({
         "membership": "invite",
         "third_party_invite": {
@@ -977,8 +932,6 @@ fn invite_via_third_party_invite_missing_mxid() {
 
 #[test]
 fn invite_via_third_party_invite_missing_token() {
-    let _guard = init_subscriber();
-
     let content = json!({
         "membership": "invite",
         "third_party_invite": {
@@ -1016,8 +969,6 @@ fn invite_via_third_party_invite_missing_token() {
 
 #[test]
 fn invite_via_third_party_invite_mxid_mismatch() {
-    let _guard = init_subscriber();
-
     let mut content = RoomMemberEventContent::new(MembershipState::Invite);
     content.third_party_invite = Some(ThirdPartyInvite::new(
         "z..@p..".to_owned(),
@@ -1056,8 +1007,6 @@ fn invite_via_third_party_invite_mxid_mismatch() {
 
 #[test]
 fn invite_via_third_party_invite_missing_room_third_party_invite() {
-    let _guard = init_subscriber();
-
     let mut content = RoomMemberEventContent::new(MembershipState::Invite);
     content.third_party_invite = Some(ThirdPartyInvite::new(
         "e..@p..".to_owned(),
@@ -1114,8 +1063,6 @@ fn invite_via_third_party_invite_missing_room_third_party_invite() {
 
 #[test]
 fn invite_via_third_party_invite_room_third_party_invite_sender_mismatch() {
-    let _guard = init_subscriber();
-
     let mut content = RoomMemberEventContent::new(MembershipState::Invite);
     content.third_party_invite = Some(ThirdPartyInvite::new(
         "e..@p..".to_owned(),
@@ -1156,8 +1103,6 @@ fn invite_via_third_party_invite_room_third_party_invite_sender_mismatch() {
 
 #[test]
 fn invite_via_third_party_invite_with_room_missing_signatures() {
-    let _guard = init_subscriber();
-
     let content = json!({
         "membership": "invite",
         "third_party_invite": {
@@ -1199,8 +1144,6 @@ fn invite_via_third_party_invite_with_room_missing_signatures() {
 
 #[test]
 fn invite_via_third_party_invite_with_room_empty_signatures() {
-    let _guard = init_subscriber();
-
     let content = json!({
         "membership": "invite",
         "third_party_invite": {
@@ -1243,8 +1186,6 @@ fn invite_via_third_party_invite_with_room_empty_signatures() {
 
 #[test]
 fn invite_via_third_party_invite_with_wrong_signature() {
-    let _guard = init_subscriber();
-
     let content = json!({
         "membership": "invite",
         "third_party_invite": {
@@ -1291,8 +1232,6 @@ fn invite_via_third_party_invite_with_wrong_signature() {
 
 #[test]
 fn invite_via_third_party_invite_with_wrong_signing_algorithm() {
-    let _guard = init_subscriber();
-
     let content = json!({
         "membership": "invite",
         "third_party_invite": {
@@ -1339,8 +1278,6 @@ fn invite_via_third_party_invite_with_wrong_signing_algorithm() {
 
 #[test]
 fn invite_via_third_party_invite() {
-    let _guard = init_subscriber();
-
     let content = json!({
         "membership": "invite",
         "third_party_invite": {
@@ -1392,8 +1329,6 @@ fn invite_via_third_party_invite() {
 
 #[test]
 fn invite_sender_not_joined() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         zara(),
@@ -1421,8 +1356,6 @@ fn invite_sender_not_joined() {
 
 #[test]
 fn invite_banned() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         alice(),
@@ -1460,8 +1393,6 @@ fn invite_banned() {
 
 #[test]
 fn invite_already_joined() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         alice(),
@@ -1489,8 +1420,6 @@ fn invite_already_joined() {
 
 #[test]
 fn invite_sender_not_enough_power() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         charlie(),
@@ -1528,8 +1457,6 @@ fn invite_sender_not_enough_power() {
 
 #[test]
 fn invite() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         charlie(),
@@ -1557,8 +1484,6 @@ fn invite() {
 
 #[test]
 fn leave_after_leave() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         ella(),
@@ -1586,8 +1511,6 @@ fn leave_after_leave() {
 
 #[test]
 fn leave_after_join() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         charlie(),
@@ -1615,8 +1538,6 @@ fn leave_after_join() {
 
 #[test]
 fn leave_after_invite() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         charlie(),
@@ -1654,8 +1575,6 @@ fn leave_after_invite() {
 
 #[test]
 fn leave_after_knock() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         charlie(),
@@ -1693,8 +1612,6 @@ fn leave_after_knock() {
 
 #[test]
 fn leave_after_knock_not_supported() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         charlie(),
@@ -1733,8 +1650,6 @@ fn leave_after_knock_not_supported() {
 
 #[test]
 fn leave_kick_sender_left() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         zara(),
@@ -1762,8 +1677,6 @@ fn leave_kick_sender_left() {
 
 #[test]
 fn leave_unban_not_enough_power() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         bob(),
@@ -1801,8 +1714,6 @@ fn leave_unban_not_enough_power() {
 
 #[test]
 fn leave_unban() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         alice(),
@@ -1840,8 +1751,6 @@ fn leave_unban() {
 
 #[test]
 fn leave_kick_not_enough_power() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         bob(),
@@ -1869,8 +1778,6 @@ fn leave_kick_not_enough_power() {
 
 #[test]
 fn leave_kick_greater_power() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         bob(),
@@ -1915,8 +1822,6 @@ fn leave_kick_greater_power() {
 
 #[test]
 fn leave_kick_same_power() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         bob(),
@@ -1961,8 +1866,6 @@ fn leave_kick_same_power() {
 
 #[test]
 fn leave_kick() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         alice(),
@@ -1990,8 +1893,6 @@ fn leave_kick() {
 
 #[test]
 fn ban_sender_not_joined() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         ella(),
@@ -2019,8 +1920,6 @@ fn ban_sender_not_joined() {
 
 #[test]
 fn ban_not_enough_power() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         charlie(),
@@ -2048,8 +1947,6 @@ fn ban_not_enough_power() {
 
 #[test]
 fn ban_greater_power() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         charlie(),
@@ -2094,8 +1991,6 @@ fn ban_greater_power() {
 
 #[test]
 fn ban_same_power() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         charlie(),
@@ -2140,8 +2035,6 @@ fn ban_same_power() {
 
 #[test]
 fn ban() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         alice(),
@@ -2169,8 +2062,6 @@ fn ban() {
 
 #[test]
 fn knock_public_join_rule() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         ella(),
@@ -2198,8 +2089,6 @@ fn knock_public_join_rule() {
 
 #[test]
 fn knock_knock_join_rule() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         ella(),
@@ -2237,8 +2126,6 @@ fn knock_knock_join_rule() {
 
 #[test]
 fn knock_knock_join_rule_not_supported() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         ella(),
@@ -2276,8 +2163,6 @@ fn knock_knock_join_rule_not_supported() {
 
 #[test]
 fn knock_knock_restricted_join_rule() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         ella(),
@@ -2318,8 +2203,6 @@ fn knock_knock_restricted_join_rule() {
 
 #[test]
 fn knock_knock_restricted_join_rule_not_supported() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         ella(),
@@ -2360,8 +2243,6 @@ fn knock_knock_restricted_join_rule_not_supported() {
 
 #[test]
 fn knock_sender_state_key_mismatch() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         zara(),
@@ -2399,8 +2280,6 @@ fn knock_sender_state_key_mismatch() {
 
 #[test]
 fn knock_after_ban() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         charlie(),
@@ -2447,8 +2326,6 @@ fn knock_after_ban() {
 
 #[test]
 fn knock_after_invite() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         charlie(),
@@ -2495,8 +2372,6 @@ fn knock_after_invite() {
 
 #[test]
 fn knock_after_join() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         charlie(),

--- a/crates/ruma-state-res/src/event_auth/tests.rs
+++ b/crates/ruma-state-res/src/event_auth/tests.rs
@@ -13,6 +13,7 @@ use ruma_events::{
     TimelineEventType,
 };
 use serde_json::{json, value::to_raw_value as to_raw_json_value};
+use test_log::test;
 
 mod room_power_levels;
 
@@ -23,10 +24,9 @@ use crate::{
     event_auth::check_room_redaction,
     events::{RoomCreateEvent, RoomPowerLevelsEvent},
     test_utils::{
-        alice, charlie, ella, event_id, init_subscriber, member_content_join,
-        room_create_v12_pdu_event, room_id, room_redaction_pdu_event, room_third_party_invite,
-        to_init_pdu_event, to_pdu_event, to_v12_pdu_event, EventHash, PduEvent, TestStateMap,
-        INITIAL_EVENTS, INITIAL_V12_EVENTS,
+        alice, charlie, ella, event_id, member_content_join, room_create_v12_pdu_event, room_id,
+        room_redaction_pdu_event, room_third_party_invite, to_init_pdu_event, to_pdu_event,
+        to_v12_pdu_event, EventHash, PduEvent, TestStateMap, INITIAL_EVENTS, INITIAL_V12_EVENTS,
     },
 };
 
@@ -182,8 +182,6 @@ fn invalid_room_create() {
 
 #[test]
 fn redact_higher_power_level() {
-    let _guard = init_subscriber();
-
     let incoming_event = room_redaction_pdu_event(
         "HELLO",
         charlie(),
@@ -207,8 +205,6 @@ fn redact_higher_power_level() {
 
 #[test]
 fn redact_same_power_level() {
-    let _guard = init_subscriber();
-
     let incoming_event = room_redaction_pdu_event(
         "HELLO",
         charlie(),
@@ -240,8 +236,6 @@ fn redact_same_power_level() {
 
 #[test]
 fn redact_same_server() {
-    let _guard = init_subscriber();
-
     let incoming_event = room_redaction_pdu_event(
         "HELLO",
         charlie(),
@@ -265,8 +259,6 @@ fn redact_same_server() {
 
 #[test]
 fn missing_room_create_in_state() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         alice(),
@@ -289,8 +281,6 @@ fn missing_room_create_in_state() {
 
 #[test]
 fn reject_missing_room_create_auth_events() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         alice(),
@@ -312,8 +302,6 @@ fn reject_missing_room_create_auth_events() {
 
 #[test]
 fn no_federate_different_server() {
-    let _guard = init_subscriber();
-
     let sender = user_id!("@aya:other.server");
     let incoming_event = to_pdu_event(
         "AYA_JOIN",
@@ -348,8 +336,6 @@ fn no_federate_different_server() {
 
 #[test]
 fn no_federate_same_server() {
-    let _guard = init_subscriber();
-
     let sender = user_id!("@aya:foo");
     let incoming_event = to_pdu_event(
         "AYA_JOIN",
@@ -383,8 +369,6 @@ fn no_federate_same_server() {
 
 #[test]
 fn room_aliases_no_state_key() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "ALIASES",
         alice(),
@@ -414,8 +398,6 @@ fn room_aliases_no_state_key() {
 
 #[test]
 fn room_aliases_other_server() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "ALIASES",
         alice(),
@@ -445,8 +427,6 @@ fn room_aliases_other_server() {
 
 #[test]
 fn room_aliases_same_server() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "ALIASES",
         alice(),
@@ -476,8 +456,6 @@ fn room_aliases_same_server() {
 
 #[test]
 fn sender_not_in_room() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         ella(),
@@ -499,8 +477,6 @@ fn sender_not_in_room() {
 
 #[test]
 fn room_third_party_invite_not_enough_power() {
-    let _guard = init_subscriber();
-
     let incoming_event = room_third_party_invite(charlie());
 
     let mut init_events = INITIAL_EVENTS();
@@ -528,8 +504,6 @@ fn room_third_party_invite_not_enough_power() {
 
 #[test]
 fn room_third_party_invite_with_enough_power() {
-    let _guard = init_subscriber();
-
     let incoming_event = room_third_party_invite(charlie());
 
     let init_events = INITIAL_EVENTS();
@@ -542,8 +516,6 @@ fn room_third_party_invite_with_enough_power() {
 
 #[test]
 fn event_type_not_enough_power() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         charlie(),
@@ -581,8 +553,6 @@ fn event_type_not_enough_power() {
 
 #[test]
 fn user_id_state_key_not_sender() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         alice(),
@@ -604,8 +574,6 @@ fn user_id_state_key_not_sender() {
 
 #[test]
 fn user_id_state_key_is_sender() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         alice(),
@@ -626,8 +594,6 @@ fn user_id_state_key_is_sender() {
 
 #[test]
 fn auth_event_in_different_room() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         alice(),
@@ -667,8 +633,6 @@ fn auth_event_in_different_room() {
 
 #[test]
 fn duplicate_auth_event_type() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         alice(),
@@ -702,8 +666,6 @@ fn duplicate_auth_event_type() {
 
 #[test]
 fn unexpected_auth_event_type() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         alice(),
@@ -737,8 +699,6 @@ fn unexpected_auth_event_type() {
 
 #[test]
 fn rejected_auth_event() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_pdu_event(
         "HELLO",
         alice(),
@@ -819,8 +779,6 @@ fn room_create_with_allowed_or_rejected_room_id() {
 
 #[test]
 fn event_without_room_id() {
-    let _guard = init_subscriber();
-
     let incoming_event = PduEvent {
         event_id: owned_event_id!("$HELLO"),
         room_id: None,
@@ -854,8 +812,6 @@ fn event_without_room_id() {
 
 #[test]
 fn allow_missing_room_create_auth_events() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_v12_pdu_event(
         "HELLO",
         alice(),
@@ -877,8 +833,6 @@ fn allow_missing_room_create_auth_events() {
 
 #[test]
 fn reject_room_create_in_auth_events() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_v12_pdu_event(
         "HELLO",
         alice(),
@@ -900,8 +854,6 @@ fn reject_room_create_in_auth_events() {
 
 #[test]
 fn missing_room_create_in_fetch_event() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_v12_pdu_event(
         "HELLO",
         alice(),
@@ -924,8 +876,6 @@ fn missing_room_create_in_fetch_event() {
 
 #[test]
 fn rejected_room_create_in_fetch_event() {
-    let _guard = init_subscriber();
-
     let incoming_event = to_v12_pdu_event(
         "HELLO",
         alice(),

--- a/crates/ruma-state-res/src/event_auth/tests/room_power_levels.rs
+++ b/crates/ruma-state-res/src/event_auth/tests/room_power_levels.rs
@@ -9,12 +9,13 @@ use serde_json::{
     value::{to_raw_value as to_raw_json_value, Map as JsonMap},
     Value as JsonValue,
 };
+use test_log::test;
 use tracing::info;
 
 use crate::{
     event_auth::check_room_power_levels,
     events::RoomPowerLevelsEvent,
-    test_utils::{alice, bob, init_subscriber, to_pdu_event, zara, PduEvent},
+    test_utils::{alice, bob, to_pdu_event, zara, PduEvent},
 };
 
 /// The default `m.room.power_levels` event when creating a public room.
@@ -32,8 +33,6 @@ pub(super) fn default_room_power_levels() -> RoomPowerLevelsEvent<Arc<PduEvent>>
 
 #[test]
 fn not_int_or_string_int_in_content() {
-    let _guard = init_subscriber();
-
     let original_content = json!({
         "users": { alice(): 100 },
     });
@@ -106,8 +105,6 @@ fn not_int_or_string_int_in_content() {
 
 #[test]
 fn not_int_or_string_int_in_events() {
-    let _guard = init_subscriber();
-
     let original_content = json!({
         "users": { alice(): 100 },
     });
@@ -177,8 +174,6 @@ fn not_int_or_string_int_in_events() {
 
 #[test]
 fn not_int_or_string_int_in_notifications() {
-    let _guard = init_subscriber();
-
     let original_content = json!({
         "users": { alice(): 100 },
     });
@@ -248,8 +243,6 @@ fn not_int_or_string_int_in_notifications() {
 
 #[test]
 fn not_user_id_in_users() {
-    let _guard = init_subscriber();
-
     let content = json!({
         "users": {
             alice(): 100,
@@ -281,8 +274,6 @@ fn not_user_id_in_users() {
 
 #[test]
 fn not_int_or_string_int_in_users() {
-    let _guard = init_subscriber();
-
     let original_content = json!({
         "users": {
             alice(): 100,
@@ -353,8 +344,6 @@ fn not_int_or_string_int_in_users() {
 
 #[test]
 fn first_power_levels_event() {
-    let _guard = init_subscriber();
-
     let content = json!({
         "users": {
             alice(): 100,
@@ -385,8 +374,6 @@ fn first_power_levels_event() {
 
 #[test]
 fn change_content_level_with_current_higher_power_level() {
-    let _guard = init_subscriber();
-
     let original_content = json!({
         "users": {
             alice(): 100,
@@ -443,8 +430,6 @@ fn change_content_level_with_current_higher_power_level() {
 
 #[test]
 fn change_content_level_with_new_higher_power_level() {
-    let _guard = init_subscriber();
-
     let original_content = json!({
         "users": {
             alice(): 100,
@@ -501,8 +486,6 @@ fn change_content_level_with_new_higher_power_level() {
 
 #[test]
 fn change_content_level_with_same_power_level() {
-    let _guard = init_subscriber();
-
     let original_content = json!({
         "users": {
             alice(): 100,
@@ -559,8 +542,6 @@ fn change_content_level_with_same_power_level() {
 
 #[test]
 fn change_events_level_with_current_higher_power_level() {
-    let _guard = init_subscriber();
-
     let current_content = json!({
         "users": {
             alice(): 100,
@@ -612,8 +593,6 @@ fn change_events_level_with_current_higher_power_level() {
 
 #[test]
 fn change_events_level_with_new_higher_power_level() {
-    let _guard = init_subscriber();
-
     let current_content = json!({
         "users": {
             alice(): 100,
@@ -665,8 +644,6 @@ fn change_events_level_with_new_higher_power_level() {
 
 #[test]
 fn change_events_level_with_same_power_level() {
-    let _guard = init_subscriber();
-
     let current_content = json!({
         "users": {
             alice(): 100,
@@ -718,8 +695,6 @@ fn change_events_level_with_same_power_level() {
 
 #[test]
 fn change_notifications_level_with_current_higher_power_level() {
-    let _guard = init_subscriber();
-
     let current_content = json!({
         "users": {
             alice(): 100,
@@ -781,8 +756,6 @@ fn change_notifications_level_with_current_higher_power_level() {
 
 #[test]
 fn change_notifications_level_with_new_higher_power_level() {
-    let _guard = init_subscriber();
-
     let current_content = json!({
         "users": {
             alice(): 100,
@@ -844,8 +817,6 @@ fn change_notifications_level_with_new_higher_power_level() {
 
 #[test]
 fn change_notifications_level_with_same_power_level() {
-    let _guard = init_subscriber();
-
     let current_content = json!({
         "users": {
             alice(): 100,
@@ -907,8 +878,6 @@ fn change_notifications_level_with_same_power_level() {
 
 #[test]
 fn change_other_user_level_with_current_higher_power_level() {
-    let _guard = init_subscriber();
-
     let current_content = json!({
         "users": {
             alice(): 100,
@@ -955,8 +924,6 @@ fn change_other_user_level_with_current_higher_power_level() {
 
 #[test]
 fn change_other_user_level_with_new_higher_power_level() {
-    let _guard = init_subscriber();
-
     let current_content = json!({
         "users": {
             alice(): 100,
@@ -1004,8 +971,6 @@ fn change_other_user_level_with_new_higher_power_level() {
 
 #[test]
 fn change_other_user_level_with_same_power_level() {
-    let _guard = init_subscriber();
-
     let current_content = json!({
         "users": {
             alice(): 100,
@@ -1053,8 +1018,6 @@ fn change_other_user_level_with_same_power_level() {
 
 #[test]
 fn change_own_user_level_to_new_higher_power_level() {
-    let _guard = init_subscriber();
-
     let current_content = json!({
         "users": {
             alice(): 100,
@@ -1100,8 +1063,6 @@ fn change_own_user_level_to_new_higher_power_level() {
 
 #[test]
 fn change_own_user_level_to_lower_power_level() {
-    let _guard = init_subscriber();
-
     let current_content = json!({
         "users": {
             alice(): 100,
@@ -1147,8 +1108,6 @@ fn change_own_user_level_to_lower_power_level() {
 
 #[test]
 fn creator_has_infinite_power() {
-    let _guard = init_subscriber();
-
     let current_content = json!({
         "users": {
             bob(): i64::from(js_int::Int::MAX),
@@ -1193,8 +1152,6 @@ fn creator_has_infinite_power() {
 
 #[test]
 fn dont_allow_creator_in_users_field() {
-    let _guard = init_subscriber();
-
     let current_content = json!({
         "users": {
             bob(): 40,

--- a/crates/ruma-state-res/src/state_res/tests.rs
+++ b/crates/ruma-state-res/src/state_res/tests.rs
@@ -15,6 +15,7 @@ use ruma_events::{
     StateEventType, TimelineEventType,
 };
 use serde_json::{json, value::to_raw_value as to_raw_json_value};
+use test_log::test;
 use tracing::debug;
 
 use super::{is_power_event, EventTypeExt, StateMap};
@@ -27,7 +28,6 @@ use crate::{
 };
 
 fn test_event_sort() {
-    let _ = tracing::subscriber::set_default(tracing_subscriber::fmt().with_test_writer().finish());
     let events = INITIAL_EVENTS();
 
     let event_map = events
@@ -94,8 +94,6 @@ fn test_sort() {
 
 #[test]
 fn ban_vs_power_level() {
-    let _ = tracing::subscriber::set_default(tracing_subscriber::fmt().with_test_writer().finish());
-
     let events = &[
         to_init_pdu_event(
             "PA",
@@ -139,8 +137,6 @@ fn ban_vs_power_level() {
 
 #[test]
 fn topic_basic() {
-    let _ = tracing::subscriber::set_default(tracing_subscriber::fmt().with_test_writer().finish());
-
     let events = &[
         to_init_pdu_event(
             "T1",
@@ -199,8 +195,6 @@ fn topic_basic() {
 
 #[test]
 fn topic_reset() {
-    let _ = tracing::subscriber::set_default(tracing_subscriber::fmt().with_test_writer().finish());
-
     let events = &[
         to_init_pdu_event(
             "T1",
@@ -244,8 +238,6 @@ fn topic_reset() {
 
 #[test]
 fn join_rule_evasion() {
-    let _ = tracing::subscriber::set_default(tracing_subscriber::fmt().with_test_writer().finish());
-
     let events = &[
         to_init_pdu_event(
             "JR",
@@ -275,8 +267,6 @@ fn join_rule_evasion() {
 
 #[test]
 fn offtopic_power_level() {
-    let _ = tracing::subscriber::set_default(tracing_subscriber::fmt().with_test_writer().finish());
-
     let events = &[
         to_init_pdu_event(
             "PA",
@@ -315,8 +305,6 @@ fn offtopic_power_level() {
 
 #[test]
 fn topic_setting() {
-    let _ = tracing::subscriber::set_default(tracing_subscriber::fmt().with_test_writer().finish());
-
     let events = &[
         to_init_pdu_event(
             "T1",
@@ -391,8 +379,6 @@ fn topic_setting() {
 
 #[test]
 fn test_event_map_none() {
-    let _ = tracing::subscriber::set_default(tracing_subscriber::fmt().with_test_writer().finish());
-
     let mut store = TestStore::<PduEvent>(hashmap! {});
 
     // build up the DAG
@@ -420,8 +406,6 @@ fn test_event_map_none() {
 
 #[test]
 fn test_reverse_topological_power_sort() {
-    let _ = tracing::subscriber::set_default(tracing_subscriber::fmt().with_test_writer().finish());
-
     let graph = hashmap! {
         event_id("l") => hashset![event_id("o")],
         event_id("m") => hashset![event_id("n"), event_id("o")],
@@ -446,7 +430,6 @@ fn test_reverse_topological_power_sort() {
 
 #[test]
 fn ban_with_auth_chains() {
-    let _ = tracing::subscriber::set_default(tracing_subscriber::fmt().with_test_writer().finish());
     let ban = BAN_STATE_SET();
 
     let edges = vec![vec!["END", "MB", "PA", "START"], vec!["END", "IME", "MB"]]
@@ -461,7 +444,6 @@ fn ban_with_auth_chains() {
 
 #[test]
 fn ban_with_auth_chains2() {
-    let _ = tracing::subscriber::set_default(tracing_subscriber::fmt().with_test_writer().finish());
     let init = INITIAL_EVENTS();
     let ban = BAN_STATE_SET();
 

--- a/crates/ruma-state-res/src/test_utils.rs
+++ b/crates/ruma-state-res/src/test_utils.rs
@@ -867,10 +867,6 @@ pub(crate) mod event {
     }
 }
 
-pub(crate) fn init_subscriber() -> tracing::dispatcher::DefaultGuard {
-    tracing::subscriber::set_default(tracing_subscriber::fmt().with_test_writer().finish())
-}
-
 /// Wrapper around a state map.
 pub(crate) struct TestStateMap(HashMap<StateEventType, HashMap<String, Arc<PduEvent>>>);
 

--- a/crates/ruma-state-res/tests/it/resolve.rs
+++ b/crates/ruma-state-res/tests/it/resolve.rs
@@ -24,7 +24,6 @@ use serde_json::{
     Value as JsonValue,
 };
 use similar::{udiff::unified_diff, Algorithm};
-use tracing_subscriber::{util::SubscriberInitExt, EnvFilter};
 
 static FIXTURES_PATH: LazyLock<&'static Path> = LazyLock::new(|| Path::new("tests/it/fixtures"));
 
@@ -36,7 +35,7 @@ static FIXTURES_PATH: LazyLock<&'static Path> = LazyLock::new(|| Path::new("test
 /// * A list of JSON files relative to `tests/it/fixtures` to load PDUs to resolve from.
 macro_rules! snapshot_test {
     ($name:ident, $paths:expr $(,)?) => {
-        #[test]
+        #[test_log::test]
         fn $name() {
             let crate::resolve::Snapshots {
                 resolved_state,
@@ -63,7 +62,7 @@ macro_rules! snapshot_test {
 ///   states to resolve.
 macro_rules! snapshot_test_contrived_states {
     ($name:ident, $pdus_path:expr, $state_set_paths:expr $(,)?) => {
-        #[test]
+        #[test_log::test]
         fn $name() {
             let crate::resolve::Snapshots {
                 resolved_state,
@@ -200,13 +199,6 @@ struct Snapshots {
 fn snapshot_test_prelude(
     paths: &[&str],
 ) -> (Vec<Vec<Pdu>>, AuthorizationRules, StateResolutionV2Rules) {
-    // Run `cargo test -- --show-output` to view traces, set `RUST_LOG` to control filtering.
-    let _subscriber = tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::from_default_env())
-        .with_test_writer()
-        .finish()
-        .set_default();
-
     let pdu_batches = paths
         .iter()
         .map(|x| {


### PR DESCRIPTION
Reduces code duplication, avoids forgetting to initialize the subscriber, and is simpler to use overall.
