### PR TITLE
client-api: Create `RoomPowerLevelsContentOverride` helper

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -1,5 +1,13 @@
 # [unreleased]
 
+Breaking changes:
+
+- `create_room::v3::Request::power_level_content_override` is now of type 
+  `Option<Raw<RoomPowerLevelsContentOverride>>`. This `RoomPowerLevelsContentOverride` 
+  type has the same signature as `RoomPowerLevelsEventContent` except all `Int` 
+  fields are `Option<Int>`, which allows uploading explicit values no matter what the 
+  default ones are.
+
 # 0.22.1
 
 Improvements:

--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -1,12 +1,12 @@
 # [unreleased]
 
-Breaking changes:
+Improvements:
 
-- `create_room::v3::Request::power_level_content_override` is now of type 
-  `Option<Raw<RoomPowerLevelsContentOverride>>`. This `RoomPowerLevelsContentOverride` 
-  type has the same signature as `RoomPowerLevelsEventContent` except all `Int` 
-  fields are `Option<Int>`, which allows uploading explicit values no matter what the 
-  default ones are.
+- Added `create_room::v3::RoomPowerLevelsContentOverride`. This has the same 
+  signature as `RoomPowerLevelsEventContent` except all `Int` fields are 
+  `Option<Int>`, which allows uploading explicit values no matter what the 
+  default ones are. When in `Raw` form, this type can be casted to
+  `RoomPowerLevelsEventContent` and used to populate `power_level_content_override`.
 
 # 0.22.1
 

--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 Improvements:
 
-- Added `create_room::v3::RoomPowerLevelsContentOverride`. This has the same 
+- Add `create_room::v3::RoomPowerLevelsContentOverride`. This has the same 
   signature as `RoomPowerLevelsEventContent` except all `Int` fields are 
   `Option<Int>`, which allows uploading explicit values no matter what the 
-  default ones are. When in `Raw` form, this type can be casted to
+  default ones are. When in `Raw` form, this type can be cast to
   `RoomPowerLevelsEventContent` and used to populate `power_level_content_override`.
 
 # 0.22.1

--- a/crates/ruma-client-api/src/room/create_room.rs
+++ b/crates/ruma-client-api/src/room/create_room.rs
@@ -19,7 +19,7 @@ pub mod v3 {
         AnyInitialStateEvent,
         room::{
             create::{PreviousRoom, RoomCreateEventContent},
-            power_levels::RoomPowerLevelsEventContent,
+            power_levels::RoomPowerLevelsContentOverride,
         },
     };
     use serde::{Deserialize, Serialize};
@@ -71,7 +71,7 @@ pub mod v3 {
 
         /// Power level content to override in the default power level event.
         #[serde(skip_serializing_if = "Option::is_none")]
-        pub power_level_content_override: Option<Raw<RoomPowerLevelsEventContent>>,
+        pub power_level_content_override: Option<Raw<RoomPowerLevelsContentOverride>>,
 
         /// Convenience parameter for setting various default state events based on a preset.
         #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/ruma-client-api/src/room/create_room.rs
+++ b/crates/ruma-client-api/src/room/create_room.rs
@@ -281,7 +281,9 @@ mod tests {
     use js_int::int;
     use maplit::btreemap;
     use ruma_common::{power_levels::NotificationPowerLevels, user_id};
-    use serde_json::json;
+    use serde_json::{json, to_value as to_json_value};
+
+    use super::RoomPowerLevelsContentOverride;
 
     #[test]
     fn serialization_of_power_levels_overridden_values_with_optional_fields_as_none() {

--- a/crates/ruma-client-api/src/room/create_room.rs
+++ b/crates/ruma-client-api/src/room/create_room.rs
@@ -5,7 +5,11 @@
 use std::collections::BTreeMap;
 
 use js_int::Int;
-use ruma_common::{OwnedUserId, power_levels::NotificationPowerLevels, serde::JsonCastable};
+use ruma_common::{
+    OwnedUserId,
+    power_levels::NotificationPowerLevels,
+    serde::{JsonCastable, JsonObject},
+};
 use ruma_events::{TimelineEventType, room::power_levels::RoomPowerLevelsEventContent};
 use serde::Serialize;
 
@@ -277,7 +281,11 @@ impl RoomPowerLevelsContentOverride {
         Self::default()
     }
 }
+
+// Allows casting `Raw<RoomPowerLevelsContentOverride>` to `Raw<RoomPowerLevelsEventContent>`.
 impl JsonCastable<RoomPowerLevelsEventContent> for RoomPowerLevelsContentOverride {}
+
+impl JsonCastable<JsonObject> for RoomPowerLevelsContentOverride {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/ruma-client-api/src/room/create_room.rs
+++ b/crates/ruma-client-api/src/room/create_room.rs
@@ -271,6 +271,12 @@ pub struct RoomPowerLevelsContentOverride {
     pub notifications: NotificationPowerLevels,
 }
 
+impl RoomPowerLevelsContentOverride {
+    /// Creates a new, empty [`RoomPowerLevelsContentOverride`] instance.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
 impl JsonCastable<RoomPowerLevelsEventContent> for RoomPowerLevelsContentOverride {}
 
 #[cfg(test)]

--- a/crates/ruma-events/src/room/power_levels.rs
+++ b/crates/ruma-events/src/room/power_levels.rs
@@ -923,89 +923,6 @@ pub enum PowerLevelUserAction {
     ChangePowerLevel,
 }
 
-/// The power level values that can be overridden when creating a room.
-#[derive(Clone, Debug, Serialize)]
-#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
-pub struct RoomPowerLevelsContentOverride {
-    /// The level required to ban a user.
-    #[serde(skip_serializing_if = "ruma_common::serde::is_default")]
-    pub ban: Option<Int>,
-
-    /// The level required to send specific event types.
-    ///
-    /// This is a mapping from event type to power level required.
-    #[serde(
-        default,
-        skip_serializing_if = "BTreeMap::is_empty",
-        deserialize_with = "ruma_common::serde::btreemap_deserialize_v1_powerlevel_values"
-    )]
-    pub events: BTreeMap<TimelineEventType, Int>,
-
-    /// The default level required to send message events.
-    #[serde(skip_serializing_if = "ruma_common::serde::is_default")]
-    pub events_default: Option<Int>,
-
-    /// The level required to invite a user.
-    #[serde(skip_serializing_if = "ruma_common::serde::is_default")]
-    pub invite: Option<Int>,
-
-    /// The level required to kick a user.
-    #[serde(skip_serializing_if = "ruma_common::serde::is_default")]
-    pub kick: Option<Int>,
-
-    /// The level required to redact an event.
-    #[serde(skip_serializing_if = "ruma_common::serde::is_default")]
-    pub redact: Option<Int>,
-
-    /// The default level required to send state events.
-    #[serde(skip_serializing_if = "ruma_common::serde::is_default")]
-    pub state_default: Option<Int>,
-
-    /// The power levels for specific users.
-    ///
-    /// This is a mapping from `user_id` to power level for that user.
-    #[serde(
-        default,
-        skip_serializing_if = "BTreeMap::is_empty",
-        deserialize_with = "ruma_common::serde::btreemap_deserialize_v1_powerlevel_values"
-    )]
-    pub users: BTreeMap<OwnedUserId, Int>,
-
-    /// The default power level for every user in the room.
-    #[serde(skip_serializing_if = "ruma_common::serde::is_default")]
-    pub users_default: Option<Int>,
-
-    /// The power level requirements for specific notification types.
-    ///
-    /// This is a mapping from `key` to power level for that notifications key.
-    #[serde(default, skip_serializing_if = "NotificationPowerLevels::is_default")]
-    pub notifications: NotificationPowerLevels,
-}
-
-impl RoomPowerLevelsContentOverride {
-    /// Creates a new, empty instance of [`RoomPowerLevelsContentOverride`].
-    pub fn new() -> Self {
-        Self {
-            ban: None,
-            events: Default::default(),
-            events_default: None,
-            invite: None,
-            kick: None,
-            redact: None,
-            state_default: None,
-            users: Default::default(),
-            users_default: None,
-            notifications: Default::default(),
-        }
-    }
-}
-
-impl Default for RoomPowerLevelsContentOverride {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
@@ -1017,8 +934,8 @@ mod tests {
     use serde_json::{json, to_value as to_json_value};
 
     use super::{
-        NotificationPowerLevels, RoomPowerLevels, RoomPowerLevelsContentOverride,
-        RoomPowerLevelsEventContent, RoomPowerLevelsSource, default_power_level,
+        NotificationPowerLevels, RoomPowerLevels, RoomPowerLevelsEventContent,
+        RoomPowerLevelsSource, default_power_level,
     };
 
     #[test]
@@ -1061,70 +978,6 @@ mod tests {
                 user.to_owned() => int!(23)
             },
             users_default: int!(23),
-            notifications: assign!(NotificationPowerLevels::new(), { room: int!(23) }),
-        };
-
-        let actual = to_json_value(&power_levels_event).unwrap();
-        let expected = json!({
-            "ban": 23,
-            "events": {
-                "m.dummy": 23
-            },
-            "events_default": 23,
-            "invite": 23,
-            "kick": 23,
-            "redact": 23,
-            "state_default": 23,
-            "users": {
-                "@carl:example.com": 23
-            },
-            "users_default": 23,
-            "notifications": {
-                "room": 23
-            },
-        });
-
-        assert_eq!(actual, expected);
-    }
-
-    #[test]
-    fn serialization_of_overridden_values_with_optional_fields_as_none() {
-        let power_levels = RoomPowerLevelsContentOverride {
-            ban: None,
-            events: BTreeMap::new(),
-            events_default: None,
-            invite: None,
-            kick: None,
-            redact: None,
-            state_default: None,
-            users: BTreeMap::new(),
-            users_default: None,
-            notifications: NotificationPowerLevels::default(),
-        };
-
-        let actual = to_json_value(&power_levels).unwrap();
-        let expected = json!({});
-
-        assert_eq!(actual, expected);
-    }
-
-    #[test]
-    fn serialization_of_overridden_values_with_all_fields() {
-        let user = user_id!("@carl:example.com");
-        let power_levels_event = RoomPowerLevelsContentOverride {
-            ban: Some(int!(23)),
-            events: btreemap! {
-                "m.dummy".into() => int!(23)
-            },
-            events_default: Some(int!(23)),
-            invite: Some(int!(23)),
-            kick: Some(int!(23)),
-            redact: Some(int!(23)),
-            state_default: Some(int!(23)),
-            users: btreemap! {
-                user.to_owned() => int!(23)
-            },
-            users_default: Some(int!(23)),
             notifications: assign!(NotificationPowerLevels::new(), { room: int!(23) }),
         };
 


### PR DESCRIPTION
And use it for `create_room::v3::Request::room_power_levels_content_override` instead of `RoomPowerLevelsEventContent`.

This allows serializing explicit values that Ruma previously assumed would be the default in the homeserver, which may not always be the case, and it doesn't modify the existing usages of `RoomPowerLevelsEventContent`.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
