### PR TITLE
serde: Make StringEnum derive macro implement Ord, PartialOrd, Eq and PartialEq

### DIFF
--- a/crates/ruma-client-api/src/dehydrated_device.rs
+++ b/crates/ruma-client-api/src/dehydrated_device.rs
@@ -71,7 +71,7 @@ impl DehydratedDeviceV2 {
 
 /// The algorithms used for dehydrated devices.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, PartialEq, Eq, StringEnum)]
+#[derive(Clone, StringEnum)]
 #[non_exhaustive]
 pub enum DeviceDehydrationAlgorithm {
     /// The `org.matrix.msc3814.v1.olm` device dehydration algorithm.

--- a/crates/ruma-client-api/src/discovery/discover_support.rs
+++ b/crates/ruma-client-api/src/discovery/discover_support.rs
@@ -102,7 +102,7 @@ impl Contact {
 
 /// An informal description of what the contact methods are used for.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, StringEnum)]
+#[derive(Clone, StringEnum)]
 #[ruma_enum(rename_all = "m.role.snake_case")]
 #[non_exhaustive]
 pub enum ContactRole {

--- a/crates/ruma-client-api/src/discovery/get_authorization_server_metadata.rs
+++ b/crates/ruma-client-api/src/discovery/get_authorization_server_metadata.rs
@@ -14,7 +14,7 @@ pub mod v1 {
     use ruma_common::{
         api::{request, response, Metadata},
         metadata,
-        serde::{OrdAsRefStr, PartialEqAsRefStr, PartialOrdAsRefStr, Raw, StringEnum},
+        serde::{OrdAsRefStr, PartialEqAsRefStr, Raw, StringEnum},
     };
     use serde::Serialize;
     use url::Url;
@@ -241,7 +241,7 @@ pub mod v1 {
 
     /// The method to use at the authorization endpoint.
     #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-    #[derive(Clone, StringEnum, PartialEqAsRefStr, Eq, PartialOrdAsRefStr, OrdAsRefStr)]
+    #[derive(Clone, StringEnum, PartialEqAsRefStr, Eq, OrdAsRefStr)]
     #[ruma_enum(rename_all = "lowercase")]
     #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
     pub enum ResponseType {
@@ -261,7 +261,7 @@ pub mod v1 {
     #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
     ///
     /// [OAuth 2.0 Multiple Response Type Encoding Practices]: https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html
-    #[derive(Clone, StringEnum, PartialEqAsRefStr, Eq, PartialOrdAsRefStr, OrdAsRefStr)]
+    #[derive(Clone, StringEnum, PartialEqAsRefStr, Eq, OrdAsRefStr)]
     #[ruma_enum(rename_all = "lowercase")]
     #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
     pub enum ResponseMode {
@@ -279,7 +279,7 @@ pub mod v1 {
 
     /// The grant type to use at the token endpoint.
     #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-    #[derive(Clone, StringEnum, PartialEqAsRefStr, Eq, PartialOrdAsRefStr, OrdAsRefStr)]
+    #[derive(Clone, StringEnum, PartialEqAsRefStr, Eq, OrdAsRefStr)]
     #[ruma_enum(rename_all = "snake_case")]
     #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
     pub enum GrantType {
@@ -306,7 +306,7 @@ pub mod v1 {
 
     /// The code challenge method to use at the authorization endpoint.
     #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-    #[derive(Clone, StringEnum, PartialEqAsRefStr, Eq, PartialOrdAsRefStr, OrdAsRefStr)]
+    #[derive(Clone, StringEnum, PartialEqAsRefStr, Eq, OrdAsRefStr)]
     #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
     pub enum CodeChallengeMethod {
         /// Use a SHA-256, base64url-encoded code challenge ([RFC 7636]).
@@ -325,7 +325,7 @@ pub mod v1 {
     ///
     /// [MSC 4191]: https://github.com/matrix-org/matrix-spec-proposals/pull/4191
     #[cfg(feature = "unstable-msc4191")]
-    #[derive(Clone, StringEnum, PartialEqAsRefStr, Eq, PartialOrdAsRefStr, OrdAsRefStr)]
+    #[derive(Clone, StringEnum, PartialEqAsRefStr, Eq, OrdAsRefStr)]
     #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
     pub enum AccountManagementAction {
         /// The user wishes to view their profile (name, avatar, contact details).
@@ -372,7 +372,7 @@ pub mod v1 {
     }
 
     /// The desired user experience when using the authorization endpoint.
-    #[derive(Clone, StringEnum, PartialEqAsRefStr, Eq, PartialOrdAsRefStr, OrdAsRefStr)]
+    #[derive(Clone, StringEnum, PartialEqAsRefStr, Eq, OrdAsRefStr)]
     #[ruma_enum(rename_all = "lowercase")]
     #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
     pub enum Prompt {

--- a/crates/ruma-client-api/src/discovery/get_authorization_server_metadata.rs
+++ b/crates/ruma-client-api/src/discovery/get_authorization_server_metadata.rs
@@ -14,7 +14,7 @@ pub mod v1 {
     use ruma_common::{
         api::{request, response, Metadata},
         metadata,
-        serde::{OrdAsRefStr, PartialEqAsRefStr, Raw, StringEnum},
+        serde::{EqAsRefStr, OrdAsRefStr, Raw, StringEnum},
     };
     use serde::Serialize;
     use url::Url;
@@ -241,7 +241,7 @@ pub mod v1 {
 
     /// The method to use at the authorization endpoint.
     #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-    #[derive(Clone, StringEnum, PartialEqAsRefStr, Eq, OrdAsRefStr)]
+    #[derive(Clone, StringEnum, EqAsRefStr, OrdAsRefStr)]
     #[ruma_enum(rename_all = "lowercase")]
     #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
     pub enum ResponseType {
@@ -261,7 +261,7 @@ pub mod v1 {
     #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
     ///
     /// [OAuth 2.0 Multiple Response Type Encoding Practices]: https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html
-    #[derive(Clone, StringEnum, PartialEqAsRefStr, Eq, OrdAsRefStr)]
+    #[derive(Clone, StringEnum, EqAsRefStr, OrdAsRefStr)]
     #[ruma_enum(rename_all = "lowercase")]
     #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
     pub enum ResponseMode {
@@ -279,7 +279,7 @@ pub mod v1 {
 
     /// The grant type to use at the token endpoint.
     #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-    #[derive(Clone, StringEnum, PartialEqAsRefStr, Eq, OrdAsRefStr)]
+    #[derive(Clone, StringEnum, EqAsRefStr, OrdAsRefStr)]
     #[ruma_enum(rename_all = "snake_case")]
     #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
     pub enum GrantType {
@@ -306,7 +306,7 @@ pub mod v1 {
 
     /// The code challenge method to use at the authorization endpoint.
     #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-    #[derive(Clone, StringEnum, PartialEqAsRefStr, Eq, OrdAsRefStr)]
+    #[derive(Clone, StringEnum, EqAsRefStr, OrdAsRefStr)]
     #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
     pub enum CodeChallengeMethod {
         /// Use a SHA-256, base64url-encoded code challenge ([RFC 7636]).
@@ -325,7 +325,7 @@ pub mod v1 {
     ///
     /// [MSC 4191]: https://github.com/matrix-org/matrix-spec-proposals/pull/4191
     #[cfg(feature = "unstable-msc4191")]
-    #[derive(Clone, StringEnum, PartialEqAsRefStr, Eq, OrdAsRefStr)]
+    #[derive(Clone, StringEnum, EqAsRefStr, OrdAsRefStr)]
     #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
     pub enum AccountManagementAction {
         /// The user wishes to view their profile (name, avatar, contact details).
@@ -372,7 +372,7 @@ pub mod v1 {
     }
 
     /// The desired user experience when using the authorization endpoint.
-    #[derive(Clone, StringEnum, PartialEqAsRefStr, Eq, OrdAsRefStr)]
+    #[derive(Clone, StringEnum, EqAsRefStr, OrdAsRefStr)]
     #[ruma_enum(rename_all = "lowercase")]
     #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
     pub enum Prompt {

--- a/crates/ruma-client-api/src/discovery/get_authorization_server_metadata.rs
+++ b/crates/ruma-client-api/src/discovery/get_authorization_server_metadata.rs
@@ -14,7 +14,7 @@ pub mod v1 {
     use ruma_common::{
         api::{request, response, Metadata},
         metadata,
-        serde::{EqAsRefStr, OrdAsRefStr, Raw, StringEnum},
+        serde::{Raw, StringEnum},
     };
     use serde::Serialize;
     use url::Url;
@@ -241,7 +241,7 @@ pub mod v1 {
 
     /// The method to use at the authorization endpoint.
     #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-    #[derive(Clone, StringEnum, EqAsRefStr, OrdAsRefStr)]
+    #[derive(Clone, StringEnum)]
     #[ruma_enum(rename_all = "lowercase")]
     #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
     pub enum ResponseType {
@@ -261,7 +261,7 @@ pub mod v1 {
     #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
     ///
     /// [OAuth 2.0 Multiple Response Type Encoding Practices]: https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html
-    #[derive(Clone, StringEnum, EqAsRefStr, OrdAsRefStr)]
+    #[derive(Clone, StringEnum)]
     #[ruma_enum(rename_all = "lowercase")]
     #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
     pub enum ResponseMode {
@@ -279,7 +279,7 @@ pub mod v1 {
 
     /// The grant type to use at the token endpoint.
     #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-    #[derive(Clone, StringEnum, EqAsRefStr, OrdAsRefStr)]
+    #[derive(Clone, StringEnum)]
     #[ruma_enum(rename_all = "snake_case")]
     #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
     pub enum GrantType {
@@ -306,7 +306,7 @@ pub mod v1 {
 
     /// The code challenge method to use at the authorization endpoint.
     #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-    #[derive(Clone, StringEnum, EqAsRefStr, OrdAsRefStr)]
+    #[derive(Clone, StringEnum)]
     #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
     pub enum CodeChallengeMethod {
         /// Use a SHA-256, base64url-encoded code challenge ([RFC 7636]).
@@ -325,7 +325,7 @@ pub mod v1 {
     ///
     /// [MSC 4191]: https://github.com/matrix-org/matrix-spec-proposals/pull/4191
     #[cfg(feature = "unstable-msc4191")]
-    #[derive(Clone, StringEnum, EqAsRefStr, OrdAsRefStr)]
+    #[derive(Clone, StringEnum)]
     #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
     pub enum AccountManagementAction {
         /// The user wishes to view their profile (name, avatar, contact details).
@@ -372,7 +372,7 @@ pub mod v1 {
     }
 
     /// The desired user experience when using the authorization endpoint.
-    #[derive(Clone, StringEnum, EqAsRefStr, OrdAsRefStr)]
+    #[derive(Clone, StringEnum)]
     #[ruma_enum(rename_all = "lowercase")]
     #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
     pub enum Prompt {

--- a/crates/ruma-client-api/src/discovery/get_capabilities.rs
+++ b/crates/ruma-client-api/src/discovery/get_capabilities.rs
@@ -261,7 +261,7 @@ pub mod v3 {
 
     /// The stability of a room version.
     #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-    #[derive(Clone, PartialEq, Eq, StringEnum)]
+    #[derive(Clone, StringEnum)]
     #[ruma_enum(rename_all = "lowercase")]
     #[non_exhaustive]
     pub enum RoomVersionStability {

--- a/crates/ruma-client-api/src/filter.rs
+++ b/crates/ruma-client-api/src/filter.rs
@@ -15,7 +15,7 @@ use crate::PrivOwnedStr;
 
 /// Format to use for returned events.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, Default, PartialEq, Eq, StringEnum)]
+#[derive(Clone, Default, StringEnum)]
 #[ruma_enum(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum EventFormat {

--- a/crates/ruma-client-api/src/keys/upload_signatures.rs
+++ b/crates/ruma-client-api/src/keys/upload_signatures.rs
@@ -107,7 +107,7 @@ pub mod v3 {
 
     /// Error code for signed key processing failures.
     #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-    #[derive(Clone, PartialEq, Eq, StringEnum)]
+    #[derive(Clone, StringEnum)]
     #[non_exhaustive]
     #[ruma_enum(rename_all = "M_MATRIX_ERROR_CASE")]
     pub enum FailureErrorCode {

--- a/crates/ruma-client-api/src/profile.rs
+++ b/crates/ruma-client-api/src/profile.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 
 use ruma_common::{
     api::{MatrixVersion, StablePathSelector, VersionHistory},
-    serde::{OrdAsRefStr, StringEnum},
+    serde::StringEnum,
     OwnedMxcUri,
 };
 use serde::Serialize;
@@ -27,7 +27,7 @@ pub use self::static_profile_field::*;
 ///
 /// [profile]: https://spec.matrix.org/latest/client-server-api/#profiles
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, PartialEq, Eq, OrdAsRefStr, StringEnum)]
+#[derive(Clone, StringEnum)]
 #[ruma_enum(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum ProfileFieldName {

--- a/crates/ruma-client-api/src/profile.rs
+++ b/crates/ruma-client-api/src/profile.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 
 use ruma_common::{
     api::{MatrixVersion, StablePathSelector, VersionHistory},
-    serde::{OrdAsRefStr, PartialOrdAsRefStr, StringEnum},
+    serde::{OrdAsRefStr, StringEnum},
     OwnedMxcUri,
 };
 use serde::Serialize;
@@ -27,7 +27,7 @@ pub use self::static_profile_field::*;
 ///
 /// [profile]: https://spec.matrix.org/latest/client-server-api/#profiles
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, PartialEq, Eq, PartialOrdAsRefStr, OrdAsRefStr, StringEnum)]
+#[derive(Clone, PartialEq, Eq, OrdAsRefStr, StringEnum)]
 #[ruma_enum(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum ProfileFieldName {

--- a/crates/ruma-client-api/src/receipt/create_receipt.rs
+++ b/crates/ruma-client-api/src/receipt/create_receipt.rs
@@ -10,7 +10,7 @@ pub mod v3 {
     use ruma_common::{
         api::{request, response, Metadata},
         metadata,
-        serde::{OrdAsRefStr, PartialEqAsRefStr, StringEnum},
+        serde::{EqAsRefStr, OrdAsRefStr, StringEnum},
         OwnedEventId, OwnedRoomId,
     };
     use ruma_events::receipt::ReceiptThread;
@@ -81,7 +81,7 @@ pub mod v3 {
 
     /// The type of receipt.
     #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-    #[derive(Clone, OrdAsRefStr, PartialEqAsRefStr, Eq, StringEnum)]
+    #[derive(Clone, OrdAsRefStr, EqAsRefStr, StringEnum)]
     #[non_exhaustive]
     pub enum ReceiptType {
         /// A [public read receipt].

--- a/crates/ruma-client-api/src/receipt/create_receipt.rs
+++ b/crates/ruma-client-api/src/receipt/create_receipt.rs
@@ -10,7 +10,7 @@ pub mod v3 {
     use ruma_common::{
         api::{request, response, Metadata},
         metadata,
-        serde::{EqAsRefStr, OrdAsRefStr, StringEnum},
+        serde::StringEnum,
         OwnedEventId, OwnedRoomId,
     };
     use ruma_events::receipt::ReceiptThread;
@@ -81,7 +81,7 @@ pub mod v3 {
 
     /// The type of receipt.
     #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-    #[derive(Clone, OrdAsRefStr, EqAsRefStr, StringEnum)]
+    #[derive(Clone, StringEnum)]
     #[non_exhaustive]
     pub enum ReceiptType {
         /// A [public read receipt].

--- a/crates/ruma-client-api/src/receipt/create_receipt.rs
+++ b/crates/ruma-client-api/src/receipt/create_receipt.rs
@@ -10,7 +10,7 @@ pub mod v3 {
     use ruma_common::{
         api::{request, response, Metadata},
         metadata,
-        serde::{OrdAsRefStr, PartialEqAsRefStr, PartialOrdAsRefStr, StringEnum},
+        serde::{OrdAsRefStr, PartialEqAsRefStr, StringEnum},
         OwnedEventId, OwnedRoomId,
     };
     use ruma_events::receipt::ReceiptThread;
@@ -81,7 +81,7 @@ pub mod v3 {
 
     /// The type of receipt.
     #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-    #[derive(Clone, PartialOrdAsRefStr, OrdAsRefStr, PartialEqAsRefStr, Eq, StringEnum)]
+    #[derive(Clone, OrdAsRefStr, PartialEqAsRefStr, Eq, StringEnum)]
     #[non_exhaustive]
     pub enum ReceiptType {
         /// A [public read receipt].

--- a/crates/ruma-client-api/src/room.rs
+++ b/crates/ruma-client-api/src/room.rs
@@ -15,7 +15,7 @@ use crate::PrivOwnedStr;
 
 /// Whether or not a newly created room will be listed in the room directory.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, Default, PartialEq, Eq, StringEnum)]
+#[derive(Clone, Default, StringEnum)]
 #[ruma_enum(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum Visibility {

--- a/crates/ruma-client-api/src/room/create_room.rs
+++ b/crates/ruma-client-api/src/room/create_room.rs
@@ -194,7 +194,7 @@ pub mod v3 {
 
     /// A convenience parameter for setting a few default state events.
     #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-    #[derive(Clone, PartialEq, Eq, StringEnum)]
+    #[derive(Clone, StringEnum)]
     #[ruma_enum(rename_all = "snake_case")]
     #[non_exhaustive]
     pub enum RoomPreset {

--- a/crates/ruma-client-api/src/search/search_events.rs
+++ b/crates/ruma-client-api/src/search/search_events.rs
@@ -250,7 +250,7 @@ pub mod v3 {
 
     /// The key within events to use for this grouping.
     #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-    #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, StringEnum)]
+    #[derive(Clone, StringEnum)]
     #[ruma_enum(rename_all = "snake_case")]
     #[non_exhaustive]
     pub enum GroupingKey {
@@ -287,7 +287,7 @@ pub mod v3 {
 
     /// The keys to search for.
     #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-    #[derive(Clone, PartialEq, Eq, StringEnum)]
+    #[derive(Clone, StringEnum)]
     #[non_exhaustive]
     pub enum SearchKeys {
         /// content.body
@@ -308,7 +308,7 @@ pub mod v3 {
 
     /// The order in which to search for results.
     #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-    #[derive(Clone, PartialEq, Eq, StringEnum)]
+    #[derive(Clone, StringEnum)]
     #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
     #[ruma_enum(rename_all = "snake_case")]
     pub enum OrderBy {

--- a/crates/ruma-client-api/src/session/get_login_types.rs
+++ b/crates/ruma-client-api/src/session/get_login_types.rs
@@ -225,7 +225,7 @@ pub mod v3 {
     ///
     /// [matrix-spec-proposals]: https://github.com/matrix-org/matrix-spec-proposals/blob/v1.1/informal/idp-brands.md
     #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-    #[derive(Clone, PartialEq, Eq, StringEnum)]
+    #[derive(Clone, StringEnum)]
     #[ruma_enum(rename_all = "lowercase")]
     #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
     pub enum IdentityProviderBrand {

--- a/crates/ruma-client-api/src/threads/get_threads.rs
+++ b/crates/ruma-client-api/src/threads/get_threads.rs
@@ -88,7 +88,7 @@ pub mod v1 {
 
     /// Which threads to include in the response.
     #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-    #[derive(Clone, Default, PartialEq, Eq, PartialOrd, Ord, StringEnum)]
+    #[derive(Clone, Default, StringEnum)]
     #[ruma_enum(rename_all = "lowercase")]
     #[non_exhaustive]
     pub enum IncludeThreads {

--- a/crates/ruma-client-api/src/uiaa.rs
+++ b/crates/ruma-client-api/src/uiaa.rs
@@ -233,7 +233,7 @@ impl<'de> Deserialize<'de> for AuthData {
 
 /// The type of an authentication stage.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, StringEnum)]
+#[derive(Clone, StringEnum)]
 #[non_exhaustive]
 pub enum AuthType {
     /// Password-based authentication (`m.login.password`).

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -6,6 +6,8 @@ Breaking changes:
   are always implemented using the same logic.
 - Rename the `PartialEqAsRefStr` derive macro to `EqAsRefStr` and make it
   implement both `PartialEq` and `Eq`.
+- The `StringEnum` derive macro also implements `Ord`, `PartialOrd`, `Eq` and
+  `PartialEq` using the `AsRef<str>` implementation of the enum.
 
 Improvements:
 

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -4,6 +4,8 @@ Breaking changes:
 
 - Merge the `PartialOrdAsRefStr` derive macro into `OrdAsRefStr`, so both traits
   are always implemented using the same logic.
+- Rename the `PartialEqAsRefStr` derive macro to `EqAsRefStr` and make it
+  implement both `PartialEq` and `Eq`.
 
 Improvements:
 

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [unreleased]
 
+Breaking changes:
+
+- Merge the `PartialOrdAsRefStr` derive macro into `OrdAsRefStr`, so both traits
+  are always implemented using the same logic.
+
 Improvements:
 
 - Add `MatrixVersion::V1_16`

--- a/crates/ruma-common/src/api/metadata.rs
+++ b/crates/ruma-common/src/api/metadata.rs
@@ -11,7 +11,7 @@ use http::{
     Method,
 };
 use percent_encoding::utf8_percent_encode;
-use ruma_macros::{OrdAsRefStr, PartialEqAsRefStr, StringEnum};
+use ruma_macros::{EqAsRefStr, OrdAsRefStr, StringEnum};
 use tracing::warn;
 
 use super::{
@@ -1180,7 +1180,7 @@ impl SupportedVersions {
 /// specification and that Ruma still supports, like the unstable version of an endpoint or a stable
 /// feature. Features behind a cargo feature are only supported when this feature is enabled.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, StringEnum, PartialEqAsRefStr, Eq, Hash, OrdAsRefStr)]
+#[derive(Clone, StringEnum, EqAsRefStr, Hash, OrdAsRefStr)]
 #[non_exhaustive]
 pub enum FeatureFlag {
     /// `fi.mau.msc2246` ([MSC])

--- a/crates/ruma-common/src/api/metadata.rs
+++ b/crates/ruma-common/src/api/metadata.rs
@@ -11,7 +11,7 @@ use http::{
     Method,
 };
 use percent_encoding::utf8_percent_encode;
-use ruma_macros::{EqAsRefStr, OrdAsRefStr, StringEnum};
+use ruma_macros::StringEnum;
 use tracing::warn;
 
 use super::{
@@ -1180,7 +1180,7 @@ impl SupportedVersions {
 /// specification and that Ruma still supports, like the unstable version of an endpoint or a stable
 /// feature. Features behind a cargo feature are only supported when this feature is enabled.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, StringEnum, EqAsRefStr, Hash, OrdAsRefStr)]
+#[derive(Clone, StringEnum, Hash)]
 #[non_exhaustive]
 pub enum FeatureFlag {
     /// `fi.mau.msc2246` ([MSC])

--- a/crates/ruma-common/src/api/metadata.rs
+++ b/crates/ruma-common/src/api/metadata.rs
@@ -11,7 +11,7 @@ use http::{
     Method,
 };
 use percent_encoding::utf8_percent_encode;
-use ruma_macros::{OrdAsRefStr, PartialEqAsRefStr, PartialOrdAsRefStr, StringEnum};
+use ruma_macros::{OrdAsRefStr, PartialEqAsRefStr, StringEnum};
 use tracing::warn;
 
 use super::{
@@ -1180,7 +1180,7 @@ impl SupportedVersions {
 /// specification and that Ruma still supports, like the unstable version of an endpoint or a stable
 /// feature. Features behind a cargo feature are only supported when this feature is enabled.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, StringEnum, PartialEqAsRefStr, Eq, Hash, PartialOrdAsRefStr, OrdAsRefStr)]
+#[derive(Clone, StringEnum, PartialEqAsRefStr, Eq, Hash, OrdAsRefStr)]
 #[non_exhaustive]
 pub enum FeatureFlag {
     /// `fi.mau.msc2246` ([MSC])

--- a/crates/ruma-common/src/authentication.rs
+++ b/crates/ruma-common/src/authentication.rs
@@ -4,7 +4,7 @@ use crate::{serde::StringEnum, PrivOwnedStr};
 
 /// Access token types.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, PartialEq, Eq, StringEnum)]
+#[derive(Clone, StringEnum)]
 #[non_exhaustive]
 pub enum TokenType {
     /// Bearer token type

--- a/crates/ruma-common/src/encryption.rs
+++ b/crates/ruma-common/src/encryption.rs
@@ -157,7 +157,7 @@ impl CrossSigningKey {
 
 /// The usage of a cross signing key.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, PartialEq, Eq, StringEnum)]
+#[derive(Clone, StringEnum)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 #[ruma_enum(rename_all = "snake_case")]
 pub enum KeyUsage {

--- a/crates/ruma-common/src/http_headers/content_disposition.rs
+++ b/crates/ruma-common/src/http_headers/content_disposition.rs
@@ -2,9 +2,7 @@
 
 use std::{fmt, ops::Deref, str::FromStr};
 
-use ruma_macros::{
-    AsRefStr, AsStrAsRefStr, DebugAsRefStr, DisplayAsRefStr, OrdAsRefStr, PartialOrdAsRefStr,
-};
+use ruma_macros::{AsRefStr, AsStrAsRefStr, DebugAsRefStr, DisplayAsRefStr, OrdAsRefStr};
 
 use super::{
     is_tchar, is_token, quote_ascii_string_if_required, rfc8187, sanitize_for_ascii_quoted_string,
@@ -340,16 +338,7 @@ pub enum ContentDispositionParseError {
 /// Comparisons with other string types are done case-insensitively.
 ///
 /// [Section 4.2 of RFC 6266]: https://datatracker.ietf.org/doc/html/rfc6266#section-4.2
-#[derive(
-    Clone,
-    Default,
-    AsRefStr,
-    DebugAsRefStr,
-    AsStrAsRefStr,
-    DisplayAsRefStr,
-    PartialOrdAsRefStr,
-    OrdAsRefStr,
-)]
+#[derive(Clone, Default, AsRefStr, DebugAsRefStr, AsStrAsRefStr, DisplayAsRefStr, OrdAsRefStr)]
 #[ruma_enum(rename_all = "lowercase")]
 #[non_exhaustive]
 pub enum ContentDispositionType {
@@ -432,16 +421,7 @@ impl<'a> PartialEq<&'a str> for ContentDispositionType {
 /// This is a string that can only contain a limited character set.
 ///
 /// [RFC 7230 Section 3.2.6]: https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.6
-#[derive(
-    Clone,
-    PartialEq,
-    Eq,
-    DebugAsRefStr,
-    AsStrAsRefStr,
-    DisplayAsRefStr,
-    PartialOrdAsRefStr,
-    OrdAsRefStr,
-)]
+#[derive(Clone, PartialEq, Eq, DebugAsRefStr, AsStrAsRefStr, DisplayAsRefStr, OrdAsRefStr)]
 pub struct TokenString(Box<str>);
 
 impl TokenString {

--- a/crates/ruma-common/src/identifiers/crypto_algorithms.rs
+++ b/crates/ruma-common/src/identifiers/crypto_algorithms.rs
@@ -8,7 +8,7 @@ use crate::PrivOwnedStr;
 ///
 /// [device keys]: https://spec.matrix.org/latest/client-server-api/#device-keys
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, StringEnum)]
+#[derive(Clone, StringEnum)]
 #[non_exhaustive]
 #[ruma_enum(rename_all = "snake_case")]
 pub enum DeviceKeyAlgorithm {
@@ -24,7 +24,7 @@ pub enum DeviceKeyAlgorithm {
 
 /// The signing key algorithms defined in the Matrix spec.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, StringEnum)]
+#[derive(Clone, Hash, StringEnum)]
 #[non_exhaustive]
 #[ruma_enum(rename_all = "snake_case")]
 pub enum SigningKeyAlgorithm {
@@ -37,7 +37,7 @@ pub enum SigningKeyAlgorithm {
 
 /// An encryption algorithm to be used to encrypt messages sent to a room.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, StringEnum)]
+#[derive(Clone, StringEnum)]
 #[non_exhaustive]
 pub enum EventEncryptionAlgorithm {
     /// Olm version 1 using Curve25519, AES-256, and SHA-256.
@@ -54,7 +54,7 @@ pub enum EventEncryptionAlgorithm {
 
 /// A key algorithm to be used to generate a key from a passphrase.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, StringEnum)]
+#[derive(Clone, StringEnum)]
 #[non_exhaustive]
 pub enum KeyDerivationAlgorithm {
     /// PBKDF2
@@ -69,7 +69,7 @@ pub enum KeyDerivationAlgorithm {
 ///
 /// [one-time and fallback keys]: https://spec.matrix.org/latest/client-server-api/#one-time-and-fallback-keys
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, StringEnum)]
+#[derive(Clone, StringEnum)]
 #[non_exhaustive]
 #[ruma_enum(rename_all = "snake_case")]
 pub enum OneTimeKeyAlgorithm {

--- a/crates/ruma-common/src/media.rs
+++ b/crates/ruma-common/src/media.rs
@@ -4,13 +4,13 @@
 
 use std::time::Duration;
 
-use ruma_macros::{OrdAsRefStr, PartialEqAsRefStr, PartialOrdAsRefStr};
+use ruma_macros::{OrdAsRefStr, PartialEqAsRefStr};
 
 use crate::{serde::StringEnum, PrivOwnedStr};
 
 /// The desired resizing method for a thumbnail.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, StringEnum, PartialEqAsRefStr, Eq, PartialOrdAsRefStr, OrdAsRefStr)]
+#[derive(Clone, StringEnum, PartialEqAsRefStr, Eq, OrdAsRefStr)]
 #[ruma_enum(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum Method {

--- a/crates/ruma-common/src/media.rs
+++ b/crates/ruma-common/src/media.rs
@@ -4,13 +4,13 @@
 
 use std::time::Duration;
 
-use ruma_macros::{OrdAsRefStr, PartialEqAsRefStr};
+use ruma_macros::{EqAsRefStr, OrdAsRefStr};
 
 use crate::{serde::StringEnum, PrivOwnedStr};
 
 /// The desired resizing method for a thumbnail.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, StringEnum, PartialEqAsRefStr, Eq, OrdAsRefStr)]
+#[derive(Clone, StringEnum, EqAsRefStr, OrdAsRefStr)]
 #[ruma_enum(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum Method {

--- a/crates/ruma-common/src/media.rs
+++ b/crates/ruma-common/src/media.rs
@@ -4,13 +4,11 @@
 
 use std::time::Duration;
 
-use ruma_macros::{EqAsRefStr, OrdAsRefStr};
-
 use crate::{serde::StringEnum, PrivOwnedStr};
 
 /// The desired resizing method for a thumbnail.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, StringEnum, EqAsRefStr, OrdAsRefStr)]
+#[derive(Clone, StringEnum)]
 #[ruma_enum(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum Method {

--- a/crates/ruma-common/src/power_levels.rs
+++ b/crates/ruma-common/src/power_levels.rs
@@ -54,7 +54,7 @@ pub fn default_power_level() -> Int {
 }
 
 /// The possible keys of [`NotificationPowerLevels`].
-#[derive(Clone, PartialEq, Eq, StringEnum)]
+#[derive(Clone, StringEnum)]
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
 #[ruma_enum(rename_all = "lowercase")]
 #[non_exhaustive]

--- a/crates/ruma-common/src/presence.rs
+++ b/crates/ruma-common/src/presence.rs
@@ -6,7 +6,7 @@ use crate::{serde::StringEnum, PrivOwnedStr};
 
 /// A description of a user's connectivity and availability for chat.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, Default, PartialEq, Eq, StringEnum)]
+#[derive(Clone, Default, StringEnum)]
 #[ruma_enum(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum PresenceState {

--- a/crates/ruma-common/src/push.rs
+++ b/crates/ruma-common/src/push.rs
@@ -763,7 +763,7 @@ impl HttpPusherData {
 ///
 /// [spec]: https://spec.matrix.org/latest/push-gateway-api/#homeserver-behaviour
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, PartialEq, Eq, StringEnum)]
+#[derive(Clone, StringEnum)]
 #[ruma_enum(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum PushFormat {
@@ -776,7 +776,7 @@ pub enum PushFormat {
 
 /// The kinds of push rules that are available.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, StringEnum)]
+#[derive(Clone, StringEnum)]
 #[ruma_enum(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum RuleKind {

--- a/crates/ruma-common/src/push/condition.rs
+++ b/crates/ruma-common/src/push/condition.rs
@@ -32,7 +32,7 @@ pub use self::{
 /// Features supported by room versions.
 #[cfg(feature = "unstable-msc3931")]
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, PartialEq, Eq, StringEnum)]
+#[derive(Clone, StringEnum)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub enum RoomVersionFeature {
     /// m.extensible_events

--- a/crates/ruma-common/src/push/predefined.rs
+++ b/crates/ruma-common/src/push/predefined.rs
@@ -621,7 +621,7 @@ impl AsRef<str> for PredefinedRuleId {
 
 /// The rule IDs of the predefined override server push rules.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, StringEnum)]
+#[derive(Clone, StringEnum)]
 #[ruma_enum(rename_all = ".m.rule.snake_case")]
 #[non_exhaustive]
 pub enum PredefinedOverrideRuleId {
@@ -687,7 +687,7 @@ impl PredefinedOverrideRuleId {
 
 /// The rule IDs of the predefined underride server push rules.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, StringEnum)]
+#[derive(Clone, StringEnum)]
 #[ruma_enum(rename_all = ".m.rule.snake_case")]
 #[non_exhaustive]
 pub enum PredefinedUnderrideRuleId {
@@ -773,7 +773,7 @@ impl PredefinedUnderrideRuleId {
 
 /// The rule IDs of the predefined content server push rules.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, StringEnum)]
+#[derive(Clone, StringEnum)]
 #[ruma_enum(rename_all = ".m.rule.snake_case")]
 #[non_exhaustive]
 pub enum PredefinedContentRuleId {

--- a/crates/ruma-common/src/room.rs
+++ b/crates/ruma-common/src/room.rs
@@ -15,7 +15,7 @@ use crate::{
 
 /// An enum of possible room types.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, PartialEq, Eq, StringEnum)]
+#[derive(Clone, StringEnum)]
 #[non_exhaustive]
 pub enum RoomType {
     /// Defines the room as a space.
@@ -211,7 +211,7 @@ impl<'de> Deserialize<'de> for AllowRule {
 
 /// The kind of rule used for users wishing to join this room.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, Default, PartialEq, Eq, StringEnum)]
+#[derive(Clone, Default, StringEnum)]
 #[ruma_enum(rename_all = "snake_case")]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub enum JoinRuleKind {

--- a/crates/ruma-common/src/serde.rs
+++ b/crates/ruma-common/src/serde.rs
@@ -144,6 +144,6 @@ where
 }
 
 pub use ruma_macros::{
-    AsRefStr, AsStrAsRefStr, DebugAsRefStr, DeserializeFromCowStr, DisplayAsRefStr, FromString,
-    OrdAsRefStr, PartialEqAsRefStr, SerializeAsRefStr, StringEnum, _FakeDeriveSerde,
+    AsRefStr, AsStrAsRefStr, DebugAsRefStr, DeserializeFromCowStr, DisplayAsRefStr, EqAsRefStr,
+    FromString, OrdAsRefStr, SerializeAsRefStr, StringEnum, _FakeDeriveSerde,
 };

--- a/crates/ruma-common/src/serde.rs
+++ b/crates/ruma-common/src/serde.rs
@@ -145,6 +145,5 @@ where
 
 pub use ruma_macros::{
     AsRefStr, AsStrAsRefStr, DebugAsRefStr, DeserializeFromCowStr, DisplayAsRefStr, FromString,
-    OrdAsRefStr, PartialEqAsRefStr, PartialOrdAsRefStr, SerializeAsRefStr, StringEnum,
-    _FakeDeriveSerde,
+    OrdAsRefStr, PartialEqAsRefStr, SerializeAsRefStr, StringEnum, _FakeDeriveSerde,
 };

--- a/crates/ruma-common/src/thirdparty.rs
+++ b/crates/ruma-common/src/thirdparty.rs
@@ -222,7 +222,7 @@ impl User {
 
 /// The medium of a third party identifier.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, PartialEq, Eq, StringEnum)]
+#[derive(Clone, StringEnum)]
 #[ruma_enum(rename_all = "lowercase")]
 #[non_exhaustive]
 pub enum Medium {

--- a/crates/ruma-common/tests/it/serde/enum_derive.rs
+++ b/crates/ruma-common/tests/it/serde/enum_derive.rs
@@ -4,7 +4,7 @@ use serde_json::{from_value as from_json_value, json, to_value as to_json_value}
 #[derive(Debug, PartialEq)]
 struct PrivOwnedStr(Box<str>);
 
-#[derive(PartialEq, StringEnum)]
+#[derive(StringEnum)]
 #[ruma_enum(rename_all = "snake_case")]
 enum MyEnum {
     First,

--- a/crates/ruma-events/src/call.rs
+++ b/crates/ruma-events/src/call.rs
@@ -78,7 +78,7 @@ impl StreamMetadata {
 
 /// The purpose of a VoIP stream.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, PartialEq, Eq, StringEnum)]
+#[derive(Clone, StringEnum)]
 #[ruma_enum(rename_all = "m.lowercase")]
 #[non_exhaustive]
 pub enum StreamPurpose {

--- a/crates/ruma-events/src/call/hangup.rs
+++ b/crates/ruma-events/src/call/hangup.rs
@@ -69,7 +69,7 @@ impl CallHangupEventContent {
 /// in the call negotiation, this should be `ice_failed` for when ICE negotiation fails or
 /// `invite_timeout` for when the other party did not answer in time.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, Default, PartialEq, Eq, StringEnum)]
+#[derive(Clone, Default, StringEnum)]
 #[ruma_enum(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum Reason {

--- a/crates/ruma-events/src/call/member.rs
+++ b/crates/ruma-events/src/call/member.rs
@@ -174,7 +174,7 @@ pub struct EmptyMembershipData {
 ///
 /// It is used when the user disconnected and a Future ([MSC4140](https://github.com/matrix-org/matrix-spec-proposals/pull/4140))
 /// was used to update the membership after the client was not reachable anymore.
-#[derive(Clone, PartialEq, StringEnum)]
+#[derive(Clone, StringEnum)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 #[ruma_enum(rename_all = "m.snake_case")]
 pub enum LeaveReason {

--- a/crates/ruma-events/src/call/member/focus.rs
+++ b/crates/ruma-events/src/call/member/focus.rs
@@ -76,7 +76,7 @@ impl ActiveLivekitFocus {
 
 /// How to select the active focus for LiveKit
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, PartialEq, StringEnum)]
+#[derive(Clone, StringEnum)]
 #[ruma_enum(rename_all = "snake_case")]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub enum FocusSelection {

--- a/crates/ruma-events/src/call/member/member_data.rs
+++ b/crates/ruma-events/src/call/member/member_data.rs
@@ -316,7 +316,7 @@ impl CallApplicationContent {
 
 /// The call scope defines different call ownership models.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, PartialEq, StringEnum)]
+#[derive(Clone, StringEnum)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 #[ruma_enum(rename_all = "m.snake_case")]
 pub enum CallScope {

--- a/crates/ruma-events/src/image_pack.rs
+++ b/crates/ruma-events/src/image_pack.rs
@@ -124,7 +124,7 @@ impl PackInfo {
 
 /// Usages for either an image pack or an individual image.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, StringEnum)]
+#[derive(Clone, StringEnum)]
 #[ruma_enum(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum PackUsage {

--- a/crates/ruma-events/src/key/verification.rs
+++ b/crates/ruma-events/src/key/verification.rs
@@ -37,7 +37,7 @@ pub const REQUEST_RECEIVED_TIMEOUT: Duration = Duration::from_secs(2 * 60);
 
 /// A hash algorithm.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, PartialEq, Eq, StringEnum)]
+#[derive(Clone, StringEnum)]
 #[ruma_enum(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum HashAlgorithm {
@@ -50,7 +50,7 @@ pub enum HashAlgorithm {
 
 /// A key agreement protocol.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, PartialEq, Eq, StringEnum)]
+#[derive(Clone, StringEnum)]
 #[ruma_enum(rename_all = "kebab-case")]
 #[non_exhaustive]
 pub enum KeyAgreementProtocol {
@@ -66,7 +66,7 @@ pub enum KeyAgreementProtocol {
 
 /// A message authentication code algorithm.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, PartialEq, Eq, StringEnum)]
+#[derive(Clone, StringEnum)]
 #[ruma_enum(rename_all = "kebab-case")]
 #[non_exhaustive]
 pub enum MessageAuthenticationCode {
@@ -87,7 +87,7 @@ pub enum MessageAuthenticationCode {
 
 /// A Short Authentication String method.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, PartialEq, Eq, StringEnum)]
+#[derive(Clone, StringEnum)]
 #[ruma_enum(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum ShortAuthenticationString {
@@ -103,7 +103,7 @@ pub enum ShortAuthenticationString {
 
 /// A Short Authentication String (SAS) verification method.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, PartialEq, Eq, StringEnum)]
+#[derive(Clone, StringEnum)]
 #[non_exhaustive]
 pub enum VerificationMethod {
     /// The `m.sas.v1` verification method.

--- a/crates/ruma-events/src/key/verification/cancel.rs
+++ b/crates/ruma-events/src/key/verification/cancel.rs
@@ -66,7 +66,7 @@ impl KeyVerificationCancelEventContent {
 ///
 /// Custom error codes should use the Java package naming convention.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, PartialEq, Eq, StringEnum)]
+#[derive(Clone, StringEnum)]
 #[ruma_enum(rename_all = "m.snake_case")]
 #[non_exhaustive]
 pub enum CancelCode {

--- a/crates/ruma-events/src/location.rs
+++ b/crates/ruma-events/src/location.rs
@@ -179,7 +179,7 @@ impl AssetContent {
 
 /// The type of an asset.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, Default, PartialEq, Eq, PartialOrd, Ord, StringEnum)]
+#[derive(Clone, Default, StringEnum)]
 #[ruma_enum(rename_all = "m.snake_case")]
 #[non_exhaustive]
 pub enum AssetType {

--- a/crates/ruma-events/src/media_preview_config.rs
+++ b/crates/ruma-events/src/media_preview_config.rs
@@ -35,7 +35,7 @@ pub struct UnstableMediaPreviewConfigEventContent(pub MediaPreviewConfigEventCon
 impl JsonCastable<MediaPreviewConfigEventContent> for UnstableMediaPreviewConfigEventContent {}
 
 /// The configuration that handles if media previews should be shown in the timeline.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, StringEnum, Default)]
+#[derive(Clone, StringEnum, Default)]
 #[ruma_enum(rename_all = "lowercase")]
 #[non_exhaustive]
 pub enum MediaPreviews {
@@ -54,7 +54,7 @@ pub enum MediaPreviews {
 }
 
 /// The configuration to handle if avatars should be shown in invites.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, StringEnum, Default)]
+#[derive(Clone, StringEnum, Default)]
 #[ruma_enum(rename_all = "lowercase")]
 #[non_exhaustive]
 pub enum InviteAvatars {

--- a/crates/ruma-events/src/policy/rule.rs
+++ b/crates/ruma-events/src/policy/rule.rs
@@ -57,7 +57,7 @@ pub struct PossiblyRedactedPolicyRuleEventContent {
 
 /// The possible actions that can be taken.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, PartialEq, Eq, StringEnum)]
+#[derive(Clone, StringEnum)]
 #[non_exhaustive]
 pub enum Recommendation {
     /// Entities affected by the rule should be banned from participation where possible.

--- a/crates/ruma-events/src/poll/start.rs
+++ b/crates/ruma-events/src/poll/start.rs
@@ -187,7 +187,7 @@ impl From<TextContentBlock> for PollQuestion {
 
 /// The kind of poll.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, Default, PartialEq, Eq, StringEnum)]
+#[derive(Clone, Default, StringEnum)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub enum PollKind {
     /// The results are revealed once the poll is closed.

--- a/crates/ruma-events/src/receipt.rs
+++ b/crates/ruma-events/src/receipt.rs
@@ -12,7 +12,7 @@ use std::{
 use ruma_common::{
     EventId, IdParseError, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedUserId, UserId,
 };
-use ruma_macros::{EventContent, OrdAsRefStr, PartialEqAsRefStr, StringEnum};
+use ruma_macros::{EqAsRefStr, EventContent, OrdAsRefStr, StringEnum};
 use serde::{Deserialize, Serialize};
 
 use crate::PrivOwnedStr;
@@ -77,7 +77,7 @@ pub type Receipts = BTreeMap<ReceiptType, UserReceipts>;
 
 /// The type of receipt.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, OrdAsRefStr, PartialEqAsRefStr, Eq, StringEnum, Hash)]
+#[derive(Clone, OrdAsRefStr, EqAsRefStr, StringEnum, Hash)]
 #[non_exhaustive]
 pub enum ReceiptType {
     /// A [public read receipt].

--- a/crates/ruma-events/src/receipt.rs
+++ b/crates/ruma-events/src/receipt.rs
@@ -12,7 +12,7 @@ use std::{
 use ruma_common::{
     EventId, IdParseError, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedUserId, UserId,
 };
-use ruma_macros::{EqAsRefStr, EventContent, OrdAsRefStr, StringEnum};
+use ruma_macros::{EventContent, StringEnum};
 use serde::{Deserialize, Serialize};
 
 use crate::PrivOwnedStr;
@@ -77,7 +77,7 @@ pub type Receipts = BTreeMap<ReceiptType, UserReceipts>;
 
 /// The type of receipt.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, OrdAsRefStr, EqAsRefStr, StringEnum, Hash)]
+#[derive(Clone, StringEnum, Hash)]
 #[non_exhaustive]
 pub enum ReceiptType {
     /// A [public read receipt].

--- a/crates/ruma-events/src/receipt.rs
+++ b/crates/ruma-events/src/receipt.rs
@@ -12,7 +12,7 @@ use std::{
 use ruma_common::{
     EventId, IdParseError, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedUserId, UserId,
 };
-use ruma_macros::{EventContent, OrdAsRefStr, PartialEqAsRefStr, PartialOrdAsRefStr, StringEnum};
+use ruma_macros::{EventContent, OrdAsRefStr, PartialEqAsRefStr, StringEnum};
 use serde::{Deserialize, Serialize};
 
 use crate::PrivOwnedStr;
@@ -77,7 +77,7 @@ pub type Receipts = BTreeMap<ReceiptType, UserReceipts>;
 
 /// The type of receipt.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, PartialOrdAsRefStr, OrdAsRefStr, PartialEqAsRefStr, Eq, StringEnum, Hash)]
+#[derive(Clone, OrdAsRefStr, PartialEqAsRefStr, Eq, StringEnum, Hash)]
 #[non_exhaustive]
 pub enum ReceiptType {
     /// A [public read receipt].

--- a/crates/ruma-events/src/relation.rs
+++ b/crates/ruma-events/src/relation.rs
@@ -292,7 +292,7 @@ impl BundledStateRelations {
 
 /// Relation types as defined in `rel_type` of an `m.relates_to` field.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, PartialEq, Eq, StringEnum)]
+#[derive(Clone, StringEnum)]
 #[ruma_enum(rename_all = "m.snake_case")]
 #[non_exhaustive]
 pub enum RelationType {

--- a/crates/ruma-events/src/room/guest_access.rs
+++ b/crates/ruma-events/src/room/guest_access.rs
@@ -51,7 +51,7 @@ impl SyncRoomGuestAccessEvent {
 
 /// A policy for guest user access to a room.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, PartialEq, Eq, StringEnum)]
+#[derive(Clone, StringEnum)]
 #[ruma_enum(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum GuestAccess {

--- a/crates/ruma-events/src/room/history_visibility.rs
+++ b/crates/ruma-events/src/room/history_visibility.rs
@@ -50,7 +50,7 @@ impl SyncRoomHistoryVisibilityEvent {
 
 /// Who can see a room's history.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, PartialEq, Eq, StringEnum)]
+#[derive(Clone, StringEnum)]
 #[ruma_enum(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum HistoryVisibility {

--- a/crates/ruma-events/src/room/member.rs
+++ b/crates/ruma-events/src/room/member.rs
@@ -278,7 +278,7 @@ impl SyncRoomMemberEvent {
 
 /// The membership state of a user.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, PartialEq, Eq, StringEnum)]
+#[derive(Clone, StringEnum)]
 #[ruma_enum(rename_all = "lowercase")]
 #[non_exhaustive]
 pub enum MembershipState {

--- a/crates/ruma-events/src/room/message.rs
+++ b/crates/ruma-events/src/room/message.rs
@@ -719,7 +719,7 @@ impl<'a> From<&'a OriginalSyncRoomMessageEvent> for ReplyMetadata<'a> {
 
 /// The format for the formatted representation of a message body.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, PartialEq, Eq, StringEnum)]
+#[derive(Clone, StringEnum)]
 #[non_exhaustive]
 pub enum MessageFormat {
     /// HTML.

--- a/crates/ruma-events/src/room/message/server_notice.rs
+++ b/crates/ruma-events/src/room/message/server_notice.rs
@@ -35,7 +35,7 @@ impl ServerNoticeMessageEventContent {
 
 /// Types of server notices.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, PartialEq, Eq, StringEnum)]
+#[derive(Clone, StringEnum)]
 #[non_exhaustive]
 pub enum ServerNoticeType {
     /// The server has exceeded some limit which requires the server administrator to intervene.
@@ -48,7 +48,7 @@ pub enum ServerNoticeType {
 
 /// Types of usage limits.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, PartialEq, Eq, StringEnum)]
+#[derive(Clone, StringEnum)]
 #[ruma_enum(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum LimitType {

--- a/crates/ruma-events/src/room_key/withheld.rs
+++ b/crates/ruma-events/src/room_key/withheld.rs
@@ -191,7 +191,7 @@ pub struct CustomRoomKeyWithheldCodeInfo {
 
 /// The possible codes for why a megolm key was not sent.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, PartialEq, Eq, StringEnum)]
+#[derive(Clone, StringEnum)]
 #[ruma_enum(rename_all = "m.snake_case")]
 #[non_exhaustive]
 pub enum RoomKeyWithheldCode {

--- a/crates/ruma-events/src/room_key_request.rs
+++ b/crates/ruma-events/src/room_key_request.rs
@@ -48,7 +48,7 @@ impl ToDeviceRoomKeyRequestEventContent {
 
 /// A new key request or a cancellation of a previous request.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, PartialEq, Eq, StringEnum)]
+#[derive(Clone, StringEnum)]
 #[ruma_enum(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum Action {

--- a/crates/ruma-events/src/rtc/notification.rs
+++ b/crates/ruma-events/src/rtc/notification.rs
@@ -97,7 +97,7 @@ impl RtcNotificationEventContent {
 
 /// How this notification should notify the receiver.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, PartialEq, Eq, StringEnum)]
+#[derive(Clone, StringEnum)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 #[ruma_enum(rename_all = "snake_case")]
 pub enum NotificationType {

--- a/crates/ruma-events/src/secret/request.rs
+++ b/crates/ruma-events/src/secret/request.rs
@@ -110,7 +110,7 @@ impl TryFrom<RequestActionJsonRepr> for RequestAction {
 
 /// The name of a secret.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, StringEnum)]
+#[derive(Clone, StringEnum)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub enum SecretName {
     /// Cross-signing master key (m.cross_signing.master).

--- a/crates/ruma-federation-api/src/query/get_profile_information.rs
+++ b/crates/ruma-federation-api/src/query/get_profile_information.rs
@@ -86,7 +86,7 @@ pub mod v1 {
     /// string with `::from()` / `.into()`. To check for values that are not available as a
     /// documented variant here, use its string representation, obtained through
     /// [`.as_str()`](Self::as_str()).
-    #[derive(Clone, PartialEq, Eq, StringEnum)]
+    #[derive(Clone, StringEnum)]
     #[non_exhaustive]
     pub enum ProfileField {
         /// Display name of the user.

--- a/crates/ruma-identity-service-api/src/lookup.rs
+++ b/crates/ruma-identity-service-api/src/lookup.rs
@@ -13,7 +13,7 @@ pub mod lookup_3pid;
 /// This type can hold an arbitrary string. To build this with a custom value, convert it from a
 /// string with `::from()` / `.into()`. To check for values that are not available as a documented
 /// variant here, use its string representation, obtained through [`.as_str()`](Self::as_str()).
-#[derive(Clone, PartialEq, Eq, StringEnum)]
+#[derive(Clone, StringEnum)]
 #[non_exhaustive]
 #[ruma_enum(rename_all = "snake_case")]
 pub enum IdentifierHashingAlgorithm {

--- a/crates/ruma-macros/src/lib.rs
+++ b/crates/ruma-macros/src/lib.rs
@@ -41,7 +41,7 @@ use self::{
         as_str_as_ref_str::expand_as_str_as_ref_str, debug_as_ref_str::expand_debug_as_ref_str,
         deserialize_from_cow_str::expand_deserialize_from_cow_str,
         display_as_ref_str::expand_display_as_ref_str, enum_as_ref_str::expand_enum_as_ref_str,
-        enum_from_string::expand_enum_from_string, eq_as_ref_str::expand_partial_eq_as_ref_str,
+        enum_from_string::expand_enum_from_string, eq_as_ref_str::expand_eq_as_ref_str,
         ord_as_ref_str::expand_ord_as_ref_str, serialize_as_ref_str::expand_serialize_as_ref_str,
     },
     util::{import_ruma_common, import_ruma_events},
@@ -651,11 +651,11 @@ pub fn derive_ord_as_ref_str(input: TokenStream) -> TokenStream {
     expand_ord_as_ref_str(&input.ident).unwrap_or_else(syn::Error::into_compile_error).into()
 }
 
-/// Derive the `PartialEq` trait using the `AsRef<str>` implementation of the type.
-#[proc_macro_derive(PartialEqAsRefStr)]
-pub fn derive_partial_eq_as_ref_str(input: TokenStream) -> TokenStream {
+/// Derive the `PartialEq` and `Eq` traits using the `AsRef<str>` implementation of the type.
+#[proc_macro_derive(EqAsRefStr)]
+pub fn derive_eq_as_ref_str(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
-    expand_partial_eq_as_ref_str(&input.ident).unwrap_or_else(syn::Error::into_compile_error).into()
+    expand_eq_as_ref_str(&input.ident).unwrap_or_else(syn::Error::into_compile_error).into()
 }
 
 /// Shorthand for the derives `AsRefStr`, `FromString`, `DisplayAsRefStr`, `DebugAsRefStr`,

--- a/crates/ruma-macros/src/lib.rs
+++ b/crates/ruma-macros/src/lib.rs
@@ -38,15 +38,11 @@ use self::{
     },
     identifiers::IdentifierInput,
     serde::{
-        as_str_as_ref_str::expand_as_str_as_ref_str,
-        debug_as_ref_str::expand_debug_as_ref_str,
+        as_str_as_ref_str::expand_as_str_as_ref_str, debug_as_ref_str::expand_debug_as_ref_str,
         deserialize_from_cow_str::expand_deserialize_from_cow_str,
-        display_as_ref_str::expand_display_as_ref_str,
-        enum_as_ref_str::expand_enum_as_ref_str,
-        enum_from_string::expand_enum_from_string,
-        eq_as_ref_str::expand_partial_eq_as_ref_str,
-        ord_as_ref_str::{expand_ord_as_ref_str, expand_partial_ord_as_ref_str},
-        serialize_as_ref_str::expand_serialize_as_ref_str,
+        display_as_ref_str::expand_display_as_ref_str, enum_as_ref_str::expand_enum_as_ref_str,
+        enum_from_string::expand_enum_from_string, eq_as_ref_str::expand_partial_eq_as_ref_str,
+        ord_as_ref_str::expand_ord_as_ref_str, serialize_as_ref_str::expand_serialize_as_ref_str,
     },
     util::{import_ruma_common, import_ruma_events},
 };
@@ -648,16 +644,7 @@ pub fn derive_deserialize_from_cow_str(input: TokenStream) -> TokenStream {
         .into()
 }
 
-/// Derive the `PartialOrd` trait using the `AsRef<str>` implementation of the type.
-#[proc_macro_derive(PartialOrdAsRefStr)]
-pub fn derive_partial_ord_as_ref_str(input: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(input as DeriveInput);
-    expand_partial_ord_as_ref_str(&input.ident)
-        .unwrap_or_else(syn::Error::into_compile_error)
-        .into()
-}
-
-/// Derive the `Ord` trait using the `AsRef<str>` implementation of the type.
+/// Derive the `Ord` and `PartialOrd` traits using the `AsRef<str>` implementation of the type.
 #[proc_macro_derive(OrdAsRefStr)]
 pub fn derive_ord_as_ref_str(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);

--- a/crates/ruma-macros/src/lib.rs
+++ b/crates/ruma-macros/src/lib.rs
@@ -659,7 +659,7 @@ pub fn derive_eq_as_ref_str(input: TokenStream) -> TokenStream {
 }
 
 /// Shorthand for the derives `AsRefStr`, `FromString`, `DisplayAsRefStr`, `DebugAsRefStr`,
-/// `SerializeAsRefStr` and `DeserializeFromCowStr`.
+/// `SerializeAsRefStr`, `DeserializeFromCowStr`, `EqAsRefStr` and `OrdAsRefStr`.
 #[proc_macro_derive(StringEnum, attributes(ruma_enum))]
 pub fn derive_string_enum(input: TokenStream) -> TokenStream {
     fn expand_all(input: ItemEnum) -> syn::Result<proc_macro2::TokenStream> {
@@ -670,6 +670,8 @@ pub fn derive_string_enum(input: TokenStream) -> TokenStream {
         let debug_impl = expand_debug_as_ref_str(&input.ident)?;
         let serialize_impl = expand_serialize_as_ref_str(&input.ident)?;
         let deserialize_impl = expand_deserialize_from_cow_str(&input.ident)?;
+        let eq_and_partial_eq_impl = expand_eq_as_ref_str(&input.ident)?;
+        let ord_and_partial_ord_impl = expand_ord_as_ref_str(&input.ident)?;
 
         Ok(quote! {
             #as_ref_str_impl
@@ -679,6 +681,8 @@ pub fn derive_string_enum(input: TokenStream) -> TokenStream {
             #debug_impl
             #serialize_impl
             #deserialize_impl
+            #eq_and_partial_eq_impl
+            #ord_and_partial_ord_impl
         })
     }
 

--- a/crates/ruma-macros/src/serde/eq_as_ref_str.rs
+++ b/crates/ruma-macros/src/serde/eq_as_ref_str.rs
@@ -1,7 +1,7 @@
 use proc_macro2::{Ident, TokenStream};
 use quote::quote;
 
-pub fn expand_partial_eq_as_ref_str(ident: &Ident) -> syn::Result<TokenStream> {
+pub fn expand_eq_as_ref_str(ident: &Ident) -> syn::Result<TokenStream> {
     Ok(quote! {
         #[automatically_derived]
         #[allow(deprecated)]
@@ -11,5 +11,9 @@ pub fn expand_partial_eq_as_ref_str(ident: &Ident) -> syn::Result<TokenStream> {
                 ::std::convert::AsRef::<::std::primitive::str>::as_ref(self) == other
             }
         }
+
+        #[automatically_derived]
+        #[allow(deprecated)]
+        impl ::std::cmp::Eq for #ident {}
     })
 }

--- a/crates/ruma-macros/src/serde/ord_as_ref_str.rs
+++ b/crates/ruma-macros/src/serde/ord_as_ref_str.rs
@@ -1,19 +1,6 @@
 use proc_macro2::{Ident, TokenStream};
 use quote::quote;
 
-pub fn expand_partial_ord_as_ref_str(ident: &Ident) -> syn::Result<TokenStream> {
-    Ok(quote! {
-        #[automatically_derived]
-        #[allow(deprecated)]
-        impl ::std::cmp::PartialOrd for #ident {
-            fn partial_cmp(&self, other: &Self) -> ::std::option::Option<::std::cmp::Ordering> {
-                let other = ::std::convert::AsRef::<::std::primitive::str>::as_ref(other);
-                ::std::convert::AsRef::<::std::primitive::str>::as_ref(self).partial_cmp(other)
-            }
-        }
-    })
-}
-
 pub fn expand_ord_as_ref_str(ident: &Ident) -> syn::Result<TokenStream> {
     Ok(quote! {
         #[automatically_derived]
@@ -22,6 +9,14 @@ pub fn expand_ord_as_ref_str(ident: &Ident) -> syn::Result<TokenStream> {
             fn cmp(&self, other: &Self) -> ::std::cmp::Ordering {
                 let other = ::std::convert::AsRef::<::std::primitive::str>::as_ref(other);
                 ::std::convert::AsRef::<::std::primitive::str>::as_ref(self).cmp(other)
+            }
+        }
+
+        #[automatically_derived]
+        #[allow(deprecated)]
+        impl ::std::cmp::PartialOrd for #ident {
+            fn partial_cmp(&self, other: &Self) -> ::std::option::Option<::std::cmp::Ordering> {
+                ::std::option::Option::Some(::std::cmp::Ord::cmp(self, other))
             }
         }
     })

--- a/crates/ruma-push-gateway-api/src/send_event_notification.rs
+++ b/crates/ruma-push-gateway-api/src/send_event_notification.rs
@@ -147,7 +147,7 @@ pub mod v1 {
     /// This type can hold an arbitrary string. To build this with a custom value, convert it from a
     /// string with `::from()` / `.into()`. To check for values that are not available as a
     /// documented variant here, use its string representation, obtained through `.as_str()`.
-    #[derive(Clone, Default, PartialEq, Eq, StringEnum)]
+    #[derive(Clone, Default, StringEnum)]
     #[ruma_enum(rename_all = "snake_case")]
     #[non_exhaustive]
     pub enum NotificationPriority {

--- a/crates/ruma-state-res/src/events/power_levels.rs
+++ b/crates/ruma-state-res/src/events/power_levels.rs
@@ -11,7 +11,7 @@ use ruma_common::{
     room_version_rules::AuthorizationRules,
     serde::{
         btreemap_deserialize_v1_powerlevel_values, deserialize_v1_powerlevel, from_raw_json_value,
-        DebugAsRefStr, DisplayAsRefStr, JsonObject, OrdAsRefStr, PartialEqAsRefStr,
+        DebugAsRefStr, DisplayAsRefStr, EqAsRefStr, JsonObject, OrdAsRefStr,
     },
     OwnedUserId, UserId,
 };
@@ -327,7 +327,7 @@ impl<E: Event> RoomPowerLevelsEventOptionExt for Option<RoomPowerLevelsEvent<E>>
 }
 
 /// Fields in the `content` of an `m.room.power_levels` event with an integer value.
-#[derive(DebugAsRefStr, Clone, Copy, DisplayAsRefStr, PartialEqAsRefStr, Eq, OrdAsRefStr)]
+#[derive(DebugAsRefStr, Clone, Copy, DisplayAsRefStr, EqAsRefStr, OrdAsRefStr)]
 #[non_exhaustive]
 pub enum RoomPowerLevelsIntField {
     /// `users_default`

--- a/crates/ruma-state-res/src/events/power_levels.rs
+++ b/crates/ruma-state-res/src/events/power_levels.rs
@@ -12,7 +12,6 @@ use ruma_common::{
     serde::{
         btreemap_deserialize_v1_powerlevel_values, deserialize_v1_powerlevel, from_raw_json_value,
         DebugAsRefStr, DisplayAsRefStr, JsonObject, OrdAsRefStr, PartialEqAsRefStr,
-        PartialOrdAsRefStr,
     },
     OwnedUserId, UserId,
 };
@@ -328,16 +327,7 @@ impl<E: Event> RoomPowerLevelsEventOptionExt for Option<RoomPowerLevelsEvent<E>>
 }
 
 /// Fields in the `content` of an `m.room.power_levels` event with an integer value.
-#[derive(
-    DebugAsRefStr,
-    Clone,
-    Copy,
-    DisplayAsRefStr,
-    PartialEqAsRefStr,
-    Eq,
-    PartialOrdAsRefStr,
-    OrdAsRefStr,
-)]
+#[derive(DebugAsRefStr, Clone, Copy, DisplayAsRefStr, PartialEqAsRefStr, Eq, OrdAsRefStr)]
 #[non_exhaustive]
 pub enum RoomPowerLevelsIntField {
     /// `users_default`


### PR DESCRIPTION
Using the `AsRef<str>` implementation. This avoids issues like the `Ord` implementation changing when a string that deserialized as the fallback variant now deserializes as a supported variant.

The 2 first commits also change the `PartialOrdAsRefStr`, `OrdAsRefStr` and `PartialEqAsRefStr` derive macros to reduce the risk of diverging implementations.

Closes #2241
