### PR TITLE
client-api: Use `RoomPowerLevelsContentOverride` in `create_room`

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -1,12 +1,11 @@
 # [unreleased]
 
-Improvements:
+Breaking changes:
 
-- Add `create_room::v3::RoomPowerLevelsContentOverride`. This has the same 
-  signature as `RoomPowerLevelsEventContent` except all `Int` fields are 
-  `Option<Int>`, which allows uploading explicit values no matter what the 
-  default ones are. When in `Raw` form, this type can be cast to
-  `RoomPowerLevelsEventContent` and used to populate `power_level_content_override`.
+- The `power_level_content_override` field of `create_room::v3::Request` use a
+  new `RoomPowerLevelsContentOverride` type. It has the same fields as
+  `RoomPowerLevelsEventContent` except all `Int` fields are `Option<Int>`, which
+  allows uploading explicit values no matter what the default ones are.
 
 # 0.22.1
 


### PR DESCRIPTION
Since we now allow breaking changes.

Fixes #2333.
