### PR TITLE
Update even more crates to Rust 2024

### DIFF
--- a/crates/ruma-html/Cargo.toml
+++ b/crates/ruma-html/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["matrix", "ruma", "html", "parser"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/ruma/ruma"
-edition = "2021"
+edition = "2024"
 rust-version = { workspace = true }
 
 [package.metadata.docs.rs]

--- a/crates/ruma-html/src/html.rs
+++ b/crates/ruma-html/src/html.rs
@@ -438,8 +438,7 @@ impl NodeRef {
     pub fn next_sibling(&self) -> Option<NodeRef> {
         let (parent, index) = self.parent_and_index()?;
         let index = index.checked_add(1)?;
-        let sibling = parent.0.children.borrow().get(index).cloned();
-        sibling
+        parent.0.children.borrow().get(index).cloned()
     }
 
     /// The previous sibling node of this node.
@@ -448,8 +447,7 @@ impl NodeRef {
     pub fn prev_sibling(&self) -> Option<NodeRef> {
         let (parent, index) = self.parent_and_index()?;
         let index = index.checked_sub(1)?;
-        let sibling = parent.0.children.borrow().get(index).cloned();
-        sibling
+        parent.0.children.borrow().get(index).cloned()
     }
 
     /// Whether this node has children.

--- a/crates/ruma-signatures/Cargo.toml
+++ b/crates/ruma-signatures/Cargo.toml
@@ -8,7 +8,7 @@ name = "ruma-signatures"
 readme = "README.md"
 repository = "https://github.com/ruma/ruma"
 version = "0.18.0"
-edition = "2021"
+edition = "2024"
 rust-version = { workspace = true }
 
 [package.metadata.docs.rs]

--- a/crates/ruma-signatures/Cargo.toml
+++ b/crates/ruma-signatures/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/ruma/ruma"
 version = "0.18.0"
 edition = "2021"
+rust-version = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/ruma-signatures/src/verification.rs
+++ b/crates/ruma-signatures/src/verification.rs
@@ -65,7 +65,9 @@ pub enum Verified {
 }
 
 /// Get the verifier for the given algorithm, if it is supported.
-pub(crate) fn verifier_from_algorithm(algorithm: &SigningKeyAlgorithm) -> Option<impl Verifier> {
+pub(crate) fn verifier_from_algorithm(
+    algorithm: &SigningKeyAlgorithm,
+) -> Option<impl Verifier + use<>> {
     match algorithm {
         SigningKeyAlgorithm::Ed25519 => Some(Ed25519Verifier),
         _ => None,

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xtask"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 
 [features]

--- a/xtask/src/release.rs
+++ b/xtask/src/release.rs
@@ -378,10 +378,10 @@ impl VersionExt for Version {
     }
 
     fn increment_pre_number(&mut self) {
-        if let Some((prefix, num)) = self.pre.as_str().rsplit_once('.') {
-            if let Ok(num) = num.parse::<u8>() {
-                self.pre = semver::Prerelease::new(&format!("{prefix}.{}", num + 1)).unwrap();
-            }
+        if let Some((prefix, num)) = self.pre.as_str().rsplit_once('.')
+            && let Ok(num) = num.parse::<u8>()
+        {
+            self.pre = semver::Prerelease::new(&format!("{prefix}.{}", num + 1)).unwrap();
         }
     }
 


### PR DESCRIPTION
After this, only `ruma-events` and `ruma-macros` remain. For `ruma-events`, the upgrade makes a function no longer compile in a way that I didn't immediately find a fix for. For `ruma-macros`, all the API crates start reporting errors with the upgrade and I haven't investigated closely yet.