### PR TITLE
api: Move ServerSignatures to ruma_federation_api::authentication

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -24,7 +24,8 @@ Breaking changes:
   - The `authentication` field of the `Metadata` struct is now an associated
     type named `Authentication`. The `AuthScheme` enum was changed from an
     `enum` to a `trait`. Its variants are now structs implementing the
-    `AuthScheme` trait. The `None` variant was renamed to `NoAuthentication`.
+    `AuthScheme` trait. The `None` variant was renamed to `NoAuthentication` and
+    the `ServerSignatures` variant was moved to ruma-federation-api.
     The `access_token` argument of `OutgoingRequest::try_into_http_request()` is
     renamed to `authentication_input` and is generic over the `Input` associated
     type of the `AuthScheme` trait.

--- a/crates/ruma-common/src/api/auth_scheme.rs
+++ b/crates/ruma-common/src/api/auth_scheme.rs
@@ -132,22 +132,6 @@ impl AuthScheme for AppserviceTokenOptional {
     }
 }
 
-/// Authentication is performed by adding an `X-Matrix` header including a signature in the request
-/// headers, as defined in the federation API.
-///
-/// Currently the `add_authentication` implementation is a noop, and the header must be computed and
-/// added manually.
-#[derive(Debug, Clone, Copy, Default)]
-pub struct ServerSignatures;
-
-impl AuthScheme for ServerSignatures {
-    type Input<'a> = ();
-
-    fn add_authentication(_headers: &mut HeaderMap, _input: ()) -> Result<(), IntoHttpError> {
-        Ok(())
-    }
-}
-
 /// Add the given access token as an `Authorization` HTTP header to the given map.
 fn add_access_token_as_authorization_header(
     headers: &mut HeaderMap,

--- a/crates/ruma-federation-api/src/authenticated_media/get_content/v1.rs
+++ b/crates/ruma-federation-api/src/authenticated_media/get_content/v1.rs
@@ -4,12 +4,12 @@
 
 use std::time::Duration;
 
-use ruma_common::{
-    api::{auth_scheme::ServerSignatures, request},
-    metadata,
-};
+use ruma_common::{api::request, metadata};
 
-use crate::authenticated_media::{ContentMetadata, FileOrLocation};
+use crate::{
+    authenticated_media::{ContentMetadata, FileOrLocation},
+    authentication::ServerSignatures,
+};
 
 metadata! {
     method: GET,

--- a/crates/ruma-federation-api/src/authenticated_media/get_content_thumbnail/v1.rs
+++ b/crates/ruma-federation-api/src/authenticated_media/get_content_thumbnail/v1.rs
@@ -5,13 +5,12 @@
 use std::time::Duration;
 
 use js_int::UInt;
-use ruma_common::{
-    api::{auth_scheme::ServerSignatures, request},
-    media::Method,
-    metadata,
-};
+use ruma_common::{api::request, media::Method, metadata};
 
-use crate::authenticated_media::{ContentMetadata, FileOrLocation};
+use crate::{
+    authenticated_media::{ContentMetadata, FileOrLocation},
+    authentication::ServerSignatures,
+};
 
 metadata! {
     method: GET,

--- a/crates/ruma-federation-api/src/authentication.rs
+++ b/crates/ruma-federation-api/src/authentication.rs
@@ -3,15 +3,35 @@
 use std::{fmt, str::FromStr};
 
 use headers::authorization::Credentials;
-use http::HeaderValue;
+use http::{HeaderMap, HeaderValue};
 use http_auth::ChallengeParser;
 use ruma_common::{
+    api::{auth_scheme::AuthScheme, error::IntoHttpError},
     http_headers::quote_ascii_string_if_required,
     serde::{Base64, Base64DecodeError},
     IdParseError, OwnedServerName, OwnedServerSigningKeyId,
 };
 use thiserror::Error;
 use tracing::debug;
+
+/// Authentication is performed by adding an `X-Matrix` header including a signature in the request
+/// headers, as defined in the [Matrix Server-Server API][spec].
+///
+/// Currently the `add_authentication` implementation is a noop, and the header must be computed and
+/// added manually.
+///
+/// [spec]: https://spec.matrix.org/latest/server-server-api/#request-authentication
+#[derive(Debug, Clone, Copy, Default)]
+#[allow(clippy::exhaustive_structs)]
+pub struct ServerSignatures;
+
+impl AuthScheme for ServerSignatures {
+    type Input<'a> = ();
+
+    fn add_authentication(_headers: &mut HeaderMap, _input: ()) -> Result<(), IntoHttpError> {
+        Ok(())
+    }
+}
 
 /// Typed representation of an `Authorization` header of scheme `X-Matrix`, as defined in the
 /// [Matrix Server-Server API][spec].

--- a/crates/ruma-federation-api/src/authorization/get_event_authorization.rs
+++ b/crates/ruma-federation-api/src/authorization/get_event_authorization.rs
@@ -8,10 +8,12 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1event_authroomideventid
 
     use ruma_common::{
-        api::{auth_scheme::ServerSignatures, request, response},
+        api::{request, response},
         metadata, OwnedEventId, OwnedRoomId,
     };
     use serde_json::value::RawValue as RawJsonValue;
+
+    use crate::authentication::ServerSignatures;
 
     metadata! {
         method: GET,

--- a/crates/ruma-federation-api/src/backfill/get_backfill.rs
+++ b/crates/ruma-federation-api/src/backfill/get_backfill.rs
@@ -9,10 +9,12 @@ pub mod v1 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{auth_scheme::ServerSignatures, request, response},
+        api::{request, response},
         metadata, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedServerName,
     };
     use serde_json::value::RawValue as RawJsonValue;
+
+    use crate::authentication::ServerSignatures;
 
     metadata! {
         method: GET,

--- a/crates/ruma-federation-api/src/device/get_devices.rs
+++ b/crates/ruma-federation-api/src/device/get_devices.rs
@@ -9,13 +9,15 @@ pub mod v1 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{auth_scheme::ServerSignatures, request, response},
+        api::{request, response},
         encryption::{CrossSigningKey, DeviceKeys},
         metadata,
         serde::Raw,
         OwnedDeviceId, OwnedUserId,
     };
     use serde::{Deserialize, Serialize};
+
+    use crate::authentication::ServerSignatures;
 
     metadata! {
         method: GET,

--- a/crates/ruma-federation-api/src/directory/get_public_rooms.rs
+++ b/crates/ruma-federation-api/src/directory/get_public_rooms.rs
@@ -9,10 +9,12 @@ pub mod v1 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{auth_scheme::ServerSignatures, request, response},
+        api::{request, response},
         directory::{PublicRoomsChunk, RoomNetwork},
         metadata,
     };
+
+    use crate::authentication::ServerSignatures;
 
     metadata! {
         method: GET,

--- a/crates/ruma-federation-api/src/directory/get_public_rooms_filtered.rs
+++ b/crates/ruma-federation-api/src/directory/get_public_rooms_filtered.rs
@@ -9,10 +9,12 @@ pub mod v1 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{auth_scheme::ServerSignatures, request, response},
+        api::{request, response},
         directory::{Filter, PublicRoomsChunk, RoomNetwork},
         metadata,
     };
+
+    use crate::authentication::ServerSignatures;
 
     metadata! {
         method: POST,

--- a/crates/ruma-federation-api/src/event/get_event.rs
+++ b/crates/ruma-federation-api/src/event/get_event.rs
@@ -8,10 +8,12 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1eventeventid
 
     use ruma_common::{
-        api::{auth_scheme::ServerSignatures, request, response},
+        api::{request, response},
         metadata, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedServerName,
     };
     use serde_json::value::RawValue as RawJsonValue;
+
+    use crate::authentication::ServerSignatures;
 
     metadata! {
         method: GET,

--- a/crates/ruma-federation-api/src/event/get_event_by_timestamp/v1.rs
+++ b/crates/ruma-federation-api/src/event/get_event_by_timestamp/v1.rs
@@ -3,9 +3,11 @@
 //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1timestamp_to_eventroomid
 
 use ruma_common::{
-    api::{auth_scheme::ServerSignatures, request, response, Direction},
+    api::{request, response, Direction},
     metadata, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId,
 };
+
+use crate::authentication::ServerSignatures;
 
 metadata! {
     method: GET,

--- a/crates/ruma-federation-api/src/event/get_missing_events.rs
+++ b/crates/ruma-federation-api/src/event/get_missing_events.rs
@@ -9,10 +9,12 @@ pub mod v1 {
 
     use js_int::{uint, UInt};
     use ruma_common::{
-        api::{auth_scheme::ServerSignatures, request, response},
+        api::{request, response},
         metadata, OwnedEventId, OwnedRoomId,
     };
     use serde_json::value::RawValue as RawJsonValue;
+
+    use crate::authentication::ServerSignatures;
 
     metadata! {
         method: POST,

--- a/crates/ruma-federation-api/src/event/get_room_state.rs
+++ b/crates/ruma-federation-api/src/event/get_room_state.rs
@@ -8,10 +8,12 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1stateroomid
 
     use ruma_common::{
-        api::{auth_scheme::ServerSignatures, request, response},
+        api::{request, response},
         metadata, OwnedEventId, OwnedRoomId,
     };
     use serde_json::value::RawValue as RawJsonValue;
+
+    use crate::authentication::ServerSignatures;
 
     metadata! {
         method: GET,

--- a/crates/ruma-federation-api/src/event/get_room_state_ids.rs
+++ b/crates/ruma-federation-api/src/event/get_room_state_ids.rs
@@ -8,9 +8,11 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1state_idsroomid
 
     use ruma_common::{
-        api::{auth_scheme::ServerSignatures, request, response},
+        api::{request, response},
         metadata, OwnedEventId, OwnedRoomId,
     };
+
+    use crate::authentication::ServerSignatures;
 
     metadata! {
         method: GET,

--- a/crates/ruma-federation-api/src/keys/claim_keys.rs
+++ b/crates/ruma-federation-api/src/keys/claim_keys.rs
@@ -10,12 +10,14 @@ pub mod v1 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{auth_scheme::ServerSignatures, request, response},
+        api::{request, response},
         encryption::OneTimeKey,
         metadata,
         serde::Raw,
         OneTimeKeyAlgorithm, OwnedDeviceId, OwnedOneTimeKeyId, OwnedUserId,
     };
+
+    use crate::authentication::ServerSignatures;
 
     metadata! {
         method: POST,

--- a/crates/ruma-federation-api/src/keys/get_keys.rs
+++ b/crates/ruma-federation-api/src/keys/get_keys.rs
@@ -10,12 +10,14 @@ pub mod v1 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{auth_scheme::ServerSignatures, request, response},
+        api::{request, response},
         encryption::{CrossSigningKey, DeviceKeys},
         metadata,
         serde::Raw,
         OwnedDeviceId, OwnedUserId,
     };
+
+    use crate::authentication::ServerSignatures;
 
     metadata! {
         method: POST,

--- a/crates/ruma-federation-api/src/membership/create_invite/v1.rs
+++ b/crates/ruma-federation-api/src/membership/create_invite/v1.rs
@@ -3,14 +3,14 @@
 //! [spec]: https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv1inviteroomideventid
 
 use ruma_common::{
-    api::{auth_scheme::ServerSignatures, request, response},
+    api::{request, response},
     metadata, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedServerName, OwnedUserId,
 };
 use ruma_events::{room::member::RoomMemberEventContent, StateEventType};
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue as RawJsonValue;
 
-use crate::membership::RawStrippedState;
+use crate::{authentication::ServerSignatures, membership::RawStrippedState};
 
 metadata! {
     method: PUT,

--- a/crates/ruma-federation-api/src/membership/create_invite/v2.rs
+++ b/crates/ruma-federation-api/src/membership/create_invite/v2.rs
@@ -5,12 +5,12 @@
 #[cfg(feature = "unstable-msc4125")]
 use ruma_common::OwnedServerName;
 use ruma_common::{
-    api::{auth_scheme::ServerSignatures, request, response},
+    api::{request, response},
     metadata, OwnedEventId, OwnedRoomId, RoomVersionId,
 };
 use serde_json::value::RawValue as RawJsonValue;
 
-use crate::membership::RawStrippedState;
+use crate::{authentication::ServerSignatures, membership::RawStrippedState};
 
 metadata! {
     method: PUT,

--- a/crates/ruma-federation-api/src/membership/create_join_event/v1.rs
+++ b/crates/ruma-federation-api/src/membership/create_join_event/v1.rs
@@ -3,11 +3,13 @@
 //! [spec]: https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv1send_joinroomideventid
 
 use ruma_common::{
-    api::{auth_scheme::ServerSignatures, request, response},
+    api::{request, response},
     metadata, OwnedEventId, OwnedRoomId,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue as RawJsonValue;
+
+use crate::authentication::ServerSignatures;
 
 metadata! {
     method: PUT,

--- a/crates/ruma-federation-api/src/membership/create_join_event/v2.rs
+++ b/crates/ruma-federation-api/src/membership/create_join_event/v2.rs
@@ -3,11 +3,13 @@
 //! [spec]: https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv2send_joinroomideventid
 
 use ruma_common::{
-    api::{auth_scheme::ServerSignatures, request, response},
+    api::{request, response},
     metadata, OwnedEventId, OwnedRoomId,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue as RawJsonValue;
+
+use crate::authentication::ServerSignatures;
 
 metadata! {
     method: PUT,

--- a/crates/ruma-federation-api/src/membership/create_knock_event/v1.rs
+++ b/crates/ruma-federation-api/src/membership/create_knock_event/v1.rs
@@ -3,12 +3,12 @@
 //! [spec]: https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv1send_knockroomideventid
 
 use ruma_common::{
-    api::{auth_scheme::ServerSignatures, request, response},
+    api::{request, response},
     metadata, OwnedEventId, OwnedRoomId,
 };
 use serde_json::value::RawValue as RawJsonValue;
 
-use crate::membership::RawStrippedState;
+use crate::{authentication::ServerSignatures, membership::RawStrippedState};
 
 metadata! {
     method: PUT,

--- a/crates/ruma-federation-api/src/membership/create_leave_event/v1.rs
+++ b/crates/ruma-federation-api/src/membership/create_leave_event/v1.rs
@@ -3,11 +3,13 @@
 //! [spec]: https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv1send_leaveroomideventid
 
 use ruma_common::{
-    api::{auth_scheme::ServerSignatures, request, response},
+    api::{request, response},
     metadata, OwnedEventId, OwnedRoomId,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue as RawJsonValue;
+
+use crate::authentication::ServerSignatures;
 
 metadata! {
     method: PUT,

--- a/crates/ruma-federation-api/src/membership/create_leave_event/v2.rs
+++ b/crates/ruma-federation-api/src/membership/create_leave_event/v2.rs
@@ -3,10 +3,12 @@
 //! [spec]: https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv2send_leaveroomideventid
 
 use ruma_common::{
-    api::{auth_scheme::ServerSignatures, request, response},
+    api::{request, response},
     metadata, OwnedEventId, OwnedRoomId,
 };
 use serde_json::value::RawValue as RawJsonValue;
+
+use crate::authentication::ServerSignatures;
 
 metadata! {
     method: PUT,

--- a/crates/ruma-federation-api/src/membership/prepare_join_event.rs
+++ b/crates/ruma-federation-api/src/membership/prepare_join_event.rs
@@ -8,10 +8,12 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1make_joinroomiduserid
 
     use ruma_common::{
-        api::{auth_scheme::ServerSignatures, request, response},
+        api::{request, response},
         metadata, OwnedRoomId, OwnedUserId, RoomVersionId,
     };
     use serde_json::value::RawValue as RawJsonValue;
+
+    use crate::authentication::ServerSignatures;
 
     metadata! {
         method: GET,

--- a/crates/ruma-federation-api/src/membership/prepare_knock_event/v1.rs
+++ b/crates/ruma-federation-api/src/membership/prepare_knock_event/v1.rs
@@ -3,10 +3,12 @@
 //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1make_knockroomiduserid
 
 use ruma_common::{
-    api::{auth_scheme::ServerSignatures, request, response},
+    api::{request, response},
     metadata, OwnedRoomId, OwnedUserId, RoomVersionId,
 };
 use serde_json::value::RawValue as RawJsonValue;
+
+use crate::authentication::ServerSignatures;
 
 metadata! {
     method: GET,

--- a/crates/ruma-federation-api/src/membership/prepare_leave_event.rs
+++ b/crates/ruma-federation-api/src/membership/prepare_leave_event.rs
@@ -9,10 +9,12 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1make_leaveroomiduserid
 
     use ruma_common::{
-        api::{auth_scheme::ServerSignatures, request, response},
+        api::{request, response},
         metadata, OwnedRoomId, OwnedUserId, RoomVersionId,
     };
     use serde_json::value::RawValue as RawJsonValue;
+
+    use crate::authentication::ServerSignatures;
 
     metadata! {
         method: GET,

--- a/crates/ruma-federation-api/src/query/get_custom_information.rs
+++ b/crates/ruma-federation-api/src/query/get_custom_information.rs
@@ -11,10 +11,12 @@ pub mod v1 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{auth_scheme::ServerSignatures, request, response},
+        api::{request, response},
         metadata,
     };
     use serde_json::Value as JsonValue;
+
+    use crate::authentication::ServerSignatures;
 
     metadata! {
         method: GET,

--- a/crates/ruma-federation-api/src/query/get_profile_information.rs
+++ b/crates/ruma-federation-api/src/query/get_profile_information.rs
@@ -8,13 +8,13 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1queryprofile
 
     use ruma_common::{
-        api::{auth_scheme::ServerSignatures, request, response},
+        api::{request, response},
         metadata,
         serde::StringEnum,
         OwnedMxcUri, OwnedUserId,
     };
 
-    use crate::PrivOwnedStr;
+    use crate::{authentication::ServerSignatures, PrivOwnedStr};
 
     metadata! {
         method: GET,

--- a/crates/ruma-federation-api/src/query/get_room_information.rs
+++ b/crates/ruma-federation-api/src/query/get_room_information.rs
@@ -8,9 +8,11 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1querydirectory
 
     use ruma_common::{
-        api::{auth_scheme::ServerSignatures, request, response},
+        api::{request, response},
         metadata, OwnedRoomAliasId, OwnedRoomId, OwnedServerName,
     };
+
+    use crate::authentication::ServerSignatures;
 
     metadata! {
         method: GET,

--- a/crates/ruma-federation-api/src/room/report_content.rs
+++ b/crates/ruma-federation-api/src/room/report_content.rs
@@ -8,9 +8,11 @@ pub mod msc3843 {
     //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/3843
 
     use ruma_common::{
-        api::{auth_scheme::ServerSignatures, request, response},
+        api::{request, response},
         metadata, OwnedEventId, OwnedRoomId,
     };
+
+    use crate::authentication::ServerSignatures;
 
     metadata! {
         method: POST,

--- a/crates/ruma-federation-api/src/space/get_hierarchy/v1.rs
+++ b/crates/ruma-federation-api/src/space/get_hierarchy/v1.rs
@@ -3,13 +3,13 @@
 //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1hierarchyroomid
 
 use ruma_common::{
-    api::{auth_scheme::ServerSignatures, request, response},
+    api::{request, response},
     metadata,
     room::RoomSummary,
     OwnedRoomId,
 };
 
-use crate::space::SpaceHierarchyParentSummary;
+use crate::{authentication::ServerSignatures, space::SpaceHierarchyParentSummary};
 
 metadata! {
     method: GET,

--- a/crates/ruma-federation-api/src/thirdparty/exchange_invite.rs
+++ b/crates/ruma-federation-api/src/thirdparty/exchange_invite.rs
@@ -12,7 +12,7 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv1exchange_third_party_inviteroomid
 
     use ruma_common::{
-        api::{auth_scheme::ServerSignatures, request, response},
+        api::{request, response},
         metadata,
         serde::Raw,
         OwnedRoomId, OwnedUserId,
@@ -25,7 +25,7 @@ pub mod v1 {
         StateEventType,
     };
 
-    use crate::thirdparty::bind_callback;
+    use crate::{authentication::ServerSignatures, thirdparty::bind_callback};
 
     metadata! {
         method: PUT,

--- a/crates/ruma-federation-api/src/transactions/send_transaction_message.rs
+++ b/crates/ruma-federation-api/src/transactions/send_transaction_message.rs
@@ -10,14 +10,14 @@ pub mod v1 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{auth_scheme::ServerSignatures, request, response},
+        api::{request, response},
         metadata,
         serde::Raw,
         MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedServerName, OwnedTransactionId,
     };
     use serde_json::value::RawValue as RawJsonValue;
 
-    use crate::transactions::edu::Edu;
+    use crate::{authentication::ServerSignatures, transactions::edu::Edu};
 
     metadata! {
         method: PUT,


### PR DESCRIPTION
Will allow to build the Authorization header using the `XMatrix` type.