### PR TITLE
ci: Upgrade nightly toolchain and actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Check spelling
-        uses: crate-ci/typos@v1.40.0
+        uses: crate-ci/typos@v1.42.1
 
       - name: Install cargo-sort
-        uses: taiki-e/cache-cargo-install-action@v2
+        uses: taiki-e/cache-cargo-install-action@v3
         with:
           tool: cargo-sort
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
   # Keep in sync with version in `rust-toolchain.toml` and `xtask/src/main.rs`
-  NIGHTLY: nightly-2025-12-12
+  NIGHTLY: nightly-2026-01-23
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,7 +242,7 @@ jobs:
 
       - name: Upload docs as artifact
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: docs
           path: docs.tar.zstd

--- a/.github/workflows/semver-comment.yml
+++ b/.github/workflows/semver-comment.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download results
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: breaking-changes-results
           run-id: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -115,7 +115,7 @@ jobs:
           echo "$BREAKING_CHANGES_RESULTS" >> breaking-changes-results.json
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: breaking-changes-results
           path: breaking-changes-results.json

--- a/crates/ruma-common/tests/it/api/ui/serde-flatten-response-body.stderr
+++ b/crates/ruma-common/tests/it/api/ui/serde-flatten-response-body.stderr
@@ -34,7 +34,11 @@ help: the trait `OutgoingResponse` is not implemented for `Response`
    |
 27 | pub struct Response {
    | ^^^^^^^^^^^^^^^^^^^
-   = help: the trait `OutgoingResponse` is implemented for `MatrixError`
+help: the trait `OutgoingResponse` is implemented for `MatrixError`
+  --> src/api/error.rs
+   |
+   | impl OutgoingResponse for MatrixError {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `ruma_common::api::IncomingRequest::OutgoingResponse`
   --> src/api.rs
    |

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 # Keep in sync with version in `xtask/src/main.rs` and `.github/workflows/ci.yml`
-channel = "nightly-2025-12-12"
+channel = "nightly-2026-01-23"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -15,7 +15,7 @@ use serde::Deserialize;
 use serde_json::from_str as from_json_str;
 
 // Keep in sync with version in `rust-toolchain.toml` and `.github/workflows/ci.yml`
-const NIGHTLY: &str = "nightly-2025-12-12";
+const NIGHTLY: &str = "nightly-2026-01-23";
 
 mod bench;
 mod cargo;


### PR DESCRIPTION
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
