### PR TITLE
client-api: Add the `m.forget_forced_upon_leave` capability

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -10,6 +10,7 @@ Breaking changes:
 Improvements:
 
 - Add the `M_TOKEN_INCORRECT` error code according to MSC4183.
+- Add the `m.forget_forced_upon_leave` capability, according to MSC4267.
 
 # 0.22.1
 

--- a/crates/ruma-client-api/src/discovery/get_capabilities.rs
+++ b/crates/ruma-client-api/src/discovery/get_capabilities.rs
@@ -133,6 +133,14 @@ pub mod v3 {
         )]
         pub profile_fields: Option<ProfileFieldsCapability>,
 
+        /// Capability to indicate if the server automatically forgets rooms that the user leaves.
+        #[serde(
+            rename = "m.forget_forced_upon_leave",
+            default,
+            skip_serializing_if = "ForgetForcedUponLeaveCapability::is_default"
+        )]
+        pub forget_forced_upon_leave: ForgetForcedUponLeaveCapability,
+
         /// Any other custom capabilities that the server supports outside of the specification,
         /// labeled using the Java package naming convention and stored as arbitrary JSON values.
         #[serde(flatten)]
@@ -163,6 +171,9 @@ pub mod v3 {
                 "m.set_avatar_url" => Some(Cow::Owned(serialize(&self.set_avatar_url))),
                 "m.3pid_changes" => Some(Cow::Owned(serialize(&self.thirdparty_id_changes))),
                 "m.get_login_token" => Some(Cow::Owned(serialize(&self.get_login_token))),
+                "m.forget_forced_upon_leave" => {
+                    Some(Cow::Owned(serialize(&self.forget_forced_upon_leave)))
+                }
                 _ => self.custom_capabilities.get(capability).map(Cow::Borrowed),
             }
         }
@@ -182,6 +193,9 @@ pub mod v3 {
                 "m.set_avatar_url" => self.set_avatar_url = from_json_value(value)?,
                 "m.3pid_changes" => self.thirdparty_id_changes = from_json_value(value)?,
                 "m.get_login_token" => self.get_login_token = from_json_value(value)?,
+                "m.forget_forced_upon_leave" => {
+                    self.forget_forced_upon_leave = from_json_value(value)?;
+                }
                 _ => {
                     self.custom_capabilities.insert(capability.to_owned(), value);
                 }
@@ -418,6 +432,29 @@ pub mod v3 {
                 // The default is that any field is allowed.
                 true
             }
+        }
+    }
+
+    /// Information about the `m.forget_forced_upon_leave` capability.
+    #[derive(Clone, Debug, Default, Serialize, Deserialize)]
+    #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+    pub struct ForgetForcedUponLeaveCapability {
+        /// Whether the server will automatically forget any room that the user leaves.
+        ///
+        /// This behavior applies irrespective of whether the user has left the room on their own
+        /// or has been kicked or banned from the room by another user.
+        pub enabled: bool,
+    }
+
+    impl ForgetForcedUponLeaveCapability {
+        /// Creates a new `ForgetForcedUponLeaveCapability` with the given enabled flag.
+        pub fn new(enabled: bool) -> Self {
+            Self { enabled }
+        }
+
+        /// Returns whether all fields have their default value.
+        pub fn is_default(&self) -> bool {
+            !self.enabled
         }
     }
 }


### PR DESCRIPTION
According to [MSC4267](https://github.com/matrix-org/matrix-spec-proposals/pull/4267) / [Spec PR](https://github.com/matrix-org/matrix-spec/issues/2292).

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
