### PR TITLE
Update contrib/ide/vscode/settings.json

### DIFF
--- a/contrib/ide/vscode/settings.json
+++ b/contrib/ide/vscode/settings.json
@@ -1,6 +1,4 @@
 {
-    "rust-analyzer.cargo.features": [
-        "__ci"
-    ],
+    "rust-analyzer.cargo.features": "all",
     "rust-analyzer.checkOnSave.command": "clippy"
 }


### PR DESCRIPTION
The __ci Cargo feature no longer exists.
