### PR TITLE
Update api crates to Rust 2024

### DIFF
--- a/crates/ruma-appservice-api/Cargo.toml
+++ b/crates/ruma-appservice-api/Cargo.toml
@@ -8,7 +8,7 @@ name = "ruma-appservice-api"
 readme = "README.md"
 repository = "https://github.com/ruma/ruma"
 version = "0.13.0"
-edition = "2021"
+edition = "2024"
 rust-version = { workspace = true }
 
 [package.metadata.docs.rs]

--- a/crates/ruma-appservice-api/src/event/push_events.rs
+++ b/crates/ruma-appservice-api/src/event/push_events.rs
@@ -15,18 +15,18 @@ pub mod v1 {
     use js_int::UInt;
     #[cfg(feature = "unstable-msc3202")]
     use ruma_common::OwnedUserId;
-    use ruma_common::{
-        api::{auth_scheme::AccessToken, request, response},
-        metadata,
-        serde::{from_raw_json_value, JsonObject, Raw},
-        OwnedTransactionId,
-    };
     #[cfg(feature = "unstable-msc3202")]
     use ruma_common::{OneTimeKeyAlgorithm, OwnedDeviceId};
+    use ruma_common::{
+        OwnedTransactionId,
+        api::{auth_scheme::AccessToken, request, response},
+        metadata,
+        serde::{JsonObject, Raw, from_raw_json_value},
+    };
     #[cfg(feature = "unstable-msc4203")]
     use ruma_events::AnyToDeviceEvent;
     use ruma_events::{
-        presence::PresenceEvent, receipt::ReceiptEvent, typing::TypingEvent, AnyTimelineEvent,
+        AnyTimelineEvent, presence::PresenceEvent, receipt::ReceiptEvent, typing::TypingEvent,
     };
     use serde::{Deserialize, Deserializer, Serialize};
     use serde_json::value::{RawValue as RawJsonValue, Value as JsonValue};
@@ -255,7 +255,7 @@ pub mod v1 {
     mod tests {
         use assert_matches2::assert_matches;
         use js_int::uint;
-        use ruma_common::{event_id, room_id, user_id, MilliSecondsSinceUnixEpoch};
+        use ruma_common::{MilliSecondsSinceUnixEpoch, event_id, room_id, user_id};
         use ruma_events::receipt::ReceiptType;
         use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
@@ -264,7 +264,7 @@ pub mod v1 {
         #[cfg(feature = "client")]
         #[test]
         fn request_contains_events_field() {
-            use ruma_common::api::{auth_scheme::SendAccessToken, OutgoingRequest};
+            use ruma_common::api::{OutgoingRequest, auth_scheme::SendAccessToken};
 
             let dummy_event_json = json!({
                 "type": "m.room.message",

--- a/crates/ruma-appservice-api/src/ping/send_ping.rs
+++ b/crates/ruma-appservice-api/src/ping/send_ping.rs
@@ -8,8 +8,9 @@ pub mod unstable {
     //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/2659
 
     use ruma_common::{
+        OwnedTransactionId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedTransactionId,
+        metadata,
     };
 
     metadata! {
@@ -55,8 +56,9 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/application-service-api/#post_matrixappv1ping
 
     use ruma_common::{
+        OwnedTransactionId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedTransactionId,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-appservice-api/src/query/query_room_alias.rs
+++ b/crates/ruma-appservice-api/src/query/query_room_alias.rs
@@ -8,8 +8,9 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/application-service-api/#get_matrixappv1roomsroomalias
 
     use ruma_common::{
+        OwnedRoomAliasId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedRoomAliasId,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-appservice-api/src/query/query_user_id.rs
+++ b/crates/ruma-appservice-api/src/query/query_user_id.rs
@@ -8,8 +8,9 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/application-service-api/#get_matrixappv1usersuserid
 
     use ruma_common::{
+        OwnedUserId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedUserId,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-appservice-api/src/thirdparty/get_location_for_room_alias.rs
+++ b/crates/ruma-appservice-api/src/thirdparty/get_location_for_room_alias.rs
@@ -8,10 +8,10 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/application-service-api/#get_matrixappv1thirdpartylocation
 
     use ruma_common::{
+        OwnedRoomAliasId,
         api::{auth_scheme::AccessToken, request, response},
         metadata,
         thirdparty::Location,
-        OwnedRoomAliasId,
     };
 
     metadata! {

--- a/crates/ruma-appservice-api/src/thirdparty/get_user_for_user_id.rs
+++ b/crates/ruma-appservice-api/src/thirdparty/get_user_for_user_id.rs
@@ -8,10 +8,10 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/application-service-api/#get_matrixappv1thirdpartyuser
 
     use ruma_common::{
+        OwnedUserId,
         api::{auth_scheme::AccessToken, request, response},
         metadata,
         thirdparty::User,
-        OwnedUserId,
     };
 
     metadata! {

--- a/crates/ruma-client-api/Cargo.toml
+++ b/crates/ruma-client-api/Cargo.toml
@@ -8,7 +8,7 @@ name = "ruma-client-api"
 readme = "README.md"
 repository = "https://github.com/ruma/ruma"
 version = "0.21.0"
-edition = "2021"
+edition = "2024"
 rust-version = { workspace = true }
 
 [package.metadata.docs.rs]

--- a/crates/ruma-client-api/src/account/add_3pid.rs
+++ b/crates/ruma-client-api/src/account/add_3pid.rs
@@ -8,8 +8,9 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3account3pidadd
 
     use ruma_common::{
+        OwnedClientSecret, OwnedSessionId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedClientSecret, OwnedSessionId,
+        metadata,
     };
 
     use crate::uiaa::{AuthData, UiaaResponse};

--- a/crates/ruma-client-api/src/account/bind_3pid.rs
+++ b/crates/ruma-client-api/src/account/bind_3pid.rs
@@ -8,8 +8,9 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3account3pidbind
 
     use ruma_common::{
+        OwnedClientSecret, OwnedSessionId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedClientSecret, OwnedSessionId,
+        metadata,
     };
 
     use crate::account::IdentityServerInfo;

--- a/crates/ruma-client-api/src/account/register.rs
+++ b/crates/ruma-client-api/src/account/register.rs
@@ -12,8 +12,9 @@ pub mod v3 {
     use std::time::Duration;
 
     use ruma_common::{
+        OwnedDeviceId, OwnedUserId,
         api::{auth_scheme::AppserviceTokenOptional, request, response},
-        metadata, OwnedDeviceId, OwnedUserId,
+        metadata,
     };
 
     use super::{LoginType, RegistrationKind};

--- a/crates/ruma-client-api/src/account/request_3pid_management_token_via_email.rs
+++ b/crates/ruma-client-api/src/account/request_3pid_management_token_via_email.rs
@@ -9,8 +9,9 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
+        OwnedClientSecret, OwnedSessionId,
         api::{auth_scheme::NoAuthentication, request, response},
-        metadata, OwnedClientSecret, OwnedSessionId,
+        metadata,
     };
 
     use crate::account::IdentityServerInfo;

--- a/crates/ruma-client-api/src/account/request_3pid_management_token_via_msisdn.rs
+++ b/crates/ruma-client-api/src/account/request_3pid_management_token_via_msisdn.rs
@@ -9,8 +9,9 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
+        OwnedClientSecret, OwnedSessionId,
         api::{auth_scheme::NoAuthentication, request, response},
-        metadata, OwnedClientSecret, OwnedSessionId,
+        metadata,
     };
 
     use crate::account::IdentityServerInfo;

--- a/crates/ruma-client-api/src/account/request_openid_token.rs
+++ b/crates/ruma-client-api/src/account/request_openid_token.rs
@@ -10,9 +10,10 @@ pub mod v3 {
     use std::time::Duration;
 
     use ruma_common::{
+        OwnedServerName, OwnedUserId,
         api::{auth_scheme::AccessToken, request, response},
         authentication::TokenType,
-        metadata, OwnedServerName, OwnedUserId,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/account/request_password_change_token_via_email.rs
+++ b/crates/ruma-client-api/src/account/request_password_change_token_via_email.rs
@@ -9,8 +9,9 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
+        OwnedClientSecret, OwnedSessionId,
         api::{auth_scheme::NoAuthentication, request, response},
-        metadata, OwnedClientSecret, OwnedSessionId,
+        metadata,
     };
 
     use crate::account::IdentityServerInfo;

--- a/crates/ruma-client-api/src/account/request_password_change_token_via_msisdn.rs
+++ b/crates/ruma-client-api/src/account/request_password_change_token_via_msisdn.rs
@@ -9,8 +9,9 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
+        OwnedClientSecret, OwnedSessionId,
         api::{auth_scheme::NoAuthentication, request, response},
-        metadata, OwnedClientSecret, OwnedSessionId,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/account/request_registration_token_via_email.rs
+++ b/crates/ruma-client-api/src/account/request_registration_token_via_email.rs
@@ -9,8 +9,9 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
+        OwnedClientSecret, OwnedSessionId,
         api::{auth_scheme::NoAuthentication, request, response},
-        metadata, OwnedClientSecret, OwnedSessionId,
+        metadata,
     };
 
     use crate::account::IdentityServerInfo;

--- a/crates/ruma-client-api/src/account/request_registration_token_via_msisdn.rs
+++ b/crates/ruma-client-api/src/account/request_registration_token_via_msisdn.rs
@@ -9,8 +9,9 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
+        OwnedClientSecret, OwnedSessionId,
         api::{auth_scheme::NoAuthentication, request, response},
-        metadata, OwnedClientSecret, OwnedSessionId,
+        metadata,
     };
 
     use crate::account::IdentityServerInfo;

--- a/crates/ruma-client-api/src/account/whoami.rs
+++ b/crates/ruma-client-api/src/account/whoami.rs
@@ -8,8 +8,9 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3accountwhoami
 
     use ruma_common::{
+        OwnedDeviceId, OwnedUserId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedDeviceId, OwnedUserId,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/alias/create_alias.rs
+++ b/crates/ruma-client-api/src/alias/create_alias.rs
@@ -8,8 +8,9 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3directoryroomroomalias
 
     use ruma_common::{
+        OwnedRoomAliasId, OwnedRoomId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedRoomAliasId, OwnedRoomId,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/alias/delete_alias.rs
+++ b/crates/ruma-client-api/src/alias/delete_alias.rs
@@ -8,8 +8,9 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#delete_matrixclientv3directoryroomroomalias
 
     use ruma_common::{
+        OwnedRoomAliasId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedRoomAliasId,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/alias/get_alias.rs
+++ b/crates/ruma-client-api/src/alias/get_alias.rs
@@ -8,8 +8,9 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3directoryroomroomalias
 
     use ruma_common::{
+        OwnedRoomAliasId, OwnedRoomId, OwnedServerName,
         api::{auth_scheme::NoAuthentication, request, response},
-        metadata, OwnedRoomAliasId, OwnedRoomId, OwnedServerName,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/appservice/request_ping.rs
+++ b/crates/ruma-client-api/src/appservice/request_ping.rs
@@ -10,8 +10,9 @@ pub mod v1 {
     use std::time::Duration;
 
     use ruma_common::{
+        OwnedTransactionId,
         api::{auth_scheme::AppserviceToken, request, response},
-        metadata, OwnedTransactionId,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/appservice/set_room_visibility.rs
+++ b/crates/ruma-client-api/src/appservice/set_room_visibility.rs
@@ -8,8 +8,9 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/application-service-api/#put_matrixclientv3directorylistappservicenetworkidroomid
 
     use ruma_common::{
+        OwnedRoomId,
         api::{auth_scheme::AppserviceToken, request, response},
-        metadata, OwnedRoomId,
+        metadata,
     };
 
     use crate::room::Visibility;

--- a/crates/ruma-client-api/src/authenticated_media/get_content.rs
+++ b/crates/ruma-client-api/src/authenticated_media/get_content.rs
@@ -11,9 +11,10 @@ pub mod v1 {
 
     use http::header::{CONTENT_DISPOSITION, CONTENT_TYPE};
     use ruma_common::{
+        IdParseError, MxcUri, OwnedServerName,
         api::{auth_scheme::AccessToken, request, response},
         http_headers::ContentDisposition,
-        metadata, IdParseError, MxcUri, OwnedServerName,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/authenticated_media/get_content_as_filename.rs
+++ b/crates/ruma-client-api/src/authenticated_media/get_content_as_filename.rs
@@ -11,9 +11,10 @@ pub mod v1 {
 
     use http::header::{CONTENT_DISPOSITION, CONTENT_TYPE};
     use ruma_common::{
+        IdParseError, MxcUri, OwnedServerName,
         api::{auth_scheme::AccessToken, request, response},
         http_headers::ContentDisposition,
-        metadata, IdParseError, MxcUri, OwnedServerName,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/authenticated_media/get_content_thumbnail.rs
+++ b/crates/ruma-client-api/src/authenticated_media/get_content_thumbnail.rs
@@ -12,10 +12,11 @@ pub mod v1 {
     use http::header::{CONTENT_DISPOSITION, CONTENT_TYPE};
     use js_int::UInt;
     use ruma_common::{
+        IdParseError, MxcUri, OwnedServerName,
         api::{auth_scheme::AccessToken, request, response},
         http_headers::ContentDisposition,
         media::Method,
-        metadata, IdParseError, MxcUri, OwnedServerName,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/authenticated_media/get_media_preview.rs
+++ b/crates/ruma-client-api/src/authenticated_media/get_media_preview.rs
@@ -8,11 +8,12 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv1mediapreview_url
 
     use ruma_common::{
+        MilliSecondsSinceUnixEpoch,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, MilliSecondsSinceUnixEpoch,
+        metadata,
     };
     use serde::Serialize;
-    use serde_json::value::{to_raw_value as to_raw_json_value, RawValue as RawJsonValue};
+    use serde_json::value::{RawValue as RawJsonValue, to_raw_value as to_raw_json_value};
 
     metadata! {
         method: GET,
@@ -80,7 +81,7 @@ pub mod v1 {
         use assert_matches2::assert_matches;
         use serde_json::{
             from_value as from_json_value, json,
-            value::{to_raw_value as to_raw_json_value, RawValue as RawJsonValue},
+            value::{RawValue as RawJsonValue, to_raw_value as to_raw_json_value},
         };
 
         // Since BTreeMap<String, Box<RawJsonValue>> deserialization doesn't seem to

--- a/crates/ruma-client-api/src/backup.rs
+++ b/crates/ruma-client-api/src/backup.rs
@@ -19,8 +19,8 @@ use std::collections::BTreeMap;
 
 use js_int::UInt;
 use ruma_common::{
-    serde::{Base64, Raw},
     CrossSigningOrDeviceSignatures,
+    serde::{Base64, Raw},
 };
 use serde::{Deserialize, Serialize};
 

--- a/crates/ruma-client-api/src/backup/add_backup_keys.rs
+++ b/crates/ruma-client-api/src/backup/add_backup_keys.rs
@@ -11,8 +11,9 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
+        OwnedRoomId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedRoomId,
+        metadata,
     };
 
     use crate::backup::RoomKeyBackup;

--- a/crates/ruma-client-api/src/backup/add_backup_keys_for_room.rs
+++ b/crates/ruma-client-api/src/backup/add_backup_keys_for_room.rs
@@ -11,10 +11,10 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
+        OwnedRoomId,
         api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
-        OwnedRoomId,
     };
 
     use crate::backup::KeyBackupData;

--- a/crates/ruma-client-api/src/backup/add_backup_keys_for_session.rs
+++ b/crates/ruma-client-api/src/backup/add_backup_keys_for_session.rs
@@ -9,10 +9,10 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
+        OwnedRoomId,
         api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
-        OwnedRoomId,
     };
 
     use crate::backup::KeyBackupData;

--- a/crates/ruma-client-api/src/backup/delete_backup_keys_for_room.rs
+++ b/crates/ruma-client-api/src/backup/delete_backup_keys_for_room.rs
@@ -9,8 +9,9 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
+        OwnedRoomId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedRoomId,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/backup/delete_backup_keys_for_session.rs
+++ b/crates/ruma-client-api/src/backup/delete_backup_keys_for_session.rs
@@ -9,8 +9,9 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
+        OwnedRoomId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedRoomId,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/backup/get_backup_info.rs
+++ b/crates/ruma-client-api/src/backup/get_backup_info.rs
@@ -14,8 +14,8 @@ pub mod v3 {
         metadata,
         serde::Raw,
     };
-    use serde::{ser, Deserialize, Deserializer, Serialize};
-    use serde_json::value::{to_raw_value as to_raw_json_value, RawValue as RawJsonValue};
+    use serde::{Deserialize, Deserializer, Serialize, ser};
+    use serde_json::value::{RawValue as RawJsonValue, to_raw_value as to_raw_json_value};
 
     use crate::backup::BackupAlgorithm;
 

--- a/crates/ruma-client-api/src/backup/get_backup_keys.rs
+++ b/crates/ruma-client-api/src/backup/get_backup_keys.rs
@@ -10,8 +10,9 @@ pub mod v3 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
+        OwnedRoomId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedRoomId,
+        metadata,
     };
 
     use crate::backup::RoomKeyBackup;

--- a/crates/ruma-client-api/src/backup/get_backup_keys_for_room.rs
+++ b/crates/ruma-client-api/src/backup/get_backup_keys_for_room.rs
@@ -10,10 +10,10 @@ pub mod v3 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
+        OwnedRoomId,
         api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
-        OwnedRoomId,
     };
 
     use crate::backup::KeyBackupData;

--- a/crates/ruma-client-api/src/backup/get_backup_keys_for_session.rs
+++ b/crates/ruma-client-api/src/backup/get_backup_keys_for_session.rs
@@ -8,10 +8,10 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3room_keyskeysroomidsessionid
 
     use ruma_common::{
+        OwnedRoomId,
         api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
-        OwnedRoomId,
     };
 
     use crate::backup::KeyBackupData;

--- a/crates/ruma-client-api/src/backup/get_latest_backup_info.rs
+++ b/crates/ruma-client-api/src/backup/get_latest_backup_info.rs
@@ -13,12 +13,12 @@ pub mod v3 {
         metadata,
         serde::Raw,
     };
-    use serde::{ser, Deserialize, Deserializer, Serialize};
+    use serde::{Deserialize, Deserializer, Serialize, ser};
     use serde_json::value::to_raw_value as to_raw_json_value;
 
     use crate::backup::{
-        get_backup_info::v3::{AlgorithmWithData, RefResponseBodyRepr, ResponseBodyRepr},
         BackupAlgorithm,
+        get_backup_info::v3::{AlgorithmWithData, RefResponseBodyRepr, ResponseBodyRepr},
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/config/get_global_account_data.rs
+++ b/crates/ruma-client-api/src/config/get_global_account_data.rs
@@ -8,10 +8,10 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3useruseridaccount_datatype
 
     use ruma_common::{
+        OwnedUserId,
         api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
-        OwnedUserId,
     };
     use ruma_events::{AnyGlobalAccountDataEventContent, GlobalAccountDataEventType};
 

--- a/crates/ruma-client-api/src/config/get_room_account_data.rs
+++ b/crates/ruma-client-api/src/config/get_room_account_data.rs
@@ -8,10 +8,10 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3useruseridroomsroomidaccount_datatype
 
     use ruma_common::{
+        OwnedRoomId, OwnedUserId,
         api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
-        OwnedRoomId, OwnedUserId,
     };
     use ruma_events::{AnyRoomAccountDataEventContent, RoomAccountDataEventType};
 

--- a/crates/ruma-client-api/src/config/set_global_account_data.rs
+++ b/crates/ruma-client-api/src/config/set_global_account_data.rs
@@ -8,10 +8,10 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3useruseridaccount_datatype
 
     use ruma_common::{
+        OwnedUserId,
         api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
-        OwnedUserId,
     };
     use ruma_events::{
         AnyGlobalAccountDataEventContent, GlobalAccountDataEventContent, GlobalAccountDataEventType,

--- a/crates/ruma-client-api/src/config/set_room_account_data.rs
+++ b/crates/ruma-client-api/src/config/set_room_account_data.rs
@@ -8,10 +8,10 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3useruseridroomsroomidaccount_datatype
 
     use ruma_common::{
+        OwnedRoomId, OwnedUserId,
         api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
-        OwnedRoomId, OwnedUserId,
     };
     use ruma_events::{
         AnyRoomAccountDataEventContent, RoomAccountDataEventContent, RoomAccountDataEventType,

--- a/crates/ruma-client-api/src/context/get_context.rs
+++ b/crates/ruma-client-api/src/context/get_context.rs
@@ -7,12 +7,12 @@ pub mod v3 {
     //!
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3roomsroomidcontexteventid
 
-    use js_int::{uint, UInt};
+    use js_int::{UInt, uint};
     use ruma_common::{
+        OwnedEventId, OwnedRoomId,
         api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
-        OwnedEventId, OwnedRoomId,
     };
     use ruma_events::{AnyStateEvent, AnyTimelineEvent};
 

--- a/crates/ruma-client-api/src/dehydrated_device/delete_dehydrated_device.rs
+++ b/crates/ruma-client-api/src/dehydrated_device/delete_dehydrated_device.rs
@@ -8,8 +8,9 @@ pub mod unstable {
     //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/3814
 
     use ruma_common::{
+        OwnedDeviceId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedDeviceId,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/dehydrated_device/get_dehydrated_device.rs
+++ b/crates/ruma-client-api/src/dehydrated_device/get_dehydrated_device.rs
@@ -8,10 +8,10 @@ pub mod unstable {
     //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/3814
 
     use ruma_common::{
+        OwnedDeviceId,
         api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
-        OwnedDeviceId,
     };
 
     use crate::dehydrated_device::DehydratedDeviceData;

--- a/crates/ruma-client-api/src/dehydrated_device/get_events.rs
+++ b/crates/ruma-client-api/src/dehydrated_device/get_events.rs
@@ -8,10 +8,10 @@ pub mod unstable {
     //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/3814
 
     use ruma_common::{
+        OwnedDeviceId,
         api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
-        OwnedDeviceId,
     };
     use ruma_events::AnyToDeviceEvent;
 

--- a/crates/ruma-client-api/src/dehydrated_device/put_dehydrated_device.rs
+++ b/crates/ruma-client-api/src/dehydrated_device/put_dehydrated_device.rs
@@ -10,11 +10,11 @@ pub mod unstable {
     use std::collections::BTreeMap;
 
     use ruma_common::{
+        OwnedDeviceId, OwnedOneTimeKeyId,
         api::{auth_scheme::AccessToken, request, response},
         encryption::{DeviceKeys, OneTimeKey},
         metadata,
         serde::Raw,
-        OwnedDeviceId, OwnedOneTimeKeyId,
     };
 
     use crate::dehydrated_device::DehydratedDeviceData;

--- a/crates/ruma-client-api/src/delayed_events/delayed_message_event.rs
+++ b/crates/ruma-client-api/src/delayed_events/delayed_message_event.rs
@@ -8,10 +8,10 @@ pub mod unstable {
     //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/4140
 
     use ruma_common::{
+        OwnedRoomId, OwnedTransactionId,
         api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
-        OwnedRoomId, OwnedTransactionId,
     };
     use ruma_events::{AnyMessageLikeEventContent, MessageLikeEventContent, MessageLikeEventType};
     use serde_json::value::to_raw_value as to_raw_json_value;
@@ -121,12 +121,12 @@ pub mod unstable {
 
         use ruma_common::{
             api::{
-                auth_scheme::SendAccessToken, MatrixVersion, OutgoingRequest, SupportedVersions,
+                MatrixVersion, OutgoingRequest, SupportedVersions, auth_scheme::SendAccessToken,
             },
             owned_room_id,
         };
         use ruma_events::room::message::RoomMessageEventContent;
-        use serde_json::{json, Value as JsonValue};
+        use serde_json::{Value as JsonValue, json};
         use web_time::Duration;
 
         use super::Request;

--- a/crates/ruma-client-api/src/delayed_events/delayed_state_event.rs
+++ b/crates/ruma-client-api/src/delayed_events/delayed_state_event.rs
@@ -8,10 +8,10 @@ pub mod unstable {
     //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/4140
 
     use ruma_common::{
+        OwnedRoomId,
         api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
-        OwnedRoomId,
     };
     use ruma_events::{AnyStateEventContent, StateEventContent, StateEventType};
     use serde_json::value::to_raw_value as to_raw_json_value;
@@ -117,12 +117,12 @@ pub mod unstable {
 
         use ruma_common::{
             api::{
-                auth_scheme::SendAccessToken, MatrixVersion, OutgoingRequest, SupportedVersions,
+                MatrixVersion, OutgoingRequest, SupportedVersions, auth_scheme::SendAccessToken,
             },
             owned_room_id,
             serde::Raw,
         };
-        use serde_json::{json, Value as JsonValue};
+        use serde_json::{Value as JsonValue, json};
         use web_time::Duration;
 
         use super::Request;

--- a/crates/ruma-client-api/src/delayed_events/update_delayed_event.rs
+++ b/crates/ruma-client-api/src/delayed_events/update_delayed_event.rs
@@ -76,9 +76,9 @@ pub mod unstable {
         use std::borrow::Cow;
 
         use ruma_common::api::{
-            auth_scheme::SendAccessToken, MatrixVersion, OutgoingRequest, SupportedVersions,
+            MatrixVersion, OutgoingRequest, SupportedVersions, auth_scheme::SendAccessToken,
         };
-        use serde_json::{json, Value as JsonValue};
+        use serde_json::{Value as JsonValue, json};
 
         use super::{Request, UpdateAction};
         #[test]

--- a/crates/ruma-client-api/src/device/delete_device.rs
+++ b/crates/ruma-client-api/src/device/delete_device.rs
@@ -8,8 +8,9 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#delete_matrixclientv3devicesdeviceid
 
     use ruma_common::{
+        OwnedDeviceId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedDeviceId,
+        metadata,
     };
 
     use crate::uiaa::{AuthData, UiaaResponse};

--- a/crates/ruma-client-api/src/device/delete_devices.rs
+++ b/crates/ruma-client-api/src/device/delete_devices.rs
@@ -8,8 +8,9 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3delete_devices
 
     use ruma_common::{
+        OwnedDeviceId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedDeviceId,
+        metadata,
     };
 
     use crate::uiaa::{AuthData, UiaaResponse};

--- a/crates/ruma-client-api/src/device/get_device.rs
+++ b/crates/ruma-client-api/src/device/get_device.rs
@@ -8,8 +8,9 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3devicesdeviceid
 
     use ruma_common::{
+        OwnedDeviceId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedDeviceId,
+        metadata,
     };
 
     use crate::device::Device;

--- a/crates/ruma-client-api/src/device/update_device.rs
+++ b/crates/ruma-client-api/src/device/update_device.rs
@@ -8,8 +8,9 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3devicesdeviceid
 
     use ruma_common::{
+        OwnedDeviceId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedDeviceId,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/directory/get_public_rooms.rs
+++ b/crates/ruma-client-api/src/directory/get_public_rooms.rs
@@ -9,9 +9,10 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
+        OwnedServerName,
         api::{auth_scheme::NoAuthentication, request, response},
         directory::PublicRoomsChunk,
-        metadata, OwnedServerName,
+        metadata,
     };
 
     metadata! {
@@ -90,8 +91,8 @@ pub mod v3 {
 
             use ruma_common::{
                 api::{
-                    auth_scheme::SendAccessToken, MatrixVersion, OutgoingRequest as _,
-                    SupportedVersions,
+                    MatrixVersion, OutgoingRequest as _, SupportedVersions,
+                    auth_scheme::SendAccessToken,
                 },
                 server_name,
             };

--- a/crates/ruma-client-api/src/directory/get_public_rooms_filtered.rs
+++ b/crates/ruma-client-api/src/directory/get_public_rooms_filtered.rs
@@ -9,9 +9,10 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
+        OwnedServerName,
         api::{auth_scheme::AccessToken, request, response},
         directory::{Filter, PublicRoomsChunk, RoomNetwork},
-        metadata, OwnedServerName,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/directory/get_room_visibility.rs
+++ b/crates/ruma-client-api/src/directory/get_room_visibility.rs
@@ -8,8 +8,9 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3directorylistroomroomid
 
     use ruma_common::{
+        OwnedRoomId,
         api::{auth_scheme::NoAuthentication, request, response},
-        metadata, OwnedRoomId,
+        metadata,
     };
 
     use crate::room::Visibility;

--- a/crates/ruma-client-api/src/directory/set_room_visibility.rs
+++ b/crates/ruma-client-api/src/directory/set_room_visibility.rs
@@ -8,8 +8,9 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3directorylistroomroomid
 
     use ruma_common::{
+        OwnedRoomId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedRoomId,
+        metadata,
     };
 
     use crate::room::Visibility;

--- a/crates/ruma-client-api/src/discovery/discover_support.rs
+++ b/crates/ruma-client-api/src/discovery/discover_support.rs
@@ -5,10 +5,10 @@
 //! Get server admin contact and support page of a homeserver's domain.
 
 use ruma_common::{
+    OwnedUserId,
     api::{auth_scheme::NoAuthentication, request, response},
     metadata,
     serde::StringEnum,
-    OwnedUserId,
 };
 use serde::{Deserialize, Serialize};
 

--- a/crates/ruma-client-api/src/discovery/get_authorization_server_metadata.rs
+++ b/crates/ruma-client-api/src/discovery/get_authorization_server_metadata.rs
@@ -389,7 +389,7 @@ pub mod v1 {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::{from_value as from_json_value, json, Value as JsonValue};
+    use serde_json::{Value as JsonValue, from_value as from_json_value, json};
     use url::Url;
 
     use super::v1::AuthorizationServerMetadata;

--- a/crates/ruma-client-api/src/discovery/get_authorization_server_metadata/serde.rs
+++ b/crates/ruma-client-api/src/discovery/get_authorization_server_metadata/serde.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeSet;
 
-use serde::{de, Deserialize};
+use serde::{Deserialize, de};
 use url::Url;
 
 #[cfg(feature = "unstable-msc4191")]
@@ -139,7 +139,7 @@ struct AuthorizationServerMetadataDeHelper {
 #[cfg(test)]
 mod tests {
     use as_variant::as_variant;
-    use serde_json::{from_value as from_json_value, value::Map as JsonMap, Value as JsonValue};
+    use serde_json::{Value as JsonValue, from_value as from_json_value, value::Map as JsonMap};
     use url::Url;
 
     #[cfg(feature = "unstable-msc4191")]
@@ -203,24 +203,36 @@ mod tests {
                 Some("https://server.local/account")
             );
             assert_eq!(metadata.account_management_actions_supported.len(), 6);
-            assert!(metadata
-                .account_management_actions_supported
-                .contains(&AccountManagementAction::Profile));
-            assert!(metadata
-                .account_management_actions_supported
-                .contains(&AccountManagementAction::SessionsList));
-            assert!(metadata
-                .account_management_actions_supported
-                .contains(&AccountManagementAction::SessionView));
-            assert!(metadata
-                .account_management_actions_supported
-                .contains(&AccountManagementAction::SessionEnd));
-            assert!(metadata
-                .account_management_actions_supported
-                .contains(&AccountManagementAction::AccountDeactivate));
-            assert!(metadata
-                .account_management_actions_supported
-                .contains(&AccountManagementAction::CrossSigningReset));
+            assert!(
+                metadata
+                    .account_management_actions_supported
+                    .contains(&AccountManagementAction::Profile)
+            );
+            assert!(
+                metadata
+                    .account_management_actions_supported
+                    .contains(&AccountManagementAction::SessionsList)
+            );
+            assert!(
+                metadata
+                    .account_management_actions_supported
+                    .contains(&AccountManagementAction::SessionView)
+            );
+            assert!(
+                metadata
+                    .account_management_actions_supported
+                    .contains(&AccountManagementAction::SessionEnd)
+            );
+            assert!(
+                metadata
+                    .account_management_actions_supported
+                    .contains(&AccountManagementAction::AccountDeactivate)
+            );
+            assert!(
+                metadata
+                    .account_management_actions_supported
+                    .contains(&AccountManagementAction::CrossSigningReset)
+            );
         }
 
         #[cfg(feature = "unstable-msc4108")]
@@ -313,9 +325,11 @@ mod tests {
 
         assert_eq!(metadata.code_challenge_methods_supported.len(), 2);
         assert!(metadata.code_challenge_methods_supported.contains(&CodeChallengeMethod::S256));
-        assert!(metadata
-            .code_challenge_methods_supported
-            .contains(&CodeChallengeMethod::from("custom")));
+        assert!(
+            metadata
+                .code_challenge_methods_supported
+                .contains(&CodeChallengeMethod::from("custom"))
+        );
 
         #[cfg(feature = "unstable-msc4191")]
         {
@@ -324,27 +338,41 @@ mod tests {
                 Some("https://server.local/account")
             );
             assert_eq!(metadata.account_management_actions_supported.len(), 7);
-            assert!(metadata
-                .account_management_actions_supported
-                .contains(&AccountManagementAction::Profile));
-            assert!(metadata
-                .account_management_actions_supported
-                .contains(&AccountManagementAction::SessionsList));
-            assert!(metadata
-                .account_management_actions_supported
-                .contains(&AccountManagementAction::SessionView));
-            assert!(metadata
-                .account_management_actions_supported
-                .contains(&AccountManagementAction::SessionEnd));
-            assert!(metadata
-                .account_management_actions_supported
-                .contains(&AccountManagementAction::AccountDeactivate));
-            assert!(metadata
-                .account_management_actions_supported
-                .contains(&AccountManagementAction::CrossSigningReset));
-            assert!(metadata
-                .account_management_actions_supported
-                .contains(&AccountManagementAction::from("custom")));
+            assert!(
+                metadata
+                    .account_management_actions_supported
+                    .contains(&AccountManagementAction::Profile)
+            );
+            assert!(
+                metadata
+                    .account_management_actions_supported
+                    .contains(&AccountManagementAction::SessionsList)
+            );
+            assert!(
+                metadata
+                    .account_management_actions_supported
+                    .contains(&AccountManagementAction::SessionView)
+            );
+            assert!(
+                metadata
+                    .account_management_actions_supported
+                    .contains(&AccountManagementAction::SessionEnd)
+            );
+            assert!(
+                metadata
+                    .account_management_actions_supported
+                    .contains(&AccountManagementAction::AccountDeactivate)
+            );
+            assert!(
+                metadata
+                    .account_management_actions_supported
+                    .contains(&AccountManagementAction::CrossSigningReset)
+            );
+            assert!(
+                metadata
+                    .account_management_actions_supported
+                    .contains(&AccountManagementAction::from("custom"))
+            );
         }
 
         #[cfg(feature = "unstable-msc4108")]

--- a/crates/ruma-client-api/src/discovery/get_capabilities.rs
+++ b/crates/ruma-client-api/src/discovery/get_capabilities.rs
@@ -14,17 +14,17 @@ pub mod v3 {
 
     use maplit::btreemap;
     use ruma_common::{
+        RoomVersionId,
         api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::StringEnum,
-        RoomVersionId,
     };
     use serde::{Deserialize, Serialize};
     use serde_json::{
-        from_value as from_json_value, to_value as to_json_value, Value as JsonValue,
+        Value as JsonValue, from_value as from_json_value, to_value as to_json_value,
     };
 
-    use crate::{profile::ProfileFieldName, PrivOwnedStr};
+    use crate::{PrivOwnedStr, profile::ProfileFieldName};
 
     metadata! {
         method: GET,

--- a/crates/ruma-client-api/src/discovery/get_supported_versions.rs
+++ b/crates/ruma-client-api/src/discovery/get_supported_versions.rs
@@ -7,7 +7,7 @@
 use std::collections::BTreeMap;
 
 use ruma_common::{
-    api::{auth_scheme::AccessTokenOptional, request, response, SupportedVersions},
+    api::{SupportedVersions, auth_scheme::AccessTokenOptional, request, response},
     metadata,
 };
 

--- a/crates/ruma-client-api/src/error.rs
+++ b/crates/ruma-client-api/src/error.rs
@@ -5,23 +5,23 @@ use std::{collections::BTreeMap, fmt, str::FromStr, sync::Arc};
 use as_variant::as_variant;
 use bytes::{BufMut, Bytes};
 use ruma_common::{
+    RoomVersionId,
     api::{
+        EndpointError, OutgoingResponse,
         error::{
             FromHttpResponseError, HeaderDeserializationError, HeaderSerializationError,
             IntoHttpError, MatrixErrorBody,
         },
-        EndpointError, OutgoingResponse,
     },
     serde::StringEnum,
-    RoomVersionId,
 };
 use serde::{Deserialize, Serialize};
-use serde_json::{from_slice as from_json_slice, Value as JsonValue};
+use serde_json::{Value as JsonValue, from_slice as from_json_slice};
 use web_time::{Duration, SystemTime};
 
 use crate::{
-    http_headers::{http_date_to_system_time, system_time_to_http_date},
     PrivOwnedStr,
+    http_headers::{http_date_to_system_time, system_time_to_http_date},
 };
 
 /// Deserialize and Serialize implementations for ErrorKind.
@@ -1163,7 +1163,7 @@ mod tests {
     use assert_matches2::assert_matches;
     use ruma_common::api::{EndpointError, OutgoingResponse};
     use serde_json::{
-        from_slice as from_json_slice, from_value as from_json_value, json, Value as JsonValue,
+        Value as JsonValue, from_slice as from_json_slice, from_value as from_json_value, json,
     };
     use web_time::{Duration, UNIX_EPOCH};
 

--- a/crates/ruma-client-api/src/filter.rs
+++ b/crates/ruma-client-api/src/filter.rs
@@ -7,7 +7,7 @@ mod lazy_load;
 mod url;
 
 use js_int::UInt;
-use ruma_common::{serde::StringEnum, OwnedRoomId, OwnedUserId};
+use ruma_common::{OwnedRoomId, OwnedUserId, serde::StringEnum};
 use serde::{Deserialize, Serialize};
 
 pub use self::{lazy_load::LazyLoadOptions, url::UrlFilter};

--- a/crates/ruma-client-api/src/filter/create_filter.rs
+++ b/crates/ruma-client-api/src/filter/create_filter.rs
@@ -8,8 +8,9 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3useruseridfilter
 
     use ruma_common::{
+        OwnedUserId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedUserId,
+        metadata,
     };
 
     use crate::filter::FilterDefinition;
@@ -89,7 +90,7 @@ pub mod v3 {
 
             use ruma_common::{
                 api::{
-                    auth_scheme::SendAccessToken, MatrixVersion, OutgoingRequest, SupportedVersions,
+                    MatrixVersion, OutgoingRequest, SupportedVersions, auth_scheme::SendAccessToken,
                 },
                 owned_user_id,
             };

--- a/crates/ruma-client-api/src/filter/get_filter.rs
+++ b/crates/ruma-client-api/src/filter/get_filter.rs
@@ -8,8 +8,9 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3useruseridfilterfilterid
 
     use ruma_common::{
+        OwnedUserId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedUserId,
+        metadata,
     };
 
     use crate::filter::FilterDefinition;

--- a/crates/ruma-client-api/src/filter/lazy_load.rs
+++ b/crates/ruma-client-api/src/filter/lazy_load.rs
@@ -1,4 +1,4 @@
-use serde::{ser::SerializeStruct as _, Deserialize, Serialize, Serializer};
+use serde::{Deserialize, Serialize, Serializer, ser::SerializeStruct as _};
 
 /// Specifies options for [lazy-loading membership events][lazy-loading] on
 /// supported endpoints

--- a/crates/ruma-client-api/src/http_headers.rs
+++ b/crates/ruma-client-api/src/http_headers.rs
@@ -1,7 +1,7 @@
 //! Helpers for HTTP headers with the `http` crate.
 #![allow(clippy::declare_interior_mutable_const)]
 
-use http::{header::HeaderName, HeaderValue};
+use http::{HeaderValue, header::HeaderName};
 use ruma_common::api::error::{HeaderDeserializationError, HeaderSerializationError};
 pub use ruma_common::http_headers::{
     ContentDisposition, ContentDispositionParseError, ContentDispositionType, TokenString,

--- a/crates/ruma-client-api/src/keys/claim_keys/v3.rs
+++ b/crates/ruma-client-api/src/keys/claim_keys/v3.rs
@@ -5,11 +5,11 @@
 use std::{collections::BTreeMap, time::Duration};
 
 use ruma_common::{
+    OneTimeKeyAlgorithm, OwnedDeviceId, OwnedOneTimeKeyId, OwnedUserId,
     api::{auth_scheme::AccessToken, request, response},
     encryption::OneTimeKey,
     metadata,
     serde::Raw,
-    OneTimeKeyAlgorithm, OwnedDeviceId, OwnedOneTimeKeyId, OwnedUserId,
 };
 use serde_json::Value as JsonValue;
 

--- a/crates/ruma-client-api/src/keys/claim_keys/v4.rs
+++ b/crates/ruma-client-api/src/keys/claim_keys/v4.rs
@@ -5,11 +5,11 @@
 use std::{collections::BTreeMap, time::Duration};
 
 use ruma_common::{
+    OneTimeKeyAlgorithm, OwnedDeviceId, OwnedOneTimeKeyId, OwnedUserId,
     api::{auth_scheme::AccessToken, request, response},
     encryption::OneTimeKey,
     metadata,
     serde::Raw,
-    OneTimeKeyAlgorithm, OwnedDeviceId, OwnedOneTimeKeyId, OwnedUserId,
 };
 use serde_json::Value as JsonValue;
 

--- a/crates/ruma-client-api/src/keys/get_key_changes.rs
+++ b/crates/ruma-client-api/src/keys/get_key_changes.rs
@@ -8,8 +8,9 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3keyschanges
 
     use ruma_common::{
+        OwnedUserId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedUserId,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/keys/get_keys.rs
+++ b/crates/ruma-client-api/src/keys/get_keys.rs
@@ -10,11 +10,11 @@ pub mod v3 {
     use std::{collections::BTreeMap, time::Duration};
 
     use ruma_common::{
+        OwnedDeviceId, OwnedUserId,
         api::{auth_scheme::AccessToken, request, response},
         encryption::{CrossSigningKey, DeviceKeys},
         metadata,
         serde::Raw,
-        OwnedDeviceId, OwnedUserId,
     };
     use serde_json::Value as JsonValue;
 

--- a/crates/ruma-client-api/src/keys/upload_keys.rs
+++ b/crates/ruma-client-api/src/keys/upload_keys.rs
@@ -11,11 +11,11 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
+        OneTimeKeyAlgorithm, OwnedOneTimeKeyId,
         api::{auth_scheme::AccessToken, request, response},
         encryption::{DeviceKeys, OneTimeKey},
         metadata,
         serde::Raw,
-        OneTimeKeyAlgorithm, OwnedOneTimeKeyId,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/keys/upload_signatures.rs
+++ b/crates/ruma-client-api/src/keys/upload_signatures.rs
@@ -10,11 +10,11 @@ pub mod v3 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
+        OwnedDeviceId, OwnedUserId,
         api::{auth_scheme::AccessToken, request, response},
         encryption::{CrossSigningKey, DeviceKeys},
         metadata,
         serde::{Raw, StringEnum},
-        OwnedDeviceId, OwnedUserId,
     };
     use serde::{Deserialize, Serialize};
     use serde_json::value::RawValue as RawJsonValue;

--- a/crates/ruma-client-api/src/knock/knock_room.rs
+++ b/crates/ruma-client-api/src/knock/knock_room.rs
@@ -8,8 +8,9 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3knockroomidoralias
 
     use ruma_common::{
-        api::{auth_scheme::AccessToken, response, Metadata},
-        metadata, OwnedRoomId, OwnedRoomOrAliasId, OwnedServerName,
+        OwnedRoomId, OwnedRoomOrAliasId, OwnedServerName,
+        api::{Metadata, auth_scheme::AccessToken, response},
+        metadata,
     };
 
     metadata! {
@@ -181,8 +182,8 @@ pub mod v3 {
 
         use ruma_common::{
             api::{
-                auth_scheme::SendAccessToken, IncomingRequest as _, MatrixVersion, OutgoingRequest,
-                SupportedVersions,
+                IncomingRequest as _, MatrixVersion, OutgoingRequest, SupportedVersions,
+                auth_scheme::SendAccessToken,
             },
             owned_room_id, owned_server_name,
         };

--- a/crates/ruma-client-api/src/media/create_content.rs
+++ b/crates/ruma-client-api/src/media/create_content.rs
@@ -9,8 +9,9 @@ pub mod v3 {
 
     use http::header::CONTENT_TYPE;
     use ruma_common::{
+        OwnedMxcUri,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedMxcUri,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/media/create_content_async.rs
+++ b/crates/ruma-client-api/src/media/create_content_async.rs
@@ -9,8 +9,9 @@ pub mod v3 {
 
     use http::header::CONTENT_TYPE;
     use ruma_common::{
+        IdParseError, MxcUri, OwnedServerName,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, IdParseError, MxcUri, OwnedServerName,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/media/create_mxc_uri.rs
+++ b/crates/ruma-client-api/src/media/create_mxc_uri.rs
@@ -8,8 +8,9 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixmediav1create
 
     use ruma_common::{
+        MilliSecondsSinceUnixEpoch, OwnedMxcUri,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, MilliSecondsSinceUnixEpoch, OwnedMxcUri,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/media/get_content.rs
+++ b/crates/ruma-client-api/src/media/get_content.rs
@@ -11,9 +11,10 @@ pub mod v3 {
 
     use http::header::{CONTENT_DISPOSITION, CONTENT_TYPE};
     use ruma_common::{
+        IdParseError, MxcUri, OwnedServerName,
         api::{auth_scheme::NoAuthentication, request, response},
         http_headers::ContentDisposition,
-        metadata, IdParseError, MxcUri, OwnedServerName,
+        metadata,
     };
 
     use crate::http_headers::CROSS_ORIGIN_RESOURCE_POLICY;

--- a/crates/ruma-client-api/src/media/get_content_as_filename.rs
+++ b/crates/ruma-client-api/src/media/get_content_as_filename.rs
@@ -11,9 +11,10 @@ pub mod v3 {
 
     use http::header::{CONTENT_DISPOSITION, CONTENT_TYPE};
     use ruma_common::{
+        IdParseError, MxcUri, OwnedServerName,
         api::{auth_scheme::NoAuthentication, request, response},
         http_headers::ContentDisposition,
-        metadata, IdParseError, MxcUri, OwnedServerName,
+        metadata,
     };
 
     use crate::http_headers::CROSS_ORIGIN_RESOURCE_POLICY;

--- a/crates/ruma-client-api/src/media/get_content_thumbnail.rs
+++ b/crates/ruma-client-api/src/media/get_content_thumbnail.rs
@@ -13,9 +13,10 @@ pub mod v3 {
     use js_int::UInt;
     pub use ruma_common::media::Method;
     use ruma_common::{
+        IdParseError, MxcUri, OwnedServerName,
         api::{auth_scheme::NoAuthentication, request, response},
         http_headers::ContentDisposition,
-        metadata, IdParseError, MxcUri, OwnedServerName,
+        metadata,
     };
 
     use crate::http_headers::CROSS_ORIGIN_RESOURCE_POLICY;

--- a/crates/ruma-client-api/src/media/get_media_preview.rs
+++ b/crates/ruma-client-api/src/media/get_media_preview.rs
@@ -8,11 +8,12 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixmediav3preview_url
 
     use ruma_common::{
+        MilliSecondsSinceUnixEpoch,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, MilliSecondsSinceUnixEpoch,
+        metadata,
     };
     use serde::Serialize;
-    use serde_json::value::{to_raw_value as to_raw_json_value, RawValue as RawJsonValue};
+    use serde_json::value::{RawValue as RawJsonValue, to_raw_value as to_raw_json_value};
 
     metadata! {
         method: GET,
@@ -86,7 +87,7 @@ pub mod v3 {
         use assert_matches2::assert_matches;
         use serde_json::{
             from_value as from_json_value, json,
-            value::{to_raw_value as to_raw_json_value, RawValue as RawJsonValue},
+            value::{RawValue as RawJsonValue, to_raw_value as to_raw_json_value},
         };
 
         // Since BTreeMap<String, Box<RawJsonValue>> deserialization doesn't seem to

--- a/crates/ruma-client-api/src/membership.rs
+++ b/crates/ruma-client-api/src/membership.rs
@@ -14,7 +14,7 @@ pub mod leave_room;
 pub mod mutual_rooms;
 pub mod unban_user;
 
-use ruma_common::{thirdparty::Medium, OwnedUserId, ServerSignatures};
+use ruma_common::{OwnedUserId, ServerSignatures, thirdparty::Medium};
 use serde::{Deserialize, Serialize};
 
 /// A signature of an `m.third_party_invite` token to prove that this user owns a third party

--- a/crates/ruma-client-api/src/membership/ban_user.rs
+++ b/crates/ruma-client-api/src/membership/ban_user.rs
@@ -8,8 +8,9 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidban
 
     use ruma_common::{
+        OwnedRoomId, OwnedUserId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedRoomId, OwnedUserId,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/membership/forget_room.rs
+++ b/crates/ruma-client-api/src/membership/forget_room.rs
@@ -8,8 +8,9 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidforget
 
     use ruma_common::{
+        OwnedRoomId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedRoomId,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/membership/get_member_events.rs
+++ b/crates/ruma-client-api/src/membership/get_member_events.rs
@@ -8,10 +8,10 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3roomsroomidmembers
 
     use ruma_common::{
+        OwnedRoomId,
         api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
-        OwnedRoomId,
     };
     use ruma_events::room::member::{MembershipState, RoomMemberEvent};
 

--- a/crates/ruma-client-api/src/membership/invite_user.rs
+++ b/crates/ruma-client-api/src/membership/invite_user.rs
@@ -13,8 +13,9 @@ pub mod v3 {
     //! [spec-3pid]: https://spec.matrix.org/latest/client-server-api/#thirdparty_post_matrixclientv3roomsroomidinvite
 
     use ruma_common::{
+        OwnedRoomId, OwnedUserId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedRoomId, OwnedUserId,
+        metadata,
     };
     use serde::{Deserialize, Serialize};
 

--- a/crates/ruma-client-api/src/membership/join_room_by_id.rs
+++ b/crates/ruma-client-api/src/membership/join_room_by_id.rs
@@ -8,8 +8,9 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidjoin
 
     use ruma_common::{
+        OwnedRoomId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedRoomId,
+        metadata,
     };
 
     use crate::membership::ThirdPartySigned;

--- a/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
+++ b/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
@@ -8,8 +8,9 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3joinroomidoralias
 
     use ruma_common::{
-        api::{auth_scheme::AccessToken, response, Metadata},
-        metadata, OwnedRoomId, OwnedRoomOrAliasId, OwnedServerName,
+        OwnedRoomId, OwnedRoomOrAliasId, OwnedServerName,
+        api::{Metadata, auth_scheme::AccessToken, response},
+        metadata,
     };
 
     use crate::membership::ThirdPartySigned;
@@ -200,8 +201,8 @@ pub mod v3 {
 
         use ruma_common::{
             api::{
-                auth_scheme::SendAccessToken, IncomingRequest as _, MatrixVersion, OutgoingRequest,
-                SupportedVersions,
+                IncomingRequest as _, MatrixVersion, OutgoingRequest, SupportedVersions,
+                auth_scheme::SendAccessToken,
             },
             owned_room_id, owned_server_name,
         };

--- a/crates/ruma-client-api/src/membership/joined_members.rs
+++ b/crates/ruma-client-api/src/membership/joined_members.rs
@@ -11,8 +11,9 @@ pub mod v3 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
+        OwnedMxcUri, OwnedRoomId, OwnedUserId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedMxcUri, OwnedRoomId, OwnedUserId,
+        metadata,
     };
     use serde::{Deserialize, Serialize};
 

--- a/crates/ruma-client-api/src/membership/joined_rooms.rs
+++ b/crates/ruma-client-api/src/membership/joined_rooms.rs
@@ -8,8 +8,9 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3joined_rooms
 
     use ruma_common::{
+        OwnedRoomId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedRoomId,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/membership/kick_user.rs
+++ b/crates/ruma-client-api/src/membership/kick_user.rs
@@ -8,8 +8,9 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidkick
 
     use ruma_common::{
+        OwnedRoomId, OwnedUserId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedRoomId, OwnedUserId,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/membership/leave_room.rs
+++ b/crates/ruma-client-api/src/membership/leave_room.rs
@@ -8,8 +8,9 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidleave
 
     use ruma_common::{
+        OwnedRoomId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedRoomId,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/membership/mutual_rooms.rs
+++ b/crates/ruma-client-api/src/membership/mutual_rooms.rs
@@ -8,8 +8,9 @@ pub mod unstable {
     //! [spec]: https://github.com/matrix-org/matrix-spec-proposals/blob/hs/shared-rooms/proposals/2666-get-rooms-in-common.md
 
     use ruma_common::{
+        OwnedRoomId, OwnedUserId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedRoomId, OwnedUserId,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/membership/unban_user.rs
+++ b/crates/ruma-client-api/src/membership/unban_user.rs
@@ -8,8 +8,9 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidunban
 
     use ruma_common::{
+        OwnedRoomId, OwnedUserId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedRoomId, OwnedUserId,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/message/get_message_events.rs
+++ b/crates/ruma-client-api/src/message/get_message_events.rs
@@ -7,12 +7,12 @@ pub mod v3 {
     //!
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3roomsroomidmessages
 
-    use js_int::{uint, UInt};
+    use js_int::{UInt, uint};
     use ruma_common::{
-        api::{auth_scheme::AccessToken, request, response, Direction},
+        OwnedRoomId,
+        api::{Direction, auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
-        OwnedRoomId,
     };
     use ruma_events::{AnyStateEvent, AnyTimelineEvent};
 
@@ -177,8 +177,8 @@ pub mod v3 {
         use js_int::uint;
         use ruma_common::{
             api::{
-                auth_scheme::SendAccessToken, Direction, MatrixVersion, OutgoingRequest,
-                SupportedVersions,
+                Direction, MatrixVersion, OutgoingRequest, SupportedVersions,
+                auth_scheme::SendAccessToken,
             },
             owned_room_id,
         };

--- a/crates/ruma-client-api/src/message/send_message_event.rs
+++ b/crates/ruma-client-api/src/message/send_message_event.rs
@@ -8,10 +8,10 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3roomsroomidsendeventtypetxnid
 
     use ruma_common::{
+        MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedTransactionId,
         api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
-        MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedTransactionId,
     };
     use ruma_events::{AnyMessageLikeEventContent, MessageLikeEventContent, MessageLikeEventType};
     use serde_json::value::to_raw_value as to_raw_json_value;

--- a/crates/ruma-client-api/src/peeking/get_current_state.rs
+++ b/crates/ruma-client-api/src/peeking/get_current_state.rs
@@ -8,13 +8,13 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3roomsroomidinitialsync
 
     use ruma_common::{
+        OwnedRoomId,
         api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
-        OwnedRoomId,
     };
     use ruma_events::{
-        room::member::MembershipState, AnyRoomAccountDataEvent, AnyStateEvent, AnyTimelineEvent,
+        AnyRoomAccountDataEvent, AnyStateEvent, AnyTimelineEvent, room::member::MembershipState,
     };
     use serde::{Deserialize, Serialize};
 

--- a/crates/ruma-client-api/src/peeking/listen_to_new_events.rs
+++ b/crates/ruma-client-api/src/peeking/listen_to_new_events.rs
@@ -10,10 +10,10 @@ pub mod v3 {
     use std::time::Duration;
 
     use ruma_common::{
+        OwnedRoomId,
         api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
-        OwnedRoomId,
     };
     use ruma_events::AnyTimelineEvent;
 

--- a/crates/ruma-client-api/src/presence/get_presence.rs
+++ b/crates/ruma-client-api/src/presence/get_presence.rs
@@ -10,10 +10,10 @@ pub mod v3 {
     use std::time::Duration;
 
     use ruma_common::{
+        OwnedUserId,
         api::{auth_scheme::AccessToken, request, response},
         metadata,
         presence::PresenceState,
-        OwnedUserId,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/presence/set_presence.rs
+++ b/crates/ruma-client-api/src/presence/set_presence.rs
@@ -8,10 +8,10 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3presenceuseridstatus
 
     use ruma_common::{
+        OwnedUserId,
         api::{auth_scheme::AccessToken, request, response},
         metadata,
         presence::PresenceState,
-        OwnedUserId,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/profile.rs
+++ b/crates/ruma-client-api/src/profile.rs
@@ -3,15 +3,15 @@
 use std::borrow::Cow;
 
 use ruma_common::{
+    OwnedMxcUri,
     api::{
-        path_builder::{StablePathSelector, VersionHistory},
         MatrixVersion,
+        path_builder::{StablePathSelector, VersionHistory},
     },
     serde::StringEnum,
-    OwnedMxcUri,
 };
 use serde::Serialize;
-use serde_json::{from_value as from_json_value, to_value as to_json_value, Value as JsonValue};
+use serde_json::{Value as JsonValue, from_value as from_json_value, to_value as to_json_value};
 
 pub mod delete_profile_field;
 pub mod get_avatar_url;

--- a/crates/ruma-client-api/src/profile/delete_profile_field.rs
+++ b/crates/ruma-client-api/src/profile/delete_profile_field.rs
@@ -8,8 +8,9 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#delete_matrixclientv3profileuseridkeyname
 
     use ruma_common::{
+        OwnedUserId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedUserId,
+        metadata,
     };
 
     use crate::profile::ProfileFieldName;

--- a/crates/ruma-client-api/src/profile/get_avatar_url.rs
+++ b/crates/ruma-client-api/src/profile/get_avatar_url.rs
@@ -8,8 +8,9 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/v1.15/client-server-api/#get_matrixclientv3profileuseridavatar_url
 
     use ruma_common::{
+        OwnedMxcUri, OwnedUserId,
         api::{auth_scheme::NoAuthentication, request, response},
-        metadata, OwnedMxcUri, OwnedUserId,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/profile/get_display_name.rs
+++ b/crates/ruma-client-api/src/profile/get_display_name.rs
@@ -8,8 +8,9 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/v1.15/client-server-api/#get_matrixclientv3profileuseriddisplayname
 
     use ruma_common::{
+        OwnedUserId,
         api::{auth_scheme::NoAuthentication, request, response},
-        metadata, OwnedUserId,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/profile/get_profile.rs
+++ b/crates/ruma-client-api/src/profile/get_profile.rs
@@ -7,11 +7,12 @@ pub mod v3 {
     //!
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3profileuserid
 
-    use std::collections::{btree_map, BTreeMap};
+    use std::collections::{BTreeMap, btree_map};
 
     use ruma_common::{
+        OwnedUserId,
         api::{auth_scheme::NoAuthentication, request, response},
-        metadata, OwnedUserId,
+        metadata,
     };
     use serde_json::Value as JsonValue;
 
@@ -136,7 +137,7 @@ pub mod v3 {
 mod tests {
     use ruma_common::owned_mxc_uri;
     use serde_json::{
-        from_slice as from_json_slice, json, to_vec as to_json_vec, Value as JsonValue,
+        Value as JsonValue, from_slice as from_json_slice, json, to_vec as to_json_vec,
     };
 
     use super::v3::Response;

--- a/crates/ruma-client-api/src/profile/get_profile_field.rs
+++ b/crates/ruma-client-api/src/profile/get_profile_field.rs
@@ -16,13 +16,14 @@ pub mod v3 {
     use std::marker::PhantomData;
 
     use ruma_common::{
-        api::{auth_scheme::NoAuthentication, path_builder::VersionHistory, Metadata},
-        metadata, OwnedUserId,
+        OwnedUserId,
+        api::{Metadata, auth_scheme::NoAuthentication, path_builder::VersionHistory},
+        metadata,
     };
 
     use crate::profile::{
-        profile_field_serde::StaticProfileFieldVisitor, ProfileFieldName, ProfileFieldValue,
-        StaticProfileField,
+        ProfileFieldName, ProfileFieldValue, StaticProfileField,
+        profile_field_serde::StaticProfileFieldVisitor,
     };
 
     metadata! {
@@ -280,7 +281,7 @@ pub mod v3 {
 mod tests {
     use ruma_common::{owned_mxc_uri, owned_user_id};
     use serde_json::{
-        from_slice as from_json_slice, json, to_vec as to_json_vec, Value as JsonValue,
+        Value as JsonValue, from_slice as from_json_slice, json, to_vec as to_json_vec,
     };
 
     use super::v3::{Request, RequestStatic, Response};
@@ -291,7 +292,7 @@ mod tests {
     fn serialize_request() {
         use std::borrow::Cow;
 
-        use ruma_common::api::{auth_scheme::SendAccessToken, OutgoingRequest, SupportedVersions};
+        use ruma_common::api::{OutgoingRequest, SupportedVersions, auth_scheme::SendAccessToken};
 
         // Profile field that existed in Matrix 1.0.
         let avatar_url_request =

--- a/crates/ruma-client-api/src/profile/profile_field_serde.rs
+++ b/crates/ruma-client-api/src/profile/profile_field_serde.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, fmt, marker::PhantomData};
 
-use serde::{de, ser::SerializeMap, Deserialize, Serialize, Serializer};
+use serde::{Deserialize, Serialize, Serializer, de, ser::SerializeMap};
 
 use super::{CustomProfileFieldValue, ProfileFieldName, ProfileFieldValue, StaticProfileField};
 

--- a/crates/ruma-client-api/src/profile/set_avatar_url.rs
+++ b/crates/ruma-client-api/src/profile/set_avatar_url.rs
@@ -8,8 +8,9 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/v1.15/client-server-api/#put_matrixclientv3profileuseridavatar_url
 
     use ruma_common::{
+        OwnedMxcUri, OwnedUserId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedMxcUri, OwnedUserId,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/profile/set_display_name.rs
+++ b/crates/ruma-client-api/src/profile/set_display_name.rs
@@ -8,8 +8,9 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/v1.15/client-server-api/#put_matrixclientv3profileuseriddisplayname
 
     use ruma_common::{
+        OwnedUserId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedUserId,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/profile/set_profile_field.rs
+++ b/crates/ruma-client-api/src/profile/set_profile_field.rs
@@ -14,11 +14,12 @@ pub mod v3 {
     //! [`set_display_name`]: crate::profile::set_display_name
 
     use ruma_common::{
-        api::{auth_scheme::AccessToken, response, Metadata},
-        metadata, OwnedUserId,
+        OwnedUserId,
+        api::{Metadata, auth_scheme::AccessToken, response},
+        metadata,
     };
 
-    use crate::profile::{profile_field_serde::ProfileFieldValueVisitor, ProfileFieldValue};
+    use crate::profile::{ProfileFieldValue, profile_field_serde::ProfileFieldValueVisitor};
 
     metadata! {
         method: PUT,
@@ -143,7 +144,7 @@ mod tests {
     use assert_matches2::assert_matches;
     use ruma_common::{owned_mxc_uri, owned_user_id};
     use serde_json::{
-        from_slice as from_json_slice, json, to_vec as to_json_vec, Value as JsonValue,
+        Value as JsonValue, from_slice as from_json_slice, json, to_vec as to_json_vec,
     };
 
     use super::v3::Request;
@@ -155,7 +156,7 @@ mod tests {
         use std::borrow::Cow;
 
         use http::header;
-        use ruma_common::api::{auth_scheme::SendAccessToken, OutgoingRequest, SupportedVersions};
+        use ruma_common::api::{OutgoingRequest, SupportedVersions, auth_scheme::SendAccessToken};
 
         // Profile field that existed in Matrix 1.0.
         let avatar_url_request = Request::new(

--- a/crates/ruma-client-api/src/profile/static_profile_field.rs
+++ b/crates/ruma-client-api/src/profile/static_profile_field.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::exhaustive_structs)]
 
 use ruma_common::OwnedMxcUri;
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{Serialize, de::DeserializeOwned};
 
 /// Trait implemented by types representing a field in a user's [profile] having a statically-known
 /// name.

--- a/crates/ruma-client-api/src/push/get_notifications.rs
+++ b/crates/ruma-client-api/src/push/get_notifications.rs
@@ -9,11 +9,11 @@ pub mod v3 {
 
     use js_int::UInt;
     use ruma_common::{
+        MilliSecondsSinceUnixEpoch, OwnedRoomId,
         api::{auth_scheme::AccessToken, request, response},
         metadata,
         push::Action,
         serde::Raw,
-        MilliSecondsSinceUnixEpoch, OwnedRoomId,
     };
     use ruma_events::AnySyncTimelineEvent;
     use serde::{Deserialize, Serialize};

--- a/crates/ruma-client-api/src/push/pusher_serde.rs
+++ b/crates/ruma-client-api/src/push/pusher_serde.rs
@@ -1,5 +1,5 @@
 use ruma_common::serde::from_raw_json_value;
-use serde::{de, ser::SerializeStruct, Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de, ser::SerializeStruct};
 use serde_json::value::RawValue as RawJsonValue;
 
 use super::{Pusher, PusherIds, PusherKind};
@@ -82,7 +82,7 @@ mod tests {
     use assert_matches2::assert_matches;
     use ruma_common::{push::HttpPusherData, serde::JsonObject};
     use serde_json::{
-        from_value as from_json_value, json, to_value as to_json_value, Value as JsonValue,
+        Value as JsonValue, from_value as from_json_value, json, to_value as to_json_value,
     };
 
     use crate::push::{CustomPusherData, EmailPusherData, PusherKind};

--- a/crates/ruma-client-api/src/push/set_pusher/set_pusher_serde.rs
+++ b/crates/ruma-client-api/src/push/set_pusher/set_pusher_serde.rs
@@ -1,6 +1,6 @@
 use js_option::JsOption;
 use ruma_common::serde::from_raw_json_value;
-use serde::{de, ser::SerializeStruct, Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de, ser::SerializeStruct};
 use serde_json::value::RawValue as RawJsonValue;
 
 use super::v3::{PusherAction, PusherPostData};
@@ -72,7 +72,7 @@ mod tests {
 
     use super::PusherAction;
     use crate::push::{
-        set_pusher::v3::PusherPostData, EmailPusherData, Pusher, PusherIds, PusherKind,
+        EmailPusherData, Pusher, PusherIds, PusherKind, set_pusher::v3::PusherPostData,
     };
 
     #[test]

--- a/crates/ruma-client-api/src/push/set_pushrule.rs
+++ b/crates/ruma-client-api/src/push/set_pushrule.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3pushrulesglobalkindruleid
 
     use ruma_common::{
-        api::{auth_scheme::AccessToken, response, Metadata},
+        api::{Metadata, auth_scheme::AccessToken, response},
         metadata,
         push::{Action, NewPushRule, PushCondition},
     };

--- a/crates/ruma-client-api/src/read_marker/set_read_marker.rs
+++ b/crates/ruma-client-api/src/read_marker/set_read_marker.rs
@@ -13,8 +13,9 @@ pub mod v3 {
     //! [`create_receipt`]: crate::receipt::create_receipt
 
     use ruma_common::{
+        OwnedEventId, OwnedRoomId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedEventId, OwnedRoomId,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/receipt/create_receipt.rs
+++ b/crates/ruma-client-api/src/receipt/create_receipt.rs
@@ -8,10 +8,10 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidreceiptreceipttypeeventid
 
     use ruma_common::{
+        OwnedEventId, OwnedRoomId,
         api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::StringEnum,
-        OwnedEventId, OwnedRoomId,
     };
     use ruma_events::receipt::ReceiptThread;
 

--- a/crates/ruma-client-api/src/redact/redact_event.rs
+++ b/crates/ruma-client-api/src/redact/redact_event.rs
@@ -8,8 +8,9 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3roomsroomidredacteventidtxnid
 
     use ruma_common::{
+        OwnedEventId, OwnedRoomId, OwnedTransactionId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedEventId, OwnedRoomId, OwnedTransactionId,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/relations/get_relating_events.rs
+++ b/crates/ruma-client-api/src/relations/get_relating_events.rs
@@ -9,10 +9,10 @@ pub mod v1 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{auth_scheme::AccessToken, request, response, Direction},
+        OwnedEventId, OwnedRoomId,
+        api::{Direction, auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
-        OwnedEventId, OwnedRoomId,
     };
     use ruma_events::AnyMessageLikeEvent;
 

--- a/crates/ruma-client-api/src/relations/get_relating_events_with_rel_type.rs
+++ b/crates/ruma-client-api/src/relations/get_relating_events_with_rel_type.rs
@@ -10,12 +10,12 @@ pub mod v1 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{auth_scheme::AccessToken, request, response, Direction},
+        OwnedEventId, OwnedRoomId,
+        api::{Direction, auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
-        OwnedEventId, OwnedRoomId,
     };
-    use ruma_events::{relation::RelationType, AnyMessageLikeEvent};
+    use ruma_events::{AnyMessageLikeEvent, relation::RelationType};
 
     metadata! {
         method: GET,

--- a/crates/ruma-client-api/src/relations/get_relating_events_with_rel_type_and_event_type.rs
+++ b/crates/ruma-client-api/src/relations/get_relating_events_with_rel_type_and_event_type.rs
@@ -10,12 +10,12 @@ pub mod v1 {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{auth_scheme::AccessToken, request, response, Direction},
+        OwnedEventId, OwnedRoomId,
+        api::{Direction, auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
-        OwnedEventId, OwnedRoomId,
     };
-    use ruma_events::{relation::RelationType, AnyMessageLikeEvent, TimelineEventType};
+    use ruma_events::{AnyMessageLikeEvent, TimelineEventType, relation::RelationType};
 
     metadata! {
         method: GET,

--- a/crates/ruma-client-api/src/rendezvous/create_rendezvous_session.rs
+++ b/crates/ruma-client-api/src/rendezvous/create_rendezvous_session.rs
@@ -8,13 +8,13 @@ pub mod unstable {
     //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/4108
 
     use http::{
-        header::{CONTENT_LENGTH, CONTENT_TYPE, ETAG, EXPIRES, LAST_MODIFIED},
         HeaderName,
+        header::{CONTENT_LENGTH, CONTENT_TYPE, ETAG, EXPIRES, LAST_MODIFIED},
     };
     #[cfg(feature = "client")]
     use ruma_common::api::error::FromHttpResponseError;
     use ruma_common::{
-        api::{auth_scheme::NoAuthentication, error::HeaderDeserializationError, Metadata},
+        api::{Metadata, auth_scheme::NoAuthentication, error::HeaderDeserializationError},
         metadata,
     };
     use serde::{Deserialize, Serialize};

--- a/crates/ruma-client-api/src/reporting/report_user.rs
+++ b/crates/ruma-client-api/src/reporting/report_user.rs
@@ -8,8 +8,9 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3usersuseridreport
 
     use ruma_common::{
+        OwnedUserId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedUserId,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/room/aliases.rs
+++ b/crates/ruma-client-api/src/room/aliases.rs
@@ -8,8 +8,9 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3roomsroomidaliases
 
     use ruma_common::{
+        OwnedRoomAliasId, OwnedRoomId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedRoomAliasId, OwnedRoomId,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/room/create_room.rs
+++ b/crates/ruma-client-api/src/room/create_room.rs
@@ -9,22 +9,22 @@ pub mod v3 {
 
     use assign::assign;
     use ruma_common::{
+        OwnedRoomId, OwnedUserId, RoomVersionId,
         api::{auth_scheme::AccessToken, request, response},
         metadata,
         room::RoomType,
         serde::{Raw, StringEnum},
-        OwnedRoomId, OwnedUserId, RoomVersionId,
     };
     use ruma_events::{
+        AnyInitialStateEvent,
         room::{
             create::{PreviousRoom, RoomCreateEventContent},
             power_levels::RoomPowerLevelsEventContent,
         },
-        AnyInitialStateEvent,
     };
     use serde::{Deserialize, Serialize};
 
-    use crate::{membership::Invite3pid, room::Visibility, PrivOwnedStr};
+    use crate::{PrivOwnedStr, membership::Invite3pid, room::Visibility};
 
     metadata! {
         method: POST,

--- a/crates/ruma-client-api/src/room/get_event_by_timestamp.rs
+++ b/crates/ruma-client-api/src/room/get_event_by_timestamp.rs
@@ -8,8 +8,9 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv1roomsroomidtimestamp_to_event
 
     use ruma_common::{
-        api::{auth_scheme::AccessToken, request, response, Direction},
-        metadata, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId,
+        MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId,
+        api::{Direction, auth_scheme::AccessToken, request, response},
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/room/get_room_event.rs
+++ b/crates/ruma-client-api/src/room/get_room_event.rs
@@ -8,10 +8,10 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3roomsroomideventeventid
 
     use ruma_common::{
+        OwnedEventId, OwnedRoomId,
         api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
-        OwnedEventId, OwnedRoomId,
     };
     use ruma_events::AnyTimelineEvent;
 

--- a/crates/ruma-client-api/src/room/get_summary.rs
+++ b/crates/ruma-client-api/src/room/get_summary.rs
@@ -8,10 +8,10 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv1room_summaryroomidoralias
 
     use ruma_common::{
+        OwnedRoomOrAliasId, OwnedServerName,
         api::{auth_scheme::AccessTokenOptional, request},
         metadata,
         room::RoomSummary,
-        OwnedRoomOrAliasId, OwnedServerName,
     };
     use ruma_events::room::member::MembershipState;
 

--- a/crates/ruma-client-api/src/room/report_content.rs
+++ b/crates/ruma-client-api/src/room/report_content.rs
@@ -9,8 +9,9 @@ pub mod v3 {
 
     use js_int::Int;
     use ruma_common::{
+        OwnedEventId, OwnedRoomId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedEventId, OwnedRoomId,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/room/report_room.rs
+++ b/crates/ruma-client-api/src/room/report_room.rs
@@ -8,8 +8,9 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidreport
 
     use ruma_common::{
+        OwnedRoomId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedRoomId,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/room/upgrade_room.rs
+++ b/crates/ruma-client-api/src/room/upgrade_room.rs
@@ -8,8 +8,9 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidupgrade
 
     use ruma_common::{
+        OwnedRoomId, OwnedUserId, RoomVersionId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedRoomId, OwnedUserId, RoomVersionId,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/search/search_events.rs
+++ b/crates/ruma-client-api/src/search/search_events.rs
@@ -9,17 +9,17 @@ pub mod v3 {
 
     use std::collections::BTreeMap;
 
-    use js_int::{uint, UInt};
+    use js_int::{UInt, uint};
     use ruma_common::{
+        OwnedEventId, OwnedMxcUri, OwnedRoomId, OwnedUserId,
         api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::{Raw, StringEnum},
-        OwnedEventId, OwnedMxcUri, OwnedRoomId, OwnedUserId,
     };
     use ruma_events::{AnyStateEvent, AnyTimelineEvent};
     use serde::{Deserialize, Serialize};
 
-    use crate::{filter::RoomEventFilter, PrivOwnedStr};
+    use crate::{PrivOwnedStr, filter::RoomEventFilter};
 
     metadata! {
         method: POST,

--- a/crates/ruma-client-api/src/server/get_user_info.rs
+++ b/crates/ruma-client-api/src/server/get_user_info.rs
@@ -10,8 +10,9 @@ pub mod v3 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
+        MilliSecondsSinceUnixEpoch, OwnedUserId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, MilliSecondsSinceUnixEpoch, OwnedUserId,
+        metadata,
     };
     use serde::{Deserialize, Serialize};
 

--- a/crates/ruma-client-api/src/session/get_login_types.rs
+++ b/crates/ruma-client-api/src/session/get_login_types.rs
@@ -11,12 +11,12 @@ pub mod v3 {
     use std::borrow::Cow;
 
     use ruma_common::{
+        OwnedMxcUri,
         api::{auth_scheme::NoAuthentication, request, response},
         metadata,
         serde::{JsonObject, StringEnum},
-        OwnedMxcUri,
     };
-    use serde::{de::DeserializeOwned, Deserialize, Serialize};
+    use serde::{Deserialize, Serialize, de::DeserializeOwned};
     use serde_json::Value as JsonValue;
 
     use crate::PrivOwnedStr;
@@ -288,7 +288,7 @@ pub mod v3 {
 
     mod login_type_serde {
         use ruma_common::serde::from_raw_json_value;
-        use serde::{de, Deserialize};
+        use serde::{Deserialize, de};
         use serde_json::value::RawValue as RawJsonValue;
 
         use super::LoginType;
@@ -328,7 +328,7 @@ pub mod v3 {
         use ruma_common::mxc_uri;
         use serde::{Deserialize, Serialize};
         use serde_json::{
-            from_value as from_json_value, json, to_value as to_json_value, Value as JsonValue,
+            Value as JsonValue, from_value as from_json_value, json, to_value as to_json_value,
         };
 
         use super::{

--- a/crates/ruma-client-api/src/session/login.rs
+++ b/crates/ruma-client-api/src/session/login.rs
@@ -10,14 +10,14 @@ pub mod v3 {
     use std::{fmt, time::Duration};
 
     use ruma_common::{
+        OwnedDeviceId, OwnedServerName, OwnedUserId,
         api::{auth_scheme::AppserviceTokenOptional, request, response},
         metadata,
         serde::JsonObject,
-        OwnedDeviceId, OwnedServerName, OwnedUserId,
     };
     use serde::{
-        de::{self, DeserializeOwned},
         Deserialize, Deserializer, Serialize,
+        de::{self, DeserializeOwned},
     };
     use serde_json::Value as JsonValue;
 
@@ -438,7 +438,7 @@ pub mod v3 {
             use std::borrow::Cow;
 
             use ruma_common::api::{
-                auth_scheme::SendAccessToken, MatrixVersion, OutgoingRequest, SupportedVersions,
+                MatrixVersion, OutgoingRequest, SupportedVersions, auth_scheme::SendAccessToken,
             };
             use serde_json::Value as JsonValue;
 

--- a/crates/ruma-client-api/src/session/login_fallback.rs
+++ b/crates/ruma-client-api/src/session/login_fallback.rs
@@ -5,8 +5,9 @@
 //! [spec]: https://spec.matrix.org/latest/client-server-api/#login-fallback
 
 use ruma_common::{
+    OwnedDeviceId,
     api::{auth_scheme::NoAuthentication, request},
-    metadata, OwnedDeviceId,
+    metadata,
 };
 
 metadata! {
@@ -77,7 +78,7 @@ impl ruma_common::api::IncomingResponse for Response {
     fn try_from_http_response<T: AsRef<[u8]>>(
         response: http::Response<T>,
     ) -> Result<Self, ruma_common::api::error::FromHttpResponseError<Self::EndpointError>> {
-        use ruma_common::api::{error::FromHttpResponseError, EndpointError};
+        use ruma_common::api::{EndpointError, error::FromHttpResponseError};
 
         if response.status().as_u16() >= 400 {
             return Err(FromHttpResponseError::Server(Self::EndpointError::from_http_response(

--- a/crates/ruma-client-api/src/session/logout.rs
+++ b/crates/ruma-client-api/src/session/logout.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3logout
 
     use ruma_common::{
-        api::{auth_scheme::AccessToken, response, Metadata},
+        api::{Metadata, auth_scheme::AccessToken, response},
         metadata,
     };
 

--- a/crates/ruma-client-api/src/session/logout_all.rs
+++ b/crates/ruma-client-api/src/session/logout_all.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3logoutall
 
     use ruma_common::{
-        api::{auth_scheme::AccessToken, response, Metadata},
+        api::{Metadata, auth_scheme::AccessToken, response},
         metadata,
     };
 

--- a/crates/ruma-client-api/src/session/sso_login.rs
+++ b/crates/ruma-client-api/src/session/sso_login.rs
@@ -79,7 +79,7 @@ pub mod v3 {
         use std::borrow::Cow;
 
         use ruma_common::api::{
-            auth_scheme::SendAccessToken, MatrixVersion, OutgoingRequest, SupportedVersions,
+            MatrixVersion, OutgoingRequest, SupportedVersions, auth_scheme::SendAccessToken,
         };
 
         use super::Request;

--- a/crates/ruma-client-api/src/session/sso_login_with_provider.rs
+++ b/crates/ruma-client-api/src/session/sso_login_with_provider.rs
@@ -86,7 +86,7 @@ pub mod v3 {
         use std::borrow::Cow;
 
         use ruma_common::api::{
-            auth_scheme::SendAccessToken, MatrixVersion, OutgoingRequest as _, SupportedVersions,
+            MatrixVersion, OutgoingRequest as _, SupportedVersions, auth_scheme::SendAccessToken,
         };
 
         use super::Request;

--- a/crates/ruma-client-api/src/space.rs
+++ b/crates/ruma-client-api/src/space.rs
@@ -6,7 +6,7 @@
 
 use ruma_common::{
     room::RoomSummary,
-    serde::{from_raw_json_value, Raw},
+    serde::{Raw, from_raw_json_value},
 };
 use ruma_events::space::child::HierarchySpaceChildEvent;
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-client-api/src/space/get_hierarchy.rs
+++ b/crates/ruma-client-api/src/space/get_hierarchy.rs
@@ -9,8 +9,9 @@ pub mod v1 {
 
     use js_int::UInt;
     use ruma_common::{
+        OwnedRoomId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedRoomId,
+        metadata,
     };
 
     use crate::space::SpaceHierarchyRoomsChunk;

--- a/crates/ruma-client-api/src/state/get_state_event_for_key.rs
+++ b/crates/ruma-client-api/src/state/get_state_event_for_key.rs
@@ -8,10 +8,10 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3roomsroomidstateeventtypestatekey
 
     use ruma_common::{
-        api::{auth_scheme::AccessToken, response, Metadata},
+        OwnedRoomId,
+        api::{Metadata, auth_scheme::AccessToken, response},
         metadata,
         serde::Raw,
-        OwnedRoomId,
     };
     use ruma_events::{AnyStateEvent, AnyStateEventContent, StateEventType};
     use serde_json::value::RawValue as RawJsonValue;

--- a/crates/ruma-client-api/src/state/get_state_events.rs
+++ b/crates/ruma-client-api/src/state/get_state_events.rs
@@ -8,10 +8,10 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3roomsroomidstate
 
     use ruma_common::{
+        OwnedRoomId,
         api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
-        OwnedRoomId,
     };
     use ruma_events::AnyStateEvent;
 

--- a/crates/ruma-client-api/src/state/send_state_event.rs
+++ b/crates/ruma-client-api/src/state/send_state_event.rs
@@ -10,10 +10,10 @@ pub mod v3 {
     use std::borrow::Borrow;
 
     use ruma_common::{
-        api::{auth_scheme::AccessToken, response, Metadata},
+        MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId,
+        api::{Metadata, auth_scheme::AccessToken, response},
         metadata,
         serde::Raw,
-        MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId,
     };
     use ruma_events::{AnyStateEventContent, StateEventContent, StateEventType};
     use serde_json::value::to_raw_value as to_raw_json_value;
@@ -204,12 +204,12 @@ pub mod v3 {
 
         use ruma_common::{
             api::{
-                auth_scheme::SendAccessToken, MatrixVersion, OutgoingRequest as _,
-                SupportedVersions,
+                MatrixVersion, OutgoingRequest as _, SupportedVersions,
+                auth_scheme::SendAccessToken,
             },
             owned_room_id,
         };
-        use ruma_events::{room::name::RoomNameEventContent, EmptyStateKey};
+        use ruma_events::{EmptyStateKey, room::name::RoomNameEventContent};
 
         let supported = SupportedVersions {
             versions: [MatrixVersion::V1_1].into(),

--- a/crates/ruma-client-api/src/sync/sync_events/v3.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v3.rs
@@ -7,16 +7,16 @@ use std::{collections::BTreeMap, time::Duration};
 use as_variant::as_variant;
 use js_int::UInt;
 use ruma_common::{
+    OneTimeKeyAlgorithm, OwnedEventId, OwnedRoomId, OwnedUserId,
     api::{auth_scheme::AccessToken, request, response},
     metadata,
     presence::PresenceState,
     serde::Raw,
-    OneTimeKeyAlgorithm, OwnedEventId, OwnedRoomId, OwnedUserId,
 };
 use ruma_events::{
-    presence::PresenceEvent, AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent,
-    AnyStrippedStateEvent, AnySyncEphemeralRoomEvent, AnySyncStateEvent, AnySyncTimelineEvent,
-    AnyToDeviceEvent,
+    AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnyStrippedStateEvent,
+    AnySyncEphemeralRoomEvent, AnySyncStateEvent, AnySyncTimelineEvent, AnyToDeviceEvent,
+    presence::PresenceEvent,
 };
 use serde::{Deserialize, Serialize};
 
@@ -712,14 +712,15 @@ mod client_tests {
 
     use assert_matches2::assert_matches;
     use ruma_common::{
+        RoomVersionId,
         api::{
-            auth_scheme::SendAccessToken, IncomingResponse as _, MatrixVersion,
-            OutgoingRequest as _, SupportedVersions,
+            IncomingResponse as _, MatrixVersion, OutgoingRequest as _, SupportedVersions,
+            auth_scheme::SendAccessToken,
         },
-        event_id, room_id, user_id, RoomVersionId,
+        event_id, room_id, user_id,
     };
     use ruma_events::AnyStrippedStateEvent;
-    use serde_json::{json, to_vec as to_json_vec, Value as JsonValue};
+    use serde_json::{Value as JsonValue, json, to_vec as to_json_vec};
 
     use super::{Filter, PresenceState, Request, Response, State};
 
@@ -1011,7 +1012,7 @@ mod server_tests {
         serde::Raw,
     };
     use ruma_events::AnySyncStateEvent;
-    use serde_json::{from_slice as from_json_slice, json, Value as JsonValue};
+    use serde_json::{Value as JsonValue, from_slice as from_json_slice, json};
 
     use super::{Filter, JoinedRoom, LeftRoom, Request, Response, State};
 

--- a/crates/ruma-client-api/src/sync/sync_events/v3/response_serde.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v3/response_serde.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 #[cfg(feature = "unstable-msc2654")]
 use js_int::UInt;
-use ruma_common::{serde::from_raw_json_value, OwnedEventId};
+use ruma_common::{OwnedEventId, serde::from_raw_json_value};
 use serde::{Deserialize, Deserializer};
 use serde_json::value::RawValue as RawJsonValue;
 

--- a/crates/ruma-client-api/src/sync/sync_events/v5.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v5.rs
@@ -12,11 +12,11 @@ use std::{collections::BTreeMap, time::Duration};
 use js_int::UInt;
 use js_option::JsOption;
 use ruma_common::{
+    OwnedMxcUri, OwnedRoomId, OwnedUserId,
     api::{auth_scheme::AccessToken, request, response},
     metadata,
     presence::PresenceState,
-    serde::{duration::opt_ms, Raw},
-    OwnedMxcUri, OwnedRoomId, OwnedUserId,
+    serde::{Raw, duration::opt_ms},
 };
 use ruma_events::{AnySyncStateEvent, AnySyncTimelineEvent, StateEventType};
 use serde::{Deserialize, Serialize};
@@ -103,7 +103,7 @@ impl Request {
 
 /// HTTP types related to a [`Request`].
 pub mod request {
-    use ruma_common::{directory::RoomTypeFilter, serde::deserialize_cow_str, RoomId};
+    use ruma_common::{RoomId, directory::RoomTypeFilter, serde::deserialize_cow_str};
     use serde::de::Error as _;
 
     use super::{BTreeMap, Deserialize, OwnedRoomId, Serialize, StateEventType, UInt};
@@ -490,8 +490,8 @@ pub mod response {
     #[cfg(feature = "unstable-msc4308")]
     use ruma_common::OwnedEventId;
     use ruma_events::{
-        receipt::SyncReceiptEvent, typing::SyncTypingEvent, AnyGlobalAccountDataEvent,
-        AnyRoomAccountDataEvent, AnyStrippedStateEvent, AnyToDeviceEvent,
+        AnyGlobalAccountDataEvent, AnyRoomAccountDataEvent, AnyStrippedStateEvent,
+        AnyToDeviceEvent, receipt::SyncReceiptEvent, typing::SyncTypingEvent,
     };
 
     use super::{

--- a/crates/ruma-client-api/src/tag/create_tag.rs
+++ b/crates/ruma-client-api/src/tag/create_tag.rs
@@ -8,8 +8,9 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3useruseridroomsroomidtagstag
 
     use ruma_common::{
+        OwnedRoomId, OwnedUserId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedRoomId, OwnedUserId,
+        metadata,
     };
     use ruma_events::tag::TagInfo;
 

--- a/crates/ruma-client-api/src/tag/delete_tag.rs
+++ b/crates/ruma-client-api/src/tag/delete_tag.rs
@@ -8,8 +8,9 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#put_matrixclientv3useruseridroomsroomidtagstag
 
     use ruma_common::{
+        OwnedRoomId, OwnedUserId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedRoomId, OwnedUserId,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/tag/get_tags.rs
+++ b/crates/ruma-client-api/src/tag/get_tags.rs
@@ -8,8 +8,9 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3useruseridroomsroomidtags
 
     use ruma_common::{
+        OwnedRoomId, OwnedUserId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedRoomId, OwnedUserId,
+        metadata,
     };
     use ruma_events::tag::Tags;
 

--- a/crates/ruma-client-api/src/thirdparty/get_location_for_room_alias.rs
+++ b/crates/ruma-client-api/src/thirdparty/get_location_for_room_alias.rs
@@ -8,10 +8,10 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3thirdpartylocation
 
     use ruma_common::{
+        OwnedRoomAliasId,
         api::{auth_scheme::AccessToken, request, response},
         metadata,
         thirdparty::Location,
-        OwnedRoomAliasId,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/thirdparty/get_user_for_user_id.rs
+++ b/crates/ruma-client-api/src/thirdparty/get_user_for_user_id.rs
@@ -8,10 +8,10 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3thirdpartyuser
 
     use ruma_common::{
+        OwnedUserId,
         api::{auth_scheme::AccessToken, request, response},
         metadata,
         thirdparty::User,
-        OwnedUserId,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/threads/get_thread_subscription.rs
+++ b/crates/ruma-client-api/src/threads/get_thread_subscription.rs
@@ -8,8 +8,9 @@ pub mod unstable {
     //! [spec]: https://github.com/matrix-org/matrix-spec-proposals/pull/4306
 
     use ruma_common::{
+        OwnedEventId, OwnedRoomId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedEventId, OwnedRoomId,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/threads/get_thread_subscriptions_changes.rs
+++ b/crates/ruma-client-api/src/threads/get_thread_subscriptions_changes.rs
@@ -11,8 +11,9 @@ pub mod unstable {
 
     use js_int::UInt;
     use ruma_common::{
-        api::{auth_scheme::AccessToken, request, response, Direction},
-        metadata, OwnedEventId, OwnedRoomId,
+        OwnedEventId, OwnedRoomId,
+        api::{Direction, auth_scheme::AccessToken, request, response},
+        metadata,
     };
     use serde::{Deserialize, Serialize};
 

--- a/crates/ruma-client-api/src/threads/get_threads.rs
+++ b/crates/ruma-client-api/src/threads/get_threads.rs
@@ -9,10 +9,10 @@ pub mod v1 {
 
     use js_int::UInt;
     use ruma_common::{
+        OwnedRoomId,
         api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::{Raw, StringEnum},
-        OwnedRoomId,
     };
     use ruma_events::AnyTimelineEvent;
 

--- a/crates/ruma-client-api/src/threads/subscribe_thread.rs
+++ b/crates/ruma-client-api/src/threads/subscribe_thread.rs
@@ -8,8 +8,9 @@ pub mod unstable {
     //! [spec]: https://github.com/matrix-org/matrix-spec-proposals/pull/4306
 
     use ruma_common::{
+        OwnedEventId, OwnedRoomId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedEventId, OwnedRoomId,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/threads/unsubscribe_thread.rs
+++ b/crates/ruma-client-api/src/threads/unsubscribe_thread.rs
@@ -8,8 +8,9 @@ pub mod unstable {
     //! [spec]: https://github.com/matrix-org/matrix-spec-proposals/pull/4306
 
     use ruma_common::{
+        OwnedEventId, OwnedRoomId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedEventId, OwnedRoomId,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-client-api/src/to_device/send_event_to_device.rs
+++ b/crates/ruma-client-api/src/to_device/send_event_to_device.rs
@@ -10,11 +10,11 @@ pub mod v3 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
+        OwnedTransactionId, OwnedUserId,
         api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Raw,
         to_device::DeviceIdOrAllDevices,
-        OwnedTransactionId, OwnedUserId,
     };
     use ruma_events::{AnyToDeviceEventContent, ToDeviceEventType};
 

--- a/crates/ruma-client-api/src/typing/create_typing_event.rs
+++ b/crates/ruma-client-api/src/typing/create_typing_event.rs
@@ -10,10 +10,11 @@ pub mod v3 {
     use std::time::Duration;
 
     use ruma_common::{
+        OwnedRoomId, OwnedUserId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedRoomId, OwnedUserId,
+        metadata,
     };
-    use serde::{de::Error, Deserialize, Deserializer, Serialize};
+    use serde::{Deserialize, Deserializer, Serialize, de::Error};
 
     metadata! {
         method: PUT,

--- a/crates/ruma-client-api/src/uiaa.rs
+++ b/crates/ruma-client-api/src/uiaa.rs
@@ -6,22 +6,22 @@ use std::{borrow::Cow, fmt};
 
 use bytes::BufMut;
 use ruma_common::{
-    api::{error::IntoHttpError, EndpointError, OutgoingResponse},
-    serde::{from_raw_json_value, JsonObject, StringEnum},
-    thirdparty::Medium,
     OwnedClientSecret, OwnedSessionId, OwnedUserId,
+    api::{EndpointError, OutgoingResponse, error::IntoHttpError},
+    serde::{JsonObject, StringEnum, from_raw_json_value},
+    thirdparty::Medium,
 };
 use serde::{
-    de::{self, DeserializeOwned},
     Deserialize, Deserializer, Serialize,
+    de::{self, DeserializeOwned},
 };
 use serde_json::{
-    from_slice as from_json_slice, value::RawValue as RawJsonValue, Value as JsonValue,
+    Value as JsonValue, from_slice as from_json_slice, value::RawValue as RawJsonValue,
 };
 
 use crate::{
-    error::{Error as MatrixError, StandardErrorBody},
     PrivOwnedStr,
+    error::{Error as MatrixError, StandardErrorBody},
 };
 
 pub mod get_uiaa_fallback_page;

--- a/crates/ruma-client-api/src/uiaa/get_uiaa_fallback_page.rs
+++ b/crates/ruma-client-api/src/uiaa/get_uiaa_fallback_page.rs
@@ -109,8 +109,8 @@ pub mod v3 {
         ) -> Result<Self, ruma_common::api::error::FromHttpResponseError<Self::EndpointError>>
         {
             use ruma_common::api::{
-                error::{DeserializationError, FromHttpResponseError, HeaderDeserializationError},
                 EndpointError,
+                error::{DeserializationError, FromHttpResponseError, HeaderDeserializationError},
             };
 
             if response.status().as_u16() >= 400 {

--- a/crates/ruma-client-api/src/uiaa/user_serde.rs
+++ b/crates/ruma-client-api/src/uiaa/user_serde.rs
@@ -2,7 +2,7 @@
 //! in the parent module.
 
 use ruma_common::{serde::from_raw_json_value, thirdparty::Medium};
-use serde::{de, ser::SerializeStruct, Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, de, ser::SerializeStruct};
 use serde_json::value::RawValue as RawJsonValue;
 
 use super::{CustomThirdPartyId, UserIdentifier};

--- a/crates/ruma-client-api/src/user_directory/search_users.rs
+++ b/crates/ruma-client-api/src/user_directory/search_users.rs
@@ -8,10 +8,11 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3user_directorysearch
 
     use http::header::ACCEPT_LANGUAGE;
-    use js_int::{uint, UInt};
+    use js_int::{UInt, uint};
     use ruma_common::{
+        OwnedMxcUri, OwnedUserId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedMxcUri, OwnedUserId,
+        metadata,
     };
     use serde::{Deserialize, Serialize};
 

--- a/crates/ruma-client-api/tests/headers.rs
+++ b/crates/ruma-client-api/tests/headers.rs
@@ -2,7 +2,7 @@
 
 use http::HeaderMap;
 use ruma_client_api::discovery::discover_homeserver;
-use ruma_common::api::{auth_scheme::SendAccessToken, OutgoingRequest as _};
+use ruma_common::api::{OutgoingRequest as _, auth_scheme::SendAccessToken};
 
 #[test]
 fn get_request_headers() {

--- a/crates/ruma-client-api/tests/uiaa.rs
+++ b/crates/ruma-client-api/tests/uiaa.rs
@@ -8,8 +8,9 @@ use ruma_client_api::{
 };
 use ruma_common::api::{EndpointError, OutgoingResponse};
 use serde_json::{
-    from_slice as from_json_slice, from_str as from_json_str, from_value as from_json_value, json,
-    to_value as to_json_value, value::to_raw_value as to_raw_json_value, Value as JsonValue,
+    Value as JsonValue, from_slice as from_json_slice, from_str as from_json_str,
+    from_value as from_json_value, json, to_value as to_json_value,
+    value::to_raw_value as to_raw_json_value,
 };
 
 #[test]

--- a/crates/ruma-federation-api/Cargo.toml
+++ b/crates/ruma-federation-api/Cargo.toml
@@ -8,7 +8,7 @@ name = "ruma-federation-api"
 readme = "README.md"
 repository = "https://github.com/ruma/ruma"
 version = "0.12.0"
-edition = "2021"
+edition = "2024"
 rust-version = { workspace = true }
 
 [package.metadata.docs.rs]

--- a/crates/ruma-federation-api/src/authenticated_media.rs
+++ b/crates/ruma-federation-api/src/authenticated_media.rs
@@ -301,8 +301,8 @@ mod tests {
     use ruma_common::http_headers::{ContentDisposition, ContentDispositionType};
 
     use super::{
-        try_from_multipart_mixed_response, try_into_multipart_mixed_response, Content,
-        ContentMetadata, FileOrLocation,
+        Content, ContentMetadata, FileOrLocation, try_from_multipart_mixed_response,
+        try_into_multipart_mixed_response,
     };
 
     #[test]

--- a/crates/ruma-federation-api/src/authenticated_media/get_content/unstable.rs
+++ b/crates/ruma-federation-api/src/authenticated_media/get_content/unstable.rs
@@ -4,7 +4,7 @@
 
 use std::time::Duration;
 
-use ruma_common::api::{path_builder::SinglePath, request, Metadata};
+use ruma_common::api::{Metadata, path_builder::SinglePath, request};
 
 use crate::authenticated_media::{ContentMetadata, FileOrLocation};
 

--- a/crates/ruma-federation-api/src/authenticated_media/get_content_thumbnail/unstable.rs
+++ b/crates/ruma-federation-api/src/authenticated_media/get_content_thumbnail/unstable.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use js_int::UInt;
 use ruma_common::{
-    api::{path_builder::SinglePath, request, Metadata},
+    api::{Metadata, path_builder::SinglePath, request},
     media::Method,
 };
 

--- a/crates/ruma-federation-api/src/authentication.rs
+++ b/crates/ruma-federation-api/src/authentication.rs
@@ -6,10 +6,10 @@ use headers::authorization::Credentials;
 use http::HeaderValue;
 use http_auth::ChallengeParser;
 use ruma_common::{
+    CanonicalJsonObject, IdParseError, OwnedServerName, OwnedServerSigningKeyId, ServerName,
     api::auth_scheme::AuthScheme,
     http_headers::quote_ascii_string_if_required,
     serde::{Base64, Base64DecodeError},
-    CanonicalJsonObject, IdParseError, OwnedServerName, OwnedServerSigningKeyId, ServerName,
 };
 use ruma_signatures::{Ed25519KeyPair, KeyPair, PublicKeyMap};
 use thiserror::Error;
@@ -390,8 +390,8 @@ pub enum XMatrixVerificationError {
 
 #[cfg(test)]
 mod tests {
-    use headers::{authorization::Credentials, HeaderValue};
-    use ruma_common::{serde::Base64, OwnedServerName};
+    use headers::{HeaderValue, authorization::Credentials};
+    use ruma_common::{OwnedServerName, serde::Base64};
 
     use super::XMatrix;
 

--- a/crates/ruma-federation-api/src/authorization/get_event_authorization.rs
+++ b/crates/ruma-federation-api/src/authorization/get_event_authorization.rs
@@ -8,8 +8,9 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1event_authroomideventid
 
     use ruma_common::{
+        OwnedEventId, OwnedRoomId,
         api::{request, response},
-        metadata, OwnedEventId, OwnedRoomId,
+        metadata,
     };
     use serde_json::value::RawValue as RawJsonValue;
 

--- a/crates/ruma-federation-api/src/backfill/get_backfill.rs
+++ b/crates/ruma-federation-api/src/backfill/get_backfill.rs
@@ -9,8 +9,9 @@ pub mod v1 {
 
     use js_int::UInt;
     use ruma_common::{
+        MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedServerName,
         api::{request, response},
-        metadata, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedServerName,
+        metadata,
     };
     use serde_json::value::RawValue as RawJsonValue;
 

--- a/crates/ruma-federation-api/src/device/get_devices.rs
+++ b/crates/ruma-federation-api/src/device/get_devices.rs
@@ -9,11 +9,11 @@ pub mod v1 {
 
     use js_int::UInt;
     use ruma_common::{
+        OwnedDeviceId, OwnedUserId,
         api::{request, response},
         encryption::{CrossSigningKey, DeviceKeys},
         metadata,
         serde::Raw,
-        OwnedDeviceId, OwnedUserId,
     };
     use serde::{Deserialize, Serialize};
 

--- a/crates/ruma-federation-api/src/discovery.rs
+++ b/crates/ruma-federation-api/src/discovery.rs
@@ -3,8 +3,8 @@
 use std::collections::BTreeMap;
 
 use ruma_common::{
-    serde::Base64, MilliSecondsSinceUnixEpoch, OwnedServerName, OwnedServerSigningKeyId,
-    ServerSignatures,
+    MilliSecondsSinceUnixEpoch, OwnedServerName, OwnedServerSigningKeyId, ServerSignatures,
+    serde::Base64,
 };
 use serde::{Deserialize, Serialize};
 

--- a/crates/ruma-federation-api/src/discovery/discover_homeserver.rs
+++ b/crates/ruma-federation-api/src/discovery/discover_homeserver.rs
@@ -5,8 +5,9 @@
 //! [spec]: https://spec.matrix.org/latest/server-server-api/#getwell-knownmatrixserver
 
 use ruma_common::{
+    OwnedServerName,
     api::{auth_scheme::NoAuthentication, request, response},
-    metadata, OwnedServerName,
+    metadata,
 };
 
 metadata! {

--- a/crates/ruma-federation-api/src/discovery/get_remote_server_keys.rs
+++ b/crates/ruma-federation-api/src/discovery/get_remote_server_keys.rs
@@ -9,10 +9,10 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixkeyv2queryservername
 
     use ruma_common::{
+        MilliSecondsSinceUnixEpoch, OwnedServerName,
         api::{auth_scheme::NoAuthentication, request, response},
         metadata,
         serde::Raw,
-        MilliSecondsSinceUnixEpoch, OwnedServerName,
     };
 
     use crate::discovery::ServerSigningKeys;

--- a/crates/ruma-federation-api/src/discovery/get_remote_server_keys_batch.rs
+++ b/crates/ruma-federation-api/src/discovery/get_remote_server_keys_batch.rs
@@ -11,10 +11,10 @@ pub mod v2 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
+        MilliSecondsSinceUnixEpoch, OwnedServerName, OwnedServerSigningKeyId,
         api::{auth_scheme::NoAuthentication, request, response},
         metadata,
         serde::Raw,
-        MilliSecondsSinceUnixEpoch, OwnedServerName, OwnedServerSigningKeyId,
     };
     use serde::{Deserialize, Serialize};
 

--- a/crates/ruma-federation-api/src/event/get_event.rs
+++ b/crates/ruma-federation-api/src/event/get_event.rs
@@ -8,8 +8,9 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1eventeventid
 
     use ruma_common::{
+        MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedServerName,
         api::{request, response},
-        metadata, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedServerName,
+        metadata,
     };
     use serde_json::value::RawValue as RawJsonValue;
 

--- a/crates/ruma-federation-api/src/event/get_event_by_timestamp/unstable.rs
+++ b/crates/ruma-federation-api/src/event/get_event_by_timestamp/unstable.rs
@@ -3,8 +3,8 @@
 //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/3030
 
 use ruma_common::{
-    api::{path_builder::SinglePath, request, response, Direction, Metadata},
     MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId,
+    api::{Direction, Metadata, path_builder::SinglePath, request, response},
 };
 
 /// Request type for the `get_event_by_timestamp` endpoint.

--- a/crates/ruma-federation-api/src/event/get_event_by_timestamp/v1.rs
+++ b/crates/ruma-federation-api/src/event/get_event_by_timestamp/v1.rs
@@ -3,8 +3,9 @@
 //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1timestamp_to_eventroomid
 
 use ruma_common::{
-    api::{request, response, Direction},
-    metadata, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId,
+    MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId,
+    api::{Direction, request, response},
+    metadata,
 };
 
 use crate::authentication::ServerSignatures;

--- a/crates/ruma-federation-api/src/event/get_missing_events.rs
+++ b/crates/ruma-federation-api/src/event/get_missing_events.rs
@@ -7,10 +7,11 @@ pub mod v1 {
     //!
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#post_matrixfederationv1get_missing_eventsroomid
 
-    use js_int::{uint, UInt};
+    use js_int::{UInt, uint};
     use ruma_common::{
+        OwnedEventId, OwnedRoomId,
         api::{request, response},
-        metadata, OwnedEventId, OwnedRoomId,
+        metadata,
     };
     use serde_json::value::RawValue as RawJsonValue;
 

--- a/crates/ruma-federation-api/src/event/get_room_state.rs
+++ b/crates/ruma-federation-api/src/event/get_room_state.rs
@@ -8,8 +8,9 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1stateroomid
 
     use ruma_common::{
+        OwnedEventId, OwnedRoomId,
         api::{request, response},
-        metadata, OwnedEventId, OwnedRoomId,
+        metadata,
     };
     use serde_json::value::RawValue as RawJsonValue;
 

--- a/crates/ruma-federation-api/src/event/get_room_state_ids.rs
+++ b/crates/ruma-federation-api/src/event/get_room_state_ids.rs
@@ -8,8 +8,9 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1state_idsroomid
 
     use ruma_common::{
+        OwnedEventId, OwnedRoomId,
         api::{request, response},
-        metadata, OwnedEventId, OwnedRoomId,
+        metadata,
     };
 
     use crate::authentication::ServerSignatures;

--- a/crates/ruma-federation-api/src/keys/claim_keys.rs
+++ b/crates/ruma-federation-api/src/keys/claim_keys.rs
@@ -10,11 +10,11 @@ pub mod v1 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
+        OneTimeKeyAlgorithm, OwnedDeviceId, OwnedOneTimeKeyId, OwnedUserId,
         api::{request, response},
         encryption::OneTimeKey,
         metadata,
         serde::Raw,
-        OneTimeKeyAlgorithm, OwnedDeviceId, OwnedOneTimeKeyId, OwnedUserId,
     };
 
     use crate::authentication::ServerSignatures;

--- a/crates/ruma-federation-api/src/keys/get_keys.rs
+++ b/crates/ruma-federation-api/src/keys/get_keys.rs
@@ -10,11 +10,11 @@ pub mod v1 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
+        OwnedDeviceId, OwnedUserId,
         api::{request, response},
         encryption::{CrossSigningKey, DeviceKeys},
         metadata,
         serde::Raw,
-        OwnedDeviceId, OwnedUserId,
     };
 
     use crate::authentication::ServerSignatures;

--- a/crates/ruma-federation-api/src/membership.rs
+++ b/crates/ruma-federation-api/src/membership.rs
@@ -1,8 +1,8 @@
 //! Room membership endpoints.
 
-use ruma_common::serde::{from_raw_json_value, Raw};
+use ruma_common::serde::{Raw, from_raw_json_value};
 use ruma_events::AnyStrippedStateEvent;
-use serde::{de, Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de};
 use serde_json::value::RawValue as RawJsonValue;
 
 pub mod create_invite;
@@ -69,7 +69,7 @@ impl From<Raw<AnyStrippedStateEvent>> for RawStrippedState {
 mod tests {
     use assert_matches2::assert_matches;
     use ruma_common::{serde::Raw, user_id};
-    use ruma_events::{room::member::MembershipState, AnyStrippedStateEvent};
+    use ruma_events::{AnyStrippedStateEvent, room::member::MembershipState};
     use serde_json::{from_value as from_json_value, json};
 
     use super::RawStrippedState;

--- a/crates/ruma-federation-api/src/membership/create_invite/v1.rs
+++ b/crates/ruma-federation-api/src/membership/create_invite/v1.rs
@@ -3,10 +3,11 @@
 //! [spec]: https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv1inviteroomideventid
 
 use ruma_common::{
+    MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedServerName, OwnedUserId,
     api::{request, response},
-    metadata, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedServerName, OwnedUserId,
+    metadata,
 };
-use ruma_events::{room::member::RoomMemberEventContent, StateEventType};
+use ruma_events::{StateEventType, room::member::RoomMemberEventContent};
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue as RawJsonValue;
 

--- a/crates/ruma-federation-api/src/membership/create_invite/v2.rs
+++ b/crates/ruma-federation-api/src/membership/create_invite/v2.rs
@@ -5,8 +5,9 @@
 #[cfg(feature = "unstable-msc4125")]
 use ruma_common::OwnedServerName;
 use ruma_common::{
+    OwnedEventId, OwnedRoomId, RoomVersionId,
     api::{request, response},
-    metadata, OwnedEventId, OwnedRoomId, RoomVersionId,
+    metadata,
 };
 use serde_json::value::RawValue as RawJsonValue;
 

--- a/crates/ruma-federation-api/src/membership/create_join_event/v1.rs
+++ b/crates/ruma-federation-api/src/membership/create_join_event/v1.rs
@@ -3,8 +3,9 @@
 //! [spec]: https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv1send_joinroomideventid
 
 use ruma_common::{
+    OwnedEventId, OwnedRoomId,
     api::{request, response},
-    metadata, OwnedEventId, OwnedRoomId,
+    metadata,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue as RawJsonValue;

--- a/crates/ruma-federation-api/src/membership/create_join_event/v2.rs
+++ b/crates/ruma-federation-api/src/membership/create_join_event/v2.rs
@@ -3,8 +3,9 @@
 //! [spec]: https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv2send_joinroomideventid
 
 use ruma_common::{
+    OwnedEventId, OwnedRoomId,
     api::{request, response},
-    metadata, OwnedEventId, OwnedRoomId,
+    metadata,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue as RawJsonValue;

--- a/crates/ruma-federation-api/src/membership/create_knock_event/unstable.rs
+++ b/crates/ruma-federation-api/src/membership/create_knock_event/unstable.rs
@@ -3,8 +3,8 @@
 //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/2403
 
 use ruma_common::{
-    api::{path_builder::SinglePath, request, response, Metadata},
     OwnedEventId, OwnedRoomId,
+    api::{Metadata, path_builder::SinglePath, request, response},
 };
 use serde_json::value::RawValue as RawJsonValue;
 

--- a/crates/ruma-federation-api/src/membership/create_knock_event/v1.rs
+++ b/crates/ruma-federation-api/src/membership/create_knock_event/v1.rs
@@ -3,8 +3,9 @@
 //! [spec]: https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv1send_knockroomideventid
 
 use ruma_common::{
+    OwnedEventId, OwnedRoomId,
     api::{request, response},
-    metadata, OwnedEventId, OwnedRoomId,
+    metadata,
 };
 use serde_json::value::RawValue as RawJsonValue;
 

--- a/crates/ruma-federation-api/src/membership/create_leave_event/v1.rs
+++ b/crates/ruma-federation-api/src/membership/create_leave_event/v1.rs
@@ -3,8 +3,9 @@
 //! [spec]: https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv1send_leaveroomideventid
 
 use ruma_common::{
+    OwnedEventId, OwnedRoomId,
     api::{request, response},
-    metadata, OwnedEventId, OwnedRoomId,
+    metadata,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue as RawJsonValue;

--- a/crates/ruma-federation-api/src/membership/create_leave_event/v2.rs
+++ b/crates/ruma-federation-api/src/membership/create_leave_event/v2.rs
@@ -3,8 +3,9 @@
 //! [spec]: https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv2send_leaveroomideventid
 
 use ruma_common::{
+    OwnedEventId, OwnedRoomId,
     api::{request, response},
-    metadata, OwnedEventId, OwnedRoomId,
+    metadata,
 };
 use serde_json::value::RawValue as RawJsonValue;
 

--- a/crates/ruma-federation-api/src/membership/prepare_join_event.rs
+++ b/crates/ruma-federation-api/src/membership/prepare_join_event.rs
@@ -8,8 +8,9 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1make_joinroomiduserid
 
     use ruma_common::{
+        OwnedRoomId, OwnedUserId, RoomVersionId,
         api::{request, response},
-        metadata, OwnedRoomId, OwnedUserId, RoomVersionId,
+        metadata,
     };
     use serde_json::value::RawValue as RawJsonValue;
 

--- a/crates/ruma-federation-api/src/membership/prepare_knock_event/unstable.rs
+++ b/crates/ruma-federation-api/src/membership/prepare_knock_event/unstable.rs
@@ -3,8 +3,8 @@
 //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/2403
 
 use ruma_common::{
-    api::{path_builder::SinglePath, request, response, Metadata},
     OwnedRoomId, OwnedUserId, RoomVersionId,
+    api::{Metadata, path_builder::SinglePath, request, response},
 };
 use serde_json::value::RawValue as RawJsonValue;
 

--- a/crates/ruma-federation-api/src/membership/prepare_knock_event/v1.rs
+++ b/crates/ruma-federation-api/src/membership/prepare_knock_event/v1.rs
@@ -3,8 +3,9 @@
 //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1make_knockroomiduserid
 
 use ruma_common::{
+    OwnedRoomId, OwnedUserId, RoomVersionId,
     api::{request, response},
-    metadata, OwnedRoomId, OwnedUserId, RoomVersionId,
+    metadata,
 };
 use serde_json::value::RawValue as RawJsonValue;
 

--- a/crates/ruma-federation-api/src/membership/prepare_leave_event.rs
+++ b/crates/ruma-federation-api/src/membership/prepare_leave_event.rs
@@ -9,8 +9,9 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1make_leaveroomiduserid
 
     use ruma_common::{
+        OwnedRoomId, OwnedUserId, RoomVersionId,
         api::{request, response},
-        metadata, OwnedRoomId, OwnedUserId, RoomVersionId,
+        metadata,
     };
     use serde_json::value::RawValue as RawJsonValue;
 

--- a/crates/ruma-federation-api/src/openid/get_openid_userinfo.rs
+++ b/crates/ruma-federation-api/src/openid/get_openid_userinfo.rs
@@ -8,8 +8,9 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1openiduserinfo
 
     use ruma_common::{
+        OwnedUserId,
         api::{auth_scheme::NoAuthentication, request, response},
-        metadata, OwnedUserId,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-federation-api/src/query/get_profile_information.rs
+++ b/crates/ruma-federation-api/src/query/get_profile_information.rs
@@ -8,13 +8,13 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1queryprofile
 
     use ruma_common::{
+        OwnedMxcUri, OwnedUserId,
         api::{request, response},
         metadata,
         serde::StringEnum,
-        OwnedMxcUri, OwnedUserId,
     };
 
-    use crate::{authentication::ServerSignatures, PrivOwnedStr};
+    use crate::{PrivOwnedStr, authentication::ServerSignatures};
 
     metadata! {
         method: GET,

--- a/crates/ruma-federation-api/src/query/get_room_information.rs
+++ b/crates/ruma-federation-api/src/query/get_room_information.rs
@@ -8,8 +8,9 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1querydirectory
 
     use ruma_common::{
+        OwnedRoomAliasId, OwnedRoomId, OwnedServerName,
         api::{request, response},
-        metadata, OwnedRoomAliasId, OwnedRoomId, OwnedServerName,
+        metadata,
     };
 
     use crate::authentication::ServerSignatures;

--- a/crates/ruma-federation-api/src/room/report_content.rs
+++ b/crates/ruma-federation-api/src/room/report_content.rs
@@ -8,8 +8,9 @@ pub mod msc3843 {
     //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/3843
 
     use ruma_common::{
+        OwnedEventId, OwnedRoomId,
         api::{request, response},
-        metadata, OwnedEventId, OwnedRoomId,
+        metadata,
     };
 
     use crate::authentication::ServerSignatures;

--- a/crates/ruma-federation-api/src/serde/pdu_process_response.rs
+++ b/crates/ruma-federation-api/src/serde/pdu_process_response.rs
@@ -2,9 +2,9 @@ use std::{collections::BTreeMap, fmt};
 
 use ruma_common::OwnedEventId;
 use serde::{
+    Deserialize, Serialize,
     de::{Deserializer, MapAccess, Visitor},
     ser::{SerializeMap, Serializer},
-    Deserialize, Serialize,
 };
 
 #[derive(Deserialize, Serialize)]
@@ -68,7 +68,7 @@ where
 mod tests {
     use std::collections::BTreeMap;
 
-    use ruma_common::{event_id, owned_event_id, OwnedEventId};
+    use ruma_common::{OwnedEventId, event_id, owned_event_id};
     use serde_json::{json, value::Serializer as JsonSerializer};
 
     use super::{deserialize, serialize};

--- a/crates/ruma-federation-api/src/space.rs
+++ b/crates/ruma-federation-api/src/space.rs
@@ -2,7 +2,7 @@
 
 use ruma_common::{
     room::RoomSummary,
-    serde::{from_raw_json_value, Raw},
+    serde::{Raw, from_raw_json_value},
 };
 use ruma_events::space::child::HierarchySpaceChildEvent;
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-federation-api/src/space/get_hierarchy/unstable.rs
+++ b/crates/ruma-federation-api/src/space/get_hierarchy/unstable.rs
@@ -3,9 +3,9 @@
 //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/2946
 
 use ruma_common::{
-    api::{path_builder::SinglePath, request, response, Metadata},
-    room::RoomSummary,
     OwnedRoomId,
+    api::{Metadata, path_builder::SinglePath, request, response},
+    room::RoomSummary,
 };
 
 use crate::space::SpaceHierarchyParentSummary;

--- a/crates/ruma-federation-api/src/space/get_hierarchy/v1.rs
+++ b/crates/ruma-federation-api/src/space/get_hierarchy/v1.rs
@@ -3,10 +3,10 @@
 //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1hierarchyroomid
 
 use ruma_common::{
+    OwnedRoomId,
     api::{request, response},
     metadata,
     room::RoomSummary,
-    OwnedRoomId,
 };
 
 use crate::{authentication::ServerSignatures, space::SpaceHierarchyParentSummary};
@@ -67,7 +67,7 @@ impl Response {
 
 #[cfg(all(test, feature = "client"))]
 mod tests {
-    use ruma_common::{api::IncomingResponse, OwnedRoomId};
+    use ruma_common::{OwnedRoomId, api::IncomingResponse};
     use serde_json::{json, to_vec as to_json_vec};
 
     use super::Response;

--- a/crates/ruma-federation-api/src/thirdparty/bind_callback.rs
+++ b/crates/ruma-federation-api/src/thirdparty/bind_callback.rs
@@ -10,11 +10,11 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv13pidonbind
 
     use ruma_common::{
+        OwnedRoomId, OwnedUserId,
         api::{auth_scheme::NoAuthentication, request, response},
         metadata,
         serde::Raw,
         thirdparty::Medium,
-        OwnedRoomId, OwnedUserId,
     };
     use ruma_events::room::member::SignedContent;
     use serde::{Deserialize, Serialize};

--- a/crates/ruma-federation-api/src/thirdparty/exchange_invite.rs
+++ b/crates/ruma-federation-api/src/thirdparty/exchange_invite.rs
@@ -12,17 +12,17 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv1exchange_third_party_inviteroomid
 
     use ruma_common::{
+        OwnedRoomId, OwnedUserId,
         api::{request, response},
         metadata,
         serde::Raw,
-        OwnedRoomId, OwnedUserId,
     };
     use ruma_events::{
+        StateEventType,
         room::{
             member::{MembershipState, RoomMemberEventContent, ThirdPartyInvite},
             third_party_invite::RoomThirdPartyInviteEventContent,
         },
-        StateEventType,
     };
 
     use crate::{authentication::ServerSignatures, thirdparty::bind_callback};

--- a/crates/ruma-federation-api/src/transactions/edu.rs
+++ b/crates/ruma-federation-api/src/transactions/edu.rs
@@ -4,15 +4,15 @@ use std::collections::BTreeMap;
 
 use js_int::UInt;
 use ruma_common::{
+    OwnedDeviceId, OwnedEventId, OwnedRoomId, OwnedTransactionId, OwnedUserId,
     encryption::{CrossSigningKey, DeviceKeys},
     presence::PresenceState,
-    serde::{from_raw_json_value, Raw},
+    serde::{Raw, from_raw_json_value},
     to_device::DeviceIdOrAllDevices,
-    OwnedDeviceId, OwnedEventId, OwnedRoomId, OwnedTransactionId, OwnedUserId,
 };
-use ruma_events::{receipt::Receipt, AnyToDeviceEventContent, ToDeviceEventType};
-use serde::{de, Deserialize, Serialize};
-use serde_json::{value::RawValue as RawJsonValue, Value as JsonValue};
+use ruma_events::{AnyToDeviceEventContent, ToDeviceEventType, receipt::Receipt};
+use serde::{Deserialize, Serialize, de};
+use serde_json::{Value as JsonValue, value::RawValue as RawJsonValue};
 
 /// Type for passing ephemeral data to homeservers.
 #[derive(Clone, Debug, Serialize)]

--- a/crates/ruma-federation-api/src/transactions/send_transaction_message.rs
+++ b/crates/ruma-federation-api/src/transactions/send_transaction_message.rs
@@ -10,10 +10,10 @@ pub mod v1 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
+        MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedServerName, OwnedTransactionId,
         api::{request, response},
         metadata,
         serde::Raw,
-        MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedServerName, OwnedTransactionId,
     };
     use serde_json::value::RawValue as RawJsonValue;
 

--- a/crates/ruma-federation-api/tests/it/authentication.rs
+++ b/crates/ruma-federation-api/tests/it/authentication.rs
@@ -2,10 +2,11 @@
 
 use js_int::uint;
 use ruma_common::{
-    api::{auth_scheme::AuthScheme, OutgoingRequest},
+    MilliSecondsSinceUnixEpoch,
+    api::{OutgoingRequest, auth_scheme::AuthScheme},
     owned_server_name,
     serde::Base64,
-    server_name, MilliSecondsSinceUnixEpoch,
+    server_name,
 };
 use ruma_federation_api::{
     authentication::{ServerSignatures, ServerSignaturesInput},

--- a/crates/ruma-federation-api/tests/it/membership/create_join_event.rs
+++ b/crates/ruma-federation-api/tests/it/membership/create_join_event.rs
@@ -3,7 +3,7 @@
 mod v1 {
     use ruma_common::api::OutgoingResponse;
     use ruma_federation_api::membership::create_join_event::v1::{Response, RoomState};
-    use serde_json::{from_slice as from_json_slice, json, Value as JsonValue};
+    use serde_json::{Value as JsonValue, from_slice as from_json_slice, json};
 
     #[test]
     fn response_body() {

--- a/crates/ruma-identity-service-api/Cargo.toml
+++ b/crates/ruma-identity-service-api/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["matrix", "chat", "messaging", "ruma"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/ruma/ruma"
-edition = "2021"
+edition = "2024"
 rust-version = { workspace = true }
 
 [package.metadata.docs.rs]

--- a/crates/ruma-identity-service-api/src/association/bind_3pid.rs
+++ b/crates/ruma-identity-service-api/src/association/bind_3pid.rs
@@ -8,11 +8,11 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/identity-service-api/#post_matrixidentityv23pidbind
 
     use ruma_common::{
+        MilliSecondsSinceUnixEpoch, OwnedClientSecret, OwnedSessionId, OwnedUserId,
+        ServerSignatures,
         api::{auth_scheme::AccessToken, request, response},
         metadata,
         thirdparty::Medium,
-        MilliSecondsSinceUnixEpoch, OwnedClientSecret, OwnedSessionId, OwnedUserId,
-        ServerSignatures,
     };
 
     metadata! {

--- a/crates/ruma-identity-service-api/src/association/check_3pid_validity.rs
+++ b/crates/ruma-identity-service-api/src/association/check_3pid_validity.rs
@@ -9,10 +9,10 @@ pub mod v2 {
 
     use js_int::UInt;
     use ruma_common::{
+        OwnedClientSecret, OwnedSessionId,
         api::{auth_scheme::AccessToken, request, response},
         metadata,
         thirdparty::Medium,
-        OwnedClientSecret, OwnedSessionId,
     };
 
     metadata! {

--- a/crates/ruma-identity-service-api/src/association/email/create_email_validation_session.rs
+++ b/crates/ruma-identity-service-api/src/association/email/create_email_validation_session.rs
@@ -9,8 +9,9 @@ pub mod v2 {
 
     use js_int::UInt;
     use ruma_common::{
+        OwnedClientSecret, OwnedSessionId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedClientSecret, OwnedSessionId,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-identity-service-api/src/association/email/validate_email.rs
+++ b/crates/ruma-identity-service-api/src/association/email/validate_email.rs
@@ -8,8 +8,9 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/identity-service-api/#post_matrixidentityv2validateemailsubmittoken
 
     use ruma_common::{
+        OwnedClientSecret, OwnedSessionId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedClientSecret, OwnedSessionId,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-identity-service-api/src/association/email/validate_email_by_end_user.rs
+++ b/crates/ruma-identity-service-api/src/association/email/validate_email_by_end_user.rs
@@ -8,8 +8,9 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/identity-service-api/#get_matrixidentityv2validateemailsubmittoken
 
     use ruma_common::{
+        OwnedClientSecret, OwnedSessionId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedClientSecret, OwnedSessionId,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-identity-service-api/src/association/msisdn/create_msisdn_validation_session.rs
+++ b/crates/ruma-identity-service-api/src/association/msisdn/create_msisdn_validation_session.rs
@@ -9,8 +9,9 @@ pub mod v2 {
 
     use js_int::UInt;
     use ruma_common::{
+        OwnedClientSecret, OwnedSessionId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedClientSecret, OwnedSessionId,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-identity-service-api/src/association/msisdn/validate_msisdn.rs
+++ b/crates/ruma-identity-service-api/src/association/msisdn/validate_msisdn.rs
@@ -8,8 +8,9 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/identity-service-api/#post_matrixidentityv2validatemsisdnsubmittoken
 
     use ruma_common::{
+        OwnedClientSecret, OwnedSessionId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedClientSecret, OwnedSessionId,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-identity-service-api/src/association/msisdn/validate_msisdn_by_phone_number.rs
+++ b/crates/ruma-identity-service-api/src/association/msisdn/validate_msisdn_by_phone_number.rs
@@ -8,8 +8,9 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/identity-service-api/#get_matrixidentityv2validatemsisdnsubmittoken
 
     use ruma_common::{
+        OwnedClientSecret, OwnedSessionId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedClientSecret, OwnedSessionId,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-identity-service-api/src/association/unbind_3pid.rs
+++ b/crates/ruma-identity-service-api/src/association/unbind_3pid.rs
@@ -8,10 +8,10 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/identity-service-api/#post_matrixidentityv23pidunbind
 
     use ruma_common::{
+        OwnedClientSecret, OwnedSessionId, OwnedUserId,
         api::{auth_scheme::AccessToken, request, response},
         metadata,
         thirdparty::Medium,
-        OwnedClientSecret, OwnedSessionId, OwnedUserId,
     };
     use serde::{Deserialize, Serialize};
 

--- a/crates/ruma-identity-service-api/src/authentication/get_account_information.rs
+++ b/crates/ruma-identity-service-api/src/authentication/get_account_information.rs
@@ -8,8 +8,9 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/identity-service-api/#get_matrixidentityv2account
 
     use ruma_common::{
+        OwnedUserId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedUserId,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-identity-service-api/src/authentication/register.rs
+++ b/crates/ruma-identity-service-api/src/authentication/register.rs
@@ -10,9 +10,10 @@ pub mod v2 {
     use std::time::Duration;
 
     use ruma_common::{
+        OwnedServerName,
         api::{auth_scheme::NoAuthentication, request, response},
         authentication::TokenType,
-        metadata, OwnedServerName,
+        metadata,
     };
 
     metadata! {

--- a/crates/ruma-identity-service-api/src/discovery/get_supported_versions.rs
+++ b/crates/ruma-identity-service-api/src/discovery/get_supported_versions.rs
@@ -13,7 +13,7 @@
 use std::collections::BTreeMap;
 
 use ruma_common::{
-    api::{auth_scheme::NoAuthentication, request, response, SupportedVersions},
+    api::{SupportedVersions, auth_scheme::NoAuthentication, request, response},
     metadata,
 };
 

--- a/crates/ruma-identity-service-api/src/invitation/sign_invitation_ed25519.rs
+++ b/crates/ruma-identity-service-api/src/invitation/sign_invitation_ed25519.rs
@@ -8,10 +8,10 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/identity-service-api/#post_matrixidentityv2sign-ed25519
 
     use ruma_common::{
+        OwnedUserId, ServerSignatures,
         api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::Base64,
-        OwnedUserId, ServerSignatures,
     };
 
     metadata! {

--- a/crates/ruma-identity-service-api/src/invitation/store_invitation.rs
+++ b/crates/ruma-identity-service-api/src/invitation/store_invitation.rs
@@ -8,15 +8,15 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/identity-service-api/#post_matrixidentityv2store-invite
 
     use ruma_common::{
+        OwnedMxcUri, OwnedRoomAliasId, OwnedRoomId, OwnedUserId,
         api::{auth_scheme::AccessToken, request, response},
         metadata,
         room::RoomType,
         third_party_invite::IdentityServerBase64PublicKey,
         thirdparty::Medium,
-        OwnedMxcUri, OwnedRoomAliasId, OwnedRoomId, OwnedUserId,
     };
     use ruma_events::room::third_party_invite::RoomThirdPartyInviteEventContent;
-    use serde::{ser::SerializeSeq, Deserialize, Serialize};
+    use serde::{Deserialize, Serialize, ser::SerializeSeq};
 
     metadata! {
         method: POST,

--- a/crates/ruma-identity-service-api/src/keys/get_public_key.rs
+++ b/crates/ruma-identity-service-api/src/keys/get_public_key.rs
@@ -8,10 +8,10 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/identity-service-api/#get_matrixidentityv2pubkeykeyid
 
     use ruma_common::{
+        OwnedServerSigningKeyId,
         api::{auth_scheme::NoAuthentication, request, response},
         metadata,
         third_party_invite::IdentityServerBase64PublicKey,
-        OwnedServerSigningKeyId,
     };
 
     metadata! {

--- a/crates/ruma-identity-service-api/src/lookup/lookup_3pid.rs
+++ b/crates/ruma-identity-service-api/src/lookup/lookup_3pid.rs
@@ -10,8 +10,9 @@ pub mod v2 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
+        OwnedUserId,
         api::{auth_scheme::AccessToken, request, response},
-        metadata, OwnedUserId,
+        metadata,
     };
 
     use crate::lookup::IdentifierHashingAlgorithm;

--- a/crates/ruma-push-gateway-api/Cargo.toml
+++ b/crates/ruma-push-gateway-api/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["matrix", "chat", "messaging", "ruma"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/ruma/ruma"
-edition = "2021"
+edition = "2024"
 rust-version = { workspace = true }
 
 [package.metadata.docs.rs]

--- a/crates/ruma-push-gateway-api/src/send_event_notification.rs
+++ b/crates/ruma-push-gateway-api/src/send_event_notification.rs
@@ -7,13 +7,13 @@ pub mod v1 {
     //!
     //! [spec]: https://spec.matrix.org/latest/push-gateway-api/#post_matrixpushv1notify
 
-    use js_int::{uint, UInt};
+    use js_int::{UInt, uint};
     use ruma_common::{
+        OwnedEventId, OwnedRoomAliasId, OwnedRoomId, OwnedUserId, SecondsSinceUnixEpoch,
         api::{auth_scheme::NoAuthentication, request, response},
         metadata,
         push::{PushFormat, Tweak},
         serde::{JsonObject, StringEnum},
-        OwnedEventId, OwnedRoomAliasId, OwnedRoomId, OwnedUserId, SecondsSinceUnixEpoch,
     };
     use ruma_events::TimelineEventType;
     use serde::{Deserialize, Serialize};
@@ -272,9 +272,9 @@ pub mod v1 {
 
         use ruma_common::push::Tweak;
         use serde::{
+            Deserializer, Serializer,
             de::{MapAccess, Visitor},
             ser::SerializeMap,
-            Deserializer, Serializer,
         };
 
         pub(super) fn serialize<S>(tweak: &[Tweak], serializer: S) -> Result<S::Ok, S::Error>
@@ -344,12 +344,12 @@ pub mod v1 {
     mod tests {
         use js_int::uint;
         use ruma_common::{
-            owned_event_id, owned_room_alias_id, owned_room_id, owned_user_id,
-            SecondsSinceUnixEpoch,
+            SecondsSinceUnixEpoch, owned_event_id, owned_room_alias_id, owned_room_id,
+            owned_user_id,
         };
         use ruma_events::TimelineEventType;
         use serde_json::{
-            from_value as from_json_value, json, to_value as to_json_value, Value as JsonValue,
+            Value as JsonValue, from_value as from_json_value, json, to_value as to_json_value,
         };
 
         use super::{Device, Notification, NotificationCounts, NotificationPriority, Tweak};


### PR DESCRIPTION
I ran `cargo fix --edition` for each of the crates before updating the `edition` field in `Cargo.toml`, but no changes were made. All source file changes were done by `cargo fmt`.