### PR TITLE
api: Make `Metadata::Authentication`'s input an associated type

### DIFF
--- a/crates/ruma-appservice-api/src/event/push_events.rs
+++ b/crates/ruma-appservice-api/src/event/push_events.rs
@@ -264,7 +264,7 @@ pub mod v1 {
         #[cfg(feature = "client")]
         #[test]
         fn request_contains_events_field() {
-            use ruma_common::api::{OutgoingRequest, SendAccessToken};
+            use ruma_common::api::{auth_scheme::SendAccessToken, OutgoingRequest};
 
             let dummy_event_json = json!({
                 "type": "m.room.message",

--- a/crates/ruma-client-api/src/delayed_events/delayed_message_event.rs
+++ b/crates/ruma-client-api/src/delayed_events/delayed_message_event.rs
@@ -120,7 +120,9 @@ pub mod unstable {
         use std::borrow::Cow;
 
         use ruma_common::{
-            api::{MatrixVersion, OutgoingRequest, SendAccessToken, SupportedVersions},
+            api::{
+                auth_scheme::SendAccessToken, MatrixVersion, OutgoingRequest, SupportedVersions,
+            },
             owned_room_id,
         };
         use ruma_events::room::message::RoomMessageEventContent;

--- a/crates/ruma-client-api/src/delayed_events/delayed_state_event.rs
+++ b/crates/ruma-client-api/src/delayed_events/delayed_state_event.rs
@@ -116,7 +116,9 @@ pub mod unstable {
         use std::borrow::Cow;
 
         use ruma_common::{
-            api::{MatrixVersion, OutgoingRequest, SendAccessToken, SupportedVersions},
+            api::{
+                auth_scheme::SendAccessToken, MatrixVersion, OutgoingRequest, SupportedVersions,
+            },
             owned_room_id,
             serde::Raw,
         };

--- a/crates/ruma-client-api/src/delayed_events/update_delayed_event.rs
+++ b/crates/ruma-client-api/src/delayed_events/update_delayed_event.rs
@@ -76,7 +76,7 @@ pub mod unstable {
         use std::borrow::Cow;
 
         use ruma_common::api::{
-            MatrixVersion, OutgoingRequest, SendAccessToken, SupportedVersions,
+            auth_scheme::SendAccessToken, MatrixVersion, OutgoingRequest, SupportedVersions,
         };
         use serde_json::{json, Value as JsonValue};
 

--- a/crates/ruma-client-api/src/directory/get_public_rooms.rs
+++ b/crates/ruma-client-api/src/directory/get_public_rooms.rs
@@ -89,7 +89,10 @@ pub mod v3 {
             use std::borrow::Cow;
 
             use ruma_common::{
-                api::{MatrixVersion, OutgoingRequest as _, SendAccessToken, SupportedVersions},
+                api::{
+                    auth_scheme::SendAccessToken, MatrixVersion, OutgoingRequest as _,
+                    SupportedVersions,
+                },
                 server_name,
             };
 

--- a/crates/ruma-client-api/src/filter/create_filter.rs
+++ b/crates/ruma-client-api/src/filter/create_filter.rs
@@ -88,7 +88,9 @@ pub mod v3 {
             use std::borrow::Cow;
 
             use ruma_common::{
-                api::{MatrixVersion, OutgoingRequest, SendAccessToken, SupportedVersions},
+                api::{
+                    auth_scheme::SendAccessToken, MatrixVersion, OutgoingRequest, SupportedVersions,
+                },
                 owned_user_id,
             };
 

--- a/crates/ruma-client-api/src/knock/knock_room.rs
+++ b/crates/ruma-client-api/src/knock/knock_room.rs
@@ -76,7 +76,7 @@ pub mod v3 {
         fn try_into_http_request<T: Default + bytes::BufMut>(
             self,
             base_url: &str,
-            access_token: ruma_common::api::SendAccessToken<'_>,
+            access_token: ruma_common::api::auth_scheme::SendAccessToken<'_>,
             considering: std::borrow::Cow<'_, ruma_common::api::SupportedVersions>,
         ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
             use http::header::{self, HeaderValue};
@@ -191,7 +191,7 @@ pub mod v3 {
 
         use ruma_common::{
             api::{
-                IncomingRequest as _, MatrixVersion, OutgoingRequest, SendAccessToken,
+                auth_scheme::SendAccessToken, IncomingRequest as _, MatrixVersion, OutgoingRequest,
                 SupportedVersions,
             },
             owned_room_id, owned_server_name,

--- a/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
+++ b/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
@@ -87,7 +87,7 @@ pub mod v3 {
         fn try_into_http_request<T: Default + bytes::BufMut>(
             self,
             base_url: &str,
-            access_token: ruma_common::api::SendAccessToken<'_>,
+            access_token: ruma_common::api::auth_scheme::SendAccessToken<'_>,
             considering: std::borrow::Cow<'_, ruma_common::api::SupportedVersions>,
         ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
             use http::header::{self, HeaderValue};
@@ -210,7 +210,7 @@ pub mod v3 {
 
         use ruma_common::{
             api::{
-                IncomingRequest as _, MatrixVersion, OutgoingRequest, SendAccessToken,
+                auth_scheme::SendAccessToken, IncomingRequest as _, MatrixVersion, OutgoingRequest,
                 SupportedVersions,
             },
             owned_room_id, owned_server_name,

--- a/crates/ruma-client-api/src/message/get_message_events.rs
+++ b/crates/ruma-client-api/src/message/get_message_events.rs
@@ -176,7 +176,10 @@ pub mod v3 {
 
         use js_int::uint;
         use ruma_common::{
-            api::{Direction, MatrixVersion, OutgoingRequest, SendAccessToken, SupportedVersions},
+            api::{
+                auth_scheme::SendAccessToken, Direction, MatrixVersion, OutgoingRequest,
+                SupportedVersions,
+            },
             owned_room_id,
         };
 

--- a/crates/ruma-client-api/src/profile/get_profile_field.rs
+++ b/crates/ruma-client-api/src/profile/get_profile_field.rs
@@ -68,7 +68,7 @@ pub mod v3 {
         fn try_into_http_request<T: Default + bytes::BufMut>(
             self,
             base_url: &str,
-            access_token: ruma_common::api::SendAccessToken<'_>,
+            access_token: ruma_common::api::auth_scheme::SendAccessToken<'_>,
             considering: std::borrow::Cow<'_, ruma_common::api::SupportedVersions>,
         ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
             use http::header::{self, HeaderValue};
@@ -173,7 +173,7 @@ pub mod v3 {
         fn try_into_http_request<T: Default + bytes::BufMut>(
             self,
             base_url: &str,
-            access_token: ruma_common::api::SendAccessToken<'_>,
+            access_token: ruma_common::api::auth_scheme::SendAccessToken<'_>,
             considering: std::borrow::Cow<'_, ruma_common::api::SupportedVersions>,
         ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
             Request::new(self.user_id, F::NAME.into()).try_into_http_request(
@@ -304,7 +304,7 @@ mod tests {
     fn serialize_request() {
         use std::borrow::Cow;
 
-        use ruma_common::api::{OutgoingRequest, SendAccessToken, SupportedVersions};
+        use ruma_common::api::{auth_scheme::SendAccessToken, OutgoingRequest, SupportedVersions};
 
         // Profile field that existed in Matrix 1.0.
         let avatar_url_request =

--- a/crates/ruma-client-api/src/profile/set_profile_field.rs
+++ b/crates/ruma-client-api/src/profile/set_profile_field.rs
@@ -58,7 +58,7 @@ pub mod v3 {
         fn try_into_http_request<T: Default + bytes::BufMut>(
             self,
             base_url: &str,
-            access_token: ruma_common::api::SendAccessToken<'_>,
+            access_token: ruma_common::api::auth_scheme::SendAccessToken<'_>,
             considering: std::borrow::Cow<'_, ruma_common::api::SupportedVersions>,
         ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
             use http::{header, HeaderValue};
@@ -162,7 +162,7 @@ mod tests {
         use std::borrow::Cow;
 
         use http::header;
-        use ruma_common::api::{OutgoingRequest, SendAccessToken, SupportedVersions};
+        use ruma_common::api::{auth_scheme::SendAccessToken, OutgoingRequest, SupportedVersions};
 
         // Profile field that existed in Matrix 1.0.
         let avatar_url_request = Request::new(

--- a/crates/ruma-client-api/src/push/set_pushrule.rs
+++ b/crates/ruma-client-api/src/push/set_pushrule.rs
@@ -67,7 +67,7 @@ pub mod v3 {
         fn try_into_http_request<T: Default + bytes::BufMut>(
             self,
             base_url: &str,
-            access_token: ruma_common::api::SendAccessToken<'_>,
+            access_token: ruma_common::api::auth_scheme::SendAccessToken<'_>,
             considering: std::borrow::Cow<'_, ruma_common::api::SupportedVersions>,
         ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
             use http::header;

--- a/crates/ruma-client-api/src/rendezvous/create_rendezvous_session.rs
+++ b/crates/ruma-client-api/src/rendezvous/create_rendezvous_session.rs
@@ -46,7 +46,7 @@ pub mod unstable {
         fn try_into_http_request<T: Default + bytes::BufMut>(
             self,
             base_url: &str,
-            _: ruma_common::api::SendAccessToken<'_>,
+            _: ruma_common::api::auth_scheme::SendAccessToken<'_>,
             considering: std::borrow::Cow<'_, ruma_common::api::SupportedVersions>,
         ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
             let url = Self::make_endpoint_url(considering, base_url, &[], "")?;

--- a/crates/ruma-client-api/src/session/login.rs
+++ b/crates/ruma-client-api/src/session/login.rs
@@ -438,7 +438,7 @@ pub mod v3 {
             use std::borrow::Cow;
 
             use ruma_common::api::{
-                MatrixVersion, OutgoingRequest, SendAccessToken, SupportedVersions,
+                auth_scheme::SendAccessToken, MatrixVersion, OutgoingRequest, SupportedVersions,
             };
             use serde_json::Value as JsonValue;
 

--- a/crates/ruma-client-api/src/session/logout.rs
+++ b/crates/ruma-client-api/src/session/logout.rs
@@ -42,7 +42,7 @@ pub mod v3 {
         fn try_into_http_request<T: Default + bytes::BufMut>(
             self,
             base_url: &str,
-            access_token: ruma_common::api::SendAccessToken<'_>,
+            access_token: ruma_common::api::auth_scheme::SendAccessToken<'_>,
             considering: std::borrow::Cow<'_, ruma_common::api::SupportedVersions>,
         ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
             let url = Self::make_endpoint_url(considering, base_url, &[], "")?;

--- a/crates/ruma-client-api/src/session/logout_all.rs
+++ b/crates/ruma-client-api/src/session/logout_all.rs
@@ -42,7 +42,7 @@ pub mod v3 {
         fn try_into_http_request<T: Default + bytes::BufMut>(
             self,
             base_url: &str,
-            access_token: ruma_common::api::SendAccessToken<'_>,
+            access_token: ruma_common::api::auth_scheme::SendAccessToken<'_>,
             considering: std::borrow::Cow<'_, ruma_common::api::SupportedVersions>,
         ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
             let url = Self::make_endpoint_url(considering, base_url, &[], "")?;

--- a/crates/ruma-client-api/src/session/sso_login.rs
+++ b/crates/ruma-client-api/src/session/sso_login.rs
@@ -79,7 +79,7 @@ pub mod v3 {
         use std::borrow::Cow;
 
         use ruma_common::api::{
-            MatrixVersion, OutgoingRequest, SendAccessToken, SupportedVersions,
+            auth_scheme::SendAccessToken, MatrixVersion, OutgoingRequest, SupportedVersions,
         };
 
         use super::Request;

--- a/crates/ruma-client-api/src/session/sso_login_with_provider.rs
+++ b/crates/ruma-client-api/src/session/sso_login_with_provider.rs
@@ -86,7 +86,7 @@ pub mod v3 {
         use std::borrow::Cow;
 
         use ruma_common::api::{
-            MatrixVersion, OutgoingRequest as _, SendAccessToken, SupportedVersions,
+            auth_scheme::SendAccessToken, MatrixVersion, OutgoingRequest as _, SupportedVersions,
         };
 
         use super::Request;

--- a/crates/ruma-client-api/src/state/get_state_event_for_key.rs
+++ b/crates/ruma-client-api/src/state/get_state_event_for_key.rs
@@ -127,7 +127,7 @@ pub mod v3 {
         fn try_into_http_request<T: Default + bytes::BufMut>(
             self,
             base_url: &str,
-            access_token: ruma_common::api::SendAccessToken<'_>,
+            access_token: ruma_common::api::auth_scheme::SendAccessToken<'_>,
             considering: std::borrow::Cow<'_, ruma_common::api::SupportedVersions>,
         ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
             use http::header;

--- a/crates/ruma-client-api/src/state/send_state_event.rs
+++ b/crates/ruma-client-api/src/state/send_state_event.rs
@@ -114,7 +114,7 @@ pub mod v3 {
         fn try_into_http_request<T: Default + bytes::BufMut>(
             self,
             base_url: &str,
-            access_token: ruma_common::api::SendAccessToken<'_>,
+            access_token: ruma_common::api::auth_scheme::SendAccessToken<'_>,
             considering: std::borrow::Cow<'_, ruma_common::api::SupportedVersions>,
         ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
             use http::header::{self, HeaderValue};
@@ -206,7 +206,10 @@ pub mod v3 {
         use std::borrow::Cow;
 
         use ruma_common::{
-            api::{MatrixVersion, OutgoingRequest as _, SendAccessToken, SupportedVersions},
+            api::{
+                auth_scheme::SendAccessToken, MatrixVersion, OutgoingRequest as _,
+                SupportedVersions,
+            },
             owned_room_id,
         };
         use ruma_events::{room::name::RoomNameEventContent, EmptyStateKey};

--- a/crates/ruma-client-api/src/sync/sync_events/v3.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v3.rs
@@ -713,8 +713,8 @@ mod client_tests {
     use assert_matches2::assert_matches;
     use ruma_common::{
         api::{
-            IncomingResponse as _, MatrixVersion, OutgoingRequest as _, SendAccessToken,
-            SupportedVersions,
+            auth_scheme::SendAccessToken, IncomingResponse as _, MatrixVersion,
+            OutgoingRequest as _, SupportedVersions,
         },
         event_id, room_id, user_id, RoomVersionId,
     };

--- a/crates/ruma-client-api/tests/headers.rs
+++ b/crates/ruma-client-api/tests/headers.rs
@@ -2,7 +2,7 @@
 
 use http::HeaderMap;
 use ruma_client_api::discovery::discover_homeserver;
-use ruma_common::api::{OutgoingRequest as _, SendAccessToken};
+use ruma_common::api::{auth_scheme::SendAccessToken, OutgoingRequest as _};
 
 #[test]
 fn get_request_headers() {

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -25,6 +25,9 @@ Breaking changes:
     type named `Authentication`. The `AuthScheme` enum was changed from an
     `enum` to a `trait`. Its variants are now structs implementing the
     `AuthScheme` trait. The `None` variant was renamed to `NoAuthentication`.
+    The `access_token` argument of `OutgoingRequest::try_into_http_request()` is
+    renamed to `authentication_input` and is generic over the `Input` associated
+    type of the `AuthScheme` trait.
   - The `history` field of the `Metadata` struct is now an associated constant
     named `PATH_BUILDER`. The type of this constant is defined by the
     `PathBuilder` associated type, which must implement the `PathBuilder` trait.

--- a/crates/ruma-common/src/api/auth_scheme.rs
+++ b/crates/ruma-common/src/api/auth_scheme.rs
@@ -3,9 +3,10 @@
 
 #![allow(clippy::exhaustive_structs)]
 
+use as_variant::as_variant;
 use http::{header, HeaderName, HeaderValue};
 
-use crate::api::{error::IntoHttpError, SendAccessToken};
+use crate::api::error::IntoHttpError;
 
 /// Trait implemented by types representing an authentication scheme used by an endpoint.
 pub trait AuthScheme: Sized {
@@ -126,4 +127,49 @@ fn access_token_to_authorization_header(
     token: &str,
 ) -> Result<(HeaderName, HeaderValue), IntoHttpError> {
     Ok((header::AUTHORIZATION, format!("Bearer {token}").try_into()?))
+}
+
+/// An enum to control whether an access token should be added to outgoing requests
+#[derive(Clone, Copy, Debug)]
+#[allow(clippy::exhaustive_enums)]
+pub enum SendAccessToken<'a> {
+    /// Add the given access token to the request only if the `METADATA` on the request requires
+    /// it.
+    IfRequired(&'a str),
+
+    /// Always add the access token.
+    Always(&'a str),
+
+    /// Add the given appservice token to the request only if the `METADATA` on the request
+    /// requires it.
+    Appservice(&'a str),
+
+    /// Don't add an access token.
+    ///
+    /// This will lead to an error if the request endpoint requires authentication
+    None,
+}
+
+impl<'a> SendAccessToken<'a> {
+    /// Get the access token for an endpoint that requires one.
+    ///
+    /// Returns `Some(_)` if `self` contains an access token.
+    pub fn get_required_for_endpoint(self) -> Option<&'a str> {
+        as_variant!(self, Self::IfRequired | Self::Appservice | Self::Always)
+    }
+
+    /// Get the access token for an endpoint that should not require one.
+    ///
+    /// Returns `Some(_)` only if `self` is `SendAccessToken::Always(_)`.
+    pub fn get_not_required_for_endpoint(self) -> Option<&'a str> {
+        as_variant!(self, Self::Always)
+    }
+
+    /// Gets the access token for an endpoint that requires one for appservices.
+    ///
+    /// Returns `Some(_)` if `self` is either `SendAccessToken::Appservice(_)`
+    /// or `SendAccessToken::Always(_)`
+    pub fn get_required_for_appservice(self) -> Option<&'a str> {
+        as_variant!(self, Self::Appservice | Self::Always)
+    }
 }

--- a/crates/ruma-common/tests/it/api/conversions.rs
+++ b/crates/ruma-common/tests/it/api/conversions.rs
@@ -5,8 +5,8 @@ use std::borrow::Cow;
 use http::header::CONTENT_TYPE;
 use ruma_common::{
     api::{
-        request, response, IncomingRequest as _, MatrixVersion, OutgoingRequest as _,
-        OutgoingRequestAppserviceExt, SendAccessToken, SupportedVersions,
+        auth_scheme::SendAccessToken, request, response, IncomingRequest as _, MatrixVersion,
+        OutgoingRequest as _, OutgoingRequestAppserviceExt, SupportedVersions,
     },
     metadata, owned_user_id, user_id, OwnedUserId,
 };
@@ -142,8 +142,8 @@ mod without_query {
     use http::header::CONTENT_TYPE;
     use ruma_common::{
         api::{
-            request, response, MatrixVersion, OutgoingRequestAppserviceExt, SendAccessToken,
-            SupportedVersions,
+            auth_scheme::SendAccessToken, request, response, MatrixVersion,
+            OutgoingRequestAppserviceExt, SupportedVersions,
         },
         metadata, owned_user_id, user_id, OwnedUserId,
     };

--- a/crates/ruma-common/tests/it/api/header_override.rs
+++ b/crates/ruma-common/tests/it/api/header_override.rs
@@ -5,8 +5,8 @@ use std::borrow::Cow;
 use http::header::{Entry, CONTENT_TYPE, LOCATION};
 use ruma_common::{
     api::{
-        request, response, MatrixVersion, OutgoingRequest as _, OutgoingResponse as _,
-        SendAccessToken, SupportedVersions,
+        auth_scheme::SendAccessToken, request, response, MatrixVersion, OutgoingRequest as _,
+        OutgoingResponse as _, SupportedVersions,
     },
     metadata,
 };

--- a/crates/ruma-common/tests/it/api/manual_endpoint_impl.rs
+++ b/crates/ruma-common/tests/it/api/manual_endpoint_impl.rs
@@ -9,11 +9,11 @@ use bytes::BufMut;
 use http::{header::CONTENT_TYPE, method::Method};
 use ruma_common::{
     api::{
-        auth_scheme::NoAuthentication,
+        auth_scheme::{NoAuthentication, SendAccessToken},
         error::{FromHttpRequestError, FromHttpResponseError, IntoHttpError, MatrixError},
         path_builder::{StablePathSelector, VersionHistory},
         EndpointError, IncomingRequest, IncomingResponse, MatrixVersion, Metadata, OutgoingRequest,
-        OutgoingResponse, SendAccessToken, SupportedVersions,
+        OutgoingResponse, SupportedVersions,
     },
     OwnedRoomAliasId, OwnedRoomId,
 };

--- a/crates/ruma-common/tests/it/api/no_fields.rs
+++ b/crates/ruma-common/tests/it/api/no_fields.rs
@@ -1,7 +1,8 @@
 use std::borrow::Cow;
 
 use ruma_common::api::{
-    MatrixVersion, OutgoingRequest as _, OutgoingResponse as _, SendAccessToken, SupportedVersions,
+    auth_scheme::SendAccessToken, MatrixVersion, OutgoingRequest as _, OutgoingResponse as _,
+    SupportedVersions,
 };
 
 mod get {

--- a/crates/ruma-common/tests/it/api/optional_headers.rs
+++ b/crates/ruma-common/tests/it/api/optional_headers.rs
@@ -4,8 +4,8 @@ use assert_matches2::assert_matches;
 use http::header::{CONTENT_DISPOSITION, LOCATION};
 use ruma_common::{
     api::{
-        request, response, IncomingRequest, IncomingResponse, MatrixVersion, OutgoingRequest,
-        OutgoingResponse, SendAccessToken, SupportedVersions,
+        auth_scheme::SendAccessToken, request, response, IncomingRequest, IncomingResponse,
+        MatrixVersion, OutgoingRequest, OutgoingResponse, SupportedVersions,
     },
     http_headers::{ContentDisposition, ContentDispositionType},
     metadata,

--- a/crates/ruma-common/tests/it/api/required_headers.rs
+++ b/crates/ruma-common/tests/it/api/required_headers.rs
@@ -4,12 +4,13 @@ use assert_matches2::assert_matches;
 use http::header::{CONTENT_DISPOSITION, LOCATION};
 use ruma_common::{
     api::{
+        auth_scheme::SendAccessToken,
         error::{
             DeserializationError, FromHttpRequestError, FromHttpResponseError,
             HeaderDeserializationError,
         },
         request, response, IncomingRequest, IncomingResponse, MatrixVersion, OutgoingRequest,
-        OutgoingResponse, SendAccessToken, SupportedVersions,
+        OutgoingResponse, SupportedVersions,
     },
     http_headers::{ContentDisposition, ContentDispositionType},
     metadata,

--- a/crates/ruma-macros/src/api/request/outgoing.rs
+++ b/crates/ruma-macros/src/api/request/outgoing.rs
@@ -88,7 +88,7 @@ impl Request {
         }));
 
         header_kvs.extend(quote! {
-            req_headers.extend(<<Self as #ruma_common::api::Metadata>::Authentication as #ruma_common::api::auth_scheme::AuthScheme>::authorization_header(access_token)?);
+            req_headers.extend(<<Self as #ruma_common::api::Metadata>::Authentication as #ruma_common::api::auth_scheme::AuthScheme>::authorization_header(authentication_input)?);
         });
 
         let request_body = if let Some(field) = self.raw_body_field() {
@@ -116,7 +116,7 @@ impl Request {
                 fn try_into_http_request<T: ::std::default::Default + #bytes::BufMut>(
                     self,
                     base_url: &::std::primitive::str,
-                    access_token: #ruma_common::api::auth_scheme::SendAccessToken<'_>,
+                    authentication_input: <<Self as #ruma_common::api::Metadata>::Authentication as #ruma_common::api::auth_scheme::AuthScheme>::Input<'_>,
                     path_builder_input: <<Self as #ruma_common::api::Metadata>::PathBuilder as #ruma_common::api::path_builder::PathBuilder>::Input<'_>,
                 ) -> ::std::result::Result<#http::Request<T>, #ruma_common::api::error::IntoHttpError> {
                     let mut req_builder = #http::Request::builder()

--- a/crates/ruma-macros/src/api/request/outgoing.rs
+++ b/crates/ruma-macros/src/api/request/outgoing.rs
@@ -116,7 +116,7 @@ impl Request {
                 fn try_into_http_request<T: ::std::default::Default + #bytes::BufMut>(
                     self,
                     base_url: &::std::primitive::str,
-                    access_token: #ruma_common::api::SendAccessToken<'_>,
+                    access_token: #ruma_common::api::auth_scheme::SendAccessToken<'_>,
                     path_builder_input: <<Self as #ruma_common::api::Metadata>::PathBuilder as #ruma_common::api::path_builder::PathBuilder>::Input<'_>,
                 ) -> ::std::result::Result<#http::Request<T>, #ruma_common::api::error::IntoHttpError> {
                     let mut req_builder = #http::Request::builder()


### PR DESCRIPTION
`ServerSignatures` needs a different input, although this doesn't add support for it (yet).


