### PR TITLE
api: Fix docs

### DIFF
--- a/crates/ruma-common/src/api.rs
+++ b/crates/ruma-common/src/api.rs
@@ -270,15 +270,22 @@ pub trait OutgoingRequest: Metadata + Clone {
 
     /// Tries to convert this request into an `http::Request`.
     ///
-    /// On endpoints with authentication, when adequate information isn't provided through
-    /// `authentication_input`, this could result in an error. It may also fail with a serialization
-    /// error in case of bugs in Ruma though.
-    ///
-    /// It may also fail if the `PathData::make_endpoint_url()` implementation returns an error.
-    ///
     /// The endpoints path will be appended to the given `base_url`, for example
     /// `https://matrix.org`. Since all paths begin with a slash, it is not necessary for the
     /// `base_url` to have a trailing slash. If it has one however, it will be ignored.
+    ///
+    /// ## Errors
+    ///
+    /// This method can return an error in the following cases:
+    ///
+    /// * On endpoints that require authentication, when adequate information isn't provided through
+    ///   `authentication_input`, i.e. when [`AuthScheme::add_authentication()`] returns an error.
+    /// * On endpoints that have several versions for the path, when there are no supported versions
+    ///   for the endpoint, i.e. when [`PathBuilder::make_endpoint_url()`] returns an error.
+    /// * If the request serialization fails, which should only happen in case of bugs in Ruma.
+    ///
+    /// [`AuthScheme::add_authentication()`]: auth_scheme::AuthScheme::add_authentication
+    /// [`PathBuilder::make_endpoint_url()`]: path_builder::PathBuilder::make_endpoint_url
     fn try_into_http_request<T: Default + BufMut + AsRef<[u8]>>(
         self,
         base_url: &str,

--- a/crates/ruma-common/src/api/error.rs
+++ b/crates/ruma-common/src/api/error.rs
@@ -351,8 +351,10 @@ impl fmt::Display for UnknownVersionError {
 
 impl StdError for UnknownVersionError {}
 
-/// An error that happens when an incorrect amount of arguments have been passed to PathData parts
-/// formatting.
+/// An error that happens when an incorrect amount of arguments have been passed to [`PathBuilder`]
+/// parts formatting.
+///
+/// [`PathBuilder`]: super::path_builder::PathBuilder
 #[derive(Debug)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct IncorrectArgumentCount {


### PR DESCRIPTION
`PathData` was the first name I found for `PathBuilder`, but there were still a few references to it in the docs. This changes those references to links, to make sure this doesn't happen again.

This also clarifies the error cases for `OutgoingRequest::try_into_http_request()`.

