### PR TITLE
events: Implement `RedactContent` for `PossiblyRedacted*EventContent`

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -19,6 +19,8 @@ Improvements:
     event.
 - Implement `From<(Redacted)*EventContent> for PossiblyRedacted*EventContent`
   for all state events.
+- Implement `RedactContent for PossiblyRedacted*EventContent` for all state
+  events. 
 
 # 0.32.1
 

--- a/crates/ruma-events/src/policy/rule/room.rs
+++ b/crates/ruma-events/src/policy/rule/room.rs
@@ -2,11 +2,12 @@
 //!
 //! [`m.policy.rule.room`]: https://spec.matrix.org/latest/client-server-api/#mpolicyruleroom
 
+use ruma_common::room_version_rules::RedactionRules;
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
 use super::{PolicyRuleEventContent, PossiblyRedactedPolicyRuleEventContent};
-use crate::{PossiblyRedactedStateEventContent, StateEventType, StaticEventContent};
+use crate::{PossiblyRedactedStateEventContent, RedactContent, StateEventType, StaticEventContent};
 
 /// The content of an `m.policy.rule.room` event.
 ///
@@ -34,6 +35,14 @@ impl PossiblyRedactedStateEventContent for PossiblyRedactedPolicyRuleRoomEventCo
 impl StaticEventContent for PossiblyRedactedPolicyRuleRoomEventContent {
     const TYPE: &'static str = PolicyRuleRoomEventContent::TYPE;
     type IsPrefix = <PolicyRuleRoomEventContent as StaticEventContent>::IsPrefix;
+}
+
+impl RedactContent for PossiblyRedactedPolicyRuleRoomEventContent {
+    type Redacted = Self;
+
+    fn redact(self, _rules: &RedactionRules) -> Self::Redacted {
+        Self(PossiblyRedactedPolicyRuleEventContent::empty())
+    }
 }
 
 impl From<PolicyRuleRoomEventContent> for PossiblyRedactedPolicyRuleRoomEventContent {

--- a/crates/ruma-events/src/policy/rule/server.rs
+++ b/crates/ruma-events/src/policy/rule/server.rs
@@ -2,11 +2,12 @@
 //!
 //! [`m.policy.rule.server`]: https://spec.matrix.org/latest/client-server-api/#mpolicyruleserver
 
+use ruma_common::room_version_rules::RedactionRules;
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
 use super::{PolicyRuleEventContent, PossiblyRedactedPolicyRuleEventContent};
-use crate::{PossiblyRedactedStateEventContent, StateEventType, StaticEventContent};
+use crate::{PossiblyRedactedStateEventContent, RedactContent, StateEventType, StaticEventContent};
 
 /// The content of an `m.policy.rule.server` event.
 ///
@@ -34,6 +35,14 @@ impl PossiblyRedactedStateEventContent for PossiblyRedactedPolicyRuleServerEvent
 impl StaticEventContent for PossiblyRedactedPolicyRuleServerEventContent {
     const TYPE: &'static str = PolicyRuleServerEventContent::TYPE;
     type IsPrefix = <PolicyRuleServerEventContent as StaticEventContent>::IsPrefix;
+}
+
+impl RedactContent for PossiblyRedactedPolicyRuleServerEventContent {
+    type Redacted = Self;
+
+    fn redact(self, _rules: &RedactionRules) -> Self::Redacted {
+        Self(PossiblyRedactedPolicyRuleEventContent::empty())
+    }
 }
 
 impl From<PolicyRuleServerEventContent> for PossiblyRedactedPolicyRuleServerEventContent {

--- a/crates/ruma-events/src/policy/rule/user.rs
+++ b/crates/ruma-events/src/policy/rule/user.rs
@@ -2,11 +2,12 @@
 //!
 //! [`m.policy.rule.user`]: https://spec.matrix.org/latest/client-server-api/#mpolicyruleuser
 
+use ruma_common::room_version_rules::RedactionRules;
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
 use super::{PolicyRuleEventContent, PossiblyRedactedPolicyRuleEventContent};
-use crate::{PossiblyRedactedStateEventContent, StateEventType, StaticEventContent};
+use crate::{PossiblyRedactedStateEventContent, RedactContent, StateEventType, StaticEventContent};
 
 /// The content of an `m.policy.rule.user` event.
 ///
@@ -34,6 +35,14 @@ impl PossiblyRedactedStateEventContent for PossiblyRedactedPolicyRuleUserEventCo
 impl StaticEventContent for PossiblyRedactedPolicyRuleUserEventContent {
     const TYPE: &'static str = PolicyRuleUserEventContent::TYPE;
     type IsPrefix = <PolicyRuleUserEventContent as StaticEventContent>::IsPrefix;
+}
+
+impl RedactContent for PossiblyRedactedPolicyRuleUserEventContent {
+    type Redacted = Self;
+
+    fn redact(self, _rules: &RedactionRules) -> Self::Redacted {
+        Self(PossiblyRedactedPolicyRuleEventContent::empty())
+    }
 }
 
 impl From<PolicyRuleUserEventContent> for PossiblyRedactedPolicyRuleUserEventContent {

--- a/crates/ruma-events/src/room/aliases.rs
+++ b/crates/ruma-events/src/room/aliases.rs
@@ -79,3 +79,12 @@ impl From<RedactedRoomAliasesEventContent> for PossiblyRedactedRoomAliasesEventC
         Self { aliases: value.aliases }
     }
 }
+
+impl RedactContent for PossiblyRedactedRoomAliasesEventContent {
+    type Redacted = Self;
+
+    fn redact(self, rules: &RedactionRules) -> Self {
+        let aliases = self.aliases.filter(|_| rules.keep_room_aliases_aliases);
+        Self { aliases }
+    }
+}

--- a/crates/ruma-events/src/room/encrypted/unstable_state.rs
+++ b/crates/ruma-events/src/room/encrypted/unstable_state.rs
@@ -1,11 +1,12 @@
 //! Types for `m.room.encrypted` state events, as defined in [MSC4362][msc].
 //!
 //! [msc]: https://github.com/matrix-org/matrix-spec-proposals/pull/4362
+use ruma_common::room_version_rules::RedactionRules;
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    PossiblyRedactedStateEventContent, StateEventType, StaticEventContent,
+    PossiblyRedactedStateEventContent, RedactContent, StateEventType, StaticEventContent,
     room::encrypted::EncryptedEventScheme,
 };
 
@@ -38,6 +39,14 @@ impl PossiblyRedactedStateEventContent for PossiblyRedactedStateRoomEncryptedEve
 
     fn event_type(&self) -> StateEventType {
         StateEventType::RoomEncrypted
+    }
+}
+
+impl RedactContent for PossiblyRedactedStateRoomEncryptedEventContent {
+    type Redacted = Self;
+
+    fn redact(self, _rules: &RedactionRules) -> Self::Redacted {
+        Self { scheme: None }
     }
 }
 

--- a/crates/ruma-events/src/room/tombstone.rs
+++ b/crates/ruma-events/src/room/tombstone.rs
@@ -6,7 +6,10 @@ use ruma_common::OwnedRoomId;
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
-use crate::{EmptyStateKey, PossiblyRedactedStateEventContent, StateEventType, StaticEventContent};
+use crate::{
+    EmptyStateKey, PossiblyRedactedStateEventContent, RedactContent, StateEventType,
+    StaticEventContent,
+};
 
 /// The content of an `m.room.tombstone` event.
 ///
@@ -63,6 +66,14 @@ impl PossiblyRedactedStateEventContent for PossiblyRedactedRoomTombstoneEventCon
 impl StaticEventContent for PossiblyRedactedRoomTombstoneEventContent {
     const TYPE: &'static str = RoomTombstoneEventContent::TYPE;
     type IsPrefix = <RoomTombstoneEventContent as StaticEventContent>::IsPrefix;
+}
+
+impl RedactContent for PossiblyRedactedRoomTombstoneEventContent {
+    type Redacted = Self;
+
+    fn redact(self, _rules: &ruma_common::room_version_rules::RedactionRules) -> Self::Redacted {
+        Self { body: None, replacement_room: None }
+    }
 }
 
 impl From<RoomTombstoneEventContent> for PossiblyRedactedRoomTombstoneEventContent {

--- a/crates/ruma-macros/src/events/event_content.rs
+++ b/crates/ruma-macros/src/events/event_content.rs
@@ -195,6 +195,55 @@ impl EventContent {
             })
             .collect::<Vec<_>>();
 
+        let should_generate_redacted = self.kind.should_generate_redacted();
+        let redacted_ident = should_generate_redacted
+            .then(|| EventContentVariation::Redacted.variation_ident(ident));
+        let redacted_field_idents = should_generate_redacted
+            .then(|| {
+                possibly_redacted_fields
+                    .iter()
+                    .filter(|field| field.skip_redaction)
+                    .map(|field| &field.inner.ident)
+            })
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+        let from_redacted_field_exprs = should_generate_redacted
+            .then(|| {
+                possibly_redacted_fields.iter().map(|field| {
+                    let ident = &field.inner.ident;
+
+                    if field.skip_redaction {
+                        quote! { #ident }
+                    } else if let Some(default_expr) = field.inner.serde_default_expr() {
+                        quote! { #ident: #default_expr() }
+                    } else {
+                        quote! { #ident: Default::default() }
+                    }
+                })
+            })
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+
+        // Implement `From<Redacted*EventContent>` if we generated it automatically.
+        let from_redacted_impl = should_generate_redacted.then(|| {
+            quote! {
+
+                impl From<#redacted_ident> for #possibly_redacted_ident {
+                    fn from(value: #redacted_ident) -> #possibly_redacted_ident {
+                        let #redacted_ident {
+                            #( #redacted_field_idents, )*
+                        } = value;
+
+                        Self {
+                            #( #from_redacted_field_exprs, )*
+                        }
+                    }
+                }
+            }
+        });
+
         // If at least one field needs to change, generate a new struct, else use a type alias.
         if field_changed {
             let possibly_redacted_event_content = self.expand_event_content_impl(
@@ -223,31 +272,22 @@ impl EventContent {
                 }
             });
 
-            // Implement `From<Redacted*EventContent>` if we generated it automatically.
-            let from_redacted_impl = self.kind.should_generate_redacted().then(|| {
-                let redacted_ident = EventContentVariation::Redacted.variation_ident(ident);
-                let redacted_field_idents = possibly_redacted_fields
-                    .iter()
-                    .filter(|field| field.skip_redaction)
-                    .map(|field| &field.inner.ident);
-                let from_redacted_field_exprs = possibly_redacted_fields.iter().map(|field| {
-                    let ident = &field.inner.ident;
+            let redact_content_impl = self.kind.should_generate_redacted().then(|| {
+                let ruma_events = &self.ruma_events;
+                let ruma_common = ruma_events.ruma_common();
 
-                    if field.skip_redaction {
-                        quote! { #ident }
-                    } else if let Some(default_expr) = field.inner.serde_default_expr() {
-                        quote! { #ident: #default_expr() }
-                    } else {
-                        quote! { #ident: Default::default() }
-                    }
-                });
+                let maybe_remaining_fields = (redacted_field_idents.len() != from_redacted_field_exprs.len()).then(|| quote! { .. });
 
                 quote! {
-                    impl From<#redacted_ident> for #possibly_redacted_ident {
-                        fn from(value: #redacted_ident) -> #possibly_redacted_ident {
-                            let #redacted_ident {
+                    #[automatically_derived]
+                    impl #ruma_events::RedactContent for #possibly_redacted_ident {
+                        type Redacted = #possibly_redacted_ident;
+
+                        fn redact(self, _rules: &#ruma_common::room_version_rules::RedactionRules) -> #possibly_redacted_ident {
+                            let Self {
                                 #( #redacted_field_idents, )*
-                            } = value;
+                                #maybe_remaining_fields
+                            } = self;
 
                             Self {
                                 #( #from_redacted_field_exprs, )*
@@ -277,6 +317,7 @@ impl EventContent {
                     }
                 }
 
+                #redact_content_impl
                 #from_redacted_impl
                 #possibly_redacted_event_content
                 #static_event_content_impl
@@ -292,6 +333,7 @@ impl EventContent {
                 #[doc = #possibly_redacted_doc]
                 #vis type #possibly_redacted_ident = #ident;
 
+                #from_redacted_impl
                 #event_content_kind_trait_impl
             })
         }


### PR DESCRIPTION
Allows to use it more easily in place of `(Redacted)*EventContent`.

Based on #2342.
