### PR TITLE
api: Run rustfmt on trybuild tests

### DIFF
--- a/crates/ruma-common/tests/it/api/ui/api-single-path-check.rs
+++ b/crates/ruma-common/tests/it/api/ui/api-single-path-check.rs
@@ -1,7 +1,7 @@
 #![allow(unexpected_cfgs)]
 
 use ruma_common::{
-    api::{auth_scheme::AccessToken, path_builder::PathBuilder, request, response, Metadata},
+    api::{Metadata, auth_scheme::AccessToken, path_builder::PathBuilder, request, response},
     metadata,
 };
 

--- a/crates/ruma-common/tests/it/api/ui/api-version-history-check.rs
+++ b/crates/ruma-common/tests/it/api/ui/api-version-history-check.rs
@@ -5,9 +5,10 @@ use std::borrow::Cow;
 use http::header::CONTENT_TYPE;
 use ruma_common::{
     api::{
+        MatrixVersion, Metadata, SupportedVersions,
         auth_scheme::NoAuthentication,
         path_builder::{PathBuilder, StablePathSelector},
-        request, response, MatrixVersion, Metadata, SupportedVersions,
+        request, response,
     },
     metadata,
     serde::Raw,

--- a/crates/ruma-common/tests/it/api/ui/move-value.rs
+++ b/crates/ruma-common/tests/it/api/ui/move-value.rs
@@ -5,8 +5,9 @@
 pub mod newtype_body {
     use http::header::CONTENT_TYPE;
     use ruma_common::{
+        OwnedUserId,
         api::{auth_scheme::NoAuthentication, request, response},
-        metadata, OwnedUserId,
+        metadata,
     };
 
     #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
@@ -51,8 +52,9 @@ pub mod newtype_body {
 pub mod raw_body {
     use http::header::CONTENT_TYPE;
     use ruma_common::{
+        OwnedUserId,
         api::{auth_scheme::NoAuthentication, request, response},
-        metadata, OwnedUserId,
+        metadata,
     };
 
     metadata! {
@@ -94,8 +96,9 @@ pub mod raw_body {
 pub mod plain {
     use http::header::CONTENT_TYPE;
     use ruma_common::{
+        OwnedUserId,
         api::{auth_scheme::NoAuthentication, request, response},
-        metadata, OwnedUserId,
+        metadata,
     };
 
     #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]

--- a/crates/ruma-common/tests/it/api/ui/request-only.rs
+++ b/crates/ruma-common/tests/it/api/ui/request-only.rs
@@ -3,9 +3,10 @@
 use bytes::BufMut;
 use ruma_common::{
     api::{
+        IncomingResponse, OutgoingResponse,
         auth_scheme::NoAuthentication,
         error::{FromHttpResponseError, IntoHttpError, MatrixError},
-        request, IncomingResponse, OutgoingResponse,
+        request,
     },
     metadata,
 };


### PR DESCRIPTION
Because they are not properly included in the module hierarchy, `cargo fmt` doesn't check them by default so we use `rustfmt` directly to check the files by path.

I tried to apply this to all trybuild tests in the repo, but only those had changes.