### PR TITLE
events: Implement `From<(Redacted)*EventContent> for PossiblyRedacted*EventContent` 

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -1,5 +1,12 @@
 # [unreleased]
 
+Breaking changes:
+
+- `PossiblyRedactedRoomMemberEventContent` is no longer a type alias for
+  `RoomMemberEventContent`. It would previously fail to deserialize if the
+  `third_party_invite` field was redacted as the `display_name` field was
+  required but it is removed during redaction.
+
 Bug fixes:
 
 - Fix a double `msgtype` in a `m.location` event.

--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -17,6 +17,8 @@ Improvements:
   possibly redacted state event contents.
   - Add `AnyStrippedStateEvent::content()` to access only the content of the
     event.
+- Implement `From<(Redacted)*EventContent> for PossiblyRedacted*EventContent`
+  for all state events.
 
 # 0.32.1
 

--- a/crates/ruma-events/src/call/member.rs
+++ b/crates/ruma-events/src/call/member.rs
@@ -225,6 +225,12 @@ impl StaticEventContent for RedactedCallMemberEventContent {
     type IsPrefix = <CallMemberEventContent as StaticEventContent>::IsPrefix;
 }
 
+impl From<RedactedCallMemberEventContent> for PossiblyRedactedCallMemberEventContent {
+    fn from(_value: RedactedCallMemberEventContent) -> Self {
+        Self::new_empty(None)
+    }
+}
+
 /// Legacy content with an array of memberships. See also: [`CallMemberEventContent`]
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]

--- a/crates/ruma-events/src/policy/rule.rs
+++ b/crates/ruma-events/src/policy/rule.rs
@@ -55,6 +55,26 @@ pub struct PossiblyRedactedPolicyRuleEventContent {
     pub reason: Option<String>,
 }
 
+impl PossiblyRedactedPolicyRuleEventContent {
+    /// Creates a new `PossiblyRedactedPolicyRuleEventContent` with the given entity, recommendation
+    /// and reason.
+    pub fn new(entity: String, recommendation: Recommendation, reason: String) -> Self {
+        Self { entity: Some(entity), recommendation: Some(recommendation), reason: Some(reason) }
+    }
+
+    /// Creates an empty `PossiblyRedactedPolicyRuleEventContent`.
+    pub(crate) fn empty() -> Self {
+        Self { entity: None, recommendation: None, reason: None }
+    }
+}
+
+impl From<PolicyRuleEventContent> for PossiblyRedactedPolicyRuleEventContent {
+    fn from(value: PolicyRuleEventContent) -> Self {
+        let PolicyRuleEventContent { entity, recommendation, reason } = value;
+        Self { entity: Some(entity), recommendation: Some(recommendation), reason: Some(reason) }
+    }
+}
+
 /// The possible actions that can be taken.
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
 #[derive(Clone, StringEnum)]

--- a/crates/ruma-events/src/policy/rule/room.rs
+++ b/crates/ruma-events/src/policy/rule/room.rs
@@ -36,6 +36,20 @@ impl StaticEventContent for PossiblyRedactedPolicyRuleRoomEventContent {
     type IsPrefix = <PolicyRuleRoomEventContent as StaticEventContent>::IsPrefix;
 }
 
+impl From<PolicyRuleRoomEventContent> for PossiblyRedactedPolicyRuleRoomEventContent {
+    fn from(value: PolicyRuleRoomEventContent) -> Self {
+        let PolicyRuleRoomEventContent(policy) = value;
+        Self(policy.into())
+    }
+}
+
+impl From<RedactedPolicyRuleRoomEventContent> for PossiblyRedactedPolicyRuleRoomEventContent {
+    fn from(value: RedactedPolicyRuleRoomEventContent) -> Self {
+        let RedactedPolicyRuleRoomEventContent {} = value;
+        Self(PossiblyRedactedPolicyRuleEventContent::empty())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use ruma_common::serde::Raw;

--- a/crates/ruma-events/src/policy/rule/server.rs
+++ b/crates/ruma-events/src/policy/rule/server.rs
@@ -35,3 +35,17 @@ impl StaticEventContent for PossiblyRedactedPolicyRuleServerEventContent {
     const TYPE: &'static str = PolicyRuleServerEventContent::TYPE;
     type IsPrefix = <PolicyRuleServerEventContent as StaticEventContent>::IsPrefix;
 }
+
+impl From<PolicyRuleServerEventContent> for PossiblyRedactedPolicyRuleServerEventContent {
+    fn from(value: PolicyRuleServerEventContent) -> Self {
+        let PolicyRuleServerEventContent(policy) = value;
+        Self(policy.into())
+    }
+}
+
+impl From<RedactedPolicyRuleServerEventContent> for PossiblyRedactedPolicyRuleServerEventContent {
+    fn from(value: RedactedPolicyRuleServerEventContent) -> Self {
+        let RedactedPolicyRuleServerEventContent {} = value;
+        Self(PossiblyRedactedPolicyRuleEventContent::empty())
+    }
+}

--- a/crates/ruma-events/src/policy/rule/user.rs
+++ b/crates/ruma-events/src/policy/rule/user.rs
@@ -35,3 +35,17 @@ impl StaticEventContent for PossiblyRedactedPolicyRuleUserEventContent {
     const TYPE: &'static str = PolicyRuleUserEventContent::TYPE;
     type IsPrefix = <PolicyRuleUserEventContent as StaticEventContent>::IsPrefix;
 }
+
+impl From<PolicyRuleUserEventContent> for PossiblyRedactedPolicyRuleUserEventContent {
+    fn from(value: PolicyRuleUserEventContent) -> Self {
+        let PolicyRuleUserEventContent(policy) = value;
+        Self(policy.into())
+    }
+}
+
+impl From<RedactedPolicyRuleUserEventContent> for PossiblyRedactedPolicyRuleUserEventContent {
+    fn from(value: RedactedPolicyRuleUserEventContent) -> Self {
+        let RedactedPolicyRuleUserEventContent {} = value;
+        Self(PossiblyRedactedPolicyRuleEventContent::empty())
+    }
+}

--- a/crates/ruma-events/src/room/aliases.rs
+++ b/crates/ruma-events/src/room/aliases.rs
@@ -73,3 +73,9 @@ impl StaticEventContent for RedactedRoomAliasesEventContent {
     const TYPE: &'static str = RoomAliasesEventContent::TYPE;
     type IsPrefix = <RoomAliasesEventContent as StaticEventContent>::IsPrefix;
 }
+
+impl From<RedactedRoomAliasesEventContent> for PossiblyRedactedRoomAliasesEventContent {
+    fn from(value: RedactedRoomAliasesEventContent) -> Self {
+        Self { aliases: value.aliases }
+    }
+}

--- a/crates/ruma-events/src/room/encrypted/unstable_state.rs
+++ b/crates/ruma-events/src/room/encrypted/unstable_state.rs
@@ -41,6 +41,21 @@ impl PossiblyRedactedStateEventContent for PossiblyRedactedStateRoomEncryptedEve
     }
 }
 
+impl From<StateRoomEncryptedEventContent> for PossiblyRedactedStateRoomEncryptedEventContent {
+    fn from(value: StateRoomEncryptedEventContent) -> Self {
+        let StateRoomEncryptedEventContent { scheme } = value;
+        Self { scheme: Some(scheme) }
+    }
+}
+
+impl From<RedactedStateRoomEncryptedEventContent>
+    for PossiblyRedactedStateRoomEncryptedEventContent
+{
+    fn from(_value: RedactedStateRoomEncryptedEventContent) -> Self {
+        Self { scheme: None }
+    }
+}
+
 #[cfg(test)]
 mod tests {
 

--- a/crates/ruma-events/src/room/join_rules.rs
+++ b/crates/ruma-events/src/room/join_rules.rs
@@ -101,6 +101,13 @@ impl<'de> Deserialize<'de> for RedactedRoomJoinRulesEventContent {
 
 impl JsonCastable<JsonObject> for RedactedRoomJoinRulesEventContent {}
 
+impl From<RedactedRoomJoinRulesEventContent> for PossiblyRedactedRoomJoinRulesEventContent {
+    fn from(value: RedactedRoomJoinRulesEventContent) -> Self {
+        let RedactedRoomJoinRulesEventContent { join_rule } = value;
+        Self { join_rule }
+    }
+}
+
 impl RoomJoinRulesEvent {
     /// Obtain the join rule, regardless of whether this event is redacted.
     pub fn join_rule(&self) -> &JoinRule {

--- a/crates/ruma-events/src/room/power_levels.rs
+++ b/crates/ruma-events/src/room/power_levels.rs
@@ -316,6 +316,35 @@ impl RedactedStateEventContent for RedactedRoomPowerLevelsEventContent {
     }
 }
 
+impl From<RedactedRoomPowerLevelsEventContent> for PossiblyRedactedRoomPowerLevelsEventContent {
+    fn from(value: RedactedRoomPowerLevelsEventContent) -> Self {
+        let RedactedRoomPowerLevelsEventContent {
+            ban,
+            events,
+            events_default,
+            invite,
+            kick,
+            redact,
+            state_default,
+            users,
+            users_default,
+        } = value;
+
+        Self {
+            ban,
+            events,
+            events_default,
+            invite,
+            kick,
+            redact,
+            state_default,
+            users,
+            users_default,
+            notifications: NotificationPowerLevels::default(),
+        }
+    }
+}
+
 /// The power level of a particular user.
 ///
 /// Is either considered "infinite" if that user is a room creator, or an integer if they are not.

--- a/crates/ruma-events/src/room/tombstone.rs
+++ b/crates/ruma-events/src/room/tombstone.rs
@@ -64,3 +64,16 @@ impl StaticEventContent for PossiblyRedactedRoomTombstoneEventContent {
     const TYPE: &'static str = RoomTombstoneEventContent::TYPE;
     type IsPrefix = <RoomTombstoneEventContent as StaticEventContent>::IsPrefix;
 }
+
+impl From<RoomTombstoneEventContent> for PossiblyRedactedRoomTombstoneEventContent {
+    fn from(value: RoomTombstoneEventContent) -> Self {
+        let RoomTombstoneEventContent { body, replacement_room } = value;
+        Self { body: Some(body), replacement_room: Some(replacement_room) }
+    }
+}
+
+impl From<RedactedRoomTombstoneEventContent> for PossiblyRedactedRoomTombstoneEventContent {
+    fn from(_value: RedactedRoomTombstoneEventContent) -> Self {
+        Self { body: None, replacement_room: None }
+    }
+}


### PR DESCRIPTION
It allows to check that the possibly-redacted type can actually represent both types and… I found that `PossiblyRedactedRoomMemberEventContent` actually needed to be fixed!

It should also somewhat help users to prepare for #1998 if it is implemented.