### PR TITLE
fix: Fix double `msgtype` for `m.location`

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [unreleased]
 
+Bug fixes:
+
+- Fix a double `msgtype` in a `m.location` event.
+
 # 0.32.1
 
 Improvements:

--- a/crates/ruma-events/src/room/message/content_serde.rs
+++ b/crates/ruma-events/src/room/message/content_serde.rs
@@ -121,7 +121,6 @@ pub(in super::super) mod msc3488 {
 
     /// Deserialize helper type for `LocationMessageEventContent` with unstable fields from msc3488.
     #[derive(Serialize, Deserialize)]
-    #[serde(tag = "msgtype", rename = "m.location")]
     pub(in super::super) struct LocationMessageEventContentSerDeHelper {
         pub body: String,
 

--- a/crates/ruma-events/tests/it/room_message.rs
+++ b/crates/ruma-events/tests/it/room_message.rs
@@ -818,6 +818,34 @@ fn location_msgtype_serialization() {
     );
 }
 
+#[cfg(feature = "unstable-msc3488")]
+#[test]
+fn location_msgtype_serialization() {
+    use ruma_events::room::message::LocationMessageEventContent;
+
+    let message_event_content =
+        RoomMessageEventContent::new(MessageType::Location(LocationMessageEventContent::new(
+            "Alice was at geo:51.5008,0.1247;u=35".to_owned(),
+            "geo:51.5008,0.1247;u=35".to_owned(),
+        )));
+
+    assert_eq!(
+        to_json_value(&message_event_content).unwrap(),
+        json!({
+            "body": "Alice was at geo:51.5008,0.1247;u=35",
+            "geo_uri": "geo:51.5008,0.1247;u=35",
+            "msgtype": "m.location",
+            "org.matrix.msc1767.text": "Alice was at geo:51.5008,0.1247;u=35",
+            "org.matrix.msc3488.asset": {
+                "type": "m.self",
+            },
+            "org.matrix.msc3488.location": {
+                "uri": "geo:51.5008,0.1247;u=35"
+            },
+        })
+    );
+}
+
 #[test]
 fn location_msgtype_deserialization() {
     let json_data = json!({


### PR DESCRIPTION
Fix https://github.com/ruma/ruma/issues/2328.

`LocationMessageEventContentSerDeHelper` is used by `LocationMessageEventContent`, which is always used behind the correct serde configuration in enums, like `MessageType::Location` that is annotated by `#[serde(rename = "m.location")]`.

I don't think there are tests about that. Do you want a regression test? If so, where to add it?

---

* Fix https://github.com/ruma/ruma/issues/2328