### PR TITLE
Add optional uniffi feature and turn event types into uniffi enums

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -54,3 +54,4 @@ deny = [
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
+allow-git = ["https://github.com/mozilla/uniffi-rs.git"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
 name = "as_variant"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,6 +220,12 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
 
 [[package]]
 name = "cast"
@@ -647,6 +659,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs-err"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1973,6 +1994,7 @@ dependencies = [
  "thiserror",
  "tracing",
  "trybuild",
+ "uniffi",
  "url",
  "web-time",
  "wildmatch",
@@ -2425,6 +2447,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_cache"
@@ -2889,6 +2917,79 @@ name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+
+[[package]]
+name = "uniffi"
+version = "0.31.0"
+source = "git+https://github.com/mozilla/uniffi-rs.git?rev=e5f4821410bea19e71984ea5e06a7bc8b11ed9e5#e5f4821410bea19e71984ea5e06a7bc8b11ed9e5"
+dependencies = [
+ "anyhow",
+ "uniffi_core",
+ "uniffi_macros",
+ "uniffi_pipeline",
+]
+
+[[package]]
+name = "uniffi_core"
+version = "0.31.0"
+source = "git+https://github.com/mozilla/uniffi-rs.git?rev=e5f4821410bea19e71984ea5e06a7bc8b11ed9e5#e5f4821410bea19e71984ea5e06a7bc8b11ed9e5"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "once_cell",
+ "static_assertions",
+]
+
+[[package]]
+name = "uniffi_internal_macros"
+version = "0.31.0"
+source = "git+https://github.com/mozilla/uniffi-rs.git?rev=e5f4821410bea19e71984ea5e06a7bc8b11ed9e5#e5f4821410bea19e71984ea5e06a7bc8b11ed9e5"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "uniffi_macros"
+version = "0.31.0"
+source = "git+https://github.com/mozilla/uniffi-rs.git?rev=e5f4821410bea19e71984ea5e06a7bc8b11ed9e5#e5f4821410bea19e71984ea5e06a7bc8b11ed9e5"
+dependencies = [
+ "camino",
+ "fs-err",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+ "toml",
+ "uniffi_meta",
+]
+
+[[package]]
+name = "uniffi_meta"
+version = "0.31.0"
+source = "git+https://github.com/mozilla/uniffi-rs.git?rev=e5f4821410bea19e71984ea5e06a7bc8b11ed9e5#e5f4821410bea19e71984ea5e06a7bc8b11ed9e5"
+dependencies = [
+ "anyhow",
+ "siphasher",
+ "uniffi_internal_macros",
+ "uniffi_pipeline",
+]
+
+[[package]]
+name = "uniffi_pipeline"
+version = "0.31.0"
+source = "git+https://github.com/mozilla/uniffi-rs.git?rev=e5f4821410bea19e71984ea5e06a7bc8b11ed9e5#e5f4821410bea19e71984ea5e06a7bc8b11ed9e5"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "tempfile",
+ "uniffi_internal_macros",
+]
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ similar = "2.6.0"
 thiserror = "2.0.0"
 toml = { version = "0.9.6", default-features = false, features = ["parse", "serde"] }
 tracing = { version = "0.1.37", default-features = false, features = ["std"] }
+uniffi = { git = "https://github.com/mozilla/uniffi-rs.git", rev = "e5f4821410bea19e71984ea5e06a7bc8b11ed9e5", version = "0.31.0", default-features = false, features = ["wasm-unstable-single-threaded"] }
 url = { version = "2.5.0" }
 web-time = "1.1.0"
 zeroize = "1.8.1"

--- a/crates/ruma-events/Cargo.toml
+++ b/crates/ruma-events/Cargo.toml
@@ -54,6 +54,7 @@ unstable-msc4334 = ["dep:language-tags"]
 unstable-msc4359 = []
 unstable-msc4362 = []
 unstable-msc4380 = []
+unstable-uniffi = ["dep:uniffi"]
 
 # Allow some mandatory fields to be missing, defaulting them to an empty string
 # in deserialization.
@@ -98,6 +99,7 @@ serde = { workspace = true }
 serde_json = { workspace = true, features = ["raw_value"] }
 thiserror = { workspace = true }
 tracing = { workspace = true, features = ["attributes"] }
+uniffi = { workspace = true, optional = true }
 url = { workspace = true }
 web-time = { workspace = true }
 wildmatch = "2.0.0"

--- a/crates/ruma-events/tests/it/ui/07-enum-sanity-check.rs
+++ b/crates/ruma-events/tests/it/ui/07-enum-sanity-check.rs
@@ -1,5 +1,8 @@
 #![allow(unexpected_cfgs)]
 
+#[cfg(feature = "unstable-uniffi")]
+uniffi::setup_scaffolding!();
+
 use ruma_macros::event_enum;
 
 event_enum! {
@@ -40,3 +43,14 @@ fn main() {
 #[doc(hidden)]
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PrivOwnedStr(Box<str>);
+
+#[cfg_attr(feature = "unstable-uniffi", derive(uniffi::Object))]
+#[doc(hidden)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PrivateString(Box<str>);
+
+#[cfg(feature = "unstable-uniffi")]
+uniffi::custom_type!(PrivOwnedStr, std::sync::Arc<PrivateString> , {
+    lower: |value| std::sync::Arc::new(PrivateString(value.0)),
+    try_lift: |value| Ok(PrivOwnedStr(value.0.clone())),
+});

--- a/crates/ruma-events/tests/it/ui/08-enum-invalid-path.rs
+++ b/crates/ruma-events/tests/it/ui/08-enum-invalid-path.rs
@@ -1,5 +1,8 @@
 #![allow(unexpected_cfgs)]
 
+#[cfg(feature = "unstable-uniffi")]
+uniffi::setup_scaffolding!();
+
 use ruma_macros::event_enum;
 
 event_enum! {
@@ -13,3 +16,14 @@ fn main() {}
 #[doc(hidden)]
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PrivOwnedStr(Box<str>);
+
+#[cfg_attr(feature = "unstable-uniffi", derive(uniffi::Object))]
+#[doc(hidden)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PrivateString(Box<str>);
+
+#[cfg(feature = "unstable-uniffi")]
+uniffi::custom_type!(PrivOwnedStr, std::sync::Arc<PrivateString> , {
+    lower: |value| std::sync::Arc::new(PrivateString(value.0)),
+    try_lift: |value| Ok(PrivOwnedStr(value.0.clone())),
+});

--- a/crates/ruma-events/tests/it/ui/08-enum-invalid-path.stderr
+++ b/crates/ruma-events/tests/it/ui/08-enum-invalid-path.stderr
@@ -1,5 +1,5 @@
 error[E0433]: failed to resolve: could not find `not` in `ruma_events`
- --> tests/it/ui/08-enum-invalid-path.rs:7:40
-  |
-7 |         "m.not.a.path" => ruma_events::not::a::path,
-  |                                        ^^^ could not find `not` in `ruma_events`
+  --> tests/it/ui/08-enum-invalid-path.rs:10:40
+   |
+10 |         "m.not.a.path" => ruma_events::not::a::path,
+   |                                        ^^^ could not find `not` in `ruma_events`

--- a/crates/ruma-events/tests/it/ui/14-enum-content-double-kind.rs
+++ b/crates/ruma-events/tests/it/ui/14-enum-content-double-kind.rs
@@ -1,5 +1,8 @@
 #![allow(unexpected_cfgs)]
 
+#[cfg(feature = "unstable-uniffi")]
+uniffi::setup_scaffolding!();
+
 use ruma_macros::event_enum;
 
 mod event {
@@ -50,3 +53,14 @@ fn main() {
 #[doc(hidden)]
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PrivOwnedStr(Box<str>);
+
+#[cfg_attr(feature = "unstable-uniffi", derive(uniffi::Object))]
+#[doc(hidden)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PrivateString(Box<str>);
+
+#[cfg(feature = "unstable-uniffi")]
+uniffi::custom_type!(PrivOwnedStr, std::sync::Arc<PrivateString> , {
+    lower: |value| std::sync::Arc::new(PrivateString(value.0)),
+    try_lift: |value| Ok(PrivOwnedStr(value.0.clone())),
+});

--- a/crates/ruma-macros/src/events/event_enum/event_type.rs
+++ b/crates/ruma-macros/src/events/event_enum/event_type.rs
@@ -71,11 +71,15 @@ impl EventTypeEnum<'_> {
             /// This type can hold an arbitrary string. To build events with a custom type, convert it
             /// from a string with `::from()` / `.into()`. To check for events that are not available as a
             /// documented variant here, use its string representation, obtained through `.to_string()`.
+            #[cfg_attr(feature = "unstable-uniffi", derive(uniffi::Enum))]
+            #[cfg_attr(feature = "unstable-uniffi", uniffi::export(Display, Eq, Hash))]
             #[derive(Clone, PartialEq, Eq, Hash)]
             #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
             pub enum #ident {
                 #( #variants )*
                 #[doc(hidden)]
+                /// This variant ensures forward compatibility of the library. It deliberately cannot be
+                /// used to create custom variants in client code.
                 _Custom(crate::PrivOwnedStr),
             }
 
@@ -286,6 +290,16 @@ impl EventTypeEnum<'_> {
             impl ::std::convert::From<::std::string::String> for #ident {
                 fn from(s: ::std::string::String) -> Self {
                     ::std::convert::From::from(s.as_str())
+                }
+            }
+
+            #[cfg(feature = "unstable-uniffi")]
+            #[uniffi::export]
+            impl #ident {
+                /// Construct a variant of the enum from a string.
+                #[uniffi::constructor]
+                pub fn from_string(s: ::std::string::String) -> Self {
+                    s.into()
                 }
             }
 

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -210,6 +210,7 @@ unstable-msc4359 = ["ruma-events?/unstable-msc4359"]
 unstable-msc4362 = ["ruma-events?/unstable-msc4362"]
 unstable-msc4380 = ["ruma-events?/unstable-msc4380"]
 unstable-msc4388 = ["ruma-common/unstable-msc4388", "ruma-client-api?/unstable-msc4388"]
+unstable-uniffi = ["ruma-events?/unstable-uniffi"]
 
 [dependencies]
 assign = { workspace = true }

--- a/crates/ruma/src/lib.rs
+++ b/crates/ruma/src/lib.rs
@@ -60,6 +60,8 @@
 //!
 //! * `unstable-mscXXXX`, where `XXXX` is the MSC number -- Upcoming Matrix features that may be
 //!   subject to change or removal.
+//! * `unstable-uniffi` -- Enables UniFFI bindings by adding conditional `uniffi` derives to _some_
+//!   types. This feature is currently a work in progress and, thus, unstable.
 //!
 //! # Common features
 //!


### PR DESCRIPTION
Relates to: #2070

This tries to mimic a similar mechanism from matrix-rust-sdk to conditionally add uniffi derives beneath a feature. This spares consumers of ruma that depend on uniffi to duplicate and manually map ruma types. As a test only the derives for the generated event type enums have been changed.

I've tried this out locally in the rust SDK but it doesn't seem to work.

```
error[E0277]: the trait bound `ruma::ruma_events::TimelineEventType: uniffi::Lift<UniFfiTag>` is not satisfied
  --> bindings/matrix-sdk-ffi/src/timeline/configuration.rs:26:63
   |
26 |     pub fn include(event_types: Vec<FilterTimelineEventType>, e: TimelineEventType) -> Arc<Self> {
   |                                                               ^ the trait `uniffi::Lift<UniFfiTag>` is not implemented for `ruma::ruma_events::TimelineEventType`
   |
   = help: the following other types implement trait `uniffi::Lift<UT>`:
             `authentication::OidcConfiguration` implements `uniffi::Lift<UT>`
             `authentication::OidcError` implements `uniffi::Lift<UT>`
             `authentication::SsoError` implements `uniffi::Lift<UT>`
             `bool` implements `uniffi::Lift<UT>`
             `client::AccountManagementAction` implements `uniffi::Lift<UT>`
             `client::AllowRule` implements `uniffi::Lift<UT>`
             `client::CreateRoomParameters` implements `uniffi::Lift<UT>`
             `client::HttpPusherData` implements `uniffi::Lift<UT>`
           and 293 others
```

So I must have done something wrong. Leaving it here as a draft for the moment.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
