### PR TITLE
room: Hold more data in the fallback variant of JoinRule

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -13,6 +13,9 @@ Improvements:
   `OutgoingRequestAppserviceExt::try_into_http_request_with_identity()` outside
   of Ruma, if using this trait is inconvenient.
 - Add `MatrixVersion::V1_17`.
+- `JoinRule` holds arbitrary data in its fallback variant, with can be accessed
+  with `JoinRule::data()`. It also means that this type won't fail to serialize
+  for undocumented variants anymore.
 
 # 0.17.0
 

--- a/crates/ruma-common/src/room.rs
+++ b/crates/ruma-common/src/room.rs
@@ -455,9 +455,10 @@ impl<'de> Deserialize<'de> for RoomSummary {
 /// documented variant here, get its kind with `.kind()` or use its string representation, obtained
 /// through `.as_str()`.
 ///
-/// This type will fail to serialize if it doesn't match one of the documented variants. It is only
-/// possible to construct an undocumented variant by deserializing it, so do not re-serialize this
-/// type.
+/// Because this type contains a few neighbouring fields instead of a whole object, and it is not
+/// possible to know which fields to parse for unknown variants, this type will fail to serialize if
+/// it doesn't match one of the documented variants. It is only possible to construct an
+/// undocumented variant by deserializing it, so do not re-serialize this type.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 #[serde(tag = "join_rule", rename_all = "snake_case")]

--- a/crates/ruma-common/src/room.rs
+++ b/crates/ruma-common/src/room.rs
@@ -10,7 +10,7 @@ use serde_json::{Value as JsonValue, value::RawValue as RawJsonValue};
 use crate::{
     EventEncryptionAlgorithm, OwnedMxcUri, OwnedRoomAliasId, OwnedRoomId, PrivOwnedStr,
     RoomVersionId,
-    serde::{StringEnum, from_raw_json_value},
+    serde::{JsonObject, StringEnum, from_raw_json_value},
 };
 
 /// An enum of possible room types.
@@ -29,8 +29,9 @@ pub enum RoomType {
 
 /// The rule used for users wishing to join this room.
 ///
-/// This type can hold an arbitrary string. To check for values that are not available as a
-/// documented variant here, use its string representation, obtained through `.as_str()`.
+/// This type can hold an arbitrary join rule. To check for values that are not available as a
+/// documented variant here, get its kind with [`.kind()`](Self::kind) or its string representation
+/// with [`.as_str()`](Self::as_str), and its associated data with [`.data()`](Self::data).
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 #[serde(tag = "join_rule", rename_all = "snake_case")]
@@ -59,8 +60,7 @@ pub enum JoinRule {
     Public,
 
     #[doc(hidden)]
-    #[serde(skip_serializing)]
-    _Custom(PrivOwnedStr),
+    _Custom(CustomJoinRule),
 }
 
 impl JoinRule {
@@ -73,7 +73,9 @@ impl JoinRule {
             Self::Restricted(_) => JoinRuleKind::Restricted,
             Self::KnockRestricted(_) => JoinRuleKind::KnockRestricted,
             Self::Public => JoinRuleKind::Public,
-            Self::_Custom(rule) => JoinRuleKind::_Custom(rule.clone()),
+            Self::_Custom(CustomJoinRule { join_rule, .. }) => {
+                JoinRuleKind::_Custom(PrivOwnedStr(join_rule.as_str().into()))
+            }
         }
     }
 
@@ -86,7 +88,36 @@ impl JoinRule {
             JoinRule::Restricted(_) => "restricted",
             JoinRule::KnockRestricted(_) => "knock_restricted",
             JoinRule::Public => "public",
-            JoinRule::_Custom(rule) => &rule.0,
+            JoinRule::_Custom(CustomJoinRule { join_rule, .. }) => join_rule,
+        }
+    }
+
+    /// Returns the associated data of this `JoinRule`.
+    ///
+    /// The returned JSON object won't contain the `join_rule` field, use
+    /// [`.kind()`](Self::kind) or [`.as_str()`](Self::as_str) to access those.
+    ///
+    /// Prefer to use the public variants of `JoinRule` where possible; this method is meant to
+    /// be used for custom join rules only.
+    pub fn data(&self) -> Cow<'_, JsonObject> {
+        fn serialize<T: Serialize>(obj: &T) -> JsonObject {
+            match serde_json::to_value(obj).expect("join rule serialization should succeed") {
+                JsonValue::Object(mut obj) => {
+                    obj.remove("body");
+                    obj
+                }
+                _ => panic!("all message types should serialize to objects"),
+            }
+        }
+
+        match self {
+            JoinRule::Invite | JoinRule::Knock | JoinRule::Private | JoinRule::Public => {
+                Cow::Owned(JsonObject::new())
+            }
+            JoinRule::Restricted(restricted) | JoinRule::KnockRestricted(restricted) => {
+                Cow::Owned(serialize(restricted))
+            }
+            Self::_Custom(c) => Cow::Borrowed(&c.data),
         }
     }
 }
@@ -116,9 +147,21 @@ impl<'de> Deserialize<'de> for JoinRule {
             "restricted" => from_raw_json_value(&json).map(Self::Restricted),
             "knock_restricted" => from_raw_json_value(&json).map(Self::KnockRestricted),
             "public" => Ok(Self::Public),
-            _ => Ok(Self::_Custom(PrivOwnedStr(join_rule.into()))),
+            _ => from_raw_json_value(&json).map(Self::_Custom),
         }
     }
+}
+
+/// The payload for an unsupported join rule.
+#[doc(hidden)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct CustomJoinRule {
+    /// The kind of join rule.
+    join_rule: String,
+
+    /// The remaining data.
+    #[serde(flatten)]
+    data: JsonObject,
 }
 
 /// Configuration of the `Restricted` join rule.
@@ -405,8 +448,16 @@ impl<'de> Deserialize<'de> for RoomSummary {
 
 /// The rule used for users wishing to join a room.
 ///
-/// In contrast to the regular `JoinRule` in `ruma_events`, this enum holds only simplified
-/// conditions for joining restricted rooms.
+/// In contrast to the regular [`JoinRule`], this enum holds only simplified conditions for joining
+/// restricted rooms.
+///
+/// This type can hold an arbitrary join rule. To check for values that are not available as a
+/// documented variant here, get its kind with `.kind()` or use its string representation, obtained
+/// through `.as_str()`.
+///
+/// This type will fail to serialize if it doesn't match one of the documented variants. It is only
+/// possible to construct an undocumented variant by deserializing it, so do not re-serialize this
+/// type.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 #[serde(tag = "join_rule", rename_all = "snake_case")]
@@ -477,7 +528,9 @@ impl From<JoinRule> for JoinRuleSummary {
             JoinRule::Restricted(restricted) => Self::Restricted(restricted.into()),
             JoinRule::KnockRestricted(restricted) => Self::KnockRestricted(restricted.into()),
             JoinRule::Public => Self::Public,
-            JoinRule::_Custom(rule) => Self::_Custom(rule),
+            JoinRule::_Custom(CustomJoinRule { join_rule, .. }) => {
+                Self::_Custom(PrivOwnedStr(join_rule.into()))
+            }
         }
     }
 }


### PR DESCRIPTION
Like we do with other enums like `MessageType` or `PusherKind`, since it actually holds a whole object.

This also documents that `JoinRuleSummary` can fail to serialize and why.

Fixes #2308.
