### PR TITLE
Add `AnyPossiblyRedactedStateEventContent`

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -4,6 +4,13 @@ Bug fixes:
 
 - Fix a double `msgtype` in a `m.location` event.
 
+Improvements:
+
+- Add `AnyPossiblyRedactedStateEventContent`, an enum containing all the
+  possibly redacted state event contents.
+  - Add `AnyStrippedStateEvent::content()` to access only the content of the
+    event.
+
 # 0.32.1
 
 Improvements:

--- a/crates/ruma-macros/src/events/event_enum.rs
+++ b/crates/ruma-macros/src/events/event_enum.rs
@@ -310,7 +310,11 @@ impl EventEnumEntry {
     }
 
     /// Get or generate the path of the event content type for this entry.
-    fn to_event_content_path(&self, kind: EventEnumKind) -> syn::Path {
+    fn to_event_content_path(
+        &self,
+        kind: EventEnumKind,
+        variation: EventContentVariation,
+    ) -> syn::Path {
         let type_prefix = match kind {
             EventEnumKind::ToDevice => "ToDevice",
             // Special case encrypted state event for MSC4362.
@@ -325,7 +329,7 @@ impl EventEnumEntry {
             _ => "",
         };
 
-        let content_name = format_ident!("{type_prefix}{}EventContent", self.ident);
+        let content_name = format_ident!("{variation}{type_prefix}{}EventContent", self.ident);
 
         let mut path = self.ev_path.clone();
         path.segments.push(content_name.into());
@@ -377,5 +381,43 @@ impl EventEnumEntry {
         }
 
         doc
+    }
+}
+
+/// The supported variations for `Any*EventContent` enums.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum EventContentVariation {
+    /// The non-redacted version of the event content, `Any{kind}EventContent`.
+    Original,
+}
+
+impl EventContentVariation {
+    /// Get the event content enum variation matching the given event variation.
+    fn from_event_variation(event_variation: EventVariation) -> Option<Self> {
+        match event_variation {
+            EventVariation::None | EventVariation::Sync | EventVariation::Initial => {
+                Some(Self::Original)
+            }
+            EventVariation::Stripped
+            | EventVariation::Original
+            | EventVariation::OriginalSync
+            | EventVariation::Redacted
+            | EventVariation::RedactedSync => None,
+        }
+    }
+
+    /// Get the event content trait matching this variation.
+    fn to_event_content_trait(self) -> EventContentTraitVariation {
+        match self {
+            Self::Original => EventContentTraitVariation::Original,
+        }
+    }
+}
+
+impl fmt::Display for EventContentVariation {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Original => Ok(()),
+        }
     }
 }

--- a/crates/ruma-macros/src/events/event_enum.rs
+++ b/crates/ruma-macros/src/events/event_enum.rs
@@ -389,6 +389,8 @@ impl EventEnumEntry {
 enum EventContentVariation {
     /// The non-redacted version of the event content, `Any{kind}EventContent`.
     Original,
+    /// The possibly redacted version of the event content, `AnyPossiblyRedacted{kind}EventContent`.
+    PossiblyRedacted,
 }
 
 impl EventContentVariation {
@@ -398,8 +400,8 @@ impl EventContentVariation {
             EventVariation::None | EventVariation::Sync | EventVariation::Initial => {
                 Some(Self::Original)
             }
-            EventVariation::Stripped
-            | EventVariation::Original
+            EventVariation::Stripped => Some(Self::PossiblyRedacted),
+            EventVariation::Original
             | EventVariation::OriginalSync
             | EventVariation::Redacted
             | EventVariation::RedactedSync => None,
@@ -410,14 +412,16 @@ impl EventContentVariation {
     fn to_event_content_trait(self) -> EventContentTraitVariation {
         match self {
             Self::Original => EventContentTraitVariation::Original,
+            Self::PossiblyRedacted => EventContentTraitVariation::PossiblyRedacted,
         }
     }
 }
 
 impl fmt::Display for EventContentVariation {
-    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Original => Ok(()),
+            Self::PossiblyRedacted => write!(f, "PossiblyRedacted"),
         }
     }
 }

--- a/crates/ruma-macros/src/events/event_enum/event_kind_enum/content.rs
+++ b/crates/ruma-macros/src/events/event_enum/event_kind_enum/content.rs
@@ -13,7 +13,7 @@ use crate::{
 
 impl EventEnum<'_> {
     /// Generate the `Any*EventContent` enum for this kind.
-    pub(super) fn expand_content_enum(&self) -> syn::Result<TokenStream> {
+    pub(super) fn expand_content_enum(&self) -> TokenStream {
         let ruma_events = self.ruma_events;
         let serde = ruma_events.reexported(RumaEventsReexport::Serde);
 
@@ -34,7 +34,7 @@ impl EventEnum<'_> {
         let serialize_custom_event_error_path =
             quote! { #ruma_events::serialize_custom_event_error }.to_string();
 
-        Ok(quote! {
+        quote! {
             #( #attrs )*
             #[derive(Clone, Debug, #serde::Serialize)]
             #[serde(untagged)]
@@ -57,7 +57,7 @@ impl EventEnum<'_> {
             #event_content_kind_trait_impl
             #from_impl
             #json_castable_impl
-        })
+        }
     }
 
     /// Generate the `ruma_events::EventContentFromType` implementation for the
@@ -153,7 +153,7 @@ impl EventEnum<'_> {
     }
 
     /// Generate an `AnyFull*EventContent` enum.
-    pub(super) fn expand_full_content_enum(&self) -> syn::Result<TokenStream> {
+    pub(super) fn expand_full_content_enum(&self) -> TokenStream {
         let ruma_events = self.ruma_events;
 
         let attrs = &self.attrs;
@@ -164,7 +164,7 @@ impl EventEnum<'_> {
         let variant_docs = &self.variant_docs;
         let event_content_types = &self.event_content_types;
 
-        Ok(quote! {
+        quote! {
             #( #attrs )*
             #[derive(Clone, Debug)]
             #[allow(clippy::large_enum_variant, unused_qualifications)]
@@ -194,7 +194,7 @@ impl EventEnum<'_> {
                     }
                 }
             }
-        })
+        }
     }
 
     /// Implement `JsonCastable<{enum}>` for all the variants and `JsonCastable<JsonObject>` for the

--- a/crates/ruma-macros/src/events/event_enum/event_kind_enum/content.rs
+++ b/crates/ruma-macros/src/events/event_enum/event_kind_enum/content.rs
@@ -1,24 +1,107 @@
 //! Functions to generate `Any*EventContent` enums.
 
-use proc_macro2::TokenStream;
-use quote::quote;
+use std::{collections::BTreeMap, ops::Deref};
+
+use proc_macro2::{Span, TokenStream};
+use quote::{format_ident, quote};
 
 use crate::{
     events::{
-        common::EventContentTraitVariation,
-        event_enum::{EventEnum, EventEnumKind},
+        common::{EventContentTraitVariation, EventVariation},
+        event_enum::{EventContentVariation, EventEnum, EventEnumKind},
     },
     util::RumaEventsReexport,
 };
 
-impl EventEnum<'_> {
-    /// Generate the `Any*EventContent` enum for this kind.
-    pub(super) fn expand_content_enum(&self) -> TokenStream {
+/// A list of `Any*EventContent` enums.
+pub(super) struct EventContentEnums<'a> {
+    inner: &'a EventEnum<'a>,
+
+    /// Enums matching an `EventContentVariation`.
+    enums: BTreeMap<EventContentVariation, EventContentEnumVariation<'a>>,
+
+    /// The special `AnyFullStateEventContent` enum.
+    full: Option<FullEventContentEnum<'a>>,
+}
+
+impl<'a> EventContentEnums<'a> {
+    /// Construct an `EventContentEnums` with the given event enum data.
+    pub(super) fn new(inner: &'a EventEnum<'a>) -> Self {
+        Self { inner, enums: BTreeMap::new(), full: None }
+    }
+
+    /// Get the `EventContentEnumVariation` matching the given event variation, if possible.
+    ///
+    /// If the event variation is supported but the corresponding `EventContentEnumVariation`
+    /// doesn't exist in this list, it is created.
+    pub(super) fn get_or_create(
+        &mut self,
+        event_variation: EventVariation,
+    ) -> Option<&EventContentEnumVariation<'a>> {
+        let variation = EventContentVariation::from_event_variation(event_variation)?;
+
+        Some(
+            self.enums
+                .entry(variation)
+                .or_insert_with(|| EventContentEnumVariation::new(self.inner, variation)),
+        )
+    }
+
+    /// Get the `FullEventContentEnum`.
+    ///
+    /// If it doesn't exist in this list, it is created.
+    pub(super) fn full_event_content_enum(&mut self) -> &FullEventContentEnum<'a> {
+        self.full.get_or_insert_with(|| FullEventContentEnum::new(self.inner))
+    }
+
+    /// Expand the event content enums in this list.
+    pub(super) fn expand(&self) -> TokenStream {
+        self.enums
+            .values()
+            .map(EventContentEnumVariation::expand)
+            .chain(self.full.iter().map(FullEventContentEnum::expand))
+            .collect()
+    }
+}
+
+/// The data for an `Any*EventContent` enum.
+pub(super) struct EventContentEnumVariation<'a> {
+    /// The event enum data.
+    inner: &'a EventEnum<'a>,
+
+    /// The variation of this enum.
+    variation: EventContentVariation,
+
+    /// The name of this enum.
+    ident: syn::Ident,
+
+    /// The paths to the `*EventContent` types of the entries.
+    event_content_types: Vec<syn::Path>,
+}
+
+impl<'a> EventContentEnumVariation<'a> {
+    fn new(inner: &'a EventEnum<'a>, variation: EventContentVariation) -> Self {
+        let kind = inner.kind;
+        let event_content_types =
+            inner.events.iter().map(|event| event.to_event_content_path(kind, variation)).collect();
+
+        Self {
+            inner,
+            variation,
+            ident: format_ident!("Any{variation}{kind}Content"),
+            event_content_types,
+        }
+    }
+}
+
+impl EventContentEnumVariation<'_> {
+    /// Generate this `Any*EventContent` enum.
+    fn expand(&self) -> TokenStream {
         let ruma_events = self.ruma_events;
         let serde = ruma_events.reexported(RumaEventsReexport::Serde);
 
         let attrs = &self.attrs;
-        let ident = &self.content_enum;
+        let ident = &self.ident;
         let variants = &self.variants;
         let variant_attrs = &self.variant_attrs;
         let variant_docs = &self.variant_docs;
@@ -66,7 +149,7 @@ impl EventEnum<'_> {
         let ruma_events = self.ruma_events;
         let serde_json = ruma_events.reexported(RumaEventsReexport::SerdeJson);
 
-        let ident = &self.content_enum;
+        let ident = &self.ident;
         let variants = &self.variants;
         let event_attrs = &self.variant_attrs;
         let event_content_types = &self.event_content_types;
@@ -121,13 +204,13 @@ impl EventEnum<'_> {
     fn expand_content_enum_event_content_kind_trait_impl(&self) -> TokenStream {
         let ruma_events = self.ruma_events;
 
-        let ident = &self.content_enum;
+        let ident = &self.ident;
         let event_type_enum = &self.event_type_enum;
         let variants = &self.variants;
         let variant_attrs = &self.variant_attrs;
 
         let event_content_kind_trait =
-            self.kind.to_content_kind_trait(EventContentTraitVariation::Original);
+            self.kind.to_content_kind_trait(self.variation.to_event_content_trait());
         let extra_event_content_impl = (self.kind == EventEnumKind::State).then(|| {
             quote! {
                 type StateKey = String;
@@ -152,12 +235,152 @@ impl EventEnum<'_> {
         }
     }
 
-    /// Generate an `AnyFull*EventContent` enum.
-    pub(super) fn expand_full_content_enum(&self) -> TokenStream {
+    /// Implement `JsonCastable<{enum}>` for all the variants and `JsonCastable<JsonObject>` for the
+    /// given event content enum.
+    fn expand_content_enum_json_castable_impl(&self) -> TokenStream {
+        let ruma_common = self.ruma_events.ruma_common();
+        let ident = &self.ident;
+
+        // All event content types are represented as objects in JSON.
+        let mut json_castable_impls = quote! {
+            #[automatically_derived]
+            impl #ruma_common::serde::JsonCastable<#ruma_common::serde::JsonObject> for #ident {}
+        };
+
+        json_castable_impls.extend(
+            self.event_content_types.iter().zip(self.variant_attrs.iter()).map(
+                |(event_content_type, variant_attrs)| {
+                    quote! {
+                        #[allow(unused_qualifications)]
+                        #[automatically_derived]
+                        #( #variant_attrs )*
+                        impl #ruma_common::serde::JsonCastable<#ident> for #event_content_type {}
+                    }
+                },
+            ),
+        );
+
+        json_castable_impls
+    }
+
+    /// Generate the accessors on an event enum to get the event content.
+    pub(super) fn expand_content_accessors(&self, maybe_redacted: bool) -> TokenStream {
+        let ruma_events = self.ruma_events;
+
+        let ident = &self.ident;
+        let variants = &self.variants;
+        let variant_attrs = &self.variant_attrs;
+
+        let event_content_kind_trait =
+            self.kind.to_content_kind_trait(self.variation.to_event_content_trait());
+
+        if maybe_redacted {
+            quote! {
+                /// Returns the content for this event if it is not redacted, or `None` if it is.
+                pub fn original_content(&self) -> Option<#ident> {
+                    match self {
+                        #(
+                            #( #variant_attrs )*
+                            Self::#variants(event) => {
+                                event.as_original().map(|ev| #ident::#variants(ev.content.clone()))
+                            }
+                        )*
+                        Self::_Custom(event) => event.as_original().map(|ev| {
+                            #ident::_Custom {
+                                event_type: crate::PrivOwnedStr(
+                                    ::std::convert::From::from(
+                                        ::std::string::ToString::to_string(
+                                            &#ruma_events::#event_content_kind_trait::event_type(
+                                                &ev.content,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            }
+                        }),
+                    }
+                }
+
+                /// Returns whether this event is redacted.
+                pub fn is_redacted(&self) -> bool {
+                    match self {
+                        #(
+                            #( #variant_attrs )*
+                            Self::#variants(event) => {
+                                event.as_original().is_none()
+                            }
+                        )*
+                        Self::_Custom(event) => event.as_original().is_none(),
+                    }
+                }
+            }
+        } else {
+            quote! {
+                /// Returns the content for this event.
+                pub fn content(&self) -> #ident {
+                    match self {
+                        #(
+                            #( #variant_attrs )*
+                            Self::#variants(event) => #ident::#variants(event.content.clone()),
+                        )*
+                        Self::_Custom(event) => #ident::_Custom {
+                            event_type: crate::PrivOwnedStr(
+                                ::std::convert::From::from(
+                                    ::std::string::ToString::to_string(
+                                        &#ruma_events::#event_content_kind_trait::event_type(&event.content)
+                                    )
+                                ),
+                            ),
+                        },
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl<'a> Deref for EventContentEnumVariation<'a> {
+    type Target = EventEnum<'a>;
+
+    fn deref(&self) -> &Self::Target {
+        self.inner
+    }
+}
+
+/// The data for the `AnyFullStateEventContent` enum.
+pub(super) struct FullEventContentEnum<'a> {
+    /// The event enum data.
+    inner: &'a EventEnum<'a>,
+
+    /// The name of the enum.
+    ident: syn::Ident,
+
+    /// The paths to the `*EventContent` types of the entries.
+    event_content_types: Vec<syn::Path>,
+}
+
+impl<'a> FullEventContentEnum<'a> {
+    /// Construct a `FullEventContentEnum` with the given event enum data.
+    fn new(inner: &'a EventEnum<'a>) -> Self {
+        let ident = syn::Ident::new("AnyFullStateEventContent", Span::call_site());
+        let kind = inner.kind;
+        let event_content_types = inner
+            .events
+            .iter()
+            .map(|event| event.to_event_content_path(kind, EventContentVariation::Original))
+            .collect();
+
+        Self { inner, ident, event_content_types }
+    }
+}
+
+impl FullEventContentEnum<'_> {
+    /// Generate the `AnyFullStateEventContent` enum.
+    fn expand(&self) -> TokenStream {
         let ruma_events = self.ruma_events;
 
         let attrs = &self.attrs;
-        let ident = &self.full_content_enum;
+        let ident = &self.ident;
         let event_type_enum = &self.event_type_enum;
         let variants = &self.variants;
         let variant_attrs = &self.variant_attrs;
@@ -197,31 +420,78 @@ impl EventEnum<'_> {
         }
     }
 
-    /// Implement `JsonCastable<{enum}>` for all the variants and `JsonCastable<JsonObject>` for the
-    /// given event content enum.
-    fn expand_content_enum_json_castable_impl(&self) -> TokenStream {
-        let ruma_common = self.ruma_events.ruma_common();
-        let ident = &self.content_enum;
+    /// Generate the accessors on an event enum to get the event content.
+    ///
+    /// `event_enum` is the name of the `*StateEvent` enum containing the `Original` and `Redacted`
+    /// variants, used by each variant of the `Any*StateEvent` enum.
+    pub(super) fn expand_content_accessors(&self, event_enum: &syn::Ident) -> TokenStream {
+        let ruma_events = self.ruma_events;
 
-        // All event content types are represented as objects in JSON.
-        let mut json_castable_impls = quote! {
-            #[automatically_derived]
-            impl #ruma_common::serde::JsonCastable<#ruma_common::serde::JsonObject> for #ident {}
-        };
+        let ident = &self.ident;
+        let variants = &self.variants;
+        let variant_attrs = &self.variant_attrs;
 
-        json_castable_impls.extend(
-            self.event_content_types.iter().zip(self.variant_attrs.iter()).map(
-                |(event_content_type, variant_attrs)| {
-                    quote! {
-                        #[allow(unused_qualifications)]
-                        #[automatically_derived]
+        let original_event_content_kind_trait =
+            self.kind.to_content_kind_trait(EventContentTraitVariation::Original);
+        let redacted_event_content_kind_trait_name =
+            self.kind.to_content_kind_trait(EventContentTraitVariation::Redacted);
+
+        quote! {
+            /// Returns the content of this state event.
+            pub fn content(&self) -> #ident {
+                match self {
+                    #(
                         #( #variant_attrs )*
-                        impl #ruma_common::serde::JsonCastable<#ident> for #event_content_type {}
-                    }
-                },
-            ),
-        );
+                        Self::#variants(event) => match event {
+                            #ruma_events::#event_enum::Original(ev) => #ident::#variants(
+                                #ruma_events::FullStateEventContent::Original {
+                                    content: ev.content.clone(),
+                                    prev_content: ev.unsigned.prev_content.clone()
+                                }
+                            ),
+                            #ruma_events::#event_enum::Redacted(ev) => #ident::#variants(
+                                #ruma_events::FullStateEventContent::Redacted(
+                                    ev.content.clone()
+                                )
+                            ),
+                        },
+                    )*
+                    Self::_Custom(event) => match event {
+                        #ruma_events::#event_enum::Original(ev) => {
+                            #ident::_Custom {
+                                event_type: crate::PrivOwnedStr(
+                                    ::std::string::ToString::to_string(
+                                        &#ruma_events::#original_event_content_kind_trait::event_type(
+                                            &ev.content,
+                                        ),
+                                    ).into_boxed_str(),
+                                ),
+                                redacted: false,
+                            }
+                        }
+                        #ruma_events::#event_enum::Redacted(ev) => {
+                            #ident::_Custom {
+                                event_type: crate::PrivOwnedStr(
+                                    ::std::string::ToString::to_string(
+                                        &#ruma_events::#redacted_event_content_kind_trait_name::event_type(
+                                            &ev.content,
+                                        ),
+                                    ).into_boxed_str(),
+                                ),
+                                redacted: true,
+                            }
+                        }
+                    },
+                }
+            }
+        }
+    }
+}
 
-        json_castable_impls
+impl<'a> Deref for FullEventContentEnum<'a> {
+    type Target = EventEnum<'a>;
+
+    fn deref(&self) -> &Self::Target {
+        self.inner
     }
 }


### PR DESCRIPTION
It is useful for users that want to handle the content of a state event without having to handle variants for the redacted and non-redacted contents.

It will also be useful if we decide to go with #1998, as it will allow users to migrate their types before upgrading Ruma to the version that contains this breaking change.

I recommend to review this commit by commit. The first ones are small refactorings. The biggest one is the third one, but it is just a big refactoring that allows the last commit that finally adds the enum.