### PR TITLE
client-api: Add the `M_TOKEN_INCORRECT` error code

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -7,6 +7,10 @@ Breaking changes:
   `RoomPowerLevelsEventContent` except all `Int` fields are `Option<Int>`, which
   allows uploading explicit values no matter what the default ones are.
 
+Improvements:
+
+- Add the `M_TOKEN_INCORRECT` error code according to MSC4183.
+
 # 0.22.1
 
 Improvements:

--- a/crates/ruma-client-api/src/error.rs
+++ b/crates/ruma-client-api/src/error.rs
@@ -294,6 +294,11 @@ pub enum ErrorKind {
     /// [third-party identifier]: https://spec.matrix.org/latest/client-server-api/#adding-account-administrative-contact-information
     ThreepidNotFound,
 
+    /// `M_TOKEN_INCORRECT`
+    ///
+    /// The token that the user entered to validate the session is incorrect.
+    TokenIncorrect,
+
     /// `M_TOO_LARGE`
     ///
     /// The request or entity was too large.
@@ -483,6 +488,7 @@ impl ErrorKind {
             ErrorKind::ThreepidInUse => ErrorCode::ThreepidInUse,
             ErrorKind::ThreepidMediumNotSupported => ErrorCode::ThreepidMediumNotSupported,
             ErrorKind::ThreepidNotFound => ErrorCode::ThreepidNotFound,
+            ErrorKind::TokenIncorrect => ErrorCode::TokenIncorrect,
             ErrorKind::TooLarge => ErrorCode::TooLarge,
             ErrorKind::UnableToAuthorizeJoin => ErrorCode::UnableToAuthorizeJoin,
             ErrorKind::UnableToGrantJoin => ErrorCode::UnableToGrantJoin,
@@ -762,6 +768,11 @@ pub enum ErrorCode {
     ///
     /// [third-party identifier]: https://spec.matrix.org/latest/client-server-api/#adding-account-administrative-contact-information
     ThreepidNotFound,
+
+    /// `M_TOKEN_INCORRECT`
+    ///
+    /// The token that the user entered to validate the session is incorrect.
+    TokenIncorrect,
 
     /// `M_TOO_LARGE`
     ///

--- a/crates/ruma-client-api/src/error/kind_serde.rs
+++ b/crates/ruma-client-api/src/error/kind_serde.rs
@@ -230,6 +230,7 @@ impl<'de> Visitor<'de> for ErrorKindVisitor {
             ErrorCode::ThreepidInUse => ErrorKind::ThreepidInUse,
             ErrorCode::ThreepidMediumNotSupported => ErrorKind::ThreepidMediumNotSupported,
             ErrorCode::ThreepidNotFound => ErrorKind::ThreepidNotFound,
+            ErrorCode::TokenIncorrect => ErrorKind::TokenIncorrect,
             ErrorCode::TooLarge => ErrorKind::TooLarge,
             ErrorCode::UnableToAuthorizeJoin => ErrorKind::UnableToAuthorizeJoin,
             ErrorCode::UnableToGrantJoin => ErrorKind::UnableToGrantJoin,


### PR DESCRIPTION
According to [MSC4183](https://github.com/matrix-org/matrix-spec-proposals/pull/4183) / [Spec PR](https://github.com/matrix-org/matrix-spec/issues/2277).

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
