### PR TITLE
Bump MSRV and tested nightly version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
   # Keep in sync with version in `rust-toolchain.toml` and `xtask/src/main.rs`
-  NIGHTLY: nightly-2025-10-01
+  NIGHTLY: nightly-2025-11-06
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,14 +74,15 @@ jobs:
       - name: Install MSRV toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.82"
+          # keep in sync with README.md, the root Cargo.toml and xtask/src/ci.rs
+          toolchain: "1.85"
 
       - uses: Swatinem/rust-cache@v2
         with:
           # A stable compiler update should automatically not reuse old caches.
           # Add the MSRV as a stable cache key too so bumping it also gets us a
           # fresh cache.
-          shared-key: msrv1.82
+          shared-key: msrv1.85
 
       - name: Get xtask
         uses: actions/cache@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,8 @@ default-members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-rust-version = "1.82"
+# Keep in sync with README.md, xtask/src/ci.rs and .github/workflows/ci.yml
+rust-version = "1.85"
 
 [workspace.dependencies]
 as_variant = "1.2.0"

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Minimum Rust version
 
-Ruma currently requires Rust 1.82. In general, we will never require beta or
+Ruma currently requires Rust 1.85. In general, we will never require beta or
 nightly for crates.io releases of our crates, and we will try to avoid releasing
 crates that depend on features that were only just stabilized.
 

--- a/crates/ruma/CHANGELOG.md
+++ b/crates/ruma/CHANGELOG.md
@@ -1,5 +1,7 @@
 # [unreleased]
 
+- Bump MSRV to 1.85
+
 # 0.13.0
 
 - The deprecated global `compat` cargo feature was removed. The `compat-*` cargo

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 # Keep in sync with version in `xtask/src/main.rs` and `.github/workflows/ci.yml`
-channel = "nightly-2025-10-01"
+channel = "nightly-2025-11-06"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -16,7 +16,8 @@ use reexport_features::check_reexport_features;
 use spec_links::check_spec_links;
 use unused_features::check_unused_features;
 
-const MSRV: &str = "1.82";
+// Keep in sync with README.md, the root Cargo.toml and .github/workflows/ci.yml
+const MSRV: &str = "1.85";
 
 #[derive(Args)]
 pub struct CiArgs {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -15,7 +15,7 @@ use serde::Deserialize;
 use serde_json::from_str as from_json_str;
 
 // Keep in sync with version in `rust-toolchain.toml` and `.github/workflows/ci.yml`
-const NIGHTLY: &str = "nightly-2025-10-01";
+const NIGHTLY: &str = "nightly-2025-11-06";
 
 mod bench;
 mod cargo;


### PR DESCRIPTION
I did a `cargo update` for fun locally. The latest version of one of our indirect dependencies requires Rust 1.85, and while we could simply not update our lockfile to that, I think 1.85 is old enough at this point to upgrade to it (around 3 months).

Leaving the actual edition upgrades to separate PRs.
Also, upgraded the nightly we use in CI, for good measure.