### PR TITLE
api: Require authentication type to be in scope

### DIFF
--- a/crates/ruma-appservice-api/src/event/push_events.rs
+++ b/crates/ruma-appservice-api/src/event/push_events.rs
@@ -16,7 +16,7 @@ pub mod v1 {
     #[cfg(feature = "unstable-msc3202")]
     use ruma_common::OwnedUserId;
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::{from_raw_json_value, JsonObject, Raw},
         OwnedTransactionId,

--- a/crates/ruma-appservice-api/src/ping/send_ping.rs
+++ b/crates/ruma-appservice-api/src/ping/send_ping.rs
@@ -8,7 +8,7 @@ pub mod unstable {
     //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/2659
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedTransactionId,
     };
 
@@ -55,7 +55,7 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/application-service-api/#post_matrixappv1ping
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedTransactionId,
     };
 

--- a/crates/ruma-appservice-api/src/query/query_room_alias.rs
+++ b/crates/ruma-appservice-api/src/query/query_room_alias.rs
@@ -8,7 +8,7 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/application-service-api/#get_matrixappv1roomsroomalias
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedRoomAliasId,
     };
 

--- a/crates/ruma-appservice-api/src/query/query_user_id.rs
+++ b/crates/ruma-appservice-api/src/query/query_user_id.rs
@@ -8,7 +8,7 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/application-service-api/#get_matrixappv1usersuserid
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedUserId,
     };
 

--- a/crates/ruma-appservice-api/src/thirdparty/get_location_for_protocol.rs
+++ b/crates/ruma-appservice-api/src/thirdparty/get_location_for_protocol.rs
@@ -10,7 +10,7 @@ pub mod v1 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         thirdparty::Location,
     };

--- a/crates/ruma-appservice-api/src/thirdparty/get_location_for_room_alias.rs
+++ b/crates/ruma-appservice-api/src/thirdparty/get_location_for_room_alias.rs
@@ -8,7 +8,7 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/application-service-api/#get_matrixappv1thirdpartylocation
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         thirdparty::Location,
         OwnedRoomAliasId,

--- a/crates/ruma-appservice-api/src/thirdparty/get_protocol.rs
+++ b/crates/ruma-appservice-api/src/thirdparty/get_protocol.rs
@@ -10,7 +10,7 @@ pub mod v1 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         thirdparty::{Protocol, ProtocolInstance, ProtocolInstanceInit},
     };

--- a/crates/ruma-appservice-api/src/thirdparty/get_user_for_protocol.rs
+++ b/crates/ruma-appservice-api/src/thirdparty/get_user_for_protocol.rs
@@ -11,7 +11,7 @@ pub mod v1 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         thirdparty::User,
     };

--- a/crates/ruma-appservice-api/src/thirdparty/get_user_for_user_id.rs
+++ b/crates/ruma-appservice-api/src/thirdparty/get_user_for_user_id.rs
@@ -8,7 +8,7 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/application-service-api/#get_matrixappv1thirdpartyuser
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         thirdparty::User,
         OwnedUserId,

--- a/crates/ruma-client-api/src/account/add_3pid.rs
+++ b/crates/ruma-client-api/src/account/add_3pid.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3account3pidadd
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedClientSecret, OwnedSessionId,
     };
 

--- a/crates/ruma-client-api/src/account/bind_3pid.rs
+++ b/crates/ruma-client-api/src/account/bind_3pid.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3account3pidbind
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedClientSecret, OwnedSessionId,
     };
 

--- a/crates/ruma-client-api/src/account/change_password.rs
+++ b/crates/ruma-client-api/src/account/change_password.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3accountpassword
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessTokenOptional, request, response},
         metadata,
     };
 

--- a/crates/ruma-client-api/src/account/check_registration_token_validity.rs
+++ b/crates/ruma-client-api/src/account/check_registration_token_validity.rs
@@ -8,7 +8,7 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv1registermloginregistration_tokenvalidity
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         metadata,
     };
 

--- a/crates/ruma-client-api/src/account/deactivate.rs
+++ b/crates/ruma-client-api/src/account/deactivate.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3accountdeactivate
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessTokenOptional, request, response},
         metadata,
     };
 

--- a/crates/ruma-client-api/src/account/delete_3pid.rs
+++ b/crates/ruma-client-api/src/account/delete_3pid.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3account3piddelete
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         thirdparty::Medium,
     };

--- a/crates/ruma-client-api/src/account/get_3pids.rs
+++ b/crates/ruma-client-api/src/account/get_3pids.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3account3pid
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         thirdparty::ThirdPartyIdentifier,
     };

--- a/crates/ruma-client-api/src/account/get_username_availability.rs
+++ b/crates/ruma-client-api/src/account/get_username_availability.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3registeravailable
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         metadata,
     };
 

--- a/crates/ruma-client-api/src/account/register.rs
+++ b/crates/ruma-client-api/src/account/register.rs
@@ -12,7 +12,7 @@ pub mod v3 {
     use std::time::Duration;
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AppserviceTokenOptional, request, response},
         metadata, OwnedDeviceId, OwnedUserId,
     };
 

--- a/crates/ruma-client-api/src/account/request_3pid_management_token_via_email.rs
+++ b/crates/ruma-client-api/src/account/request_3pid_management_token_via_email.rs
@@ -9,7 +9,7 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         metadata, OwnedClientSecret, OwnedSessionId,
     };
 

--- a/crates/ruma-client-api/src/account/request_3pid_management_token_via_msisdn.rs
+++ b/crates/ruma-client-api/src/account/request_3pid_management_token_via_msisdn.rs
@@ -9,7 +9,7 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         metadata, OwnedClientSecret, OwnedSessionId,
     };
 

--- a/crates/ruma-client-api/src/account/request_openid_token.rs
+++ b/crates/ruma-client-api/src/account/request_openid_token.rs
@@ -10,7 +10,7 @@ pub mod v3 {
     use std::time::Duration;
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         authentication::TokenType,
         metadata, OwnedServerName, OwnedUserId,
     };

--- a/crates/ruma-client-api/src/account/request_password_change_token_via_email.rs
+++ b/crates/ruma-client-api/src/account/request_password_change_token_via_email.rs
@@ -9,7 +9,7 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         metadata, OwnedClientSecret, OwnedSessionId,
     };
 

--- a/crates/ruma-client-api/src/account/request_password_change_token_via_msisdn.rs
+++ b/crates/ruma-client-api/src/account/request_password_change_token_via_msisdn.rs
@@ -9,7 +9,7 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         metadata, OwnedClientSecret, OwnedSessionId,
     };
 

--- a/crates/ruma-client-api/src/account/request_registration_token_via_email.rs
+++ b/crates/ruma-client-api/src/account/request_registration_token_via_email.rs
@@ -9,7 +9,7 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         metadata, OwnedClientSecret, OwnedSessionId,
     };
 

--- a/crates/ruma-client-api/src/account/request_registration_token_via_msisdn.rs
+++ b/crates/ruma-client-api/src/account/request_registration_token_via_msisdn.rs
@@ -9,7 +9,7 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         metadata, OwnedClientSecret, OwnedSessionId,
     };
 

--- a/crates/ruma-client-api/src/account/unbind_3pid.rs
+++ b/crates/ruma-client-api/src/account/unbind_3pid.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3account3pidunbind
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         thirdparty::Medium,
     };

--- a/crates/ruma-client-api/src/account/whoami.rs
+++ b/crates/ruma-client-api/src/account/whoami.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3accountwhoami
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedDeviceId, OwnedUserId,
     };
 

--- a/crates/ruma-client-api/src/alias/create_alias.rs
+++ b/crates/ruma-client-api/src/alias/create_alias.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3directoryroomroomalias
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedRoomAliasId, OwnedRoomId,
     };
 

--- a/crates/ruma-client-api/src/alias/delete_alias.rs
+++ b/crates/ruma-client-api/src/alias/delete_alias.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#delete_matrixclientv3directoryroomroomalias
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedRoomAliasId,
     };
 

--- a/crates/ruma-client-api/src/alias/get_alias.rs
+++ b/crates/ruma-client-api/src/alias/get_alias.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3directoryroomroomalias
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         metadata, OwnedRoomAliasId, OwnedRoomId, OwnedServerName,
     };
 

--- a/crates/ruma-client-api/src/appservice/request_ping.rs
+++ b/crates/ruma-client-api/src/appservice/request_ping.rs
@@ -10,7 +10,7 @@ pub mod v1 {
     use std::time::Duration;
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AppserviceToken, request, response},
         metadata, OwnedTransactionId,
     };
 

--- a/crates/ruma-client-api/src/appservice/set_room_visibility.rs
+++ b/crates/ruma-client-api/src/appservice/set_room_visibility.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/application-service-api/#put_matrixclientv3directorylistappservicenetworkidroomid
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AppserviceToken, request, response},
         metadata, OwnedRoomId,
     };
 

--- a/crates/ruma-client-api/src/authenticated_media/get_content.rs
+++ b/crates/ruma-client-api/src/authenticated_media/get_content.rs
@@ -11,7 +11,7 @@ pub mod v1 {
 
     use http::header::{CONTENT_DISPOSITION, CONTENT_TYPE};
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         http_headers::ContentDisposition,
         metadata, IdParseError, MxcUri, OwnedServerName,
     };

--- a/crates/ruma-client-api/src/authenticated_media/get_content_as_filename.rs
+++ b/crates/ruma-client-api/src/authenticated_media/get_content_as_filename.rs
@@ -11,7 +11,7 @@ pub mod v1 {
 
     use http::header::{CONTENT_DISPOSITION, CONTENT_TYPE};
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         http_headers::ContentDisposition,
         metadata, IdParseError, MxcUri, OwnedServerName,
     };

--- a/crates/ruma-client-api/src/authenticated_media/get_content_thumbnail.rs
+++ b/crates/ruma-client-api/src/authenticated_media/get_content_thumbnail.rs
@@ -12,7 +12,7 @@ pub mod v1 {
     use http::header::{CONTENT_DISPOSITION, CONTENT_TYPE};
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         http_headers::ContentDisposition,
         media::Method,
         metadata, IdParseError, MxcUri, OwnedServerName,

--- a/crates/ruma-client-api/src/authenticated_media/get_media_config.rs
+++ b/crates/ruma-client-api/src/authenticated_media/get_media_config.rs
@@ -9,7 +9,7 @@ pub mod v1 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
     };
 

--- a/crates/ruma-client-api/src/authenticated_media/get_media_preview.rs
+++ b/crates/ruma-client-api/src/authenticated_media/get_media_preview.rs
@@ -8,7 +8,7 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv1mediapreview_url
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, MilliSecondsSinceUnixEpoch,
     };
     use serde::Serialize;

--- a/crates/ruma-client-api/src/backup/add_backup_keys.rs
+++ b/crates/ruma-client-api/src/backup/add_backup_keys.rs
@@ -11,7 +11,7 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedRoomId,
     };
 

--- a/crates/ruma-client-api/src/backup/add_backup_keys_for_room.rs
+++ b/crates/ruma-client-api/src/backup/add_backup_keys_for_room.rs
@@ -11,7 +11,7 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
         OwnedRoomId,

--- a/crates/ruma-client-api/src/backup/add_backup_keys_for_session.rs
+++ b/crates/ruma-client-api/src/backup/add_backup_keys_for_session.rs
@@ -9,7 +9,7 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
         OwnedRoomId,

--- a/crates/ruma-client-api/src/backup/create_backup_version.rs
+++ b/crates/ruma-client-api/src/backup/create_backup_version.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3room_keysversion
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
     };

--- a/crates/ruma-client-api/src/backup/delete_backup_keys.rs
+++ b/crates/ruma-client-api/src/backup/delete_backup_keys.rs
@@ -11,7 +11,7 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
     };
 

--- a/crates/ruma-client-api/src/backup/delete_backup_keys_for_room.rs
+++ b/crates/ruma-client-api/src/backup/delete_backup_keys_for_room.rs
@@ -9,7 +9,7 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedRoomId,
     };
 

--- a/crates/ruma-client-api/src/backup/delete_backup_keys_for_session.rs
+++ b/crates/ruma-client-api/src/backup/delete_backup_keys_for_session.rs
@@ -9,7 +9,7 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedRoomId,
     };
 

--- a/crates/ruma-client-api/src/backup/delete_backup_version.rs
+++ b/crates/ruma-client-api/src/backup/delete_backup_version.rs
@@ -10,7 +10,7 @@ pub mod v3 {
     //! This deletes a backup version and its room keys.
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
     };
 

--- a/crates/ruma-client-api/src/backup/get_backup_info.rs
+++ b/crates/ruma-client-api/src/backup/get_backup_info.rs
@@ -10,7 +10,7 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
     };

--- a/crates/ruma-client-api/src/backup/get_backup_keys.rs
+++ b/crates/ruma-client-api/src/backup/get_backup_keys.rs
@@ -10,7 +10,7 @@ pub mod v3 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedRoomId,
     };
 

--- a/crates/ruma-client-api/src/backup/get_backup_keys_for_room.rs
+++ b/crates/ruma-client-api/src/backup/get_backup_keys_for_room.rs
@@ -10,7 +10,7 @@ pub mod v3 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
         OwnedRoomId,

--- a/crates/ruma-client-api/src/backup/get_backup_keys_for_session.rs
+++ b/crates/ruma-client-api/src/backup/get_backup_keys_for_session.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3room_keyskeysroomidsessionid
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
         OwnedRoomId,

--- a/crates/ruma-client-api/src/backup/get_latest_backup_info.rs
+++ b/crates/ruma-client-api/src/backup/get_latest_backup_info.rs
@@ -9,7 +9,7 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
     };

--- a/crates/ruma-client-api/src/backup/update_backup_version.rs
+++ b/crates/ruma-client-api/src/backup/update_backup_version.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3room_keysversionversion
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
     };

--- a/crates/ruma-client-api/src/config/get_global_account_data.rs
+++ b/crates/ruma-client-api/src/config/get_global_account_data.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3useruseridaccount_datatype
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
         OwnedUserId,

--- a/crates/ruma-client-api/src/config/get_room_account_data.rs
+++ b/crates/ruma-client-api/src/config/get_room_account_data.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3useruseridroomsroomidaccount_datatype
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
         OwnedRoomId, OwnedUserId,

--- a/crates/ruma-client-api/src/config/set_global_account_data.rs
+++ b/crates/ruma-client-api/src/config/set_global_account_data.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3useruseridaccount_datatype
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
         OwnedUserId,

--- a/crates/ruma-client-api/src/config/set_room_account_data.rs
+++ b/crates/ruma-client-api/src/config/set_room_account_data.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3useruseridroomsroomidaccount_datatype
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
         OwnedRoomId, OwnedUserId,

--- a/crates/ruma-client-api/src/context/get_context.rs
+++ b/crates/ruma-client-api/src/context/get_context.rs
@@ -9,7 +9,7 @@ pub mod v3 {
 
     use js_int::{uint, UInt};
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
         OwnedEventId, OwnedRoomId,

--- a/crates/ruma-client-api/src/dehydrated_device/delete_dehydrated_device.rs
+++ b/crates/ruma-client-api/src/dehydrated_device/delete_dehydrated_device.rs
@@ -8,7 +8,7 @@ pub mod unstable {
     //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/3814
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedDeviceId,
     };
 

--- a/crates/ruma-client-api/src/dehydrated_device/get_dehydrated_device.rs
+++ b/crates/ruma-client-api/src/dehydrated_device/get_dehydrated_device.rs
@@ -8,7 +8,7 @@ pub mod unstable {
     //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/3814
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
         OwnedDeviceId,

--- a/crates/ruma-client-api/src/dehydrated_device/get_events.rs
+++ b/crates/ruma-client-api/src/dehydrated_device/get_events.rs
@@ -8,7 +8,7 @@ pub mod unstable {
     //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/3814
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
         OwnedDeviceId,

--- a/crates/ruma-client-api/src/dehydrated_device/put_dehydrated_device.rs
+++ b/crates/ruma-client-api/src/dehydrated_device/put_dehydrated_device.rs
@@ -10,7 +10,7 @@ pub mod unstable {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         encryption::{DeviceKeys, OneTimeKey},
         metadata,
         serde::Raw,

--- a/crates/ruma-client-api/src/delayed_events/delayed_message_event.rs
+++ b/crates/ruma-client-api/src/delayed_events/delayed_message_event.rs
@@ -8,7 +8,7 @@ pub mod unstable {
     //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/4140
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
         OwnedRoomId, OwnedTransactionId,

--- a/crates/ruma-client-api/src/delayed_events/delayed_state_event.rs
+++ b/crates/ruma-client-api/src/delayed_events/delayed_state_event.rs
@@ -8,7 +8,7 @@ pub mod unstable {
     //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/4140
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
         OwnedRoomId,

--- a/crates/ruma-client-api/src/delayed_events/update_delayed_event.rs
+++ b/crates/ruma-client-api/src/delayed_events/update_delayed_event.rs
@@ -9,7 +9,7 @@ pub mod unstable {
     //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/4140
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::StringEnum,
     };

--- a/crates/ruma-client-api/src/device/delete_device.rs
+++ b/crates/ruma-client-api/src/device/delete_device.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#delete_matrixclientv3devicesdeviceid
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedDeviceId,
     };
 

--- a/crates/ruma-client-api/src/device/delete_devices.rs
+++ b/crates/ruma-client-api/src/device/delete_devices.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3delete_devices
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedDeviceId,
     };
 

--- a/crates/ruma-client-api/src/device/get_device.rs
+++ b/crates/ruma-client-api/src/device/get_device.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3devicesdeviceid
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedDeviceId,
     };
 

--- a/crates/ruma-client-api/src/device/get_devices.rs
+++ b/crates/ruma-client-api/src/device/get_devices.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3devices
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
     };
 

--- a/crates/ruma-client-api/src/device/update_device.rs
+++ b/crates/ruma-client-api/src/device/update_device.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3devicesdeviceid
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedDeviceId,
     };
 

--- a/crates/ruma-client-api/src/directory/get_public_rooms.rs
+++ b/crates/ruma-client-api/src/directory/get_public_rooms.rs
@@ -9,7 +9,7 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         directory::PublicRoomsChunk,
         metadata, OwnedServerName,
     };

--- a/crates/ruma-client-api/src/directory/get_public_rooms_filtered.rs
+++ b/crates/ruma-client-api/src/directory/get_public_rooms_filtered.rs
@@ -9,7 +9,7 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         directory::{Filter, PublicRoomsChunk, RoomNetwork},
         metadata, OwnedServerName,
     };

--- a/crates/ruma-client-api/src/directory/get_room_visibility.rs
+++ b/crates/ruma-client-api/src/directory/get_room_visibility.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3directorylistroomroomid
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         metadata, OwnedRoomId,
     };
 

--- a/crates/ruma-client-api/src/directory/set_room_visibility.rs
+++ b/crates/ruma-client-api/src/directory/set_room_visibility.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3directorylistroomroomid
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedRoomId,
     };
 

--- a/crates/ruma-client-api/src/discovery/discover_homeserver.rs
+++ b/crates/ruma-client-api/src/discovery/discover_homeserver.rs
@@ -10,7 +10,7 @@ use std::borrow::Cow;
 #[cfg(feature = "unstable-msc4143")]
 use ruma_common::serde::JsonObject;
 use ruma_common::{
-    api::{request, response},
+    api::{auth_scheme::NoAuthentication, request, response},
     metadata,
 };
 #[cfg(feature = "unstable-msc4143")]

--- a/crates/ruma-client-api/src/discovery/discover_support.rs
+++ b/crates/ruma-client-api/src/discovery/discover_support.rs
@@ -5,7 +5,7 @@
 //! Get server admin contact and support page of a homeserver's domain.
 
 use ruma_common::{
-    api::{request, response},
+    api::{auth_scheme::NoAuthentication, request, response},
     metadata,
     serde::StringEnum,
     OwnedUserId,

--- a/crates/ruma-client-api/src/discovery/get_authorization_server_metadata.rs
+++ b/crates/ruma-client-api/src/discovery/get_authorization_server_metadata.rs
@@ -12,7 +12,7 @@ pub mod v1 {
     use std::collections::BTreeSet;
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         metadata,
         serde::{Raw, StringEnum},
     };

--- a/crates/ruma-client-api/src/discovery/get_capabilities.rs
+++ b/crates/ruma-client-api/src/discovery/get_capabilities.rs
@@ -14,7 +14,7 @@ pub mod v3 {
 
     use maplit::btreemap;
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::StringEnum,
         RoomVersionId,

--- a/crates/ruma-client-api/src/discovery/get_supported_versions.rs
+++ b/crates/ruma-client-api/src/discovery/get_supported_versions.rs
@@ -7,7 +7,7 @@
 use std::collections::BTreeMap;
 
 use ruma_common::{
-    api::{request, response, SupportedVersions},
+    api::{auth_scheme::AccessTokenOptional, request, response, SupportedVersions},
     metadata,
 };
 

--- a/crates/ruma-client-api/src/filter/create_filter.rs
+++ b/crates/ruma-client-api/src/filter/create_filter.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3useruseridfilter
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedUserId,
     };
 

--- a/crates/ruma-client-api/src/filter/get_filter.rs
+++ b/crates/ruma-client-api/src/filter/get_filter.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3useruseridfilterfilterid
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedUserId,
     };
 

--- a/crates/ruma-client-api/src/keys/claim_keys/v3.rs
+++ b/crates/ruma-client-api/src/keys/claim_keys/v3.rs
@@ -5,7 +5,7 @@
 use std::{collections::BTreeMap, time::Duration};
 
 use ruma_common::{
-    api::{request, response},
+    api::{auth_scheme::AccessToken, request, response},
     encryption::OneTimeKey,
     metadata,
     serde::Raw,

--- a/crates/ruma-client-api/src/keys/claim_keys/v4.rs
+++ b/crates/ruma-client-api/src/keys/claim_keys/v4.rs
@@ -5,7 +5,7 @@
 use std::{collections::BTreeMap, time::Duration};
 
 use ruma_common::{
-    api::{request, response},
+    api::{auth_scheme::AccessToken, request, response},
     encryption::OneTimeKey,
     metadata,
     serde::Raw,

--- a/crates/ruma-client-api/src/keys/get_key_changes.rs
+++ b/crates/ruma-client-api/src/keys/get_key_changes.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3keyschanges
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedUserId,
     };
 

--- a/crates/ruma-client-api/src/keys/get_keys.rs
+++ b/crates/ruma-client-api/src/keys/get_keys.rs
@@ -10,7 +10,7 @@ pub mod v3 {
     use std::{collections::BTreeMap, time::Duration};
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         encryption::{CrossSigningKey, DeviceKeys},
         metadata,
         serde::Raw,

--- a/crates/ruma-client-api/src/keys/upload_keys.rs
+++ b/crates/ruma-client-api/src/keys/upload_keys.rs
@@ -11,7 +11,7 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         encryption::{DeviceKeys, OneTimeKey},
         metadata,
         serde::Raw,

--- a/crates/ruma-client-api/src/keys/upload_signatures.rs
+++ b/crates/ruma-client-api/src/keys/upload_signatures.rs
@@ -10,7 +10,7 @@ pub mod v3 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         encryption::{CrossSigningKey, DeviceKeys},
         metadata,
         serde::{Raw, StringEnum},

--- a/crates/ruma-client-api/src/keys/upload_signing_keys.rs
+++ b/crates/ruma-client-api/src/keys/upload_signing_keys.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3keysdevice_signingupload
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         encryption::CrossSigningKey,
         metadata,
         serde::Raw,

--- a/crates/ruma-client-api/src/knock/knock_room.rs
+++ b/crates/ruma-client-api/src/knock/knock_room.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3knockroomidoralias
 
     use ruma_common::{
-        api::{response, Metadata},
+        api::{auth_scheme::AccessToken, response, Metadata},
         metadata, OwnedRoomId, OwnedRoomOrAliasId, OwnedServerName,
     };
 

--- a/crates/ruma-client-api/src/media/create_content.rs
+++ b/crates/ruma-client-api/src/media/create_content.rs
@@ -9,7 +9,7 @@ pub mod v3 {
 
     use http::header::CONTENT_TYPE;
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedMxcUri,
     };
 

--- a/crates/ruma-client-api/src/media/create_content_async.rs
+++ b/crates/ruma-client-api/src/media/create_content_async.rs
@@ -9,7 +9,7 @@ pub mod v3 {
 
     use http::header::CONTENT_TYPE;
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, IdParseError, MxcUri, OwnedServerName,
     };
 

--- a/crates/ruma-client-api/src/media/create_mxc_uri.rs
+++ b/crates/ruma-client-api/src/media/create_mxc_uri.rs
@@ -8,7 +8,7 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixmediav1create
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, MilliSecondsSinceUnixEpoch, OwnedMxcUri,
     };
 

--- a/crates/ruma-client-api/src/media/get_content.rs
+++ b/crates/ruma-client-api/src/media/get_content.rs
@@ -11,7 +11,7 @@ pub mod v3 {
 
     use http::header::{CONTENT_DISPOSITION, CONTENT_TYPE};
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         http_headers::ContentDisposition,
         metadata, IdParseError, MxcUri, OwnedServerName,
     };

--- a/crates/ruma-client-api/src/media/get_content_as_filename.rs
+++ b/crates/ruma-client-api/src/media/get_content_as_filename.rs
@@ -11,7 +11,7 @@ pub mod v3 {
 
     use http::header::{CONTENT_DISPOSITION, CONTENT_TYPE};
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         http_headers::ContentDisposition,
         metadata, IdParseError, MxcUri, OwnedServerName,
     };

--- a/crates/ruma-client-api/src/media/get_content_thumbnail.rs
+++ b/crates/ruma-client-api/src/media/get_content_thumbnail.rs
@@ -13,7 +13,7 @@ pub mod v3 {
     use js_int::UInt;
     pub use ruma_common::media::Method;
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         http_headers::ContentDisposition,
         metadata, IdParseError, MxcUri, OwnedServerName,
     };

--- a/crates/ruma-client-api/src/media/get_media_config.rs
+++ b/crates/ruma-client-api/src/media/get_media_config.rs
@@ -9,7 +9,7 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
     };
 

--- a/crates/ruma-client-api/src/media/get_media_preview.rs
+++ b/crates/ruma-client-api/src/media/get_media_preview.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixmediav3preview_url
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, MilliSecondsSinceUnixEpoch,
     };
     use serde::Serialize;

--- a/crates/ruma-client-api/src/membership/ban_user.rs
+++ b/crates/ruma-client-api/src/membership/ban_user.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidban
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedRoomId, OwnedUserId,
     };
 

--- a/crates/ruma-client-api/src/membership/forget_room.rs
+++ b/crates/ruma-client-api/src/membership/forget_room.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidforget
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedRoomId,
     };
 

--- a/crates/ruma-client-api/src/membership/get_member_events.rs
+++ b/crates/ruma-client-api/src/membership/get_member_events.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3roomsroomidmembers
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
         OwnedRoomId,

--- a/crates/ruma-client-api/src/membership/invite_user.rs
+++ b/crates/ruma-client-api/src/membership/invite_user.rs
@@ -13,7 +13,7 @@ pub mod v3 {
     //! [spec-3pid]: https://spec.matrix.org/latest/client-server-api/#thirdparty_post_matrixclientv3roomsroomidinvite
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedRoomId, OwnedUserId,
     };
     use serde::{Deserialize, Serialize};

--- a/crates/ruma-client-api/src/membership/join_room_by_id.rs
+++ b/crates/ruma-client-api/src/membership/join_room_by_id.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidjoin
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedRoomId,
     };
 

--- a/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
+++ b/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3joinroomidoralias
 
     use ruma_common::{
-        api::{response, Metadata},
+        api::{auth_scheme::AccessToken, response, Metadata},
         metadata, OwnedRoomId, OwnedRoomOrAliasId, OwnedServerName,
     };
 

--- a/crates/ruma-client-api/src/membership/joined_members.rs
+++ b/crates/ruma-client-api/src/membership/joined_members.rs
@@ -11,7 +11,7 @@ pub mod v3 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedMxcUri, OwnedRoomId, OwnedUserId,
     };
     use serde::{Deserialize, Serialize};

--- a/crates/ruma-client-api/src/membership/joined_rooms.rs
+++ b/crates/ruma-client-api/src/membership/joined_rooms.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3joined_rooms
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedRoomId,
     };
 

--- a/crates/ruma-client-api/src/membership/kick_user.rs
+++ b/crates/ruma-client-api/src/membership/kick_user.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidkick
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedRoomId, OwnedUserId,
     };
 

--- a/crates/ruma-client-api/src/membership/leave_room.rs
+++ b/crates/ruma-client-api/src/membership/leave_room.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidleave
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedRoomId,
     };
 

--- a/crates/ruma-client-api/src/membership/mutual_rooms.rs
+++ b/crates/ruma-client-api/src/membership/mutual_rooms.rs
@@ -8,7 +8,7 @@ pub mod unstable {
     //! [spec]: https://github.com/matrix-org/matrix-spec-proposals/blob/hs/shared-rooms/proposals/2666-get-rooms-in-common.md
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedRoomId, OwnedUserId,
     };
 

--- a/crates/ruma-client-api/src/membership/unban_user.rs
+++ b/crates/ruma-client-api/src/membership/unban_user.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidunban
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedRoomId, OwnedUserId,
     };
 

--- a/crates/ruma-client-api/src/message/get_message_events.rs
+++ b/crates/ruma-client-api/src/message/get_message_events.rs
@@ -9,7 +9,7 @@ pub mod v3 {
 
     use js_int::{uint, UInt};
     use ruma_common::{
-        api::{request, response, Direction},
+        api::{auth_scheme::AccessToken, request, response, Direction},
         metadata,
         serde::Raw,
         OwnedRoomId,

--- a/crates/ruma-client-api/src/message/send_message_event.rs
+++ b/crates/ruma-client-api/src/message/send_message_event.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3roomsroomidsendeventtypetxnid
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
         MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedTransactionId,

--- a/crates/ruma-client-api/src/peeking/get_current_state.rs
+++ b/crates/ruma-client-api/src/peeking/get_current_state.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3roomsroomidinitialsync
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
         OwnedRoomId,

--- a/crates/ruma-client-api/src/peeking/listen_to_new_events.rs
+++ b/crates/ruma-client-api/src/peeking/listen_to_new_events.rs
@@ -10,7 +10,7 @@ pub mod v3 {
     use std::time::Duration;
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
         OwnedRoomId,

--- a/crates/ruma-client-api/src/presence/get_presence.rs
+++ b/crates/ruma-client-api/src/presence/get_presence.rs
@@ -10,7 +10,7 @@ pub mod v3 {
     use std::time::Duration;
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         presence::PresenceState,
         OwnedUserId,

--- a/crates/ruma-client-api/src/presence/set_presence.rs
+++ b/crates/ruma-client-api/src/presence/set_presence.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3presenceuseridstatus
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         presence::PresenceState,
         OwnedUserId,

--- a/crates/ruma-client-api/src/profile/delete_profile_field.rs
+++ b/crates/ruma-client-api/src/profile/delete_profile_field.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#delete_matrixclientv3profileuseridkeyname
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedUserId,
     };
 

--- a/crates/ruma-client-api/src/profile/get_avatar_url.rs
+++ b/crates/ruma-client-api/src/profile/get_avatar_url.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/v1.15/client-server-api/#get_matrixclientv3profileuseridavatar_url
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         metadata, OwnedMxcUri, OwnedUserId,
     };
 

--- a/crates/ruma-client-api/src/profile/get_display_name.rs
+++ b/crates/ruma-client-api/src/profile/get_display_name.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/v1.15/client-server-api/#get_matrixclientv3profileuseriddisplayname
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         metadata, OwnedUserId,
     };
 

--- a/crates/ruma-client-api/src/profile/get_profile.rs
+++ b/crates/ruma-client-api/src/profile/get_profile.rs
@@ -10,7 +10,7 @@ pub mod v3 {
     use std::collections::{btree_map, BTreeMap};
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         metadata, OwnedUserId,
     };
     use serde_json::Value as JsonValue;

--- a/crates/ruma-client-api/src/profile/get_profile_field.rs
+++ b/crates/ruma-client-api/src/profile/get_profile_field.rs
@@ -16,7 +16,7 @@ pub mod v3 {
     use std::marker::PhantomData;
 
     use ruma_common::{
-        api::{path_builder::VersionHistory, Metadata},
+        api::{auth_scheme::NoAuthentication, path_builder::VersionHistory, Metadata},
         metadata, OwnedUserId,
     };
 

--- a/crates/ruma-client-api/src/profile/set_avatar_url.rs
+++ b/crates/ruma-client-api/src/profile/set_avatar_url.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/v1.15/client-server-api/#put_matrixclientv3profileuseridavatar_url
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedMxcUri, OwnedUserId,
     };
 

--- a/crates/ruma-client-api/src/profile/set_display_name.rs
+++ b/crates/ruma-client-api/src/profile/set_display_name.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/v1.15/client-server-api/#put_matrixclientv3profileuseriddisplayname
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedUserId,
     };
 

--- a/crates/ruma-client-api/src/profile/set_profile_field.rs
+++ b/crates/ruma-client-api/src/profile/set_profile_field.rs
@@ -14,7 +14,7 @@ pub mod v3 {
     //! [`set_display_name`]: crate::profile::set_display_name
 
     use ruma_common::{
-        api::{response, Metadata},
+        api::{auth_scheme::AccessToken, response, Metadata},
         metadata, OwnedUserId,
     };
 

--- a/crates/ruma-client-api/src/push/delete_pushrule.rs
+++ b/crates/ruma-client-api/src/push/delete_pushrule.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#delete_matrixclientv3pushrulesglobalkindruleid
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
     };
 

--- a/crates/ruma-client-api/src/push/get_notifications.rs
+++ b/crates/ruma-client-api/src/push/get_notifications.rs
@@ -9,7 +9,7 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         push::Action,
         serde::Raw,

--- a/crates/ruma-client-api/src/push/get_pushers.rs
+++ b/crates/ruma-client-api/src/push/get_pushers.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3pushers
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
     };
 

--- a/crates/ruma-client-api/src/push/get_pushrule.rs
+++ b/crates/ruma-client-api/src/push/get_pushrule.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3pushrulesglobalkindruleid
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
     };
 

--- a/crates/ruma-client-api/src/push/get_pushrule_actions.rs
+++ b/crates/ruma-client-api/src/push/get_pushrule_actions.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3pushrulesglobalkindruleidactions
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         push::Action,
     };

--- a/crates/ruma-client-api/src/push/get_pushrule_enabled.rs
+++ b/crates/ruma-client-api/src/push/get_pushrule_enabled.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3pushrulesglobalkindruleidenabled
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
     };
 

--- a/crates/ruma-client-api/src/push/get_pushrules_all.rs
+++ b/crates/ruma-client-api/src/push/get_pushrules_all.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3pushrules
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         push::Ruleset,
     };

--- a/crates/ruma-client-api/src/push/get_pushrules_global_scope.rs
+++ b/crates/ruma-client-api/src/push/get_pushrules_global_scope.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3pushrulesglobal
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         push::Ruleset,
     };

--- a/crates/ruma-client-api/src/push/set_pusher.rs
+++ b/crates/ruma-client-api/src/push/set_pusher.rs
@@ -10,7 +10,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3pushersset
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
     };
     use serde::Serialize;

--- a/crates/ruma-client-api/src/push/set_pushrule.rs
+++ b/crates/ruma-client-api/src/push/set_pushrule.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3pushrulesglobalkindruleid
 
     use ruma_common::{
-        api::{response, Metadata},
+        api::{auth_scheme::AccessToken, response, Metadata},
         metadata,
         push::{Action, NewPushRule, PushCondition},
     };

--- a/crates/ruma-client-api/src/push/set_pushrule_actions.rs
+++ b/crates/ruma-client-api/src/push/set_pushrule_actions.rs
@@ -9,7 +9,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3pushrulesglobalkindruleidactions
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         push::Action,
     };

--- a/crates/ruma-client-api/src/push/set_pushrule_enabled.rs
+++ b/crates/ruma-client-api/src/push/set_pushrule_enabled.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3pushrulesglobalkindruleidenabled
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
     };
 

--- a/crates/ruma-client-api/src/read_marker/set_read_marker.rs
+++ b/crates/ruma-client-api/src/read_marker/set_read_marker.rs
@@ -13,7 +13,7 @@ pub mod v3 {
     //! [`create_receipt`]: crate::receipt::create_receipt
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedEventId, OwnedRoomId,
     };
 

--- a/crates/ruma-client-api/src/receipt/create_receipt.rs
+++ b/crates/ruma-client-api/src/receipt/create_receipt.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidreceiptreceipttypeeventid
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::StringEnum,
         OwnedEventId, OwnedRoomId,

--- a/crates/ruma-client-api/src/redact/redact_event.rs
+++ b/crates/ruma-client-api/src/redact/redact_event.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3roomsroomidredacteventidtxnid
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedEventId, OwnedRoomId, OwnedTransactionId,
     };
 

--- a/crates/ruma-client-api/src/relations/get_relating_events.rs
+++ b/crates/ruma-client-api/src/relations/get_relating_events.rs
@@ -9,7 +9,7 @@ pub mod v1 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response, Direction},
+        api::{auth_scheme::AccessToken, request, response, Direction},
         metadata,
         serde::Raw,
         OwnedEventId, OwnedRoomId,

--- a/crates/ruma-client-api/src/relations/get_relating_events_with_rel_type.rs
+++ b/crates/ruma-client-api/src/relations/get_relating_events_with_rel_type.rs
@@ -10,7 +10,7 @@ pub mod v1 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response, Direction},
+        api::{auth_scheme::AccessToken, request, response, Direction},
         metadata,
         serde::Raw,
         OwnedEventId, OwnedRoomId,

--- a/crates/ruma-client-api/src/relations/get_relating_events_with_rel_type_and_event_type.rs
+++ b/crates/ruma-client-api/src/relations/get_relating_events_with_rel_type_and_event_type.rs
@@ -10,7 +10,7 @@ pub mod v1 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response, Direction},
+        api::{auth_scheme::AccessToken, request, response, Direction},
         metadata,
         serde::Raw,
         OwnedEventId, OwnedRoomId,

--- a/crates/ruma-client-api/src/rendezvous/create_rendezvous_session.rs
+++ b/crates/ruma-client-api/src/rendezvous/create_rendezvous_session.rs
@@ -14,7 +14,7 @@ pub mod unstable {
     #[cfg(feature = "client")]
     use ruma_common::api::error::FromHttpResponseError;
     use ruma_common::{
-        api::{error::HeaderDeserializationError, Metadata},
+        api::{auth_scheme::NoAuthentication, error::HeaderDeserializationError, Metadata},
         metadata,
     };
     use serde::{Deserialize, Serialize};

--- a/crates/ruma-client-api/src/reporting/report_user.rs
+++ b/crates/ruma-client-api/src/reporting/report_user.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3usersuseridreport
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedUserId,
     };
 

--- a/crates/ruma-client-api/src/room/aliases.rs
+++ b/crates/ruma-client-api/src/room/aliases.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3roomsroomidaliases
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedRoomAliasId, OwnedRoomId,
     };
 

--- a/crates/ruma-client-api/src/room/create_room.rs
+++ b/crates/ruma-client-api/src/room/create_room.rs
@@ -9,7 +9,7 @@ pub mod v3 {
 
     use assign::assign;
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         room::RoomType,
         serde::{Raw, StringEnum},

--- a/crates/ruma-client-api/src/room/get_event_by_timestamp.rs
+++ b/crates/ruma-client-api/src/room/get_event_by_timestamp.rs
@@ -8,7 +8,7 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv1roomsroomidtimestamp_to_event
 
     use ruma_common::{
-        api::{request, response, Direction},
+        api::{auth_scheme::AccessToken, request, response, Direction},
         metadata, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId,
     };
 

--- a/crates/ruma-client-api/src/room/get_room_event.rs
+++ b/crates/ruma-client-api/src/room/get_room_event.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3roomsroomideventeventid
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
         OwnedEventId, OwnedRoomId,

--- a/crates/ruma-client-api/src/room/get_summary.rs
+++ b/crates/ruma-client-api/src/room/get_summary.rs
@@ -8,7 +8,10 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv1room_summaryroomidoralias
 
     use ruma_common::{
-        api::request, metadata, room::RoomSummary, OwnedRoomOrAliasId, OwnedServerName,
+        api::{auth_scheme::AccessTokenOptional, request},
+        metadata,
+        room::RoomSummary,
+        OwnedRoomOrAliasId, OwnedServerName,
     };
     use ruma_events::room::member::MembershipState;
 

--- a/crates/ruma-client-api/src/room/report_content.rs
+++ b/crates/ruma-client-api/src/room/report_content.rs
@@ -9,7 +9,7 @@ pub mod v3 {
 
     use js_int::Int;
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedEventId, OwnedRoomId,
     };
 

--- a/crates/ruma-client-api/src/room/report_room.rs
+++ b/crates/ruma-client-api/src/room/report_room.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidreport
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedRoomId,
     };
 

--- a/crates/ruma-client-api/src/room/upgrade_room.rs
+++ b/crates/ruma-client-api/src/room/upgrade_room.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidupgrade
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedRoomId, OwnedUserId, RoomVersionId,
     };
 

--- a/crates/ruma-client-api/src/search/search_events.rs
+++ b/crates/ruma-client-api/src/search/search_events.rs
@@ -11,7 +11,7 @@ pub mod v3 {
 
     use js_int::{uint, UInt};
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::{Raw, StringEnum},
         OwnedEventId, OwnedMxcUri, OwnedRoomId, OwnedUserId,

--- a/crates/ruma-client-api/src/server/get_user_info.rs
+++ b/crates/ruma-client-api/src/server/get_user_info.rs
@@ -10,7 +10,7 @@ pub mod v3 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, MilliSecondsSinceUnixEpoch, OwnedUserId,
     };
     use serde::{Deserialize, Serialize};

--- a/crates/ruma-client-api/src/session/get_login_token.rs
+++ b/crates/ruma-client-api/src/session/get_login_token.rs
@@ -10,7 +10,7 @@ pub mod v1 {
     use std::time::Duration;
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
     };
 

--- a/crates/ruma-client-api/src/session/get_login_types.rs
+++ b/crates/ruma-client-api/src/session/get_login_types.rs
@@ -11,7 +11,7 @@ pub mod v3 {
     use std::borrow::Cow;
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         metadata,
         serde::{JsonObject, StringEnum},
         OwnedMxcUri,

--- a/crates/ruma-client-api/src/session/login.rs
+++ b/crates/ruma-client-api/src/session/login.rs
@@ -10,7 +10,7 @@ pub mod v3 {
     use std::{fmt, time::Duration};
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AppserviceTokenOptional, request, response},
         metadata,
         serde::JsonObject,
         OwnedDeviceId, OwnedServerName, OwnedUserId,

--- a/crates/ruma-client-api/src/session/login_fallback.rs
+++ b/crates/ruma-client-api/src/session/login_fallback.rs
@@ -4,7 +4,10 @@
 //!
 //! [spec]: https://spec.matrix.org/latest/client-server-api/#login-fallback
 
-use ruma_common::{api::request, metadata, OwnedDeviceId};
+use ruma_common::{
+    api::{auth_scheme::NoAuthentication, request},
+    metadata, OwnedDeviceId,
+};
 
 metadata! {
     method: GET,

--- a/crates/ruma-client-api/src/session/logout.rs
+++ b/crates/ruma-client-api/src/session/logout.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3logout
 
     use ruma_common::{
-        api::{response, Metadata},
+        api::{auth_scheme::AccessToken, response, Metadata},
         metadata,
     };
 

--- a/crates/ruma-client-api/src/session/logout_all.rs
+++ b/crates/ruma-client-api/src/session/logout_all.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3logoutall
 
     use ruma_common::{
-        api::{response, Metadata},
+        api::{auth_scheme::AccessToken, response, Metadata},
         metadata,
     };
 

--- a/crates/ruma-client-api/src/session/refresh_token.rs
+++ b/crates/ruma-client-api/src/session/refresh_token.rs
@@ -28,7 +28,7 @@ pub mod v3 {
     use std::time::Duration;
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         metadata,
     };
 

--- a/crates/ruma-client-api/src/session/sso_login.rs
+++ b/crates/ruma-client-api/src/session/sso_login.rs
@@ -7,7 +7,7 @@ pub mod v3 {
 
     use http::header::{LOCATION, SET_COOKIE};
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         metadata,
     };
 

--- a/crates/ruma-client-api/src/session/sso_login_with_provider.rs
+++ b/crates/ruma-client-api/src/session/sso_login_with_provider.rs
@@ -9,7 +9,7 @@ pub mod v3 {
 
     use http::header::{LOCATION, SET_COOKIE};
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         metadata,
     };
 

--- a/crates/ruma-client-api/src/space/get_hierarchy.rs
+++ b/crates/ruma-client-api/src/space/get_hierarchy.rs
@@ -9,7 +9,7 @@ pub mod v1 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedRoomId,
     };
 

--- a/crates/ruma-client-api/src/state/get_state_event_for_key.rs
+++ b/crates/ruma-client-api/src/state/get_state_event_for_key.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3roomsroomidstateeventtypestatekey
 
     use ruma_common::{
-        api::{response, Metadata},
+        api::{auth_scheme::AccessToken, response, Metadata},
         metadata,
         serde::Raw,
         OwnedRoomId,

--- a/crates/ruma-client-api/src/state/get_state_events.rs
+++ b/crates/ruma-client-api/src/state/get_state_events.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3roomsroomidstate
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
         OwnedRoomId,

--- a/crates/ruma-client-api/src/state/send_state_event.rs
+++ b/crates/ruma-client-api/src/state/send_state_event.rs
@@ -10,7 +10,7 @@ pub mod v3 {
     use std::borrow::Borrow;
 
     use ruma_common::{
-        api::{response, Metadata},
+        api::{auth_scheme::AccessToken, response, Metadata},
         metadata,
         serde::Raw,
         MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId,

--- a/crates/ruma-client-api/src/sync/sync_events/v3.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v3.rs
@@ -7,7 +7,7 @@ use std::{collections::BTreeMap, time::Duration};
 use as_variant::as_variant;
 use js_int::UInt;
 use ruma_common::{
-    api::{request, response},
+    api::{auth_scheme::AccessToken, request, response},
     metadata,
     presence::PresenceState,
     serde::Raw,

--- a/crates/ruma-client-api/src/sync/sync_events/v5.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v5.rs
@@ -12,7 +12,7 @@ use std::{collections::BTreeMap, time::Duration};
 use js_int::UInt;
 use js_option::JsOption;
 use ruma_common::{
-    api::{request, response},
+    api::{auth_scheme::AccessToken, request, response},
     metadata,
     presence::PresenceState,
     serde::{duration::opt_ms, Raw},

--- a/crates/ruma-client-api/src/tag/create_tag.rs
+++ b/crates/ruma-client-api/src/tag/create_tag.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3useruseridroomsroomidtagstag
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedRoomId, OwnedUserId,
     };
     use ruma_events::tag::TagInfo;

--- a/crates/ruma-client-api/src/tag/delete_tag.rs
+++ b/crates/ruma-client-api/src/tag/delete_tag.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3useruseridroomsroomidtagstag
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedRoomId, OwnedUserId,
     };
 

--- a/crates/ruma-client-api/src/tag/get_tags.rs
+++ b/crates/ruma-client-api/src/tag/get_tags.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3useruseridroomsroomidtags
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedRoomId, OwnedUserId,
     };
     use ruma_events::tag::Tags;

--- a/crates/ruma-client-api/src/thirdparty/get_location_for_protocol.rs
+++ b/crates/ruma-client-api/src/thirdparty/get_location_for_protocol.rs
@@ -10,7 +10,7 @@ pub mod v3 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         thirdparty::Location,
     };

--- a/crates/ruma-client-api/src/thirdparty/get_location_for_room_alias.rs
+++ b/crates/ruma-client-api/src/thirdparty/get_location_for_room_alias.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3thirdpartylocation
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         thirdparty::Location,
         OwnedRoomAliasId,

--- a/crates/ruma-client-api/src/thirdparty/get_protocol.rs
+++ b/crates/ruma-client-api/src/thirdparty/get_protocol.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3thirdpartyprotocolprotocol
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         thirdparty::Protocol,
     };

--- a/crates/ruma-client-api/src/thirdparty/get_protocols.rs
+++ b/crates/ruma-client-api/src/thirdparty/get_protocols.rs
@@ -10,7 +10,7 @@ pub mod v3 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         thirdparty::Protocol,
     };

--- a/crates/ruma-client-api/src/thirdparty/get_user_for_protocol.rs
+++ b/crates/ruma-client-api/src/thirdparty/get_user_for_protocol.rs
@@ -10,7 +10,7 @@ pub mod v3 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         thirdparty::User,
     };

--- a/crates/ruma-client-api/src/thirdparty/get_user_for_user_id.rs
+++ b/crates/ruma-client-api/src/thirdparty/get_user_for_user_id.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3thirdpartyuser
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         thirdparty::User,
         OwnedUserId,

--- a/crates/ruma-client-api/src/threads/get_thread_subscription.rs
+++ b/crates/ruma-client-api/src/threads/get_thread_subscription.rs
@@ -8,7 +8,7 @@ pub mod unstable {
     //! [spec]: https://github.com/matrix-org/matrix-spec-proposals/pull/4306
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedEventId, OwnedRoomId,
     };
 

--- a/crates/ruma-client-api/src/threads/get_thread_subscriptions_changes.rs
+++ b/crates/ruma-client-api/src/threads/get_thread_subscriptions_changes.rs
@@ -11,7 +11,7 @@ pub mod unstable {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response, Direction},
+        api::{auth_scheme::AccessToken, request, response, Direction},
         metadata, OwnedEventId, OwnedRoomId,
     };
     use serde::{Deserialize, Serialize};

--- a/crates/ruma-client-api/src/threads/get_threads.rs
+++ b/crates/ruma-client-api/src/threads/get_threads.rs
@@ -9,7 +9,7 @@ pub mod v1 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::{Raw, StringEnum},
         OwnedRoomId,

--- a/crates/ruma-client-api/src/threads/subscribe_thread.rs
+++ b/crates/ruma-client-api/src/threads/subscribe_thread.rs
@@ -8,7 +8,7 @@ pub mod unstable {
     //! [spec]: https://github.com/matrix-org/matrix-spec-proposals/pull/4306
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedEventId, OwnedRoomId,
     };
 

--- a/crates/ruma-client-api/src/threads/unsubscribe_thread.rs
+++ b/crates/ruma-client-api/src/threads/unsubscribe_thread.rs
@@ -8,7 +8,7 @@ pub mod unstable {
     //! [spec]: https://github.com/matrix-org/matrix-spec-proposals/pull/4306
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedEventId, OwnedRoomId,
     };
 

--- a/crates/ruma-client-api/src/to_device/send_event_to_device.rs
+++ b/crates/ruma-client-api/src/to_device/send_event_to_device.rs
@@ -10,7 +10,7 @@ pub mod v3 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
         to_device::DeviceIdOrAllDevices,

--- a/crates/ruma-client-api/src/typing/create_typing_event.rs
+++ b/crates/ruma-client-api/src/typing/create_typing_event.rs
@@ -10,7 +10,7 @@ pub mod v3 {
     use std::time::Duration;
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedRoomId, OwnedUserId,
     };
     use serde::{de::Error, Deserialize, Deserializer, Serialize};

--- a/crates/ruma-client-api/src/uiaa/get_uiaa_fallback_page.rs
+++ b/crates/ruma-client-api/src/uiaa/get_uiaa_fallback_page.rs
@@ -7,7 +7,10 @@ pub mod v3 {
     //!
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#fallback
 
-    use ruma_common::{api::request, metadata};
+    use ruma_common::{
+        api::{auth_scheme::NoAuthentication, request},
+        metadata,
+    };
 
     use crate::uiaa::AuthType;
 

--- a/crates/ruma-client-api/src/user_directory/search_users.rs
+++ b/crates/ruma-client-api/src/user_directory/search_users.rs
@@ -10,7 +10,7 @@ pub mod v3 {
     use http::header::ACCEPT_LANGUAGE;
     use js_int::{uint, UInt};
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedMxcUri, OwnedUserId,
     };
     use serde::{Deserialize, Serialize};

--- a/crates/ruma-client-api/src/voip/get_turn_server_info.rs
+++ b/crates/ruma-client-api/src/voip/get_turn_server_info.rs
@@ -10,7 +10,7 @@ pub mod v3 {
     use std::time::Duration;
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
     };
 

--- a/crates/ruma-common/src/api.rs
+++ b/crates/ruma-common/src/api.rs
@@ -74,7 +74,7 @@ use bytes::BufMut;
 /// ```
 /// pub mod do_a_thing {
 ///     use ruma_common::{api::request, OwnedRoomId};
-///     # use ruma_common::{api::response, metadata};
+///     # use ruma_common::{api::{auth_scheme::NoAuthentication, response}, metadata};
 ///
 ///     // metadata! { ... };
 ///     # metadata! {
@@ -107,7 +107,7 @@ use bytes::BufMut;
 /// pub mod upload_file {
 ///     use http::header::CONTENT_TYPE;
 ///     use ruma_common::api::request;
-///     # use ruma_common::{api::response, metadata};
+///     # use ruma_common::{api::{auth_scheme::NoAuthentication, response}, metadata};
 ///
 ///     // metadata! { ... };
 ///     # metadata! {
@@ -186,7 +186,7 @@ pub use ruma_macros::request;
 /// ```
 /// pub mod do_a_thing {
 ///     use ruma_common::{api::response, OwnedRoomId};
-///     # use ruma_common::{api::request, metadata};
+///     # use ruma_common::{api::{auth_scheme::NoAuthentication, request}, metadata};
 ///
 ///     // metadata! { ... };
 ///     # metadata! {
@@ -213,7 +213,7 @@ pub use ruma_macros::request;
 /// pub mod download_file {
 ///     use http::header::CONTENT_TYPE;
 ///     use ruma_common::api::response;
-///     # use ruma_common::{api::request, metadata};
+///     # use ruma_common::{api::{auth_scheme::NoAuthentication, request}, metadata};
 ///
 ///     // metadata! { ... };
 ///     # metadata! {

--- a/crates/ruma-common/src/api/metadata.rs
+++ b/crates/ruma-common/src/api/metadata.rs
@@ -28,7 +28,7 @@ use crate::{api::error::IntoHttpError, serde::slice_to_buf, PrivOwnedStr, RoomVe
 /// * `rate_limited` - Whether the endpoint should be rate-limited, according to the specification.
 ///   Its value must be a `bool`.
 /// * `authentication` - The type of authentication that is required for the endpoint, according to
-///   the specification. Its value must be one of the variants of [`AuthScheme`].
+///   the specification. The type must be in scope and implement [`AuthScheme`].
 ///
 /// And either of the following fields to define the path(s) of the endpoint.
 ///
@@ -89,7 +89,10 @@ use crate::{api::error::IntoHttpError, serde::slice_to_buf, PrivOwnedStr, RoomVe
 /// ## Example
 ///
 /// ```
-/// use ruma_common::metadata;
+/// use ruma_common::{
+///     api::auth_scheme::{AccessToken, NoAuthentication},
+///     metadata,
+/// };
 ///
 /// /// A Request with a path version history.
 /// pub struct Request {
@@ -145,8 +148,8 @@ macro_rules! metadata {
 
     ( @field rate_limited: $rate_limited:literal ) => { const RATE_LIMITED: bool = $rate_limited; };
 
-    ( @field authentication: $scheme:ident ) => {
-        type Authentication = $crate::api::auth_scheme::$scheme;
+    ( @field authentication: $scheme:path ) => {
+        type Authentication = $scheme;
     };
 
     ( @field path: $path:literal ) => {

--- a/crates/ruma-common/tests/it/api/conversions.rs
+++ b/crates/ruma-common/tests/it/api/conversions.rs
@@ -5,8 +5,9 @@ use std::borrow::Cow;
 use http::header::CONTENT_TYPE;
 use ruma_common::{
     api::{
-        auth_scheme::SendAccessToken, request, response, IncomingRequest as _, MatrixVersion,
-        OutgoingRequest as _, OutgoingRequestAppserviceExt, SupportedVersions,
+        auth_scheme::{NoAuthentication, SendAccessToken},
+        request, response, IncomingRequest as _, MatrixVersion, OutgoingRequest as _,
+        OutgoingRequestAppserviceExt, SupportedVersions,
     },
     metadata, owned_user_id, user_id, OwnedUserId,
 };
@@ -142,8 +143,8 @@ mod without_query {
     use http::header::CONTENT_TYPE;
     use ruma_common::{
         api::{
-            auth_scheme::SendAccessToken, request, response, MatrixVersion,
-            OutgoingRequestAppserviceExt, SupportedVersions,
+            auth_scheme::{NoAuthentication, SendAccessToken},
+            request, response, MatrixVersion, OutgoingRequestAppserviceExt, SupportedVersions,
         },
         metadata, owned_user_id, user_id, OwnedUserId,
     };

--- a/crates/ruma-common/tests/it/api/default_status.rs
+++ b/crates/ruma-common/tests/it/api/default_status.rs
@@ -3,7 +3,7 @@
 
 use http::StatusCode;
 use ruma_common::{
-    api::{request, response, OutgoingResponse as _},
+    api::{auth_scheme::NoAuthentication, request, response, OutgoingResponse as _},
     metadata,
 };
 

--- a/crates/ruma-common/tests/it/api/header_override.rs
+++ b/crates/ruma-common/tests/it/api/header_override.rs
@@ -5,8 +5,9 @@ use std::borrow::Cow;
 use http::header::{Entry, CONTENT_TYPE, LOCATION};
 use ruma_common::{
     api::{
-        auth_scheme::SendAccessToken, request, response, MatrixVersion, OutgoingRequest as _,
-        OutgoingResponse as _, SupportedVersions,
+        auth_scheme::{NoAuthentication, SendAccessToken},
+        request, response, MatrixVersion, OutgoingRequest as _, OutgoingResponse as _,
+        SupportedVersions,
     },
     metadata,
 };

--- a/crates/ruma-common/tests/it/api/no_fields.rs
+++ b/crates/ruma-common/tests/it/api/no_fields.rs
@@ -7,7 +7,7 @@ use ruma_common::api::{
 
 mod get {
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         metadata,
     };
 
@@ -31,7 +31,7 @@ mod get {
 
 mod post {
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         metadata,
     };
 

--- a/crates/ruma-common/tests/it/api/optional_headers.rs
+++ b/crates/ruma-common/tests/it/api/optional_headers.rs
@@ -4,8 +4,9 @@ use assert_matches2::assert_matches;
 use http::header::{CONTENT_DISPOSITION, LOCATION};
 use ruma_common::{
     api::{
-        auth_scheme::SendAccessToken, request, response, IncomingRequest, IncomingResponse,
-        MatrixVersion, OutgoingRequest, OutgoingResponse, SupportedVersions,
+        auth_scheme::{NoAuthentication, SendAccessToken},
+        request, response, IncomingRequest, IncomingResponse, MatrixVersion, OutgoingRequest,
+        OutgoingResponse, SupportedVersions,
     },
     http_headers::{ContentDisposition, ContentDispositionType},
     metadata,

--- a/crates/ruma-common/tests/it/api/required_headers.rs
+++ b/crates/ruma-common/tests/it/api/required_headers.rs
@@ -4,7 +4,7 @@ use assert_matches2::assert_matches;
 use http::header::{CONTENT_DISPOSITION, LOCATION};
 use ruma_common::{
     api::{
-        auth_scheme::SendAccessToken,
+        auth_scheme::{NoAuthentication, SendAccessToken},
         error::{
             DeserializationError, FromHttpRequestError, FromHttpResponseError,
             HeaderDeserializationError,

--- a/crates/ruma-common/tests/it/api/ruma_api_macros.rs
+++ b/crates/ruma-common/tests/it/api/ruma_api_macros.rs
@@ -4,7 +4,7 @@
 pub mod some_endpoint {
     use http::header::CONTENT_TYPE;
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         metadata,
         serde::Raw,
         OwnedUserId,
@@ -66,7 +66,7 @@ pub mod some_endpoint {
 
 pub mod newtype_body_endpoint {
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         metadata,
     };
 
@@ -101,7 +101,7 @@ pub mod newtype_body_endpoint {
 
 pub mod raw_body_endpoint {
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         metadata,
     };
 
@@ -136,7 +136,7 @@ pub mod raw_body_endpoint {
 
 pub mod query_all_enum_endpoint {
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         metadata,
     };
 
@@ -170,7 +170,7 @@ pub mod query_all_enum_endpoint {
 
 pub mod query_all_vec_endpoint {
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         metadata,
     };
 

--- a/crates/ruma-common/tests/it/api/status_override.rs
+++ b/crates/ruma-common/tests/it/api/status_override.rs
@@ -6,7 +6,7 @@ use http::{
     StatusCode,
 };
 use ruma_common::{
-    api::{request, response, OutgoingResponse as _},
+    api::{auth_scheme::NoAuthentication, request, response, OutgoingResponse as _},
     metadata,
 };
 

--- a/crates/ruma-common/tests/it/api/ui/api-single-path-check.rs
+++ b/crates/ruma-common/tests/it/api/ui/api-single-path-check.rs
@@ -1,7 +1,7 @@
 #![allow(unexpected_cfgs)]
 
 use ruma_common::{
-    api::{path_builder::PathBuilder, request, response, Metadata},
+    api::{auth_scheme::AccessToken, path_builder::PathBuilder, request, response, Metadata},
     metadata,
 };
 

--- a/crates/ruma-common/tests/it/api/ui/api-version-history-check.rs
+++ b/crates/ruma-common/tests/it/api/ui/api-version-history-check.rs
@@ -5,6 +5,7 @@ use std::borrow::Cow;
 use http::header::CONTENT_TYPE;
 use ruma_common::{
     api::{
+        auth_scheme::NoAuthentication,
         path_builder::{PathBuilder, StablePathSelector},
         request, response, MatrixVersion, Metadata, SupportedVersions,
     },

--- a/crates/ruma-common/tests/it/api/ui/deprecated-without-added.rs
+++ b/crates/ruma-common/tests/it/api/ui/deprecated-without-added.rs
@@ -1,4 +1,4 @@
-use ruma_common::metadata;
+use ruma_common::{api::auth_scheme::NoAuthentication, metadata};
 
 metadata! {
     method: GET,

--- a/crates/ruma-common/tests/it/api/ui/move-value.rs
+++ b/crates/ruma-common/tests/it/api/ui/move-value.rs
@@ -5,7 +5,7 @@
 pub mod newtype_body {
     use http::header::CONTENT_TYPE;
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         metadata, OwnedUserId,
     };
 
@@ -51,7 +51,7 @@ pub mod newtype_body {
 pub mod raw_body {
     use http::header::CONTENT_TYPE;
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         metadata, OwnedUserId,
     };
 
@@ -94,7 +94,7 @@ pub mod raw_body {
 pub mod plain {
     use http::header::CONTENT_TYPE;
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         metadata, OwnedUserId,
     };
 

--- a/crates/ruma-common/tests/it/api/ui/removed-without-deprecated.rs
+++ b/crates/ruma-common/tests/it/api/ui/removed-without-deprecated.rs
@@ -1,4 +1,7 @@
-use ruma_common::{api::Metadata, metadata};
+use ruma_common::{
+    api::{auth_scheme::NoAuthentication, Metadata},
+    metadata,
+};
 
 metadata! {
     method: GET,

--- a/crates/ruma-common/tests/it/api/ui/removed-without-deprecated.stderr
+++ b/crates/ruma-common/tests/it/api/ui/removed-without-deprecated.stderr
@@ -1,7 +1,7 @@
 error: no rules expected `removed`
- --> tests/it/api/ui/removed-without-deprecated.rs:9:16
-  |
-9 |         1.1 => removed,
-  |                ^^^^^^^ no rules expected this token in macro call
-  |
-  = note: while trying to match sequence start
+  --> tests/it/api/ui/removed-without-deprecated.rs:12:16
+   |
+12 |         1.1 => removed,
+   |                ^^^^^^^ no rules expected this token in macro call
+   |
+   = note: while trying to match sequence start

--- a/crates/ruma-common/tests/it/api/ui/request-only.rs
+++ b/crates/ruma-common/tests/it/api/ui/request-only.rs
@@ -3,6 +3,7 @@
 use bytes::BufMut;
 use ruma_common::{
     api::{
+        auth_scheme::NoAuthentication,
         error::{FromHttpResponseError, IntoHttpError, MatrixError},
         request, IncomingResponse, OutgoingResponse,
     },

--- a/crates/ruma-common/tests/it/api/ui/serde-flatten-request-body.rs
+++ b/crates/ruma-common/tests/it/api/ui/serde-flatten-request-body.rs
@@ -1,7 +1,7 @@
 #![allow(unexpected_cfgs)]
 
 use ruma_common::{
-    api::{request, response},
+    api::{auth_scheme::NoAuthentication, request, response},
     metadata,
 };
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-common/tests/it/api/ui/serde-flatten-response-body.rs
+++ b/crates/ruma-common/tests/it/api/ui/serde-flatten-response-body.rs
@@ -1,7 +1,7 @@
 #![allow(unexpected_cfgs)]
 
 use ruma_common::{
-    api::{request, response},
+    api::{auth_scheme::NoAuthentication, request, response},
     metadata,
 };
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-federation-api/src/authenticated_media/get_content/v1.rs
+++ b/crates/ruma-federation-api/src/authenticated_media/get_content/v1.rs
@@ -4,7 +4,10 @@
 
 use std::time::Duration;
 
-use ruma_common::{api::request, metadata};
+use ruma_common::{
+    api::{auth_scheme::ServerSignatures, request},
+    metadata,
+};
 
 use crate::authenticated_media::{ContentMetadata, FileOrLocation};
 

--- a/crates/ruma-federation-api/src/authenticated_media/get_content_thumbnail/v1.rs
+++ b/crates/ruma-federation-api/src/authenticated_media/get_content_thumbnail/v1.rs
@@ -5,7 +5,11 @@
 use std::time::Duration;
 
 use js_int::UInt;
-use ruma_common::{api::request, media::Method, metadata};
+use ruma_common::{
+    api::{auth_scheme::ServerSignatures, request},
+    media::Method,
+    metadata,
+};
 
 use crate::authenticated_media::{ContentMetadata, FileOrLocation};
 

--- a/crates/ruma-federation-api/src/authorization/get_event_authorization.rs
+++ b/crates/ruma-federation-api/src/authorization/get_event_authorization.rs
@@ -8,7 +8,7 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1event_authroomideventid
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::ServerSignatures, request, response},
         metadata, OwnedEventId, OwnedRoomId,
     };
     use serde_json::value::RawValue as RawJsonValue;

--- a/crates/ruma-federation-api/src/backfill/get_backfill.rs
+++ b/crates/ruma-federation-api/src/backfill/get_backfill.rs
@@ -9,7 +9,7 @@ pub mod v1 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::ServerSignatures, request, response},
         metadata, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedServerName,
     };
     use serde_json::value::RawValue as RawJsonValue;

--- a/crates/ruma-federation-api/src/device/get_devices.rs
+++ b/crates/ruma-federation-api/src/device/get_devices.rs
@@ -9,7 +9,7 @@ pub mod v1 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::ServerSignatures, request, response},
         encryption::{CrossSigningKey, DeviceKeys},
         metadata,
         serde::Raw,

--- a/crates/ruma-federation-api/src/directory/get_public_rooms.rs
+++ b/crates/ruma-federation-api/src/directory/get_public_rooms.rs
@@ -9,7 +9,7 @@ pub mod v1 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::ServerSignatures, request, response},
         directory::{PublicRoomsChunk, RoomNetwork},
         metadata,
     };

--- a/crates/ruma-federation-api/src/directory/get_public_rooms_filtered.rs
+++ b/crates/ruma-federation-api/src/directory/get_public_rooms_filtered.rs
@@ -9,7 +9,7 @@ pub mod v1 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::ServerSignatures, request, response},
         directory::{Filter, PublicRoomsChunk, RoomNetwork},
         metadata,
     };

--- a/crates/ruma-federation-api/src/discovery/discover_homeserver.rs
+++ b/crates/ruma-federation-api/src/discovery/discover_homeserver.rs
@@ -5,7 +5,7 @@
 //! [spec]: https://spec.matrix.org/latest/server-server-api/#getwell-knownmatrixserver
 
 use ruma_common::{
-    api::{request, response},
+    api::{auth_scheme::NoAuthentication, request, response},
     metadata, OwnedServerName,
 };
 

--- a/crates/ruma-federation-api/src/discovery/get_remote_server_keys.rs
+++ b/crates/ruma-federation-api/src/discovery/get_remote_server_keys.rs
@@ -9,7 +9,7 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixkeyv2queryservername
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         metadata,
         serde::Raw,
         MilliSecondsSinceUnixEpoch, OwnedServerName,

--- a/crates/ruma-federation-api/src/discovery/get_remote_server_keys_batch.rs
+++ b/crates/ruma-federation-api/src/discovery/get_remote_server_keys_batch.rs
@@ -11,7 +11,7 @@ pub mod v2 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         metadata,
         serde::Raw,
         MilliSecondsSinceUnixEpoch, OwnedServerName, OwnedServerSigningKeyId,

--- a/crates/ruma-federation-api/src/discovery/get_server_keys.rs
+++ b/crates/ruma-federation-api/src/discovery/get_server_keys.rs
@@ -8,7 +8,7 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixkeyv2server
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         metadata,
         serde::Raw,
     };

--- a/crates/ruma-federation-api/src/discovery/get_server_version.rs
+++ b/crates/ruma-federation-api/src/discovery/get_server_version.rs
@@ -8,7 +8,7 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1version
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         metadata,
     };
     use serde::{Deserialize, Serialize};

--- a/crates/ruma-federation-api/src/discovery/get_server_versions.rs
+++ b/crates/ruma-federation-api/src/discovery/get_server_versions.rs
@@ -6,7 +6,7 @@ pub mod msc3723 {
     //! [GET /_matrix/federation/versions](https://github.com/matrix-org/matrix-spec-proposals/pull/3723)
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         metadata,
     };
 

--- a/crates/ruma-federation-api/src/event/get_event.rs
+++ b/crates/ruma-federation-api/src/event/get_event.rs
@@ -8,7 +8,7 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1eventeventid
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::ServerSignatures, request, response},
         metadata, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedServerName,
     };
     use serde_json::value::RawValue as RawJsonValue;

--- a/crates/ruma-federation-api/src/event/get_event_by_timestamp/v1.rs
+++ b/crates/ruma-federation-api/src/event/get_event_by_timestamp/v1.rs
@@ -3,7 +3,7 @@
 //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1timestamp_to_eventroomid
 
 use ruma_common::{
-    api::{request, response, Direction},
+    api::{auth_scheme::ServerSignatures, request, response, Direction},
     metadata, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId,
 };
 

--- a/crates/ruma-federation-api/src/event/get_missing_events.rs
+++ b/crates/ruma-federation-api/src/event/get_missing_events.rs
@@ -9,7 +9,7 @@ pub mod v1 {
 
     use js_int::{uint, UInt};
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::ServerSignatures, request, response},
         metadata, OwnedEventId, OwnedRoomId,
     };
     use serde_json::value::RawValue as RawJsonValue;

--- a/crates/ruma-federation-api/src/event/get_room_state.rs
+++ b/crates/ruma-federation-api/src/event/get_room_state.rs
@@ -8,7 +8,7 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1stateroomid
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::ServerSignatures, request, response},
         metadata, OwnedEventId, OwnedRoomId,
     };
     use serde_json::value::RawValue as RawJsonValue;

--- a/crates/ruma-federation-api/src/event/get_room_state_ids.rs
+++ b/crates/ruma-federation-api/src/event/get_room_state_ids.rs
@@ -8,7 +8,7 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1state_idsroomid
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::ServerSignatures, request, response},
         metadata, OwnedEventId, OwnedRoomId,
     };
 

--- a/crates/ruma-federation-api/src/keys/claim_keys.rs
+++ b/crates/ruma-federation-api/src/keys/claim_keys.rs
@@ -10,7 +10,7 @@ pub mod v1 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::ServerSignatures, request, response},
         encryption::OneTimeKey,
         metadata,
         serde::Raw,

--- a/crates/ruma-federation-api/src/keys/get_keys.rs
+++ b/crates/ruma-federation-api/src/keys/get_keys.rs
@@ -10,7 +10,7 @@ pub mod v1 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::ServerSignatures, request, response},
         encryption::{CrossSigningKey, DeviceKeys},
         metadata,
         serde::Raw,

--- a/crates/ruma-federation-api/src/membership/create_invite/v1.rs
+++ b/crates/ruma-federation-api/src/membership/create_invite/v1.rs
@@ -3,7 +3,7 @@
 //! [spec]: https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv1inviteroomideventid
 
 use ruma_common::{
-    api::{request, response},
+    api::{auth_scheme::ServerSignatures, request, response},
     metadata, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedServerName, OwnedUserId,
 };
 use ruma_events::{room::member::RoomMemberEventContent, StateEventType};

--- a/crates/ruma-federation-api/src/membership/create_invite/v2.rs
+++ b/crates/ruma-federation-api/src/membership/create_invite/v2.rs
@@ -5,7 +5,7 @@
 #[cfg(feature = "unstable-msc4125")]
 use ruma_common::OwnedServerName;
 use ruma_common::{
-    api::{request, response},
+    api::{auth_scheme::ServerSignatures, request, response},
     metadata, OwnedEventId, OwnedRoomId, RoomVersionId,
 };
 use serde_json::value::RawValue as RawJsonValue;

--- a/crates/ruma-federation-api/src/membership/create_join_event/v1.rs
+++ b/crates/ruma-federation-api/src/membership/create_join_event/v1.rs
@@ -3,7 +3,7 @@
 //! [spec]: https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv1send_joinroomideventid
 
 use ruma_common::{
-    api::{request, response},
+    api::{auth_scheme::ServerSignatures, request, response},
     metadata, OwnedEventId, OwnedRoomId,
 };
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-federation-api/src/membership/create_join_event/v2.rs
+++ b/crates/ruma-federation-api/src/membership/create_join_event/v2.rs
@@ -3,7 +3,7 @@
 //! [spec]: https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv2send_joinroomideventid
 
 use ruma_common::{
-    api::{request, response},
+    api::{auth_scheme::ServerSignatures, request, response},
     metadata, OwnedEventId, OwnedRoomId,
 };
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-federation-api/src/membership/create_knock_event/v1.rs
+++ b/crates/ruma-federation-api/src/membership/create_knock_event/v1.rs
@@ -3,7 +3,7 @@
 //! [spec]: https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv1send_knockroomideventid
 
 use ruma_common::{
-    api::{request, response},
+    api::{auth_scheme::ServerSignatures, request, response},
     metadata, OwnedEventId, OwnedRoomId,
 };
 use serde_json::value::RawValue as RawJsonValue;

--- a/crates/ruma-federation-api/src/membership/create_leave_event/v1.rs
+++ b/crates/ruma-federation-api/src/membership/create_leave_event/v1.rs
@@ -3,7 +3,7 @@
 //! [spec]: https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv1send_leaveroomideventid
 
 use ruma_common::{
-    api::{request, response},
+    api::{auth_scheme::ServerSignatures, request, response},
     metadata, OwnedEventId, OwnedRoomId,
 };
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-federation-api/src/membership/create_leave_event/v2.rs
+++ b/crates/ruma-federation-api/src/membership/create_leave_event/v2.rs
@@ -3,7 +3,7 @@
 //! [spec]: https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv2send_leaveroomideventid
 
 use ruma_common::{
-    api::{request, response},
+    api::{auth_scheme::ServerSignatures, request, response},
     metadata, OwnedEventId, OwnedRoomId,
 };
 use serde_json::value::RawValue as RawJsonValue;

--- a/crates/ruma-federation-api/src/membership/prepare_join_event.rs
+++ b/crates/ruma-federation-api/src/membership/prepare_join_event.rs
@@ -8,7 +8,7 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1make_joinroomiduserid
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::ServerSignatures, request, response},
         metadata, OwnedRoomId, OwnedUserId, RoomVersionId,
     };
     use serde_json::value::RawValue as RawJsonValue;

--- a/crates/ruma-federation-api/src/membership/prepare_knock_event/v1.rs
+++ b/crates/ruma-federation-api/src/membership/prepare_knock_event/v1.rs
@@ -3,7 +3,7 @@
 //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1make_knockroomiduserid
 
 use ruma_common::{
-    api::{request, response},
+    api::{auth_scheme::ServerSignatures, request, response},
     metadata, OwnedRoomId, OwnedUserId, RoomVersionId,
 };
 use serde_json::value::RawValue as RawJsonValue;

--- a/crates/ruma-federation-api/src/membership/prepare_leave_event.rs
+++ b/crates/ruma-federation-api/src/membership/prepare_leave_event.rs
@@ -9,7 +9,7 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1make_leaveroomiduserid
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::ServerSignatures, request, response},
         metadata, OwnedRoomId, OwnedUserId, RoomVersionId,
     };
     use serde_json::value::RawValue as RawJsonValue;

--- a/crates/ruma-federation-api/src/openid/get_openid_userinfo.rs
+++ b/crates/ruma-federation-api/src/openid/get_openid_userinfo.rs
@@ -8,7 +8,7 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1openiduserinfo
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         metadata, OwnedUserId,
     };
 

--- a/crates/ruma-federation-api/src/query/get_custom_information.rs
+++ b/crates/ruma-federation-api/src/query/get_custom_information.rs
@@ -11,7 +11,7 @@ pub mod v1 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::ServerSignatures, request, response},
         metadata,
     };
     use serde_json::Value as JsonValue;
@@ -19,7 +19,7 @@ pub mod v1 {
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: AccessToken,
+        authentication: ServerSignatures,
         path: "/_matrix/federation/v1/query/{query_type}",
     }
 

--- a/crates/ruma-federation-api/src/query/get_profile_information.rs
+++ b/crates/ruma-federation-api/src/query/get_profile_information.rs
@@ -8,7 +8,7 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1queryprofile
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::ServerSignatures, request, response},
         metadata,
         serde::StringEnum,
         OwnedMxcUri, OwnedUserId,

--- a/crates/ruma-federation-api/src/query/get_room_information.rs
+++ b/crates/ruma-federation-api/src/query/get_room_information.rs
@@ -8,7 +8,7 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1querydirectory
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::ServerSignatures, request, response},
         metadata, OwnedRoomAliasId, OwnedRoomId, OwnedServerName,
     };
 

--- a/crates/ruma-federation-api/src/room/report_content.rs
+++ b/crates/ruma-federation-api/src/room/report_content.rs
@@ -8,7 +8,7 @@ pub mod msc3843 {
     //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/3843
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::ServerSignatures, request, response},
         metadata, OwnedEventId, OwnedRoomId,
     };
 

--- a/crates/ruma-federation-api/src/space/get_hierarchy/v1.rs
+++ b/crates/ruma-federation-api/src/space/get_hierarchy/v1.rs
@@ -3,7 +3,7 @@
 //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1hierarchyroomid
 
 use ruma_common::{
-    api::{request, response},
+    api::{auth_scheme::ServerSignatures, request, response},
     metadata,
     room::RoomSummary,
     OwnedRoomId,

--- a/crates/ruma-federation-api/src/thirdparty/bind_callback.rs
+++ b/crates/ruma-federation-api/src/thirdparty/bind_callback.rs
@@ -10,7 +10,7 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv13pidonbind
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         metadata,
         serde::Raw,
         thirdparty::Medium,

--- a/crates/ruma-federation-api/src/thirdparty/exchange_invite.rs
+++ b/crates/ruma-federation-api/src/thirdparty/exchange_invite.rs
@@ -12,7 +12,7 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv1exchange_third_party_inviteroomid
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::ServerSignatures, request, response},
         metadata,
         serde::Raw,
         OwnedRoomId, OwnedUserId,
@@ -30,7 +30,7 @@ pub mod v1 {
     metadata! {
         method: PUT,
         rate_limited: false,
-        authentication: AccessToken,
+        authentication: ServerSignatures,
         path: "/_matrix/federation/v1/exchange_third_party_invite/{room_id}",
     }
 

--- a/crates/ruma-federation-api/src/transactions/send_transaction_message.rs
+++ b/crates/ruma-federation-api/src/transactions/send_transaction_message.rs
@@ -10,7 +10,7 @@ pub mod v1 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::ServerSignatures, request, response},
         metadata,
         serde::Raw,
         MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedServerName, OwnedTransactionId,

--- a/crates/ruma-identity-service-api/src/association/bind_3pid.rs
+++ b/crates/ruma-identity-service-api/src/association/bind_3pid.rs
@@ -8,7 +8,7 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/identity-service-api/#post_matrixidentityv23pidbind
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         thirdparty::Medium,
         MilliSecondsSinceUnixEpoch, OwnedClientSecret, OwnedSessionId, OwnedUserId,

--- a/crates/ruma-identity-service-api/src/association/check_3pid_validity.rs
+++ b/crates/ruma-identity-service-api/src/association/check_3pid_validity.rs
@@ -9,7 +9,7 @@ pub mod v2 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         thirdparty::Medium,
         OwnedClientSecret, OwnedSessionId,

--- a/crates/ruma-identity-service-api/src/association/email/create_email_validation_session.rs
+++ b/crates/ruma-identity-service-api/src/association/email/create_email_validation_session.rs
@@ -9,7 +9,7 @@ pub mod v2 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedClientSecret, OwnedSessionId,
     };
 

--- a/crates/ruma-identity-service-api/src/association/email/validate_email.rs
+++ b/crates/ruma-identity-service-api/src/association/email/validate_email.rs
@@ -8,7 +8,7 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/identity-service-api/#post_matrixidentityv2validateemailsubmittoken
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedClientSecret, OwnedSessionId,
     };
 

--- a/crates/ruma-identity-service-api/src/association/email/validate_email_by_end_user.rs
+++ b/crates/ruma-identity-service-api/src/association/email/validate_email_by_end_user.rs
@@ -8,7 +8,7 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/identity-service-api/#get_matrixidentityv2validateemailsubmittoken
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedClientSecret, OwnedSessionId,
     };
 

--- a/crates/ruma-identity-service-api/src/association/msisdn/create_msisdn_validation_session.rs
+++ b/crates/ruma-identity-service-api/src/association/msisdn/create_msisdn_validation_session.rs
@@ -9,7 +9,7 @@ pub mod v2 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedClientSecret, OwnedSessionId,
     };
 

--- a/crates/ruma-identity-service-api/src/association/msisdn/validate_msisdn.rs
+++ b/crates/ruma-identity-service-api/src/association/msisdn/validate_msisdn.rs
@@ -8,7 +8,7 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/identity-service-api/#post_matrixidentityv2validatemsisdnsubmittoken
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedClientSecret, OwnedSessionId,
     };
 

--- a/crates/ruma-identity-service-api/src/association/msisdn/validate_msisdn_by_phone_number.rs
+++ b/crates/ruma-identity-service-api/src/association/msisdn/validate_msisdn_by_phone_number.rs
@@ -8,7 +8,7 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/identity-service-api/#get_matrixidentityv2validatemsisdnsubmittoken
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedClientSecret, OwnedSessionId,
     };
 

--- a/crates/ruma-identity-service-api/src/association/unbind_3pid.rs
+++ b/crates/ruma-identity-service-api/src/association/unbind_3pid.rs
@@ -8,7 +8,7 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/identity-service-api/#post_matrixidentityv23pidunbind
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         thirdparty::Medium,
         OwnedClientSecret, OwnedSessionId, OwnedUserId,

--- a/crates/ruma-identity-service-api/src/authentication/get_account_information.rs
+++ b/crates/ruma-identity-service-api/src/authentication/get_account_information.rs
@@ -8,7 +8,7 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/identity-service-api/#get_matrixidentityv2account
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedUserId,
     };
 

--- a/crates/ruma-identity-service-api/src/authentication/logout.rs
+++ b/crates/ruma-identity-service-api/src/authentication/logout.rs
@@ -9,7 +9,7 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/identity-service-api/#post_matrixidentityv2accountlogout
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
     };
 

--- a/crates/ruma-identity-service-api/src/authentication/register.rs
+++ b/crates/ruma-identity-service-api/src/authentication/register.rs
@@ -10,7 +10,7 @@ pub mod v2 {
     use std::time::Duration;
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         authentication::TokenType,
         metadata, OwnedServerName,
     };

--- a/crates/ruma-identity-service-api/src/discovery/get_server_status.rs
+++ b/crates/ruma-identity-service-api/src/discovery/get_server_status.rs
@@ -8,7 +8,7 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/identity-service-api/#get_matrixidentityv2
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         metadata,
     };
 

--- a/crates/ruma-identity-service-api/src/discovery/get_supported_versions.rs
+++ b/crates/ruma-identity-service-api/src/discovery/get_supported_versions.rs
@@ -13,7 +13,7 @@
 use std::collections::BTreeMap;
 
 use ruma_common::{
-    api::{request, response, SupportedVersions},
+    api::{auth_scheme::NoAuthentication, request, response, SupportedVersions},
     metadata,
 };
 

--- a/crates/ruma-identity-service-api/src/invitation/sign_invitation_ed25519.rs
+++ b/crates/ruma-identity-service-api/src/invitation/sign_invitation_ed25519.rs
@@ -8,7 +8,7 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/identity-service-api/#post_matrixidentityv2sign-ed25519
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Base64,
         OwnedUserId, ServerSignatures,

--- a/crates/ruma-identity-service-api/src/invitation/store_invitation.rs
+++ b/crates/ruma-identity-service-api/src/invitation/store_invitation.rs
@@ -8,7 +8,7 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/identity-service-api/#post_matrixidentityv2store-invite
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
         room::RoomType,
         third_party_invite::IdentityServerBase64PublicKey,

--- a/crates/ruma-identity-service-api/src/keys/check_public_key_validity.rs
+++ b/crates/ruma-identity-service-api/src/keys/check_public_key_validity.rs
@@ -9,7 +9,7 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/identity-service-api/#get_matrixidentityv2pubkeyisvalid
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         metadata,
         third_party_invite::IdentityServerBase64PublicKey,
     };

--- a/crates/ruma-identity-service-api/src/keys/get_public_key.rs
+++ b/crates/ruma-identity-service-api/src/keys/get_public_key.rs
@@ -8,7 +8,7 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/identity-service-api/#get_matrixidentityv2pubkeykeyid
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         metadata,
         third_party_invite::IdentityServerBase64PublicKey,
         OwnedServerSigningKeyId,

--- a/crates/ruma-identity-service-api/src/keys/validate_ephemeral_key.rs
+++ b/crates/ruma-identity-service-api/src/keys/validate_ephemeral_key.rs
@@ -8,7 +8,7 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/identity-service-api/#get_matrixidentityv2pubkeyephemeralisvalid
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         metadata,
         third_party_invite::IdentityServerBase64PublicKey,
     };

--- a/crates/ruma-identity-service-api/src/lookup/get_hash_parameters.rs
+++ b/crates/ruma-identity-service-api/src/lookup/get_hash_parameters.rs
@@ -9,7 +9,7 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/identity-service-api/#get_matrixidentityv2hash_details
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
     };
 

--- a/crates/ruma-identity-service-api/src/lookup/lookup_3pid.rs
+++ b/crates/ruma-identity-service-api/src/lookup/lookup_3pid.rs
@@ -10,7 +10,7 @@ pub mod v2 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata, OwnedUserId,
     };
 

--- a/crates/ruma-identity-service-api/src/tos/accept_terms_of_service.rs
+++ b/crates/ruma-identity-service-api/src/tos/accept_terms_of_service.rs
@@ -8,7 +8,7 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/identity-service-api/#post_matrixidentityv2terms
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::AccessToken, request, response},
         metadata,
     };
 

--- a/crates/ruma-identity-service-api/src/tos/get_terms_of_service.rs
+++ b/crates/ruma-identity-service-api/src/tos/get_terms_of_service.rs
@@ -10,7 +10,7 @@ pub mod v2 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         metadata,
     };
     use serde::{Deserialize, Serialize};

--- a/crates/ruma-push-gateway-api/src/send_event_notification.rs
+++ b/crates/ruma-push-gateway-api/src/send_event_notification.rs
@@ -9,7 +9,7 @@ pub mod v1 {
 
     use js_int::{uint, UInt};
     use ruma_common::{
-        api::{request, response},
+        api::{auth_scheme::NoAuthentication, request, response},
         metadata,
         push::{PushFormat, Tweak},
         serde::{JsonObject, StringEnum},


### PR DESCRIPTION
Instead of only supporting the types in `ruma_common::api::auth_scheme`.

This allows to use custom types. This is also necessary to complete the implementation of `OutgoingRequest::add_authentication` of `ServerSignatures`, we need to use the `XMatrix` type in ruma-federation-api. One solution is to move `ServerSignatures` to that crate.

