### PR TITLE
api: Make Metadata's authentication scheme an associated type

### DIFF
--- a/crates/ruma-client-api/src/account/check_registration_token_validity.rs
+++ b/crates/ruma-client-api/src/account/check_registration_token_validity.rs
@@ -15,7 +15,7 @@ pub mod v1 {
     metadata! {
         method: GET,
         rate_limited: true,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             unstable => "/_matrix/client/unstable/org.matrix.msc3231/register/org.matrix.msc3231.login.registration_token/validity",
             1.2 => "/_matrix/client/v1/register/m.login.registration_token/validity",

--- a/crates/ruma-client-api/src/account/get_username_availability.rs
+++ b/crates/ruma-client-api/src/account/get_username_availability.rs
@@ -15,7 +15,7 @@ pub mod v3 {
     metadata! {
         method: GET,
         rate_limited: true,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             1.0 => "/_matrix/client/r0/register/available",
             1.1 => "/_matrix/client/v3/register/available",

--- a/crates/ruma-client-api/src/account/request_3pid_management_token_via_email.rs
+++ b/crates/ruma-client-api/src/account/request_3pid_management_token_via_email.rs
@@ -18,7 +18,7 @@ pub mod v3 {
     metadata! {
         method: POST,
         rate_limited: false,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             1.0 => "/_matrix/client/r0/account/3pid/email/requestToken",
             1.1 => "/_matrix/client/v3/account/3pid/email/requestToken",

--- a/crates/ruma-client-api/src/account/request_3pid_management_token_via_msisdn.rs
+++ b/crates/ruma-client-api/src/account/request_3pid_management_token_via_msisdn.rs
@@ -18,7 +18,7 @@ pub mod v3 {
     metadata! {
         method: POST,
         rate_limited: false,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             1.0 => "/_matrix/client/r0/account/3pid/msisdn/requestToken",
             1.1 => "/_matrix/client/v3/account/3pid/msisdn/requestToken",

--- a/crates/ruma-client-api/src/account/request_password_change_token_via_email.rs
+++ b/crates/ruma-client-api/src/account/request_password_change_token_via_email.rs
@@ -18,7 +18,7 @@ pub mod v3 {
     metadata! {
         method: POST,
         rate_limited: false,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             1.0 => "/_matrix/client/r0/account/password/email/requestToken",
             1.1 => "/_matrix/client/v3/account/password/email/requestToken",

--- a/crates/ruma-client-api/src/account/request_password_change_token_via_msisdn.rs
+++ b/crates/ruma-client-api/src/account/request_password_change_token_via_msisdn.rs
@@ -16,7 +16,7 @@ pub mod v3 {
     metadata! {
         method: POST,
         rate_limited: false,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             1.0 => "/_matrix/client/r0/account/password/msisdn/requestToken",
             1.1 => "/_matrix/client/v3/account/password/msisdn/requestToken",

--- a/crates/ruma-client-api/src/account/request_registration_token_via_email.rs
+++ b/crates/ruma-client-api/src/account/request_registration_token_via_email.rs
@@ -18,7 +18,7 @@ pub mod v3 {
     metadata! {
         method: POST,
         rate_limited: false,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             1.0 => "/_matrix/client/r0/register/email/requestToken",
             1.1 => "/_matrix/client/v3/register/email/requestToken",

--- a/crates/ruma-client-api/src/account/request_registration_token_via_msisdn.rs
+++ b/crates/ruma-client-api/src/account/request_registration_token_via_msisdn.rs
@@ -18,7 +18,7 @@ pub mod v3 {
     metadata! {
         method: POST,
         rate_limited: false,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             1.0 => "/_matrix/client/r0/register/msisdn/requestToken",
             1.1 => "/_matrix/client/v3/register/msisdn/requestToken",

--- a/crates/ruma-client-api/src/alias/get_alias.rs
+++ b/crates/ruma-client-api/src/alias/get_alias.rs
@@ -15,7 +15,7 @@ pub mod v3 {
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             1.0 => "/_matrix/client/r0/directory/room/{room_alias}",
             1.1 => "/_matrix/client/v3/directory/room/{room_alias}",

--- a/crates/ruma-client-api/src/directory/get_public_rooms.rs
+++ b/crates/ruma-client-api/src/directory/get_public_rooms.rs
@@ -17,7 +17,7 @@ pub mod v3 {
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             1.0 => "/_matrix/client/r0/publicRooms",
             1.1 => "/_matrix/client/v3/publicRooms",

--- a/crates/ruma-client-api/src/directory/get_room_visibility.rs
+++ b/crates/ruma-client-api/src/directory/get_room_visibility.rs
@@ -17,7 +17,7 @@ pub mod v3 {
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             1.0 => "/_matrix/client/r0/directory/list/room/{room_id}",
             1.1 => "/_matrix/client/v3/directory/list/room/{room_id}",

--- a/crates/ruma-client-api/src/discovery/discover_homeserver.rs
+++ b/crates/ruma-client-api/src/discovery/discover_homeserver.rs
@@ -22,7 +22,7 @@ use serde_json::Value as JsonValue;
 metadata! {
     method: GET,
     rate_limited: false,
-    authentication: None,
+    authentication: NoAuthentication,
     history: {
         1.0 => "/.well-known/matrix/client",
     }

--- a/crates/ruma-client-api/src/discovery/discover_support.rs
+++ b/crates/ruma-client-api/src/discovery/discover_support.rs
@@ -17,7 +17,7 @@ use crate::PrivOwnedStr;
 metadata! {
     method: GET,
     rate_limited: false,
-    authentication: None,
+    authentication: NoAuthentication,
     history: {
         1.10 => "/.well-known/matrix/support",
     }

--- a/crates/ruma-client-api/src/discovery/get_authorization_server_metadata.rs
+++ b/crates/ruma-client-api/src/discovery/get_authorization_server_metadata.rs
@@ -24,7 +24,7 @@ pub mod v1 {
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             unstable => "/_matrix/client/unstable/org.matrix.msc2965/auth_metadata",
             1.15 => "/_matrix/client/v1/auth_metadata",

--- a/crates/ruma-client-api/src/media/get_content.rs
+++ b/crates/ruma-client-api/src/media/get_content.rs
@@ -21,7 +21,7 @@ pub mod v3 {
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             1.0 => "/_matrix/media/r0/download/{server_name}/{media_id}",
             1.1 => "/_matrix/media/v3/download/{server_name}/{media_id}",

--- a/crates/ruma-client-api/src/media/get_content_as_filename.rs
+++ b/crates/ruma-client-api/src/media/get_content_as_filename.rs
@@ -21,7 +21,7 @@ pub mod v3 {
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             1.0 => "/_matrix/media/r0/download/{server_name}/{media_id}/{filename}",
             1.1 => "/_matrix/media/v3/download/{server_name}/{media_id}/{filename}",

--- a/crates/ruma-client-api/src/media/get_content_thumbnail.rs
+++ b/crates/ruma-client-api/src/media/get_content_thumbnail.rs
@@ -23,7 +23,7 @@ pub mod v3 {
     metadata! {
         method: GET,
         rate_limited: true,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             1.0 => "/_matrix/media/r0/thumbnail/{server_name}/{media_id}",
             1.1 => "/_matrix/media/v3/thumbnail/{server_name}/{media_id}",

--- a/crates/ruma-client-api/src/profile/get_avatar_url.rs
+++ b/crates/ruma-client-api/src/profile/get_avatar_url.rs
@@ -15,7 +15,7 @@ pub mod v3 {
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             1.0 => "/_matrix/client/r0/profile/{user_id}/avatar_url",
             1.1 => "/_matrix/client/v3/profile/{user_id}/avatar_url",

--- a/crates/ruma-client-api/src/profile/get_display_name.rs
+++ b/crates/ruma-client-api/src/profile/get_display_name.rs
@@ -15,7 +15,7 @@ pub mod v3 {
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             1.0 => "/_matrix/client/r0/profile/{user_id}/displayname",
             1.1 => "/_matrix/client/v3/profile/{user_id}/displayname",

--- a/crates/ruma-client-api/src/profile/get_profile.rs
+++ b/crates/ruma-client-api/src/profile/get_profile.rs
@@ -20,7 +20,7 @@ pub mod v3 {
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             1.0 => "/_matrix/client/r0/profile/{user_id}",
             1.1 => "/_matrix/client/v3/profile/{user_id}",

--- a/crates/ruma-client-api/src/profile/get_profile_field.rs
+++ b/crates/ruma-client-api/src/profile/get_profile_field.rs
@@ -16,7 +16,7 @@ pub mod v3 {
     use std::marker::PhantomData;
 
     use ruma_common::{
-        api::{AuthScheme, Metadata, VersionHistory},
+        api::{Metadata, VersionHistory},
         metadata, OwnedUserId,
     };
 
@@ -28,7 +28,7 @@ pub mod v3 {
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: None,
+        authentication: NoAuthentication,
         // History valid for fields that existed in Matrix 1.0, i.e. `displayname` and `avatar_url`.
         history: {
             unstable("uk.tcpip.msc4133") => "/_matrix/client/unstable/uk.tcpip.msc4133/profile/{user_id}/{field}",
@@ -159,7 +159,7 @@ pub mod v3 {
     impl<F: StaticProfileField> Metadata for RequestStatic<F> {
         const METHOD: http::Method = Request::METHOD;
         const RATE_LIMITED: bool = Request::RATE_LIMITED;
-        const AUTHENTICATION: AuthScheme = Request::AUTHENTICATION;
+        type Authentication = <Request as Metadata>::Authentication;
         const HISTORY: VersionHistory = Request::HISTORY;
     }
 

--- a/crates/ruma-client-api/src/rendezvous/create_rendezvous_session.rs
+++ b/crates/ruma-client-api/src/rendezvous/create_rendezvous_session.rs
@@ -24,7 +24,7 @@ pub mod unstable {
     metadata! {
         method: POST,
         rate_limited: true,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             unstable("org.matrix.msc4108") => "/_matrix/client/unstable/org.matrix.msc4108/rendezvous",
         }

--- a/crates/ruma-client-api/src/session/get_login_types.rs
+++ b/crates/ruma-client-api/src/session/get_login_types.rs
@@ -24,7 +24,7 @@ pub mod v3 {
     metadata! {
         method: GET,
         rate_limited: true,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             1.0 => "/_matrix/client/r0/login",
             1.1 => "/_matrix/client/v3/login",

--- a/crates/ruma-client-api/src/session/login_fallback.rs
+++ b/crates/ruma-client-api/src/session/login_fallback.rs
@@ -9,7 +9,7 @@ use ruma_common::{api::request, metadata, OwnedDeviceId};
 metadata! {
     method: GET,
     rate_limited: false,
-    authentication: None,
+    authentication: NoAuthentication,
     history: {
         1.0 => "/_matrix/static/client/login/",
     }

--- a/crates/ruma-client-api/src/session/refresh_token.rs
+++ b/crates/ruma-client-api/src/session/refresh_token.rs
@@ -35,7 +35,7 @@ pub mod v3 {
     metadata! {
         method: POST,
         rate_limited: true,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             unstable => "/_matrix/client/unstable/org.matrix.msc2918/refresh",
             1.3 => "/_matrix/client/v3/refresh",

--- a/crates/ruma-client-api/src/session/sso_login.rs
+++ b/crates/ruma-client-api/src/session/sso_login.rs
@@ -17,7 +17,7 @@ pub mod v3 {
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             1.0 => "/_matrix/client/r0/login/sso/redirect",
             1.1 => "/_matrix/client/v3/login/sso/redirect",

--- a/crates/ruma-client-api/src/session/sso_login_with_provider.rs
+++ b/crates/ruma-client-api/src/session/sso_login_with_provider.rs
@@ -19,7 +19,7 @@ pub mod v3 {
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             unstable => "/_matrix/client/unstable/org.matrix.msc2858/login/sso/redirect/{idp_id}",
             1.1 => "/_matrix/client/v3/login/sso/redirect/{idp_id}",

--- a/crates/ruma-client-api/src/uiaa/get_uiaa_fallback_page.rs
+++ b/crates/ruma-client-api/src/uiaa/get_uiaa_fallback_page.rs
@@ -14,7 +14,7 @@ pub mod v3 {
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             1.0 => "/_matrix/client/r0/auth/{auth_type}/fallback/web",
             1.1 => "/_matrix/client/v3/auth/{auth_type}/fallback/web",

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -18,11 +18,17 @@ Breaking changes:
   backwards-compatibility for clients.
 - Macros no longer support importing the `ruma` and `ruma-events` crate from the
   `matrix-sdk-appservice` crate. This crate was dropped 2 years ago.
-- `Metadata` was changed from a `struct` to a `trait`.
-  - Its fields are now associated constants with the same name converted to
-    uppercase.
-  - The `metadata!` macro generates the trait implementation for a type named
-    `Request` by default. The type can be changed with an `@for` setting.
+- `Metadata` and `AuthScheme` were changed from a `struct` and an enum
+  respectively to `trait`s.
+  - The variants of the `AuthScheme` enum are now structs implementing the
+    `AuthScheme` trait. The `None` variant was renamed to `NoAuthentication`.
+  - The `authentication` field of the `Metadata` struct is now an associated
+    type named `Authentication` that must implement `AuthScheme`. 
+  - The other fields of the `Metadata` struct are now associated constants with
+    the same name converted to uppercase.
+  - The `metadata!` macro generates the `Metadata` trait implementation for a
+    type named `Request` by default. This type can be changed with an `@for`
+    setting.
   - `Metadata` is a supertrait of `OutgoingRequest` and `IncomingRequest`.
 
 Improvements:

--- a/crates/ruma-common/src/api.rs
+++ b/crates/ruma-common/src/api.rs
@@ -77,7 +77,7 @@ use bytes::BufMut;
 ///     # metadata! {
 ///     #     method: POST,
 ///     #     rate_limited: false,
-///     #     authentication: None,
+///     #     authentication: NoAuthentication,
 ///     #     history: {
 ///     #         unstable => "/_matrix/some/endpoint/{room_id}",
 ///     #     },
@@ -110,7 +110,7 @@ use bytes::BufMut;
 ///     # metadata! {
 ///     #     method: POST,
 ///     #     rate_limited: false,
-///     #     authentication: None,
+///     #     authentication: NoAuthentication,
 ///     #     history: {
 ///     #         unstable => "/_matrix/some/endpoint/{file_name}",
 ///     #     },
@@ -185,7 +185,7 @@ pub use ruma_macros::request;
 ///     # metadata! {
 ///     #     method: POST,
 ///     #     rate_limited: false,
-///     #     authentication: None,
+///     #     authentication: NoAuthentication,
 ///     #     history: {
 ///     #         unstable => "/_matrix/some/endpoint",
 ///     #     },
@@ -212,7 +212,7 @@ pub use ruma_macros::request;
 ///     # metadata! {
 ///     #     method: POST,
 ///     #     rate_limited: false,
-///     #     authentication: None,
+///     #     authentication: NoAuthentication,
 ///     #     history: {
 ///     #         unstable => "/_matrix/some/endpoint",
 ///     #     },
@@ -241,6 +241,7 @@ use self::error::{FromHttpRequestError, FromHttpResponseError, IntoHttpError};
 pub use crate::metadata;
 use crate::UserId;
 
+pub mod auth_scheme;
 pub mod error;
 mod metadata;
 
@@ -428,44 +429,6 @@ pub trait EndpointError: OutgoingResponse + StdError + Sized + Send + 'static {
     /// This will always return `Err` variant when no `error` field is defined in
     /// the `ruma_api` macro.
     fn from_http_response<T: AsRef<[u8]>>(response: http::Response<T>) -> Self;
-}
-
-/// Authentication scheme used by the endpoint.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[allow(clippy::exhaustive_enums)]
-pub enum AuthScheme {
-    /// No authentication is performed.
-    None,
-
-    /// Authentication is performed by including an access token in the `Authentication` http
-    /// header, or an `access_token` query parameter.
-    ///
-    /// Using the query parameter is deprecated since Matrix 1.11.
-    AccessToken,
-
-    /// Authentication is optional, and it is performed by including an access token in the
-    /// `Authentication` http header, or an `access_token` query parameter.
-    ///
-    /// Using the query parameter is deprecated since Matrix 1.11.
-    AccessTokenOptional,
-
-    /// Authentication is required, and can only be performed for appservices, by including an
-    /// appservice access token in the `Authentication` http header, or `access_token` query
-    /// parameter.
-    ///
-    /// Using the query parameter is deprecated since Matrix 1.11.
-    AppserviceToken,
-
-    /// No authentication is performed for clients, but it can be performed for appservices, by
-    /// including an appservice access token in the `Authentication` http header, or an
-    /// `access_token` query parameter.
-    ///
-    /// Using the query parameter is deprecated since Matrix 1.11.
-    AppserviceTokenOptional,
-
-    /// Authentication is performed by including X-Matrix signatures in the request headers,
-    /// as defined in the federation API.
-    ServerSignatures,
 }
 
 /// The direction to return events from.

--- a/crates/ruma-common/src/api/auth_scheme.rs
+++ b/crates/ruma-common/src/api/auth_scheme.rs
@@ -1,0 +1,129 @@
+//! The `AuthScheme` trait used to specify the authentication scheme used by endpoints and the types
+//! that implement it.
+
+#![allow(clippy::exhaustive_structs)]
+
+use http::{header, HeaderName, HeaderValue};
+
+use crate::api::{error::IntoHttpError, SendAccessToken};
+
+/// Trait implemented by types representing an authentication scheme used by an endpoint.
+pub trait AuthScheme: Sized {
+    /// The `Authorization` HTTP header to add to an outgoing request with this scheme.
+    ///
+    /// Transforms the `SendAccessToken` into an access token if the endpoint requires it, or if it
+    /// is `SendAccessToken::Force`.
+    ///
+    /// Fails if the endpoint requires an access token but the parameter is `SendAccessToken::None`,
+    /// or if the access token can't be converted to a [`HeaderValue`].
+    fn authorization_header(
+        access_token: SendAccessToken<'_>,
+    ) -> Result<Option<(HeaderName, HeaderValue)>, IntoHttpError>;
+}
+
+/// No authentication is performed.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NoAuthentication;
+
+impl AuthScheme for NoAuthentication {
+    fn authorization_header(
+        access_token: SendAccessToken<'_>,
+    ) -> Result<Option<(HeaderName, HeaderValue)>, IntoHttpError> {
+        access_token
+            .get_not_required_for_endpoint()
+            .map(access_token_to_authorization_header)
+            .transpose()
+    }
+}
+
+/// Authentication is performed by including an access token in the `Authentication` http
+/// header, or an `access_token` query parameter.
+///
+/// Using the query parameter is deprecated since Matrix 1.11.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct AccessToken;
+
+impl AuthScheme for AccessToken {
+    fn authorization_header(
+        access_token: SendAccessToken<'_>,
+    ) -> Result<Option<(HeaderName, HeaderValue)>, IntoHttpError> {
+        let token =
+            access_token.get_required_for_endpoint().ok_or(IntoHttpError::NeedsAuthentication)?;
+        access_token_to_authorization_header(token).map(Some)
+    }
+}
+
+/// Authentication is optional, and it is performed by including an access token in the
+/// `Authentication` http header, or an `access_token` query parameter.
+///
+/// Using the query parameter is deprecated since Matrix 1.11.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct AccessTokenOptional;
+
+impl AuthScheme for AccessTokenOptional {
+    fn authorization_header(
+        access_token: SendAccessToken<'_>,
+    ) -> Result<Option<(HeaderName, HeaderValue)>, IntoHttpError> {
+        access_token
+            .get_required_for_endpoint()
+            .map(access_token_to_authorization_header)
+            .transpose()
+    }
+}
+
+/// Authentication is required, and can only be performed for appservices, by including an
+/// appservice access token in the `Authentication` http header, or `access_token` query
+/// parameter.
+///
+/// Using the query parameter is deprecated since Matrix 1.11.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct AppserviceToken;
+
+impl AuthScheme for AppserviceToken {
+    fn authorization_header(
+        access_token: SendAccessToken<'_>,
+    ) -> Result<Option<(HeaderName, HeaderValue)>, IntoHttpError> {
+        let token =
+            access_token.get_required_for_appservice().ok_or(IntoHttpError::NeedsAuthentication)?;
+        access_token_to_authorization_header(token).map(Some)
+    }
+}
+
+/// No authentication is performed for clients, but it can be performed for appservices, by
+/// including an appservice access token in the `Authentication` http header, or an
+/// `access_token` query parameter.
+///
+/// Using the query parameter is deprecated since Matrix 1.11.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct AppserviceTokenOptional;
+
+impl AuthScheme for AppserviceTokenOptional {
+    fn authorization_header(
+        access_token: SendAccessToken<'_>,
+    ) -> Result<Option<(HeaderName, HeaderValue)>, IntoHttpError> {
+        access_token
+            .get_required_for_appservice()
+            .map(access_token_to_authorization_header)
+            .transpose()
+    }
+}
+
+/// Authentication is performed by including X-Matrix signatures in the request headers,
+/// as defined in the federation API.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ServerSignatures;
+
+impl AuthScheme for ServerSignatures {
+    fn authorization_header(
+        _access_token: SendAccessToken<'_>,
+    ) -> Result<Option<(HeaderName, HeaderValue)>, IntoHttpError> {
+        Ok(None)
+    }
+}
+
+/// Convert the given access token to an `Authorization` HTTP header.
+fn access_token_to_authorization_header(
+    token: &str,
+) -> Result<(HeaderName, HeaderValue), IntoHttpError> {
+    Ok((header::AUTHORIZATION, format!("Bearer {token}").try_into()?))
+}

--- a/crates/ruma-common/tests/it/api/conversions.rs
+++ b/crates/ruma-common/tests/it/api/conversions.rs
@@ -12,7 +12,7 @@ use ruma_common::{
 metadata! {
     method: POST,
     rate_limited: false,
-    authentication: None,
+    authentication: NoAuthentication,
     history: {
         unstable => "/_matrix/foo/{bar}/{user}",
     }
@@ -144,7 +144,7 @@ mod without_query {
     metadata! {
         method: POST,
         rate_limited: false,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             unstable => "/_matrix/foo/{bar}/{user}",
         }

--- a/crates/ruma-common/tests/it/api/default_status.rs
+++ b/crates/ruma-common/tests/it/api/default_status.rs
@@ -10,7 +10,7 @@ use ruma_common::{
 metadata! {
     method: GET,
     rate_limited: false,
-    authentication: None,
+    authentication: NoAuthentication,
     history: {
         unstable => "/_matrix/my/endpoint",
     }

--- a/crates/ruma-common/tests/it/api/header_override.rs
+++ b/crates/ruma-common/tests/it/api/header_override.rs
@@ -12,7 +12,7 @@ use ruma_common::{
 metadata! {
     method: GET,
     rate_limited: false,
-    authentication: None,
+    authentication: NoAuthentication,
     history: {
         unstable => "/_matrix/my/endpoint",
     }

--- a/crates/ruma-common/tests/it/api/manual_endpoint_impl.rs
+++ b/crates/ruma-common/tests/it/api/manual_endpoint_impl.rs
@@ -7,10 +7,10 @@ use bytes::BufMut;
 use http::{header::CONTENT_TYPE, method::Method};
 use ruma_common::{
     api::{
+        auth_scheme::NoAuthentication,
         error::{FromHttpRequestError, FromHttpResponseError, IntoHttpError, MatrixError},
-        AuthScheme, EndpointError, IncomingRequest, IncomingResponse, MatrixVersion, Metadata,
-        OutgoingRequest, OutgoingResponse, SendAccessToken, StablePathSelector, SupportedVersions,
-        VersionHistory,
+        EndpointError, IncomingRequest, IncomingResponse, MatrixVersion, Metadata, OutgoingRequest,
+        OutgoingResponse, SendAccessToken, StablePathSelector, SupportedVersions, VersionHistory,
     },
     OwnedRoomAliasId, OwnedRoomId,
 };
@@ -26,7 +26,7 @@ pub struct Request {
 impl Metadata for Request {
     const METHOD: Method = Method::PUT;
     const RATE_LIMITED: bool = false;
-    const AUTHENTICATION: AuthScheme = AuthScheme::None;
+    type Authentication = NoAuthentication;
     const HISTORY: VersionHistory = VersionHistory::new(
         &[
             (None, "/_matrix/client/unstable/directory/room/{room_alias}"),

--- a/crates/ruma-common/tests/it/api/no_fields.rs
+++ b/crates/ruma-common/tests/it/api/no_fields.rs
@@ -11,7 +11,7 @@ mod get {
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             unstable => "/_matrix/my/endpoint",
         }
@@ -35,7 +35,7 @@ mod post {
     metadata! {
         method: POST,
         rate_limited: false,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             unstable => "/_matrix/my/endpoint",
         }

--- a/crates/ruma-common/tests/it/api/optional_headers.rs
+++ b/crates/ruma-common/tests/it/api/optional_headers.rs
@@ -12,7 +12,7 @@ use ruma_common::{
 metadata! {
     method: GET,
     rate_limited: false,
-    authentication: None,
+    authentication: NoAuthentication,
     history: {
         unstable => "/_matrix/my/endpoint",
     }

--- a/crates/ruma-common/tests/it/api/required_headers.rs
+++ b/crates/ruma-common/tests/it/api/required_headers.rs
@@ -16,7 +16,7 @@ use ruma_common::{
 metadata! {
     method: GET,
     rate_limited: false,
-    authentication: None,
+    authentication: NoAuthentication,
     history: {
         unstable => "/_matrix/my/endpoint",
     }

--- a/crates/ruma-common/tests/it/api/ruma_api_macros.rs
+++ b/crates/ruma-common/tests/it/api/ruma_api_macros.rs
@@ -13,7 +13,7 @@ pub mod some_endpoint {
     metadata! {
         method: POST, // An `http::Method` constant. No imports required.
         rate_limited: false,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             unstable => "/_matrix/some/endpoint/{user}",
         }
@@ -78,7 +78,7 @@ pub mod newtype_body_endpoint {
     metadata! {
         method: PUT,
         rate_limited: false,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             unstable => "/_matrix/some/newtype/body/endpoint",
         }
@@ -113,7 +113,7 @@ pub mod raw_body_endpoint {
     metadata! {
         method: PUT,
         rate_limited: false,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             unstable => "/_matrix/some/newtype/body/endpoint",
         }
@@ -150,7 +150,7 @@ pub mod query_all_enum_endpoint {
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             unstable => "/_matrix/some/query/map/endpoint",
         }
@@ -177,7 +177,7 @@ pub mod query_all_vec_endpoint {
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             unstable => "/_matrix/some/query/map/endpoint",
         }

--- a/crates/ruma-common/tests/it/api/status_override.rs
+++ b/crates/ruma-common/tests/it/api/status_override.rs
@@ -13,7 +13,7 @@ use ruma_common::{
 metadata! {
     method: GET,
     rate_limited: false,
-    authentication: None,
+    authentication: NoAuthentication,
     history: {
         unstable => "/_matrix/my/endpoint",
     }

--- a/crates/ruma-common/tests/it/api/ui/api-sanity-check.rs
+++ b/crates/ruma-common/tests/it/api/ui/api-sanity-check.rs
@@ -10,7 +10,7 @@ use ruma_common::{
 metadata! {
     method: POST, // An `http::Method` constant. No imports required.
     rate_limited: false,
-    authentication: None,
+    authentication: NoAuthentication,
     history: {
         unstable => "/_matrix/some/msc1234/endpoint/{baz}",
         unstable("org.bar.msc1234") => "/_matrix/unstable/org.bar.msc1234/endpoint/{baz}",

--- a/crates/ruma-common/tests/it/api/ui/deprecated-without-added.rs
+++ b/crates/ruma-common/tests/it/api/ui/deprecated-without-added.rs
@@ -3,7 +3,7 @@ use ruma_common::metadata;
 metadata! {
     method: GET,
     rate_limited: false,
-    authentication: None,
+    authentication: NoAuthentication,
     history: {
         unstable => "/a/path",
         1.1 => deprecated,

--- a/crates/ruma-common/tests/it/api/ui/move-value.rs
+++ b/crates/ruma-common/tests/it/api/ui/move-value.rs
@@ -15,7 +15,7 @@ pub mod newtype_body {
     metadata! {
         method: POST,
         rate_limited: false,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             unstable => "/_matrix/foo/{bar}/",
         }
@@ -58,7 +58,7 @@ pub mod raw_body {
     metadata! {
         method: POST,
         rate_limited: false,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             unstable => "/_matrix/foo/{bar}/",
         }
@@ -104,7 +104,7 @@ pub mod plain {
     metadata! {
         method: POST,
         rate_limited: false,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             unstable => "/_matrix/foo/{bar}/",
         }

--- a/crates/ruma-common/tests/it/api/ui/removed-without-deprecated.rs
+++ b/crates/ruma-common/tests/it/api/ui/removed-without-deprecated.rs
@@ -3,7 +3,7 @@ use ruma_common::{api::Metadata, metadata};
 metadata! {
     method: GET,
     rate_limited: false,
-    authentication: None,
+    authentication: NoAuthentication,
     history: {
         unstable => "/a/path",
         1.1 => removed,

--- a/crates/ruma-common/tests/it/api/ui/request-only.rs
+++ b/crates/ruma-common/tests/it/api/ui/request-only.rs
@@ -12,7 +12,7 @@ use ruma_common::{
 metadata! {
     method: POST, // An `http::Method` constant. No imports required.
     rate_limited: false,
-    authentication: None,
+    authentication: NoAuthentication,
     history: {
         unstable => "/_matrix/some/endpoint/{foo}",
     }

--- a/crates/ruma-common/tests/it/api/ui/serde-flatten-request-body.rs
+++ b/crates/ruma-common/tests/it/api/ui/serde-flatten-request-body.rs
@@ -14,7 +14,7 @@ pub struct CustomRequestBody {
 metadata! {
     method: POST, // An `http::Method` constant. No imports required.
     rate_limited: false,
-    authentication: None,
+    authentication: NoAuthentication,
     history: {
         unstable => "/_matrix/some/endpoint",
     }

--- a/crates/ruma-common/tests/it/api/ui/serde-flatten-response-body.rs
+++ b/crates/ruma-common/tests/it/api/ui/serde-flatten-response-body.rs
@@ -14,7 +14,7 @@ pub struct CustomResponseBody {
 metadata! {
     method: GET, // An `http::Method` constant. No imports required.
     rate_limited: false,
-    authentication: None,
+    authentication: NoAuthentication,
     history: {
         unstable => "/_matrix/some/endpoint",
     }

--- a/crates/ruma-federation-api/src/discovery/discover_homeserver.rs
+++ b/crates/ruma-federation-api/src/discovery/discover_homeserver.rs
@@ -12,7 +12,7 @@ use ruma_common::{
 metadata! {
     method: GET,
     rate_limited: false,
-    authentication: None,
+    authentication: NoAuthentication,
     history: {
         1.0 => "/.well-known/matrix/server",
     }

--- a/crates/ruma-federation-api/src/discovery/get_remote_server_keys.rs
+++ b/crates/ruma-federation-api/src/discovery/get_remote_server_keys.rs
@@ -20,7 +20,7 @@ pub mod v2 {
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             1.0 => "/_matrix/key/v2/query/{server_name}",
         }

--- a/crates/ruma-federation-api/src/discovery/get_remote_server_keys_batch.rs
+++ b/crates/ruma-federation-api/src/discovery/get_remote_server_keys_batch.rs
@@ -23,7 +23,7 @@ pub mod v2 {
     metadata! {
         method: POST,
         rate_limited: false,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             1.0 => "/_matrix/key/v2/query",
         }

--- a/crates/ruma-federation-api/src/discovery/get_server_keys.rs
+++ b/crates/ruma-federation-api/src/discovery/get_server_keys.rs
@@ -18,7 +18,7 @@ pub mod v2 {
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             1.0 => "/_matrix/key/v2/server",
         }

--- a/crates/ruma-federation-api/src/discovery/get_server_version.rs
+++ b/crates/ruma-federation-api/src/discovery/get_server_version.rs
@@ -16,7 +16,7 @@ pub mod v1 {
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             1.0 => "/_matrix/federation/v1/version",
         }

--- a/crates/ruma-federation-api/src/discovery/get_server_versions.rs
+++ b/crates/ruma-federation-api/src/discovery/get_server_versions.rs
@@ -13,7 +13,7 @@ pub mod msc3723 {
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             unstable => "/_matrix/federation/unstable/org.matrix.msc3723/versions",
         }

--- a/crates/ruma-federation-api/src/openid/get_openid_userinfo.rs
+++ b/crates/ruma-federation-api/src/openid/get_openid_userinfo.rs
@@ -15,7 +15,7 @@ pub mod v1 {
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             1.0 => "/_matrix/federation/v1/openid/userinfo",
         }

--- a/crates/ruma-federation-api/src/thirdparty/bind_callback.rs
+++ b/crates/ruma-federation-api/src/thirdparty/bind_callback.rs
@@ -22,7 +22,7 @@ pub mod v1 {
     metadata! {
         method: PUT,
         rate_limited: false,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             1.0 => "/_matrix/federation/v1/3pid/onbind",
         }

--- a/crates/ruma-identity-service-api/src/authentication/register.rs
+++ b/crates/ruma-identity-service-api/src/authentication/register.rs
@@ -18,7 +18,7 @@ pub mod v2 {
     metadata! {
         method: POST,
         rate_limited: false,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             1.0 => "/_matrix/identity/v2/account/register",
         }

--- a/crates/ruma-identity-service-api/src/discovery/get_server_status.rs
+++ b/crates/ruma-identity-service-api/src/discovery/get_server_status.rs
@@ -15,7 +15,7 @@ pub mod v2 {
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             1.0 => "/_matrix/identity/v2",
         }

--- a/crates/ruma-identity-service-api/src/discovery/get_supported_versions.rs
+++ b/crates/ruma-identity-service-api/src/discovery/get_supported_versions.rs
@@ -20,7 +20,7 @@ use ruma_common::{
 metadata! {
     method: GET,
     rate_limited: false,
-    authentication: None,
+    authentication: NoAuthentication,
     history: {
         1.1 => "/_matrix/identity/versions",
     }

--- a/crates/ruma-identity-service-api/src/keys/check_public_key_validity.rs
+++ b/crates/ruma-identity-service-api/src/keys/check_public_key_validity.rs
@@ -17,7 +17,7 @@ pub mod v2 {
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             1.0 => "/_matrix/identity/v2/pubkey/isvalid",
         }

--- a/crates/ruma-identity-service-api/src/keys/get_public_key.rs
+++ b/crates/ruma-identity-service-api/src/keys/get_public_key.rs
@@ -17,7 +17,7 @@ pub mod v2 {
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             1.0 => "/_matrix/identity/v2/pubkey/{key_id}",
         }

--- a/crates/ruma-identity-service-api/src/keys/validate_ephemeral_key.rs
+++ b/crates/ruma-identity-service-api/src/keys/validate_ephemeral_key.rs
@@ -16,7 +16,7 @@ pub mod v2 {
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             1.0 => "/_matrix/identity/v2/pubkey/ephemeral/isvalid",
         }

--- a/crates/ruma-identity-service-api/src/tos/get_terms_of_service.rs
+++ b/crates/ruma-identity-service-api/src/tos/get_terms_of_service.rs
@@ -18,7 +18,7 @@ pub mod v2 {
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             1.0 => "/_matrix/identity/v2/terms",
         }

--- a/crates/ruma-macros/src/api/request/outgoing.rs
+++ b/crates/ruma-macros/src/api/request/outgoing.rs
@@ -81,7 +81,7 @@ impl Request {
         }));
 
         header_kvs.extend(quote! {
-            req_headers.extend(<Self as #ruma_common::api::Metadata>::authorization_header(access_token)?);
+            req_headers.extend(<<Self as #ruma_common::api::Metadata>::Authentication as #ruma_common::api::auth_scheme::AuthScheme>::authorization_header(access_token)?);
         });
 
         let request_body = if let Some(field) = self.raw_body_field() {

--- a/crates/ruma-push-gateway-api/src/send_event_notification.rs
+++ b/crates/ruma-push-gateway-api/src/send_event_notification.rs
@@ -24,7 +24,7 @@ pub mod v1 {
     metadata! {
         method: POST,
         rate_limited: false,
-        authentication: None,
+        authentication: NoAuthentication,
         history: {
             1.0 => "/_matrix/push/v1/notify",
         }


### PR DESCRIPTION
`AuthScheme` is changed to a trait, and its variants are now structs. The `None` variant was renamed to `NoAuthentication` to make the type name clearer and also because otherwise it conflicts with the usual `None` (`Option::None`) when it is in scope.

This allows to add a bound on requests per authentication scheme.

Closes #2251.