### PR TITLE
api: Default Content-Type to application/octet-stream with raw_body

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -38,6 +38,12 @@ Breaking changes:
     type named `Request` by default. This type can be changed with an `@for`
     setting.
 
+Bug fixes:
+
+- With the `request` and `response` attribute macros, the `Content-Type` header
+  defaults to `application/octet-stream` instead of `application/json` if the
+  `raw_body` attribute is set on a field.
+
 Improvements:
 
 - Add `MatrixVersion::V1_16`

--- a/crates/ruma-common/src/api.rs
+++ b/crates/ruma-common/src/api.rs
@@ -29,6 +29,10 @@ use bytes::BufMut;
 /// alongside a `Response` type that implements [`OutgoingResponse`] (for
 /// `cfg(feature = "server")`) and / or [`IncomingResponse`] (for `cfg(feature = "client")`).
 ///
+/// The `Content-Type` header of the `OutgoingRequest` is unset for endpoints using the `GET`
+/// method, and defaults to `application/json` for all other methods, except if the `raw_body`
+/// attribute is set on a field, in which case it defaults to `application/octet-stream`.
+///
 /// By default, the type this macro is used on gets a `#[non_exhaustive]` attribute. This
 /// behavior can be controlled by setting the `ruma_unstable_exhaustive_types` compile-time
 /// `cfg` setting as `--cfg=ruma_unstable_exhaustive_types` using `RUSTFLAGS` or
@@ -143,6 +147,10 @@ pub use ruma_macros::request;
 /// The `IncomingResponse` impl is feature-gated behind `cfg(feature = "client")`.
 ///
 /// The generated code expects a `METADATA` constant of type [`Metadata`] to be in scope.
+///
+/// The `Content-Type` header of the `OutgoingResponse` defaults to `application/json`, except
+/// if the `raw_body` attribute is set on a field, in which case it defaults to
+/// `application/octet-stream`.
 ///
 /// By default, the type this macro is used on gets a `#[non_exhaustive]` attribute. This
 /// behavior can be controlled by setting the `ruma_unstable_exhaustive_types` compile-time

--- a/crates/ruma-macros/src/api/request/outgoing.rs
+++ b/crates/ruma-macros/src/api/request/outgoing.rs
@@ -44,11 +44,18 @@ impl Request {
         // `application/json` content-type would be wrong. It may also cause problems with CORS
         // policies that don't allow the `Content-Type` header (for things such as `.well-known`
         // that are commonly handled by something else than a homeserver).
-        let mut header_kvs = if self.raw_body_field().is_some() || self.has_body_fields() {
+        let mut header_kvs = if self.has_body_fields() {
             quote! {
                 req_headers.insert(
                     #http::header::CONTENT_TYPE,
                     #http::header::HeaderValue::from_static("application/json"),
+                );
+            }
+        } else if self.raw_body_field().is_some() {
+            quote! {
+                req_headers.insert(
+                    #http::header::CONTENT_TYPE,
+                    #http::header::HeaderValue::from_static("application/octet-stream"),
                 );
             }
         } else {


### PR DESCRIPTION
Since this attribute is not meant to be used with JSON bodies, and it is wrong to default to `application/json` on the media endpoints when the Content-Type header is not overriden.
