### PR TITLE
api: Allow to extract AuthScheme data from incoming requests

### DIFF
--- a/crates/ruma-client-api/src/knock/knock_room.rs
+++ b/crates/ruma-client-api/src/knock/knock_room.rs
@@ -108,7 +108,9 @@ pub mod v3 {
                 .header(http::header::CONTENT_TYPE, ruma_common::http_headers::APPLICATION_JSON)
                 .body(ruma_common::serde::json_to_buf(&RequestBody { reason: self.reason })?)?;
 
-            Self::Authentication::add_authentication(&mut http_request, access_token)?;
+            Self::Authentication::add_authentication(&mut http_request, access_token).map_err(
+                |error| ruma_common::api::error::IntoHttpError::Authentication(error.into()),
+            )?;
 
             Ok(http_request)
         }

--- a/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
+++ b/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
@@ -122,7 +122,9 @@ pub mod v3 {
                     reason: self.reason,
                 })?)?;
 
-            Self::Authentication::add_authentication(&mut http_request, access_token)?;
+            Self::Authentication::add_authentication(&mut http_request, access_token).map_err(
+                |error| ruma_common::api::error::IntoHttpError::Authentication(error.into()),
+            )?;
 
             Ok(http_request)
         }

--- a/crates/ruma-client-api/src/profile/set_profile_field.rs
+++ b/crates/ruma-client-api/src/profile/set_profile_field.rs
@@ -82,7 +82,9 @@ pub mod v3 {
                 .header(http::header::CONTENT_TYPE, ruma_common::http_headers::APPLICATION_JSON)
                 .body(ruma_common::serde::json_to_buf(&self.value)?)?;
 
-            Self::Authentication::add_authentication(&mut http_request, access_token)?;
+            Self::Authentication::add_authentication(&mut http_request, access_token).map_err(
+                |error| ruma_common::api::error::IntoHttpError::Authentication(error.into()),
+            )?;
 
             Ok(http_request)
         }

--- a/crates/ruma-client-api/src/push/set_pushrule.rs
+++ b/crates/ruma-client-api/src/push/set_pushrule.rs
@@ -92,7 +92,9 @@ pub mod v3 {
                 .header(http::header::CONTENT_TYPE, ruma_common::http_headers::APPLICATION_JSON)
                 .body(ruma_common::serde::json_to_buf(&body)?)?;
 
-            Self::Authentication::add_authentication(&mut http_request, access_token)?;
+            Self::Authentication::add_authentication(&mut http_request, access_token).map_err(
+                |error| ruma_common::api::error::IntoHttpError::Authentication(error.into()),
+            )?;
 
             Ok(http_request)
         }

--- a/crates/ruma-client-api/src/session/logout.rs
+++ b/crates/ruma-client-api/src/session/logout.rs
@@ -52,7 +52,9 @@ pub mod v3 {
             let mut http_request =
                 http::Request::builder().method(Self::METHOD).uri(url).body(T::default())?;
 
-            Self::Authentication::add_authentication(&mut http_request, access_token)?;
+            Self::Authentication::add_authentication(&mut http_request, access_token).map_err(
+                |error| ruma_common::api::error::IntoHttpError::Authentication(error.into()),
+            )?;
 
             Ok(http_request)
         }

--- a/crates/ruma-client-api/src/session/logout_all.rs
+++ b/crates/ruma-client-api/src/session/logout_all.rs
@@ -52,7 +52,9 @@ pub mod v3 {
             let mut http_request =
                 http::Request::builder().method(Self::METHOD).uri(url).body(T::default())?;
 
-            Self::Authentication::add_authentication(&mut http_request, access_token)?;
+            Self::Authentication::add_authentication(&mut http_request, access_token).map_err(
+                |error| ruma_common::api::error::IntoHttpError::Authentication(error.into()),
+            )?;
 
             Ok(http_request)
         }

--- a/crates/ruma-client-api/src/state/get_state_event_for_key.rs
+++ b/crates/ruma-client-api/src/state/get_state_event_for_key.rs
@@ -144,7 +144,9 @@ pub mod v3 {
                 )?)
                 .body(T::default())?;
 
-            Self::Authentication::add_authentication(&mut http_request, access_token)?;
+            Self::Authentication::add_authentication(&mut http_request, access_token).map_err(
+                |error| ruma_common::api::error::IntoHttpError::Authentication(error.into()),
+            )?;
 
             Ok(http_request)
         }

--- a/crates/ruma-client-api/src/state/send_state_event.rs
+++ b/crates/ruma-client-api/src/state/send_state_event.rs
@@ -133,7 +133,9 @@ pub mod v3 {
                 .header(http::header::CONTENT_TYPE, ruma_common::http_headers::APPLICATION_JSON)
                 .body(ruma_common::serde::json_to_buf(&self.body)?)?;
 
-            Self::Authentication::add_authentication(&mut http_request, access_token)?;
+            Self::Authentication::add_authentication(&mut http_request, access_token).map_err(
+                |error| ruma_common::api::error::IntoHttpError::Authentication(error.into()),
+            )?;
 
             Ok(http_request)
         }

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -65,6 +65,8 @@ Improvements:
 - `PushCondition::ContainsDisplayName` is deprecated, according to MSC4210.
 - Add `SinglePath` as a `PathBuilder`. It should be used for APIs that don't
   have a `/versions` endpoint and for endpoints that can't be versioned.
+- `AuthScheme` data can be extracted from incoming HTTP requests with
+  `AuthScheme::extract_authentication()`.
 
 # 0.16.0
 

--- a/crates/ruma-common/tests/it/api.rs
+++ b/crates/ruma-common/tests/it/api.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "api")]
 #![allow(unreachable_pub)]
 
+mod auth_scheme;
 mod conversions;
 mod default_status;
 mod header_override;

--- a/crates/ruma-common/tests/it/api/auth_scheme.rs
+++ b/crates/ruma-common/tests/it/api/auth_scheme.rs
@@ -1,0 +1,160 @@
+use assert_matches2::assert_matches;
+use http::header;
+use ruma_common::api::auth_scheme::{
+    AccessToken, AccessTokenOptional, AppserviceToken, AppserviceTokenOptional, AuthScheme,
+    NoAuthentication, SendAccessToken,
+};
+
+const TOKEN: &str = "token";
+const HEADER_VALUE: http::HeaderValue = http::HeaderValue::from_static("Bearer token");
+
+fn http_request() -> http::Request<Vec<u8>> {
+    http::Request::builder()
+        .method(http::Method::GET)
+        .uri("http://localhost/_matrix/client/versions")
+        .body(vec![])
+        .unwrap()
+}
+
+#[test]
+fn send_access_token_none() {
+    let input = SendAccessToken::None;
+    let mut request = http_request();
+
+    NoAuthentication::add_authentication(&mut request, input).unwrap();
+    assert_eq!(request.headers_mut().remove(header::AUTHORIZATION), None);
+
+    AccessToken::add_authentication(&mut request, input).unwrap_err();
+
+    AccessTokenOptional::add_authentication(&mut request, input).unwrap();
+    assert_eq!(request.headers_mut().remove(header::AUTHORIZATION), None);
+
+    AppserviceToken::add_authentication(&mut request, input).unwrap_err();
+
+    AppserviceTokenOptional::add_authentication(&mut request, input).unwrap();
+    assert_eq!(request.headers_mut().remove(header::AUTHORIZATION), None);
+}
+
+#[test]
+fn send_access_token_if_required() {
+    let input = SendAccessToken::IfRequired(TOKEN);
+    let mut request = http_request();
+
+    NoAuthentication::add_authentication(&mut request, input).unwrap();
+    assert_eq!(request.headers_mut().remove(header::AUTHORIZATION), None);
+
+    AccessToken::add_authentication(&mut request, input).unwrap();
+    assert_matches!(request.headers_mut().remove(header::AUTHORIZATION), Some(value));
+    assert_eq!(value, HEADER_VALUE);
+
+    AccessTokenOptional::add_authentication(&mut request, input).unwrap();
+    assert_matches!(request.headers_mut().remove(header::AUTHORIZATION), Some(value));
+    assert_eq!(value, HEADER_VALUE);
+
+    AppserviceToken::add_authentication(&mut request, input).unwrap_err();
+
+    AppserviceTokenOptional::add_authentication(&mut request, input).unwrap();
+    assert_eq!(request.headers_mut().remove(header::AUTHORIZATION), None);
+}
+
+#[test]
+fn send_access_token_always() {
+    let input = SendAccessToken::Always(TOKEN);
+    let mut request = http_request();
+
+    NoAuthentication::add_authentication(&mut request, input).unwrap();
+    assert_matches!(request.headers_mut().remove(header::AUTHORIZATION), Some(value));
+    assert_eq!(value, HEADER_VALUE);
+
+    AccessToken::add_authentication(&mut request, input).unwrap();
+    assert_matches!(request.headers_mut().remove(header::AUTHORIZATION), Some(value));
+    assert_eq!(value, HEADER_VALUE);
+
+    AccessTokenOptional::add_authentication(&mut request, input).unwrap();
+    assert_matches!(request.headers_mut().remove(header::AUTHORIZATION), Some(value));
+    assert_eq!(value, HEADER_VALUE);
+
+    AppserviceToken::add_authentication(&mut request, input).unwrap();
+    assert_matches!(request.headers_mut().remove(header::AUTHORIZATION), Some(value));
+    assert_eq!(value, HEADER_VALUE);
+
+    AppserviceTokenOptional::add_authentication(&mut request, input).unwrap();
+    assert_matches!(request.headers_mut().remove(header::AUTHORIZATION), Some(value));
+    assert_eq!(value, HEADER_VALUE);
+}
+
+#[test]
+fn send_access_token_appservice() {
+    let input = SendAccessToken::Appservice(TOKEN);
+    let mut request = http_request();
+
+    NoAuthentication::add_authentication(&mut request, input).unwrap();
+    assert_eq!(request.headers_mut().remove(header::AUTHORIZATION), None);
+
+    AccessToken::add_authentication(&mut request, input).unwrap();
+    assert_matches!(request.headers_mut().remove(header::AUTHORIZATION), Some(value));
+    assert_eq!(value, HEADER_VALUE);
+
+    AccessTokenOptional::add_authentication(&mut request, input).unwrap();
+    assert_matches!(request.headers_mut().remove(header::AUTHORIZATION), Some(value));
+    assert_eq!(value, HEADER_VALUE);
+
+    AppserviceToken::add_authentication(&mut request, input).unwrap();
+    assert_matches!(request.headers_mut().remove(header::AUTHORIZATION), Some(value));
+    assert_eq!(value, HEADER_VALUE);
+
+    AppserviceTokenOptional::add_authentication(&mut request, input).unwrap();
+    assert_matches!(request.headers_mut().remove(header::AUTHORIZATION), Some(value));
+    assert_eq!(value, HEADER_VALUE);
+}
+
+#[test]
+fn extract_authentication_bearer() {
+    let request_without_token = http_request();
+    let mut request_with_valid_header = http_request();
+    request_with_valid_header.headers_mut().insert(header::AUTHORIZATION, HEADER_VALUE);
+    let mut request_with_invalid_scheme = http_request();
+    request_with_invalid_scheme
+        .headers_mut()
+        .insert(header::AUTHORIZATION, http::HeaderValue::from_static("Basic dGVzdDoxMjPCow=="));
+    let mut request_with_query = http_request();
+    *request_with_query.uri_mut() = http::Uri::from_static(
+        "http://localhost/_matrix/client/versions?foo=bar&access_token=token",
+    );
+
+    NoAuthentication::extract_authentication(&request_without_token).unwrap();
+    NoAuthentication::extract_authentication(&request_with_valid_header).unwrap();
+    NoAuthentication::extract_authentication(&request_with_invalid_scheme).unwrap();
+    NoAuthentication::extract_authentication(&request_with_query).unwrap();
+
+    AccessToken::extract_authentication(&request_without_token).unwrap_err();
+    let token = AccessToken::extract_authentication(&request_with_valid_header).unwrap();
+    assert_eq!(token, TOKEN);
+    AccessToken::extract_authentication(&request_with_invalid_scheme).unwrap_err();
+    let token = AccessToken::extract_authentication(&request_with_query).unwrap();
+    assert_eq!(token, TOKEN);
+
+    let token = AccessTokenOptional::extract_authentication(&request_without_token).unwrap();
+    assert_eq!(token, None);
+    let token = AccessTokenOptional::extract_authentication(&request_with_valid_header).unwrap();
+    assert_eq!(token.as_deref(), Some(TOKEN));
+    AccessTokenOptional::extract_authentication(&request_with_invalid_scheme).unwrap_err();
+    let token = AccessTokenOptional::extract_authentication(&request_with_query).unwrap();
+    assert_eq!(token.as_deref(), Some(TOKEN));
+
+    AppserviceToken::extract_authentication(&request_without_token).unwrap_err();
+    let token = AppserviceToken::extract_authentication(&request_with_valid_header).unwrap();
+    assert_eq!(token, TOKEN);
+    AppserviceToken::extract_authentication(&request_with_invalid_scheme).unwrap_err();
+    let token = AppserviceToken::extract_authentication(&request_with_query).unwrap();
+    assert_eq!(token, TOKEN);
+
+    let token = AppserviceTokenOptional::extract_authentication(&request_without_token).unwrap();
+    assert_eq!(token, None);
+    let token =
+        AppserviceTokenOptional::extract_authentication(&request_with_valid_header).unwrap();
+    assert_eq!(token.as_deref(), Some(TOKEN));
+    AppserviceTokenOptional::extract_authentication(&request_with_invalid_scheme).unwrap_err();
+    let token = AppserviceTokenOptional::extract_authentication(&request_with_query).unwrap();
+    assert_eq!(token.as_deref(), Some(TOKEN));
+}

--- a/crates/ruma-federation-api/CHANGELOG.md
+++ b/crates/ruma-federation-api/CHANGELOG.md
@@ -17,6 +17,8 @@ Improvements:
 - `XMatrix::request_object()` allows to construct the canonical JSON object to
   sign from a request.
 - `XMatrix` can be constructed from a request with `try_from_http_request()`.
+- The signature in the `sig` field of `XMatrix` can be used to verify a request
+  with `verify_request()`.
 
 # 0.12.0
 

--- a/crates/ruma-macros/src/api/request/outgoing.rs
+++ b/crates/ruma-macros/src/api/request/outgoing.rs
@@ -136,7 +136,11 @@ impl Request {
 
                     #header_kvs
 
-                    <<Self as #ruma_common::api::Metadata>::Authentication as #ruma_common::api::auth_scheme::AuthScheme>::add_authentication(&mut http_request, authentication_input)?;
+                    <<Self as #ruma_common::api::Metadata>::Authentication as #ruma_common::api::auth_scheme::AuthScheme>::add_authentication(
+                        &mut http_request,
+                        authentication_input
+                    )
+                        .map_err(|error| #ruma_common::api::error::IntoHttpError::Authentication(error.into()))?;
 
                     Ok(http_request)
                 }


### PR DESCRIPTION
And to check a request with the signature in `XMatrix`.

Closes #372.