### PR TITLE
api: Reduce code duplication in custom `(Outgoing/Incoming)Request` implementations

### DIFF
--- a/crates/ruma-client-api/src/error.rs
+++ b/crates/ruma-client-api/src/error.rs
@@ -978,7 +978,7 @@ impl OutgoingResponse for Error {
         self,
     ) -> Result<http::Response<T>, IntoHttpError> {
         let mut builder = http::Response::builder()
-            .header(http::header::CONTENT_TYPE, "application/json")
+            .header(http::header::CONTENT_TYPE, ruma_common::http_headers::APPLICATION_JSON)
             .status(self.status_code);
 
         #[allow(clippy::collapsible_match)]

--- a/crates/ruma-client-api/src/knock/knock_room.rs
+++ b/crates/ruma-client-api/src/knock/knock_room.rs
@@ -79,7 +79,7 @@ pub mod v3 {
             access_token: ruma_common::api::auth_scheme::SendAccessToken<'_>,
             considering: std::borrow::Cow<'_, ruma_common::api::SupportedVersions>,
         ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
-            use http::header::{self, HeaderValue};
+            use ruma_common::api::auth_scheme::AuthScheme;
 
             // Only send `server_name` if the `via` parameter is not supported by the server.
             // `via` was introduced in Matrix 1.12.
@@ -97,27 +97,24 @@ pub mod v3 {
             let query_string =
                 serde_html_form::to_string(RequestQuery { server_name, via: self.via })?;
 
-            let http_request = http::Request::builder()
-                .method(Self::METHOD)
-                .uri(Self::make_endpoint_url(
+            let mut http_request_builder =
+                http::Request::builder().method(Self::METHOD).uri(Self::make_endpoint_url(
                     considering,
                     base_url,
                     &[&self.room_id_or_alias],
                     &query_string,
-                )?)
-                .header(header::CONTENT_TYPE, ruma_common::http_headers::APPLICATION_JSON)
-                .header(
-                    header::AUTHORIZATION,
-                    HeaderValue::from_str(&format!(
-                        "Bearer {}",
-                        access_token
-                            .get_required_for_endpoint()
-                            .ok_or(ruma_common::api::error::IntoHttpError::NeedsAuthentication)?
-                    ))?,
-                )
-                .body(ruma_common::serde::json_to_buf(&RequestBody { reason: self.reason })?)?;
+                )?);
 
-            Ok(http_request)
+            if let Some(headers) = http_request_builder.headers_mut() {
+                headers.insert(
+                    http::header::CONTENT_TYPE,
+                    ruma_common::http_headers::APPLICATION_JSON,
+                );
+                Self::Authentication::add_authentication(headers, access_token)?;
+            }
+
+            Ok(http_request_builder
+                .body(ruma_common::serde::json_to_buf(&RequestBody { reason: self.reason })?)?)
         }
     }
 

--- a/crates/ruma-client-api/src/knock/knock_room.rs
+++ b/crates/ruma-client-api/src/knock/knock_room.rs
@@ -131,12 +131,7 @@ pub mod v3 {
             B: AsRef<[u8]>,
             S: AsRef<str>,
         {
-            if request.method() != Self::METHOD {
-                return Err(ruma_common::api::error::FromHttpRequestError::MethodMismatch {
-                    expected: Self::METHOD,
-                    received: request.method().clone(),
-                });
-            }
+            Self::check_request_method(request.method())?;
 
             let (room_id_or_alias,) =
                 serde::Deserialize::deserialize(serde::de::value::SeqDeserializer::<

--- a/crates/ruma-client-api/src/knock/knock_room.rs
+++ b/crates/ruma-client-api/src/knock/knock_room.rs
@@ -105,7 +105,7 @@ pub mod v3 {
                     &[&self.room_id_or_alias],
                     &query_string,
                 )?)
-                .header(header::CONTENT_TYPE, "application/json")
+                .header(header::CONTENT_TYPE, ruma_common::http_headers::APPLICATION_JSON)
                 .header(
                     header::AUTHORIZATION,
                     HeaderValue::from_str(&format!(

--- a/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
+++ b/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
@@ -116,7 +116,7 @@ pub mod v3 {
                     &[&self.room_id_or_alias],
                     &query_string,
                 )?)
-                .header(header::CONTENT_TYPE, "application/json")
+                .header(header::CONTENT_TYPE, ruma_common::http_headers::APPLICATION_JSON)
                 .header(
                     header::AUTHORIZATION,
                     HeaderValue::from_str(&format!(

--- a/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
+++ b/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
@@ -144,12 +144,7 @@ pub mod v3 {
             B: AsRef<[u8]>,
             S: AsRef<str>,
         {
-            if request.method() != Self::METHOD {
-                return Err(ruma_common::api::error::FromHttpRequestError::MethodMismatch {
-                    expected: Self::METHOD,
-                    received: request.method().clone(),
-                });
-            }
+            Self::check_request_method(request.method())?;
 
             let (room_id_or_alias,) =
                 serde::Deserialize::deserialize(serde::de::value::SeqDeserializer::<

--- a/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
+++ b/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
@@ -90,7 +90,7 @@ pub mod v3 {
             access_token: ruma_common::api::auth_scheme::SendAccessToken<'_>,
             considering: std::borrow::Cow<'_, ruma_common::api::SupportedVersions>,
         ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
-            use http::header::{self, HeaderValue};
+            use ruma_common::api::auth_scheme::AuthScheme;
 
             // Only send `server_name` if the `via` parameter is not supported by the server.
             // `via` was introduced in Matrix 1.12.
@@ -108,30 +108,26 @@ pub mod v3 {
             let query_string =
                 serde_html_form::to_string(RequestQuery { server_name, via: self.via })?;
 
-            let http_request = http::Request::builder()
-                .method(Self::METHOD)
-                .uri(Self::make_endpoint_url(
+            let mut http_request_builder =
+                http::Request::builder().method(Self::METHOD).uri(Self::make_endpoint_url(
                     considering,
                     base_url,
                     &[&self.room_id_or_alias],
                     &query_string,
-                )?)
-                .header(header::CONTENT_TYPE, ruma_common::http_headers::APPLICATION_JSON)
-                .header(
-                    header::AUTHORIZATION,
-                    HeaderValue::from_str(&format!(
-                        "Bearer {}",
-                        access_token
-                            .get_required_for_endpoint()
-                            .ok_or(ruma_common::api::error::IntoHttpError::NeedsAuthentication)?
-                    ))?,
-                )
-                .body(ruma_common::serde::json_to_buf(&RequestBody {
-                    third_party_signed: self.third_party_signed,
-                    reason: self.reason,
-                })?)?;
+                )?);
 
-            Ok(http_request)
+            if let Some(headers) = http_request_builder.headers_mut() {
+                headers.insert(
+                    http::header::CONTENT_TYPE,
+                    ruma_common::http_headers::APPLICATION_JSON,
+                );
+                Self::Authentication::add_authentication(headers, access_token)?;
+            }
+
+            Ok(http_request_builder.body(ruma_common::serde::json_to_buf(&RequestBody {
+                third_party_signed: self.third_party_signed,
+                reason: self.reason,
+            })?)?)
         }
     }
 

--- a/crates/ruma-client-api/src/profile/get_profile_field.rs
+++ b/crates/ruma-client-api/src/profile/get_profile_field.rs
@@ -107,12 +107,7 @@ pub mod v3 {
             B: AsRef<[u8]>,
             S: AsRef<str>,
         {
-            if request.method() != Self::METHOD {
-                return Err(ruma_common::api::error::FromHttpRequestError::MethodMismatch {
-                    expected: Self::METHOD,
-                    received: request.method().clone(),
-                });
-            }
+            Self::check_request_method(request.method())?;
 
             let (user_id, field) =
                 serde::Deserialize::deserialize(serde::de::value::SeqDeserializer::<

--- a/crates/ruma-client-api/src/profile/get_profile_field.rs
+++ b/crates/ruma-client-api/src/profile/get_profile_field.rs
@@ -88,7 +88,7 @@ pub mod v3 {
             let mut http_request_builder = http::Request::builder()
                 .method(Self::METHOD)
                 .uri(url)
-                .header(header::CONTENT_TYPE, "application/json");
+                .header(header::CONTENT_TYPE, ruma_common::http_headers::APPLICATION_JSON);
 
             if let Some(access_token) = access_token.get_not_required_for_endpoint() {
                 http_request_builder = http_request_builder.header(
@@ -242,7 +242,7 @@ pub mod v3 {
 
             Ok(http::Response::builder()
                 .status(http::StatusCode::OK)
-                .header(http::header::CONTENT_TYPE, "application/json")
+                .header(http::header::CONTENT_TYPE, ruma_common::http_headers::APPLICATION_JSON)
                 .body(body)?)
         }
     }

--- a/crates/ruma-client-api/src/profile/set_profile_field.rs
+++ b/crates/ruma-client-api/src/profile/set_profile_field.rs
@@ -61,8 +61,7 @@ pub mod v3 {
             access_token: ruma_common::api::auth_scheme::SendAccessToken<'_>,
             considering: std::borrow::Cow<'_, ruma_common::api::SupportedVersions>,
         ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
-            use http::{header, HeaderValue};
-            use ruma_common::api::path_builder::PathBuilder;
+            use ruma_common::api::{auth_scheme::AuthScheme, path_builder::PathBuilder};
 
             let field = self.value.field_name();
 
@@ -77,25 +76,21 @@ pub mod v3 {
                 )?
             };
 
-            let http_request = http::Request::builder()
-                .method(Self::METHOD)
-                .uri(url)
-                .header(header::CONTENT_TYPE, ruma_common::http_headers::APPLICATION_JSON)
-                .header(
-                    header::AUTHORIZATION,
-                    HeaderValue::from_str(&format!(
-                        "Bearer {}",
-                        access_token
-                            .get_required_for_endpoint()
-                            .ok_or(ruma_common::api::error::IntoHttpError::NeedsAuthentication)?
-                    ))?,
-                )
+            let mut http_request_builder = http::Request::builder().method(Self::METHOD).uri(url);
+
+            if let Some(headers) = http_request_builder.headers_mut() {
+                headers.insert(
+                    http::header::CONTENT_TYPE,
+                    ruma_common::http_headers::APPLICATION_JSON,
+                );
+                Self::Authentication::add_authentication(headers, access_token)?;
+            }
+
+            Ok(http_request_builder
                 .body(ruma_common::serde::json_to_buf(&self.value)?)
                 // this cannot fail because we don't give user-supplied data to any of the
                 // builder methods
-                .unwrap();
-
-            Ok(http_request)
+                .unwrap())
         }
     }
 

--- a/crates/ruma-client-api/src/profile/set_profile_field.rs
+++ b/crates/ruma-client-api/src/profile/set_profile_field.rs
@@ -111,6 +111,8 @@ pub mod v3 {
 
             use crate::profile::ProfileFieldName;
 
+            Self::check_request_method(request.method())?;
+
             let (user_id, field): (OwnedUserId, ProfileFieldName) =
                 serde::Deserialize::deserialize(serde::de::value::SeqDeserializer::<
                     _,

--- a/crates/ruma-client-api/src/profile/set_profile_field.rs
+++ b/crates/ruma-client-api/src/profile/set_profile_field.rs
@@ -80,7 +80,7 @@ pub mod v3 {
             let http_request = http::Request::builder()
                 .method(Self::METHOD)
                 .uri(url)
-                .header(header::CONTENT_TYPE, "application/json")
+                .header(header::CONTENT_TYPE, ruma_common::http_headers::APPLICATION_JSON)
                 .header(
                     header::AUTHORIZATION,
                     HeaderValue::from_str(&format!(

--- a/crates/ruma-client-api/src/push/set_pushrule.rs
+++ b/crates/ruma-client-api/src/push/set_pushrule.rs
@@ -70,7 +70,7 @@ pub mod v3 {
             access_token: ruma_common::api::auth_scheme::SendAccessToken<'_>,
             considering: std::borrow::Cow<'_, ruma_common::api::SupportedVersions>,
         ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
-            use http::header;
+            use ruma_common::api::auth_scheme::AuthScheme;
 
             let query_string = serde_html_form::to_string(RequestQuery {
                 before: self.before,
@@ -86,21 +86,17 @@ pub mod v3 {
 
             let body: RequestBody = self.rule.into();
 
-            http::Request::builder()
-                .method(Self::METHOD)
-                .uri(url)
-                .header(header::CONTENT_TYPE, ruma_common::http_headers::APPLICATION_JSON)
-                .header(
-                    header::AUTHORIZATION,
-                    format!(
-                        "Bearer {}",
-                        access_token
-                            .get_required_for_endpoint()
-                            .ok_or(ruma_common::api::error::IntoHttpError::NeedsAuthentication)?,
-                    ),
-                )
-                .body(ruma_common::serde::json_to_buf(&body)?)
-                .map_err(Into::into)
+            let mut http_request_builder = http::Request::builder().method(Self::METHOD).uri(url);
+
+            if let Some(headers) = http_request_builder.headers_mut() {
+                headers.insert(
+                    http::header::CONTENT_TYPE,
+                    ruma_common::http_headers::APPLICATION_JSON,
+                );
+                Self::Authentication::add_authentication(headers, access_token)?;
+            }
+
+            Ok(http_request_builder.body(ruma_common::serde::json_to_buf(&body)?)?)
         }
     }
 

--- a/crates/ruma-client-api/src/push/set_pushrule.rs
+++ b/crates/ruma-client-api/src/push/set_pushrule.rs
@@ -89,7 +89,7 @@ pub mod v3 {
             http::Request::builder()
                 .method(Self::METHOD)
                 .uri(url)
-                .header(header::CONTENT_TYPE, "application/json")
+                .header(header::CONTENT_TYPE, ruma_common::http_headers::APPLICATION_JSON)
                 .header(
                     header::AUTHORIZATION,
                     format!(

--- a/crates/ruma-client-api/src/push/set_pushrule.rs
+++ b/crates/ruma-client-api/src/push/set_pushrule.rs
@@ -134,6 +134,8 @@ pub mod v3 {
                 after: Option<String>,
             }
 
+            Self::check_request_method(request.method())?;
+
             let (kind, rule_id): (RuleKind, String) =
                 Deserialize::deserialize(serde::de::value::SeqDeserializer::<
                     _,

--- a/crates/ruma-client-api/src/rendezvous/create_rendezvous_session.rs
+++ b/crates/ruma-client-api/src/rendezvous/create_rendezvous_session.rs
@@ -79,6 +79,8 @@ pub mod unstable {
 
             use ruma_common::api::error::DeserializationError;
 
+            Self::check_request_method(request.method())?;
+
             let content_type = request
                 .headers()
                 .get(CONTENT_TYPE)

--- a/crates/ruma-client-api/src/rendezvous/create_rendezvous_session.rs
+++ b/crates/ruma-client-api/src/rendezvous/create_rendezvous_session.rs
@@ -193,7 +193,7 @@ pub mod unstable {
 
             Ok(http::Response::builder()
                 .status(http::StatusCode::OK)
-                .header(CONTENT_TYPE, "application/json")
+                .header(CONTENT_TYPE, ruma_common::http_headers::APPLICATION_JSON)
                 .header(PRAGMA, "no-cache")
                 .header(CACHE_CONTROL, "no-store")
                 .header(ETAG, self.etag)

--- a/crates/ruma-client-api/src/room/get_summary.rs
+++ b/crates/ruma-client-api/src/room/get_summary.rs
@@ -91,7 +91,7 @@ pub mod v1 {
             let body = ResponseSerHelper { summary: self.summary, membership: self.membership };
 
             http::Response::builder()
-                .header(http::header::CONTENT_TYPE, "application/json")
+                .header(http::header::CONTENT_TYPE, ruma_common::http_headers::APPLICATION_JSON)
                 .body(ruma_common::serde::json_to_buf(&body)?)
                 .map_err(Into::into)
         }

--- a/crates/ruma-client-api/src/session/logout.rs
+++ b/crates/ruma-client-api/src/session/logout.rs
@@ -72,12 +72,7 @@ pub mod v3 {
             B: AsRef<[u8]>,
             S: AsRef<str>,
         {
-            if request.method() != Self::METHOD {
-                return Err(ruma_common::api::error::FromHttpRequestError::MethodMismatch {
-                    expected: Self::METHOD,
-                    received: request.method().clone(),
-                });
-            }
+            Self::check_request_method(request.method())?;
 
             Ok(Self {})
         }

--- a/crates/ruma-client-api/src/session/logout_all.rs
+++ b/crates/ruma-client-api/src/session/logout_all.rs
@@ -72,12 +72,7 @@ pub mod v3 {
             B: AsRef<[u8]>,
             S: AsRef<str>,
         {
-            if request.method() != Self::METHOD {
-                return Err(ruma_common::api::error::FromHttpRequestError::MethodMismatch {
-                    expected: Self::METHOD,
-                    received: request.method().clone(),
-                });
-            }
+            Self::check_request_method(request.method())?;
 
             Ok(Self {})
         }

--- a/crates/ruma-client-api/src/state/get_state_event_for_key.rs
+++ b/crates/ruma-client-api/src/state/get_state_event_for_key.rs
@@ -163,6 +163,8 @@ pub mod v3 {
             B: AsRef<[u8]>,
             S: AsRef<str>,
         {
+            Self::check_request_method(request.method())?;
+
             // FIXME: find a way to make this if-else collapse with serde recognizing trailing
             // Option
             let (room_id, event_type, state_key): (OwnedRoomId, StateEventType, String) =

--- a/crates/ruma-client-api/src/state/get_state_event_for_key.rs
+++ b/crates/ruma-client-api/src/state/get_state_event_for_key.rs
@@ -130,30 +130,23 @@ pub mod v3 {
             access_token: ruma_common::api::auth_scheme::SendAccessToken<'_>,
             considering: std::borrow::Cow<'_, ruma_common::api::SupportedVersions>,
         ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
-            use http::header;
+            use ruma_common::api::auth_scheme::AuthScheme;
 
             let query_string = serde_html_form::to_string(RequestQuery { format: self.format })?;
 
-            http::Request::builder()
-                .method(http::Method::GET)
-                .uri(Self::make_endpoint_url(
+            let mut http_request_builder =
+                http::Request::builder().method(Self::METHOD).uri(Self::make_endpoint_url(
                     considering,
                     base_url,
                     &[&self.room_id, &self.event_type, &self.state_key],
                     &query_string,
-                )?)
-                .header(header::CONTENT_TYPE, ruma_common::http_headers::APPLICATION_JSON)
-                .header(
-                    header::AUTHORIZATION,
-                    format!(
-                        "Bearer {}",
-                        access_token
-                            .get_required_for_endpoint()
-                            .ok_or(ruma_common::api::error::IntoHttpError::NeedsAuthentication)?,
-                    ),
-                )
-                .body(T::default())
-                .map_err(Into::into)
+                )?);
+
+            if let Some(headers) = http_request_builder.headers_mut() {
+                Self::Authentication::add_authentication(headers, access_token)?;
+            }
+
+            Ok(http_request_builder.body(T::default())?)
         }
     }
 

--- a/crates/ruma-client-api/src/state/get_state_event_for_key.rs
+++ b/crates/ruma-client-api/src/state/get_state_event_for_key.rs
@@ -142,7 +142,7 @@ pub mod v3 {
                     &[&self.room_id, &self.event_type, &self.state_key],
                     &query_string,
                 )?)
-                .header(header::CONTENT_TYPE, "application/json")
+                .header(header::CONTENT_TYPE, ruma_common::http_headers::APPLICATION_JSON)
                 .header(
                     header::AUTHORIZATION,
                     format!(

--- a/crates/ruma-client-api/src/state/send_state_event.rs
+++ b/crates/ruma-client-api/src/state/send_state_event.rs
@@ -155,6 +155,8 @@ pub mod v3 {
             B: AsRef<[u8]>,
             S: AsRef<str>,
         {
+            Self::check_request_method(request.method())?;
+
             // FIXME: find a way to make this if-else collapse with serde recognizing trailing
             // Option
             let (room_id, event_type, state_key): (OwnedRoomId, StateEventType, String) =

--- a/crates/ruma-client-api/src/state/send_state_event.rs
+++ b/crates/ruma-client-api/src/state/send_state_event.rs
@@ -130,7 +130,7 @@ pub mod v3 {
                     &[&self.room_id, &self.event_type, &self.state_key],
                     &query_string,
                 )?)
-                .header(header::CONTENT_TYPE, "application/json")
+                .header(header::CONTENT_TYPE, ruma_common::http_headers::APPLICATION_JSON)
                 .header(
                     header::AUTHORIZATION,
                     HeaderValue::from_str(&format!(

--- a/crates/ruma-client-api/src/uiaa.rs
+++ b/crates/ruma-client-api/src/uiaa.rs
@@ -713,7 +713,7 @@ impl OutgoingResponse for UiaaResponse {
     ) -> Result<http::Response<T>, IntoHttpError> {
         match self {
             UiaaResponse::AuthResponse(authentication_info) => http::Response::builder()
-                .header(http::header::CONTENT_TYPE, "application/json")
+                .header(http::header::CONTENT_TYPE, ruma_common::http_headers::APPLICATION_JSON)
                 .status(http::StatusCode::UNAUTHORIZED)
                 .body(ruma_common::serde::json_to_buf(&authentication_info)?)
                 .map_err(Into::into),

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -40,6 +40,7 @@ Breaking changes:
   - The `metadata!` macro generates the `Metadata` trait implementation for a
     type named `Request` by default. This type can be changed with an `@for`
     setting.
+- The `http_headers` module is now behind the `api` cargo feature.
 
 Bug fixes:
 

--- a/crates/ruma-common/src/api.rs
+++ b/crates/ruma-common/src/api.rs
@@ -352,6 +352,21 @@ pub trait IncomingRequest: Metadata {
     /// Response type to return when the request is successful.
     type OutgoingResponse: OutgoingResponse;
 
+    /// Check whether the given HTTP method from an incoming request is compatible with the expected
+    /// [`METHOD`](Metadata::METHOD) of this endpoint.
+    fn check_request_method(method: &http::Method) -> Result<(), FromHttpRequestError> {
+        if !(method == Self::METHOD
+            || (Self::METHOD == http::Method::GET && method == http::Method::HEAD))
+        {
+            return Err(FromHttpRequestError::MethodMismatch {
+                expected: Self::METHOD,
+                received: method.clone(),
+            });
+        }
+
+        Ok(())
+    }
+
     /// Tries to turn the given `http::Request` into this request type,
     /// together with the corresponding path arguments.
     ///

--- a/crates/ruma-common/src/api/error.rs
+++ b/crates/ruma-common/src/api/error.rs
@@ -40,7 +40,7 @@ impl OutgoingResponse for MatrixError {
         self,
     ) -> Result<http::Response<T>, IntoHttpError> {
         http::Response::builder()
-            .header(http::header::CONTENT_TYPE, "application/json")
+            .header(http::header::CONTENT_TYPE, crate::http_headers::APPLICATION_JSON)
             .status(self.status_code)
             .body(match self.body {
                 MatrixErrorBody::Json(json) => crate::serde::json_to_buf(&json)?,

--- a/crates/ruma-common/src/http_headers.rs
+++ b/crates/ruma-common/src/http_headers.rs
@@ -5,10 +5,19 @@ use std::borrow::Cow;
 mod content_disposition;
 mod rfc8187;
 
+use http::HeaderValue;
+
 pub use self::content_disposition::{
     ContentDisposition, ContentDispositionParseError, ContentDispositionType, TokenString,
     TokenStringParseError,
 };
+
+/// The `application/json` media type as a [`HeaderValue`].
+pub const APPLICATION_JSON: HeaderValue = HeaderValue::from_static("application/json");
+
+/// The `application/octet-stream` media type as a [`HeaderValue`].
+pub const APPLICATION_OCTET_STREAM: HeaderValue =
+    HeaderValue::from_static("application/octet-stream");
 
 /// Whether the given byte is a [`token` char].
 ///

--- a/crates/ruma-common/src/lib.rs
+++ b/crates/ruma-common/src/lib.rs
@@ -24,6 +24,7 @@ pub mod authentication;
 pub mod canonical_json;
 pub mod directory;
 pub mod encryption;
+#[cfg(feature = "api")]
 pub mod http_headers;
 mod identifiers;
 pub mod media;

--- a/crates/ruma-common/tests/it/api/manual_endpoint_impl.rs
+++ b/crates/ruma-common/tests/it/api/manual_endpoint_impl.rs
@@ -95,6 +95,8 @@ impl IncomingRequest for Request {
         B: AsRef<[u8]>,
         S: AsRef<str>,
     {
+        Self::check_request_method(request.method())?;
+
         let (room_alias,) = Deserialize::deserialize(serde::de::value::SeqDeserializer::<
             _,
             serde::de::value::Error,

--- a/crates/ruma-common/tests/it/api/manual_endpoint_impl.rs
+++ b/crates/ruma-common/tests/it/api/manual_endpoint_impl.rs
@@ -136,7 +136,7 @@ impl OutgoingResponse for Response {
         self,
     ) -> Result<http::Response<T>, IntoHttpError> {
         let response = http::Response::builder()
-            .header(CONTENT_TYPE, "application/json")
+            .header(CONTENT_TYPE, ruma_common::http_headers::APPLICATION_JSON)
             .body(ruma_common::serde::slice_to_buf(b"{}"))
             .unwrap();
 

--- a/crates/ruma-macros/src/api/request/incoming.rs
+++ b/crates/ruma-macros/src/api/request/incoming.rs
@@ -191,15 +191,7 @@ impl Request {
                     B: ::std::convert::AsRef<[::std::primitive::u8]>,
                     S: ::std::convert::AsRef<::std::primitive::str>,
                 {
-                    if !(request.method() == <Self as #ruma_common::api::Metadata>::METHOD
-                        || request.method() == #http::Method::HEAD
-                            && <Self as #ruma_common::api::Metadata>::METHOD == #http::Method::GET)
-                    {
-                        return Err(#ruma_common::api::error::FromHttpRequestError::MethodMismatch {
-                            expected: <Self as #ruma_common::api::Metadata>::METHOD,
-                            received: request.method().clone(),
-                        });
-                    }
+                    <Self as #ruma_common::api::IncomingRequest>::check_request_method(request.method())?;
 
                     #parse_request_path
                     #parse_query

--- a/crates/ruma-macros/src/api/request/outgoing.rs
+++ b/crates/ruma-macros/src/api/request/outgoing.rs
@@ -88,7 +88,7 @@ impl Request {
         }));
 
         header_kvs.extend(quote! {
-            req_headers.extend(<<Self as #ruma_common::api::Metadata>::Authentication as #ruma_common::api::auth_scheme::AuthScheme>::authorization_header(authentication_input)?);
+            <<Self as #ruma_common::api::Metadata>::Authentication as #ruma_common::api::auth_scheme::AuthScheme>::add_authentication(req_headers, authentication_input)?;
         });
 
         let request_body = if let Some(field) = self.raw_body_field() {

--- a/crates/ruma-macros/src/api/request/outgoing.rs
+++ b/crates/ruma-macros/src/api/request/outgoing.rs
@@ -48,14 +48,14 @@ impl Request {
             quote! {
                 req_headers.insert(
                     #http::header::CONTENT_TYPE,
-                    #http::header::HeaderValue::from_static("application/json"),
+                    #ruma_common::http_headers::APPLICATION_JSON,
                 );
             }
         } else if self.raw_body_field().is_some() {
             quote! {
                 req_headers.insert(
                     #http::header::CONTENT_TYPE,
-                    #http::header::HeaderValue::from_static("application/octet-stream"),
+                    #ruma_common::http_headers::APPLICATION_OCTET_STREAM,
                 );
             }
         } else {

--- a/crates/ruma-macros/src/api/response/outgoing.rs
+++ b/crates/ruma-macros/src/api/response/outgoing.rs
@@ -15,14 +15,14 @@ impl Response {
             quote! {
                 headers.insert(
                     #http::header::CONTENT_TYPE,
-                    #http::header::HeaderValue::from_static("application/octet-stream"),
+                    #ruma_common::http_headers::APPLICATION_OCTET_STREAM,
                 );
             }
         } else {
             quote! {
                 headers.insert(
                     #http::header::CONTENT_TYPE,
-                    #http::header::HeaderValue::from_static("application/json"),
+                    #ruma_common::http_headers::APPLICATION_JSON,
                 );
             }
         };


### PR DESCRIPTION
This adds several constants and methods to reduce code duplication, to avoid possible typos and other mistakes.

See each commit message for details.