### PR TITLE
signatures: Use `VerifyingKey`'s `TryFrom<&[u8]>` implementation

### DIFF
--- a/crates/ruma-signatures/CHANGELOG.md
+++ b/crates/ruma-signatures/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [unreleased]
 
+Improvements:
+
+- Get a better error message when verifying a signature with a public key that
+  has the wrong length.
+
 # 0.19.0
 
 No changes for this version

--- a/crates/ruma-signatures/src/verification.rs
+++ b/crates/ruma-signatures/src/verification.rs
@@ -33,15 +33,11 @@ impl Verifier for Ed25519Verifier {
         signature: &[u8],
         message: &[u8],
     ) -> Result<(), Error> {
-        VerifyingKey::from_bytes(
-            public_key
-                .try_into()
-                .map_err(|_| ParseError::PublicKey(ed25519_dalek::SignatureError::new()))?,
-        )
-        .map_err(ParseError::PublicKey)?
-        .verify(message, &signature.try_into().map_err(ParseError::Signature)?)
-        .map_err(VerificationError::Signature)
-        .map_err(Error::from)
+        VerifyingKey::try_from(public_key)
+            .map_err(ParseError::PublicKey)?
+            .verify(message, &signature.try_into().map_err(ParseError::Signature)?)
+            .map_err(VerificationError::Signature)
+            .map_err(Error::from)
     }
 }
 


### PR DESCRIPTION
… rather than converting the public key slice to an array manually and then using `from_bytes`. If we create a `SignatureError` manually, there are no details about the error, but if we use the upstream crate's implementation we get an error message about the key's length.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
