### PR TITLE
Add `assert_to_canonical_json_eq!` macro and use it in tests

### DIFF
--- a/crates/ruma-appservice-api/src/event/push_events.rs
+++ b/crates/ruma-appservice-api/src/event/push_events.rs
@@ -328,9 +328,12 @@ pub mod v1 {
     mod tests {
         use assert_matches2::assert_matches;
         use js_int::uint;
-        use ruma_common::{MilliSecondsSinceUnixEpoch, event_id, room_id, user_id};
+        use ruma_common::{
+            MilliSecondsSinceUnixEpoch, canonical_json::assert_to_canonical_json_eq, event_id,
+            room_id, user_id,
+        };
         use ruma_events::receipt::ReceiptType;
-        use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+        use serde_json::{from_value as from_json_value, json};
 
         use super::EphemeralData;
 
@@ -392,8 +395,7 @@ pub mod v1 {
             assert_eq!(typing.room_id, room_id);
             assert_eq!(typing.content.user_ids, &[user_id.to_owned()]);
 
-            let serialized_data = to_json_value(data).unwrap();
-            assert_eq!(serialized_data, typing_json);
+            assert_to_canonical_json_eq!(data, typing_json);
 
             // Test m.receipt serde.
             let receipt_json = json!({
@@ -418,8 +420,7 @@ pub mod v1 {
             let event_user_read_receipt = event_read_receipts.get(user_id).unwrap();
             assert_eq!(event_user_read_receipt.ts, Some(MilliSecondsSinceUnixEpoch(uint!(453))));
 
-            let serialized_data = to_json_value(data).unwrap();
-            assert_eq!(serialized_data, receipt_json);
+            assert_to_canonical_json_eq!(data, receipt_json);
 
             // Test m.presence serde.
             let presence_json = json!({
@@ -439,8 +440,7 @@ pub mod v1 {
             assert_eq!(presence.sender, user_id);
             assert_eq!(presence.content.currently_active, Some(false));
 
-            let serialized_data = to_json_value(data).unwrap();
-            assert_eq!(serialized_data, presence_json);
+            assert_to_canonical_json_eq!(data, presence_json);
 
             // Test custom serde.
             let custom_json = json!({
@@ -453,8 +453,7 @@ pub mod v1 {
 
             let data = from_json_value::<EphemeralData>(custom_json.clone()).unwrap();
 
-            let serialized_data = to_json_value(data).unwrap();
-            assert_eq!(serialized_data, custom_json);
+            assert_to_canonical_json_eq!(data, custom_json);
         }
 
         #[test]

--- a/crates/ruma-client-api/src/discovery/discover_homeserver.rs
+++ b/crates/ruma-client-api/src/discovery/discover_homeserver.rs
@@ -235,7 +235,9 @@ mod tests {
     #[cfg(feature = "unstable-msc4143")]
     use assert_matches2::assert_matches;
     #[cfg(feature = "unstable-msc4143")]
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+    use ruma_common::canonical_json::assert_to_canonical_json_eq;
+    #[cfg(feature = "unstable-msc4143")]
+    use serde_json::{from_value as from_json_value, json};
 
     #[cfg(feature = "unstable-msc4143")]
     use super::RtcFocusInfo;
@@ -263,12 +265,9 @@ mod tests {
         // Given a LiveKit RTC focus info.
         let focus = RtcFocusInfo::livekit("https://livekit.example.com".to_owned());
 
-        // When serializing it to JSON.
-        let json = to_json_value(&focus).unwrap();
-
-        // Then it should match the expected JSON structure.
-        assert_eq!(
-            json,
+        // When serializing to JSON, it should match the expected JSON structure.
+        assert_to_canonical_json_eq!(
+            focus,
             json!({
                 "type": "livekit",
                 "livekit_service_url": "https://livekit.example.com"
@@ -306,10 +305,7 @@ mod tests {
 
         assert!(!data.contains_key("type"));
 
-        // When serializing it back to JSON.
-        let serialized = to_json_value(&focus).unwrap();
-
-        // Then it should match the original JSON.
-        assert_eq!(serialized, json);
+        // When serializing it back to JSON, it should match the original JSON.
+        assert_to_canonical_json_eq!(focus, json);
     }
 }

--- a/crates/ruma-client-api/src/filter.rs
+++ b/crates/ruma-client-api/src/filter.rs
@@ -367,42 +367,41 @@ can_be_empty!(RoomFilter);
 
 #[cfg(test)]
 mod tests {
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+    use ruma_common::canonical_json::assert_to_canonical_json_eq;
+    use serde_json::{
+        from_str as from_json_str, from_value as from_json_value, json, to_string as to_json_string,
+    };
 
     use super::{
         Filter, FilterDefinition, LazyLoadOptions, RoomEventFilter, RoomFilter, UrlFilter,
     };
 
     #[test]
-    fn default_filters_are_empty() -> serde_json::Result<()> {
-        assert_eq!(to_json_value(Filter::default())?, json!({}));
-        assert_eq!(to_json_value(FilterDefinition::default())?, json!({}));
-        assert_eq!(to_json_value(RoomEventFilter::default())?, json!({}));
-        assert_eq!(to_json_value(RoomFilter::default())?, json!({}));
-
-        Ok(())
+    fn default_filters_are_empty() {
+        assert_to_canonical_json_eq!(Filter::default(), json!({}));
+        assert_to_canonical_json_eq!(FilterDefinition::default(), json!({}));
+        assert_to_canonical_json_eq!(RoomEventFilter::default(), json!({}));
+        assert_to_canonical_json_eq!(RoomFilter::default(), json!({}));
     }
 
     #[test]
-    fn filter_definition_roundtrip() -> serde_json::Result<()> {
+    fn filter_definition_roundtrip() {
         let filter = FilterDefinition::default();
-        let filter_str = to_json_value(&filter)?;
+        assert_to_canonical_json_eq!(filter, json!({}));
 
-        let incoming_filter = from_json_value::<FilterDefinition>(filter_str)?;
+        let filter_str = to_json_string(&filter).unwrap();
+        let incoming_filter = from_json_str::<FilterDefinition>(&filter_str).unwrap();
         assert!(incoming_filter.is_empty());
-
-        Ok(())
     }
 
     #[test]
-    fn room_filter_definition_roundtrip() -> serde_json::Result<()> {
+    fn room_filter_definition_roundtrip() {
         let filter = RoomFilter::default();
-        let room_filter = to_json_value(filter)?;
+        assert_to_canonical_json_eq!(filter, json!({}));
 
-        let incoming_room_filter = from_json_value::<RoomFilter>(room_filter)?;
+        let filter_str = to_json_string(&filter).unwrap();
+        let incoming_room_filter = from_json_str::<RoomFilter>(&filter_str).unwrap();
         assert!(incoming_room_filter.is_empty());
-
-        Ok(())
     }
 
     #[test]

--- a/crates/ruma-client-api/src/filter/lazy_load.rs
+++ b/crates/ruma-client-api/src/filter/lazy_load.rs
@@ -73,27 +73,28 @@ impl From<LazyLoadJsonRepr> for LazyLoadOptions {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+    use ruma_common::canonical_json::assert_to_canonical_json_eq;
+    use serde_json::{from_value as from_json_value, json};
 
     use super::LazyLoadOptions;
 
     #[test]
     fn serialize_disabled() {
         let lazy_load_options = LazyLoadOptions::Disabled;
-        assert_eq!(to_json_value(lazy_load_options).unwrap(), json!({}));
+        assert_to_canonical_json_eq!(lazy_load_options, json!({}));
     }
 
     #[test]
     fn serialize_no_redundant() {
         let lazy_load_options = LazyLoadOptions::Enabled { include_redundant_members: false };
-        assert_eq!(to_json_value(lazy_load_options).unwrap(), json!({ "lazy_load_members": true }));
+        assert_to_canonical_json_eq!(lazy_load_options, json!({ "lazy_load_members": true }));
     }
 
     #[test]
     fn serialize_with_redundant() {
         let lazy_load_options = LazyLoadOptions::Enabled { include_redundant_members: true };
-        assert_eq!(
-            to_json_value(lazy_load_options).unwrap(),
+        assert_to_canonical_json_eq!(
+            lazy_load_options,
             json!({ "lazy_load_members": true, "include_redundant_members": true })
         );
     }

--- a/crates/ruma-client-api/src/filter/url.rs
+++ b/crates/ruma-client-api/src/filter/url.rs
@@ -40,20 +40,21 @@ impl<'de> Deserialize<'de> for UrlFilter {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+    use ruma_common::canonical_json::assert_to_canonical_json_eq;
+    use serde_json::{from_value as from_json_value, json};
 
     use super::UrlFilter;
 
     #[test]
     fn serialize_filter_events_with_url() {
         let events_with_url = UrlFilter::EventsWithUrl;
-        assert_eq!(to_json_value(events_with_url).unwrap(), json!(true));
+        assert_to_canonical_json_eq!(events_with_url, json!(true));
     }
 
     #[test]
     fn serialize_filter_events_without_url() {
         let events_without_url = UrlFilter::EventsWithoutUrl;
-        assert_eq!(to_json_value(events_without_url).unwrap(), json!(false));
+        assert_to_canonical_json_eq!(events_without_url, json!(false));
     }
 
     #[test]

--- a/crates/ruma-client-api/src/profile.rs
+++ b/crates/ruma-client-api/src/profile.rs
@@ -157,8 +157,8 @@ const EXTENDED_PROFILE_FIELD_HISTORY: VersionHistory = VersionHistory::new(
 
 #[cfg(test)]
 mod tests {
-    use ruma_common::owned_mxc_uri;
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+    use ruma_common::{canonical_json::assert_to_canonical_json_eq, owned_mxc_uri};
+    use serde_json::{from_value as from_json_value, json};
 
     use super::ProfileFieldValue;
 
@@ -166,18 +166,15 @@ mod tests {
     fn serialize_profile_field_value() {
         // Avatar URL.
         let value = ProfileFieldValue::AvatarUrl(owned_mxc_uri!("mxc://localhost/abcdef"));
-        assert_eq!(
-            to_json_value(value).unwrap(),
-            json!({ "avatar_url": "mxc://localhost/abcdef" })
-        );
+        assert_to_canonical_json_eq!(value, json!({ "avatar_url": "mxc://localhost/abcdef" }));
 
         // Display name.
         let value = ProfileFieldValue::DisplayName("Alice".to_owned());
-        assert_eq!(to_json_value(value).unwrap(), json!({ "displayname": "Alice" }));
+        assert_to_canonical_json_eq!(value, json!({ "displayname": "Alice" }));
 
         // Custom field.
         let value = ProfileFieldValue::new("custom_field", "value".into()).unwrap();
-        assert_eq!(to_json_value(value).unwrap(), json!({ "custom_field": "value" }));
+        assert_to_canonical_json_eq!(value, json!({ "custom_field": "value" }));
     }
 
     #[test]

--- a/crates/ruma-client-api/src/push/pusher_serde.rs
+++ b/crates/ruma-client-api/src/push/pusher_serde.rs
@@ -80,10 +80,10 @@ impl<'de> Deserialize<'de> for PusherKind {
 #[cfg(test)]
 mod tests {
     use assert_matches2::assert_matches;
-    use ruma_common::{push::HttpPusherData, serde::JsonObject};
-    use serde_json::{
-        Value as JsonValue, from_value as from_json_value, json, to_value as to_json_value,
+    use ruma_common::{
+        canonical_json::assert_to_canonical_json_eq, push::HttpPusherData, serde::JsonObject,
     };
+    use serde_json::{Value as JsonValue, from_value as from_json_value, json};
 
     use crate::push::{CustomPusherData, EmailPusherData, PusherKind};
 
@@ -93,8 +93,8 @@ mod tests {
         let mut data = EmailPusherData::new();
         let action = PusherKind::Email(data.clone());
 
-        assert_eq!(
-            to_json_value(action).unwrap(),
+        assert_to_canonical_json_eq!(
+            action,
             json!({
                 "kind": "email",
                 "data": {},
@@ -105,8 +105,8 @@ mod tests {
         data.data.insert("custom_key".to_owned(), "value".into());
         let action = PusherKind::Email(data);
 
-        assert_eq!(
-            to_json_value(action).unwrap(),
+        assert_to_canonical_json_eq!(
+            action,
             json!({
                 "kind": "email",
                 "data": {
@@ -122,8 +122,8 @@ mod tests {
         let mut data = HttpPusherData::new("http://localhost".to_owned());
         let action = PusherKind::Http(data.clone());
 
-        assert_eq!(
-            to_json_value(action).unwrap(),
+        assert_to_canonical_json_eq!(
+            action,
             json!({
                 "kind": "http",
                 "data": {
@@ -136,8 +136,8 @@ mod tests {
         data.data.insert("custom_key".to_owned(), "value".into());
         let action = PusherKind::Http(data);
 
-        assert_eq!(
-            to_json_value(action).unwrap(),
+        assert_to_canonical_json_eq!(
+            action,
             json!({
                 "kind": "http",
                 "data": {
@@ -155,8 +155,8 @@ mod tests {
             data: JsonObject::new(),
         });
 
-        assert_eq!(
-            to_json_value(action).unwrap(),
+        assert_to_canonical_json_eq!(
+            action,
             json!({
                 "kind": "my.custom.kind",
                 "data": {}

--- a/crates/ruma-client-api/src/push/set_pusher/set_pusher_serde.rs
+++ b/crates/ruma-client-api/src/push/set_pusher/set_pusher_serde.rs
@@ -68,7 +68,8 @@ impl<'de> Deserialize<'de> for PusherAction {
 #[cfg(test)]
 mod tests {
     use assert_matches2::assert_matches;
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+    use ruma_common::canonical_json::assert_to_canonical_json_eq;
+    use serde_json::{from_value as from_json_value, json};
 
     use super::PusherAction;
     use crate::push::{
@@ -89,8 +90,8 @@ mod tests {
             append: false,
         });
 
-        assert_eq!(
-            to_json_value(action).unwrap(),
+        assert_to_canonical_json_eq!(
+            action,
             json!({
                 "pushkey": "abcdef",
                 "app_id": "my.matrix.app",
@@ -108,8 +109,8 @@ mod tests {
         let action =
             PusherAction::Delete(PusherIds::new("abcdef".to_owned(), "my.matrix.app".to_owned()));
 
-        assert_eq!(
-            to_json_value(action).unwrap(),
+        assert_to_canonical_json_eq!(
+            action,
             json!({
                 "pushkey": "abcdef",
                 "app_id": "my.matrix.app",

--- a/crates/ruma-client-api/src/room/create_room.rs
+++ b/crates/ruma-client-api/src/room/create_room.rs
@@ -294,8 +294,10 @@ mod tests {
     use assign::assign;
     use js_int::int;
     use maplit::btreemap;
-    use ruma_common::{power_levels::NotificationPowerLevels, user_id};
-    use serde_json::{json, to_value as to_json_value};
+    use ruma_common::{
+        canonical_json::assert_to_canonical_json_eq, power_levels::NotificationPowerLevels, user_id,
+    };
+    use serde_json::json;
 
     use super::RoomPowerLevelsContentOverride;
 
@@ -314,10 +316,7 @@ mod tests {
             notifications: NotificationPowerLevels::default(),
         };
 
-        let actual = to_json_value(&power_levels).unwrap();
-        let expected = json!({});
-
-        assert_eq!(actual, expected);
+        assert_to_canonical_json_eq!(power_levels, json!({}));
     }
 
     #[test]
@@ -340,26 +339,26 @@ mod tests {
             notifications: assign!(NotificationPowerLevels::new(), { room: int!(23) }),
         };
 
-        let actual = to_json_value(&power_levels_event).unwrap();
-        let expected = json!({
-            "ban": 23,
-            "events": {
-                "m.dummy": 23
-            },
-            "events_default": 23,
-            "invite": 23,
-            "kick": 23,
-            "redact": 23,
-            "state_default": 23,
-            "users": {
-                "@carl:example.com": 23
-            },
-            "users_default": 23,
-            "notifications": {
-                "room": 23
-            },
-        });
-
-        assert_eq!(actual, expected);
+        assert_to_canonical_json_eq!(
+            power_levels_event,
+            json!({
+                "ban": 23,
+                "events": {
+                    "m.dummy": 23
+                },
+                "events_default": 23,
+                "invite": 23,
+                "kick": 23,
+                "redact": 23,
+                "state_default": 23,
+                "users": {
+                    "@carl:example.com": 23
+                },
+                "users_default": 23,
+                "notifications": {
+                    "room": 23
+                },
+            })
+        );
     }
 }

--- a/crates/ruma-client-api/src/rtc/transports.rs
+++ b/crates/ruma-client-api/src/rtc/transports.rs
@@ -185,9 +185,8 @@ pub mod v1 {
 #[cfg(test)]
 mod tests {
     use assert_matches2::assert_matches;
-    use serde_json::{
-        Value as JsonValue, from_value as from_json_value, json, to_value as to_json_value,
-    };
+    use ruma_common::canonical_json::assert_to_canonical_json_eq;
+    use serde_json::{Value as JsonValue, from_value as from_json_value, json};
 
     use super::v1::{LivekitMultiSfuTransport, RtcTransport};
 
@@ -211,7 +210,7 @@ mod tests {
 
         assert_eq!(transport.transport_type(), transport_type);
         assert_eq!(*transport.data().as_ref(), transport_data);
-        assert_eq!(to_json_value(&transport).unwrap(), json);
+        assert_to_canonical_json_eq!(transport, json.clone());
         assert_eq!(from_json_value::<RtcTransport>(json).unwrap(), transport);
     }
 
@@ -228,7 +227,7 @@ mod tests {
         });
 
         assert_eq!(transport.transport_type(), transport_type);
-        assert_eq!(to_json_value(&transport).unwrap(), json);
+        assert_to_canonical_json_eq!(transport, json.clone());
         assert_eq!(from_json_value::<RtcTransport>(json).unwrap(), transport);
     }
 }

--- a/crates/ruma-client-api/src/session/get_login_types.rs
+++ b/crates/ruma-client-api/src/session/get_login_types.rs
@@ -325,11 +325,9 @@ pub mod v3 {
     #[cfg(test)]
     mod tests {
         use assert_matches2::assert_matches;
-        use ruma_common::mxc_uri;
+        use ruma_common::{canonical_json::assert_to_canonical_json_eq, mxc_uri};
         use serde::{Deserialize, Serialize};
-        use serde_json::{
-            Value as JsonValue, from_value as from_json_value, json, to_value as to_json_value,
-        };
+        use serde_json::{Value as JsonValue, from_value as from_json_value, json};
 
         use super::{
             IdentityProvider, IdentityProviderBrand, LoginType, SsoLoginType, TokenLoginType,
@@ -420,7 +418,7 @@ pub mod v3 {
 
         #[test]
         fn serialize_sso_login_type() {
-            let wrapper = to_json_value(Wrapper {
+            let wrapper = Wrapper {
                 flows: vec![
                     LoginType::Token(TokenLoginType::new()),
                     LoginType::Sso(SsoLoginType {
@@ -434,10 +432,9 @@ pub mod v3 {
                         delegated_oidc_compatibility: false,
                     }),
                 ],
-            })
-            .unwrap();
+            };
 
-            assert_eq!(
+            assert_to_canonical_json_eq!(
                 wrapper,
                 json!({
                     "flows": [

--- a/crates/ruma-client-api/src/sync/sync_events/v3.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v3.rs
@@ -684,7 +684,8 @@ impl ToDevice {
 #[cfg(test)]
 mod tests {
     use assign::assign;
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+    use ruma_common::canonical_json::assert_to_canonical_json_eq;
+    use serde_json::{from_value as from_json_value, json};
 
     use super::Timeline;
 
@@ -692,13 +693,13 @@ mod tests {
     fn timeline_serde() {
         let timeline = assign!(Timeline::new(), { limited: true });
         let timeline_serialized = json!({ "events": [], "limited": true });
-        assert_eq!(to_json_value(timeline).unwrap(), timeline_serialized);
+        assert_to_canonical_json_eq!(timeline, timeline_serialized.clone());
 
         let timeline_deserialized = from_json_value::<Timeline>(timeline_serialized).unwrap();
         assert!(timeline_deserialized.limited);
 
         let timeline_default = Timeline::default();
-        assert_eq!(to_json_value(timeline_default).unwrap(), json!({ "events": [] }));
+        assert_to_canonical_json_eq!(timeline_default, json!({ "events": [] }));
 
         let timeline_default_deserialized =
             from_json_value::<Timeline>(json!({ "events": [] })).unwrap();

--- a/crates/ruma-client-api/src/uiaa/auth_data/data_serde.rs
+++ b/crates/ruma-client-api/src/uiaa/auth_data/data_serde.rs
@@ -142,27 +142,26 @@ impl<'de> Deserialize<'de> for UserIdentifier {
 #[cfg(test)]
 mod tests {
     use assert_matches2::assert_matches;
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+    use ruma_common::canonical_json::assert_to_canonical_json_eq;
+    use serde_json::{from_value as from_json_value, json};
 
     use crate::uiaa::UserIdentifier;
 
     #[test]
     fn serialize() {
-        assert_eq!(
-            to_json_value(UserIdentifier::UserIdOrLocalpart("@user:notareal.hs".to_owned()))
-                .unwrap(),
+        assert_to_canonical_json_eq!(
+            UserIdentifier::UserIdOrLocalpart("@user:notareal.hs".to_owned()),
             json!({
                 "type": "m.id.user",
                 "user": "@user:notareal.hs",
             })
         );
 
-        assert_eq!(
-            to_json_value(UserIdentifier::PhoneNumber {
+        assert_to_canonical_json_eq!(
+            UserIdentifier::PhoneNumber {
                 country: "33".to_owned(),
                 phone: "0102030405".to_owned()
-            })
-            .unwrap(),
+            },
             json!({
                 "type": "m.id.phone",
                 "country": "33",
@@ -170,9 +169,8 @@ mod tests {
             })
         );
 
-        assert_eq!(
-            to_json_value(UserIdentifier::Email { address: "me@myprovider.net".to_owned() })
-                .unwrap(),
+        assert_to_canonical_json_eq!(
+            UserIdentifier::Email { address: "me@myprovider.net".to_owned() },
             json!({
                 "type": "m.id.thirdparty",
                 "medium": "email",
@@ -180,8 +178,8 @@ mod tests {
             })
         );
 
-        assert_eq!(
-            to_json_value(UserIdentifier::Msisdn { number: "330102030405".to_owned() }).unwrap(),
+        assert_to_canonical_json_eq!(
+            UserIdentifier::Msisdn { number: "330102030405".to_owned() },
             json!({
                 "type": "m.id.thirdparty",
                 "medium": "msisdn",
@@ -189,9 +187,8 @@ mod tests {
             })
         );
 
-        assert_eq!(
-            to_json_value(UserIdentifier::third_party_id("robot".into(), "01001110".to_owned()))
-                .unwrap(),
+        assert_to_canonical_json_eq!(
+            UserIdentifier::third_party_id("robot".into(), "01001110".to_owned()),
             json!({
                 "type": "m.id.thirdparty",
                 "medium": "robot",

--- a/crates/ruma-client-api/src/uiaa/auth_params.rs
+++ b/crates/ruma-client-api/src/uiaa/auth_params.rs
@@ -92,7 +92,8 @@ impl OAuthParams {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+    use ruma_common::canonical_json::assert_to_canonical_json_eq;
+    use serde_json::{from_value as from_json_value, json};
 
     use super::{LoginTermsParams, PolicyDefinition, PolicyTranslation};
 
@@ -120,8 +121,8 @@ mod tests {
         );
         let params = LoginTermsParams::new([("privacy".to_owned(), privacy_definition)].into());
 
-        assert_eq!(
-            to_json_value(&params).unwrap(),
+        assert_to_canonical_json_eq!(
+            params,
             json!({
                 "policies": {
                     "privacy": {

--- a/crates/ruma-client-api/tests/it/uiaa.rs
+++ b/crates/ruma-client-api/tests/it/uiaa.rs
@@ -6,11 +6,13 @@ use ruma_client_api::{
     error::ErrorKind,
     uiaa::{self, AuthData, AuthFlow, AuthType, UiaaInfo, UiaaResponse, UserIdentifier},
 };
-use ruma_common::api::{EndpointError, OutgoingResponse};
+use ruma_common::{
+    api::{EndpointError, OutgoingResponse},
+    canonical_json::assert_to_canonical_json_eq,
+};
 use serde_json::{
     Value as JsonValue, from_slice as from_json_slice, from_str as from_json_str,
-    from_value as from_json_value, json, to_value as to_json_value,
-    value::to_raw_value as to_raw_json_value,
+    from_value as from_json_value, json, value::to_raw_value as to_raw_json_value,
 };
 
 #[test]
@@ -33,8 +35,8 @@ fn serialize_auth_data_registration_token() {
             session: Some("session".to_owned()),
         }));
 
-    assert_eq!(
-        to_json_value(auth_data).unwrap(),
+    assert_to_canonical_json_eq!(
+        auth_data,
         json!({
             "type": "m.login.registration_token",
             "token": "mytoken",
@@ -61,7 +63,7 @@ fn serialize_auth_data_fallback() {
     let auth_data =
         AuthData::FallbackAcknowledgement(uiaa::FallbackAcknowledgement::new("ZXY000".to_owned()));
 
-    assert_eq!(json!({ "session": "ZXY000" }), to_json_value(auth_data).unwrap());
+    assert_to_canonical_json_eq!(auth_data, json!({ "session": "ZXY000" }));
 }
 
 #[test]
@@ -86,16 +88,18 @@ fn serialize_uiaa_info() {
         completed: vec!["m.login.password".into()],
     });
 
-    let json = json!({
-        "flows": [{ "stages": ["m.login.password", "m.login.dummy"] }],
-        "completed": ["m.login.password"],
-        "params": {
-            "example.type.baz": {
-                "example_key": "foobar"
+    assert_to_canonical_json_eq!(
+        uiaa_info,
+        json!({
+            "flows": [{ "stages": ["m.login.password", "m.login.dummy"] }],
+            "completed": ["m.login.password"],
+            "params": {
+                "example.type.baz": {
+                    "example_key": "foobar"
+                }
             }
-        }
-    });
-    assert_eq!(to_json_value(uiaa_info).unwrap(), json);
+        })
+    );
 }
 
 #[test]

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -17,6 +17,8 @@ Improvements:
   a `CanonicalJsonValue`, with stricter rules than
   `serde_json::value::Serializer`. This serializer is also used in
   `to_canonical_value()`.
+- Add the `assert_to_canonical_json_eq!` macro that can be used in tests to
+  check the canonical JSON serialization of a type against its expected value.
 
 # 0.17.1
 

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -8,6 +8,8 @@ Breaking changes:
   - Serializing bytes.
   - Serializing booleans and integers as keys for an object.
   - Serializing the same key twice in an object.
+- The `canonical-json` feature was removed. The `canonical_json` module is no
+  longer gated behind a cargo feature.
 
 Improvements:
 

--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -21,7 +21,6 @@ client = []
 server = []
 
 api = ["dep:http", "dep:konst"]
-canonical-json = []
 js = ["dep:js-sys", "getrandom?/js", "uuid?/js"]
 rand = ["dep:rand", "dep:getrandom", "dep:uuid"]
 

--- a/crates/ruma-common/src/canonical_json/macros.rs
+++ b/crates/ruma-common/src/canonical_json/macros.rs
@@ -1,0 +1,52 @@
+/// Asserts that the canonical JSON serialization of a type is equal to an expected JSON value.
+///
+/// By calling [`to_canonical_value()`] internally this macro enforces strict serialization rules
+/// which allows to avoid some pitfalls like having a [`serde::Serialize`] implementation that
+/// generates the same key twice in an object, which is ignored by [`serde_json::to_value()`].
+///
+/// The expression on the left is the one whose serialization needs to be checked. It must
+/// implement [`serde::Serialize`], and is serialized using [`to_canonical_value()`].
+///
+/// The expression on the right is the expected JSON serialization as a [`serde_json::Value`]. It is
+/// usually a declaration using the [`serde_json::json!`] macro. It is then converted to a
+/// [`CanonicalJsonValue`] and compared with the result of the serialization of the expression on
+/// the left.
+///
+/// Panics if the expression on the left fails to serialize, if the expected JSON fails to be
+/// converted to a [`CanonicalJsonValue`], or if the two values are not equal.
+///
+/// This macro will print the error if the serialization or the conversion fails, or both debug
+/// representations of the [`CanonicalJsonValue`]s if they are not equal.
+///
+/// ## Example
+///
+/// ```
+/// use ruma_common::canonical_json::assert_to_canonical_json_eq;
+/// use serde::Serialize;
+/// use serde_json::json;
+///
+/// #[derive(Serialize)]
+/// struct Data {
+///     id: String,
+///     flag: bool,
+/// }
+///
+/// let data = Data { id: "abcdef".to_owned(), flag: true };
+/// assert_to_canonical_json_eq!(data, json!({ "id": "abcdef", "flag": true }));
+/// ```
+///
+/// [`CanonicalJsonValue`]: super::CanonicalJsonValue
+/// [`to_canonical_value()`]: super::to_canonical_value
+#[doc(hidden)]
+#[macro_export]
+macro_rules! assert_to_canonical_json_eq {
+    ($left:expr, $right:expr $(,)?) => {
+        let left_val =
+            $crate::canonical_json::to_canonical_value(&$left).expect("left serialization failed");
+        let right_val = <serde_json::Value as TryInto<
+            $crate::canonical_json::CanonicalJsonValue,
+        >>::try_into($right)
+        .expect("right conversion failed");
+        assert_eq!(left_val, right_val);
+    };
+}

--- a/crates/ruma-common/src/directory.rs
+++ b/crates/ruma-common/src/directory.rs
@@ -286,10 +286,10 @@ impl From<Option<RoomType>> for RoomTypeFilter {
 #[cfg(test)]
 mod tests {
     use assert_matches2::assert_matches;
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+    use serde_json::{from_value as from_json_value, json};
 
     use super::{Filter, RoomNetwork, RoomTypeFilter};
-    use crate::room::RoomType;
+    use crate::{assert_to_canonical_json_eq, room::RoomType};
 
     #[test]
     fn test_from_room_type() {
@@ -300,8 +300,7 @@ mod tests {
 
     #[test]
     fn serialize_matrix_network_only() {
-        let json = json!({});
-        assert_eq!(to_json_value(RoomNetwork::Matrix).unwrap(), json);
+        assert_to_canonical_json_eq!(RoomNetwork::Matrix, json!({}));
     }
 
     #[test]
@@ -312,8 +311,7 @@ mod tests {
 
     #[test]
     fn serialize_default_network_is_empty() {
-        let json = json!({});
-        assert_eq!(to_json_value(RoomNetwork::default()).unwrap(), json);
+        assert_to_canonical_json_eq!(RoomNetwork::default(), json!({}));
     }
 
     #[test]
@@ -324,8 +322,7 @@ mod tests {
 
     #[test]
     fn serialize_include_all_networks() {
-        let json = json!({ "include_all_networks": true });
-        assert_eq!(to_json_value(RoomNetwork::All).unwrap(), json);
+        assert_to_canonical_json_eq!(RoomNetwork::All, json!({ "include_all_networks": true }));
     }
 
     #[test]
@@ -336,8 +333,10 @@ mod tests {
 
     #[test]
     fn serialize_third_party_network() {
-        let json = json!({ "third_party_instance_id": "freenode" });
-        assert_eq!(to_json_value(RoomNetwork::ThirdParty("freenode".to_owned())).unwrap(), json);
+        assert_to_canonical_json_eq!(
+            RoomNetwork::ThirdParty("freenode".to_owned()),
+            json!({ "third_party_instance_id": "freenode" }),
+        );
     }
 
     #[test]
@@ -360,9 +359,7 @@ mod tests {
 
     #[test]
     fn serialize_filter_empty() {
-        let filter = Filter::default();
-        let json = json!({});
-        assert_eq!(to_json_value(filter).unwrap(), json);
+        assert_to_canonical_json_eq!(Filter::default(), json!({}));
     }
 
     #[test]
@@ -383,8 +380,10 @@ mod tests {
                 Some("custom_type").into(),
             ],
         };
-        let json = json!({ "room_types": [null, "m.space", "custom_type"] });
-        assert_eq!(to_json_value(filter).unwrap(), json);
+        assert_to_canonical_json_eq!(
+            filter,
+            json!({ "room_types": [null, "m.space", "custom_type"] }),
+        );
     }
 
     #[test]

--- a/crates/ruma-common/src/identifiers/voip_version_id.rs
+++ b/crates/ruma-common/src/identifiers/voip_version_id.rs
@@ -152,10 +152,10 @@ impl From<String> for VoipVersionId {
 mod tests {
     use assert_matches2::assert_matches;
     use js_int::uint;
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+    use serde_json::{from_value as from_json_value, json};
 
     use super::VoipVersionId;
-    use crate::IdParseError;
+    use crate::{IdParseError, assert_to_canonical_json_eq};
 
     #[test]
     fn valid_version_0() {
@@ -183,7 +183,7 @@ mod tests {
 
     #[test]
     fn serialize_version_0() {
-        assert_eq!(to_json_value(&VoipVersionId::V0).unwrap(), json!(0));
+        assert_to_canonical_json_eq!(VoipVersionId::V0, json!(0));
     }
 
     #[test]
@@ -193,7 +193,7 @@ mod tests {
 
     #[test]
     fn serialize_version_1() {
-        assert_eq!(to_json_value(&VoipVersionId::V1).unwrap(), json!("1"));
+        assert_to_canonical_json_eq!(VoipVersionId::V1, json!("1"));
     }
 
     #[test]
@@ -204,7 +204,7 @@ mod tests {
     #[test]
     fn serialize_custom_string() {
         let version = VoipVersionId::from("io.ruma.1");
-        assert_eq!(to_json_value(&version).unwrap(), json!("io.ruma.1"));
+        assert_to_canonical_json_eq!(version, json!("io.ruma.1"));
     }
 
     #[test]

--- a/crates/ruma-common/src/lib.rs
+++ b/crates/ruma-common/src/lib.rs
@@ -20,7 +20,6 @@ extern crate self as ruma_common;
 #[cfg(feature = "api")]
 pub mod api;
 pub mod authentication;
-#[cfg(feature = "canonical-json")]
 pub mod canonical_json;
 pub mod directory;
 pub mod encryption;
@@ -42,9 +41,8 @@ pub mod to_device;
 
 use std::fmt;
 
-#[cfg(feature = "canonical-json")]
-pub use self::canonical_json::{CanonicalJsonError, CanonicalJsonObject, CanonicalJsonValue};
 pub use self::{
+    canonical_json::{CanonicalJsonError, CanonicalJsonObject, CanonicalJsonValue},
     identifiers::*,
     time::{MilliSecondsSinceUnixEpoch, SecondsSinceUnixEpoch},
 };

--- a/crates/ruma-common/src/push.rs
+++ b/crates/ruma-common/src/push.rs
@@ -1035,8 +1035,7 @@ mod tests {
     use js_int::{int, uint};
     use macro_rules_attribute::apply;
     use serde_json::{
-        Value as JsonValue, from_value as from_json_value, json, to_value as to_json_value,
-        value::RawValue as RawJsonValue,
+        Value as JsonValue, from_value as from_json_value, json, value::RawValue as RawJsonValue,
     };
     use smol_macros::test;
 
@@ -1048,7 +1047,7 @@ mod tests {
         },
     };
     use crate::{
-        owned_room_id, owned_user_id,
+        assert_to_canonical_json_eq, owned_room_id, owned_user_id,
         power_levels::NotificationPowerLevels,
         push::{PredefinedContentRuleId, PredefinedOverrideRuleId},
         room_version_rules::{AuthorizationRules, RoomPowerLevelsRules},
@@ -1174,9 +1173,8 @@ mod tests {
             ],
         };
 
-        let rule_value: JsonValue = to_json_value(rule).unwrap();
-        assert_eq!(
-            rule_value,
+        assert_to_canonical_json_eq!(
+            rule,
             json!({
                 "conditions": [
                     {
@@ -1218,9 +1216,8 @@ mod tests {
             rule_id: owned_room_id!("!roomid:server.name"),
         };
 
-        let rule_value: JsonValue = to_json_value(rule).unwrap();
-        assert_eq!(
-            rule_value,
+        assert_to_canonical_json_eq!(
+            rule,
             json!({
                 "actions": [
                     "notify"
@@ -1249,9 +1246,8 @@ mod tests {
             rule_id: ".m.rule.contains_user_name".into(),
         };
 
-        let rule_value: JsonValue = to_json_value(rule).unwrap();
-        assert_eq!(
-            rule_value,
+        assert_to_canonical_json_eq!(
+            rule,
             json!({
                 "actions": [
                     "notify",
@@ -1302,9 +1298,8 @@ mod tests {
             default: true,
         });
 
-        let set_value: JsonValue = to_json_value(set).unwrap();
-        assert_eq!(
-            set_value,
+        assert_to_canonical_json_eq!(
+            set,
             json!({
                 "override": [
                     {

--- a/crates/ruma-common/src/push/action.rs
+++ b/crates/ruma-common/src/push/action.rs
@@ -204,41 +204,42 @@ mod tweak_serde {
 #[cfg(test)]
 mod tests {
     use assert_matches2::assert_matches;
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+    use serde_json::{from_value as from_json_value, json};
 
     use super::{Action, Tweak};
+    use crate::assert_to_canonical_json_eq;
 
     #[test]
     fn serialize_notify() {
-        assert_eq!(to_json_value(Action::Notify).unwrap(), json!("notify"));
+        assert_to_canonical_json_eq!(Action::Notify, json!("notify"));
     }
 
     #[cfg(feature = "unstable-msc3768")]
     #[test]
     fn serialize_notify_in_app() {
-        assert_eq!(
-            to_json_value(Action::NotifyInApp).unwrap(),
-            json!("org.matrix.msc3768.notify_in_app")
+        assert_to_canonical_json_eq!(
+            Action::NotifyInApp,
+            json!("org.matrix.msc3768.notify_in_app"),
         );
     }
 
     #[test]
     fn serialize_tweak_sound() {
-        assert_eq!(
-            to_json_value(Action::SetTweak(Tweak::Sound("default".into()))).unwrap(),
+        assert_to_canonical_json_eq!(
+            Action::SetTweak(Tweak::Sound("default".into())),
             json!({ "set_tweak": "sound", "value": "default" })
         );
     }
 
     #[test]
     fn serialize_tweak_highlight() {
-        assert_eq!(
-            to_json_value(Action::SetTweak(Tweak::Highlight(true))).unwrap(),
+        assert_to_canonical_json_eq!(
+            Action::SetTweak(Tweak::Highlight(true)),
             json!({ "set_tweak": "highlight" })
         );
 
-        assert_eq!(
-            to_json_value(Action::SetTweak(Tweak::Highlight(false))).unwrap(),
+        assert_to_canonical_json_eq!(
+            Action::SetTweak(Tweak::Highlight(false)),
             json!({ "set_tweak": "highlight", "value": false })
         );
     }

--- a/crates/ruma-common/src/push/condition.rs
+++ b/crates/ruma-common/src/push/condition.rs
@@ -624,7 +624,7 @@ mod tests {
     use assert_matches2::assert_matches;
     use js_int::{Int, int, uint};
     use macro_rules_attribute::apply;
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+    use serde_json::{from_value as from_json_value, json};
     use smol_macros::test;
 
     use super::{
@@ -632,60 +632,51 @@ mod tests {
         RoomMemberCountIs, StrExt,
     };
     use crate::{
-        OwnedUserId, owned_room_id, owned_user_id,
+        OwnedUserId, assert_to_canonical_json_eq, owned_room_id, owned_user_id,
         power_levels::{NotificationPowerLevels, NotificationPowerLevelsKey},
         room_version_rules::{AuthorizationRules, RoomPowerLevelsRules},
     };
 
     #[test]
     fn serialize_event_match_condition() {
-        let json_data = json!({
-            "key": "content.msgtype",
-            "kind": "event_match",
-            "pattern": "m.notice"
-        });
-        assert_eq!(
-            to_json_value(PushCondition::EventMatch {
-                key: "content.msgtype".into(),
-                pattern: "m.notice".into(),
-            })
-            .unwrap(),
-            json_data
+        assert_to_canonical_json_eq!(
+            PushCondition::EventMatch { key: "content.msgtype".into(), pattern: "m.notice".into() },
+            json!({
+                "key": "content.msgtype",
+                "kind": "event_match",
+                "pattern": "m.notice"
+            }),
         );
     }
 
     #[test]
     #[allow(deprecated)]
     fn serialize_contains_display_name_condition() {
-        assert_eq!(
-            to_json_value(PushCondition::ContainsDisplayName).unwrap(),
-            json!({ "kind": "contains_display_name" })
+        assert_to_canonical_json_eq!(
+            PushCondition::ContainsDisplayName,
+            json!({ "kind": "contains_display_name" }),
         );
     }
 
     #[test]
     fn serialize_room_member_count_condition() {
-        let json_data = json!({
-            "is": "2",
-            "kind": "room_member_count"
-        });
-        assert_eq!(
-            to_json_value(PushCondition::RoomMemberCount { is: RoomMemberCountIs::from(uint!(2)) })
-                .unwrap(),
-            json_data
+        assert_to_canonical_json_eq!(
+            PushCondition::RoomMemberCount { is: RoomMemberCountIs::from(uint!(2)) },
+            json!({
+                "is": "2",
+                "kind": "room_member_count"
+            }),
         );
     }
 
     #[test]
     fn serialize_sender_notification_permission_condition() {
-        let json_data = json!({
-            "key": "room",
-            "kind": "sender_notification_permission"
-        });
-        assert_eq!(
-            json_data,
-            to_json_value(PushCondition::SenderNotificationPermission { key: "room".into() })
-                .unwrap()
+        assert_to_canonical_json_eq!(
+            PushCondition::SenderNotificationPermission { key: "room".into() },
+            json!({
+                "key": "room",
+                "kind": "sender_notification_permission"
+            }),
         );
     }
 

--- a/crates/ruma-common/src/room.rs
+++ b/crates/ruma-common/src/room.rs
@@ -606,12 +606,13 @@ mod tests {
     use assert_matches2::assert_matches;
     use js_int::uint;
     use ruma_common::{OwnedRoomId, owned_room_id};
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+    use serde_json::{from_value as from_json_value, json};
 
     use super::{
         AllowRule, CustomAllowRule, JoinRule, JoinRuleSummary, Restricted, RestrictedSummary,
         RoomMembership, RoomSummary,
     };
+    use crate::assert_to_canonical_json_eq;
 
     #[test]
     fn deserialize_summary_no_join_rule() {
@@ -697,8 +698,8 @@ mod tests {
             false,
         );
 
-        assert_eq!(
-            to_json_value(&summary).unwrap(),
+        assert_to_canonical_json_eq!(
+            summary,
             json!({
                 "room_id": "!room:localhost",
                 "num_joined_members": 5,
@@ -721,8 +722,8 @@ mod tests {
             false,
         );
 
-        assert_eq!(
-            to_json_value(&summary).unwrap(),
+        assert_to_canonical_json_eq!(
+            summary,
             json!({
                 "room_id": "!room:localhost",
                 "num_joined_members": 5,

--- a/crates/ruma-common/src/thirdparty.rs
+++ b/crates/ruma-common/src/thirdparty.rs
@@ -299,10 +299,10 @@ impl From<ThirdPartyIdentifierInit> for ThirdPartyIdentifier {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+    use serde_json::{from_value as from_json_value, json};
 
     use super::{Medium, ThirdPartyIdentifier};
-    use crate::MilliSecondsSinceUnixEpoch;
+    use crate::{MilliSecondsSinceUnixEpoch, assert_to_canonical_json_eq};
 
     #[test]
     fn third_party_identifier_serde() {
@@ -320,7 +320,7 @@ mod tests {
             "added_at": 1_535_336_848_756_u64
         });
 
-        assert_eq!(to_json_value(third_party_id.clone()).unwrap(), third_party_id_serialized);
+        assert_to_canonical_json_eq!(third_party_id, third_party_id_serialized.clone());
         assert_eq!(third_party_id, from_json_value(third_party_id_serialized).unwrap());
     }
 }

--- a/crates/ruma-common/tests/it/serde/empty_strings.rs
+++ b/crates/ruma-common/tests/it/serde/empty_strings.rs
@@ -1,6 +1,7 @@
 mod string {
+    use ruma_common::canonical_json::assert_to_canonical_json_eq;
     use serde::{Deserialize, Serialize};
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+    use serde_json::{from_value as from_json_value, json};
 
     #[derive(Serialize, Deserialize, PartialEq, Debug)]
     struct StringStruct {
@@ -15,15 +16,13 @@ mod string {
     #[test]
     fn none_se() {
         let decoded = StringStruct { x: None };
-        let encoded = json!({ "x": "" });
-        assert_eq!(to_json_value(decoded).unwrap(), encoded);
+        assert_to_canonical_json_eq!(decoded, json!({ "x": "" }));
     }
 
     #[test]
     fn some_se() {
         let decoded = StringStruct { x: Some("foo".into()) };
-        let encoded = json!({ "x": "foo" });
-        assert_eq!(to_json_value(decoded).unwrap(), encoded);
+        assert_to_canonical_json_eq!(decoded, json!({ "x": "foo" }));
     }
 
     #[test]
@@ -49,9 +48,9 @@ mod string {
 }
 
 mod user {
-    use ruma_common::{OwnedUserId, UserId, user_id};
+    use ruma_common::{OwnedUserId, UserId, canonical_json::assert_to_canonical_json_eq, user_id};
     use serde::{Deserialize, Serialize};
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+    use serde_json::{from_value as from_json_value, json};
 
     const CARL: &str = "@carl:example.com";
 
@@ -72,15 +71,13 @@ mod user {
     #[test]
     fn none_se() {
         let decoded = User { x: None };
-        let encoded = json!({ "x": "" });
-        assert_eq!(to_json_value(decoded).unwrap(), encoded);
+        assert_to_canonical_json_eq!(decoded, json!({ "x": "" }));
     }
 
     #[test]
     fn some_se() {
         let decoded = User { x: Some(carl().to_owned()) };
-        let encoded = json!({ "x": CARL });
-        assert_eq!(to_json_value(decoded).unwrap(), encoded);
+        assert_to_canonical_json_eq!(decoded, json!({ "x": CARL }));
     }
 
     #[test]

--- a/crates/ruma-common/tests/it/serde/enum_derive.rs
+++ b/crates/ruma-common/tests/it/serde/enum_derive.rs
@@ -1,5 +1,5 @@
 use ruma_common::serde::StringEnum;
-use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+use serde_json::{from_value as from_json_value, json};
 
 #[derive(Debug, PartialEq)]
 struct PrivOwnedStr(Box<str>);
@@ -116,20 +116,19 @@ fn from_string() {
 
 #[test]
 fn serialize() {
-    assert_eq!(to_json_value(MyEnum::First).unwrap(), json!("first"));
-    assert_eq!(to_json_value(MyEnum::HelloWorld).unwrap(), json!("hello_world"));
-    assert_eq!(to_json_value(MyEnum::Stable).unwrap(), json!("io.ruma.unstable"));
-    assert_eq!(
-        to_json_value(MyEnum::_Custom(PrivOwnedStr("\\\n\\".into()))).unwrap(),
-        json!("\\\n\\")
-    );
+    use ruma_common::canonical_json::assert_to_canonical_json_eq;
 
-    assert_eq!(to_json_value(MyUnstableEnum::First).unwrap(), json!("unstable-first"));
-    assert_eq!(to_json_value(MyUnstableEnum::HelloWorld).unwrap(), json!("unstable-hello-world"));
-    assert_eq!(to_json_value(MyUnstableEnum::Stable).unwrap(), json!("io.ruma.unstable"));
-    assert_eq!(
-        to_json_value(MyUnstableEnum::_Custom(PrivOwnedStr("\\\n\\".into()))).unwrap(),
-        json!("\\\n\\")
+    assert_to_canonical_json_eq!(MyEnum::First, json!("first"));
+    assert_to_canonical_json_eq!(MyEnum::HelloWorld, json!("hello_world"));
+    assert_to_canonical_json_eq!(MyEnum::Stable, json!("io.ruma.unstable"));
+    assert_to_canonical_json_eq!(MyEnum::_Custom(PrivOwnedStr("\\\n\\".into())), json!("\\\n\\"));
+
+    assert_to_canonical_json_eq!(MyUnstableEnum::First, json!("unstable-first"));
+    assert_to_canonical_json_eq!(MyUnstableEnum::HelloWorld, json!("unstable-hello-world"));
+    assert_to_canonical_json_eq!(MyUnstableEnum::Stable, json!("io.ruma.unstable"));
+    assert_to_canonical_json_eq!(
+        MyUnstableEnum::_Custom(PrivOwnedStr("\\\n\\".into())),
+        json!("\\\n\\"),
     );
 }
 

--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -6,6 +6,8 @@ Breaking changes:
   `RoomMemberEventContent`. It would previously fail to deserialize if the
   `third_party_invite` field was redacted as the `display_name` field was
   required but it is removed during redaction.
+- The `canonical-json` feature was removed. The code that was behind it is no
+  longer gated behind a cargo feature.
 
 Bug fixes:
 

--- a/crates/ruma-events/Cargo.toml
+++ b/crates/ruma-events/Cargo.toml
@@ -14,7 +14,6 @@ rust-version = { workspace = true }
 all-features = true
 
 [features]
-canonical-json = ["ruma-common/canonical-json"]
 html = ["dep:ruma-html"]
 markdown = ["dep:pulldown-cmark"]
 unstable-msc1767 = []

--- a/crates/ruma-events/src/call/notify.rs
+++ b/crates/ruma-events/src/call/notify.rs
@@ -66,7 +66,8 @@ impl From<Application> for ApplicationType {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+    use ruma_common::canonical_json::assert_to_canonical_json_eq;
+    use serde_json::{from_value as from_json_value, json};
 
     use crate::{
         Mentions,
@@ -95,8 +96,8 @@ mod tests {
             Mentions::with_room_mention(),
         );
 
-        assert_eq!(
-            to_json_value(&content_user_mention).unwrap(),
+        assert_to_canonical_json_eq!(
+            content_user_mention,
             json!({
                 "call_id": "abcdef",
                 "application": "m.call",
@@ -106,8 +107,8 @@ mod tests {
                 "notify_type": "ring",
             })
         );
-        assert_eq!(
-            to_json_value(&content_room_mention).unwrap(),
+        assert_to_canonical_json_eq!(
+            content_room_mention,
             json!({
                 "call_id": "abcdef",
                 "application": "m.call",

--- a/crates/ruma-events/src/direct.rs
+++ b/crates/ruma-events/src/direct.rs
@@ -190,7 +190,9 @@ impl FromIterator<(OwnedDirectUserIdentifier, Vec<OwnedRoomId>)> for DirectEvent
 mod tests {
     use std::collections::BTreeMap;
 
-    use ruma_common::{OwnedUserId, owned_room_id, user_id};
+    use ruma_common::{
+        OwnedUserId, canonical_json::assert_to_canonical_json_eq, owned_room_id, user_id,
+    };
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     use super::{DirectEvent, DirectEventContent};
@@ -212,7 +214,7 @@ mod tests {
             alice_mail: mail_rooms,
         });
 
-        assert_eq!(to_json_value(&content).unwrap(), json_data);
+        assert_to_canonical_json_eq!(content, json_data);
     }
 
     #[test]

--- a/crates/ruma-events/src/do_not_disturb.rs
+++ b/crates/ruma-events/src/do_not_disturb.rs
@@ -87,8 +87,8 @@ mod tests {
     use std::collections::BTreeMap;
 
     use assert_matches2::assert_matches;
-    use ruma_common::owned_room_id;
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+    use ruma_common::{canonical_json::assert_to_canonical_json_eq, owned_room_id};
+    use serde_json::{from_value as from_json_value, json};
 
     use super::DoNotDisturbEventContent;
     use crate::{AnyGlobalAccountDataEvent, do_not_disturb::DoNotDisturbRoomKey};
@@ -98,13 +98,14 @@ mod tests {
         let do_not_disturb_room_list: DoNotDisturbEventContent =
             vec![owned_room_id!("!foo:bar.baz")].into_iter().collect();
 
-        let json = json!({
-            "rooms": {
-                "!foo:bar.baz": {}
-            },
-        });
-
-        assert_eq!(to_json_value(do_not_disturb_room_list).unwrap(), json);
+        assert_to_canonical_json_eq!(
+            do_not_disturb_room_list,
+            json!({
+                "rooms": {
+                    "!foo:bar.baz": {}
+                },
+            }),
+        );
     }
 
     #[test]
@@ -114,13 +115,14 @@ mod tests {
             Default::default(),
         )]));
 
-        let json = json!({
-            "rooms": {
-                "*": {}
-            },
-        });
-
-        assert_eq!(to_json_value(do_not_disturb_room_list).unwrap(), json);
+        assert_to_canonical_json_eq!(
+            do_not_disturb_room_list,
+            json!({
+                "rooms": {
+                    "*": {}
+                },
+            }),
+        );
     }
 
     #[test]

--- a/crates/ruma-events/src/ignored_user_list.rs
+++ b/crates/ruma-events/src/ignored_user_list.rs
@@ -51,8 +51,8 @@ impl IgnoredUser {
 #[cfg(test)]
 mod tests {
     use assert_matches2::assert_matches;
-    use ruma_common::{owned_user_id, user_id};
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+    use ruma_common::{canonical_json::assert_to_canonical_json_eq, owned_user_id, user_id};
+    use serde_json::{from_value as from_json_value, json};
 
     use super::IgnoredUserListEventContent;
     use crate::AnyGlobalAccountDataEvent;
@@ -62,13 +62,14 @@ mod tests {
         let ignored_user_list =
             IgnoredUserListEventContent::users(vec![owned_user_id!("@carl:example.com")]);
 
-        let json = json!({
-            "ignored_users": {
-                "@carl:example.com": {}
-            },
-        });
-
-        assert_eq!(to_json_value(ignored_user_list).unwrap(), json);
+        assert_to_canonical_json_eq!(
+            ignored_user_list,
+            json!({
+                "ignored_users": {
+                    "@carl:example.com": {}
+                },
+            }),
+        );
     }
 
     #[test]

--- a/crates/ruma-events/src/invite_permission_config.rs
+++ b/crates/ruma-events/src/invite_permission_config.rs
@@ -33,7 +33,8 @@ impl InvitePermissionConfigEventContent {
 #[cfg(test)]
 mod tests {
     use assert_matches2::assert_matches;
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+    use ruma_common::canonical_json::assert_to_canonical_json_eq;
+    use serde_json::{from_value as from_json_value, json};
 
     use super::InvitePermissionConfigEventContent;
     use crate::AnyGlobalAccountDataEvent;
@@ -42,11 +43,12 @@ mod tests {
     fn serialization() {
         let invite_permission_config = InvitePermissionConfigEventContent::new(true);
 
-        let json = json!({
-            "block_all": true
-        });
-
-        assert_eq!(to_json_value(invite_permission_config).unwrap(), json);
+        assert_to_canonical_json_eq!(
+            invite_permission_config,
+            json!({
+                "block_all": true,
+            }),
+        );
     }
 
     #[test]

--- a/crates/ruma-events/src/key/verification/accept.rs
+++ b/crates/ruma-events/src/key/verification/accept.rs
@@ -166,12 +166,11 @@ mod tests {
 
     use assert_matches2::assert_matches;
     use ruma_common::{
+        canonical_json::assert_to_canonical_json_eq,
         event_id,
         serde::{Base64, Raw},
     };
-    use serde_json::{
-        Value as JsonValue, from_value as from_json_value, json, to_value as to_json_value,
-    };
+    use serde_json::{Value as JsonValue, from_value as from_json_value, json};
 
     use super::{
         _CustomContent, AcceptMethod, HashAlgorithm, KeyAgreementProtocol,
@@ -193,23 +192,18 @@ mod tests {
             }),
         };
 
-        let json_data = json!({
-            "transaction_id": "456",
-            "method": "m.sas.v1",
-            "commitment": "aGVsbG8",
-            "key_agreement_protocol": "curve25519",
-            "hash": "sha256",
-            "message_authentication_code": "hkdf-hmac-sha256.v2",
-            "short_authentication_string": ["decimal"]
-        });
-
-        assert_eq!(to_json_value(&key_verification_accept_content).unwrap(), json_data);
-
-        let json_data = json!({
-            "transaction_id": "456",
-            "method": "m.sas.custom",
-            "test": "field",
-        });
+        assert_to_canonical_json_eq!(
+            key_verification_accept_content,
+            json!({
+                "transaction_id": "456",
+                "method": "m.sas.v1",
+                "commitment": "aGVsbG8",
+                "key_agreement_protocol": "curve25519",
+                "hash": "sha256",
+                "message_authentication_code": "hkdf-hmac-sha256.v2",
+                "short_authentication_string": ["decimal"],
+            }),
+        );
 
         let key_verification_accept_content = ToDeviceKeyVerificationAcceptEventContent {
             transaction_id: "456".into(),
@@ -221,7 +215,14 @@ mod tests {
             }),
         };
 
-        assert_eq!(to_json_value(&key_verification_accept_content).unwrap(), json_data);
+        assert_to_canonical_json_eq!(
+            key_verification_accept_content,
+            json!({
+                "transaction_id": "456",
+                "method": "m.sas.custom",
+                "test": "field",
+            }),
+        );
     }
 
     #[test]
@@ -239,20 +240,21 @@ mod tests {
             }),
         };
 
-        let json_data = json!({
-            "method": "m.sas.v1",
-            "commitment": "aGVsbG8",
-            "key_agreement_protocol": "curve25519",
-            "hash": "sha256",
-            "message_authentication_code": "hkdf-hmac-sha256.v2",
-            "short_authentication_string": ["decimal"],
-            "m.relates_to": {
-                "rel_type": "m.reference",
-                "event_id": event_id,
-            }
-        });
-
-        assert_eq!(to_json_value(&key_verification_accept_content).unwrap(), json_data);
+        assert_to_canonical_json_eq!(
+            key_verification_accept_content,
+            json!({
+                "method": "m.sas.v1",
+                "commitment": "aGVsbG8",
+                "key_agreement_protocol": "curve25519",
+                "hash": "sha256",
+                "message_authentication_code": "hkdf-hmac-sha256.v2",
+                "short_authentication_string": ["decimal"],
+                "m.relates_to": {
+                    "rel_type": "m.reference",
+                    "event_id": event_id,
+                },
+            }),
+        );
     }
 
     #[test]

--- a/crates/ruma-events/src/key/verification/cancel.rs
+++ b/crates/ruma-events/src/key/verification/cancel.rs
@@ -118,18 +118,19 @@ pub enum CancelCode {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+    use ruma_common::canonical_json::assert_to_canonical_json_eq;
+    use serde_json::{from_value as from_json_value, json};
 
     use super::CancelCode;
 
     #[test]
     fn cancel_codes_serialize_to_display_form() {
-        assert_eq!(to_json_value(&CancelCode::User).unwrap(), json!("m.user"));
+        assert_to_canonical_json_eq!(CancelCode::User, json!("m.user"));
     }
 
     #[test]
     fn custom_cancel_codes_serialize_to_display_form() {
-        assert_eq!(to_json_value(CancelCode::from("io.ruma.test")).unwrap(), json!("io.ruma.test"));
+        assert_to_canonical_json_eq!(CancelCode::from("io.ruma.test"), json!("io.ruma.test"));
     }
 
     #[test]

--- a/crates/ruma-events/src/key/verification/done.rs
+++ b/crates/ruma-events/src/key/verification/done.rs
@@ -49,8 +49,8 @@ impl KeyVerificationDoneEventContent {
 
 #[cfg(test)]
 mod tests {
-    use ruma_common::owned_event_id;
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+    use ruma_common::{canonical_json::assert_to_canonical_json_eq, owned_event_id};
+    use serde_json::{from_value as from_json_value, json};
 
     use super::KeyVerificationDoneEventContent;
     use crate::relation::Reference;
@@ -58,17 +58,19 @@ mod tests {
     #[test]
     fn serialization() {
         let event_id = owned_event_id!("$1598361704261elfgc:localhost");
+        let content = KeyVerificationDoneEventContent {
+            relates_to: Reference { event_id: event_id.clone() },
+        };
 
-        let json_data = json!({
-            "m.relates_to": {
-                "rel_type": "m.reference",
-                "event_id": event_id,
-            }
-        });
-
-        let content = KeyVerificationDoneEventContent { relates_to: Reference { event_id } };
-
-        assert_eq!(to_json_value(&content).unwrap(), json_data);
+        assert_to_canonical_json_eq!(
+            content,
+            json!({
+                "m.relates_to": {
+                    "rel_type": "m.reference",
+                    "event_id": event_id,
+                },
+            }),
+        );
     }
 
     #[test]

--- a/crates/ruma-events/src/key/verification/ready.rs
+++ b/crates/ruma-events/src/key/verification/ready.rs
@@ -75,8 +75,8 @@ impl KeyVerificationReadyEventContent {
 
 #[cfg(test)]
 mod tests {
-    use ruma_common::{OwnedDeviceId, owned_event_id};
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+    use ruma_common::{OwnedDeviceId, canonical_json::assert_to_canonical_json_eq, owned_event_id};
+    use serde_json::{from_value as from_json_value, json};
 
     use super::{KeyVerificationReadyEventContent, ToDeviceKeyVerificationReadyEventContent};
     use crate::{key::verification::VerificationMethod, relation::Reference};
@@ -86,36 +86,38 @@ mod tests {
         let event_id = owned_event_id!("$1598361704261elfgc:localhost");
         let device: OwnedDeviceId = "123".into();
 
-        let json_data = json!({
-            "from_device": device,
-            "methods": ["m.sas.v1"],
-            "m.relates_to": {
-                "rel_type": "m.reference",
-                "event_id": event_id,
-            }
-        });
-
         let content = KeyVerificationReadyEventContent {
             from_device: device.clone(),
-            relates_to: Reference { event_id },
+            relates_to: Reference { event_id: event_id.clone() },
             methods: vec![VerificationMethod::SasV1],
         };
 
-        assert_eq!(to_json_value(&content).unwrap(), json_data);
-
-        let json_data = json!({
-            "from_device": device,
-            "methods": ["m.sas.v1"],
-            "transaction_id": "456",
-        });
+        assert_to_canonical_json_eq!(
+            content,
+            json!({
+                "from_device": device,
+                "methods": ["m.sas.v1"],
+                "m.relates_to": {
+                    "rel_type": "m.reference",
+                    "event_id": event_id,
+                },
+            }),
+        );
 
         let content = ToDeviceKeyVerificationReadyEventContent {
-            from_device: device,
+            from_device: device.clone(),
             transaction_id: "456".into(),
             methods: vec![VerificationMethod::SasV1],
         };
 
-        assert_eq!(to_json_value(&content).unwrap(), json_data);
+        assert_to_canonical_json_eq!(
+            content,
+            json!({
+                "from_device": device,
+                "methods": ["m.sas.v1"],
+                "transaction_id": "456",
+            }),
+        );
     }
 
     #[test]

--- a/crates/ruma-events/src/key/verification/start.rs
+++ b/crates/ruma-events/src/key/verification/start.rs
@@ -210,10 +210,8 @@ mod tests {
     use std::collections::BTreeMap;
 
     use assert_matches2::assert_matches;
-    use ruma_common::{event_id, serde::Base64};
-    use serde_json::{
-        Value as JsonValue, from_value as from_json_value, json, to_value as to_json_value,
-    };
+    use ruma_common::{canonical_json::assert_to_canonical_json_eq, event_id, serde::Base64};
+    use serde_json::{Value as JsonValue, from_value as from_json_value, json};
 
     use super::{
         _CustomContent, HashAlgorithm, KeyAgreementProtocol, KeyVerificationStartEventContent,
@@ -238,24 +236,18 @@ mod tests {
             ),
         };
 
-        let json_data = json!({
-            "from_device": "123",
-            "transaction_id": "456",
-            "method": "m.sas.v1",
-            "key_agreement_protocols": ["curve25519"],
-            "hashes": ["sha256"],
-            "message_authentication_codes": ["hkdf-hmac-sha256.v2"],
-            "short_authentication_string": ["decimal"]
-        });
-
-        assert_eq!(to_json_value(&key_verification_start_content).unwrap(), json_data);
-
-        let json_data = json!({
-            "from_device": "123",
-            "transaction_id": "456",
-            "method": "m.sas.custom",
-            "test": "field",
-        });
+        assert_to_canonical_json_eq!(
+            key_verification_start_content,
+            json!({
+                "from_device": "123",
+                "transaction_id": "456",
+                "method": "m.sas.v1",
+                "key_agreement_protocols": ["curve25519"],
+                "hashes": ["sha256"],
+                "message_authentication_codes": ["hkdf-hmac-sha256.v2"],
+                "short_authentication_string": ["decimal"],
+            }),
+        );
 
         let key_verification_start_content = ToDeviceKeyVerificationStartEventContent {
             from_device: "123".into(),
@@ -268,26 +260,33 @@ mod tests {
             }),
         };
 
-        assert_eq!(to_json_value(&key_verification_start_content).unwrap(), json_data);
+        assert_to_canonical_json_eq!(
+            key_verification_start_content,
+            json!({
+                "from_device": "123",
+                "transaction_id": "456",
+                "method": "m.sas.custom",
+                "test": "field",
+            }),
+        );
 
-        {
-            let secret = Base64::new(b"This is a secret to everybody".to_vec());
+        let secret = Base64::new(b"This is a secret to everybody".to_vec());
 
-            let key_verification_start_content = ToDeviceKeyVerificationStartEventContent {
-                from_device: "123".into(),
-                transaction_id: "456".into(),
-                method: StartMethod::ReciprocateV1(ReciprocateV1Content::new(secret.clone())),
-            };
+        let key_verification_start_content = ToDeviceKeyVerificationStartEventContent {
+            from_device: "123".into(),
+            transaction_id: "456".into(),
+            method: StartMethod::ReciprocateV1(ReciprocateV1Content::new(secret.clone())),
+        };
 
-            let json_data = json!({
+        assert_to_canonical_json_eq!(
+            key_verification_start_content,
+            json!({
                 "from_device": "123",
                 "method": "m.reciprocate.v1",
                 "secret": secret,
-                "transaction_id": "456"
-            });
-
-            assert_eq!(to_json_value(&key_verification_start_content).unwrap(), json_data);
-        }
+                "transaction_id": "456",
+            }),
+        );
     }
 
     #[test]
@@ -308,20 +307,21 @@ mod tests {
             ),
         };
 
-        let json_data = json!({
-            "from_device": "123",
-            "method": "m.sas.v1",
-            "key_agreement_protocols": ["curve25519"],
-            "hashes": ["sha256"],
-            "message_authentication_codes": ["hkdf-hmac-sha256.v2"],
-            "short_authentication_string": ["decimal"],
-            "m.relates_to": {
-                "rel_type": "m.reference",
-                "event_id": event_id,
-            }
-        });
-
-        assert_eq!(to_json_value(&key_verification_start_content).unwrap(), json_data);
+        assert_to_canonical_json_eq!(
+            key_verification_start_content,
+            json!({
+                "from_device": "123",
+                "method": "m.sas.v1",
+                "key_agreement_protocols": ["curve25519"],
+                "hashes": ["sha256"],
+                "message_authentication_codes": ["hkdf-hmac-sha256.v2"],
+                "short_authentication_string": ["decimal"],
+                "m.relates_to": {
+                    "rel_type": "m.reference",
+                    "event_id": event_id,
+                },
+            }),
+        );
 
         let secret = Base64::new(b"This is a secret to everybody".to_vec());
 
@@ -331,17 +331,18 @@ mod tests {
             method: StartMethod::ReciprocateV1(ReciprocateV1Content::new(secret.clone())),
         };
 
-        let json_data = json!({
-            "from_device": "123",
-            "method": "m.reciprocate.v1",
-            "secret": secret,
-            "m.relates_to": {
-                "rel_type": "m.reference",
-                "event_id": event_id,
-            }
-        });
-
-        assert_eq!(to_json_value(&key_verification_start_content).unwrap(), json_data);
+        assert_to_canonical_json_eq!(
+            key_verification_start_content,
+            json!({
+                "from_device": "123",
+                "method": "m.reciprocate.v1",
+                "secret": secret,
+                "m.relates_to": {
+                    "rel_type": "m.reference",
+                    "event_id": event_id,
+                },
+            }),
+        );
     }
 
     #[test]

--- a/crates/ruma-events/src/marked_unread.rs
+++ b/crates/ruma-events/src/marked_unread.rs
@@ -66,7 +66,8 @@ impl From<UnstableMarkedUnreadEventContent> for MarkedUnreadEventContent {
 #[cfg(all(test, feature = "unstable-msc2867"))]
 mod tests {
     use assert_matches2::assert_matches;
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+    use ruma_common::canonical_json::assert_to_canonical_json_eq;
+    use serde_json::{from_value as from_json_value, json};
 
     use super::{MarkedUnreadEventContent, UnstableMarkedUnreadEventContent};
     use crate::{AnyRoomAccountDataEvent, RoomAccountDataEvent};
@@ -106,8 +107,8 @@ mod tests {
     fn serialize() {
         let marked_unread = MarkedUnreadEventContent::new(true);
         let marked_unread_account_data = RoomAccountDataEvent { content: marked_unread.clone() };
-        assert_eq!(
-            to_json_value(marked_unread_account_data).unwrap(),
+        assert_to_canonical_json_eq!(
+            marked_unread_account_data,
             json!({
                 "type": "m.marked_unread",
                 "content": {
@@ -119,8 +120,8 @@ mod tests {
         let unstable_marked_unread = UnstableMarkedUnreadEventContent::from(marked_unread);
         let unstable_marked_unread_account_data =
             RoomAccountDataEvent { content: unstable_marked_unread };
-        assert_eq!(
-            to_json_value(unstable_marked_unread_account_data).unwrap(),
+        assert_to_canonical_json_eq!(
+            unstable_marked_unread_account_data,
             json!({
                 "type": "com.famedly.marked_unread",
                 "content": {

--- a/crates/ruma-events/src/media_preview_config.rs
+++ b/crates/ruma-events/src/media_preview_config.rs
@@ -122,7 +122,8 @@ impl From<UnstableMediaPreviewConfigEventContent> for MediaPreviewConfigEventCon
 #[cfg(all(test, feature = "unstable-msc4278"))]
 mod tests {
     use assert_matches2::assert_matches;
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+    use ruma_common::canonical_json::assert_to_canonical_json_eq;
+    use serde_json::{from_value as from_json_value, json};
 
     use super::{MediaPreviewConfigEventContent, UnstableMediaPreviewConfigEventContent};
     use crate::{
@@ -178,8 +179,8 @@ mod tests {
         );
         let unstable_media_preview_config_account_data =
             GlobalAccountDataEvent { content: unstable_media_preview_config };
-        assert_eq!(
-            to_json_value(unstable_media_preview_config_account_data).unwrap(),
+        assert_to_canonical_json_eq!(
+            unstable_media_preview_config_account_data,
             json!({
                 "type": "io.element.msc4278.media_preview_config",
                 "content": {
@@ -194,8 +195,8 @@ mod tests {
             .invite_avatars(Some(InviteAvatars::Off));
         let media_preview_config_account_data =
             GlobalAccountDataEvent { content: media_preview_config };
-        assert_eq!(
-            to_json_value(media_preview_config_account_data).unwrap(),
+        assert_to_canonical_json_eq!(
+            media_preview_config_account_data,
             json!({
                 "type": "m.media_preview_config",
                 "content": {

--- a/crates/ruma-events/src/policy/rule/room.rs
+++ b/crates/ruma-events/src/policy/rule/room.rs
@@ -52,8 +52,8 @@ impl From<RedactedPolicyRuleRoomEventContent> for PossiblyRedactedPolicyRuleRoom
 
 #[cfg(test)]
 mod tests {
-    use ruma_common::serde::Raw;
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+    use ruma_common::{canonical_json::assert_to_canonical_json_eq, serde::Raw};
+    use serde_json::{from_value as from_json_value, json};
 
     use super::{OriginalPolicyRuleRoomEvent, PolicyRuleRoomEventContent};
     use crate::policy::rule::{PolicyRuleEventContent, Recommendation};
@@ -66,13 +66,14 @@ mod tests {
             recommendation: Recommendation::Ban,
         });
 
-        let json = json!({
-            "entity": "#*:example.org",
-            "reason": "undesirable content",
-            "recommendation": "m.ban"
-        });
-
-        assert_eq!(to_json_value(content).unwrap(), json);
+        assert_to_canonical_json_eq!(
+            content,
+            json!({
+                "entity": "#*:example.org",
+                "reason": "undesirable content",
+                "recommendation": "m.ban",
+            }),
+        );
     }
 
     #[test]

--- a/crates/ruma-events/src/presence.rs
+++ b/crates/ruma-events/src/presence.rs
@@ -72,8 +72,10 @@ impl PresenceEventContent {
 #[cfg(test)]
 mod tests {
     use js_int::uint;
-    use ruma_common::{mxc_uri, presence::PresenceState};
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+    use ruma_common::{
+        canonical_json::assert_to_canonical_json_eq, mxc_uri, presence::PresenceState,
+    };
+    use serde_json::{from_value as from_json_value, json};
 
     use super::{PresenceEvent, PresenceEventContent};
 
@@ -88,15 +90,16 @@ mod tests {
             status_msg: Some("Making cupcakes".into()),
         };
 
-        let json = json!({
-            "avatar_url": "mxc://localhost/wefuiwegh8742w",
-            "currently_active": false,
-            "last_active_ago": 2_478_593,
-            "presence": "online",
-            "status_msg": "Making cupcakes"
-        });
-
-        assert_eq!(to_json_value(&content).unwrap(), json);
+        assert_to_canonical_json_eq!(
+            content,
+            json!({
+                "avatar_url": "mxc://localhost/wefuiwegh8742w",
+                "currently_active": false,
+                "last_active_ago": 2_478_593,
+                "presence": "online",
+                "status_msg": "Making cupcakes",
+            }),
+        );
     }
 
     #[test]

--- a/crates/ruma-events/src/reaction.rs
+++ b/crates/ruma-events/src/reaction.rs
@@ -37,8 +37,8 @@ impl From<Annotation> for ReactionEventContent {
 #[cfg(test)]
 mod tests {
     use assert_matches2::assert_matches;
-    use ruma_common::{owned_event_id, serde::Raw};
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+    use ruma_common::{canonical_json::assert_to_canonical_json_eq, owned_event_id, serde::Raw};
+    use serde_json::{from_value as from_json_value, json};
 
     use super::ReactionEventContent;
     use crate::relation::Annotation;
@@ -68,8 +68,8 @@ mod tests {
             "🏠".to_owned(),
         ));
 
-        assert_eq!(
-            to_json_value(&content).unwrap(),
+        assert_to_canonical_json_eq!(
+            content,
             json!({
                 "m.relates_to": {
                     "rel_type": "m.annotation",

--- a/crates/ruma-events/src/receipt.rs
+++ b/crates/ruma-events/src/receipt.rs
@@ -212,29 +212,31 @@ where
 #[cfg(test)]
 mod tests {
     use assert_matches2::assert_matches;
-    use ruma_common::{MilliSecondsSinceUnixEpoch, owned_event_id};
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+    use ruma_common::{
+        MilliSecondsSinceUnixEpoch, canonical_json::assert_to_canonical_json_eq, owned_event_id,
+    };
+    use serde_json::{from_value as from_json_value, json};
 
     use super::{Receipt, ReceiptThread};
 
     #[test]
     fn serialize_receipt() {
         let mut receipt = Receipt::default();
-        assert_eq!(to_json_value(receipt.clone()).unwrap(), json!({}));
+        assert_to_canonical_json_eq!(receipt.clone(), json!({}));
 
         receipt.thread = ReceiptThread::Main;
-        assert_eq!(to_json_value(receipt.clone()).unwrap(), json!({ "thread_id": "main" }));
+        assert_to_canonical_json_eq!(receipt.clone(), json!({ "thread_id": "main" }));
 
         receipt.thread = ReceiptThread::Thread(owned_event_id!("$abcdef76543"));
-        assert_eq!(to_json_value(receipt).unwrap(), json!({ "thread_id": "$abcdef76543" }));
+        assert_to_canonical_json_eq!(receipt, json!({ "thread_id": "$abcdef76543" }));
 
         let mut receipt =
             Receipt::new(MilliSecondsSinceUnixEpoch(1_664_702_144_365_u64.try_into().unwrap()));
-        assert_eq!(to_json_value(receipt.clone()).unwrap(), json!({ "ts": 1_664_702_144_365_u64 }));
+        assert_to_canonical_json_eq!(receipt.clone(), json!({ "ts": 1_664_702_144_365_u64 }));
 
         receipt.thread = ReceiptThread::try_from(Some("io.ruma.unknown")).unwrap();
-        assert_eq!(
-            to_json_value(receipt).unwrap(),
+        assert_to_canonical_json_eq!(
+            receipt,
             json!({ "ts": 1_664_702_144_365_u64, "thread_id": "io.ruma.unknown" })
         );
     }

--- a/crates/ruma-events/src/room/canonical_alias.rs
+++ b/crates/ruma-events/src/room/canonical_alias.rs
@@ -40,8 +40,8 @@ impl RoomCanonicalAliasEventContent {
 
 #[cfg(test)]
 mod tests {
-    use ruma_common::owned_room_alias_id;
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+    use ruma_common::{canonical_json::assert_to_canonical_json_eq, owned_room_alias_id};
+    use serde_json::{from_value as from_json_value, json};
 
     use super::RoomCanonicalAliasEventContent;
     use crate::OriginalStateEvent;
@@ -53,12 +53,12 @@ mod tests {
             alt_aliases: Vec::new(),
         };
 
-        let actual = to_json_value(&content).unwrap();
-        let expected = json!({
-            "alias": "#somewhere:localhost",
-        });
-
-        assert_eq!(actual, expected);
+        assert_to_canonical_json_eq!(
+            content,
+            json!({
+                "alias": "#somewhere:localhost",
+            }),
+        );
     }
 
     #[test]

--- a/crates/ruma-events/src/room/create.rs
+++ b/crates/ruma-events/src/room/create.rs
@@ -165,8 +165,8 @@ impl RedactedStateEventContent for RedactedRoomCreateEventContent {
 #[cfg(test)]
 mod tests {
     use assert_matches2::assert_matches;
-    use ruma_common::{RoomVersionId, owned_user_id};
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+    use ruma_common::{RoomVersionId, canonical_json::assert_to_canonical_json_eq, owned_user_id};
+    use serde_json::{from_value as from_json_value, json};
 
     use super::{RoomCreateEventContent, RoomType};
 
@@ -182,13 +182,14 @@ mod tests {
             additional_creators: Vec::new(),
         };
 
-        let json = json!({
-            "creator": "@carl:example.com",
-            "m.federate": false,
-            "room_version": "4"
-        });
-
-        assert_eq!(to_json_value(&content).unwrap(), json);
+        assert_to_canonical_json_eq!(
+            content,
+            json!({
+                "creator": "@carl:example.com",
+                "m.federate": false,
+                "room_version": "4",
+            }),
+        );
     }
 
     #[test]
@@ -203,14 +204,15 @@ mod tests {
             additional_creators: Vec::new(),
         };
 
-        let json = json!({
-            "creator": "@carl:example.com",
-            "m.federate": false,
-            "room_version": "4",
-            "type": "m.space"
-        });
-
-        assert_eq!(to_json_value(&content).unwrap(), json);
+        assert_to_canonical_json_eq!(
+            content,
+            json!({
+                "creator": "@carl:example.com",
+                "m.federate": false,
+                "room_version": "4",
+                "type": "m.space",
+            }),
+        );
     }
 
     #[test]

--- a/crates/ruma-events/src/room/encrypted.rs
+++ b/crates/ruma-events/src/room/encrypted.rs
@@ -289,8 +289,10 @@ impl From<MegolmV1AesSha2ContentInit> for MegolmV1AesSha2Content {
 mod tests {
     use assert_matches2::assert_matches;
     use js_int::uint;
-    use ruma_common::{device_id, owned_event_id, serde::Raw};
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+    use ruma_common::{
+        canonical_json::assert_to_canonical_json_eq, device_id, owned_event_id, serde::Raw,
+    };
+    use serde_json::{from_value as from_json_value, json};
 
     use super::{
         EncryptedEventScheme, InReplyTo, MegolmV1AesSha2ContentInit, Relation,
@@ -314,20 +316,21 @@ mod tests {
             }),
         };
 
-        let json_data = json!({
-            "algorithm": "m.megolm.v1.aes-sha2",
-            "ciphertext": "ciphertext",
-            "sender_key": "sender_key",
-            "device_id": "device_id",
-            "session_id": "session_id",
-            "m.relates_to": {
-                "m.in_reply_to": {
-                    "event_id": "$h29iv0s8:example.com"
-                }
-            },
-        });
-
-        assert_eq!(to_json_value(&key_verification_start_content).unwrap(), json_data);
+        assert_to_canonical_json_eq!(
+            key_verification_start_content,
+            json!({
+                "algorithm": "m.megolm.v1.aes-sha2",
+                "ciphertext": "ciphertext",
+                "sender_key": "sender_key",
+                "device_id": "device_id",
+                "session_id": "session_id",
+                "m.relates_to": {
+                    "m.in_reply_to": {
+                        "event_id": "$h29iv0s8:example.com"
+                    }
+                },
+            }),
+        );
     }
 
     #[test]

--- a/crates/ruma-events/src/room/encrypted/unstable_state.rs
+++ b/crates/ruma-events/src/room/encrypted/unstable_state.rs
@@ -61,8 +61,10 @@ mod tests {
 
     use assert_matches2::assert_matches;
     use js_int::uint;
-    use ruma_common::{MilliSecondsSinceUnixEpoch, room_id, user_id};
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+    use ruma_common::{
+        MilliSecondsSinceUnixEpoch, canonical_json::assert_to_canonical_json_eq, room_id, user_id,
+    };
+    use serde_json::{from_value as from_json_value, json};
 
     use crate::{
         AnyStateEvent, StateEvent,
@@ -86,15 +88,16 @@ mod tests {
             ),
         };
 
-        let json_data = json!({
-            "algorithm": "m.megolm.v1.aes-sha2",
-            "ciphertext": "ciphertext",
-            "sender_key": "sender_key",
-            "device_id": "device_id",
-            "session_id": "session_id",
-        });
-
-        assert_eq!(to_json_value(&key_verification_start_content).unwrap(), json_data);
+        assert_to_canonical_json_eq!(
+            key_verification_start_content,
+            json!({
+                "algorithm": "m.megolm.v1.aes-sha2",
+                "ciphertext": "ciphertext",
+                "sender_key": "sender_key",
+                "device_id": "device_id",
+                "session_id": "session_id",
+            }),
+        );
     }
 
     #[test]

--- a/crates/ruma-events/src/room/language.rs
+++ b/crates/ruma-events/src/room/language.rs
@@ -28,7 +28,8 @@ impl RoomLanguageEventContent {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+    use ruma_common::canonical_json::assert_to_canonical_json_eq;
+    use serde_json::{from_value as from_json_value, json};
 
     use super::RoomLanguageEventContent;
     use crate::{OriginalStateEvent, room::language::LanguageTag};
@@ -37,12 +38,12 @@ mod tests {
     fn serialization() {
         let content = RoomLanguageEventContent { language: LanguageTag::parse("fr").unwrap() };
 
-        let actual = to_json_value(content).unwrap();
-        let expected = json!({
-            "language": "fr",
-        });
-
-        assert_eq!(actual, expected);
+        assert_to_canonical_json_eq!(
+            content,
+            json!({
+                "language": "fr",
+            }),
+        );
     }
 
     #[test]

--- a/crates/ruma-events/src/room/name.rs
+++ b/crates/ruma-events/src/room/name.rs
@@ -27,7 +27,8 @@ impl RoomNameEventContent {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+    use ruma_common::canonical_json::assert_to_canonical_json_eq;
+    use serde_json::{from_value as from_json_value, json};
 
     use super::RoomNameEventContent;
     use crate::OriginalStateEvent;
@@ -36,12 +37,12 @@ mod tests {
     fn serialization() {
         let content = RoomNameEventContent { name: "The room name".to_owned() };
 
-        let actual = to_json_value(content).unwrap();
-        let expected = json!({
-            "name": "The room name",
-        });
-
-        assert_eq!(actual, expected);
+        assert_to_canonical_json_eq!(
+            content,
+            json!({
+                "name": "The room name",
+            }),
+        );
     }
 
     #[test]

--- a/crates/ruma-events/src/room/power_levels.rs
+++ b/crates/ruma-events/src/room/power_levels.rs
@@ -959,8 +959,11 @@ mod tests {
     use assign::assign;
     use js_int::int;
     use maplit::btreemap;
-    use ruma_common::{owned_user_id, room_version_rules::AuthorizationRules, user_id};
-    use serde_json::{json, to_value as to_json_value};
+    use ruma_common::{
+        canonical_json::assert_to_canonical_json_eq, owned_user_id,
+        room_version_rules::AuthorizationRules, user_id,
+    };
+    use serde_json::json;
 
     use super::{
         NotificationPowerLevels, RoomPowerLevels, RoomPowerLevelsEventContent,
@@ -984,10 +987,7 @@ mod tests {
             notifications: NotificationPowerLevels::default(),
         };
 
-        let actual = to_json_value(&power_levels).unwrap();
-        let expected = json!({});
-
-        assert_eq!(actual, expected);
+        assert_to_canonical_json_eq!(power_levels, json!({}));
     }
 
     #[test]
@@ -1010,27 +1010,27 @@ mod tests {
             notifications: assign!(NotificationPowerLevels::new(), { room: int!(23) }),
         };
 
-        let actual = to_json_value(&power_levels_event).unwrap();
-        let expected = json!({
-            "ban": 23,
-            "events": {
-                "m.dummy": 23
-            },
-            "events_default": 23,
-            "invite": 23,
-            "kick": 23,
-            "redact": 23,
-            "state_default": 23,
-            "users": {
-                "@carl:example.com": 23
-            },
-            "users_default": 23,
-            "notifications": {
-                "room": 23
-            },
-        });
-
-        assert_eq!(actual, expected);
+        assert_to_canonical_json_eq!(
+            power_levels_event,
+            json!({
+                "ban": 23,
+                "events": {
+                    "m.dummy": 23,
+                },
+                "events_default": 23,
+                "invite": 23,
+                "kick": 23,
+                "redact": 23,
+                "state_default": 23,
+                "users": {
+                    "@carl:example.com": 23,
+                },
+                "users_default": 23,
+                "notifications": {
+                    "room": 23,
+                },
+            }),
+        );
     }
 
     #[test]

--- a/crates/ruma-events/src/room/redaction.rs
+++ b/crates/ruma-events/src/room/redaction.rs
@@ -4,11 +4,10 @@
 
 use as_variant::as_variant;
 use js_int::Int;
-#[cfg(feature = "canonical-json")]
-use ruma_common::canonical_json::RedactionEvent;
 use ruma_common::{
     EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedTransactionId,
     OwnedUserId, RoomId, UserId,
+    canonical_json::RedactionEvent,
     room_version_rules::RedactionRules,
     serde::{CanBeEmpty, JsonCastable, JsonObject},
 };
@@ -435,13 +434,12 @@ impl OriginalSyncRoomRedactionEvent {
     }
 }
 
-#[cfg(feature = "canonical-json")]
 impl RedactionEvent for OriginalRoomRedactionEvent {}
-#[cfg(feature = "canonical-json")]
+
 impl RedactionEvent for OriginalSyncRoomRedactionEvent {}
-#[cfg(feature = "canonical-json")]
+
 impl RedactionEvent for RoomRedactionEvent {}
-#[cfg(feature = "canonical-json")]
+
 impl RedactionEvent for SyncRoomRedactionEvent {}
 
 /// Extra information about a redaction that is not incorporated into the event's hash.

--- a/crates/ruma-events/src/room/topic.rs
+++ b/crates/ruma-events/src/room/topic.rs
@@ -101,7 +101,8 @@ impl From<TextContentBlock> for TopicContentBlock {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+    use ruma_common::canonical_json::assert_to_canonical_json_eq;
+    use serde_json::{from_value as from_json_value, json};
 
     use super::RoomTopicEventContent;
     use crate::message::TextContentBlock;
@@ -110,8 +111,8 @@ mod tests {
     fn serialize_content() {
         // Content with plain text block.
         let mut content = RoomTopicEventContent::new("Hot Topic".to_owned());
-        assert_eq!(
-            to_json_value(&content).unwrap(),
+        assert_to_canonical_json_eq!(
+            content,
             json!({
                 "topic": "Hot Topic",
                 "m.topic": {
@@ -124,8 +125,8 @@ mod tests {
 
         // Content without block.
         content.topic_block.text = TextContentBlock::from(vec![]);
-        assert_eq!(
-            to_json_value(&content).unwrap(),
+        assert_to_canonical_json_eq!(
+            content,
             json!({
                 "topic": "Hot Topic",
             })
@@ -133,8 +134,8 @@ mod tests {
 
         // Content with HTML block.
         let content = RoomTopicEventContent::html("Hot Topic", "<strong>Hot</strong> Topic");
-        assert_eq!(
-            to_json_value(&content).unwrap(),
+        assert_to_canonical_json_eq!(
+            content,
             json!({
                 "topic": "Hot Topic",
                 "m.topic": {

--- a/crates/ruma-events/src/room_key.rs
+++ b/crates/ruma-events/src/room_key.rs
@@ -63,8 +63,8 @@ impl ToDeviceRoomKeyEventContent {
 
 #[cfg(test)]
 mod tests {
-    use ruma_common::owned_room_id;
-    use serde_json::{json, to_value as to_json_value};
+    use ruma_common::{canonical_json::assert_to_canonical_json_eq, owned_room_id};
+    use serde_json::json;
 
     use super::ToDeviceRoomKeyEventContent;
     use crate::EventEncryptionAlgorithm;
@@ -81,8 +81,8 @@ mod tests {
         };
 
         #[cfg(not(feature = "unstable-msc3061"))]
-        assert_eq!(
-            to_json_value(content).unwrap(),
+        assert_to_canonical_json_eq!(
+            content,
             json!({
                 "algorithm": "m.megolm.v1.aes-sha2",
                 "room_id": "!testroomid:example.org",
@@ -92,8 +92,8 @@ mod tests {
         );
 
         #[cfg(feature = "unstable-msc3061")]
-        assert_eq!(
-            to_json_value(content).unwrap(),
+        assert_to_canonical_json_eq!(
+            content,
             json!({
                 "algorithm": "m.megolm.v1.aes-sha2",
                 "room_id": "!testroomid:example.org",

--- a/crates/ruma-events/src/room_key/withheld.rs
+++ b/crates/ruma-events/src/room_key/withheld.rs
@@ -231,7 +231,10 @@ pub enum RoomKeyWithheldCode {
 #[cfg(test)]
 mod tests {
     use assert_matches2::assert_matches;
-    use ruma_common::{EventEncryptionAlgorithm, owned_room_id, serde::Base64};
+    use ruma_common::{
+        EventEncryptionAlgorithm, canonical_json::assert_to_canonical_json_eq, owned_room_id,
+        serde::Base64,
+    };
     use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
 
     use super::{
@@ -249,8 +252,8 @@ mod tests {
             Base64::new(PUBLIC_KEY.to_owned()),
         );
 
-        assert_eq!(
-            to_json_value(content).unwrap(),
+        assert_to_canonical_json_eq!(
+            content,
             json!({
                 "algorithm": "m.megolm.v1.aes-sha2",
                 "code": "m.no_olm",
@@ -270,8 +273,8 @@ mod tests {
             Base64::new(PUBLIC_KEY.to_owned()),
         );
 
-        assert_eq!(
-            to_json_value(content).unwrap(),
+        assert_to_canonical_json_eq!(
+            content,
             json!({
                 "algorithm": "m.megolm.v1.aes-sha2",
                 "code": "m.blacklisted",

--- a/crates/ruma-events/src/rtc/decline.rs
+++ b/crates/ruma-events/src/rtc/decline.rs
@@ -33,8 +33,8 @@ impl RtcDeclineEventContent {
 mod tests {
     use assert_matches2::assert_matches;
     use js_int::uint;
-    use ruma_common::owned_event_id;
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+    use ruma_common::{canonical_json::assert_to_canonical_json_eq, owned_event_id};
+    use serde_json::{from_value as from_json_value, json};
 
     use super::RtcDeclineEventContent;
     use crate::{AnyMessageLikeEvent, MessageLikeEvent};
@@ -43,9 +43,8 @@ mod tests {
     fn decline_event_serialization() {
         let content = RtcDeclineEventContent::new(owned_event_id!("$abc:example.org"));
 
-        let value = to_json_value(&content).unwrap();
-        assert_eq!(
-            value,
+        assert_to_canonical_json_eq!(
+            content,
             json!({
                 "m.relates_to": {
                     "rel_type": "m.reference",

--- a/crates/ruma-events/src/rtc/notification.rs
+++ b/crates/ruma-events/src/rtc/notification.rs
@@ -117,8 +117,10 @@ mod tests {
 
     use assert_matches2::assert_matches;
     use js_int::UInt;
-    use ruma_common::{MilliSecondsSinceUnixEpoch, owned_event_id};
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+    use ruma_common::{
+        MilliSecondsSinceUnixEpoch, canonical_json::assert_to_canonical_json_eq, owned_event_id,
+    };
+    use serde_json::{from_value as from_json_value, json};
 
     use super::{NotificationType, RtcNotificationEventContent};
     use crate::{AnyMessageLikeEvent, Mentions, MessageLikeEvent};
@@ -133,8 +135,8 @@ mod tests {
         content.mentions = Some(Mentions::with_room_mention());
         content.relates_to = Some(ruma_events::relation::Reference::new(owned_event_id!("$m:ex")));
 
-        assert_eq!(
-            to_json_value(&content).unwrap(),
+        assert_to_canonical_json_eq!(
+            content,
             json!({
                 "sender_ts": 1_752_583_130_365_u64,
                 "lifetime": 30_000_u32,

--- a/crates/ruma-events/src/secret/request.rs
+++ b/crates/ruma-events/src/secret/request.rs
@@ -142,7 +142,8 @@ impl From<SecretName> for GlobalAccountDataEventType {
 #[cfg(test)]
 mod tests {
     use assert_matches2::assert_matches;
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+    use ruma_common::canonical_json::assert_to_canonical_json_eq;
+    use serde_json::{from_value as from_json_value, json};
 
     use super::{RequestAction, SecretName, ToDeviceSecretRequestEventContent};
     use crate::PrivOwnedStr;
@@ -155,14 +156,15 @@ mod tests {
             "randomly_generated_id_9573".into(),
         );
 
-        let json = json!({
-            "name": "org.example.some.secret",
-            "action": "request",
-            "requesting_device_id": "ABCDEFG",
-            "request_id": "randomly_generated_id_9573"
-        });
-
-        assert_eq!(to_json_value(&content).unwrap(), json);
+        assert_to_canonical_json_eq!(
+            content,
+            json!({
+                "name": "org.example.some.secret",
+                "action": "request",
+                "requesting_device_id": "ABCDEFG",
+                "request_id": "randomly_generated_id_9573",
+            }),
+        );
     }
 
     #[test]
@@ -173,14 +175,15 @@ mod tests {
             "this_is_a_request_id".into(),
         );
 
-        let json = json!({
-            "name": "m.megolm_backup.v1",
-            "action": "request",
-            "requesting_device_id": "XYZxyz",
-            "request_id": "this_is_a_request_id"
-        });
-
-        assert_eq!(to_json_value(&content).unwrap(), json);
+        assert_to_canonical_json_eq!(
+            content,
+            json!({
+                "name": "m.megolm_backup.v1",
+                "action": "request",
+                "requesting_device_id": "XYZxyz",
+                "request_id": "this_is_a_request_id",
+            }),
+        );
     }
 
     #[test]
@@ -191,13 +194,14 @@ mod tests {
             "this_is_a_request_id".into(),
         );
 
-        let json = json!({
-            "action": "my_custom_action",
-            "requesting_device_id": "XYZxyz",
-            "request_id": "this_is_a_request_id"
-        });
-
-        assert_eq!(to_json_value(&content).unwrap(), json);
+        assert_to_canonical_json_eq!(
+            content,
+            json!({
+                "action": "my_custom_action",
+                "requesting_device_id": "XYZxyz",
+                "request_id": "this_is_a_request_id",
+            }),
+        );
     }
 
     #[test]
@@ -208,13 +212,14 @@ mod tests {
             "randomly_generated_id_9573".into(),
         );
 
-        let json = json!({
-            "action": "request_cancellation",
-            "requesting_device_id": "ABCDEFG",
-            "request_id": "randomly_generated_id_9573"
-        });
-
-        assert_eq!(to_json_value(&content).unwrap(), json);
+        assert_to_canonical_json_eq!(
+            content,
+            json!({
+                "action": "request_cancellation",
+                "requesting_device_id": "ABCDEFG",
+                "request_id": "randomly_generated_id_9573",
+            }),
+        );
     }
 
     #[test]

--- a/crates/ruma-events/src/secret_storage/key.rs
+++ b/crates/ruma-events/src/secret_storage/key.rs
@@ -172,10 +172,11 @@ pub struct CustomSecretEncryptionAlgorithm {
 mod tests {
     use assert_matches2::assert_matches;
     use js_int::uint;
-    use ruma_common::{KeyDerivationAlgorithm, serde::Base64};
+    use ruma_common::{
+        KeyDerivationAlgorithm, canonical_json::assert_to_canonical_json_eq, serde::Base64,
+    };
     use serde_json::{
-        from_value as from_json_value, json, to_value as to_json_value,
-        value::to_raw_value as to_raw_json_value,
+        from_value as from_json_value, json, value::to_raw_value as to_raw_json_value,
     };
 
     use super::{
@@ -195,14 +196,15 @@ mod tests {
         );
         content.name = Some("my_key".to_owned());
 
-        let json = json!({
-            "name": "my_key",
-            "algorithm": "m.secret_storage.v1.aes-hmac-sha2",
-            "iv": "YWJjZGVmZ2hpamtsbW5vcA",
-            "mac": "aWRvbnRrbm93d2hhdGFtYWNsb29rc2xpa2U"
-        });
-
-        assert_eq!(to_json_value(&content).unwrap(), json);
+        assert_to_canonical_json_eq!(
+            content,
+            json!({
+                "name": "my_key",
+                "algorithm": "m.secret_storage.v1.aes-hmac-sha2",
+                "iv": "YWJjZGVmZ2hpamtsbW5vcA",
+                "mac": "aWRvbnRrbm93d2hhdGFtYWNsb29rc2xpa2U",
+            }),
+        );
     }
 
     #[test]
@@ -273,19 +275,20 @@ mod tests {
         };
         content.name = Some("my_key".to_owned());
 
-        let json = json!({
-            "name": "my_key",
-            "algorithm": "m.secret_storage.v1.aes-hmac-sha2",
-            "iv": "YWJjZGVmZ2hpamtsbW5vcA",
-            "mac": "aWRvbnRrbm93d2hhdGFtYWNsb29rc2xpa2U",
-            "passphrase": {
-                "algorithm": "m.pbkdf2",
-                "salt": "rocksalt",
-                "iterations": 8
-            }
-        });
-
-        assert_eq!(to_json_value(&content).unwrap(), json);
+        assert_to_canonical_json_eq!(
+            content,
+            json!({
+                "name": "my_key",
+                "algorithm": "m.secret_storage.v1.aes-hmac-sha2",
+                "iv": "YWJjZGVmZ2hpamtsbW5vcA",
+                "mac": "aWRvbnRrbm93d2hhdGFtYWNsb29rc2xpa2U",
+                "passphrase": {
+                    "algorithm": "m.pbkdf2",
+                    "salt": "rocksalt",
+                    "iterations": 8,
+                },
+            }),
+        );
     }
 
     #[test]
@@ -336,14 +339,15 @@ mod tests {
         );
         content.name = Some("my_key".to_owned());
 
-        let json = json!({
-            "name": "my_key",
-            "algorithm": "m.secret_storage.v1.aes-hmac-sha2",
-            "iv": "YWJjZGVmZ2hpamtsbW5vcA",
-            "mac": "aWRvbnRrbm93d2hhdGFtYWNsb29rc2xpa2U"
-        });
-
-        assert_eq!(to_json_value(&content).unwrap(), json);
+        assert_to_canonical_json_eq!(
+            content,
+            json!({
+                "name": "my_key",
+                "algorithm": "m.secret_storage.v1.aes-hmac-sha2",
+                "iv": "YWJjZGVmZ2hpamtsbW5vcA",
+                "mac": "aWRvbnRrbm93d2hhdGFtYWNsb29rc2xpa2U",
+            }),
+        );
     }
 
     #[test]
@@ -358,17 +362,18 @@ mod tests {
         content.name = Some("my_key".to_owned());
         let event = GlobalAccountDataEvent { content };
 
-        let json = json!({
-            "type": "m.secret_storage.key.my_key_id",
-            "content": {
-                "name": "my_key",
-                "algorithm": "m.secret_storage.v1.aes-hmac-sha2",
-                "iv": "YWJjZGVmZ2hpamtsbW5vcA",
-                "mac": "aWRvbnRrbm93d2hhdGFtYWNsb29rc2xpa2U"
-            }
-        });
-
-        assert_eq!(to_json_value(&event).unwrap(), json);
+        assert_to_canonical_json_eq!(
+            event,
+            json!({
+                "type": "m.secret_storage.key.my_key_id",
+                "content": {
+                    "name": "my_key",
+                    "algorithm": "m.secret_storage.v1.aes-hmac-sha2",
+                    "iv": "YWJjZGVmZ2hpamtsbW5vcA",
+                    "mac": "aWRvbnRrbm93d2hhdGFtYWNsb29rc2xpa2U",
+                },
+            }),
+        );
     }
 
     #[test]

--- a/crates/ruma-events/src/secret_storage/secret.rs
+++ b/crates/ruma-events/src/secret_storage/secret.rs
@@ -45,8 +45,8 @@ mod tests {
     use std::collections::BTreeMap;
 
     use assert_matches2::assert_matches;
-    use ruma_common::serde::Base64;
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+    use ruma_common::{canonical_json::assert_to_canonical_json_eq, serde::Base64};
+    use serde_json::{from_value as from_json_value, json};
 
     use super::{SecretEncryptedData, SecretEventContent};
 
@@ -63,17 +63,18 @@ mod tests {
 
         let content = SecretEventContent::new(encrypted);
 
-        let json = json!({
-            "encrypted": {
-                "key_one" : {
-                    "iv": "YWJjZGVmZ2hpamtsbW5vcA",
-                    "ciphertext": "dGhpc2lzZGVmaW5pdGVseWNpcGhlcnRleHQ",
-                    "mac": "aWRvbnRrbm93d2hhdGFtYWNsb29rc2xpa2U"
-                }
-            }
-        });
-
-        assert_eq!(to_json_value(content).unwrap(), json);
+        assert_to_canonical_json_eq!(
+            content,
+            json!({
+                "encrypted": {
+                    "key_one" : {
+                        "iv": "YWJjZGVmZ2hpamtsbW5vcA",
+                        "ciphertext": "dGhpc2lzZGVmaW5pdGVseWNpcGhlcnRleHQ",
+                        "mac": "aWRvbnRrbm93d2hhdGFtYWNsb29rc2xpa2U",
+                    },
+                },
+            }),
+        );
     }
 
     #[test]

--- a/crates/ruma-events/src/space/child.rs
+++ b/crates/ruma-events/src/space/child.rs
@@ -291,10 +291,11 @@ mod tests {
 
     use js_int::{UInt, uint};
     use ruma_common::{
-        MilliSecondsSinceUnixEpoch, RoomId, SpaceChildOrder, owned_server_name, owned_user_id,
-        room_id, server_name,
+        MilliSecondsSinceUnixEpoch, RoomId, SpaceChildOrder,
+        canonical_json::assert_to_canonical_json_eq, owned_server_name, owned_user_id, room_id,
+        server_name,
     };
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+    use serde_json::{from_value as from_json_value, json};
 
     use super::{
         HierarchySpaceChildEvent, SpaceChildEventContent, SpaceChildOrd, SpaceChildOrdHelper,
@@ -308,21 +309,20 @@ mod tests {
             suggested: false,
         };
 
-        let json = json!({
-            "via": ["example.com"],
-            "order": "uwu",
-        });
-
-        assert_eq!(to_json_value(&content).unwrap(), json);
+        assert_to_canonical_json_eq!(
+            content,
+            json!({
+                "via": ["example.com"],
+                "order": "uwu",
+            }),
+        );
     }
 
     #[test]
     fn space_child_empty_serialization() {
         let content = SpaceChildEventContent { via: vec![], order: None, suggested: false };
 
-        let json = json!({ "via": [] });
-
-        assert_eq!(to_json_value(&content).unwrap(), json);
+        assert_to_canonical_json_eq!(content, json!({ "via": [] }));
     }
 
     #[test]

--- a/crates/ruma-events/src/space/parent.rs
+++ b/crates/ruma-events/src/space/parent.rs
@@ -42,8 +42,8 @@ impl SpaceParentEventContent {
 
 #[cfg(test)]
 mod tests {
-    use ruma_common::server_name;
-    use serde_json::{json, to_value as to_json_value};
+    use ruma_common::{canonical_json::assert_to_canonical_json_eq, server_name};
+    use serde_json::json;
 
     use super::SpaceParentEventContent;
 
@@ -54,20 +54,19 @@ mod tests {
             canonical: true,
         };
 
-        let json = json!({
-            "via": ["example.com"],
-            "canonical": true,
-        });
-
-        assert_eq!(to_json_value(&content).unwrap(), json);
+        assert_to_canonical_json_eq!(
+            content,
+            json!({
+                "via": ["example.com"],
+                "canonical": true,
+            })
+        );
     }
 
     #[test]
     fn space_parent_empty_serialization() {
         let content = SpaceParentEventContent { via: vec![], canonical: false };
 
-        let json = json!({ "via": [] });
-
-        assert_eq!(to_json_value(&content).unwrap(), json);
+        assert_to_canonical_json_eq!(content, json!({ "via": [] }));
     }
 }

--- a/crates/ruma-events/src/space_order.rs
+++ b/crates/ruma-events/src/space_order.rs
@@ -30,8 +30,8 @@ impl SpaceOrderEventContent {
 #[cfg(test)]
 mod tests {
     use assert_matches2::assert_matches;
-    use ruma_common::SpaceChildOrder;
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+    use ruma_common::{SpaceChildOrder, canonical_json::assert_to_canonical_json_eq};
+    use serde_json::{from_value as from_json_value, json};
 
     use super::SpaceOrderEventContent;
     use crate::{AnyRoomAccountDataEvent, RoomAccountDataEvent};
@@ -68,8 +68,8 @@ mod tests {
     fn serialize() {
         let space_order = SpaceOrderEventContent::new(SpaceChildOrder::parse("a").unwrap());
         let space_order_account_data = RoomAccountDataEvent { content: space_order };
-        assert_eq!(
-            to_json_value(space_order_account_data).unwrap(),
+        assert_to_canonical_json_eq!(
+            space_order_account_data,
             json!({
                 "type": "org.matrix.msc3230.space_order",
                 "content": {

--- a/crates/ruma-events/tests/it/audio.rs
+++ b/crates/ruma-events/tests/it/audio.rs
@@ -5,7 +5,9 @@ use std::time::Duration;
 use assert_matches2::assert_matches;
 use js_int::uint;
 use ruma_common::{
-    MilliSecondsSinceUnixEpoch, mxc_uri, owned_event_id,
+    MilliSecondsSinceUnixEpoch,
+    canonical_json::assert_to_canonical_json_eq,
+    mxc_uri, owned_event_id,
     serde::{Base64, CanBeEmpty},
 };
 #[cfg(feature = "unstable-msc3246")]
@@ -18,7 +20,7 @@ use ruma_events::{
     relation::InReplyTo,
     room::{JsonWebKeyInit, message::Relation},
 };
-use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+use serde_json::{from_value as from_json_value, json};
 
 #[cfg(feature = "unstable-msc3246")]
 #[test]
@@ -39,8 +41,8 @@ fn plain_content_serialization() {
         ),
     );
 
-    assert_eq!(
-        to_json_value(&event_content).unwrap(),
+    assert_to_canonical_json_eq!(
+        event_content,
         json!({
             "org.matrix.msc1767.text": [
                 { "body": "Upload: my_sound.ogg" },
@@ -81,8 +83,8 @@ fn encrypted_content_serialization() {
         ),
     );
 
-    assert_eq!(
-        to_json_value(&event_content).unwrap(),
+    assert_to_canonical_json_eq!(
+        event_content,
         json!({
             "org.matrix.msc1767.text": [
                 { "body": "Upload: my_sound.ogg" },
@@ -123,8 +125,8 @@ fn event_serialization() {
         in_reply_to: InReplyTo::new(owned_event_id!("$replyevent:example.com")),
     });
 
-    assert_eq!(
-        to_json_value(&content).unwrap(),
+    assert_to_canonical_json_eq!(
+        content,
         json!({
             "org.matrix.msc1767.text": [
                 { "mimetype": "text/html", "body": "Upload: <strong>my_mix.mp3</strong>" },

--- a/crates/ruma-events/tests/it/beacon.rs
+++ b/crates/ruma-events/tests/it/beacon.rs
@@ -3,14 +3,13 @@
 use assert_matches2::assert_matches;
 use js_int::uint;
 use ruma_common::{
-    MilliSecondsSinceUnixEpoch, owned_event_id, room_id, serde::CanBeEmpty, user_id,
+    MilliSecondsSinceUnixEpoch, canonical_json::assert_to_canonical_json_eq, owned_event_id,
+    room_id, serde::CanBeEmpty, user_id,
 };
 use ruma_events::{
     AnyMessageLikeEvent, MessageLikeEvent, beacon::BeaconEventContent, relation::Reference,
 };
-use serde_json::{
-    Value as JsonValue, from_value as from_json_value, json, to_value as to_json_value,
-};
+use serde_json::{Value as JsonValue, from_value as from_json_value, json};
 
 fn get_beacon_event_content() -> BeaconEventContent {
     BeaconEventContent::new(
@@ -37,7 +36,7 @@ fn get_beacon_event_content_json() -> JsonValue {
 fn beacon_event_content_serialization() {
     let event_content = get_beacon_event_content();
 
-    assert_eq!(to_json_value(&event_content).unwrap(), get_beacon_event_content_json());
+    assert_to_canonical_json_eq!(event_content, get_beacon_event_content_json());
 }
 
 #[test]

--- a/crates/ruma-events/tests/it/beacon_info.rs
+++ b/crates/ruma-events/tests/it/beacon_info.rs
@@ -4,11 +4,14 @@ use std::time::Duration;
 
 use assert_matches2::assert_matches;
 use js_int::uint;
-use ruma_common::{MilliSecondsSinceUnixEpoch, event_id, room_id, serde::CanBeEmpty, user_id};
+use ruma_common::{
+    MilliSecondsSinceUnixEpoch, canonical_json::assert_to_canonical_json_eq, event_id, room_id,
+    serde::CanBeEmpty, user_id,
+};
 use ruma_events::{
     AnyStateEvent, StateEvent, beacon_info::BeaconInfoEventContent, location::AssetType,
 };
-use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+use serde_json::{from_value as from_json_value, json};
 
 fn get_beacon_info_event_content(
     duration: Option<Duration>,
@@ -56,8 +59,8 @@ fn beacon_info_stop_event() {
 
     event_content.stop();
 
-    assert_eq!(
-        to_json_value(&event_content).unwrap(),
+    assert_to_canonical_json_eq!(
+        event_content,
         json!({
             "org.matrix.msc3488.ts": 1_636_829_458,
             "org.matrix.msc3488.asset": {
@@ -83,8 +86,8 @@ fn beacon_info_start_event() {
 
     event_content.start();
 
-    assert_eq!(
-        to_json_value(&event_content).unwrap(),
+    assert_to_canonical_json_eq!(
+        event_content,
         json!({
             "org.matrix.msc3488.ts": 1_636_829_458,
             "org.matrix.msc3488.asset": {
@@ -103,8 +106,8 @@ fn beacon_info_start_event_content_serialization() {
 
     let event_content = get_beacon_info_event_content(None, ts);
 
-    assert_eq!(
-        to_json_value(&event_content).unwrap(),
+    assert_to_canonical_json_eq!(
+        event_content,
         json!({
             "org.matrix.msc3488.ts": 1_636_829_458,
             "org.matrix.msc3488.asset": {

--- a/crates/ruma-events/tests/it/call.rs
+++ b/crates/ruma-events/tests/it/call.rs
@@ -2,7 +2,10 @@ use assert_matches2::assert_matches;
 #[cfg(feature = "unstable-msc2747")]
 use assign::assign;
 use js_int::uint;
-use ruma_common::{MilliSecondsSinceUnixEpoch, VoipVersionId, room_id, serde::CanBeEmpty};
+use ruma_common::{
+    MilliSecondsSinceUnixEpoch, VoipVersionId, canonical_json::assert_to_canonical_json_eq,
+    room_id, serde::CanBeEmpty,
+};
 #[cfg(feature = "unstable-msc2747")]
 use ruma_events::call::CallCapabilities;
 use ruma_events::{
@@ -18,7 +21,7 @@ use ruma_events::{
         select_answer::CallSelectAnswerEventContent,
     },
 };
-use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+use serde_json::{from_value as from_json_value, json};
 
 #[test]
 fn answer_v0_content_serialization() {
@@ -27,8 +30,8 @@ fn answer_v0_content_serialization() {
         "abcdef".into(),
     );
 
-    assert_eq!(
-        to_json_value(&event_content).unwrap(),
+    assert_to_canonical_json_eq!(
+        event_content,
         json!({
             "call_id": "abcdef",
             "version": 0,
@@ -138,8 +141,8 @@ fn invite_v0_content_serialization() {
         SessionDescription::new("offer".to_owned(), "not a real sdp".to_owned()),
     );
 
-    assert_eq!(
-        to_json_value(&event_content).unwrap(),
+    assert_to_canonical_json_eq!(
+        event_content,
         json!({
             "call_id": "abcdef",
             "lifetime": 30000,
@@ -159,8 +162,8 @@ fn candidates_v0_content_serialization() {
         vec![Candidate::version_0("not a real candidate".to_owned(), "0".to_owned(), uint!(0))],
     );
 
-    assert_eq!(
-        to_json_value(&event_content).unwrap(),
+    assert_to_canonical_json_eq!(
+        event_content,
         json!({
             "call_id": "abcdef",
             "version": 0,
@@ -179,8 +182,8 @@ fn candidates_v0_content_serialization() {
 fn hangup_v0_content_serialization() {
     let event_content = CallHangupEventContent::version_0("abcdef".into());
 
-    assert_eq!(
-        to_json_value(&event_content).unwrap(),
+    assert_to_canonical_json_eq!(
+        event_content,
         json!({
             "call_id": "abcdef",
             "version": 0,
@@ -198,8 +201,8 @@ fn invite_v1_event_serialization() {
         SessionDescription::new("offer".to_owned(), "not a real sdp".to_owned()),
     );
 
-    assert_eq!(
-        to_json_value(&content).unwrap(),
+    assert_to_canonical_json_eq!(
+        content,
         json!({
             "call_id": "abcdef",
             "party_id": "9876",
@@ -255,8 +258,8 @@ fn answer_v1_event_serialization() {
         "9876".into(),
     );
 
-    assert_eq!(
-        to_json_value(&content).unwrap(),
+    assert_to_canonical_json_eq!(
+        content,
         json!({
             "call_id": "abcdef",
             "party_id": "9876",
@@ -283,8 +286,8 @@ fn answer_v1_event_capabilities_serialization() {
         }
     );
 
-    assert_eq!(
-        to_json_value(&content).unwrap(),
+    assert_to_canonical_json_eq!(
+        content,
         json!({
             "call_id": "abcdef",
             "party_id": "9876",
@@ -349,8 +352,8 @@ fn candidates_v1_event_serialization() {
         ],
     );
 
-    assert_eq!(
-        to_json_value(&content).unwrap(),
+    assert_to_canonical_json_eq!(
+        content,
         json!({
             "call_id": "abcdef",
             "party_id": "9876",
@@ -430,8 +433,8 @@ fn hangup_v1_event_serialization() {
     let content =
         CallHangupEventContent::version_1("abcdef".into(), "9876".into(), Reason::IceFailed);
 
-    assert_eq!(
-        to_json_value(&content).unwrap(),
+    assert_to_canonical_json_eq!(
+        content,
         json!({
             "call_id": "abcdef",
             "party_id": "9876",
@@ -477,8 +480,8 @@ fn negotiate_v1_event_serialization() {
         SessionDescription::new("offer".to_owned(), "not a real sdp".to_owned()),
     );
 
-    assert_eq!(
-        to_json_value(&content).unwrap(),
+    assert_to_canonical_json_eq!(
+        content,
         json!({
             "call_id": "abcdef",
             "party_id": "9876",
@@ -529,8 +532,8 @@ fn negotiate_v1_event_deserialization() {
 fn reject_v1_event_serialization() {
     let content = CallRejectEventContent::version_1("abcdef".into(), "9876".into());
 
-    assert_eq!(
-        to_json_value(&content).unwrap(),
+    assert_to_canonical_json_eq!(
+        content,
         json!({
             "call_id": "abcdef",
             "party_id": "9876",
@@ -570,8 +573,8 @@ fn select_v1_answer_event_serialization() {
     let content =
         CallSelectAnswerEventContent::version_1("abcdef".into(), "9876".into(), "6336".into());
 
-    assert_eq!(
-        to_json_value(&content).unwrap(),
+    assert_to_canonical_json_eq!(
+        content,
         json!({
             "call_id": "abcdef",
             "party_id": "9876",

--- a/crates/ruma-events/tests/it/encrypted.rs
+++ b/crates/ruma-events/tests/it/encrypted.rs
@@ -1,5 +1,7 @@
 use assert_matches2::assert_matches;
-use ruma_common::{owned_device_id, owned_event_id, serde::Raw};
+use ruma_common::{
+    canonical_json::assert_to_canonical_json_eq, owned_device_id, owned_event_id, serde::Raw,
+};
 use ruma_events::{
     relation::{Annotation, CustomRelation, InReplyTo, Reference, Thread},
     room::encrypted::{
@@ -7,9 +9,7 @@ use ruma_events::{
         RoomEncryptedEventContent,
     },
 };
-use serde_json::{
-    Value as JsonValue, from_value as from_json_value, json, to_value as to_json_value,
-};
+use serde_json::{Value as JsonValue, from_value as from_json_value, json};
 
 fn encrypted_scheme() -> EncryptedEventScheme {
     EncryptedEventScheme::MegolmV1AesSha2(
@@ -33,8 +33,8 @@ fn encrypted_scheme() -> EncryptedEventScheme {
 fn content_no_relation_serialization() {
     let content = RoomEncryptedEventContent::new(encrypted_scheme(), None);
 
-    assert_eq!(
-        to_json_value(&content).unwrap(),
+    assert_to_canonical_json_eq!(
+        content,
         json!({
             "algorithm": "m.megolm.v1.aes-sha2",
             "sender_key": "aV9BpqYFqJpKYmgERyGv/6QyKMcgLqxM05V0gvzg9Yk",
@@ -100,8 +100,8 @@ fn content_reply_serialization() {
         Some(Relation::Reply { in_reply_to: InReplyTo::new(owned_event_id!("$replied_to_event")) }),
     );
 
-    assert_eq!(
-        to_json_value(&content).unwrap(),
+    assert_to_canonical_json_eq!(
+        content,
         json!({
             "algorithm": "m.megolm.v1.aes-sha2",
             "sender_key": "aV9BpqYFqJpKYmgERyGv/6QyKMcgLqxM05V0gvzg9Yk",
@@ -183,8 +183,8 @@ fn content_replacement_serialization() {
         Some(Relation::Replacement(Replacement::new(owned_event_id!("$replaced_event")))),
     );
 
-    assert_eq!(
-        to_json_value(&content).unwrap(),
+    assert_to_canonical_json_eq!(
+        content,
         json!({
             "algorithm": "m.megolm.v1.aes-sha2",
             "sender_key": "aV9BpqYFqJpKYmgERyGv/6QyKMcgLqxM05V0gvzg9Yk",
@@ -264,8 +264,8 @@ fn content_reference_serialization() {
         Some(Relation::Reference(Reference::new(owned_event_id!("$referenced_event")))),
     );
 
-    assert_eq!(
-        to_json_value(&content).unwrap(),
+    assert_to_canonical_json_eq!(
+        content,
         json!({
             "algorithm": "m.megolm.v1.aes-sha2",
             "sender_key": "aV9BpqYFqJpKYmgERyGv/6QyKMcgLqxM05V0gvzg9Yk",
@@ -348,8 +348,8 @@ fn content_thread_serialization() {
         ))),
     );
 
-    assert_eq!(
-        to_json_value(&content).unwrap(),
+    assert_to_canonical_json_eq!(
+        content,
         json!({
             "algorithm": "m.megolm.v1.aes-sha2",
             "sender_key": "aV9BpqYFqJpKYmgERyGv/6QyKMcgLqxM05V0gvzg9Yk",
@@ -441,8 +441,8 @@ fn content_annotation_serialization() {
         ))),
     );
 
-    assert_eq!(
-        to_json_value(&content).unwrap(),
+    assert_to_canonical_json_eq!(
+        content,
         json!({
             "algorithm": "m.megolm.v1.aes-sha2",
             "sender_key": "aV9BpqYFqJpKYmgERyGv/6QyKMcgLqxM05V0gvzg9Yk",
@@ -571,8 +571,8 @@ fn custom_relation_serialization() {
     let content =
         RoomEncryptedEventContent::new(encrypted_scheme(), Some(Relation::_Custom(relation)));
 
-    assert_eq!(
-        to_json_value(&content).unwrap(),
+    assert_to_canonical_json_eq!(
+        content,
         json!({
             "algorithm": "m.megolm.v1.aes-sha2",
             "sender_key": "aV9BpqYFqJpKYmgERyGv/6QyKMcgLqxM05V0gvzg9Yk",

--- a/crates/ruma-events/tests/it/ephemeral_event.rs
+++ b/crates/ruma-events/tests/it/ephemeral_event.rs
@@ -1,24 +1,27 @@
 use assert_matches2::assert_matches;
 use js_int::uint;
 use maplit::btreemap;
-use ruma_common::{MilliSecondsSinceUnixEpoch, event_id, owned_event_id, owned_user_id, user_id};
+use ruma_common::{
+    MilliSecondsSinceUnixEpoch, canonical_json::assert_to_canonical_json_eq, event_id,
+    owned_event_id, owned_user_id, user_id,
+};
 use ruma_events::{
     AnySyncEphemeralRoomEvent,
     receipt::{Receipt, ReceiptEventContent, ReceiptType},
     typing::TypingEventContent,
 };
-use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+use serde_json::{from_value as from_json_value, json};
 
 #[test]
 fn ephemeral_serialize_typing() {
     let content = TypingEventContent::new(vec![owned_user_id!("@carl:example.com")]);
 
-    let actual = to_json_value(&content).unwrap();
-    let expected = json!({
-        "user_ids": ["@carl:example.com"],
-    });
-
-    assert_eq!(actual, expected);
+    assert_to_canonical_json_eq!(
+        content,
+        json!({
+            "user_ids": ["@carl:example.com"],
+        }),
+    );
 }
 
 #[test]
@@ -51,16 +54,16 @@ fn ephemeral_serialize_receipt() {
         },
     });
 
-    let actual = to_json_value(&content).unwrap();
-    let expected = json!({
-        "$h29iv0s8:example.com": {
-            "m.read": {
-                "@carl:example.com": { "ts": 1 }
-            }
-        }
-    });
-
-    assert_eq!(actual, expected);
+    assert_to_canonical_json_eq!(
+        content,
+        json!({
+            "$h29iv0s8:example.com": {
+                "m.read": {
+                    "@carl:example.com": { "ts": 1 },
+                },
+            },
+        }),
+    );
 }
 
 #[test]

--- a/crates/ruma-events/tests/it/file.rs
+++ b/crates/ruma-events/tests/it/file.rs
@@ -3,7 +3,9 @@
 use assert_matches2::assert_matches;
 use js_int::uint;
 use ruma_common::{
-    MilliSecondsSinceUnixEpoch, mxc_uri, owned_event_id,
+    MilliSecondsSinceUnixEpoch,
+    canonical_json::assert_to_canonical_json_eq,
+    mxc_uri, owned_event_id,
     serde::{Base64, CanBeEmpty},
 };
 use ruma_events::{
@@ -13,7 +15,7 @@ use ruma_events::{
     relation::InReplyTo,
     room::{JsonWebKeyInit, message::Relation},
 };
-use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+use serde_json::{from_value as from_json_value, json};
 
 #[test]
 fn plain_content_serialization() {
@@ -23,8 +25,8 @@ fn plain_content_serialization() {
         "my_file.txt".to_owned(),
     );
 
-    assert_eq!(
-        to_json_value(&event_content).unwrap(),
+    assert_to_canonical_json_eq!(
+        event_content,
         json!({
             "org.matrix.msc1767.text": [
                 { "body": "Upload: my_file.txt" },
@@ -63,8 +65,8 @@ fn encrypted_content_serialization() {
         .into(),
     );
 
-    assert_eq!(
-        to_json_value(&event_content).unwrap(),
+    assert_to_canonical_json_eq!(
+        event_content,
         json!({
             "org.matrix.msc1767.text": [
                 { "body": "Upload: my_file.txt" },
@@ -102,8 +104,8 @@ fn file_event_serialization() {
         in_reply_to: InReplyTo::new(owned_event_id!("$replyevent:example.com")),
     });
 
-    assert_eq!(
-        to_json_value(&content).unwrap(),
+    assert_to_canonical_json_eq!(
+        content,
         json!({
             "org.matrix.msc1767.text": [
                 { "mimetype": "text/html", "body": "Upload: <strong>my_file.txt</strong>" },

--- a/crates/ruma-events/tests/it/image.rs
+++ b/crates/ruma-events/tests/it/image.rs
@@ -3,7 +3,9 @@
 use assert_matches2::assert_matches;
 use js_int::uint;
 use ruma_common::{
-    MilliSecondsSinceUnixEpoch, mxc_uri, owned_event_id,
+    MilliSecondsSinceUnixEpoch,
+    canonical_json::assert_to_canonical_json_eq,
+    mxc_uri, owned_event_id,
     serde::{Base64, CanBeEmpty},
 };
 use ruma_events::{
@@ -17,7 +19,7 @@ use ruma_events::{
     relation::InReplyTo,
     room::{JsonWebKeyInit, message::Relation},
 };
-use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+use serde_json::{from_value as from_json_value, json};
 
 #[test]
 fn plain_content_serialization() {
@@ -29,8 +31,8 @@ fn plain_content_serialization() {
         ),
     );
 
-    assert_eq!(
-        to_json_value(&event_content).unwrap(),
+    assert_to_canonical_json_eq!(
+        event_content,
         json!({
             "org.matrix.msc1767.text": [
                 { "body": "Upload: my_image.jpg" },
@@ -71,8 +73,8 @@ fn encrypted_content_serialization() {
         ),
     );
 
-    assert_eq!(
-        to_json_value(&event_content).unwrap(),
+    assert_to_canonical_json_eq!(
+        event_content,
         json!({
             "org.matrix.msc1767.text": [
                 { "body": "Upload: my_image.jpg" },
@@ -124,8 +126,8 @@ fn image_event_serialization() {
         in_reply_to: InReplyTo::new(owned_event_id!("$replyevent:example.com")),
     });
 
-    assert_eq!(
-        to_json_value(&content).unwrap(),
+    assert_to_canonical_json_eq!(
+        content,
         json!({
             "org.matrix.msc1767.text": [
                 { "mimetype": "text/html", "body": "Upload: <strong>my_house.jpg</strong>" },

--- a/crates/ruma-events/tests/it/location.rs
+++ b/crates/ruma-events/tests/it/location.rs
@@ -4,7 +4,8 @@ use assert_matches2::assert_matches;
 use assign::assign;
 use js_int::uint;
 use ruma_common::{
-    MilliSecondsSinceUnixEpoch, event_id, owned_event_id, room_id, serde::CanBeEmpty, user_id,
+    MilliSecondsSinceUnixEpoch, canonical_json::assert_to_canonical_json_eq, event_id,
+    owned_event_id, room_id, serde::CanBeEmpty, user_id,
 };
 use ruma_events::{
     AnyMessageLikeEvent, MessageLikeEvent,
@@ -13,7 +14,7 @@ use ruma_events::{
     relation::InReplyTo,
     room::message::{LocationMessageEventContent, MessageType, Relation, RoomMessageEventContent},
 };
-use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+use serde_json::{from_value as from_json_value, json};
 
 #[test]
 fn plain_content_serialization() {
@@ -22,8 +23,8 @@ fn plain_content_serialization() {
         LocationContent::new("geo:51.5008,0.1247;u=35".to_owned()),
     );
 
-    assert_eq!(
-        to_json_value(&event_content).unwrap(),
+    assert_to_canonical_json_eq!(
+        event_content,
         json!({
             "org.matrix.msc1767.text": [
                 { "body": "Alice was at geo:51.5008,0.1247;u=35" },
@@ -59,8 +60,8 @@ fn event_serialization() {
         }
     );
 
-    assert_eq!(
-        to_json_value(&content).unwrap(),
+    assert_to_canonical_json_eq!(
+        content,
         json!({
             "org.matrix.msc1767.text": [
                 {
@@ -215,8 +216,8 @@ fn room_message_unstable_serialization() {
             "Alice was at geo:51.5008,0.1247;u=35".to_owned(),
             "geo:51.5008,0.1247;u=35".to_owned(),
         )));
-    assert_eq!(
-        to_json_value(&message_event_content).unwrap(),
+    assert_to_canonical_json_eq!(
+        message_event_content,
         json!({
             "body": "Alice was at geo:51.5008,0.1247;u=35",
             "geo_uri": "geo:51.5008,0.1247;u=35",

--- a/crates/ruma-events/tests/it/message.rs
+++ b/crates/ruma-events/tests/it/message.rs
@@ -3,7 +3,10 @@
 use assert_matches2::assert_matches;
 use assign::assign;
 use js_int::uint;
-use ruma_common::{MilliSecondsSinceUnixEpoch, owned_event_id, serde::CanBeEmpty};
+use ruma_common::{
+    MilliSecondsSinceUnixEpoch, canonical_json::assert_to_canonical_json_eq, owned_event_id,
+    serde::CanBeEmpty,
+};
 #[cfg(feature = "unstable-msc3954")]
 use ruma_events::emote::EmoteEventContent;
 use ruma_events::{
@@ -12,15 +15,15 @@ use ruma_events::{
     relation::InReplyTo,
     room::message::Relation,
 };
-use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+use serde_json::{from_value as from_json_value, json};
 
 #[test]
 fn html_content_serialization() {
     let message_event_content =
         MessageEventContent::html("Hello, World!", "Hello, <em>World</em>!");
 
-    assert_eq!(
-        to_json_value(&message_event_content).unwrap(),
+    assert_to_canonical_json_eq!(
+        message_event_content,
         json!({
             "org.matrix.msc1767.text": [
                 { "mimetype": "text/html", "body": "Hello, <em>World</em>!" },
@@ -35,8 +38,8 @@ fn plain_text_content_serialization() {
     let message_event_content =
         MessageEventContent::plain("> <@test:example.com> test\n\ntest reply");
 
-    assert_eq!(
-        to_json_value(&message_event_content).unwrap(),
+    assert_to_canonical_json_eq!(
+        message_event_content,
         json!({
             "org.matrix.msc1767.text": [
                 { "body": "> <@test:example.com> test\n\ntest reply" },
@@ -55,8 +58,8 @@ fn unknown_mimetype_content_serialization() {
         ),
     ]));
 
-    assert_eq!(
-        to_json_value(&message_event_content).unwrap(),
+    assert_to_canonical_json_eq!(
+        message_event_content,
         json!({
             "org.matrix.msc1767.text": [
                 {
@@ -76,8 +79,8 @@ fn unknown_mimetype_content_serialization() {
 fn markdown_content_serialization() {
     let formatted_message = MessageEventContent::markdown("Testing **bold** and _italic_!");
 
-    assert_eq!(
-        to_json_value(&formatted_message).unwrap(),
+    assert_to_canonical_json_eq!(
+        formatted_message,
         json!({
             "org.matrix.msc1767.text": [
                 {
@@ -93,8 +96,8 @@ fn markdown_content_serialization() {
 
     let plain_message_simple = MessageEventContent::markdown("Testing a simple phrase…");
 
-    assert_eq!(
-        to_json_value(&plain_message_simple).unwrap(),
+    assert_to_canonical_json_eq!(
+        plain_message_simple,
         json!({
             "org.matrix.msc1767.text": [
                 { "body": "Testing a simple phrase…" },
@@ -105,8 +108,8 @@ fn markdown_content_serialization() {
     let plain_message_paragraphs =
         MessageEventContent::markdown("Testing\n\nSeveral\n\nParagraphs.");
 
-    assert_eq!(
-        to_json_value(&plain_message_paragraphs).unwrap(),
+    assert_to_canonical_json_eq!(
+        plain_message_paragraphs,
         json!({
             "org.matrix.msc1767.text": [
                 {
@@ -133,25 +136,26 @@ fn reply_content_serialization() {
             }),
         });
 
-    let json_data = json!({
-        "org.matrix.msc1767.text": [
-            { "body": "> <@test:example.com> test\n\ntest reply" },
-        ],
-        "m.relates_to": {
-            "m.in_reply_to": {
-                "event_id": "$15827405538098VGFWH:example.com"
-            }
-        }
-    });
-
-    assert_eq!(to_json_value(&message_event_content).unwrap(), json_data);
+    assert_to_canonical_json_eq!(
+        message_event_content,
+        json!({
+            "org.matrix.msc1767.text": [
+                { "body": "> <@test:example.com> test\n\ntest reply" },
+            ],
+            "m.relates_to": {
+                "m.in_reply_to": {
+                    "event_id": "$15827405538098VGFWH:example.com",
+                },
+            },
+        }),
+    );
 }
 
 #[test]
 fn message_event_serialization() {
     let content = MessageEventContent::plain("Hello, World!");
-    assert_eq!(
-        to_json_value(&content).unwrap(),
+    assert_to_canonical_json_eq!(
+        content,
         json!({
             "org.matrix.msc1767.text": [
                 { "body": "Hello, World!" },
@@ -283,8 +287,8 @@ fn emote_event_serialization() {
     let content =
         EmoteEventContent::html("is testing some code…", "is testing some <code>code</code>…");
 
-    assert_eq!(
-        to_json_value(&content).unwrap(),
+    assert_to_canonical_json_eq!(
+        content,
         json!({
             "org.matrix.msc1767.text": [
                 { "mimetype": "text/html", "body": "is testing some <code>code</code>…" },
@@ -335,8 +339,8 @@ fn lang_serialization() {
         assign!(TextRepresentation::plain("Hello World!"), { lang: "en".into() }),
     ]);
 
-    assert_eq!(
-        to_json_value(content).unwrap(),
+    assert_to_canonical_json_eq!(
+        content,
         json!([
             { "body": "Bonjour le monde !", "org.matrix.msc3554.lang": "fr"},
             { "body": "Hallo Welt!", "org.matrix.msc3554.lang": "de"},
@@ -367,8 +371,8 @@ fn automated_content_serialization() {
         MessageEventContent::plain("> <@test:example.com> test\n\ntest reply");
     message_event_content.automated = true;
 
-    assert_eq!(
-        to_json_value(&message_event_content).unwrap(),
+    assert_to_canonical_json_eq!(
+        message_event_content,
         json!({
             "org.matrix.msc1767.text": [
                 { "body": "> <@test:example.com> test\n\ntest reply" },

--- a/crates/ruma-events/tests/it/poll.rs
+++ b/crates/ruma-events/tests/it/poll.rs
@@ -4,7 +4,9 @@ use std::{collections::BTreeMap, ops::Range};
 
 use assert_matches2::assert_matches;
 use js_int::{UInt, uint};
-use ruma_common::{MilliSecondsSinceUnixEpoch, owned_event_id};
+use ruma_common::{
+    MilliSecondsSinceUnixEpoch, canonical_json::assert_to_canonical_json_eq, owned_event_id,
+};
 use ruma_events::{
     AnyMessageLikeEvent, MessageLikeEvent,
     message::TextContentBlock,
@@ -29,7 +31,7 @@ use ruma_events::{
     relation::Reference,
     room::message::{Relation, RelationWithoutReplacement},
 };
-use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+use serde_json::{from_value as from_json_value, json};
 
 #[test]
 fn poll_answers_deserialization_valid() {
@@ -98,8 +100,8 @@ fn start_content_serialization() {
         ),
     );
 
-    assert_eq!(
-        to_json_value(&event_content).unwrap(),
+    assert_to_canonical_json_eq!(
+        event_content,
         json!({
             "m.text": [{ "body": "How's the weather?\n1. Not bad…\n2. Fine.\n3. Amazing!" }],
             "m.poll": {
@@ -133,8 +135,8 @@ fn start_content_other_serialization() {
         poll,
     );
 
-    assert_eq!(
-        to_json_value(&content).unwrap(),
+    assert_to_canonical_json_eq!(
+        content,
         json!({
             "m.text": [{ "body": "How's the weather?\n1. Not bad…\n2. Fine.\n3. Amazing!" }],
             "m.poll": {
@@ -242,8 +244,8 @@ fn response_content_serialization() {
         owned_event_id!("$related_event:notareal.hs"),
     );
 
-    assert_eq!(
-        to_json_value(&event_content).unwrap(),
+    assert_to_canonical_json_eq!(
+        event_content,
         json!({
             "m.selections": ["my-answer"],
             "m.relates_to": {
@@ -261,8 +263,8 @@ fn response_content_other_serialization() {
         owned_event_id!("$related_event:notareal.hs"),
     );
 
-    assert_eq!(
-        to_json_value(&content).unwrap(),
+    assert_to_canonical_json_eq!(
+        content,
         json!({
             "m.selections": ["first-answer", "second-answer"],
             "m.relates_to": {
@@ -309,8 +311,8 @@ fn end_content_serialization() {
         owned_event_id!("$related_event:notareal.hs"),
     );
 
-    assert_eq!(
-        to_json_value(&event_content).unwrap(),
+    assert_to_canonical_json_eq!(
+        event_content,
         json!({
             "m.text":  [{ "body": "The poll has closed. Top answer: Amazing!" }],
             "m.relates_to": {
@@ -336,8 +338,8 @@ fn end_content_with_results_serialization() {
         .into(),
     );
 
-    assert_eq!(
-        to_json_value(&content).unwrap(),
+    assert_to_canonical_json_eq!(
+        content,
         json!({
             "m.text":  [{ "body": "The poll has closed. Top answer: Amazing!" }],
             "m.poll.results": {
@@ -400,8 +402,8 @@ fn new_unstable_start_content_serialization() {
         ),
     );
 
-    assert_eq!(
-        to_json_value(&event_content).unwrap(),
+    assert_to_canonical_json_eq!(
+        event_content,
         json!({
             "org.matrix.msc1767.text": "How's the weather?\n1. Not bad…\n2. Fine.\n3. Amazing!",
             "org.matrix.msc3381.poll.start": {
@@ -436,8 +438,8 @@ fn replacement_unstable_start_content_serialization() {
         replaces.clone(),
     );
 
-    assert_eq!(
-        to_json_value(&event_content).unwrap(),
+    assert_to_canonical_json_eq!(
+        event_content,
         json!({
             "m.new_content": {
                 "org.matrix.msc1767.text": "How's the weather?\n1. Not bad…\n2. Fine.\n3. Amazing!",
@@ -596,8 +598,8 @@ fn unstable_response_content_serialization() {
         owned_event_id!("$related_event:notareal.hs"),
     );
 
-    assert_eq!(
-        to_json_value(&event_content).unwrap(),
+    assert_to_canonical_json_eq!(
+        event_content,
         json!({
             "org.matrix.msc3381.poll.response": {
                 "answers": ["my-answer"],
@@ -648,8 +650,8 @@ fn unstable_end_content_serialization() {
         owned_event_id!("$related_event:notareal.hs"),
     );
 
-    assert_eq!(
-        to_json_value(&event_content).unwrap(),
+    assert_to_canonical_json_eq!(
+        event_content,
         json!({
             "org.matrix.msc1767.text":  "The poll has closed. Top answer: Amazing!",
             "org.matrix.msc3381.poll.end": {},

--- a/crates/ruma-events/tests/it/redacted.rs
+++ b/crates/ruma-events/tests/it/redacted.rs
@@ -1,5 +1,7 @@
 use assert_matches2::assert_matches;
-use ruma_common::room_version_rules::RedactionRules;
+use ruma_common::{
+    canonical_json::assert_to_canonical_json_eq, room_version_rules::RedactionRules,
+};
 use ruma_events::{
     AnyMessageLikeEvent, AnySyncMessageLikeEvent, AnySyncStateEvent, AnySyncTimelineEvent,
     AnyTimelineEvent, EventContentFromType, MessageLikeEvent, RedactContent, SyncMessageLikeEvent,
@@ -12,7 +14,7 @@ use ruma_events::{
     },
 };
 use serde_json::{
-    Value as JsonValue, from_value as from_json_value, json, to_value as to_json_value,
+    Value as JsonValue, from_value as from_json_value, json,
     value::to_raw_value as to_raw_json_value,
 };
 
@@ -31,19 +33,20 @@ fn unsigned() -> JsonValue {
 
 #[test]
 fn serialize_redacted_message_event_content() {
-    assert_eq!(to_json_value(RedactedRoomMessageEventContent::new()).unwrap(), json!({}));
+    assert_to_canonical_json_eq!(RedactedRoomMessageEventContent::new(), json!({}));
 }
 
 #[test]
 fn serialize_empty_redacted_aliases_event_content() {
-    assert_eq!(to_json_value(RedactedRoomAliasesEventContent::default()).unwrap(), json!({}));
+    assert_to_canonical_json_eq!(RedactedRoomAliasesEventContent::default(), json!({}));
 }
 
 #[test]
 fn redacted_aliases_event_serialize_with_content() {
-    let expected = json!({ "aliases": [] });
-    let actual = to_json_value(RedactedRoomAliasesEventContent::new_v1(vec![])).unwrap();
-    assert_eq!(actual, expected);
+    assert_to_canonical_json_eq!(
+        RedactedRoomAliasesEventContent::new_v1(vec![]),
+        json!({ "aliases": [] }),
+    );
 }
 
 #[test]

--- a/crates/ruma-events/tests/it/redaction.rs
+++ b/crates/ruma-events/tests/it/redaction.rs
@@ -1,25 +1,25 @@
 use assert_matches2::assert_matches;
 use js_int::uint;
 use ruma_common::{
-    MilliSecondsSinceUnixEpoch, owned_event_id, room_version_rules::RedactionRules,
-    serde::CanBeEmpty,
+    MilliSecondsSinceUnixEpoch, canonical_json::assert_to_canonical_json_eq, owned_event_id,
+    room_version_rules::RedactionRules, serde::CanBeEmpty,
 };
 use ruma_events::{
     AnyMessageLikeEvent,
     room::redaction::{RoomRedactionEvent, RoomRedactionEventContent},
 };
-use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+use serde_json::{from_value as from_json_value, json};
 
 #[test]
 fn serialize_redaction_content() {
     let content = RoomRedactionEventContent::new_v1().with_reason("being very unfriendly".into());
 
-    let actual = to_json_value(content).unwrap();
-    let expected = json!({
-        "reason": "being very unfriendly"
-    });
-
-    assert_eq!(actual, expected);
+    assert_to_canonical_json_eq!(
+        content,
+        json!({
+            "reason": "being very unfriendly",
+        }),
+    );
 }
 
 #[test]
@@ -28,13 +28,13 @@ fn serialize_redaction_content_v11() {
     let content = RoomRedactionEventContent::new_v11(redacts.clone())
         .with_reason("being very unfriendly".into());
 
-    let actual = to_json_value(content).unwrap();
-    let expected = json!({
-        "redacts": redacts,
-        "reason": "being very unfriendly"
-    });
-
-    assert_eq!(actual, expected);
+    assert_to_canonical_json_eq!(
+        content,
+        json!({
+            "redacts": redacts,
+            "reason": "being very unfriendly",
+        }),
+    );
 }
 
 #[test]

--- a/crates/ruma-events/tests/it/relations.rs
+++ b/crates/ruma-events/tests/it/relations.rs
@@ -4,7 +4,7 @@ use assert_matches2::assert_matches;
 use assign::assign;
 #[cfg(feature = "unstable-msc3381")]
 use ruma_common::event_id;
-use ruma_common::{owned_event_id, serde::Raw};
+use ruma_common::{canonical_json::assert_to_canonical_json_eq, owned_event_id, serde::Raw};
 #[cfg(feature = "unstable-msc3381")]
 use ruma_events::poll::{
     start::{PollAnswer, PollContentBlock, PollStartEventContent},
@@ -23,9 +23,7 @@ use ruma_events::{
     relation::{CustomRelation, InReplyTo, Replacement, Thread},
     room::message::{MessageType, Relation, RoomMessageEventContent},
 };
-use serde_json::{
-    Value as JsonValue, from_value as from_json_value, json, to_value as to_json_value,
-};
+use serde_json::{Value as JsonValue, from_value as from_json_value, json};
 
 #[test]
 fn reply_deserialize() {
@@ -56,8 +54,8 @@ fn reply_serialize() {
         relates_to: Some(Relation::Reply { in_reply_to: InReplyTo::new(owned_event_id!("$1598361704261elfgc")) }),
     });
 
-    assert_eq!(
-        to_json_value(content).unwrap(),
+    assert_to_canonical_json_eq!(
+        content,
         json!({
             "msgtype": "m.text",
             "body": "This is a reply",
@@ -100,8 +98,8 @@ fn replacement_serialize() {
         }
     );
 
-    assert_eq!(
-        to_json_value(content).unwrap(),
+    assert_to_canonical_json_eq!(
+        content,
         json!({
             "msgtype": "m.text",
             "body": "<text msg>",
@@ -181,8 +179,8 @@ fn thread_plain_serialize() {
         }
     );
 
-    assert_eq!(
-        to_json_value(content).unwrap(),
+    assert_to_canonical_json_eq!(
+        content,
         json!({
             "msgtype": "m.text",
             "body": "<text msg>",
@@ -212,8 +210,8 @@ fn thread_reply_serialize() {
         }
     );
 
-    assert_eq!(
-        to_json_value(content).unwrap(),
+    assert_to_canonical_json_eq!(
+        content,
         json!({
             "msgtype": "m.text",
             "body": "<text msg>",
@@ -362,8 +360,8 @@ fn custom_serialize() {
     let mut content = RoomMessageEventContent::text_plain("<text msg>");
     content.relates_to = Some(Relation::_Custom(relation));
 
-    assert_eq!(
-        to_json_value(&content).unwrap(),
+    assert_to_canonical_json_eq!(
+        content,
         json!({
             "msgtype": "m.text",
             "body": "<text msg>",

--- a/crates/ruma-events/tests/it/sticker.rs
+++ b/crates/ruma-events/tests/it/sticker.rs
@@ -1,14 +1,17 @@
 use assert_matches2::assert_matches;
 use assign::assign;
 use js_int::{UInt, uint};
-use ruma_common::{MilliSecondsSinceUnixEpoch, mxc_uri, owned_event_id, serde::CanBeEmpty};
+use ruma_common::{
+    MilliSecondsSinceUnixEpoch, canonical_json::assert_to_canonical_json_eq, mxc_uri,
+    owned_event_id, serde::CanBeEmpty,
+};
 use ruma_events::{
     AnyMessageLikeEvent, MessageLikeEvent,
     relation::Replacement,
     room::{ImageInfo, MediaSource, ThumbnailInfo, message::Relation},
     sticker::{StickerEventContent, StickerEventContentWithoutRelation, StickerMediaSource},
 };
-use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+use serde_json::{from_value as from_json_value, json};
 
 #[test]
 fn content_serialization() {
@@ -18,8 +21,8 @@ fn content_serialization() {
         mxc_uri!("mxc://notareal.hs/file").to_owned(),
     );
 
-    assert_eq!(
-        to_json_value(&message_event_content).unwrap(),
+    assert_to_canonical_json_eq!(
+        message_event_content,
         json!({
             "body": "Upload: my_image.jpg",
             "url": "mxc://notareal.hs/file",
@@ -46,8 +49,8 @@ fn replace_content_serialization() {
     let relation = Relation::Replacement(replacement);
     message_event_content.relates_to = Some(relation);
 
-    assert_eq!(
-        to_json_value(&message_event_content).unwrap(),
+    assert_to_canonical_json_eq!(
+        message_event_content,
         json!({
             "body": "* Upload: my_image.jpg",
             "url": "mxc://notareal.hs/file",
@@ -85,26 +88,26 @@ fn event_serialization() {
         mxc_uri!("mxc://matrix.org/rnsldl8srs98IRrs").to_owned(),
     );
 
-    let actual = to_json_value(&content).unwrap();
-
-    let expected = json!({
-        "body": "Hello",
-        "info": {
-            "h": 423,
-            "mimetype": "image/png",
-            "size": 84242,
-            "thumbnail_info": {
-                "h": 334,
+    assert_to_canonical_json_eq!(
+        content,
+        json!({
+            "body": "Hello",
+            "info": {
+                "h": 423,
                 "mimetype": "image/png",
-                "size": 82595,
-                "w": 800
+                "size": 84242,
+                "thumbnail_info": {
+                    "h": 334,
+                    "mimetype": "image/png",
+                    "size": 82595,
+                    "w": 800,
+                },
+                "thumbnail_url": "mxc://matrix.org/irsns989Rrsn",
+                "w": 1011,
             },
-            "thumbnail_url": "mxc://matrix.org/irsns989Rrsn",
-            "w": 1011
-            },
-        "url": "mxc://matrix.org/rnsldl8srs98IRrs",
-    });
-    assert_eq!(actual, expected);
+            "url": "mxc://matrix.org/rnsldl8srs98IRrs",
+        }),
+    );
 }
 
 #[test]

--- a/crates/ruma-events/tests/it/stripped.rs
+++ b/crates/ruma-events/tests/it/stripped.rs
@@ -1,18 +1,16 @@
 use assert_matches2::assert_matches;
 use js_int::uint;
-use ruma_common::mxc_uri;
+use ruma_common::{canonical_json::assert_to_canonical_json_eq, mxc_uri};
 use ruma_events::{
     AnyStrippedStateEvent,
     room::{join_rules::JoinRule, topic::RoomTopicEventContent},
 };
-use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+use serde_json::{from_value as from_json_value, json};
 
 #[test]
 fn serialize_stripped_state_event_any_content() {
-    let json = to_json_value(RoomTopicEventContent::new("Testing room".into())).unwrap();
-
-    assert_eq!(
-        json,
+    assert_to_canonical_json_eq!(
+        RoomTopicEventContent::new("Testing room".into()),
         json!({
             "topic": "Testing room",
             "m.topic": {

--- a/crates/ruma-events/tests/it/to_device.rs
+++ b/crates/ruma-events/tests/it/to_device.rs
@@ -1,6 +1,8 @@
-use ruma_common::{EventEncryptionAlgorithm, owned_room_id};
+use ruma_common::{
+    EventEncryptionAlgorithm, canonical_json::assert_to_canonical_json_eq, owned_room_id,
+};
 use ruma_events::room_key::ToDeviceRoomKeyEventContent;
-use serde_json::{json, to_value as to_json_value};
+use serde_json::json;
 
 #[test]
 fn serialization() {
@@ -11,8 +13,8 @@ fn serialization() {
         "SessKey".into(),
     );
 
-    assert_eq!(
-        to_json_value(&content).unwrap(),
+    assert_to_canonical_json_eq!(
+        content,
         json!({
             "algorithm": "m.megolm.v1.aes-sha2",
             "room_id": "!testroomid:example.org",

--- a/crates/ruma-events/tests/it/video.rs
+++ b/crates/ruma-events/tests/it/video.rs
@@ -5,7 +5,9 @@ use std::time::Duration;
 use assert_matches2::assert_matches;
 use js_int::uint;
 use ruma_common::{
-    MilliSecondsSinceUnixEpoch, mxc_uri, owned_event_id,
+    MilliSecondsSinceUnixEpoch,
+    canonical_json::assert_to_canonical_json_eq,
+    mxc_uri, owned_event_id,
     serde::{Base64, CanBeEmpty},
 };
 use ruma_events::{
@@ -17,7 +19,7 @@ use ruma_events::{
     room::{JsonWebKeyInit, message::Relation},
     video::{VideoDetailsContentBlock, VideoEventContent},
 };
-use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+use serde_json::{from_value as from_json_value, json};
 
 #[test]
 fn plain_content_serialization() {
@@ -29,8 +31,8 @@ fn plain_content_serialization() {
         ),
     );
 
-    assert_eq!(
-        to_json_value(&event_content).unwrap(),
+    assert_to_canonical_json_eq!(
+        event_content,
         json!({
             "org.matrix.msc1767.text": [
                 {"body": "Upload: my_video.webm" },
@@ -71,8 +73,8 @@ fn encrypted_content_serialization() {
         ),
     );
 
-    assert_eq!(
-        to_json_value(&event_content).unwrap(),
+    assert_to_canonical_json_eq!(
+        event_content,
         json!({
             "org.matrix.msc1767.text": [
                 { "body": "Upload: my_video.webm" },
@@ -129,8 +131,8 @@ fn event_serialization() {
         in_reply_to: InReplyTo::new(owned_event_id!("$replyevent:example.com")),
     });
 
-    assert_eq!(
-        to_json_value(&content).unwrap(),
+    assert_to_canonical_json_eq!(
+        content,
         json!({
             "org.matrix.msc1767.text": [
                 { "mimetype": "text/html", "body": "Upload: <strong>my_lava_lamp.webm</strong>" },

--- a/crates/ruma-events/tests/it/voice.rs
+++ b/crates/ruma-events/tests/it/voice.rs
@@ -4,7 +4,10 @@ use std::time::Duration;
 
 use assert_matches2::assert_matches;
 use js_int::uint;
-use ruma_common::{MilliSecondsSinceUnixEpoch, mxc_uri, owned_event_id, serde::CanBeEmpty};
+use ruma_common::{
+    MilliSecondsSinceUnixEpoch, canonical_json::assert_to_canonical_json_eq, mxc_uri,
+    owned_event_id, serde::CanBeEmpty,
+};
 use ruma_events::{
     AnyMessageLikeEvent, MessageLikeEvent,
     audio::Amplitude,
@@ -13,7 +16,7 @@ use ruma_events::{
     room::message::Relation,
     voice::{VoiceAudioDetailsContentBlock, VoiceEventContent},
 };
-use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+use serde_json::{from_value as from_json_value, json};
 
 #[test]
 fn event_serialization() {
@@ -35,8 +38,8 @@ fn event_serialization() {
         in_reply_to: InReplyTo::new(owned_event_id!("$replyevent:example.com")),
     });
 
-    assert_eq!(
-        to_json_value(&content).unwrap(),
+    assert_to_canonical_json_eq!(
+        content,
         json!({
             "org.matrix.msc1767.text": [
                 { "body": "Voice message" },

--- a/crates/ruma-events/tests/it/without_relation.rs
+++ b/crates/ruma-events/tests/it/without_relation.rs
@@ -1,10 +1,10 @@
 use assert_matches2::assert_matches;
-use ruma_common::owned_event_id;
+use ruma_common::{canonical_json::assert_to_canonical_json_eq, owned_event_id};
 use ruma_events::{
     relation::InReplyTo,
     room::message::{MessageType, Relation, RoomMessageEventContent},
 };
-use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+use serde_json::{from_value as from_json_value, json};
 
 #[test]
 fn serialize_room_message_content_without_relation() {
@@ -13,8 +13,8 @@ fn serialize_room_message_content_without_relation() {
         Some(Relation::Reply { in_reply_to: InReplyTo::new(owned_event_id!("$eventId")) });
     let without_relation = MessageType::from(content);
 
-    assert_eq!(
-        to_json_value(&without_relation).unwrap(),
+    assert_to_canonical_json_eq!(
+        without_relation,
         json!({
             "body": "Hello, world!",
             "msgtype": "m.text",

--- a/crates/ruma-push-gateway-api/src/send_event_notification.rs
+++ b/crates/ruma-push-gateway-api/src/send_event_notification.rs
@@ -344,44 +344,16 @@ pub mod v1 {
     mod tests {
         use js_int::uint;
         use ruma_common::{
-            SecondsSinceUnixEpoch, owned_event_id, owned_room_alias_id, owned_room_id,
-            owned_user_id,
+            SecondsSinceUnixEpoch, canonical_json::assert_to_canonical_json_eq, owned_event_id,
+            owned_room_alias_id, owned_room_id, owned_user_id,
         };
         use ruma_events::TimelineEventType;
-        use serde_json::{
-            Value as JsonValue, from_value as from_json_value, json, to_value as to_json_value,
-        };
+        use serde_json::{Value as JsonValue, from_value as from_json_value, json};
 
         use super::{Device, Notification, NotificationCounts, NotificationPriority, Tweak};
 
         #[test]
         fn serialize_request() {
-            let expected = json!({
-                "event_id": "$3957tyerfgewrf384",
-                "room_id": "!slw48wfj34rtnrf:example.com",
-                "type": "m.room.message",
-                "sender": "@exampleuser:matrix.org",
-                "sender_display_name": "Major Tom",
-                "room_alias": "#exampleroom:matrix.org",
-                "prio": "low",
-                "content": {},
-                "counts": {
-                  "unread": 2,
-                },
-                "devices": [
-                  {
-                    "app_id": "org.matrix.matrixConsole.ios",
-                    "pushkey": "V2h5IG9uIGVhcnRoIGRpZCB5b3UgZGVjb2RlIHRoaXM/",
-                    "pushkey_ts": 123,
-                    "tweaks": {
-                      "sound": "silence",
-                      "highlight": true,
-                      "custom": "go wild"
-                    }
-                  }
-                ]
-            });
-
             let eid = owned_event_id!("$3957tyerfgewrf384");
             let rid = owned_room_id!("!slw48wfj34rtnrf:example.com");
             let uid = owned_user_id!("@exampleuser:matrix.org");
@@ -420,7 +392,34 @@ pub mod v1 {
                 ..Notification::default()
             };
 
-            assert_eq!(expected, to_json_value(notice).unwrap());
+            assert_to_canonical_json_eq!(
+                notice,
+                json!({
+                    "event_id": "$3957tyerfgewrf384",
+                    "room_id": "!slw48wfj34rtnrf:example.com",
+                    "type": "m.room.message",
+                    "sender": "@exampleuser:matrix.org",
+                    "sender_display_name": "Major Tom",
+                    "room_alias": "#exampleroom:matrix.org",
+                    "prio": "low",
+                    "content": {},
+                    "counts": {
+                      "unread": 2,
+                    },
+                    "devices": [
+                      {
+                        "app_id": "org.matrix.matrixConsole.ios",
+                        "pushkey": "V2h5IG9uIGVhcnRoIGRpZCB5b3UgZGVjb2RlIHRoaXM/",
+                        "pushkey_ts": 123,
+                        "tweaks": {
+                          "sound": "silence",
+                          "highlight": true,
+                          "custom": "go wild"
+                        },
+                      }
+                    ],
+                }),
+            );
         }
     }
 }

--- a/crates/ruma-signatures/Cargo.toml
+++ b/crates/ruma-signatures/Cargo.toml
@@ -23,7 +23,7 @@ ed25519-dalek = { version = "2.0.0", features = ["pkcs8", "rand_core"] }
 memchr = { version = "2.4", optional = true }
 pkcs8 = { version = "0.10.0", features = ["alloc"] }
 rand = { workspace = true }
-ruma-common = { workspace = true, features = ["canonical-json"] }
+ruma-common = { workspace = true }
 serde_json = { workspace = true }
 sha2 = "0.10.6"
 thiserror = { workspace = true }

--- a/crates/ruma-state-res/Cargo.toml
+++ b/crates/ruma-state-res/Cargo.toml
@@ -20,7 +20,7 @@ __criterion = ["dep:criterion"]
 
 [dependencies]
 js_int = { workspace = true }
-ruma-common = { workspace = true, features = ["canonical-json"] }
+ruma-common = { workspace = true }
 ruma-events = { workspace = true }
 ruma-signatures = { workspace = true }
 serde = { workspace = true }

--- a/crates/ruma/CHANGELOG.md
+++ b/crates/ruma/CHANGELOG.md
@@ -1,5 +1,7 @@
 # [unreleased]
 
+- The `canonical-json` feature was removed.
+
 # 0.14.1
 
 Please refer to the changelogs of:

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -16,9 +16,8 @@ all-features = true
 
 [features]
 api = ["ruma-common/api"]
-canonical-json = ["ruma-common/canonical-json", "ruma-events?/canonical-json"]
 events = ["dep:ruma-events"]
-signatures = ["dep:ruma-signatures", "canonical-json"]
+signatures = ["dep:ruma-signatures"]
 state-res = ["dep:ruma-state-res"]
 
 appservice-api-c = ["api", "events", "dep:ruma-appservice-api", "ruma-appservice-api?/client"]

--- a/crates/ruma/src/lib.rs
+++ b/crates/ruma/src/lib.rs
@@ -141,9 +141,7 @@ pub use js_option::JsOption;
 #[cfg(all(feature = "events", feature = "unstable-msc4334"))]
 #[doc(no_inline)]
 pub use language_tags::LanguageTag;
-pub use ruma_common::*;
-#[cfg(feature = "canonical-json")]
 pub use ruma_common::{
-    CanonicalJsonError, CanonicalJsonObject, CanonicalJsonValue, canonical_json,
+    CanonicalJsonError, CanonicalJsonObject, CanonicalJsonValue, canonical_json, *,
 };
 pub use web_time as time;

--- a/crates/ruma/src/lib.rs
+++ b/crates/ruma/src/lib.rs
@@ -132,6 +132,16 @@ pub mod api {
     pub use ruma_push_gateway_api as push_gateway;
 }
 
+/// Canonical JSON types and related functions.
+pub mod canonical_json {
+    // The assert_to_canonical_json_eq macro is `#[doc(hidden)]` by default to only show it in the
+    // `canonical_json` module instead of at the root of `ruma_common`, so we need to explicitly
+    // inline it where we want it.
+    #[doc(inline)]
+    pub use ruma_common::canonical_json::assert_to_canonical_json_eq;
+    pub use ruma_common::canonical_json::*;
+}
+
 #[doc(no_inline)]
 pub use assign::assign;
 #[doc(no_inline)]
@@ -141,7 +151,5 @@ pub use js_option::JsOption;
 #[cfg(all(feature = "events", feature = "unstable-msc4334"))]
 #[doc(no_inline)]
 pub use language_tags::LanguageTag;
-pub use ruma_common::{
-    CanonicalJsonError, CanonicalJsonObject, CanonicalJsonValue, canonical_json, *,
-};
+pub use ruma_common::{CanonicalJsonError, CanonicalJsonObject, CanonicalJsonValue, *};
 pub use web_time as time;

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -472,7 +472,6 @@ impl Metadata {
                 let mut features = ruma_package.filtered_features(FeatureFilter::Unstable);
                 features.extend([
                     "api",
-                    "canonical-json",
                     "client-api",
                     "events",
                     "html-matrix",


### PR DESCRIPTION
To replace `assert_eq!(serde_json::to_value(value), json!({…}))` patterns which don't check for duplicate keys during serialization.