### PR TITLE
api: Add AppserviceUserIdentity::maybe_add_to_uri()

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -1,5 +1,12 @@
 # [unreleased]
 
+Improvements:
+
+- Add `AppserviceUserIdentity::maybe_add_to_uri()` to add an identity
+  assertion to an `http::Uri`. This allows to reimplement the behavior of
+  `OutgoingRequestAppserviceExt::try_into_http_request_with_identity()` outside
+  of Ruma, if using this trait is inconvenient.
+
 # 0.17.0
 
 Breaking changes:


### PR DESCRIPTION
To add an identity assertion to an `http::Uri`. This allows to reimplement the behavior of
`OutgoingRequestAppserviceExt::try_into_http_request_with_identity()` outside of Ruma, if using this trait is inconvenient.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
