### PR TITLE
ci: Check API client and server features independently

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,14 @@ jobs:
             cmd: clippy-default
             components: clippy
 
+          - name: Clippy Client API Features
+            cmd: clippy-api-client
+            components: clippy
+
+          - name: Clippy Server API Features
+            cmd: clippy-api-server
+            components: clippy
+
           - name: Clippy All Features
             cmd: clippy-all
             components: clippy

--- a/crates/ruma-client-api/src/context/get_context.rs
+++ b/crates/ruma-client-api/src/context/get_context.rs
@@ -108,6 +108,7 @@ pub mod v3 {
         uint!(10)
     }
 
+    #[cfg(feature = "client")]
     #[allow(clippy::trivially_copy_pass_by_ref)]
     fn is_default_limit(val: &UInt) -> bool {
         *val == default_limit()

--- a/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
+++ b/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
@@ -9,7 +9,7 @@ pub mod v3 {
 
     use ruma_common::{
         OwnedRoomId, OwnedRoomOrAliasId, OwnedServerName,
-        api::{Metadata, auth_scheme::AccessToken, response},
+        api::{auth_scheme::AccessToken, response},
         metadata,
     };
 
@@ -91,7 +91,7 @@ pub mod v3 {
             access_token: ruma_common::api::auth_scheme::SendAccessToken<'_>,
             considering: std::borrow::Cow<'_, ruma_common::api::SupportedVersions>,
         ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
-            use ruma_common::api::auth_scheme::AuthScheme;
+            use ruma_common::api::{Metadata, auth_scheme::AuthScheme};
 
             // Only send `server_name` if the `via` parameter is not supported by the server.
             // `via` was introduced in Matrix 1.12.
@@ -194,22 +194,19 @@ pub mod v3 {
         }
     }
 
-    #[cfg(all(test, any(feature = "client", feature = "server")))]
-    mod tests {
-        #[cfg(feature = "client")]
+    #[cfg(all(test, feature = "client"))]
+    mod tests_client {
         use std::borrow::Cow;
 
         use ruma_common::{
             api::{
-                IncomingRequest as _, MatrixVersion, OutgoingRequest, SupportedVersions,
-                auth_scheme::SendAccessToken,
+                MatrixVersion, OutgoingRequest, SupportedVersions, auth_scheme::SendAccessToken,
             },
             owned_room_id, owned_server_name,
         };
 
         use super::Request;
 
-        #[cfg(feature = "client")]
         #[test]
         fn serialize_request_via_and_server_name() {
             let mut req = Request::new(owned_room_id!("!foo:b.ar").into());
@@ -229,7 +226,6 @@ pub mod v3 {
             assert_eq!(req.uri().query(), Some("via=f.oo&server_name=f.oo"));
         }
 
-        #[cfg(feature = "client")]
         #[test]
         fn serialize_request_only_via() {
             let mut req = Request::new(owned_room_id!("!foo:b.ar").into());
@@ -248,8 +244,14 @@ pub mod v3 {
                 .unwrap();
             assert_eq!(req.uri().query(), Some("via=f.oo"));
         }
+    }
 
-        #[cfg(feature = "server")]
+    #[cfg(all(test, feature = "server"))]
+    mod tests_server {
+        use ruma_common::{api::IncomingRequest as _, owned_server_name};
+
+        use super::Request;
+
         #[test]
         fn deserialize_request_wrong_method() {
             Request::try_from_http_request(
@@ -263,7 +265,6 @@ pub mod v3 {
             .expect_err("Should not deserialize request with illegal method");
         }
 
-        #[cfg(feature = "server")]
         #[test]
         fn deserialize_request_only_via() {
             let req = Request::try_from_http_request(
@@ -281,7 +282,6 @@ pub mod v3 {
             assert_eq!(req.via, vec![owned_server_name!("f.oo")]);
         }
 
-        #[cfg(feature = "server")]
         #[test]
         fn deserialize_request_only_server_name() {
             let req = Request::try_from_http_request(
@@ -299,7 +299,6 @@ pub mod v3 {
             assert_eq!(req.via, vec![owned_server_name!("f.oo")]);
         }
 
-        #[cfg(feature = "server")]
         #[test]
         fn deserialize_request_via_and_server_name() {
             let req = Request::try_from_http_request(

--- a/crates/ruma-client-api/src/message/get_message_events.rs
+++ b/crates/ruma-client-api/src/message/get_message_events.rs
@@ -165,6 +165,7 @@ pub mod v3 {
         uint!(10)
     }
 
+    #[cfg(feature = "client")]
     #[allow(clippy::trivially_copy_pass_by_ref)]
     fn is_default_limit(val: &UInt) -> bool {
         *val == default_limit()

--- a/crates/ruma-client-api/src/profile.rs
+++ b/crates/ruma-client-api/src/profile.rs
@@ -2,14 +2,12 @@
 
 use std::borrow::Cow;
 
-use ruma_common::{
-    OwnedMxcUri,
-    api::{
-        MatrixVersion,
-        path_builder::{StablePathSelector, VersionHistory},
-    },
-    serde::StringEnum,
+#[cfg(feature = "client")]
+use ruma_common::api::{
+    MatrixVersion,
+    path_builder::{StablePathSelector, VersionHistory},
 };
+use ruma_common::{OwnedMxcUri, serde::StringEnum};
 use serde::Serialize;
 use serde_json::{Value as JsonValue, from_value as from_json_value, to_value as to_json_value};
 
@@ -52,6 +50,7 @@ pub enum ProfileFieldName {
 impl ProfileFieldName {
     /// Whether this field name existed already before custom fields were officially supported in
     /// profiles.
+    #[cfg(feature = "client")]
     fn existed_before_extended_profiles(&self) -> bool {
         matches!(self, Self::AvatarUrl | Self::DisplayName)
     }
@@ -142,6 +141,7 @@ pub struct CustomProfileFieldValue {
 }
 
 /// Endpoint version history valid only for profile fields that didn't exist before Matrix 1.16.
+#[cfg(feature = "client")]
 const EXTENDED_PROFILE_FIELD_HISTORY: VersionHistory = VersionHistory::new(
     &[(
         Some("uk.tcpip.msc4133"),

--- a/crates/ruma-client-api/src/profile/get_profile.rs
+++ b/crates/ruma-client-api/src/profile/get_profile.rs
@@ -135,17 +135,15 @@ pub mod v3 {
 
 #[cfg(test)]
 mod tests {
-    use ruma_common::owned_mxc_uri;
-    use serde_json::{
-        Value as JsonValue, from_slice as from_json_slice, json, to_vec as to_json_vec,
-    };
+    use serde_json::json;
 
     use super::v3::Response;
 
     #[test]
     #[cfg(feature = "server")]
     fn serialize_response() {
-        use ruma_common::api::OutgoingResponse;
+        use ruma_common::{api::OutgoingResponse, owned_mxc_uri};
+        use serde_json::{Value as JsonValue, from_slice as from_json_slice};
 
         use crate::profile::ProfileFieldValue;
 
@@ -173,6 +171,7 @@ mod tests {
     #[cfg(feature = "client")]
     fn deserialize_response() {
         use ruma_common::api::IncomingResponse;
+        use serde_json::to_vec as to_json_vec;
 
         use crate::profile::{AvatarUrl, DisplayName};
 

--- a/crates/ruma-client-api/src/profile/profile_field_serde.rs
+++ b/crates/ruma-client-api/src/profile/profile_field_serde.rs
@@ -1,13 +1,17 @@
-use std::{borrow::Cow, fmt, marker::PhantomData};
+use std::fmt;
 
 use serde::{Deserialize, Serialize, Serializer, de, ser::SerializeMap};
 
-use super::{CustomProfileFieldValue, ProfileFieldName, ProfileFieldValue, StaticProfileField};
+use super::{CustomProfileFieldValue, ProfileFieldName, ProfileFieldValue};
 
 /// Helper type to deserialize any type that implements [`StaticProfileField`].
-pub(super) struct StaticProfileFieldVisitor<F: StaticProfileField>(pub(super) PhantomData<F>);
+#[cfg(feature = "client")]
+pub(super) struct StaticProfileFieldVisitor<F: super::StaticProfileField>(
+    pub(super) std::marker::PhantomData<F>,
+);
 
-impl<'de, F: StaticProfileField> de::Visitor<'de> for StaticProfileFieldVisitor<F> {
+#[cfg(feature = "client")]
+impl<'de, F: super::StaticProfileField> de::Visitor<'de> for StaticProfileFieldVisitor<F> {
     type Value = Option<F::Value>;
 
     fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -18,6 +22,8 @@ impl<'de, F: StaticProfileField> de::Visitor<'de> for StaticProfileFieldVisitor<
     where
         V: de::MapAccess<'de>,
     {
+        use std::borrow::Cow;
+
         let mut found = false;
 
         while let Some(key) = map.next_key::<Cow<'_, str>>()? {

--- a/crates/ruma-client-api/src/rendezvous/create_rendezvous_session.rs
+++ b/crates/ruma-client-api/src/rendezvous/create_rendezvous_session.rs
@@ -7,14 +7,11 @@ pub mod unstable {
     //!
     //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/4108
 
-    use http::{
-        HeaderName,
-        header::{CONTENT_LENGTH, CONTENT_TYPE, ETAG, EXPIRES, LAST_MODIFIED},
-    };
+    use http::header::{CONTENT_TYPE, ETAG, EXPIRES, LAST_MODIFIED};
     #[cfg(feature = "client")]
     use ruma_common::api::error::FromHttpResponseError;
     use ruma_common::{
-        api::{Metadata, auth_scheme::NoAuthentication, error::HeaderDeserializationError},
+        api::{auth_scheme::NoAuthentication, error::HeaderDeserializationError},
         metadata,
     };
     use serde::{Deserialize, Serialize};
@@ -49,6 +46,9 @@ pub mod unstable {
             _: ruma_common::api::auth_scheme::SendAccessToken<'_>,
             considering: std::borrow::Cow<'_, ruma_common::api::SupportedVersions>,
         ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
+            use http::header::CONTENT_LENGTH;
+            use ruma_common::api::Metadata;
+
             let url = Self::make_endpoint_url(considering, base_url, &[], "")?;
             let body = self.content.as_bytes();
             let content_length = body.len();
@@ -152,7 +152,7 @@ pub mod unstable {
                 ));
             }
 
-            let get_date = |header: HeaderName| -> Result<SystemTime, FromHttpResponseError<Self::EndpointError>> {
+            let get_date = |header: http::HeaderName| -> Result<SystemTime, FromHttpResponseError<Self::EndpointError>> {
                 let date = response
                     .headers()
                     .get(&header)

--- a/crates/ruma-client-api/src/session/logout.rs
+++ b/crates/ruma-client-api/src/session/logout.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3logout
 
     use ruma_common::{
-        api::{Metadata, auth_scheme::AccessToken, response},
+        api::{auth_scheme::AccessToken, response},
         metadata,
     };
 
@@ -45,7 +45,7 @@ pub mod v3 {
             access_token: ruma_common::api::auth_scheme::SendAccessToken<'_>,
             considering: std::borrow::Cow<'_, ruma_common::api::SupportedVersions>,
         ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
-            use ruma_common::api::auth_scheme::AuthScheme;
+            use ruma_common::api::{Metadata, auth_scheme::AuthScheme};
 
             let url = Self::make_endpoint_url(considering, base_url, &[], "")?;
 

--- a/crates/ruma-client-api/src/session/logout_all.rs
+++ b/crates/ruma-client-api/src/session/logout_all.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3logoutall
 
     use ruma_common::{
-        api::{Metadata, auth_scheme::AccessToken, response},
+        api::{auth_scheme::AccessToken, response},
         metadata,
     };
 
@@ -45,7 +45,7 @@ pub mod v3 {
             access_token: ruma_common::api::auth_scheme::SendAccessToken<'_>,
             considering: std::borrow::Cow<'_, ruma_common::api::SupportedVersions>,
         ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
-            use ruma_common::api::auth_scheme::AuthScheme;
+            use ruma_common::api::{Metadata, auth_scheme::AuthScheme};
 
             let url = Self::make_endpoint_url(considering, base_url, &[], "")?;
 

--- a/crates/ruma-client-api/src/state/get_state_event_for_key.rs
+++ b/crates/ruma-client-api/src/state/get_state_event_for_key.rs
@@ -9,7 +9,7 @@ pub mod v3 {
 
     use ruma_common::{
         OwnedRoomId,
-        api::{Metadata, auth_scheme::AccessToken, response},
+        api::{auth_scheme::AccessToken, response},
         metadata,
         serde::Raw,
     };
@@ -130,7 +130,7 @@ pub mod v3 {
             access_token: ruma_common::api::auth_scheme::SendAccessToken<'_>,
             considering: std::borrow::Cow<'_, ruma_common::api::SupportedVersions>,
         ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
-            use ruma_common::api::auth_scheme::AuthScheme;
+            use ruma_common::api::{Metadata, auth_scheme::AuthScheme};
 
             let query_string = serde_html_form::to_string(RequestQuery { format: self.format })?;
 

--- a/crates/ruma-client-api/src/state/send_state_event.rs
+++ b/crates/ruma-client-api/src/state/send_state_event.rs
@@ -11,7 +11,7 @@ pub mod v3 {
 
     use ruma_common::{
         MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId,
-        api::{Metadata, auth_scheme::AccessToken, response},
+        api::{auth_scheme::AccessToken, response},
         metadata,
         serde::Raw,
     };
@@ -117,7 +117,7 @@ pub mod v3 {
             access_token: ruma_common::api::auth_scheme::SendAccessToken<'_>,
             considering: std::borrow::Cow<'_, ruma_common::api::SupportedVersions>,
         ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
-            use ruma_common::api::auth_scheme::AuthScheme;
+            use ruma_common::api::{Metadata, auth_scheme::AuthScheme};
 
             let query_string =
                 serde_html_form::to_string(RequestQuery { timestamp: self.timestamp })?;

--- a/crates/ruma-client-api/src/threads/get_thread_subscriptions_changes.rs
+++ b/crates/ruma-client-api/src/threads/get_thread_subscriptions_changes.rs
@@ -34,6 +34,8 @@ pub mod unstable {
         /// Only `Direction::Backward` is meant to be supported, which is why this field is private
         /// for now (as of 2025-08-21).
         #[ruma_api(query)]
+        // Because this field is private, it is never read.
+        #[allow(dead_code)]
         dir: Direction,
 
         /// A token to continue pagination from.

--- a/crates/ruma-client-api/src/uiaa/get_uiaa_fallback_page.rs
+++ b/crates/ruma-client-api/src/uiaa/get_uiaa_fallback_page.rs
@@ -138,18 +138,14 @@ pub mod v3 {
         }
     }
 
-    #[cfg(all(test, any(feature = "client", feature = "server")))]
-    mod tests {
+    #[cfg(all(test, feature = "client"))]
+    mod tests_client {
         use assert_matches2::assert_matches;
         use http::header::{CONTENT_TYPE, LOCATION};
-        #[cfg(feature = "client")]
         use ruma_common::api::IncomingResponse;
-        #[cfg(feature = "server")]
-        use ruma_common::api::OutgoingResponse;
 
         use super::Response;
 
-        #[cfg(feature = "client")]
         #[test]
         fn incoming_redirect() {
             use super::Redirect;
@@ -165,7 +161,6 @@ pub mod v3 {
             assert_eq!(url, "http://localhost/redirect");
         }
 
-        #[cfg(feature = "client")]
         #[test]
         fn incoming_html() {
             use super::HtmlPage;
@@ -180,8 +175,15 @@ pub mod v3 {
             assert_matches!(response, Response::Html(HtmlPage { body }));
             assert_eq!(body, b"<h1>My Page</h1>");
         }
+    }
 
-        #[cfg(feature = "server")]
+    #[cfg(all(test, feature = "server"))]
+    mod tests_server {
+        use http::header::{CONTENT_TYPE, LOCATION};
+        use ruma_common::api::OutgoingResponse;
+
+        use super::Response;
+
         #[test]
         fn outgoing_redirect() {
             let response = Response::redirect("http://localhost/redirect".to_owned());
@@ -196,7 +198,6 @@ pub mod v3 {
             assert!(http_response.into_body().is_empty());
         }
 
-        #[cfg(feature = "server")]
         #[test]
         fn outgoing_html() {
             let response = Response::html(b"<h1>My Page</h1>".to_vec());

--- a/crates/ruma-client-api/src/user_directory/search_users.rs
+++ b/crates/ruma-client-api/src/user_directory/search_users.rs
@@ -75,6 +75,7 @@ pub mod v3 {
         uint!(10)
     }
 
+    #[cfg(feature = "client")]
     fn is_default_limit(limit: &UInt) -> bool {
         limit == &default_limit()
     }

--- a/crates/ruma-federation-api/src/authenticated_media.rs
+++ b/crates/ruma-federation-api/src/authenticated_media.rs
@@ -11,8 +11,10 @@ pub mod get_content_thumbnail;
 /// The `multipart/mixed` mime "essence".
 const MULTIPART_MIXED: &str = "multipart/mixed";
 /// The maximum number of headers to parse in a body part.
+#[cfg(feature = "client")]
 const MAX_HEADERS_COUNT: usize = 32;
 /// The length of the generated boundary.
+#[cfg(feature = "server")]
 const GENERATED_BOUNDARY_LENGTH: usize = 30;
 
 /// The metadata of a file from the content repository.

--- a/crates/ruma-federation-api/src/event/get_missing_events.rs
+++ b/crates/ruma-federation-api/src/event/get_missing_events.rs
@@ -88,6 +88,7 @@ pub mod v1 {
         uint!(10)
     }
 
+    #[cfg(feature = "client")]
     fn is_default_limit(val: &UInt) -> bool {
         *val == default_limit()
     }

--- a/crates/ruma-federation-api/src/membership/prepare_join_event.rs
+++ b/crates/ruma-federation-api/src/membership/prepare_join_event.rs
@@ -53,10 +53,12 @@ pub mod v1 {
         pub event: Box<RawJsonValue>,
     }
 
+    #[cfg(feature = "server")]
     fn default_ver() -> Vec<RoomVersionId> {
         vec![RoomVersionId::V1]
     }
 
+    #[cfg(feature = "client")]
     fn is_default_ver(ver: &[RoomVersionId]) -> bool {
         *ver == [RoomVersionId::V1]
     }

--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -100,6 +100,12 @@ impl Package {
                     FeatureFilter::UnstableAndCompat => {
                         FeatureFilter::is_unstable(feature) || FeatureFilter::is_compat(feature)
                     }
+                    FeatureFilter::ApiClient => {
+                        FeatureFilter::is_api_client(feature) || FeatureFilter::is_unstable(feature)
+                    }
+                    FeatureFilter::ApiServer => {
+                        FeatureFilter::is_api_server(feature) || FeatureFilter::is_unstable(feature)
+                    }
                     FeatureFilter::All => true,
                 }
             })
@@ -297,6 +303,12 @@ pub enum FeatureFilter {
     /// Only the unstable and compat features.
     UnstableAndCompat,
 
+    /// The client API and unstable features.
+    ApiClient,
+
+    /// The server API and unstable features.
+    ApiServer,
+
     /// All the public features.
     All,
 }
@@ -315,6 +327,16 @@ impl FeatureFilter {
     /// Whether the given features is a private feature.
     fn is_private(feature: &str) -> bool {
         feature.starts_with("_")
+    }
+
+    /// Whether the given features is a client API feature.
+    fn is_api_client(feature: &str) -> bool {
+        feature.ends_with("-api-c")
+    }
+
+    /// Whether the given features is a server API feature.
+    fn is_api_server(feature: &str) -> bool {
+        feature.ends_with("-api-s")
     }
 }
 


### PR DESCRIPTION
To find errors when only one the features is enabled, like the one in #2303.