### PR TITLE
macros: Remove support for matrix-sdk-appservice

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -16,6 +16,8 @@ Breaking changes:
   `PredefinedOverrideRuleId`, and they are still supported in
   `PatternedPushRule::applies_to()` and `ConditionalPushRule::applies()`, for
   backwards-compatibility for clients.
+- Macros no longer support importing the `ruma` and `ruma-events` crate from the
+  `matrix-sdk-appservice` crate. This crate was dropped 2 years ago.
 
 Improvements:
 

--- a/crates/ruma-macros/src/util.rs
+++ b/crates/ruma-macros/src/util.rs
@@ -13,9 +13,6 @@ pub(crate) fn import_ruma_common() -> TokenStream {
     } else if let Ok(FoundCrate::Name(name)) = crate_name("matrix-sdk") {
         let import = format_ident!("{name}");
         quote! { ::#import::ruma }
-    } else if let Ok(FoundCrate::Name(name)) = crate_name("matrix-sdk-appservice") {
-        let import = format_ident!("{name}");
-        quote! { ::#import::ruma }
     } else {
         quote! { ::ruma_common }
     }
@@ -29,9 +26,6 @@ pub(crate) fn import_ruma_events() -> TokenStream {
         let import = format_ident!("{name}");
         quote! { ::#import::events }
     } else if let Ok(FoundCrate::Name(name)) = crate_name("matrix-sdk") {
-        let import = format_ident!("{name}");
-        quote! { ::#import::ruma::events }
-    } else if let Ok(FoundCrate::Name(name)) = crate_name("matrix-sdk-appservice") {
         let import = format_ident!("{name}");
         quote! { ::#import::ruma::events }
     } else {


### PR DESCRIPTION
This crate was dropped 2 years ago.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
