### PR TITLE
api: Change Metadata struct to a trait

### DIFF
--- a/crates/ruma-appservice-api/src/event/push_events.rs
+++ b/crates/ruma-appservice-api/src/event/push_events.rs
@@ -16,7 +16,7 @@ pub mod v1 {
     #[cfg(feature = "unstable-msc3202")]
     use ruma_common::OwnedUserId;
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         serde::{from_raw_json_value, JsonObject, Raw},
         OwnedTransactionId,
@@ -31,14 +31,14 @@ pub mod v1 {
     use serde::{Deserialize, Deserializer, Serialize};
     use serde_json::value::{RawValue as RawJsonValue, Value as JsonValue};
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: PUT,
         rate_limited: false,
         authentication: AccessToken,
         history: {
             1.0 => "/_matrix/app/v1/transactions/{txn_id}",
         }
-    };
+    }
 
     /// Request type for the `push_events` endpoint.
     #[request]

--- a/crates/ruma-appservice-api/src/ping/send_ping.rs
+++ b/crates/ruma-appservice-api/src/ping/send_ping.rs
@@ -8,11 +8,11 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/application-service-api/#post_matrixappv1ping
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedTransactionId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: AccessToken,
@@ -20,7 +20,7 @@ pub mod v1 {
             unstable => "/_matrix/app/unstable/fi.mau.msc2659/ping",
             1.7 => "/_matrix/app/v1/ping",
         }
-    };
+    }
 
     /// Request type for the `send_ping` endpoint.
     #[request]

--- a/crates/ruma-appservice-api/src/query/query_room_alias.rs
+++ b/crates/ruma-appservice-api/src/query/query_room_alias.rs
@@ -8,18 +8,18 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/application-service-api/#get_matrixappv1roomsroomalias
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedRoomAliasId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
         history: {
             1.0 => "/_matrix/app/v1/rooms/{room_alias}",
         }
-    };
+    }
 
     /// Request type for the `query_room_alias` endpoint.
     #[request]

--- a/crates/ruma-appservice-api/src/query/query_user_id.rs
+++ b/crates/ruma-appservice-api/src/query/query_user_id.rs
@@ -8,18 +8,18 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/application-service-api/#get_matrixappv1usersuserid
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedUserId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
         history: {
             1.0 => "/_matrix/app/v1/users/{user_id}",
         }
-    };
+    }
 
     /// Request type for the `query_user_id` endpoint.
     #[request]

--- a/crates/ruma-appservice-api/src/thirdparty/get_location_for_protocol.rs
+++ b/crates/ruma-appservice-api/src/thirdparty/get_location_for_protocol.rs
@@ -10,19 +10,19 @@ pub mod v1 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         thirdparty::Location,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
         history: {
             1.0 => "/_matrix/app/v1/thirdparty/location/{protocol}",
         }
-    };
+    }
 
     /// Request type for the `get_location_for_protocol` endpoint.
     #[request]

--- a/crates/ruma-appservice-api/src/thirdparty/get_location_for_room_alias.rs
+++ b/crates/ruma-appservice-api/src/thirdparty/get_location_for_room_alias.rs
@@ -8,20 +8,20 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/application-service-api/#get_matrixappv1thirdpartylocation
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         thirdparty::Location,
         OwnedRoomAliasId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
         history: {
             1.0 => "/_matrix/app/v1/thirdparty/location",
         }
-    };
+    }
 
     /// Request type for the `get_location_for_room_alias` endpoint.
     #[request]

--- a/crates/ruma-appservice-api/src/thirdparty/get_protocol.rs
+++ b/crates/ruma-appservice-api/src/thirdparty/get_protocol.rs
@@ -10,20 +10,20 @@ pub mod v1 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         thirdparty::{Protocol, ProtocolInstance, ProtocolInstanceInit},
     };
     use serde::{Deserialize, Serialize};
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
         history: {
             1.0 => "/_matrix/app/v1/thirdparty/protocol/{protocol}",
         }
-    };
+    }
 
     /// Request type for the `get_protocol` endpoint.
     #[request]

--- a/crates/ruma-appservice-api/src/thirdparty/get_user_for_protocol.rs
+++ b/crates/ruma-appservice-api/src/thirdparty/get_user_for_protocol.rs
@@ -11,19 +11,19 @@ pub mod v1 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         thirdparty::User,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
         history: {
             1.0 => "/_matrix/app/v1/thirdparty/user/{protocol}",
         }
-    };
+    }
 
     /// Request type for the `get_user_for_protocol` endpoint.
     #[request]

--- a/crates/ruma-appservice-api/src/thirdparty/get_user_for_user_id.rs
+++ b/crates/ruma-appservice-api/src/thirdparty/get_user_for_user_id.rs
@@ -8,20 +8,20 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/application-service-api/#get_matrixappv1thirdpartyuser
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         thirdparty::User,
         OwnedUserId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
         history: {
             1.0 => "/_matrix/app/v1/thirdparty/user",
         }
-    };
+    }
 
     /// Request type for the `get_user_for_user_id` endpoint.
     #[request]

--- a/crates/ruma-client-api/src/account/add_3pid.rs
+++ b/crates/ruma-client-api/src/account/add_3pid.rs
@@ -8,13 +8,13 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3account3pidadd
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedClientSecret, OwnedSessionId,
     };
 
     use crate::uiaa::{AuthData, UiaaResponse};
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: true,
         authentication: AccessToken,
@@ -22,7 +22,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/account/3pid/add",
             1.1 => "/_matrix/client/v3/account/3pid/add",
         }
-    };
+    }
 
     /// Request type for the `add_3pid` endpoint.
     #[request(error = UiaaResponse)]

--- a/crates/ruma-client-api/src/account/bind_3pid.rs
+++ b/crates/ruma-client-api/src/account/bind_3pid.rs
@@ -8,13 +8,13 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3account3pidbind
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedClientSecret, OwnedSessionId,
     };
 
     use crate::account::IdentityServerInfo;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: true,
         authentication: AccessToken,
@@ -22,7 +22,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/account/3pid/bind",
             1.1 => "/_matrix/client/v3/account/3pid/bind",
         }
-    };
+    }
 
     /// Request type for the `bind_3pid` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/account/change_password.rs
+++ b/crates/ruma-client-api/src/account/change_password.rs
@@ -8,13 +8,13 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3accountpassword
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
     };
 
     use crate::uiaa::{AuthData, UiaaResponse};
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: true,
         authentication: AccessTokenOptional,
@@ -22,7 +22,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/account/password",
             1.1 => "/_matrix/client/v3/account/password",
         }
-    };
+    }
 
     /// Request type for the `change_password` endpoint.
     #[request(error = UiaaResponse)]

--- a/crates/ruma-client-api/src/account/check_registration_token_validity.rs
+++ b/crates/ruma-client-api/src/account/check_registration_token_validity.rs
@@ -8,11 +8,11 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv1registermloginregistration_tokenvalidity
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: true,
         authentication: None,
@@ -20,7 +20,7 @@ pub mod v1 {
             unstable => "/_matrix/client/unstable/org.matrix.msc3231/register/org.matrix.msc3231.login.registration_token/validity",
             1.2 => "/_matrix/client/v1/register/m.login.registration_token/validity",
         }
-    };
+    }
 
     /// Request type for the `check_registration_token_validity` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/account/deactivate.rs
+++ b/crates/ruma-client-api/src/account/deactivate.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3accountdeactivate
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
     };
 
@@ -17,7 +17,7 @@ pub mod v3 {
         uiaa::{AuthData, UiaaResponse},
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: true,
         authentication: AccessTokenOptional,
@@ -25,7 +25,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/account/deactivate",
             1.1 => "/_matrix/client/v3/account/deactivate",
         }
-    };
+    }
 
     /// Request type for the `deactivate` endpoint.
     #[request(error = UiaaResponse)]

--- a/crates/ruma-client-api/src/account/delete_3pid.rs
+++ b/crates/ruma-client-api/src/account/delete_3pid.rs
@@ -8,14 +8,14 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3account3piddelete
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         thirdparty::Medium,
     };
 
     use crate::account::ThirdPartyIdRemovalStatus;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: AccessToken,
@@ -23,7 +23,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/account/3pid/delete",
             1.1 => "/_matrix/client/v3/account/3pid/delete",
         }
-    };
+    }
 
     /// Request type for the `delete_3pid` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/account/get_3pids.rs
+++ b/crates/ruma-client-api/src/account/get_3pids.rs
@@ -8,12 +8,12 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3account3pid
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         thirdparty::ThirdPartyIdentifier,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
@@ -21,7 +21,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/account/3pid",
             1.1 => "/_matrix/client/v3/account/3pid",
         }
-    };
+    }
 
     /// Request type for the `get_3pids` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/account/get_username_availability.rs
+++ b/crates/ruma-client-api/src/account/get_username_availability.rs
@@ -8,11 +8,11 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3registeravailable
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: true,
         authentication: None,
@@ -20,7 +20,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/register/available",
             1.1 => "/_matrix/client/v3/register/available",
         }
-    };
+    }
 
     /// Request type for the `get_username_availability` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/account/register.rs
+++ b/crates/ruma-client-api/src/account/register.rs
@@ -12,14 +12,14 @@ pub mod v3 {
     use std::time::Duration;
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedDeviceId, OwnedUserId,
     };
 
     use super::{LoginType, RegistrationKind};
     use crate::uiaa::{AuthData, UiaaResponse};
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: true,
         authentication: AppserviceTokenOptional,
@@ -27,7 +27,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/register",
             1.1 => "/_matrix/client/v3/register",
         }
-    };
+    }
 
     /// Request type for the `register` endpoint.
     #[request(error = UiaaResponse)]

--- a/crates/ruma-client-api/src/account/request_3pid_management_token_via_email.rs
+++ b/crates/ruma-client-api/src/account/request_3pid_management_token_via_email.rs
@@ -9,13 +9,13 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedClientSecret, OwnedSessionId,
     };
 
     use crate::account::IdentityServerInfo;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: None,
@@ -23,7 +23,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/account/3pid/email/requestToken",
             1.1 => "/_matrix/client/v3/account/3pid/email/requestToken",
         }
-    };
+    }
 
     /// Request type for the `request_3pid_management_token_via_email` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/account/request_3pid_management_token_via_msisdn.rs
+++ b/crates/ruma-client-api/src/account/request_3pid_management_token_via_msisdn.rs
@@ -9,13 +9,13 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedClientSecret, OwnedSessionId,
     };
 
     use crate::account::IdentityServerInfo;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: None,
@@ -23,7 +23,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/account/3pid/msisdn/requestToken",
             1.1 => "/_matrix/client/v3/account/3pid/msisdn/requestToken",
         }
-    };
+    }
 
     /// Request type for the `request_3pid_management_token_via_msisdn` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/account/request_openid_token.rs
+++ b/crates/ruma-client-api/src/account/request_openid_token.rs
@@ -10,12 +10,12 @@ pub mod v3 {
     use std::time::Duration;
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         authentication::TokenType,
         metadata, OwnedServerName, OwnedUserId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: true,
         authentication: AccessToken,
@@ -23,7 +23,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/user/{user_id}/openid/request_token",
             1.1 => "/_matrix/client/v3/user/{user_id}/openid/request_token",
         }
-    };
+    }
 
     /// Request type for the `request_openid_token` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/account/request_password_change_token_via_email.rs
+++ b/crates/ruma-client-api/src/account/request_password_change_token_via_email.rs
@@ -9,13 +9,13 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedClientSecret, OwnedSessionId,
     };
 
     use crate::account::IdentityServerInfo;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: None,
@@ -23,7 +23,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/account/password/email/requestToken",
             1.1 => "/_matrix/client/v3/account/password/email/requestToken",
         }
-    };
+    }
 
     /// Request type for the `request_password_change_token_via_email` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/account/request_password_change_token_via_msisdn.rs
+++ b/crates/ruma-client-api/src/account/request_password_change_token_via_msisdn.rs
@@ -9,11 +9,11 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedClientSecret, OwnedSessionId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: None,
@@ -21,7 +21,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/account/password/msisdn/requestToken",
             1.1 => "/_matrix/client/v3/account/password/msisdn/requestToken",
         }
-    };
+    }
 
     /// Request type for the `request_password_change_token_via_msisdn` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/account/request_registration_token_via_email.rs
+++ b/crates/ruma-client-api/src/account/request_registration_token_via_email.rs
@@ -9,13 +9,13 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedClientSecret, OwnedSessionId,
     };
 
     use crate::account::IdentityServerInfo;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: None,
@@ -23,7 +23,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/register/email/requestToken",
             1.1 => "/_matrix/client/v3/register/email/requestToken",
         }
-    };
+    }
 
     /// Request type for the `request_registration_token_via_email` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/account/request_registration_token_via_msisdn.rs
+++ b/crates/ruma-client-api/src/account/request_registration_token_via_msisdn.rs
@@ -9,13 +9,13 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedClientSecret, OwnedSessionId,
     };
 
     use crate::account::IdentityServerInfo;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: None,
@@ -23,7 +23,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/register/msisdn/requestToken",
             1.1 => "/_matrix/client/v3/register/msisdn/requestToken",
         }
-    };
+    }
 
     /// Request type for the `request_registration_token_via_msisdn` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/account/unbind_3pid.rs
+++ b/crates/ruma-client-api/src/account/unbind_3pid.rs
@@ -8,14 +8,14 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3account3pidunbind
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         thirdparty::Medium,
     };
 
     use crate::account::ThirdPartyIdRemovalStatus;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: AccessToken,
@@ -23,7 +23,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/account/3pid/unbind",
             1.1 => "/_matrix/client/v3/account/3pid/unbind",
         }
-    };
+    }
 
     /// Request type for the `unbind_3pid` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/account/whoami.rs
+++ b/crates/ruma-client-api/src/account/whoami.rs
@@ -8,11 +8,11 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3accountwhoami
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedDeviceId, OwnedUserId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: true,
         authentication: AccessToken,
@@ -20,7 +20,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/account/whoami",
             1.1 => "/_matrix/client/v3/account/whoami",
         }
-    };
+    }
 
     /// Request type for the `whoami` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/alias/create_alias.rs
+++ b/crates/ruma-client-api/src/alias/create_alias.rs
@@ -8,11 +8,11 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3directoryroomroomalias
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedRoomAliasId, OwnedRoomId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: PUT,
         rate_limited: false,
         authentication: AccessToken,
@@ -20,7 +20,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/directory/room/{room_alias}",
             1.1 => "/_matrix/client/v3/directory/room/{room_alias}",
         }
-    };
+    }
 
     /// Request type for the `create_alias` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/alias/delete_alias.rs
+++ b/crates/ruma-client-api/src/alias/delete_alias.rs
@@ -8,11 +8,11 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#delete_matrixclientv3directoryroomroomalias
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedRoomAliasId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: DELETE,
         rate_limited: false,
         authentication: AccessToken,
@@ -20,7 +20,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/directory/room/{room_alias}",
             1.1 => "/_matrix/client/v3/directory/room/{room_alias}",
         }
-    };
+    }
 
     /// Request type for the `delete_alias` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/alias/get_alias.rs
+++ b/crates/ruma-client-api/src/alias/get_alias.rs
@@ -8,11 +8,11 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3directoryroomroomalias
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedRoomAliasId, OwnedRoomId, OwnedServerName,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: None,
@@ -20,7 +20,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/directory/room/{room_alias}",
             1.1 => "/_matrix/client/v3/directory/room/{room_alias}",
         }
-    };
+    }
 
     /// Request type for the `get_alias` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/appservice/request_ping.rs
+++ b/crates/ruma-client-api/src/appservice/request_ping.rs
@@ -10,11 +10,11 @@ pub mod v1 {
     use std::time::Duration;
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedTransactionId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: AppserviceToken,
@@ -22,7 +22,7 @@ pub mod v1 {
             unstable("fi.mau.msc2659") => "/_matrix/client/unstable/fi.mau.msc2659/appservice/{appservice_id}/ping",
             1.7 | stable("fi.mau.msc2659.stable") => "/_matrix/client/v1/appservice/{appservice_id}/ping",
         }
-    };
+    }
 
     /// Request type for the `request_ping` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/appservice/set_room_visibility.rs
+++ b/crates/ruma-client-api/src/appservice/set_room_visibility.rs
@@ -8,13 +8,13 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/application-service-api/#put_matrixclientv3directorylistappservicenetworkidroomid
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedRoomId,
     };
 
     use crate::room::Visibility;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: PUT,
         rate_limited: false,
         authentication: AppserviceToken,
@@ -22,7 +22,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/directory/list/appservice/{network_id}/{room_id}",
             1.1 => "/_matrix/client/v3/directory/list/appservice/{network_id}/{room_id}",
         }
-    };
+    }
 
     /// Request type for the `set_room_visibility` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/authenticated_media/get_content.rs
+++ b/crates/ruma-client-api/src/authenticated_media/get_content.rs
@@ -11,12 +11,12 @@ pub mod v1 {
 
     use http::header::{CONTENT_DISPOSITION, CONTENT_TYPE};
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         http_headers::ContentDisposition,
         metadata, IdParseError, MxcUri, OwnedServerName,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: true,
         authentication: AccessToken,
@@ -24,7 +24,7 @@ pub mod v1 {
             unstable("org.matrix.msc3916") => "/_matrix/client/unstable/org.matrix.msc3916/media/download/{server_name}/{media_id}",
             1.11 | stable("org.matrix.msc3916.stable") => "/_matrix/client/v1/media/download/{server_name}/{media_id}",
         }
-    };
+    }
 
     /// Request type for the `get_media_content` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/authenticated_media/get_content_as_filename.rs
+++ b/crates/ruma-client-api/src/authenticated_media/get_content_as_filename.rs
@@ -11,12 +11,12 @@ pub mod v1 {
 
     use http::header::{CONTENT_DISPOSITION, CONTENT_TYPE};
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         http_headers::ContentDisposition,
         metadata, IdParseError, MxcUri, OwnedServerName,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: true,
         authentication: AccessToken,
@@ -24,7 +24,7 @@ pub mod v1 {
             unstable("org.matrix.msc3916") => "/_matrix/client/unstable/org.matrix.msc3916/media/download/{server_name}/{media_id}/{filename}",
             1.11 | stable("org.matrix.msc3916.stable") => "/_matrix/client/v1/media/download/{server_name}/{media_id}/{filename}",
         }
-    };
+    }
 
     /// Request type for the `get_media_content_as_filename` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/authenticated_media/get_content_thumbnail.rs
+++ b/crates/ruma-client-api/src/authenticated_media/get_content_thumbnail.rs
@@ -12,13 +12,13 @@ pub mod v1 {
     use http::header::{CONTENT_DISPOSITION, CONTENT_TYPE};
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         http_headers::ContentDisposition,
         media::Method,
         metadata, IdParseError, MxcUri, OwnedServerName,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: true,
         authentication: AccessToken,
@@ -26,7 +26,7 @@ pub mod v1 {
             unstable("org.matrix.msc3916") => "/_matrix/client/unstable/org.matrix.msc3916/media/thumbnail/{server_name}/{media_id}",
             1.11 | stable("org.matrix.msc3916.stable") => "/_matrix/client/v1/media/thumbnail/{server_name}/{media_id}",
         }
-    };
+    }
 
     /// Request type for the `get_content_thumbnail` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/authenticated_media/get_media_config.rs
+++ b/crates/ruma-client-api/src/authenticated_media/get_media_config.rs
@@ -9,11 +9,11 @@ pub mod v1 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: true,
         authentication: AccessToken,
@@ -21,7 +21,7 @@ pub mod v1 {
             unstable("org.matrix.msc3916") => "/_matrix/client/unstable/org.matrix.msc3916/media/config",
             1.11 | stable("org.matrix.msc3916.stable") => "/_matrix/client/v1/media/config",
         }
-    };
+    }
 
     /// Request type for the `get_media_config` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/authenticated_media/get_media_preview.rs
+++ b/crates/ruma-client-api/src/authenticated_media/get_media_preview.rs
@@ -8,13 +8,13 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv1mediapreview_url
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, MilliSecondsSinceUnixEpoch,
     };
     use serde::Serialize;
     use serde_json::value::{to_raw_value as to_raw_json_value, RawValue as RawJsonValue};
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: true,
         authentication: AccessToken,
@@ -22,7 +22,7 @@ pub mod v1 {
             unstable("org.matrix.msc3916") => "/_matrix/client/unstable/org.matrix.msc3916/media/preview_url",
             1.11 | stable("org.matrix.msc3916.stable") => "/_matrix/client/v1/media/preview_url",
         }
-    };
+    }
 
     /// Request type for the `get_media_preview` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/backup/add_backup_keys.rs
+++ b/crates/ruma-client-api/src/backup/add_backup_keys.rs
@@ -11,13 +11,13 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedRoomId,
     };
 
     use crate::backup::RoomKeyBackup;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: PUT,
         rate_limited: true,
         authentication: AccessToken,
@@ -25,7 +25,7 @@ pub mod v3 {
             unstable => "/_matrix/client/unstable/room_keys/keys",
             1.1 => "/_matrix/client/v3/room_keys/keys",
         }
-    };
+    }
 
     /// Request type for the `add_backup_keys` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/backup/add_backup_keys_for_room.rs
+++ b/crates/ruma-client-api/src/backup/add_backup_keys_for_room.rs
@@ -11,7 +11,7 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         serde::Raw,
         OwnedRoomId,
@@ -19,7 +19,7 @@ pub mod v3 {
 
     use crate::backup::KeyBackupData;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: PUT,
         rate_limited: true,
         authentication: AccessToken,
@@ -28,7 +28,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/room_keys/keys/{room_id}",
             1.1 => "/_matrix/client/v3/room_keys/keys/{room_id}",
         }
-    };
+    }
 
     /// Request type for the `add_backup_keys_for_room` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/backup/add_backup_keys_for_session.rs
+++ b/crates/ruma-client-api/src/backup/add_backup_keys_for_session.rs
@@ -9,7 +9,7 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         serde::Raw,
         OwnedRoomId,
@@ -17,7 +17,7 @@ pub mod v3 {
 
     use crate::backup::KeyBackupData;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: PUT,
         rate_limited: true,
         authentication: AccessToken,
@@ -26,7 +26,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/room_keys/keys/{room_id}/{session_id}",
             1.1 => "/_matrix/client/v3/room_keys/keys/{room_id}/{session_id}",
         }
-    };
+    }
 
     /// Request type for the `add_backup_keys_for_session` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/backup/create_backup_version.rs
+++ b/crates/ruma-client-api/src/backup/create_backup_version.rs
@@ -8,14 +8,14 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3room_keysversion
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         serde::Raw,
     };
 
     use crate::backup::BackupAlgorithm;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: true,
         authentication: AccessToken,
@@ -23,7 +23,7 @@ pub mod v3 {
             unstable => "/_matrix/client/unstable/room_keys/version",
             1.1 => "/_matrix/client/v3/room_keys/version",
         }
-    };
+    }
 
     /// Request type for the `create_backup_version` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/backup/delete_backup_keys.rs
+++ b/crates/ruma-client-api/src/backup/delete_backup_keys.rs
@@ -11,11 +11,11 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: DELETE,
         rate_limited: true,
         authentication: AccessToken,
@@ -24,7 +24,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/room_keys/keys",
             1.1 => "/_matrix/client/v3/room_keys/keys",
         }
-    };
+    }
 
     /// Request type for the `delete_backup_keys` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/backup/delete_backup_keys_for_room.rs
+++ b/crates/ruma-client-api/src/backup/delete_backup_keys_for_room.rs
@@ -9,11 +9,11 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedRoomId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: DELETE,
         rate_limited: true,
         authentication: AccessToken,
@@ -22,7 +22,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/room_keys/keys/{room_id}",
             1.1 => "/_matrix/client/v3/room_keys/keys/{room_id}",
         }
-    };
+    }
 
     /// Request type for the `delete_backup_keys_for_room` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/backup/delete_backup_keys_for_session.rs
+++ b/crates/ruma-client-api/src/backup/delete_backup_keys_for_session.rs
@@ -9,11 +9,11 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedRoomId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: DELETE,
         rate_limited: true,
         authentication: AccessToken,
@@ -22,7 +22,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/room_keys/keys/{room_id}/{session_id}",
             1.1 => "/_matrix/client/v3/room_keys/keys/{room_id}/{session_id}",
         }
-    };
+    }
 
     /// Request type for the `delete_backup_keys_for_session` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/backup/delete_backup_version.rs
+++ b/crates/ruma-client-api/src/backup/delete_backup_version.rs
@@ -10,11 +10,11 @@ pub mod v3 {
     //! This deletes a backup version and its room keys.
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: DELETE,
         rate_limited: true,
         authentication: AccessToken,
@@ -23,7 +23,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/room_keys/version/{version}",
             1.1 => "/_matrix/client/v3/room_keys/version/{version}",
         }
-    };
+    }
 
     /// Request type for the `delete_backup_version` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/backup/get_backup_info.rs
+++ b/crates/ruma-client-api/src/backup/get_backup_info.rs
@@ -10,7 +10,7 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         serde::Raw,
     };
@@ -19,7 +19,7 @@ pub mod v3 {
 
     use crate::backup::BackupAlgorithm;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: true,
         authentication: AccessToken,
@@ -27,7 +27,7 @@ pub mod v3 {
             unstable => "/_matrix/client/unstable/room_keys/version/{version}",
             1.1 => "/_matrix/client/v3/room_keys/version/{version}",
         }
-    };
+    }
 
     /// Request type for the `get_backup_info` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/backup/get_backup_keys.rs
+++ b/crates/ruma-client-api/src/backup/get_backup_keys.rs
@@ -10,13 +10,13 @@ pub mod v3 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedRoomId,
     };
 
     use crate::backup::RoomKeyBackup;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: true,
         authentication: AccessToken,
@@ -25,7 +25,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/room_keys/keys",
             1.1 => "/_matrix/client/v3/room_keys/keys",
         }
-    };
+    }
 
     /// Request type for the `get_backup_keys` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/backup/get_backup_keys_for_room.rs
+++ b/crates/ruma-client-api/src/backup/get_backup_keys_for_room.rs
@@ -10,7 +10,7 @@ pub mod v3 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         serde::Raw,
         OwnedRoomId,
@@ -18,7 +18,7 @@ pub mod v3 {
 
     use crate::backup::KeyBackupData;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: true,
         authentication: AccessToken,
@@ -27,7 +27,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/room_keys/keys/{room_id}",
             1.1 => "/_matrix/client/v3/room_keys/keys/{room_id}",
         }
-    };
+    }
 
     /// Request type for the `get_backup_keys_for_room` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/backup/get_backup_keys_for_session.rs
+++ b/crates/ruma-client-api/src/backup/get_backup_keys_for_session.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3room_keyskeysroomidsessionid
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         serde::Raw,
         OwnedRoomId,
@@ -16,7 +16,7 @@ pub mod v3 {
 
     use crate::backup::KeyBackupData;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: true,
         authentication: AccessToken,
@@ -25,7 +25,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/room_keys/keys/{room_id}/{session_id}",
             1.1 => "/_matrix/client/v3/room_keys/keys/{room_id}/{session_id}",
         }
-    };
+    }
 
     /// Request type for the `get_backup_keys_for_session` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/backup/get_latest_backup_info.rs
+++ b/crates/ruma-client-api/src/backup/get_latest_backup_info.rs
@@ -9,7 +9,7 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         serde::Raw,
     };
@@ -21,7 +21,7 @@ pub mod v3 {
         BackupAlgorithm,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: true,
         authentication: AccessToken,
@@ -30,7 +30,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/room_keys/version",
             1.1 => "/_matrix/client/v3/room_keys/version",
         }
-    };
+    }
 
     /// Request type for the `get_latest_backup_info` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/backup/update_backup_version.rs
+++ b/crates/ruma-client-api/src/backup/update_backup_version.rs
@@ -8,14 +8,14 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3room_keysversionversion
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         serde::Raw,
     };
 
     use crate::backup::BackupAlgorithm;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: PUT,
         rate_limited: true,
         authentication: AccessToken,
@@ -23,7 +23,7 @@ pub mod v3 {
             unstable => "/_matrix/client/unstable/room_keys/version/{version}",
             1.1 => "/_matrix/client/v3/room_keys/version/{version}",
         }
-    };
+    }
 
     /// Request type for the `update_backup_version` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/config/get_global_account_data.rs
+++ b/crates/ruma-client-api/src/config/get_global_account_data.rs
@@ -8,14 +8,14 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3useruseridaccount_datatype
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         serde::Raw,
         OwnedUserId,
     };
     use ruma_events::{AnyGlobalAccountDataEventContent, GlobalAccountDataEventType};
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
@@ -23,7 +23,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/user/{user_id}/account_data/{event_type}",
             1.1 => "/_matrix/client/v3/user/{user_id}/account_data/{event_type}",
         }
-    };
+    }
 
     /// Request type for the `get_global_account_data` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/config/get_room_account_data.rs
+++ b/crates/ruma-client-api/src/config/get_room_account_data.rs
@@ -8,14 +8,14 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3useruseridroomsroomidaccount_datatype
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         serde::Raw,
         OwnedRoomId, OwnedUserId,
     };
     use ruma_events::{AnyRoomAccountDataEventContent, RoomAccountDataEventType};
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
@@ -23,7 +23,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/user/{user_id}/rooms/{room_id}/account_data/{event_type}",
             1.1 => "/_matrix/client/v3/user/{user_id}/rooms/{room_id}/account_data/{event_type}",
         }
-    };
+    }
 
     /// Request type for the `get_room_account_data` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/config/set_global_account_data.rs
+++ b/crates/ruma-client-api/src/config/set_global_account_data.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3useruseridaccount_datatype
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         serde::Raw,
         OwnedUserId,
@@ -18,7 +18,7 @@ pub mod v3 {
     };
     use serde_json::value::to_raw_value as to_raw_json_value;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: PUT,
         rate_limited: false,
         authentication: AccessToken,
@@ -26,7 +26,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/user/{user_id}/account_data/{event_type}",
             1.1 => "/_matrix/client/v3/user/{user_id}/account_data/{event_type}",
         }
-    };
+    }
 
     /// Request type for the `set_global_account_data` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/config/set_room_account_data.rs
+++ b/crates/ruma-client-api/src/config/set_room_account_data.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3useruseridroomsroomidaccount_datatype
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         serde::Raw,
         OwnedRoomId, OwnedUserId,
@@ -18,7 +18,7 @@ pub mod v3 {
     };
     use serde_json::value::to_raw_value as to_raw_json_value;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: PUT,
         rate_limited: false,
         authentication: AccessToken,
@@ -26,7 +26,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/user/{user_id}/rooms/{room_id}/account_data/{event_type}",
             1.1 => "/_matrix/client/v3/user/{user_id}/rooms/{room_id}/account_data/{event_type}",
         }
-    };
+    }
 
     /// Request type for the `set_room_account_data` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/context/get_context.rs
+++ b/crates/ruma-client-api/src/context/get_context.rs
@@ -9,7 +9,7 @@ pub mod v3 {
 
     use js_int::{uint, UInt};
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         serde::Raw,
         OwnedEventId, OwnedRoomId,
@@ -18,7 +18,7 @@ pub mod v3 {
 
     use crate::filter::RoomEventFilter;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
@@ -26,7 +26,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/rooms/{room_id}/context/{event_id}",
             1.1 => "/_matrix/client/v3/rooms/{room_id}/context/{event_id}",
         }
-    };
+    }
 
     /// Request type for the `get_context` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/dehydrated_device/delete_dehydrated_device.rs
+++ b/crates/ruma-client-api/src/dehydrated_device/delete_dehydrated_device.rs
@@ -8,18 +8,18 @@ pub mod unstable {
     //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/3814
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedDeviceId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: DELETE,
         rate_limited: false,
         authentication: AccessToken,
         history: {
             unstable => "/_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device",
         }
-    };
+    }
 
     /// Request type for the `DELETE` `dehydrated_device` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/dehydrated_device/get_dehydrated_device.rs
+++ b/crates/ruma-client-api/src/dehydrated_device/get_dehydrated_device.rs
@@ -8,7 +8,7 @@ pub mod unstable {
     //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/3814
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         serde::Raw,
         OwnedDeviceId,
@@ -16,14 +16,14 @@ pub mod unstable {
 
     use crate::dehydrated_device::DehydratedDeviceData;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
         history: {
             unstable => "/_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device",
         }
-    };
+    }
 
     /// Request type for the `GET` `dehydrated_device` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/dehydrated_device/get_events.rs
+++ b/crates/ruma-client-api/src/dehydrated_device/get_events.rs
@@ -8,21 +8,21 @@ pub mod unstable {
     //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/3814
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         serde::Raw,
         OwnedDeviceId,
     };
     use ruma_events::AnyToDeviceEvent;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: AccessToken,
         history: {
             unstable => "/_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device/{device_id}/events",
         }
-    };
+    }
 
     /// Request type for the `dehydrated_device/{device_id}/events` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/dehydrated_device/put_dehydrated_device.rs
+++ b/crates/ruma-client-api/src/dehydrated_device/put_dehydrated_device.rs
@@ -10,7 +10,7 @@ pub mod unstable {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         encryption::{DeviceKeys, OneTimeKey},
         metadata,
         serde::Raw,
@@ -19,14 +19,14 @@ pub mod unstable {
 
     use crate::dehydrated_device::DehydratedDeviceData;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: PUT,
         rate_limited: false,
         authentication: AccessToken,
         history: {
             unstable => "/_matrix/client/unstable/org.matrix.msc3814.v1/dehydrated_device",
         }
-    };
+    }
 
     /// Request type for the `PUT` `dehydrated_device` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/delayed_events/delayed_message_event.rs
+++ b/crates/ruma-client-api/src/delayed_events/delayed_message_event.rs
@@ -8,7 +8,7 @@ pub mod unstable {
     //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/4140
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         serde::Raw,
         OwnedRoomId, OwnedTransactionId,
@@ -18,7 +18,7 @@ pub mod unstable {
 
     use crate::delayed_events::DelayParameters;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: PUT,
         rate_limited: false,
         authentication: AccessToken,
@@ -26,7 +26,7 @@ pub mod unstable {
             // We use the unstable prefix for the delay query parameter but the stable v3 endpoint.
             unstable => "/_matrix/client/v3/rooms/{room_id}/send/{event_type}/{txn_id}",
         }
-    };
+    }
     /// Request type for the [`delayed_message_event`](crate::delayed_events::delayed_message_event)
     /// endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/delayed_events/delayed_state_event.rs
+++ b/crates/ruma-client-api/src/delayed_events/delayed_state_event.rs
@@ -8,7 +8,7 @@ pub mod unstable {
     //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/4140
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         serde::Raw,
         OwnedRoomId,
@@ -18,7 +18,7 @@ pub mod unstable {
 
     use crate::delayed_events::DelayParameters;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: PUT,
         rate_limited: false,
         authentication: AccessToken,
@@ -26,7 +26,7 @@ pub mod unstable {
             // We use the unstable prefix for the delay query parameter but the stable v3 endpoint.
             unstable => "/_matrix/client/v3/rooms/{room_id}/state/{event_type}/{state_key}",
         }
-    };
+    }
 
     /// Request type for the [`delayed_state_event`](crate::delayed_events::delayed_state_event)
     /// endpoint.

--- a/crates/ruma-client-api/src/delayed_events/update_delayed_event.rs
+++ b/crates/ruma-client-api/src/delayed_events/update_delayed_event.rs
@@ -9,21 +9,21 @@ pub mod unstable {
     //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/4140
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         serde::StringEnum,
     };
 
     use crate::PrivOwnedStr;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: true,
         authentication: AccessToken,
         history: {
             unstable("org.matrix.msc4140") => "/_matrix/client/unstable/org.matrix.msc4140/delayed_events/{delay_id}",
         }
-    };
+    }
 
     /// The possible update actions we can do for updating a delayed event.
     #[derive(Clone, StringEnum)]

--- a/crates/ruma-client-api/src/device/delete_device.rs
+++ b/crates/ruma-client-api/src/device/delete_device.rs
@@ -8,13 +8,13 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#delete_matrixclientv3devicesdeviceid
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedDeviceId,
     };
 
     use crate::uiaa::{AuthData, UiaaResponse};
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: DELETE,
         rate_limited: false,
         authentication: AccessToken,
@@ -22,7 +22,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/devices/{device_id}",
             1.1 => "/_matrix/client/v3/devices/{device_id}",
         }
-    };
+    }
 
     /// Request type for the `delete_device` endpoint.
     #[request(error = UiaaResponse)]

--- a/crates/ruma-client-api/src/device/delete_devices.rs
+++ b/crates/ruma-client-api/src/device/delete_devices.rs
@@ -8,13 +8,13 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3delete_devices
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedDeviceId,
     };
 
     use crate::uiaa::{AuthData, UiaaResponse};
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: AccessToken,
@@ -22,7 +22,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/delete_devices",
             1.1 => "/_matrix/client/v3/delete_devices",
         }
-    };
+    }
 
     /// Request type for the `delete_devices` endpoint.
     #[request(error = UiaaResponse)]

--- a/crates/ruma-client-api/src/device/get_device.rs
+++ b/crates/ruma-client-api/src/device/get_device.rs
@@ -8,13 +8,13 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3devicesdeviceid
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedDeviceId,
     };
 
     use crate::device::Device;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
@@ -22,7 +22,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/devices/{device_id}",
             1.1 => "/_matrix/client/v3/devices/{device_id}",
         }
-    };
+    }
 
     /// Request type for the `get_device` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/device/get_devices.rs
+++ b/crates/ruma-client-api/src/device/get_devices.rs
@@ -8,13 +8,13 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3devices
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
     };
 
     use crate::device::Device;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
@@ -22,7 +22,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/devices",
             1.1 => "/_matrix/client/v3/devices",
         }
-    };
+    }
 
     /// Request type for the `get_devices` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/device/update_device.rs
+++ b/crates/ruma-client-api/src/device/update_device.rs
@@ -8,11 +8,11 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3devicesdeviceid
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedDeviceId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: PUT,
         rate_limited: false,
         authentication: AccessToken,
@@ -20,7 +20,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/devices/{device_id}",
             1.1 => "/_matrix/client/v3/devices/{device_id}",
         }
-    };
+    }
 
     /// Request type for the `update_device` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/directory/get_public_rooms.rs
+++ b/crates/ruma-client-api/src/directory/get_public_rooms.rs
@@ -9,12 +9,12 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         directory::PublicRoomsChunk,
         metadata, OwnedServerName,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: None,
@@ -22,7 +22,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/publicRooms",
             1.1 => "/_matrix/client/v3/publicRooms",
         }
-    };
+    }
 
     /// Request type for the `get_public_rooms` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/directory/get_public_rooms_filtered.rs
+++ b/crates/ruma-client-api/src/directory/get_public_rooms_filtered.rs
@@ -9,12 +9,12 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         directory::{Filter, PublicRoomsChunk, RoomNetwork},
         metadata, OwnedServerName,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: AccessToken,
@@ -22,7 +22,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/publicRooms",
             1.1 => "/_matrix/client/v3/publicRooms",
         }
-    };
+    }
 
     /// Request type for the `get_public_rooms_filtered` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/directory/get_room_visibility.rs
+++ b/crates/ruma-client-api/src/directory/get_room_visibility.rs
@@ -8,13 +8,13 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3directorylistroomroomid
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedRoomId,
     };
 
     use crate::room::Visibility;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: None,
@@ -22,7 +22,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/directory/list/room/{room_id}",
             1.1 => "/_matrix/client/v3/directory/list/room/{room_id}",
         }
-    };
+    }
 
     /// Request type for the `get_room_visibility` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/directory/set_room_visibility.rs
+++ b/crates/ruma-client-api/src/directory/set_room_visibility.rs
@@ -8,13 +8,13 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3directorylistroomroomid
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedRoomId,
     };
 
     use crate::room::Visibility;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: PUT,
         rate_limited: false,
         authentication: AccessToken,
@@ -22,7 +22,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/directory/list/room/{room_id}",
             1.1 => "/_matrix/client/v3/directory/list/room/{room_id}",
         }
-    };
+    }
 
     /// Request type for the `set_room_visibility` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/discovery/discover_homeserver.rs
+++ b/crates/ruma-client-api/src/discovery/discover_homeserver.rs
@@ -10,7 +10,7 @@ use std::borrow::Cow;
 #[cfg(feature = "unstable-msc4143")]
 use ruma_common::serde::JsonObject;
 use ruma_common::{
-    api::{request, response, Metadata},
+    api::{request, response},
     metadata,
 };
 #[cfg(feature = "unstable-msc4143")]
@@ -19,14 +19,14 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "unstable-msc4143")]
 use serde_json::Value as JsonValue;
 
-const METADATA: Metadata = metadata! {
+metadata! {
     method: GET,
     rate_limited: false,
     authentication: None,
     history: {
         1.0 => "/.well-known/matrix/client",
     }
-};
+}
 
 /// Request type for the `client_well_known` endpoint.
 #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/discovery/discover_support.rs
+++ b/crates/ruma-client-api/src/discovery/discover_support.rs
@@ -5,7 +5,7 @@
 //! Get server admin contact and support page of a homeserver's domain.
 
 use ruma_common::{
-    api::{request, response, Metadata},
+    api::{request, response},
     metadata,
     serde::StringEnum,
     OwnedUserId,
@@ -14,14 +14,14 @@ use serde::{Deserialize, Serialize};
 
 use crate::PrivOwnedStr;
 
-const METADATA: Metadata = metadata! {
+metadata! {
     method: GET,
     rate_limited: false,
     authentication: None,
     history: {
         1.10 => "/.well-known/matrix/support",
     }
-};
+}
 
 /// Request type for the `discover_support` endpoint.
 #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/discovery/get_authorization_server_metadata.rs
+++ b/crates/ruma-client-api/src/discovery/get_authorization_server_metadata.rs
@@ -12,7 +12,7 @@ pub mod v1 {
     use std::collections::BTreeSet;
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         serde::{Raw, StringEnum},
     };
@@ -21,7 +21,7 @@ pub mod v1 {
 
     use crate::PrivOwnedStr;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: None,
@@ -29,7 +29,7 @@ pub mod v1 {
             unstable => "/_matrix/client/unstable/org.matrix.msc2965/auth_metadata",
             1.15 => "/_matrix/client/v1/auth_metadata",
         }
-    };
+    }
 
     /// Request type for the `auth_metadata` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/discovery/get_capabilities.rs
+++ b/crates/ruma-client-api/src/discovery/get_capabilities.rs
@@ -14,7 +14,7 @@ pub mod v3 {
 
     use maplit::btreemap;
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         serde::StringEnum,
         RoomVersionId,
@@ -26,7 +26,7 @@ pub mod v3 {
 
     use crate::{profile::ProfileFieldName, PrivOwnedStr};
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: true,
         authentication: AccessToken,
@@ -34,7 +34,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/capabilities",
             1.1 => "/_matrix/client/v3/capabilities",
         }
-    };
+    }
 
     /// Request type for the `get_capabilities` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/discovery/get_supported_versions.rs
+++ b/crates/ruma-client-api/src/discovery/get_supported_versions.rs
@@ -7,18 +7,18 @@
 use std::collections::BTreeMap;
 
 use ruma_common::{
-    api::{request, response, Metadata, SupportedVersions},
+    api::{request, response, SupportedVersions},
     metadata,
 };
 
-const METADATA: Metadata = metadata! {
+metadata! {
     method: GET,
     rate_limited: false,
     authentication: AccessTokenOptional,
     history: {
         1.0 => "/_matrix/client/versions",
     }
-};
+}
 
 /// Request type for the `api_versions` endpoint.
 #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/filter/create_filter.rs
+++ b/crates/ruma-client-api/src/filter/create_filter.rs
@@ -8,13 +8,13 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3useruseridfilter
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedUserId,
     };
 
     use crate::filter::FilterDefinition;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: AccessToken,
@@ -22,7 +22,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/user/{user_id}/filter",
             1.1 => "/_matrix/client/v3/user/{user_id}/filter",
         }
-    };
+    }
 
     /// Request type for the `create_filter` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/filter/get_filter.rs
+++ b/crates/ruma-client-api/src/filter/get_filter.rs
@@ -8,13 +8,13 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3useruseridfilterfilterid
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedUserId,
     };
 
     use crate::filter::FilterDefinition;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
@@ -22,7 +22,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/user/{user_id}/filter/{filter_id}",
             1.1 => "/_matrix/client/v3/user/{user_id}/filter/{filter_id}",
         }
-    };
+    }
 
     /// Request type for the `get_filter` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/keys/claim_keys/v3.rs
+++ b/crates/ruma-client-api/src/keys/claim_keys/v3.rs
@@ -5,7 +5,7 @@
 use std::{collections::BTreeMap, time::Duration};
 
 use ruma_common::{
-    api::{request, response, Metadata},
+    api::{request, response},
     encryption::OneTimeKey,
     metadata,
     serde::Raw,
@@ -13,7 +13,7 @@ use ruma_common::{
 };
 use serde_json::Value as JsonValue;
 
-const METADATA: Metadata = metadata! {
+metadata! {
     method: POST,
     rate_limited: false,
     authentication: AccessToken,
@@ -21,7 +21,7 @@ const METADATA: Metadata = metadata! {
         1.0 => "/_matrix/client/r0/keys/claim",
         1.1 => "/_matrix/client/v3/keys/claim",
     }
-};
+}
 
 /// Request type for the `claim_keys` endpoint.
 #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/keys/claim_keys/v4.rs
+++ b/crates/ruma-client-api/src/keys/claim_keys/v4.rs
@@ -5,7 +5,7 @@
 use std::{collections::BTreeMap, time::Duration};
 
 use ruma_common::{
-    api::{request, response, Metadata},
+    api::{request, response},
     encryption::OneTimeKey,
     metadata,
     serde::Raw,
@@ -13,14 +13,14 @@ use ruma_common::{
 };
 use serde_json::Value as JsonValue;
 
-const METADATA: Metadata = metadata! {
+metadata! {
     method: POST,
     rate_limited: false,
     authentication: AccessToken,
     history: {
         unstable => "/_matrix/client/unstable/org.matrix.msc3983/keys/claim",
     }
-};
+}
 
 /// Request type for the `claim_keys` endpoint.
 #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/keys/get_key_changes.rs
+++ b/crates/ruma-client-api/src/keys/get_key_changes.rs
@@ -8,11 +8,11 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3keyschanges
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedUserId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
@@ -20,7 +20,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/keys/changes",
             1.1 => "/_matrix/client/v3/keys/changes",
         }
-    };
+    }
 
     /// Request type for the `get_key_changes` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/keys/get_keys.rs
+++ b/crates/ruma-client-api/src/keys/get_keys.rs
@@ -10,7 +10,7 @@ pub mod v3 {
     use std::{collections::BTreeMap, time::Duration};
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         encryption::{CrossSigningKey, DeviceKeys},
         metadata,
         serde::Raw,
@@ -18,7 +18,7 @@ pub mod v3 {
     };
     use serde_json::Value as JsonValue;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: AccessToken,
@@ -26,7 +26,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/keys/query",
             1.1 => "/_matrix/client/v3/keys/query",
         }
-    };
+    }
 
     /// Request type for the `get_keys` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/keys/upload_keys.rs
+++ b/crates/ruma-client-api/src/keys/upload_keys.rs
@@ -11,14 +11,14 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         encryption::{DeviceKeys, OneTimeKey},
         metadata,
         serde::Raw,
         OneTimeKeyAlgorithm, OwnedOneTimeKeyId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: AccessToken,
@@ -26,7 +26,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/keys/upload",
             1.1 => "/_matrix/client/v3/keys/upload",
         }
-    };
+    }
 
     /// Request type for the `upload_keys` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/keys/upload_signatures.rs
+++ b/crates/ruma-client-api/src/keys/upload_signatures.rs
@@ -10,7 +10,7 @@ pub mod v3 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         encryption::{CrossSigningKey, DeviceKeys},
         metadata,
         serde::{Raw, StringEnum},
@@ -22,7 +22,7 @@ pub mod v3 {
     pub use super::iter::SignedKeysIter;
     use crate::PrivOwnedStr;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: AccessToken,
@@ -30,7 +30,7 @@ pub mod v3 {
             unstable => "/_matrix/client/unstable/keys/signatures/upload",
             1.1 => "/_matrix/client/v3/keys/signatures/upload",
         }
-    };
+    }
 
     /// Request type for the `upload_signatures` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/keys/upload_signing_keys.rs
+++ b/crates/ruma-client-api/src/keys/upload_signing_keys.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3keysdevice_signingupload
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         encryption::CrossSigningKey,
         metadata,
         serde::Raw,
@@ -16,7 +16,7 @@ pub mod v3 {
 
     use crate::uiaa::{AuthData, UiaaResponse};
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: AccessToken,
@@ -24,7 +24,7 @@ pub mod v3 {
             unstable => "/_matrix/client/unstable/keys/device_signing/upload",
             1.1 => "/_matrix/client/v3/keys/device_signing/upload",
         }
-    };
+    }
 
     /// Request type for the `upload_signing_keys` endpoint.
     #[request(error = UiaaResponse)]

--- a/crates/ruma-client-api/src/knock/knock_room.rs
+++ b/crates/ruma-client-api/src/knock/knock_room.rs
@@ -12,7 +12,7 @@ pub mod v3 {
         metadata, OwnedRoomId, OwnedRoomOrAliasId, OwnedServerName,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: true,
         authentication: AccessToken,
@@ -20,7 +20,7 @@ pub mod v3 {
             unstable => "/_matrix/client/unstable/xyz.amorgan.knock/knock/{room_id_or_alias}",
             1.1 => "/_matrix/client/v3/knock/{room_id_or_alias}",
         }
-    };
+    }
 
     /// Request type for the `knock_room` endpoint.
     #[derive(Clone, Debug)]
@@ -73,8 +73,6 @@ pub mod v3 {
         type EndpointError = crate::Error;
         type IncomingResponse = Response;
 
-        const METADATA: Metadata = METADATA;
-
         fn try_into_http_request<T: Default + bytes::BufMut>(
             self,
             base_url: &str,
@@ -100,8 +98,8 @@ pub mod v3 {
                 serde_html_form::to_string(RequestQuery { server_name, via: self.via })?;
 
             let http_request = http::Request::builder()
-                .method(METADATA.method)
-                .uri(METADATA.make_endpoint_url(
+                .method(Self::METHOD)
+                .uri(Self::make_endpoint_url(
                     considering,
                     base_url,
                     &[&self.room_id_or_alias],
@@ -128,8 +126,6 @@ pub mod v3 {
         type EndpointError = crate::Error;
         type OutgoingResponse = Response;
 
-        const METADATA: Metadata = METADATA;
-
         fn try_from_http_request<B, S>(
             request: http::Request<B>,
             path_args: &[S],
@@ -138,9 +134,9 @@ pub mod v3 {
             B: AsRef<[u8]>,
             S: AsRef<str>,
         {
-            if request.method() != METADATA.method {
+            if request.method() != Self::METHOD {
                 return Err(ruma_common::api::error::FromHttpRequestError::MethodMismatch {
-                    expected: METADATA.method,
+                    expected: Self::METHOD,
                     received: request.method().clone(),
                 });
             }

--- a/crates/ruma-client-api/src/media/create_content.rs
+++ b/crates/ruma-client-api/src/media/create_content.rs
@@ -9,11 +9,11 @@ pub mod v3 {
 
     use http::header::CONTENT_TYPE;
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedMxcUri,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: true,
         authentication: AccessToken,
@@ -21,7 +21,7 @@ pub mod v3 {
             1.0 => "/_matrix/media/r0/upload",
             1.1 => "/_matrix/media/v3/upload",
         }
-    };
+    }
 
     /// Request type for the `create_media_content` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/media/create_content_async.rs
+++ b/crates/ruma-client-api/src/media/create_content_async.rs
@@ -9,11 +9,11 @@ pub mod v3 {
 
     use http::header::CONTENT_TYPE;
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, IdParseError, MxcUri, OwnedServerName,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: PUT,
         rate_limited: true,
         authentication: AccessToken,
@@ -21,7 +21,7 @@ pub mod v3 {
             unstable("fi.mau.msc2246") => "/_matrix/media/unstable/fi.mau.msc2246/upload/{server_name}/{media_id}",
             1.7 => "/_matrix/media/v3/upload/{server_name}/{media_id}",
         }
-    };
+    }
 
     /// Request type for the `create_content_async` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/media/create_mxc_uri.rs
+++ b/crates/ruma-client-api/src/media/create_mxc_uri.rs
@@ -8,11 +8,11 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixmediav1create
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, MilliSecondsSinceUnixEpoch, OwnedMxcUri,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: true,
         authentication: AccessToken,
@@ -20,7 +20,7 @@ pub mod v1 {
             unstable("fi.mau.msc2246") => "/_matrix/media/unstable/fi.mau.msc2246/create",
             1.7 => "/_matrix/media/v1/create",
         }
-    };
+    }
 
     /// Request type for the `create_mxc_uri` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/media/get_content.rs
+++ b/crates/ruma-client-api/src/media/get_content.rs
@@ -11,14 +11,14 @@ pub mod v3 {
 
     use http::header::{CONTENT_DISPOSITION, CONTENT_TYPE};
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         http_headers::ContentDisposition,
         metadata, IdParseError, MxcUri, OwnedServerName,
     };
 
     use crate::http_headers::CROSS_ORIGIN_RESOURCE_POLICY;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: None,
@@ -27,7 +27,7 @@ pub mod v3 {
             1.1 => "/_matrix/media/v3/download/{server_name}/{media_id}",
             1.11 => deprecated,
         }
-    };
+    }
 
     /// Request type for the `get_media_content` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/media/get_content_as_filename.rs
+++ b/crates/ruma-client-api/src/media/get_content_as_filename.rs
@@ -11,14 +11,14 @@ pub mod v3 {
 
     use http::header::{CONTENT_DISPOSITION, CONTENT_TYPE};
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         http_headers::ContentDisposition,
         metadata, IdParseError, MxcUri, OwnedServerName,
     };
 
     use crate::http_headers::CROSS_ORIGIN_RESOURCE_POLICY;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: None,
@@ -27,7 +27,7 @@ pub mod v3 {
             1.1 => "/_matrix/media/v3/download/{server_name}/{media_id}/{filename}",
             1.11 => deprecated,
         }
-    };
+    }
 
     /// Request type for the `get_media_content_as_filename` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/media/get_content_thumbnail.rs
+++ b/crates/ruma-client-api/src/media/get_content_thumbnail.rs
@@ -13,14 +13,14 @@ pub mod v3 {
     use js_int::UInt;
     pub use ruma_common::media::Method;
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         http_headers::ContentDisposition,
         metadata, IdParseError, MxcUri, OwnedServerName,
     };
 
     use crate::http_headers::CROSS_ORIGIN_RESOURCE_POLICY;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: true,
         authentication: None,
@@ -29,7 +29,7 @@ pub mod v3 {
             1.1 => "/_matrix/media/v3/thumbnail/{server_name}/{media_id}",
             1.11 => deprecated,
         }
-    };
+    }
 
     /// Request type for the `get_content_thumbnail` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/media/get_media_config.rs
+++ b/crates/ruma-client-api/src/media/get_media_config.rs
@@ -9,11 +9,11 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: true,
         authentication: AccessToken,
@@ -22,7 +22,7 @@ pub mod v3 {
             1.1 => "/_matrix/media/v3/config",
             1.11 => deprecated,
         }
-    };
+    }
 
     /// Request type for the `get_media_config` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/media/get_media_preview.rs
+++ b/crates/ruma-client-api/src/media/get_media_preview.rs
@@ -8,13 +8,13 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixmediav3preview_url
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, MilliSecondsSinceUnixEpoch,
     };
     use serde::Serialize;
     use serde_json::value::{to_raw_value as to_raw_json_value, RawValue as RawJsonValue};
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: true,
         authentication: AccessToken,
@@ -23,7 +23,7 @@ pub mod v3 {
             1.1 => "/_matrix/media/v3/preview_url",
             1.11 => deprecated,
         }
-    };
+    }
 
     /// Request type for the `get_media_preview` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/membership/ban_user.rs
+++ b/crates/ruma-client-api/src/membership/ban_user.rs
@@ -8,11 +8,11 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidban
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedRoomId, OwnedUserId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: AccessToken,
@@ -20,7 +20,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/rooms/{room_id}/ban",
             1.1 => "/_matrix/client/v3/rooms/{room_id}/ban",
         }
-    };
+    }
 
     /// Request type for the `ban_user` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/membership/forget_room.rs
+++ b/crates/ruma-client-api/src/membership/forget_room.rs
@@ -8,11 +8,11 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidforget
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedRoomId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: true,
         authentication: AccessToken,
@@ -20,7 +20,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/rooms/{room_id}/forget",
             1.1 => "/_matrix/client/v3/rooms/{room_id}/forget",
         }
-    };
+    }
 
     /// Request type for the `forget_room` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/membership/get_member_events.rs
+++ b/crates/ruma-client-api/src/membership/get_member_events.rs
@@ -8,14 +8,14 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3roomsroomidmembers
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         serde::Raw,
         OwnedRoomId,
     };
     use ruma_events::room::member::{MembershipState, RoomMemberEvent};
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
@@ -23,7 +23,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/rooms/{room_id}/members",
             1.1 => "/_matrix/client/v3/rooms/{room_id}/members",
         }
-    };
+    }
 
     /// Request type for the `get_member_events` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/membership/invite_user.rs
+++ b/crates/ruma-client-api/src/membership/invite_user.rs
@@ -13,14 +13,14 @@ pub mod v3 {
     //! [spec-3pid]: https://spec.matrix.org/latest/client-server-api/#thirdparty_post_matrixclientv3roomsroomidinvite
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedRoomId, OwnedUserId,
     };
     use serde::{Deserialize, Serialize};
 
     use crate::membership::Invite3pid;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: true,
         authentication: AccessToken,
@@ -28,7 +28,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/rooms/{room_id}/invite",
             1.1 => "/_matrix/client/v3/rooms/{room_id}/invite",
         }
-    };
+    }
 
     /// Request type for the `invite_user` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/membership/join_room_by_id.rs
+++ b/crates/ruma-client-api/src/membership/join_room_by_id.rs
@@ -8,13 +8,13 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidjoin
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedRoomId,
     };
 
     use crate::membership::ThirdPartySigned;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: true,
         authentication: AccessToken,
@@ -22,7 +22,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/rooms/{room_id}/join",
             1.1 => "/_matrix/client/v3/rooms/{room_id}/join",
         }
-    };
+    }
 
     /// Request type for the `join_room_by_id` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
+++ b/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
@@ -14,7 +14,7 @@ pub mod v3 {
 
     use crate::membership::ThirdPartySigned;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: true,
         authentication: AccessToken,
@@ -22,7 +22,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/join/{room_id_or_alias}",
             1.1 => "/_matrix/client/v3/join/{room_id_or_alias}",
         }
-    };
+    }
 
     /// Request type for the `join_room_by_id_or_alias` endpoint.
     #[derive(Clone, Debug)]
@@ -84,8 +84,6 @@ pub mod v3 {
         type EndpointError = crate::Error;
         type IncomingResponse = Response;
 
-        const METADATA: Metadata = METADATA;
-
         fn try_into_http_request<T: Default + bytes::BufMut>(
             self,
             base_url: &str,
@@ -111,8 +109,8 @@ pub mod v3 {
                 serde_html_form::to_string(RequestQuery { server_name, via: self.via })?;
 
             let http_request = http::Request::builder()
-                .method(METADATA.method)
-                .uri(METADATA.make_endpoint_url(
+                .method(Self::METHOD)
+                .uri(Self::make_endpoint_url(
                     considering,
                     base_url,
                     &[&self.room_id_or_alias],
@@ -142,8 +140,6 @@ pub mod v3 {
         type EndpointError = crate::Error;
         type OutgoingResponse = Response;
 
-        const METADATA: Metadata = METADATA;
-
         fn try_from_http_request<B, S>(
             request: http::Request<B>,
             path_args: &[S],
@@ -152,9 +148,9 @@ pub mod v3 {
             B: AsRef<[u8]>,
             S: AsRef<str>,
         {
-            if request.method() != METADATA.method {
+            if request.method() != Self::METHOD {
                 return Err(ruma_common::api::error::FromHttpRequestError::MethodMismatch {
-                    expected: METADATA.method,
+                    expected: Self::METHOD,
                     received: request.method().clone(),
                 });
             }

--- a/crates/ruma-client-api/src/membership/joined_members.rs
+++ b/crates/ruma-client-api/src/membership/joined_members.rs
@@ -11,12 +11,12 @@ pub mod v3 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedMxcUri, OwnedRoomId, OwnedUserId,
     };
     use serde::{Deserialize, Serialize};
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
@@ -24,7 +24,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/rooms/{room_id}/joined_members",
             1.1 => "/_matrix/client/v3/rooms/{room_id}/joined_members",
         }
-    };
+    }
 
     /// Request type for the `joined_members` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/membership/joined_rooms.rs
+++ b/crates/ruma-client-api/src/membership/joined_rooms.rs
@@ -8,11 +8,11 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3joined_rooms
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedRoomId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
@@ -20,7 +20,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/joined_rooms",
             1.1 => "/_matrix/client/v3/joined_rooms",
         }
-    };
+    }
 
     /// Request type for the `joined_rooms` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/membership/kick_user.rs
+++ b/crates/ruma-client-api/src/membership/kick_user.rs
@@ -8,11 +8,11 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidkick
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedRoomId, OwnedUserId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: AccessToken,
@@ -20,7 +20,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/rooms/{room_id}/kick",
             1.1 => "/_matrix/client/v3/rooms/{room_id}/kick",
         }
-    };
+    }
 
     /// Request type for the `kick_user` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/membership/leave_room.rs
+++ b/crates/ruma-client-api/src/membership/leave_room.rs
@@ -8,11 +8,11 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidleave
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedRoomId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: true,
         authentication: AccessToken,
@@ -20,7 +20,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/rooms/{room_id}/leave",
             1.1 => "/_matrix/client/v3/rooms/{room_id}/leave",
         }
-    };
+    }
 
     /// Request type for the `leave_room` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/membership/mutual_rooms.rs
+++ b/crates/ruma-client-api/src/membership/mutual_rooms.rs
@@ -8,18 +8,18 @@ pub mod unstable {
     //! [spec]: https://github.com/matrix-org/matrix-spec-proposals/blob/hs/shared-rooms/proposals/2666-get-rooms-in-common.md
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedRoomId, OwnedUserId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: true,
         authentication: AccessToken,
         history: {
             unstable("uk.half-shot.msc2666.query_mutual_rooms") => "/_matrix/client/unstable/uk.half-shot.msc2666/user/mutual_rooms",
         }
-    };
+    }
 
     /// Request type for the `mutual_rooms` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/membership/unban_user.rs
+++ b/crates/ruma-client-api/src/membership/unban_user.rs
@@ -8,11 +8,11 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidunban
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedRoomId, OwnedUserId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: AccessToken,
@@ -20,7 +20,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/rooms/{room_id}/unban",
             1.1 => "/_matrix/client/v3/rooms/{room_id}/unban",
         }
-    };
+    }
 
     /// Request type for the `unban_user` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/message/get_message_events.rs
+++ b/crates/ruma-client-api/src/message/get_message_events.rs
@@ -9,7 +9,7 @@ pub mod v3 {
 
     use js_int::{uint, UInt};
     use ruma_common::{
-        api::{request, response, Direction, Metadata},
+        api::{request, response, Direction},
         metadata,
         serde::Raw,
         OwnedRoomId,
@@ -18,7 +18,7 @@ pub mod v3 {
 
     use crate::filter::RoomEventFilter;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
@@ -26,7 +26,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/rooms/{room_id}/messages",
             1.1 => "/_matrix/client/v3/rooms/{room_id}/messages",
         }
-    };
+    }
 
     /// Request type for the `get_message_events` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/message/send_message_event.rs
+++ b/crates/ruma-client-api/src/message/send_message_event.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3roomsroomidsendeventtypetxnid
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         serde::Raw,
         MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedTransactionId,
@@ -16,7 +16,7 @@ pub mod v3 {
     use ruma_events::{AnyMessageLikeEventContent, MessageLikeEventContent, MessageLikeEventType};
     use serde_json::value::to_raw_value as to_raw_json_value;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: PUT,
         rate_limited: false,
         authentication: AccessToken,
@@ -24,7 +24,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/rooms/{room_id}/send/{event_type}/{txn_id}",
             1.1 => "/_matrix/client/v3/rooms/{room_id}/send/{event_type}/{txn_id}",
         }
-    };
+    }
 
     /// Request type for the `create_message_event` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/peeking/get_current_state.rs
+++ b/crates/ruma-client-api/src/peeking/get_current_state.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3roomsroomidinitialsync
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         serde::Raw,
         OwnedRoomId,
@@ -20,7 +20,7 @@ pub mod v3 {
 
     use crate::room::Visibility;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
@@ -28,7 +28,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/rooms/{room_id}/initialSync",
             1.1 => "/_matrix/client/v3/rooms/{room_id}/initialSync",
         }
-    };
+    }
 
     /// Request type for the `get_current_state` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/peeking/listen_to_new_events.rs
+++ b/crates/ruma-client-api/src/peeking/listen_to_new_events.rs
@@ -10,14 +10,14 @@ pub mod v3 {
     use std::time::Duration;
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         serde::Raw,
         OwnedRoomId,
     };
     use ruma_events::AnyTimelineEvent;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
@@ -25,7 +25,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/events",
             1.1 => "/_matrix/client/v3/events",
         }
-    };
+    }
 
     /// Request type for the `listen_to_new_events` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/presence/get_presence.rs
+++ b/crates/ruma-client-api/src/presence/get_presence.rs
@@ -10,13 +10,13 @@ pub mod v3 {
     use std::time::Duration;
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         presence::PresenceState,
         OwnedUserId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
@@ -24,7 +24,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/presence/{user_id}/status",
             1.1 => "/_matrix/client/v3/presence/{user_id}/status",
         }
-    };
+    }
 
     /// Request type for the `get_presence` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/presence/set_presence.rs
+++ b/crates/ruma-client-api/src/presence/set_presence.rs
@@ -8,13 +8,13 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3presenceuseridstatus
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         presence::PresenceState,
         OwnedUserId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: PUT,
         rate_limited: true,
         authentication: AccessToken,
@@ -22,7 +22,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/presence/{user_id}/status",
             1.1 => "/_matrix/client/v3/presence/{user_id}/status",
         }
-    };
+    }
 
     /// Request type for the `set_presence` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/profile/delete_profile_field.rs
+++ b/crates/ruma-client-api/src/profile/delete_profile_field.rs
@@ -8,13 +8,13 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#delete_matrixclientv3profileuseridkeyname
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedUserId,
     };
 
     use crate::profile::ProfileFieldName;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: DELETE,
         rate_limited: true,
         authentication: AccessToken,
@@ -22,7 +22,7 @@ pub mod v3 {
             unstable("uk.tcpip.msc4133") => "/_matrix/client/unstable/uk.tcpip.msc4133/profile/{user_id}/{field}",
             1.16 => "/_matrix/client/v3/profile/{user_id}/{field}",
         }
-    };
+    }
 
     /// Request type for the `delete_profile_field` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/profile/get_avatar_url.rs
+++ b/crates/ruma-client-api/src/profile/get_avatar_url.rs
@@ -8,11 +8,11 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/v1.15/client-server-api/#get_matrixclientv3profileuseridavatar_url
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedMxcUri, OwnedUserId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: None,
@@ -20,7 +20,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/profile/{user_id}/avatar_url",
             1.1 => "/_matrix/client/v3/profile/{user_id}/avatar_url",
         }
-    };
+    }
 
     /// Request type for the `get_avatar_url` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/profile/get_display_name.rs
+++ b/crates/ruma-client-api/src/profile/get_display_name.rs
@@ -8,11 +8,11 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/v1.15/client-server-api/#get_matrixclientv3profileuseriddisplayname
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedUserId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: None,
@@ -20,7 +20,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/profile/{user_id}/displayname",
             1.1 => "/_matrix/client/v3/profile/{user_id}/displayname",
         }
-    };
+    }
 
     /// Request type for the `get_display_name` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/profile/get_profile.rs
+++ b/crates/ruma-client-api/src/profile/get_profile.rs
@@ -10,14 +10,14 @@ pub mod v3 {
     use std::collections::{btree_map, BTreeMap};
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedUserId,
     };
     use serde_json::Value as JsonValue;
 
     use crate::profile::{ProfileFieldName, ProfileFieldValue, StaticProfileField};
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: None,
@@ -25,7 +25,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/profile/{user_id}",
             1.1 => "/_matrix/client/v3/profile/{user_id}",
         }
-    };
+    }
 
     /// Request type for the `get_profile` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/profile/set_avatar_url.rs
+++ b/crates/ruma-client-api/src/profile/set_avatar_url.rs
@@ -8,11 +8,11 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/v1.15/client-server-api/#put_matrixclientv3profileuseridavatar_url
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedMxcUri, OwnedUserId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: PUT,
         rate_limited: true,
         authentication: AccessToken,
@@ -20,7 +20,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/profile/{user_id}/avatar_url",
             1.1 => "/_matrix/client/v3/profile/{user_id}/avatar_url",
         }
-    };
+    }
 
     /// Request type for the `set_avatar_url` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/profile/set_display_name.rs
+++ b/crates/ruma-client-api/src/profile/set_display_name.rs
@@ -8,11 +8,11 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/v1.15/client-server-api/#put_matrixclientv3profileuseriddisplayname
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedUserId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: PUT,
         rate_limited: true,
         authentication: AccessToken,
@@ -20,7 +20,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/profile/{user_id}/displayname",
             1.1 => "/_matrix/client/v3/profile/{user_id}/displayname",
         }
-    };
+    }
 
     /// Request type for the `set_display_name` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/profile/set_profile_field.rs
+++ b/crates/ruma-client-api/src/profile/set_profile_field.rs
@@ -20,7 +20,7 @@ pub mod v3 {
 
     use crate::profile::{profile_field_serde::ProfileFieldValueVisitor, ProfileFieldValue};
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: PUT,
         rate_limited: true,
         authentication: AccessToken,
@@ -30,7 +30,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/profile/{user_id}/{field}",
             1.1 => "/_matrix/client/v3/profile/{user_id}/{field}",
         }
-    };
+    }
 
     /// Request type for the `set_profile_field` endpoint.
     #[derive(Debug, Clone)]
@@ -55,8 +55,6 @@ pub mod v3 {
         type EndpointError = crate::Error;
         type IncomingResponse = Response;
 
-        const METADATA: Metadata = METADATA;
-
         fn try_into_http_request<T: Default + bytes::BufMut>(
             self,
             base_url: &str,
@@ -68,7 +66,7 @@ pub mod v3 {
             let field = self.value.field_name();
 
             let url = if field.existed_before_extended_profiles() {
-                METADATA.make_endpoint_url(considering, base_url, &[&self.user_id, &field], "")?
+                Self::make_endpoint_url(considering, base_url, &[&self.user_id, &field], "")?
             } else {
                 crate::profile::EXTENDED_PROFILE_FIELD_HISTORY.make_endpoint_url(
                     considering,
@@ -79,7 +77,7 @@ pub mod v3 {
             };
 
             let http_request = http::Request::builder()
-                .method(METADATA.method)
+                .method(Self::METHOD)
                 .uri(url)
                 .header(header::CONTENT_TYPE, "application/json")
                 .header(
@@ -104,8 +102,6 @@ pub mod v3 {
     impl ruma_common::api::IncomingRequest for Request {
         type EndpointError = crate::Error;
         type OutgoingResponse = Response;
-
-        const METADATA: Metadata = METADATA;
 
         fn try_from_http_request<B, S>(
             request: http::Request<B>,

--- a/crates/ruma-client-api/src/push/delete_pushrule.rs
+++ b/crates/ruma-client-api/src/push/delete_pushrule.rs
@@ -8,13 +8,13 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#delete_matrixclientv3pushrulesglobalkindruleid
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
     };
 
     use crate::push::RuleKind;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: DELETE,
         rate_limited: false,
         authentication: AccessToken,
@@ -22,7 +22,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/pushrules/global/{kind}/{rule_id}",
             1.1 => "/_matrix/client/v3/pushrules/global/{kind}/{rule_id}",
         }
-    };
+    }
 
     /// Request type for the `delete_pushrule` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/push/get_notifications.rs
+++ b/crates/ruma-client-api/src/push/get_notifications.rs
@@ -9,7 +9,7 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         push::Action,
         serde::Raw,
@@ -18,7 +18,7 @@ pub mod v3 {
     use ruma_events::AnySyncTimelineEvent;
     use serde::{Deserialize, Serialize};
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
@@ -26,7 +26,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/notifications",
             1.1 => "/_matrix/client/v3/notifications",
         }
-    };
+    }
 
     /// Request type for the `get_notifications` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/push/get_pushers.rs
+++ b/crates/ruma-client-api/src/push/get_pushers.rs
@@ -8,13 +8,13 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3pushers
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
     };
 
     use crate::push::Pusher;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
@@ -22,7 +22,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/pushers",
             1.1 => "/_matrix/client/v3/pushers",
         }
-    };
+    }
 
     /// Request type for the `get_pushers` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/push/get_pushrule.rs
+++ b/crates/ruma-client-api/src/push/get_pushrule.rs
@@ -8,13 +8,13 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3pushrulesglobalkindruleid
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
     };
 
     use crate::push::{PushRule, RuleKind};
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
@@ -22,7 +22,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/pushrules/global/{kind}/{rule_id}",
             1.1 => "/_matrix/client/v3/pushrules/global/{kind}/{rule_id}",
         }
-    };
+    }
 
     /// Request type for the `get_pushrule` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/push/get_pushrule_actions.rs
+++ b/crates/ruma-client-api/src/push/get_pushrule_actions.rs
@@ -8,14 +8,14 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3pushrulesglobalkindruleidactions
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         push::Action,
     };
 
     use crate::push::RuleKind;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
@@ -23,7 +23,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/pushrules/global/{kind}/{rule_id}/actions",
             1.1 => "/_matrix/client/v3/pushrules/global/{kind}/{rule_id}/actions",
         }
-    };
+    }
 
     /// Request type for the `get_pushrule_actions` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/push/get_pushrule_enabled.rs
+++ b/crates/ruma-client-api/src/push/get_pushrule_enabled.rs
@@ -8,13 +8,13 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3pushrulesglobalkindruleidenabled
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
     };
 
     use crate::push::RuleKind;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
@@ -22,7 +22,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/pushrules/global/{kind}/{rule_id}/enabled",
             1.1 => "/_matrix/client/v3/pushrules/global/{kind}/{rule_id}/enabled",
         }
-    };
+    }
 
     /// Request type for the `get_pushrule_enabled` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/push/get_pushrules_all.rs
+++ b/crates/ruma-client-api/src/push/get_pushrules_all.rs
@@ -8,12 +8,12 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3pushrules
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         push::Ruleset,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
@@ -21,7 +21,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/pushrules/",
             1.1 => "/_matrix/client/v3/pushrules/",
         }
-    };
+    }
 
     /// Request type for the `get_pushrules_all` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/push/get_pushrules_global_scope.rs
+++ b/crates/ruma-client-api/src/push/get_pushrules_global_scope.rs
@@ -8,12 +8,12 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3pushrulesglobal
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         push::Ruleset,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
@@ -21,7 +21,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/pushrules/global/",
             1.1 => "/_matrix/client/v3/pushrules/global/",
         }
-    };
+    }
 
     /// Request type for the `get_pushrules_global_scope` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/push/set_pusher.rs
+++ b/crates/ruma-client-api/src/push/set_pusher.rs
@@ -10,14 +10,14 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3pushersset
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
     };
     use serde::Serialize;
 
     use crate::push::{Pusher, PusherIds};
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: true,
         authentication: AccessToken,
@@ -25,7 +25,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/pushers/set",
             1.1 => "/_matrix/client/v3/pushers/set",
         }
-    };
+    }
 
     /// Request type for the `set_pusher` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/push/set_pushrule.rs
+++ b/crates/ruma-client-api/src/push/set_pushrule.rs
@@ -14,7 +14,7 @@ pub mod v3 {
     };
     use serde::{Deserialize, Serialize};
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: PUT,
         rate_limited: true,
         authentication: AccessToken,
@@ -22,7 +22,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/pushrules/global/{kind}/{rule_id}",
             1.1 => "/_matrix/client/v3/pushrules/global/{kind}/{rule_id}",
         }
-    };
+    }
 
     /// Request type for the `set_pushrule` endpoint.
     #[derive(Clone, Debug)]
@@ -64,8 +64,6 @@ pub mod v3 {
         type EndpointError = crate::Error;
         type IncomingResponse = Response;
 
-        const METADATA: Metadata = METADATA;
-
         fn try_into_http_request<T: Default + bytes::BufMut>(
             self,
             base_url: &str,
@@ -79,7 +77,7 @@ pub mod v3 {
                 after: self.after,
             })?;
 
-            let url = METADATA.make_endpoint_url(
+            let url = Self::make_endpoint_url(
                 considering,
                 base_url,
                 &[&self.rule.kind(), &self.rule.rule_id()],
@@ -89,7 +87,7 @@ pub mod v3 {
             let body: RequestBody = self.rule.into();
 
             http::Request::builder()
-                .method(METADATA.method)
+                .method(Self::METHOD)
                 .uri(url)
                 .header(header::CONTENT_TYPE, "application/json")
                 .header(
@@ -110,8 +108,6 @@ pub mod v3 {
     impl ruma_common::api::IncomingRequest for Request {
         type EndpointError = crate::Error;
         type OutgoingResponse = Response;
-
-        const METADATA: Metadata = METADATA;
 
         fn try_from_http_request<B, S>(
             request: http::Request<B>,

--- a/crates/ruma-client-api/src/push/set_pushrule_actions.rs
+++ b/crates/ruma-client-api/src/push/set_pushrule_actions.rs
@@ -9,14 +9,14 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3pushrulesglobalkindruleidactions
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         push::Action,
     };
 
     use crate::push::RuleKind;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: PUT,
         rate_limited: false,
         authentication: AccessToken,
@@ -24,7 +24,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/pushrules/global/{kind}/{rule_id}/actions",
             1.1 => "/_matrix/client/v3/pushrules/global/{kind}/{rule_id}/actions",
         }
-    };
+    }
 
     /// Request type for the `set_pushrule_actions` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/push/set_pushrule_enabled.rs
+++ b/crates/ruma-client-api/src/push/set_pushrule_enabled.rs
@@ -8,13 +8,13 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3pushrulesglobalkindruleidenabled
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
     };
 
     use crate::push::RuleKind;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: PUT,
         rate_limited: false,
         authentication: AccessToken,
@@ -22,7 +22,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/pushrules/global/{kind}/{rule_id}/enabled",
             1.1 => "/_matrix/client/v3/pushrules/global/{kind}/{rule_id}/enabled",
         }
-    };
+    }
 
     /// Request type for the `set_pushrule_enabled` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/read_marker/set_read_marker.rs
+++ b/crates/ruma-client-api/src/read_marker/set_read_marker.rs
@@ -13,11 +13,11 @@ pub mod v3 {
     //! [`create_receipt`]: crate::receipt::create_receipt
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedEventId, OwnedRoomId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: true,
         authentication: AccessToken,
@@ -25,7 +25,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/rooms/{room_id}/read_markers",
             1.1 => "/_matrix/client/v3/rooms/{room_id}/read_markers",
         }
-    };
+    }
 
     /// Request type for the `set_read_marker` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/receipt/create_receipt.rs
+++ b/crates/ruma-client-api/src/receipt/create_receipt.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidreceiptreceipttypeeventid
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         serde::StringEnum,
         OwnedEventId, OwnedRoomId,
@@ -17,7 +17,7 @@ pub mod v3 {
 
     use crate::PrivOwnedStr;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: true,
         authentication: AccessToken,
@@ -25,7 +25,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/rooms/{room_id}/receipt/{receipt_type}/{event_id}",
             1.1 => "/_matrix/client/v3/rooms/{room_id}/receipt/{receipt_type}/{event_id}",
         }
-    };
+    }
 
     /// Request type for the `create_receipt` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/redact/redact_event.rs
+++ b/crates/ruma-client-api/src/redact/redact_event.rs
@@ -8,11 +8,11 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3roomsroomidredacteventidtxnid
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedEventId, OwnedRoomId, OwnedTransactionId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: PUT,
         rate_limited: false,
         authentication: AccessToken,
@@ -20,7 +20,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/rooms/{room_id}/redact/{event_id}/{txn_id}",
             1.1 => "/_matrix/client/v3/rooms/{room_id}/redact/{event_id}/{txn_id}",
         }
-    };
+    }
 
     /// Request type for the `redact_event` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/relations/get_relating_events.rs
+++ b/crates/ruma-client-api/src/relations/get_relating_events.rs
@@ -9,14 +9,14 @@ pub mod v1 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response, Direction, Metadata},
+        api::{request, response, Direction},
         metadata,
         serde::Raw,
         OwnedEventId, OwnedRoomId,
     };
     use ruma_events::AnyMessageLikeEvent;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
@@ -24,7 +24,7 @@ pub mod v1 {
             unstable => "/_matrix/client/unstable/rooms/{room_id}/relations/{event_id}",
             1.3 => "/_matrix/client/v1/rooms/{room_id}/relations/{event_id}",
         }
-    };
+    }
 
     /// Request type for the `get_relating_events` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/relations/get_relating_events_with_rel_type.rs
+++ b/crates/ruma-client-api/src/relations/get_relating_events_with_rel_type.rs
@@ -10,14 +10,14 @@ pub mod v1 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response, Direction, Metadata},
+        api::{request, response, Direction},
         metadata,
         serde::Raw,
         OwnedEventId, OwnedRoomId,
     };
     use ruma_events::{relation::RelationType, AnyMessageLikeEvent};
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
@@ -25,7 +25,7 @@ pub mod v1 {
             unstable => "/_matrix/client/unstable/rooms/{room_id}/relations/{event_id}/{rel_type}",
             1.3 => "/_matrix/client/v1/rooms/{room_id}/relations/{event_id}/{rel_type}",
         }
-    };
+    }
 
     /// Request type for the `get_relating_events_with_rel_type` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/relations/get_relating_events_with_rel_type_and_event_type.rs
+++ b/crates/ruma-client-api/src/relations/get_relating_events_with_rel_type_and_event_type.rs
@@ -10,14 +10,14 @@ pub mod v1 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response, Direction, Metadata},
+        api::{request, response, Direction},
         metadata,
         serde::Raw,
         OwnedEventId, OwnedRoomId,
     };
     use ruma_events::{relation::RelationType, AnyMessageLikeEvent, TimelineEventType};
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
@@ -25,7 +25,7 @@ pub mod v1 {
             unstable => "/_matrix/client/unstable/rooms/{room_id}/relations/{event_id}/{rel_type}/{event_type}",
             1.3 => "/_matrix/client/v1/rooms/{room_id}/relations/{event_id}/{rel_type}/{event_type}",
         }
-    };
+    }
 
     /// Request type for the `get_relating_events_with_rel_type_and_event_type` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/rendezvous/create_rendezvous_session.rs
+++ b/crates/ruma-client-api/src/rendezvous/create_rendezvous_session.rs
@@ -21,14 +21,14 @@ pub mod unstable {
     use url::Url;
     use web_time::SystemTime;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: true,
         authentication: None,
         history: {
             unstable("org.matrix.msc4108") => "/_matrix/client/unstable/org.matrix.msc4108/rendezvous",
         }
-    };
+    }
 
     /// Request type for the `POST` `rendezvous` endpoint.
     #[derive(Debug, Default, Clone)]
@@ -42,7 +42,6 @@ pub mod unstable {
     impl ruma_common::api::OutgoingRequest for Request {
         type EndpointError = crate::Error;
         type IncomingResponse = Response;
-        const METADATA: Metadata = METADATA;
 
         fn try_into_http_request<T: Default + bytes::BufMut>(
             self,
@@ -50,12 +49,12 @@ pub mod unstable {
             _: ruma_common::api::SendAccessToken<'_>,
             considering: &'_ ruma_common::api::SupportedVersions,
         ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
-            let url = METADATA.make_endpoint_url(considering, base_url, &[], "")?;
+            let url = Self::make_endpoint_url(considering, base_url, &[], "")?;
             let body = self.content.as_bytes();
             let content_length = body.len();
 
             Ok(http::Request::builder()
-                .method(METADATA.method)
+                .method(Self::METHOD)
                 .uri(url)
                 .header(CONTENT_TYPE, "text/plain")
                 .header(CONTENT_LENGTH, content_length)
@@ -67,7 +66,6 @@ pub mod unstable {
     impl ruma_common::api::IncomingRequest for Request {
         type EndpointError = crate::Error;
         type OutgoingResponse = Response;
-        const METADATA: Metadata = METADATA;
 
         fn try_from_http_request<B, S>(
             request: http::Request<B>,

--- a/crates/ruma-client-api/src/reporting/report_user.rs
+++ b/crates/ruma-client-api/src/reporting/report_user.rs
@@ -8,11 +8,11 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3usersuseridreport
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedUserId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: true,
         authentication: AccessToken,
@@ -20,7 +20,7 @@ pub mod v3 {
             unstable => "/_matrix/client/unstable/org.matrix.msc4260/users/{user_id}/report",
             1.14 => "/_matrix/client/v3/users/{user_id}/report",
         }
-    };
+    }
 
     /// Request type for the `report_user` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/room/aliases.rs
+++ b/crates/ruma-client-api/src/room/aliases.rs
@@ -8,11 +8,11 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3roomsroomidaliases
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedRoomAliasId, OwnedRoomId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: true,
         authentication: AccessToken,
@@ -21,7 +21,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/rooms/{room_id}/aliases",
             1.1 => "/_matrix/client/v3/rooms/{room_id}/aliases",
         }
-    };
+    }
 
     /// Request type for the `aliases` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/room/create_room.rs
+++ b/crates/ruma-client-api/src/room/create_room.rs
@@ -9,7 +9,7 @@ pub mod v3 {
 
     use assign::assign;
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         room::RoomType,
         serde::{Raw, StringEnum},
@@ -26,7 +26,7 @@ pub mod v3 {
 
     use crate::{membership::Invite3pid, room::Visibility, PrivOwnedStr};
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: AccessToken,
@@ -34,7 +34,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/createRoom",
             1.1 => "/_matrix/client/v3/createRoom",
         }
-    };
+    }
 
     /// Request type for the `create_room` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/room/get_event_by_timestamp.rs
+++ b/crates/ruma-client-api/src/room/get_event_by_timestamp.rs
@@ -8,11 +8,11 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv1roomsroomidtimestamp_to_event
 
     use ruma_common::{
-        api::{request, response, Direction, Metadata},
+        api::{request, response, Direction},
         metadata, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: true,
         authentication: AccessToken,
@@ -20,7 +20,7 @@ pub mod v1 {
             unstable("org.matrix.msc3030") => "/_matrix/client/unstable/org.matrix.msc3030/rooms/{room_id}/timestamp_to_event",
             1.6 => "/_matrix/client/v1/rooms/{room_id}/timestamp_to_event",
         }
-    };
+    }
 
     /// Request type for the `get_event_by_timestamp` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/room/get_room_event.rs
+++ b/crates/ruma-client-api/src/room/get_room_event.rs
@@ -8,14 +8,14 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3roomsroomideventeventid
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         serde::Raw,
         OwnedEventId, OwnedRoomId,
     };
     use ruma_events::AnyTimelineEvent;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
@@ -23,7 +23,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/rooms/{room_id}/event/{event_id}",
             1.1 => "/_matrix/client/v3/rooms/{room_id}/event/{event_id}",
         }
-    };
+    }
 
     /// Request type for the `get_room_event` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/room/get_summary.rs
+++ b/crates/ruma-client-api/src/room/get_summary.rs
@@ -8,14 +8,11 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv1room_summaryroomidoralias
 
     use ruma_common::{
-        api::{request, Metadata},
-        metadata,
-        room::RoomSummary,
-        OwnedRoomOrAliasId, OwnedServerName,
+        api::request, metadata, room::RoomSummary, OwnedRoomOrAliasId, OwnedServerName,
     };
     use ruma_events::room::member::MembershipState;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessTokenOptional,
@@ -23,7 +20,7 @@ pub mod v1 {
             unstable => "/_matrix/client/unstable/im.nheko.summary/rooms/{room_id_or_alias}/summary",
             1.15 => "/_matrix/client/v1/room_summary/{room_id_or_alias}",
         }
-    };
+    }
 
     /// Request type for the `get_summary` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/room/report_content.rs
+++ b/crates/ruma-client-api/src/room/report_content.rs
@@ -9,11 +9,11 @@ pub mod v3 {
 
     use js_int::Int;
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedEventId, OwnedRoomId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: AccessToken,
@@ -21,7 +21,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/rooms/{room_id}/report/{event_id}",
             1.1 => "/_matrix/client/v3/rooms/{room_id}/report/{event_id}",
         }
-    };
+    }
 
     /// Request type for the `report_content` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/room/report_room.rs
+++ b/crates/ruma-client-api/src/room/report_room.rs
@@ -8,11 +8,11 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidreport
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedRoomId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: true,
         authentication: AccessToken,
@@ -20,7 +20,7 @@ pub mod v3 {
             unstable => "/_matrix/client/unstable/org.matrix.msc4151/rooms/{room_id}/report",
             1.13 => "/_matrix/client/v3/rooms/{room_id}/report",
         }
-    };
+    }
 
     /// Request type for the `report_room` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/room/upgrade_room.rs
+++ b/crates/ruma-client-api/src/room/upgrade_room.rs
@@ -8,11 +8,11 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidupgrade
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedRoomId, OwnedUserId, RoomVersionId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: AccessToken,
@@ -20,7 +20,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/rooms/{room_id}/upgrade",
             1.1 => "/_matrix/client/v3/rooms/{room_id}/upgrade",
         }
-    };
+    }
 
     /// Request type for the `upgrade_room` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/search/search_events.rs
+++ b/crates/ruma-client-api/src/search/search_events.rs
@@ -11,7 +11,7 @@ pub mod v3 {
 
     use js_int::{uint, UInt};
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         serde::{Raw, StringEnum},
         OwnedEventId, OwnedMxcUri, OwnedRoomId, OwnedUserId,
@@ -21,7 +21,7 @@ pub mod v3 {
 
     use crate::{filter::RoomEventFilter, PrivOwnedStr};
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: true,
         authentication: AccessToken,
@@ -29,7 +29,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/search",
             1.1 => "/_matrix/client/v3/search",
         }
-    };
+    }
 
     /// Request type for the `search` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/server/get_user_info.rs
+++ b/crates/ruma-client-api/src/server/get_user_info.rs
@@ -10,12 +10,12 @@ pub mod v3 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, MilliSecondsSinceUnixEpoch, OwnedUserId,
     };
     use serde::{Deserialize, Serialize};
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
@@ -23,7 +23,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/admin/whois/{user_id}",
             1.1 => "/_matrix/client/v3/admin/whois/{user_id}",
         }
-    };
+    }
 
     /// Request type for the `get_user_info` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/session/get_login_token.rs
+++ b/crates/ruma-client-api/src/session/get_login_token.rs
@@ -10,13 +10,13 @@ pub mod v1 {
     use std::time::Duration;
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
     };
 
     use crate::uiaa::{AuthData, UiaaResponse};
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: true,
         authentication: AccessToken,
@@ -24,7 +24,7 @@ pub mod v1 {
             unstable("org.matrix.msc3882") => "/_matrix/client/unstable/org.matrix.msc3882/login/get_token",
             1.7 => "/_matrix/client/v1/login/get_token",
         }
-    };
+    }
 
     /// Request type for the `login` endpoint.
     #[request(error = UiaaResponse)]

--- a/crates/ruma-client-api/src/session/get_login_types.rs
+++ b/crates/ruma-client-api/src/session/get_login_types.rs
@@ -11,7 +11,7 @@ pub mod v3 {
     use std::borrow::Cow;
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         serde::{JsonObject, StringEnum},
         OwnedMxcUri,
@@ -21,7 +21,7 @@ pub mod v3 {
 
     use crate::PrivOwnedStr;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: true,
         authentication: None,
@@ -29,7 +29,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/login",
             1.1 => "/_matrix/client/v3/login",
         }
-    };
+    }
 
     /// Request type for the `get_login_types` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/session/login.rs
+++ b/crates/ruma-client-api/src/session/login.rs
@@ -10,7 +10,7 @@ pub mod v3 {
     use std::{fmt, time::Duration};
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         serde::JsonObject,
         OwnedDeviceId, OwnedServerName, OwnedUserId,
@@ -23,7 +23,7 @@ pub mod v3 {
 
     use crate::uiaa::UserIdentifier;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: true,
         authentication: AppserviceTokenOptional,
@@ -31,7 +31,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/login",
             1.1 => "/_matrix/client/v3/login",
         }
-    };
+    }
 
     /// Request type for the `login` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/session/login_fallback.rs
+++ b/crates/ruma-client-api/src/session/login_fallback.rs
@@ -4,19 +4,16 @@
 //!
 //! [spec]: https://spec.matrix.org/latest/client-server-api/#login-fallback
 
-use ruma_common::{
-    api::{request, Metadata},
-    metadata, OwnedDeviceId,
-};
+use ruma_common::{api::request, metadata, OwnedDeviceId};
 
-const METADATA: Metadata = metadata! {
+metadata! {
     method: GET,
     rate_limited: false,
     authentication: None,
     history: {
         1.0 => "/_matrix/static/client/login/",
     }
-};
+}
 
 /// Request type for the `login_fallback` endpoint.
 #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/session/logout.rs
+++ b/crates/ruma-client-api/src/session/logout.rs
@@ -12,7 +12,7 @@ pub mod v3 {
         metadata,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: AccessToken,
@@ -20,7 +20,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/logout",
             1.1 => "/_matrix/client/v3/logout",
         }
-    };
+    }
 
     /// Request type for the `logout` endpoint.
     #[derive(Debug, Clone, Default)]
@@ -39,18 +39,16 @@ pub mod v3 {
         type EndpointError = crate::Error;
         type IncomingResponse = Response;
 
-        const METADATA: Metadata = METADATA;
-
         fn try_into_http_request<T: Default + bytes::BufMut>(
             self,
             base_url: &str,
             access_token: ruma_common::api::SendAccessToken<'_>,
             considering: &'_ ruma_common::api::SupportedVersions,
         ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
-            let url = METADATA.make_endpoint_url(considering, base_url, &[], "")?;
+            let url = Self::make_endpoint_url(considering, base_url, &[], "")?;
 
             http::Request::builder()
-                .method(METADATA.method)
+                .method(Self::METHOD)
                 .uri(url)
                 .header(
                     http::header::AUTHORIZATION,
@@ -71,8 +69,6 @@ pub mod v3 {
         type EndpointError = crate::Error;
         type OutgoingResponse = Response;
 
-        const METADATA: Metadata = METADATA;
-
         fn try_from_http_request<B, S>(
             request: http::Request<B>,
             _path_args: &[S],
@@ -81,9 +77,9 @@ pub mod v3 {
             B: AsRef<[u8]>,
             S: AsRef<str>,
         {
-            if request.method() != METADATA.method {
+            if request.method() != Self::METHOD {
                 return Err(ruma_common::api::error::FromHttpRequestError::MethodMismatch {
-                    expected: METADATA.method,
+                    expected: Self::METHOD,
                     received: request.method().clone(),
                 });
             }

--- a/crates/ruma-client-api/src/session/logout_all.rs
+++ b/crates/ruma-client-api/src/session/logout_all.rs
@@ -12,7 +12,7 @@ pub mod v3 {
         metadata,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: AccessToken,
@@ -20,7 +20,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/logout/all",
             1.1 => "/_matrix/client/v3/logout/all",
         }
-    };
+    }
 
     /// Request type for the `logout_all` endpoint.
     #[derive(Debug, Clone, Default)]
@@ -39,18 +39,16 @@ pub mod v3 {
         type EndpointError = crate::Error;
         type IncomingResponse = Response;
 
-        const METADATA: Metadata = METADATA;
-
         fn try_into_http_request<T: Default + bytes::BufMut>(
             self,
             base_url: &str,
             access_token: ruma_common::api::SendAccessToken<'_>,
             considering: &'_ ruma_common::api::SupportedVersions,
         ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
-            let url = METADATA.make_endpoint_url(considering, base_url, &[], "")?;
+            let url = Self::make_endpoint_url(considering, base_url, &[], "")?;
 
             http::Request::builder()
-                .method(METADATA.method)
+                .method(Self::METHOD)
                 .uri(url)
                 .header(
                     http::header::AUTHORIZATION,
@@ -71,8 +69,6 @@ pub mod v3 {
         type EndpointError = crate::Error;
         type OutgoingResponse = Response;
 
-        const METADATA: Metadata = METADATA;
-
         fn try_from_http_request<B, S>(
             request: http::Request<B>,
             _path_args: &[S],
@@ -81,9 +77,9 @@ pub mod v3 {
             B: AsRef<[u8]>,
             S: AsRef<str>,
         {
-            if request.method() != METADATA.method {
+            if request.method() != Self::METHOD {
                 return Err(ruma_common::api::error::FromHttpRequestError::MethodMismatch {
-                    expected: METADATA.method,
+                    expected: Self::METHOD,
                     received: request.method().clone(),
                 });
             }

--- a/crates/ruma-client-api/src/session/refresh_token.rs
+++ b/crates/ruma-client-api/src/session/refresh_token.rs
@@ -28,11 +28,11 @@ pub mod v3 {
     use std::time::Duration;
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: true,
         authentication: None,
@@ -40,7 +40,7 @@ pub mod v3 {
             unstable => "/_matrix/client/unstable/org.matrix.msc2918/refresh",
             1.3 => "/_matrix/client/v3/refresh",
         }
-    };
+    }
 
     /// Request type for the `refresh` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/session/sso_login.rs
+++ b/crates/ruma-client-api/src/session/sso_login.rs
@@ -7,14 +7,14 @@ pub mod v3 {
 
     use http::header::{LOCATION, SET_COOKIE};
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
     };
 
     #[cfg(feature = "unstable-msc3824")]
     use crate::session::SsoRedirectOidcAction;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: None,
@@ -22,7 +22,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/login/sso/redirect",
             1.1 => "/_matrix/client/v3/login/sso/redirect",
         }
-    };
+    }
 
     /// Request type for the `sso_login` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/session/sso_login_with_provider.rs
+++ b/crates/ruma-client-api/src/session/sso_login_with_provider.rs
@@ -9,14 +9,14 @@ pub mod v3 {
 
     use http::header::{LOCATION, SET_COOKIE};
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
     };
 
     #[cfg(feature = "unstable-msc3824")]
     use crate::session::SsoRedirectOidcAction;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: None,
@@ -24,7 +24,7 @@ pub mod v3 {
             unstable => "/_matrix/client/unstable/org.matrix.msc2858/login/sso/redirect/{idp_id}",
             1.1 => "/_matrix/client/v3/login/sso/redirect/{idp_id}",
         }
-    };
+    }
 
     /// Request type for the `sso_login_with_provider` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/space/get_hierarchy.rs
+++ b/crates/ruma-client-api/src/space/get_hierarchy.rs
@@ -9,13 +9,13 @@ pub mod v1 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedRoomId,
     };
 
     use crate::space::SpaceHierarchyRoomsChunk;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: true,
         authentication: AccessToken,
@@ -23,7 +23,7 @@ pub mod v1 {
             unstable => "/_matrix/client/unstable/org.matrix.msc2946/rooms/{room_id}/hierarchy",
             1.2 => "/_matrix/client/v1/rooms/{room_id}/hierarchy",
         }
-    };
+    }
 
     /// Request type for the `hierarchy` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/state/get_state_event_for_key.rs
+++ b/crates/ruma-client-api/src/state/get_state_event_for_key.rs
@@ -16,7 +16,7 @@ pub mod v3 {
     use ruma_events::{AnyStateEvent, AnyStateEventContent, StateEventType};
     use serde_json::value::RawValue as RawJsonValue;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
@@ -24,7 +24,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/rooms/{room_id}/state/{event_type}/{state_key}",
             1.1 => "/_matrix/client/v3/rooms/{room_id}/state/{event_type}/{state_key}",
         }
-    };
+    }
 
     /// Request type for the `get_state_events_for_key` endpoint.
     #[derive(Clone, Debug)]
@@ -124,8 +124,6 @@ pub mod v3 {
         type EndpointError = crate::Error;
         type IncomingResponse = Response;
 
-        const METADATA: Metadata = METADATA;
-
         fn try_into_http_request<T: Default + bytes::BufMut>(
             self,
             base_url: &str,
@@ -138,7 +136,7 @@ pub mod v3 {
 
             http::Request::builder()
                 .method(http::Method::GET)
-                .uri(METADATA.make_endpoint_url(
+                .uri(Self::make_endpoint_url(
                     considering,
                     base_url,
                     &[&self.room_id, &self.event_type, &self.state_key],
@@ -163,8 +161,6 @@ pub mod v3 {
     impl ruma_common::api::IncomingRequest for Request {
         type EndpointError = crate::Error;
         type OutgoingResponse = Response;
-
-        const METADATA: Metadata = METADATA;
 
         fn try_from_http_request<B, S>(
             request: http::Request<B>,

--- a/crates/ruma-client-api/src/state/get_state_events.rs
+++ b/crates/ruma-client-api/src/state/get_state_events.rs
@@ -8,14 +8,14 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3roomsroomidstate
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         serde::Raw,
         OwnedRoomId,
     };
     use ruma_events::AnyStateEvent;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
@@ -23,7 +23,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/rooms/{room_id}/state",
             1.1 => "/_matrix/client/v3/rooms/{room_id}/state",
         }
-    };
+    }
 
     /// Request type for the `get_state_events` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/state/send_state_event.rs
+++ b/crates/ruma-client-api/src/state/send_state_event.rs
@@ -18,7 +18,7 @@ pub mod v3 {
     use ruma_events::{AnyStateEventContent, StateEventContent, StateEventType};
     use serde_json::value::to_raw_value as to_raw_json_value;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: PUT,
         rate_limited: false,
         authentication: AccessToken,
@@ -26,7 +26,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/rooms/{room_id}/state/{event_type}/{state_key}",
             1.1 => "/_matrix/client/v3/rooms/{room_id}/state/{event_type}/{state_key}",
         }
-    };
+    }
 
     /// Request type for the `send_state_event` endpoint.
     #[derive(Clone, Debug)]
@@ -111,8 +111,6 @@ pub mod v3 {
         type EndpointError = crate::Error;
         type IncomingResponse = Response;
 
-        const METADATA: Metadata = METADATA;
-
         fn try_into_http_request<T: Default + bytes::BufMut>(
             self,
             base_url: &str,
@@ -126,7 +124,7 @@ pub mod v3 {
 
             let http_request = http::Request::builder()
                 .method(http::Method::PUT)
-                .uri(METADATA.make_endpoint_url(
+                .uri(Self::make_endpoint_url(
                     considering,
                     base_url,
                     &[&self.room_id, &self.event_type, &self.state_key],
@@ -152,8 +150,6 @@ pub mod v3 {
     impl ruma_common::api::IncomingRequest for Request {
         type EndpointError = crate::Error;
         type OutgoingResponse = Response;
-
-        const METADATA: Metadata = METADATA;
 
         fn try_from_http_request<B, S>(
             request: http::Request<B>,

--- a/crates/ruma-client-api/src/sync/sync_events/v3.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v3.rs
@@ -7,7 +7,7 @@ use std::{collections::BTreeMap, time::Duration};
 use as_variant::as_variant;
 use js_int::UInt;
 use ruma_common::{
-    api::{request, response, Metadata},
+    api::{request, response},
     metadata,
     presence::PresenceState,
     serde::Raw,
@@ -25,7 +25,7 @@ mod response_serde;
 use super::{DeviceLists, UnreadNotificationsCount};
 use crate::filter::FilterDefinition;
 
-const METADATA: Metadata = metadata! {
+metadata! {
     method: GET,
     rate_limited: false,
     authentication: AccessToken,
@@ -33,7 +33,7 @@ const METADATA: Metadata = metadata! {
         1.0 => "/_matrix/client/r0/sync",
         1.1 => "/_matrix/client/v3/sync",
     }
-};
+}
 
 /// Request type for the `sync` endpoint.
 #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/sync/sync_events/v5.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v5.rs
@@ -12,7 +12,7 @@ use std::{collections::BTreeMap, time::Duration};
 use js_int::UInt;
 use js_option::JsOption;
 use ruma_common::{
-    api::{request, response, Metadata},
+    api::{request, response},
     metadata,
     presence::PresenceState,
     serde::{duration::opt_ms, Raw},
@@ -23,7 +23,7 @@ use serde::{Deserialize, Serialize};
 
 use super::UnreadNotificationsCount;
 
-const METADATA: Metadata = metadata! {
+metadata! {
     method: POST,
     rate_limited: false,
     authentication: AccessToken,
@@ -31,7 +31,7 @@ const METADATA: Metadata = metadata! {
         unstable("org.matrix.simplified_msc3575") => "/_matrix/client/unstable/org.matrix.simplified_msc3575/sync",
         // 1.4 => "/_matrix/client/v5/sync",
     }
-};
+}
 
 /// Request type for the `/sync` endpoint.
 #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/tag/create_tag.rs
+++ b/crates/ruma-client-api/src/tag/create_tag.rs
@@ -8,12 +8,12 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3useruseridroomsroomidtagstag
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedRoomId, OwnedUserId,
     };
     use ruma_events::tag::TagInfo;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: PUT,
         rate_limited: false,
         authentication: AccessToken,
@@ -21,7 +21,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/user/{user_id}/rooms/{room_id}/tags/{tag}",
             1.1 => "/_matrix/client/v3/user/{user_id}/rooms/{room_id}/tags/{tag}",
         }
-    };
+    }
 
     /// Request type for the `create_tag` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/tag/delete_tag.rs
+++ b/crates/ruma-client-api/src/tag/delete_tag.rs
@@ -8,11 +8,11 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3useruseridroomsroomidtagstag
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedRoomId, OwnedUserId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: DELETE,
         rate_limited: false,
         authentication: AccessToken,
@@ -20,7 +20,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/user/{user_id}/rooms/{room_id}/tags/{tag}",
             1.1 => "/_matrix/client/v3/user/{user_id}/rooms/{room_id}/tags/{tag}",
         }
-    };
+    }
 
     /// Request type for the `delete_tag` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/tag/get_tags.rs
+++ b/crates/ruma-client-api/src/tag/get_tags.rs
@@ -8,12 +8,12 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3useruseridroomsroomidtags
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedRoomId, OwnedUserId,
     };
     use ruma_events::tag::Tags;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
@@ -21,7 +21,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/user/{user_id}/rooms/{room_id}/tags",
             1.1 => "/_matrix/client/v3/user/{user_id}/rooms/{room_id}/tags",
         }
-    };
+    }
 
     /// Request type for the `get_tags` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/thirdparty/get_location_for_protocol.rs
+++ b/crates/ruma-client-api/src/thirdparty/get_location_for_protocol.rs
@@ -10,12 +10,12 @@ pub mod v3 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         thirdparty::Location,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
@@ -23,7 +23,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/thirdparty/location/{protocol}",
             1.1 => "/_matrix/client/v3/thirdparty/location/{protocol}",
         }
-    };
+    }
 
     /// Request type for the `get_location_for_protocol` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/thirdparty/get_location_for_room_alias.rs
+++ b/crates/ruma-client-api/src/thirdparty/get_location_for_room_alias.rs
@@ -8,13 +8,13 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3thirdpartylocation
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         thirdparty::Location,
         OwnedRoomAliasId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
@@ -22,7 +22,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/thirdparty/location",
             1.1 => "/_matrix/client/v3/thirdparty/location",
         }
-    };
+    }
 
     /// Request type for the `get_location_for_room_alias` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/thirdparty/get_protocol.rs
+++ b/crates/ruma-client-api/src/thirdparty/get_protocol.rs
@@ -8,12 +8,12 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3thirdpartyprotocolprotocol
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         thirdparty::Protocol,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
@@ -21,7 +21,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/thirdparty/protocol/{protocol}",
             1.1 => "/_matrix/client/v3/thirdparty/protocol/{protocol}",
         }
-    };
+    }
 
     /// Request type for the `get_protocol` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/thirdparty/get_protocols.rs
+++ b/crates/ruma-client-api/src/thirdparty/get_protocols.rs
@@ -10,12 +10,12 @@ pub mod v3 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         thirdparty::Protocol,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
@@ -23,7 +23,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/thirdparty/protocols",
             1.1 => "/_matrix/client/v3/thirdparty/protocols",
         }
-    };
+    }
 
     /// Request type for the `get_protocols` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/thirdparty/get_user_for_protocol.rs
+++ b/crates/ruma-client-api/src/thirdparty/get_user_for_protocol.rs
@@ -10,12 +10,12 @@ pub mod v3 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         thirdparty::User,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
@@ -23,7 +23,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/thirdparty/user/{protocol}",
             1.1 => "/_matrix/client/v3/thirdparty/user/{protocol}",
         }
-    };
+    }
 
     /// Request type for the `get_user_for_protocol` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/thirdparty/get_user_for_user_id.rs
+++ b/crates/ruma-client-api/src/thirdparty/get_user_for_user_id.rs
@@ -8,13 +8,13 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3thirdpartyuser
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         thirdparty::User,
         OwnedUserId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
@@ -22,7 +22,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/thirdparty/user",
             1.1 => "/_matrix/client/v3/thirdparty/user",
         }
-    };
+    }
 
     /// Request type for the `get_user_for_user_id` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/threads/get_thread_subscription.rs
+++ b/crates/ruma-client-api/src/threads/get_thread_subscription.rs
@@ -8,18 +8,18 @@ pub mod unstable {
     //! [spec]: https://github.com/matrix-org/matrix-spec-proposals/pull/4306
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedEventId, OwnedRoomId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: true,
         authentication: AccessToken,
         history: {
             unstable("org.matrix.msc4306") => "/_matrix/client/unstable/io.element.msc4306/rooms/{room_id}/thread/{thread_root}/subscription",
         }
-    };
+    }
 
     /// Request type for the `get_thread_subscription` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/threads/get_thread_subscriptions_changes.rs
+++ b/crates/ruma-client-api/src/threads/get_thread_subscriptions_changes.rs
@@ -11,19 +11,19 @@ pub mod unstable {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response, Direction, Metadata},
+        api::{request, response, Direction},
         metadata, OwnedEventId, OwnedRoomId,
     };
     use serde::{Deserialize, Serialize};
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: true,
         authentication: AccessToken,
         history: {
             unstable("org.matrix.msc4308") => "/_matrix/client/unstable/io.element.msc4308/thread_subscriptions",
         }
-    };
+    }
 
     /// Request type for the `get_thread_subscriptions_changes` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/threads/get_threads.rs
+++ b/crates/ruma-client-api/src/threads/get_threads.rs
@@ -9,7 +9,7 @@ pub mod v1 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         serde::{Raw, StringEnum},
         OwnedRoomId,
@@ -18,7 +18,7 @@ pub mod v1 {
 
     use crate::PrivOwnedStr;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: true,
         authentication: AccessToken,
@@ -26,7 +26,7 @@ pub mod v1 {
             unstable => "/_matrix/client/unstable/org.matrix.msc3856/rooms/{room_id}/threads",
             1.4 => "/_matrix/client/v1/rooms/{room_id}/threads",
         }
-    };
+    }
 
     /// Request type for the `get_thread_roots` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/threads/subscribe_thread.rs
+++ b/crates/ruma-client-api/src/threads/subscribe_thread.rs
@@ -8,18 +8,18 @@ pub mod unstable {
     //! [spec]: https://github.com/matrix-org/matrix-spec-proposals/pull/4306
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedEventId, OwnedRoomId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: PUT,
         rate_limited: true,
         authentication: AccessToken,
         history: {
             unstable("org.matrix.msc4306") => "/_matrix/client/unstable/io.element.msc4306/rooms/{room_id}/thread/{thread_root}/subscription",
         }
-    };
+    }
 
     /// Request type for the `subscribe_thread` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/threads/unsubscribe_thread.rs
+++ b/crates/ruma-client-api/src/threads/unsubscribe_thread.rs
@@ -8,18 +8,18 @@ pub mod unstable {
     //! [spec]: https://github.com/matrix-org/matrix-spec-proposals/pull/4306
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedEventId, OwnedRoomId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: DELETE,
         rate_limited: true,
         authentication: AccessToken,
         history: {
             unstable("org.matrix.msc4306") => "/_matrix/client/unstable/io.element.msc4306/rooms/{room_id}/thread/{thread_root}/subscription",
         }
-    };
+    }
 
     /// Request type for the `unsubscribe_thread` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/to_device/send_event_to_device.rs
+++ b/crates/ruma-client-api/src/to_device/send_event_to_device.rs
@@ -10,7 +10,7 @@ pub mod v3 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         serde::Raw,
         to_device::DeviceIdOrAllDevices,
@@ -18,7 +18,7 @@ pub mod v3 {
     };
     use ruma_events::{AnyToDeviceEventContent, ToDeviceEventType};
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: PUT,
         rate_limited: false,
         authentication: AccessToken,
@@ -26,7 +26,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/sendToDevice/{event_type}/{txn_id}",
             1.1 => "/_matrix/client/v3/sendToDevice/{event_type}/{txn_id}",
         }
-    };
+    }
 
     /// Request type for the `send_event_to_device` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/typing/create_typing_event.rs
+++ b/crates/ruma-client-api/src/typing/create_typing_event.rs
@@ -10,12 +10,12 @@ pub mod v3 {
     use std::time::Duration;
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedRoomId, OwnedUserId,
     };
     use serde::{de::Error, Deserialize, Deserializer, Serialize};
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: PUT,
         authentication: AccessToken,
         rate_limited: true,
@@ -23,7 +23,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/rooms/{room_id}/typing/{user_id}",
             1.1 => "/_matrix/client/v3/rooms/{room_id}/typing/{user_id}",
         }
-    };
+    }
 
     /// Request type for the `create_typing_event` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/uiaa/get_uiaa_fallback_page.rs
+++ b/crates/ruma-client-api/src/uiaa/get_uiaa_fallback_page.rs
@@ -7,14 +7,11 @@ pub mod v3 {
     //!
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#fallback
 
-    use ruma_common::{
-        api::{request, Metadata},
-        metadata,
-    };
+    use ruma_common::{api::request, metadata};
 
     use crate::uiaa::AuthType;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: None,
@@ -22,7 +19,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/auth/{auth_type}/fallback/web",
             1.1 => "/_matrix/client/v3/auth/{auth_type}/fallback/web",
         }
-    };
+    }
 
     /// Request type for the `authorize_fallback` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/user_directory/search_users.rs
+++ b/crates/ruma-client-api/src/user_directory/search_users.rs
@@ -10,12 +10,12 @@ pub mod v3 {
     use http::header::ACCEPT_LANGUAGE;
     use js_int::{uint, UInt};
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedMxcUri, OwnedUserId,
     };
     use serde::{Deserialize, Serialize};
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: true,
         authentication: AccessToken,
@@ -23,7 +23,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/user_directory/search",
             1.1 => "/_matrix/client/v3/user_directory/search",
         }
-    };
+    }
 
     /// Request type for the `search_users` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-client-api/src/voip/get_turn_server_info.rs
+++ b/crates/ruma-client-api/src/voip/get_turn_server_info.rs
@@ -10,11 +10,11 @@ pub mod v3 {
     use std::time::Duration;
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: true,
         authentication: AccessToken,
@@ -22,7 +22,7 @@ pub mod v3 {
             1.0 => "/_matrix/client/r0/voip/turnServer",
             1.1 => "/_matrix/client/v3/voip/turnServer",
         }
-    };
+    }
 
     /// Request type for the `turn_server_info` endpoint.
     #[request(error = crate::Error)]

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -18,6 +18,12 @@ Breaking changes:
   backwards-compatibility for clients.
 - Macros no longer support importing the `ruma` and `ruma-events` crate from the
   `matrix-sdk-appservice` crate. This crate was dropped 2 years ago.
+- `Metadata` was changed from a `struct` to a `trait`.
+  - Its fields are now associated constants with the same name converted to
+    uppercase.
+  - The `metadata!` macro generates the trait implementation for a type named
+    `Request` by default. The type can be changed with an `@for` setting.
+  - `Metadata` is a supertrait of `OutgoingRequest` and `IncomingRequest`.
 
 Improvements:
 

--- a/crates/ruma-common/src/api.rs
+++ b/crates/ruma-common/src/api.rs
@@ -71,20 +71,17 @@ use bytes::BufMut;
 /// ```
 /// pub mod do_a_thing {
 ///     use ruma_common::{api::request, OwnedRoomId};
-///     # use ruma_common::{
-///     #     api::{response, Metadata},
-///     #     metadata,
-///     # };
+///     # use ruma_common::{api::response, metadata};
 ///
-///     // const METADATA: Metadata = metadata! { ... };
-///     # const METADATA: Metadata = metadata! {
+///     // metadata! { ... };
+///     # metadata! {
 ///     #     method: POST,
 ///     #     rate_limited: false,
 ///     #     authentication: None,
 ///     #     history: {
 ///     #         unstable => "/_matrix/some/endpoint/{room_id}",
 ///     #     },
-///     # };
+///     # }
 ///
 ///     #[request]
 ///     pub struct Request {
@@ -107,20 +104,17 @@ use bytes::BufMut;
 /// pub mod upload_file {
 ///     use http::header::CONTENT_TYPE;
 ///     use ruma_common::api::request;
-///     # use ruma_common::{
-///     #     api::{response, Metadata},
-///     #     metadata,
-///     # };
+///     # use ruma_common::{api::response, metadata};
 ///
-///     // const METADATA: Metadata = metadata! { ... };
-///     # const METADATA: Metadata = metadata! {
+///     // metadata! { ... };
+///     # metadata! {
 ///     #     method: POST,
 ///     #     rate_limited: false,
 ///     #     authentication: None,
 ///     #     history: {
 ///     #         unstable => "/_matrix/some/endpoint/{file_name}",
 ///     #     },
-///     # };
+///     # }
 ///
 ///     #[request]
 ///     pub struct Request {
@@ -185,20 +179,17 @@ pub use ruma_macros::request;
 /// ```
 /// pub mod do_a_thing {
 ///     use ruma_common::{api::response, OwnedRoomId};
-///     # use ruma_common::{
-///     #     api::{request, Metadata},
-///     #     metadata,
-///     # };
+///     # use ruma_common::{api::request, metadata};
 ///
-///     // const METADATA: Metadata = metadata! { ... };
-///     # const METADATA: Metadata = metadata! {
+///     // metadata! { ... };
+///     # metadata! {
 ///     #     method: POST,
 ///     #     rate_limited: false,
 ///     #     authentication: None,
 ///     #     history: {
 ///     #         unstable => "/_matrix/some/endpoint",
 ///     #     },
-///     # };
+///     # }
 ///
 ///     // #[request]
 ///     // pub struct Request { ... }
@@ -215,20 +206,17 @@ pub use ruma_macros::request;
 /// pub mod download_file {
 ///     use http::header::CONTENT_TYPE;
 ///     use ruma_common::api::response;
-///     # use ruma_common::{
-///     #     api::{request, Metadata},
-///     #     metadata,
-///     # };
+///     # use ruma_common::{api::request, metadata};
 ///
-///     // const METADATA: Metadata = metadata! { ... };
-///     # const METADATA: Metadata = metadata! {
+///     // metadata! { ... };
+///     # metadata! {
 ///     #     method: POST,
 ///     #     rate_limited: false,
 ///     #     authentication: None,
 ///     #     history: {
 ///     #         unstable => "/_matrix/some/endpoint",
 ///     #     },
-///     # };
+///     # }
 ///
 ///     // #[request]
 ///     // pub struct Request { ... }
@@ -307,15 +295,12 @@ impl<'a> SendAccessToken<'a> {
 }
 
 /// A request type for a Matrix API endpoint, used for sending requests.
-pub trait OutgoingRequest: Sized + Clone {
+pub trait OutgoingRequest: Metadata + Clone {
     /// A type capturing the expected error conditions the server can return.
     type EndpointError: EndpointError;
 
     /// Response type returned when the request is successful.
     type IncomingResponse: IncomingResponse<EndpointError = Self::EndpointError>;
-
-    /// Metadata about the endpoint.
-    const METADATA: Metadata;
 
     /// Tries to convert this request into an `http::Request`.
     ///
@@ -351,7 +336,7 @@ pub trait OutgoingRequest: Sized + Clone {
     /// stable or unstable feature, and homeservers should not advertise support for a Matrix
     /// version unless they support all of its features.
     fn is_supported(considering_versions: &SupportedVersions) -> bool {
-        Self::METADATA.history.is_supported(considering_versions)
+        Self::HISTORY.is_supported(considering_versions)
     }
 }
 
@@ -405,15 +390,12 @@ pub trait OutgoingRequestAppserviceExt: OutgoingRequest {
 impl<T: OutgoingRequest> OutgoingRequestAppserviceExt for T {}
 
 /// A request type for a Matrix API endpoint, used for receiving requests.
-pub trait IncomingRequest: Sized {
+pub trait IncomingRequest: Metadata {
     /// A type capturing the error conditions that can be returned in the response.
     type EndpointError: EndpointError;
 
     /// Response type to return when the request is successful.
     type OutgoingResponse: OutgoingResponse;
-
-    /// Metadata about the endpoint.
-    const METADATA: Metadata;
 
     /// Tries to turn the given `http::Request` into this request type,
     /// together with the corresponding path arguments.

--- a/crates/ruma-common/src/api/metadata.rs
+++ b/crates/ruma-common/src/api/metadata.rs
@@ -1292,29 +1292,17 @@ mod tests {
     use std::collections::{BTreeMap, BTreeSet};
 
     use assert_matches2::assert_matches;
-    use http::Method;
 
     use super::{
-        AuthScheme,
         MatrixVersion::{self, V1_0, V1_1, V1_2, V1_3},
-        Metadata, StablePathSelector, SupportedVersions, VersionHistory,
+        StablePathSelector, SupportedVersions, VersionHistory,
     };
     use crate::api::error::IntoHttpError;
 
-    fn stable_only_metadata(
+    fn stable_only_history(
         stable_paths: &'static [(StablePathSelector, &'static str)],
-    ) -> Metadata {
-        Metadata {
-            method: Method::GET,
-            rate_limited: false,
-            authentication: AuthScheme::None,
-            history: VersionHistory {
-                unstable_paths: &[],
-                stable_paths,
-                deprecated: None,
-                removed: None,
-            },
-        }
+    ) -> VersionHistory {
+        VersionHistory { unstable_paths: &[], stable_paths, deprecated: None, removed: None }
     }
 
     fn version_only_supported(versions: &[MatrixVersion]) -> SupportedVersions {
@@ -1328,8 +1316,8 @@ mod tests {
 
     #[test]
     fn make_simple_endpoint_url() {
-        let meta = stable_only_metadata(&[(StablePathSelector::Version(V1_0), "/s")]);
-        let url = meta
+        let history = stable_only_history(&[(StablePathSelector::Version(V1_0), "/s")]);
+        let url = history
             .make_endpoint_url(&version_only_supported(&[V1_0]), "https://example.org", &[], "")
             .unwrap();
         assert_eq!(url, "https://example.org/s");
@@ -1337,8 +1325,8 @@ mod tests {
 
     #[test]
     fn make_endpoint_url_with_path_args() {
-        let meta = stable_only_metadata(&[(StablePathSelector::Version(V1_0), "/s/{x}")]);
-        let url = meta
+        let history = stable_only_history(&[(StablePathSelector::Version(V1_0), "/s/{x}")]);
+        let url = history
             .make_endpoint_url(
                 &version_only_supported(&[V1_0]),
                 "https://example.org",
@@ -1351,8 +1339,8 @@ mod tests {
 
     #[test]
     fn make_endpoint_url_with_path_args_with_dash() {
-        let meta = stable_only_metadata(&[(StablePathSelector::Version(V1_0), "/s/{x}")]);
-        let url = meta
+        let history = stable_only_history(&[(StablePathSelector::Version(V1_0), "/s/{x}")]);
+        let url = history
             .make_endpoint_url(
                 &version_only_supported(&[V1_0]),
                 "https://example.org",
@@ -1365,8 +1353,8 @@ mod tests {
 
     #[test]
     fn make_endpoint_url_with_path_args_with_reserved_char() {
-        let meta = stable_only_metadata(&[(StablePathSelector::Version(V1_0), "/s/{x}")]);
-        let url = meta
+        let history = stable_only_history(&[(StablePathSelector::Version(V1_0), "/s/{x}")]);
+        let url = history
             .make_endpoint_url(
                 &version_only_supported(&[V1_0]),
                 "https://example.org",
@@ -1379,8 +1367,8 @@ mod tests {
 
     #[test]
     fn make_endpoint_url_with_query() {
-        let meta = stable_only_metadata(&[(StablePathSelector::Version(V1_0), "/s/")]);
-        let url = meta
+        let history = stable_only_history(&[(StablePathSelector::Version(V1_0), "/s/")]);
+        let url = history
             .make_endpoint_url(
                 &version_only_supported(&[V1_0]),
                 "https://example.org",
@@ -1394,8 +1382,8 @@ mod tests {
     #[test]
     #[should_panic]
     fn make_endpoint_url_wrong_num_path_args() {
-        let meta = stable_only_metadata(&[(StablePathSelector::Version(V1_0), "/s/{x}")]);
-        _ = meta.make_endpoint_url(
+        let history = stable_only_history(&[(StablePathSelector::Version(V1_0), "/s/{x}")]);
+        _ = history.make_endpoint_url(
             &version_only_supported(&[V1_0]),
             "https://example.org",
             &[],
@@ -1662,8 +1650,8 @@ mod tests {
     #[test]
     #[should_panic]
     fn make_endpoint_url_with_path_args_old_syntax() {
-        let meta = stable_only_metadata(&[(StablePathSelector::Version(V1_0), "/s/:x")]);
-        let url = meta
+        let history = stable_only_history(&[(StablePathSelector::Version(V1_0), "/s/:x")]);
+        let url = history
             .make_endpoint_url(
                 &version_only_supported(&[V1_0]),
                 "https://example.org",

--- a/crates/ruma-common/tests/it/api/conversions.rs
+++ b/crates/ruma-common/tests/it/api/conversions.rs
@@ -3,20 +3,20 @@
 use http::header::CONTENT_TYPE;
 use ruma_common::{
     api::{
-        request, response, IncomingRequest as _, MatrixVersion, Metadata, OutgoingRequest as _,
+        request, response, IncomingRequest as _, MatrixVersion, OutgoingRequest as _,
         OutgoingRequestAppserviceExt, SendAccessToken, SupportedVersions,
     },
     metadata, owned_user_id, user_id, OwnedUserId,
 };
 
-const METADATA: Metadata = metadata! {
+metadata! {
     method: POST,
     rate_limited: false,
     authentication: None,
     history: {
         unstable => "/_matrix/foo/{bar}/{user}",
     }
-};
+}
 
 /// Request type for the `my_endpoint` endpoint.
 #[request]
@@ -135,20 +135,20 @@ mod without_query {
     use http::header::CONTENT_TYPE;
     use ruma_common::{
         api::{
-            request, response, MatrixVersion, Metadata, OutgoingRequestAppserviceExt,
-            SendAccessToken, SupportedVersions,
+            request, response, MatrixVersion, OutgoingRequestAppserviceExt, SendAccessToken,
+            SupportedVersions,
         },
         metadata, owned_user_id, user_id, OwnedUserId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: None,
         history: {
             unstable => "/_matrix/foo/{bar}/{user}",
         }
-    };
+    }
 
     /// Request type for the `my_endpoint` endpoint.
     #[request]

--- a/crates/ruma-common/tests/it/api/default_status.rs
+++ b/crates/ruma-common/tests/it/api/default_status.rs
@@ -3,18 +3,18 @@
 
 use http::StatusCode;
 use ruma_common::{
-    api::{request, response, Metadata, OutgoingResponse as _},
+    api::{request, response, OutgoingResponse as _},
     metadata,
 };
 
-const METADATA: Metadata = metadata! {
+metadata! {
     method: GET,
     rate_limited: false,
     authentication: None,
     history: {
         unstable => "/_matrix/my/endpoint",
     }
-};
+}
 
 /// Request type for the `default_status` endpoint.
 #[request]

--- a/crates/ruma-common/tests/it/api/header_override.rs
+++ b/crates/ruma-common/tests/it/api/header_override.rs
@@ -3,20 +3,20 @@
 use http::header::{Entry, CONTENT_TYPE, LOCATION};
 use ruma_common::{
     api::{
-        request, response, MatrixVersion, Metadata, OutgoingRequest as _, OutgoingResponse as _,
+        request, response, MatrixVersion, OutgoingRequest as _, OutgoingResponse as _,
         SendAccessToken, SupportedVersions,
     },
     metadata,
 };
 
-const METADATA: Metadata = metadata! {
+metadata! {
     method: GET,
     rate_limited: false,
     authentication: None,
     history: {
         unstable => "/_matrix/my/endpoint",
     }
-};
+}
 
 /// Request type for the `no_fields` endpoint.
 #[request]

--- a/crates/ruma-common/tests/it/api/no_fields.rs
+++ b/crates/ruma-common/tests/it/api/no_fields.rs
@@ -4,18 +4,18 @@ use ruma_common::api::{
 
 mod get {
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: None,
         history: {
             unstable => "/_matrix/my/endpoint",
         }
-    };
+    }
 
     /// Request type for the `no_fields` endpoint.
     #[request]
@@ -28,18 +28,18 @@ mod get {
 
 mod post {
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: None,
         history: {
             unstable => "/_matrix/my/endpoint",
         }
-    };
+    }
 
     /// Request type for the `no_fields` endpoint.
     #[request]

--- a/crates/ruma-common/tests/it/api/optional_headers.rs
+++ b/crates/ruma-common/tests/it/api/optional_headers.rs
@@ -2,21 +2,21 @@ use assert_matches2::assert_matches;
 use http::header::{CONTENT_DISPOSITION, LOCATION};
 use ruma_common::{
     api::{
-        request, response, IncomingRequest, IncomingResponse, MatrixVersion, Metadata,
-        OutgoingRequest, OutgoingResponse, SendAccessToken, SupportedVersions,
+        request, response, IncomingRequest, IncomingResponse, MatrixVersion, OutgoingRequest,
+        OutgoingResponse, SendAccessToken, SupportedVersions,
     },
     http_headers::{ContentDisposition, ContentDispositionType},
     metadata,
 };
 
-const METADATA: Metadata = metadata! {
+metadata! {
     method: GET,
     rate_limited: false,
     authentication: None,
     history: {
         unstable => "/_matrix/my/endpoint",
     }
-};
+}
 
 /// Request type for the `optional_headers` endpoint.
 #[request]

--- a/crates/ruma-common/tests/it/api/required_headers.rs
+++ b/crates/ruma-common/tests/it/api/required_headers.rs
@@ -6,21 +6,21 @@ use ruma_common::{
             DeserializationError, FromHttpRequestError, FromHttpResponseError,
             HeaderDeserializationError,
         },
-        request, response, IncomingRequest, IncomingResponse, MatrixVersion, Metadata,
-        OutgoingRequest, OutgoingResponse, SendAccessToken, SupportedVersions,
+        request, response, IncomingRequest, IncomingResponse, MatrixVersion, OutgoingRequest,
+        OutgoingResponse, SendAccessToken, SupportedVersions,
     },
     http_headers::{ContentDisposition, ContentDispositionType},
     metadata,
 };
 
-const METADATA: Metadata = metadata! {
+metadata! {
     method: GET,
     rate_limited: false,
     authentication: None,
     history: {
         unstable => "/_matrix/my/endpoint",
     }
-};
+}
 
 /// Request type for the `required_headers` endpoint.
 #[request]

--- a/crates/ruma-common/tests/it/api/ruma_api_macros.rs
+++ b/crates/ruma-common/tests/it/api/ruma_api_macros.rs
@@ -4,20 +4,20 @@
 pub mod some_endpoint {
     use http::header::CONTENT_TYPE;
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         serde::Raw,
         OwnedUserId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST, // An `http::Method` constant. No imports required.
         rate_limited: false,
         authentication: None,
         history: {
             unstable => "/_matrix/some/endpoint/{user}",
         }
-    };
+    }
 
     /// Request type for the `some_endpoint` endpoint.
     #[request]
@@ -66,7 +66,7 @@ pub mod some_endpoint {
 
 pub mod newtype_body_endpoint {
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
     };
 
@@ -75,14 +75,14 @@ pub mod newtype_body_endpoint {
         pub a_field: String,
     }
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: PUT,
         rate_limited: false,
         authentication: None,
         history: {
             unstable => "/_matrix/some/newtype/body/endpoint",
         }
-    };
+    }
 
     /// Request type for the `newtype_body_endpoint` endpoint.
     #[request]
@@ -101,7 +101,7 @@ pub mod newtype_body_endpoint {
 
 pub mod raw_body_endpoint {
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
     };
 
@@ -110,14 +110,14 @@ pub mod raw_body_endpoint {
         pub a_field: String,
     }
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: PUT,
         rate_limited: false,
         authentication: None,
         history: {
             unstable => "/_matrix/some/newtype/body/endpoint",
         }
-    };
+    }
 
     /// Request type for the `newtype_body_endpoint` endpoint.
     #[request]
@@ -136,7 +136,7 @@ pub mod raw_body_endpoint {
 
 pub mod query_all_enum_endpoint {
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
     };
 
@@ -147,14 +147,14 @@ pub mod query_all_enum_endpoint {
         VariantB { field_b: String },
     }
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: None,
         history: {
             unstable => "/_matrix/some/query/map/endpoint",
         }
-    };
+    }
 
     /// Request type for the `query_all_enum_endpoint` endpoint.
     #[request]
@@ -170,18 +170,18 @@ pub mod query_all_enum_endpoint {
 
 pub mod query_all_vec_endpoint {
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: None,
         history: {
             unstable => "/_matrix/some/query/map/endpoint",
         }
-    };
+    }
 
     /// Request type for the `query_all_vec_endpoint` endpoint.
     #[request]

--- a/crates/ruma-common/tests/it/api/status_override.rs
+++ b/crates/ruma-common/tests/it/api/status_override.rs
@@ -6,18 +6,18 @@ use http::{
     StatusCode,
 };
 use ruma_common::{
-    api::{request, response, Metadata, OutgoingResponse as _},
+    api::{request, response, OutgoingResponse as _},
     metadata,
 };
 
-const METADATA: Metadata = metadata! {
+metadata! {
     method: GET,
     rate_limited: false,
     authentication: None,
     history: {
         unstable => "/_matrix/my/endpoint",
     }
-};
+}
 
 /// Request type for the `status_override` endpoint.
 #[request]

--- a/crates/ruma-common/tests/it/api/ui/api-sanity-check.rs
+++ b/crates/ruma-common/tests/it/api/ui/api-sanity-check.rs
@@ -7,7 +7,7 @@ use ruma_common::{
     serde::Raw,
 };
 
-const METADATA: Metadata = metadata! {
+metadata! {
     method: POST, // An `http::Method` constant. No imports required.
     rate_limited: false,
     authentication: None,
@@ -20,7 +20,7 @@ const METADATA: Metadata = metadata! {
         1.2 => deprecated,
         1.3 => removed,
     }
-};
+}
 
 /// Request type for the `some_endpoint` endpoint.
 #[request]
@@ -70,14 +70,14 @@ fn main() {
     use ruma_common::api::{MatrixVersion, StablePathSelector};
 
     assert_eq!(
-        METADATA.history.unstable_paths().collect::<Vec<_>>(),
+        Request::HISTORY.unstable_paths().collect::<Vec<_>>(),
         &[
             (None, "/_matrix/some/msc1234/endpoint/{baz}"),
             (Some("org.bar.msc1234"), "/_matrix/unstable/org.bar.msc1234/endpoint/{baz}")
         ],
     );
     assert_eq!(
-        METADATA.history.stable_paths().collect::<Vec<_>>(),
+        Request::HISTORY.stable_paths().collect::<Vec<_>>(),
         &[
             (
                 StablePathSelector::Feature("org.bar.msc1234.stable"),
@@ -94,7 +94,7 @@ fn main() {
         ],
     );
     assert_eq!(
-        METADATA.history.all_paths().collect::<Vec<_>>(),
+        Request::HISTORY.all_paths().collect::<Vec<_>>(),
         &[
             "/_matrix/some/msc1234/endpoint/{baz}",
             "/_matrix/unstable/org.bar.msc1234/endpoint/{baz}",
@@ -104,7 +104,7 @@ fn main() {
         ],
     );
 
-    assert_eq!(METADATA.history.added_in(), Some(MatrixVersion::V1_0));
-    assert_eq!(METADATA.history.deprecated_in(), Some(MatrixVersion::V1_2));
-    assert_eq!(METADATA.history.removed_in(), Some(MatrixVersion::V1_3));
+    assert_eq!(Request::HISTORY.added_in(), Some(MatrixVersion::V1_0));
+    assert_eq!(Request::HISTORY.deprecated_in(), Some(MatrixVersion::V1_2));
+    assert_eq!(Request::HISTORY.removed_in(), Some(MatrixVersion::V1_3));
 }

--- a/crates/ruma-common/tests/it/api/ui/deprecated-without-added.rs
+++ b/crates/ruma-common/tests/it/api/ui/deprecated-without-added.rs
@@ -1,6 +1,6 @@
-use ruma_common::{api::Metadata, metadata};
+use ruma_common::metadata;
 
-const _: Metadata = metadata! {
+metadata! {
     method: GET,
     rate_limited: false,
     authentication: None,
@@ -8,6 +8,8 @@ const _: Metadata = metadata! {
         unstable => "/a/path",
         1.1 => deprecated,
     }
-};
+}
+
+pub struct Request;
 
 fn main() {}

--- a/crates/ruma-common/tests/it/api/ui/move-value.rs
+++ b/crates/ruma-common/tests/it/api/ui/move-value.rs
@@ -5,21 +5,21 @@
 pub mod newtype_body {
     use http::header::CONTENT_TYPE;
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedUserId,
     };
 
     #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
     pub struct Foo;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: None,
         history: {
             unstable => "/_matrix/foo/{bar}/",
         }
-    };
+    }
 
     /// Request type for the `my_endpoint` endpoint.
     #[request]
@@ -51,18 +51,18 @@ pub mod newtype_body {
 pub mod raw_body {
     use http::header::CONTENT_TYPE;
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedUserId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: None,
         history: {
             unstable => "/_matrix/foo/{bar}/",
         }
-    };
+    }
 
     /// Request type for the `my_endpoint` endpoint.
     #[request]
@@ -94,21 +94,21 @@ pub mod raw_body {
 pub mod plain {
     use http::header::CONTENT_TYPE;
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedUserId,
     };
 
     #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
     pub struct Foo;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: None,
         history: {
             unstable => "/_matrix/foo/{bar}/",
         }
-    };
+    }
 
     /// Request type for the `my_endpoint` endpoint.
     #[request]

--- a/crates/ruma-common/tests/it/api/ui/removed-without-deprecated.rs
+++ b/crates/ruma-common/tests/it/api/ui/removed-without-deprecated.rs
@@ -1,6 +1,6 @@
 use ruma_common::{api::Metadata, metadata};
 
-const METADATA: Metadata = metadata! {
+metadata! {
     method: GET,
     rate_limited: false,
     authentication: None,
@@ -8,6 +8,8 @@ const METADATA: Metadata = metadata! {
         unstable => "/a/path",
         1.1 => removed,
     }
-};
+}
+
+pub struct Request;
 
 fn main() {}

--- a/crates/ruma-common/tests/it/api/ui/request-only.rs
+++ b/crates/ruma-common/tests/it/api/ui/request-only.rs
@@ -4,19 +4,19 @@ use bytes::BufMut;
 use ruma_common::{
     api::{
         error::{FromHttpResponseError, IntoHttpError, MatrixError},
-        request, IncomingResponse, Metadata, OutgoingResponse,
+        request, IncomingResponse, OutgoingResponse,
     },
     metadata,
 };
 
-const METADATA: Metadata = metadata! {
+metadata! {
     method: POST, // An `http::Method` constant. No imports required.
     rate_limited: false,
     authentication: None,
     history: {
         unstable => "/_matrix/some/endpoint/{foo}",
     }
-};
+}
 
 #[request]
 #[derive(PartialEq)] // Make sure attributes work

--- a/crates/ruma-common/tests/it/api/ui/serde-flatten-request-body.rs
+++ b/crates/ruma-common/tests/it/api/ui/serde-flatten-request-body.rs
@@ -1,7 +1,7 @@
 #![allow(unexpected_cfgs)]
 
 use ruma_common::{
-    api::{request, response, Metadata},
+    api::{request, response},
     metadata,
 };
 use serde::{Deserialize, Serialize};
@@ -11,14 +11,14 @@ pub struct CustomRequestBody {
     pub bar: String,
 }
 
-const METADATA: Metadata = metadata! {
+metadata! {
     method: POST, // An `http::Method` constant. No imports required.
     rate_limited: false,
     authentication: None,
     history: {
         unstable => "/_matrix/some/endpoint",
     }
-};
+}
 
 #[request]
 pub struct Request {

--- a/crates/ruma-common/tests/it/api/ui/serde-flatten-response-body.rs
+++ b/crates/ruma-common/tests/it/api/ui/serde-flatten-response-body.rs
@@ -1,7 +1,7 @@
 #![allow(unexpected_cfgs)]
 
 use ruma_common::{
-    api::{request, response, Metadata},
+    api::{request, response},
     metadata,
 };
 use serde::{Deserialize, Serialize};
@@ -11,14 +11,14 @@ pub struct CustomResponseBody {
     pub bar: String,
 }
 
-const METADATA: Metadata = metadata! {
+metadata! {
     method: GET, // An `http::Method` constant. No imports required.
     rate_limited: false,
     authentication: None,
     history: {
         unstable => "/_matrix/some/endpoint",
     }
-};
+}
 
 #[request]
 pub struct Request;

--- a/crates/ruma-federation-api/src/authenticated_media/get_content.rs
+++ b/crates/ruma-federation-api/src/authenticated_media/get_content.rs
@@ -9,14 +9,11 @@ pub mod v1 {
 
     use std::time::Duration;
 
-    use ruma_common::{
-        api::{request, Metadata},
-        metadata,
-    };
+    use ruma_common::{api::request, metadata};
 
     use crate::authenticated_media::{ContentMetadata, FileOrLocation};
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: true,
         authentication: ServerSignatures,
@@ -24,7 +21,7 @@ pub mod v1 {
             unstable => "/_matrix/federation/unstable/org.matrix.msc3916.v2/media/download/{media_id}",
             1.11 => "/_matrix/federation/v1/media/download/{media_id}",
         }
-    };
+    }
 
     /// Request type for the `get_content` endpoint.
     #[request]

--- a/crates/ruma-federation-api/src/authenticated_media/get_content_thumbnail.rs
+++ b/crates/ruma-federation-api/src/authenticated_media/get_content_thumbnail.rs
@@ -10,15 +10,11 @@ pub mod v1 {
     use std::time::Duration;
 
     use js_int::UInt;
-    use ruma_common::{
-        api::{request, Metadata},
-        media::Method,
-        metadata,
-    };
+    use ruma_common::{api::request, media::Method, metadata};
 
     use crate::authenticated_media::{ContentMetadata, FileOrLocation};
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: true,
         authentication: ServerSignatures,
@@ -26,7 +22,7 @@ pub mod v1 {
             unstable => "/_matrix/federation/unstable/org.matrix.msc3916.v2/media/thumbnail/{media_id}",
             1.11 => "/_matrix/federation/v1/media/thumbnail/{media_id}",
         }
-    };
+    }
 
     /// Request type for the `get_content_thumbnail` endpoint.
     #[request]

--- a/crates/ruma-federation-api/src/authorization/get_event_authorization.rs
+++ b/crates/ruma-federation-api/src/authorization/get_event_authorization.rs
@@ -8,19 +8,19 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1event_authroomideventid
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedEventId, OwnedRoomId,
     };
     use serde_json::value::RawValue as RawJsonValue;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: ServerSignatures,
         history: {
             1.0 => "/_matrix/federation/v1/event_auth/{room_id}/{event_id}",
         }
-    };
+    }
 
     /// Request type for the `get_event_authorization` endpoint.
     #[request]

--- a/crates/ruma-federation-api/src/backfill/get_backfill.rs
+++ b/crates/ruma-federation-api/src/backfill/get_backfill.rs
@@ -9,19 +9,19 @@ pub mod v1 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedServerName,
     };
     use serde_json::value::RawValue as RawJsonValue;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: ServerSignatures,
         history: {
             1.0 => "/_matrix/federation/v1/backfill/{room_id}",
         }
-    };
+    }
 
     /// Request type for the `get_backfill` endpoint.
     #[request]

--- a/crates/ruma-federation-api/src/device/get_devices.rs
+++ b/crates/ruma-federation-api/src/device/get_devices.rs
@@ -9,7 +9,7 @@ pub mod v1 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         encryption::{CrossSigningKey, DeviceKeys},
         metadata,
         serde::Raw,
@@ -17,14 +17,14 @@ pub mod v1 {
     };
     use serde::{Deserialize, Serialize};
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: ServerSignatures,
         history: {
             1.0 => "/_matrix/federation/v1/user/devices/{user_id}",
         }
-    };
+    }
 
     /// Request type for the `get_devices` endpoint.
     #[request]

--- a/crates/ruma-federation-api/src/directory/get_public_rooms.rs
+++ b/crates/ruma-federation-api/src/directory/get_public_rooms.rs
@@ -9,19 +9,19 @@ pub mod v1 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         directory::{PublicRoomsChunk, RoomNetwork},
         metadata,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: ServerSignatures,
         history: {
             1.0 => "/_matrix/federation/v1/publicRooms",
         }
-    };
+    }
 
     /// Request type for the `get_public_rooms` endpoint.
     #[request]

--- a/crates/ruma-federation-api/src/directory/get_public_rooms_filtered.rs
+++ b/crates/ruma-federation-api/src/directory/get_public_rooms_filtered.rs
@@ -9,19 +9,19 @@ pub mod v1 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         directory::{Filter, PublicRoomsChunk, RoomNetwork},
         metadata,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: ServerSignatures,
         history: {
             1.0 => "/_matrix/federation/v1/publicRooms",
         }
-    };
+    }
 
     /// Request type for the `get_public_rooms_filtered` endpoint.
     #[request]

--- a/crates/ruma-federation-api/src/discovery/discover_homeserver.rs
+++ b/crates/ruma-federation-api/src/discovery/discover_homeserver.rs
@@ -5,18 +5,18 @@
 //! [spec]: https://spec.matrix.org/latest/server-server-api/#getwell-knownmatrixserver
 
 use ruma_common::{
-    api::{request, response, Metadata},
+    api::{request, response},
     metadata, OwnedServerName,
 };
 
-const METADATA: Metadata = metadata! {
+metadata! {
     method: GET,
     rate_limited: false,
     authentication: None,
     history: {
         1.0 => "/.well-known/matrix/server",
     }
-};
+}
 
 /// Request type for the `discover_homeserver` endpoint.
 #[request]

--- a/crates/ruma-federation-api/src/discovery/get_remote_server_keys.rs
+++ b/crates/ruma-federation-api/src/discovery/get_remote_server_keys.rs
@@ -9,7 +9,7 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixkeyv2queryservername
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         serde::Raw,
         MilliSecondsSinceUnixEpoch, OwnedServerName,
@@ -17,14 +17,14 @@ pub mod v2 {
 
     use crate::discovery::ServerSigningKeys;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: None,
         history: {
             1.0 => "/_matrix/key/v2/query/{server_name}",
         }
-    };
+    }
 
     /// Request type for the `get_remote_server_keys` endpoint.
     #[request]

--- a/crates/ruma-federation-api/src/discovery/get_remote_server_keys_batch.rs
+++ b/crates/ruma-federation-api/src/discovery/get_remote_server_keys_batch.rs
@@ -11,7 +11,7 @@ pub mod v2 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         serde::Raw,
         MilliSecondsSinceUnixEpoch, OwnedServerName, OwnedServerSigningKeyId,
@@ -20,14 +20,14 @@ pub mod v2 {
 
     use crate::discovery::ServerSigningKeys;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: None,
         history: {
             1.0 => "/_matrix/key/v2/query",
         }
-    };
+    }
 
     /// Request type for the `get_remote_server_keys_batch` endpoint.
     #[request]

--- a/crates/ruma-federation-api/src/discovery/get_server_keys.rs
+++ b/crates/ruma-federation-api/src/discovery/get_server_keys.rs
@@ -8,21 +8,21 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixkeyv2server
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         serde::Raw,
     };
 
     use crate::discovery::ServerSigningKeys;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: None,
         history: {
             1.0 => "/_matrix/key/v2/server",
         }
-    };
+    }
 
     /// Request type for the `get_server_keys` endpoint.
     #[request]

--- a/crates/ruma-federation-api/src/discovery/get_server_version.rs
+++ b/crates/ruma-federation-api/src/discovery/get_server_version.rs
@@ -8,19 +8,19 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1version
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
     };
     use serde::{Deserialize, Serialize};
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: None,
         history: {
             1.0 => "/_matrix/federation/v1/version",
         }
-    };
+    }
 
     /// Request type for the `get_server_version` endpoint.
     #[request]

--- a/crates/ruma-federation-api/src/discovery/get_server_versions.rs
+++ b/crates/ruma-federation-api/src/discovery/get_server_versions.rs
@@ -6,18 +6,18 @@ pub mod msc3723 {
     //! [GET /_matrix/federation/versions](https://github.com/matrix-org/matrix-spec-proposals/pull/3723)
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: None,
         history: {
             unstable => "/_matrix/federation/unstable/org.matrix.msc3723/versions",
         }
-    };
+    }
 
     /// Request type for the `get_server_versions` endpoint.
     #[request]

--- a/crates/ruma-federation-api/src/event/get_event.rs
+++ b/crates/ruma-federation-api/src/event/get_event.rs
@@ -8,19 +8,19 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1eventeventid
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedServerName,
     };
     use serde_json::value::RawValue as RawJsonValue;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: ServerSignatures,
         history: {
             1.0 => "/_matrix/federation/v1/event/{event_id}",
         }
-    };
+    }
 
     /// Request type for the `get_event` endpoint.
     #[request]

--- a/crates/ruma-federation-api/src/event/get_event_by_timestamp.rs
+++ b/crates/ruma-federation-api/src/event/get_event_by_timestamp.rs
@@ -8,11 +8,11 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1timestamp_to_eventroomid
 
     use ruma_common::{
-        api::{request, response, Direction, Metadata},
+        api::{request, response, Direction},
         metadata, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: ServerSignatures,
@@ -20,7 +20,7 @@ pub mod v1 {
             unstable => "/_matrix/federation/unstable/org.matrix.msc3030/timestamp_to_event/{room_id}",
             1.6 => "/_matrix/federation/v1/timestamp_to_event/{room_id}",
         }
-    };
+    }
 
     /// Request type for the `get_event_by_timestamp` endpoint.
     #[request]

--- a/crates/ruma-federation-api/src/event/get_missing_events.rs
+++ b/crates/ruma-federation-api/src/event/get_missing_events.rs
@@ -9,19 +9,19 @@ pub mod v1 {
 
     use js_int::{uint, UInt};
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedEventId, OwnedRoomId,
     };
     use serde_json::value::RawValue as RawJsonValue;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: ServerSignatures,
         history: {
             1.0 => "/_matrix/federation/v1/get_missing_events/{room_id}",
         }
-    };
+    }
 
     /// Request type for the `get_missing_events` endpoint.
     #[request]

--- a/crates/ruma-federation-api/src/event/get_room_state.rs
+++ b/crates/ruma-federation-api/src/event/get_room_state.rs
@@ -8,19 +8,19 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1stateroomid
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedEventId, OwnedRoomId,
     };
     use serde_json::value::RawValue as RawJsonValue;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: ServerSignatures,
         history: {
             1.0 => "/_matrix/federation/v1/state/{room_id}",
         }
-    };
+    }
 
     /// Request type for the `get_room_state` endpoint.
     #[request]

--- a/crates/ruma-federation-api/src/event/get_room_state_ids.rs
+++ b/crates/ruma-federation-api/src/event/get_room_state_ids.rs
@@ -8,18 +8,18 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1state_idsroomid
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedEventId, OwnedRoomId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: ServerSignatures,
         history: {
             1.0 => "/_matrix/federation/v1/state_ids/{room_id}",
         }
-    };
+    }
 
     /// Request type for the `get_room_state_ids` endpoint.
     #[request]

--- a/crates/ruma-federation-api/src/keys/claim_keys.rs
+++ b/crates/ruma-federation-api/src/keys/claim_keys.rs
@@ -10,21 +10,21 @@ pub mod v1 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         encryption::OneTimeKey,
         metadata,
         serde::Raw,
         OneTimeKeyAlgorithm, OwnedDeviceId, OwnedOneTimeKeyId, OwnedUserId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: ServerSignatures,
         history: {
             1.0 => "/_matrix/federation/v1/user/keys/claim",
         }
-    };
+    }
 
     /// Request type for the `claim_keys` endpoint.
     #[request]

--- a/crates/ruma-federation-api/src/keys/get_keys.rs
+++ b/crates/ruma-federation-api/src/keys/get_keys.rs
@@ -10,21 +10,21 @@ pub mod v1 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         encryption::{CrossSigningKey, DeviceKeys},
         metadata,
         serde::Raw,
         OwnedDeviceId, OwnedUserId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: ServerSignatures,
         history: {
             1.0 => "/_matrix/federation/v1/user/keys/query",
         }
-    };
+    }
 
     /// Request type for the `get_keys` endpoint.
     #[request]

--- a/crates/ruma-federation-api/src/membership/create_invite/v1.rs
+++ b/crates/ruma-federation-api/src/membership/create_invite/v1.rs
@@ -3,7 +3,7 @@
 //! [spec]: https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv1inviteroomideventid
 
 use ruma_common::{
-    api::{request, response, Metadata},
+    api::{request, response},
     metadata, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedServerName, OwnedUserId,
 };
 use ruma_events::{room::member::RoomMemberEventContent, StateEventType};
@@ -12,14 +12,14 @@ use serde_json::value::RawValue as RawJsonValue;
 
 use crate::membership::RawStrippedState;
 
-const METADATA: Metadata = metadata! {
+metadata! {
     method: PUT,
     rate_limited: false,
     authentication: ServerSignatures,
     history: {
         1.0 => "/_matrix/federation/v1/invite/{room_id}/{event_id}",
     }
-};
+}
 
 /// Request type for the `create_invite` endpoint.
 #[request]

--- a/crates/ruma-federation-api/src/membership/create_invite/v2.rs
+++ b/crates/ruma-federation-api/src/membership/create_invite/v2.rs
@@ -5,21 +5,21 @@
 #[cfg(feature = "unstable-msc4125")]
 use ruma_common::OwnedServerName;
 use ruma_common::{
-    api::{request, response, Metadata},
+    api::{request, response},
     metadata, OwnedEventId, OwnedRoomId, RoomVersionId,
 };
 use serde_json::value::RawValue as RawJsonValue;
 
 use crate::membership::RawStrippedState;
 
-const METADATA: Metadata = metadata! {
+metadata! {
     method: PUT,
     rate_limited: false,
     authentication: ServerSignatures,
     history: {
         1.0 => "/_matrix/federation/v2/invite/{room_id}/{event_id}",
     }
-};
+}
 
 /// Request type for the `create_invite` endpoint.
 #[request]

--- a/crates/ruma-federation-api/src/membership/create_join_event/v1.rs
+++ b/crates/ruma-federation-api/src/membership/create_join_event/v1.rs
@@ -3,13 +3,13 @@
 //! [spec]: https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv1send_joinroomideventid
 
 use ruma_common::{
-    api::{request, response, Metadata},
+    api::{request, response},
     metadata, OwnedEventId, OwnedRoomId,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue as RawJsonValue;
 
-const METADATA: Metadata = metadata! {
+metadata! {
     method: PUT,
     rate_limited: false,
     authentication: ServerSignatures,
@@ -17,7 +17,7 @@ const METADATA: Metadata = metadata! {
         1.0 => "/_matrix/federation/v1/send_join/{room_id}/{event_id}",
         1.0 => deprecated,
     }
-};
+}
 
 /// Request type for the `create_join_event` endpoint.
 #[request]

--- a/crates/ruma-federation-api/src/membership/create_join_event/v2.rs
+++ b/crates/ruma-federation-api/src/membership/create_join_event/v2.rs
@@ -3,20 +3,20 @@
 //! [spec]: https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv2send_joinroomideventid
 
 use ruma_common::{
-    api::{request, response, Metadata},
+    api::{request, response},
     metadata, OwnedEventId, OwnedRoomId,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue as RawJsonValue;
 
-const METADATA: Metadata = metadata! {
+metadata! {
     method: PUT,
     rate_limited: false,
     authentication: ServerSignatures,
     history: {
         1.0 => "/_matrix/federation/v2/send_join/{room_id}/{event_id}",
     }
-};
+}
 
 /// Request type for the `create_join_event` endpoint.
 #[request]

--- a/crates/ruma-federation-api/src/membership/create_knock_event.rs
+++ b/crates/ruma-federation-api/src/membership/create_knock_event.rs
@@ -8,14 +8,14 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv1send_knockroomideventid
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedEventId, OwnedRoomId,
     };
     use serde_json::value::RawValue as RawJsonValue;
 
     use crate::membership::RawStrippedState;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: PUT,
         rate_limited: false,
         authentication: ServerSignatures,
@@ -23,7 +23,7 @@ pub mod v1 {
             unstable => "/_matrix/federation/unstable/xyz.amorgan.knock/send_knock/{room_id}/{event_id}",
             1.1 => "/_matrix/federation/v1/send_knock/{room_id}/{event_id}",
         }
-    };
+    }
 
     /// Request type for the `send_knock` endpoint.
     #[request]

--- a/crates/ruma-federation-api/src/membership/create_leave_event/v1.rs
+++ b/crates/ruma-federation-api/src/membership/create_leave_event/v1.rs
@@ -3,13 +3,13 @@
 //! [spec]: https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv1send_leaveroomideventid
 
 use ruma_common::{
-    api::{request, response, Metadata},
+    api::{request, response},
     metadata, OwnedEventId, OwnedRoomId,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue as RawJsonValue;
 
-const METADATA: Metadata = metadata! {
+metadata! {
     method: PUT,
     rate_limited: false,
     authentication: ServerSignatures,
@@ -17,7 +17,7 @@ const METADATA: Metadata = metadata! {
         1.0 => "/_matrix/federation/v1/send_leave/{room_id}/{event_id}",
         1.0 => deprecated,
     }
-};
+}
 
 /// Request type for the `create_leave_event` endpoint.
 #[request]

--- a/crates/ruma-federation-api/src/membership/create_leave_event/v2.rs
+++ b/crates/ruma-federation-api/src/membership/create_leave_event/v2.rs
@@ -3,19 +3,19 @@
 //! [spec]: https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv2send_leaveroomideventid
 
 use ruma_common::{
-    api::{request, response, Metadata},
+    api::{request, response},
     metadata, OwnedEventId, OwnedRoomId,
 };
 use serde_json::value::RawValue as RawJsonValue;
 
-const METADATA: Metadata = metadata! {
+metadata! {
     method: PUT,
     rate_limited: false,
     authentication: ServerSignatures,
     history: {
         1.0 => "/_matrix/federation/v2/send_leave/{room_id}/{event_id}",
     }
-};
+}
 
 /// Request type for the `create_leave_event` endpoint.
 #[request]

--- a/crates/ruma-federation-api/src/membership/prepare_join_event.rs
+++ b/crates/ruma-federation-api/src/membership/prepare_join_event.rs
@@ -8,19 +8,19 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1make_joinroomiduserid
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedRoomId, OwnedUserId, RoomVersionId,
     };
     use serde_json::value::RawValue as RawJsonValue;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: ServerSignatures,
         history: {
             1.0 => "/_matrix/federation/v1/make_join/{room_id}/{user_id}",
         }
-    };
+    }
 
     /// Request type for the `create_join_event_template` endpoint.
     #[request]

--- a/crates/ruma-federation-api/src/membership/prepare_knock_event.rs
+++ b/crates/ruma-federation-api/src/membership/prepare_knock_event.rs
@@ -8,12 +8,12 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1make_knockroomiduserid
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedRoomId, OwnedUserId, RoomVersionId,
     };
     use serde_json::value::RawValue as RawJsonValue;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: ServerSignatures,
@@ -21,7 +21,7 @@ pub mod v1 {
             unstable => "/_matrix/federation/unstable/xyz.amorgan.knock/make_knock/{room_id}/{user_id}",
             1.1 => "/_matrix/federation/v1/make_knock/{room_id}/{user_id}",
         }
-    };
+    }
 
     /// Request type for the `create_knock_event_template` endpoint.
     #[request]

--- a/crates/ruma-federation-api/src/membership/prepare_leave_event.rs
+++ b/crates/ruma-federation-api/src/membership/prepare_leave_event.rs
@@ -9,19 +9,19 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1make_leaveroomiduserid
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedRoomId, OwnedUserId, RoomVersionId,
     };
     use serde_json::value::RawValue as RawJsonValue;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: ServerSignatures,
         history: {
             1.0 => "/_matrix/federation/v1/make_leave/{room_id}/{user_id}",
         }
-    };
+    }
 
     /// Request type for the `get_leave_event` endpoint.
     #[request]

--- a/crates/ruma-federation-api/src/openid/get_openid_userinfo.rs
+++ b/crates/ruma-federation-api/src/openid/get_openid_userinfo.rs
@@ -8,18 +8,18 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1openiduserinfo
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedUserId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: None,
         history: {
             1.0 => "/_matrix/federation/v1/openid/userinfo",
         }
-    };
+    }
 
     /// Request type for the `get_openid_userinfo` endpoint.
     #[request]

--- a/crates/ruma-federation-api/src/query/get_custom_information.rs
+++ b/crates/ruma-federation-api/src/query/get_custom_information.rs
@@ -11,19 +11,19 @@ pub mod v1 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
     };
     use serde_json::Value as JsonValue;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
         history: {
             1.0 => "/_matrix/federation/v1/query/{query_type}",
         }
-    };
+    }
 
     /// Request type for the `get_custom_information` endpoint.
     #[request]

--- a/crates/ruma-federation-api/src/query/get_profile_information.rs
+++ b/crates/ruma-federation-api/src/query/get_profile_information.rs
@@ -8,7 +8,7 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1queryprofile
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         serde::StringEnum,
         OwnedMxcUri, OwnedUserId,
@@ -16,14 +16,14 @@ pub mod v1 {
 
     use crate::PrivOwnedStr;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: ServerSignatures,
         history: {
             1.0 => "/_matrix/federation/v1/query/profile",
         }
-    };
+    }
 
     /// Request type for the `get_profile_information` endpoint.
     #[request]

--- a/crates/ruma-federation-api/src/query/get_room_information.rs
+++ b/crates/ruma-federation-api/src/query/get_room_information.rs
@@ -8,18 +8,18 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1querydirectory
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedRoomAliasId, OwnedRoomId, OwnedServerName,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: ServerSignatures,
         history: {
             1.0 => "/_matrix/federation/v1/query/directory",
         }
-    };
+    }
 
     /// Request type for the `get_room_information` endpoint.
     #[request]

--- a/crates/ruma-federation-api/src/room/report_content.rs
+++ b/crates/ruma-federation-api/src/room/report_content.rs
@@ -8,18 +8,18 @@ pub mod msc3843 {
     //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/3843
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedEventId, OwnedRoomId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: ServerSignatures,
         history: {
             unstable => "/_matrix/federation/unstable/org.matrix.msc3843/rooms/{room_id}/report/{event_id}",
         }
-    };
+    }
 
     /// Request type for the `report_content` endpoint.
     #[request]

--- a/crates/ruma-federation-api/src/space/get_hierarchy.rs
+++ b/crates/ruma-federation-api/src/space/get_hierarchy.rs
@@ -8,7 +8,7 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1hierarchyroomid
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         room::RoomSummary,
         OwnedRoomId,
@@ -16,7 +16,7 @@ pub mod v1 {
 
     use crate::space::SpaceHierarchyParentSummary;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: ServerSignatures,
@@ -24,7 +24,7 @@ pub mod v1 {
             unstable => "/_matrix/federation/unstable/org.matrix.msc2946/hierarchy/{room_id}",
             1.2 => "/_matrix/federation/v1/hierarchy/{room_id}",
         }
-    };
+    }
 
     /// Request type for the `hierarchy` endpoint.
     #[request]

--- a/crates/ruma-federation-api/src/thirdparty/bind_callback.rs
+++ b/crates/ruma-federation-api/src/thirdparty/bind_callback.rs
@@ -10,7 +10,7 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv13pidonbind
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         serde::Raw,
         thirdparty::Medium,
@@ -19,14 +19,14 @@ pub mod v1 {
     use ruma_events::room::member::SignedContent;
     use serde::{Deserialize, Serialize};
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: PUT,
         rate_limited: false,
         authentication: None,
         history: {
             1.0 => "/_matrix/federation/v1/3pid/onbind",
         }
-    };
+    }
 
     /// Request type for the `bind_callback` endpoint.
     #[request]

--- a/crates/ruma-federation-api/src/thirdparty/exchange_invite.rs
+++ b/crates/ruma-federation-api/src/thirdparty/exchange_invite.rs
@@ -12,7 +12,7 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv1exchange_third_party_inviteroomid
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         serde::Raw,
         OwnedRoomId, OwnedUserId,
@@ -27,14 +27,14 @@ pub mod v1 {
 
     use crate::thirdparty::bind_callback;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: PUT,
         rate_limited: false,
         authentication: AccessToken,
         history: {
             1.0 => "/_matrix/federation/v1/exchange_third_party_invite/{room_id}",
         }
-    };
+    }
 
     /// Request type for the `exchange_invite` endpoint.
     #[request]

--- a/crates/ruma-federation-api/src/transactions/send_transaction_message.rs
+++ b/crates/ruma-federation-api/src/transactions/send_transaction_message.rs
@@ -10,7 +10,7 @@ pub mod v1 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         serde::Raw,
         MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedServerName, OwnedTransactionId,
@@ -19,14 +19,14 @@ pub mod v1 {
 
     use crate::transactions::edu::Edu;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: PUT,
         rate_limited: false,
         authentication: ServerSignatures,
         history: {
             1.0 => "/_matrix/federation/v1/send/{transaction_id}",
         }
-    };
+    }
 
     /// Request type for the `send_transaction_message` endpoint.
     #[request]

--- a/crates/ruma-identity-service-api/src/association/bind_3pid.rs
+++ b/crates/ruma-identity-service-api/src/association/bind_3pid.rs
@@ -8,21 +8,21 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/identity-service-api/#post_matrixidentityv23pidbind
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         thirdparty::Medium,
         MilliSecondsSinceUnixEpoch, OwnedClientSecret, OwnedSessionId, OwnedUserId,
         ServerSignatures,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: AccessToken,
         history: {
             1.0 => "/_matrix/identity/v2/3pid/bind",
         }
-    };
+    }
 
     /// Request type for the `bind_3pid` endpoint.
     #[request]

--- a/crates/ruma-identity-service-api/src/association/check_3pid_validity.rs
+++ b/crates/ruma-identity-service-api/src/association/check_3pid_validity.rs
@@ -9,20 +9,20 @@ pub mod v2 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         thirdparty::Medium,
         OwnedClientSecret, OwnedSessionId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
         history: {
             1.0 => "/_matrix/identity/v2/3pid/getValidated3pid/",
         }
-    };
+    }
 
     /// Request type for the `check_3pid_validity` endpoint.
     #[request]

--- a/crates/ruma-identity-service-api/src/association/email/create_email_validation_session.rs
+++ b/crates/ruma-identity-service-api/src/association/email/create_email_validation_session.rs
@@ -9,18 +9,18 @@ pub mod v2 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedClientSecret, OwnedSessionId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: AccessToken,
         history: {
             1.0 => "/_matrix/identity/v2/validate/email/requestToken",
         }
-    };
+    }
 
     /// Request type for the `create_email_validation_session` endpoint.
     #[request]

--- a/crates/ruma-identity-service-api/src/association/email/validate_email.rs
+++ b/crates/ruma-identity-service-api/src/association/email/validate_email.rs
@@ -8,18 +8,18 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/identity-service-api/#post_matrixidentityv2validateemailsubmittoken
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedClientSecret, OwnedSessionId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: AccessToken,
         history: {
             1.0 => "/_matrix/identity/v2/validate/email/submitToken",
         }
-    };
+    }
 
     /// Request type for the `validate_email` endpoint.
     #[request]

--- a/crates/ruma-identity-service-api/src/association/email/validate_email_by_end_user.rs
+++ b/crates/ruma-identity-service-api/src/association/email/validate_email_by_end_user.rs
@@ -8,18 +8,18 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/identity-service-api/#get_matrixidentityv2validateemailsubmittoken
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedClientSecret, OwnedSessionId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
         history: {
             1.0 => "/_matrix/identity/v2/validate/email/submitToken",
         }
-    };
+    }
 
     /// Request type for the `validate_email_by_end_user` endpoint.
     #[request]

--- a/crates/ruma-identity-service-api/src/association/msisdn/create_msisdn_validation_session.rs
+++ b/crates/ruma-identity-service-api/src/association/msisdn/create_msisdn_validation_session.rs
@@ -9,18 +9,18 @@ pub mod v2 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedClientSecret, OwnedSessionId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: AccessToken,
         history: {
             1.0 => "/_matrix/identity/v2/validate/msisdn/requestToken",
         }
-    };
+    }
 
     /// Request type for the `create_msisdn_validation_session` endpoint.
     #[request]

--- a/crates/ruma-identity-service-api/src/association/msisdn/validate_msisdn.rs
+++ b/crates/ruma-identity-service-api/src/association/msisdn/validate_msisdn.rs
@@ -8,18 +8,18 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/identity-service-api/#post_matrixidentityv2validatemsisdnsubmittoken
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedClientSecret, OwnedSessionId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: AccessToken,
         history: {
             1.0 => "/_matrix/identity/v2/validate/msisdn/submitToken",
         }
-    };
+    }
 
     /// Request type for the `validate_msisdn` endpoint.
     #[request]

--- a/crates/ruma-identity-service-api/src/association/msisdn/validate_msisdn_by_phone_number.rs
+++ b/crates/ruma-identity-service-api/src/association/msisdn/validate_msisdn_by_phone_number.rs
@@ -8,18 +8,18 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/identity-service-api/#get_matrixidentityv2validatemsisdnsubmittoken
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedClientSecret, OwnedSessionId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
         history: {
             1.0 => "/_matrix/identity/v2/validate/msisdn/submitToken",
         }
-    };
+    }
 
     /// Request type for the `validate_email_by_end_user` endpoint.
     #[request]

--- a/crates/ruma-identity-service-api/src/association/unbind_3pid.rs
+++ b/crates/ruma-identity-service-api/src/association/unbind_3pid.rs
@@ -8,21 +8,21 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/identity-service-api/#post_matrixidentityv23pidunbind
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         thirdparty::Medium,
         OwnedClientSecret, OwnedSessionId, OwnedUserId,
     };
     use serde::{Deserialize, Serialize};
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: AccessToken,
         history: {
             1.0 => "/_matrix/identity/v2/3pid/unbind",
         }
-    };
+    }
 
     /// Request type for the `unbind_3pid` endpoint.
     #[request]

--- a/crates/ruma-identity-service-api/src/authentication/get_account_information.rs
+++ b/crates/ruma-identity-service-api/src/authentication/get_account_information.rs
@@ -8,18 +8,18 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/identity-service-api/#get_matrixidentityv2account
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedUserId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: AccessToken,
         history: {
             1.0 => "/_matrix/identity/v2/account",
         }
-    };
+    }
 
     /// Request type for the `get_account_information` endpoint.
     #[request]

--- a/crates/ruma-identity-service-api/src/authentication/logout.rs
+++ b/crates/ruma-identity-service-api/src/authentication/logout.rs
@@ -9,18 +9,18 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/identity-service-api/#post_matrixidentityv2accountlogout
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: AccessToken,
         history: {
             1.0 => "/_matrix/identity/v2/account/logout",
         }
-    };
+    }
 
     /// Request type for the `logout` endpoint.
     #[request]

--- a/crates/ruma-identity-service-api/src/authentication/register.rs
+++ b/crates/ruma-identity-service-api/src/authentication/register.rs
@@ -10,19 +10,19 @@ pub mod v2 {
     use std::time::Duration;
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         authentication::TokenType,
         metadata, OwnedServerName,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: None,
         history: {
             1.0 => "/_matrix/identity/v2/account/register",
         }
-    };
+    }
 
     /// Request type for the `register_account` endpoint.
     #[request]

--- a/crates/ruma-identity-service-api/src/discovery/get_server_status.rs
+++ b/crates/ruma-identity-service-api/src/discovery/get_server_status.rs
@@ -8,18 +8,18 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/identity-service-api/#get_matrixidentityv2
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: None,
         history: {
             1.0 => "/_matrix/identity/v2",
         }
-    };
+    }
 
     /// Request type for the `status` endpoint.
     #[request]

--- a/crates/ruma-identity-service-api/src/discovery/get_supported_versions.rs
+++ b/crates/ruma-identity-service-api/src/discovery/get_supported_versions.rs
@@ -13,18 +13,18 @@
 use std::collections::BTreeMap;
 
 use ruma_common::{
-    api::{request, response, Metadata, SupportedVersions},
+    api::{request, response, SupportedVersions},
     metadata,
 };
 
-const METADATA: Metadata = metadata! {
+metadata! {
     method: GET,
     rate_limited: false,
     authentication: None,
     history: {
         1.1 => "/_matrix/identity/versions",
     }
-};
+}
 
 /// Request type for the `versions` endpoint.
 #[request]

--- a/crates/ruma-identity-service-api/src/invitation/sign_invitation_ed25519.rs
+++ b/crates/ruma-identity-service-api/src/invitation/sign_invitation_ed25519.rs
@@ -8,20 +8,20 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/identity-service-api/#post_matrixidentityv2sign-ed25519
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         serde::Base64,
         OwnedUserId, ServerSignatures,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: AccessToken,
         history: {
             1.0 => "/_matrix/identity/v2/sign-ed25519",
         }
-    };
+    }
 
     /// Request type for the `sign_invitation_ed25519` endpoint.
     #[request]

--- a/crates/ruma-identity-service-api/src/invitation/store_invitation.rs
+++ b/crates/ruma-identity-service-api/src/invitation/store_invitation.rs
@@ -8,7 +8,7 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/identity-service-api/#post_matrixidentityv2store-invite
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         room::RoomType,
         third_party_invite::IdentityServerBase64PublicKey,
@@ -18,14 +18,14 @@ pub mod v2 {
     use ruma_events::room::third_party_invite::RoomThirdPartyInviteEventContent;
     use serde::{ser::SerializeSeq, Deserialize, Serialize};
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: AccessToken,
         history: {
             1.0 => "/_matrix/identity/v2/store-invite",
         }
-    };
+    }
 
     /// Request type for the `store_invitation` endpoint.
     #[request]

--- a/crates/ruma-identity-service-api/src/keys/check_public_key_validity.rs
+++ b/crates/ruma-identity-service-api/src/keys/check_public_key_validity.rs
@@ -9,19 +9,19 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/identity-service-api/#get_matrixidentityv2pubkeyisvalid
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         third_party_invite::IdentityServerBase64PublicKey,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: None,
         history: {
             1.0 => "/_matrix/identity/v2/pubkey/isvalid",
         }
-    };
+    }
 
     /// Request type for the `check_public_key_validity` endpoint.
     #[request]

--- a/crates/ruma-identity-service-api/src/keys/get_public_key.rs
+++ b/crates/ruma-identity-service-api/src/keys/get_public_key.rs
@@ -8,20 +8,20 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/identity-service-api/#get_matrixidentityv2pubkeykeyid
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         third_party_invite::IdentityServerBase64PublicKey,
         OwnedServerSigningKeyId,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: None,
         history: {
             1.0 => "/_matrix/identity/v2/pubkey/{key_id}",
         }
-    };
+    }
 
     /// Request type for the `get_public_key` endpoint.
     #[request]

--- a/crates/ruma-identity-service-api/src/keys/validate_ephemeral_key.rs
+++ b/crates/ruma-identity-service-api/src/keys/validate_ephemeral_key.rs
@@ -8,19 +8,19 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/identity-service-api/#get_matrixidentityv2pubkeyephemeralisvalid
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         third_party_invite::IdentityServerBase64PublicKey,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: None,
         history: {
             1.0 => "/_matrix/identity/v2/pubkey/ephemeral/isvalid",
         }
-    };
+    }
 
     /// Request type for the `validate_ephemeral_key` endpoint.
     #[request]

--- a/crates/ruma-identity-service-api/src/lookup/get_hash_parameters.rs
+++ b/crates/ruma-identity-service-api/src/lookup/get_hash_parameters.rs
@@ -9,20 +9,20 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/identity-service-api/#get_matrixidentityv2hash_details
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
     };
 
     use crate::lookup::IdentifierHashingAlgorithm;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: AccessToken,
         history: {
             1.0 => "/_matrix/identity/v2/hash_details",
         }
-    };
+    }
 
     /// Request type for the `get_hash_parameters` endpoint.
     #[request]

--- a/crates/ruma-identity-service-api/src/lookup/lookup_3pid.rs
+++ b/crates/ruma-identity-service-api/src/lookup/lookup_3pid.rs
@@ -10,20 +10,20 @@ pub mod v2 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata, OwnedUserId,
     };
 
     use crate::lookup::IdentifierHashingAlgorithm;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: AccessToken,
         history: {
             1.0 => "/_matrix/identity/v2/lookup",
         }
-    };
+    }
 
     /// Request type for the `lookup_3pid` endpoint.
     #[request]

--- a/crates/ruma-identity-service-api/src/tos/accept_terms_of_service.rs
+++ b/crates/ruma-identity-service-api/src/tos/accept_terms_of_service.rs
@@ -8,18 +8,18 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/identity-service-api/#post_matrixidentityv2terms
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
     };
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: AccessToken,
         history: {
             1.0 => "/_matrix/identity/v2/terms",
         }
-    };
+    }
 
     /// Request type for the `accept_terms_of_service` endpoint.
     #[request]

--- a/crates/ruma-identity-service-api/src/tos/get_terms_of_service.rs
+++ b/crates/ruma-identity-service-api/src/tos/get_terms_of_service.rs
@@ -10,19 +10,19 @@ pub mod v2 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
     };
     use serde::{Deserialize, Serialize};
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: GET,
         rate_limited: false,
         authentication: None,
         history: {
             1.0 => "/_matrix/identity/v2/terms",
         }
-    };
+    }
 
     /// Request type for the `get_terms_of_service` endpoint.
     #[request]

--- a/crates/ruma-macros/src/api/request.rs
+++ b/crates/ruma-macros/src/api/request.rs
@@ -282,11 +282,13 @@ impl Request {
             ));
         }
 
+        let ident = &self.ident;
+
         let path_fields = self.path_fields().map(|f| f.ident.as_ref().unwrap().to_string());
         let mut tests = quote! {
             #[::std::prelude::v1::test]
             fn path_parameters() {
-                let path_params = super::METADATA._path_parameters();
+                let path_params = <super::#ident as #ruma_common::api::Metadata>::_path_parameters();
                 let request_path_fields: &[&::std::primitive::str] = &[#(#path_fields),*];
                 ::std::assert_eq!(
                     path_params, request_path_fields,
@@ -300,7 +302,7 @@ impl Request {
                 #[::std::prelude::v1::test]
                 fn request_is_not_get() {
                     ::std::assert_ne!(
-                        super::METADATA.method, #http::Method::GET,
+                        <super::#ident as #ruma_common::api::Metadata>::METHOD, #http::Method::GET,
                         "GET endpoints can't have body fields",
                     );
                 }

--- a/crates/ruma-macros/src/api/request/incoming.rs
+++ b/crates/ruma-macros/src/api/request/incoming.rs
@@ -183,8 +183,6 @@ impl Request {
                 type EndpointError = #error_ty;
                 type OutgoingResponse = Response;
 
-                const METADATA: #ruma_common::api::Metadata = METADATA;
-
                 fn try_from_http_request<B, S>(
                     request: #http::Request<B>,
                     path_args: &[S],
@@ -193,12 +191,12 @@ impl Request {
                     B: ::std::convert::AsRef<[::std::primitive::u8]>,
                     S: ::std::convert::AsRef<::std::primitive::str>,
                 {
-                    if !(request.method() == METADATA.method
+                    if !(request.method() == <Self as #ruma_common::api::Metadata>::METHOD
                         || request.method() == #http::Method::HEAD
-                            && METADATA.method == #http::Method::GET)
+                            && <Self as #ruma_common::api::Metadata>::METHOD == #http::Method::GET)
                     {
                         return Err(#ruma_common::api::error::FromHttpRequestError::MethodMismatch {
-                            expected: METADATA.method,
+                            expected: <Self as #ruma_common::api::Metadata>::METHOD,
                             received: request.method().clone(),
                         });
                     }

--- a/crates/ruma-macros/src/api/request/outgoing.rs
+++ b/crates/ruma-macros/src/api/request/outgoing.rs
@@ -81,7 +81,7 @@ impl Request {
         }));
 
         header_kvs.extend(quote! {
-            req_headers.extend(METADATA.authorization_header(access_token)?);
+            req_headers.extend(<Self as #ruma_common::api::Metadata>::authorization_header(access_token)?);
         });
 
         let request_body = if let Some(field) = self.raw_body_field() {
@@ -94,7 +94,7 @@ impl Request {
                 #ruma_common::serde::json_to_buf(&RequestBody { #initializers })?
             }
         } else {
-            quote! { METADATA.empty_request_body::<T>() }
+            quote! { <Self as #ruma_common::api::Metadata>::empty_request_body::<T>() }
         };
 
         let (impl_generics, ty_generics, where_clause) = self.generics.split_for_impl();
@@ -106,8 +106,6 @@ impl Request {
                 type EndpointError = #error_ty;
                 type IncomingResponse = Response;
 
-                const METADATA: #ruma_common::api::Metadata = METADATA;
-
                 fn try_into_http_request<T: ::std::default::Default + #bytes::BufMut>(
                     self,
                     base_url: &::std::primitive::str,
@@ -115,8 +113,8 @@ impl Request {
                     considering: &'_ #ruma_common::api::SupportedVersions,
                 ) -> ::std::result::Result<#http::Request<T>, #ruma_common::api::error::IntoHttpError> {
                     let mut req_builder = #http::Request::builder()
-                        .method(METADATA.method)
-                        .uri(METADATA.make_endpoint_url(
+                        .method(<Self as #ruma_common::api::Metadata>::METHOD)
+                        .uri(<Self as #ruma_common::api::Metadata>::make_endpoint_url(
                             considering,
                             base_url,
                             &[ #( &self.#path_fields ),* ],

--- a/crates/ruma-push-gateway-api/src/send_event_notification.rs
+++ b/crates/ruma-push-gateway-api/src/send_event_notification.rs
@@ -9,7 +9,7 @@ pub mod v1 {
 
     use js_int::{uint, UInt};
     use ruma_common::{
-        api::{request, response, Metadata},
+        api::{request, response},
         metadata,
         push::{PushFormat, Tweak},
         serde::{JsonObject, StringEnum},
@@ -21,14 +21,14 @@ pub mod v1 {
 
     use crate::PrivOwnedStr;
 
-    const METADATA: Metadata = metadata! {
+    metadata! {
         method: POST,
         rate_limited: false,
         authentication: None,
         history: {
             1.0 => "/_matrix/push/v1/notify",
         }
-    };
+    }
 
     /// Request type for the `send_event_notification` endpoint.
     #[request]


### PR DESCRIPTION
Its fields are now associated constants with the same name converted to uppercase.

The `metadata!` macro generates the trait implementation for a type named `Request` by default. The type can be changed with an `@for` setting.

`Metadata` is a supertrait of `OutgoingRequest` and `IncomingRequest`.

The goal of this is to be able in the future to change some of the associated constants to associated types to use them in bounds.

Part of #2251.