### PR TITLE
events: Change `content()` accessor on `Any(Sync)StateEvent`

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -15,6 +15,8 @@ Breaking changes:
   `(Any)StateEventContentChange` to reflect better the purpose of those enums.
   The method to access `AnyStateEventContentChange` on `Any(Sync)StateEvent` is
   called `content_change()`.
+- The `content()` method on `Any(Sync)StateEvent` returns an
+  `AnyPossiblyRedactedStateEventContent`.
 
 Bug fixes:
 

--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -11,6 +11,10 @@ Breaking changes:
 - The `Reply` struct variant of `message::Relation`, `encrypted::Relation` and
   `RelationWithoutReplacement` is now a tuple variant containing a
   non-exhaustive struct.
+- The `(Any)FullStateEventContent` enums were renamed to
+  `(Any)StateEventContentChange` to reflect better the purpose of those enums.
+  The method to access `AnyStateEventContentChange` on `Any(Sync)StateEvent` is
+  called `content_change()`.
 
 Bug fixes:
 

--- a/crates/ruma-events/src/kinds.rs
+++ b/crates/ruma-events/src/kinds.rs
@@ -830,12 +830,11 @@ pub struct DecryptedMegolmV1Event<C: MessageLikeEventContent> {
     pub room_id: OwnedRoomId,
 }
 
-/// A possibly-redacted state event content.
-///
-/// A non-redacted content also contains the `prev_content` from the unsigned event data.
+/// A possibly-redacted state event content and the corresponding previous content from the unsigned
+/// event data, if available.
 #[allow(clippy::exhaustive_enums)]
 #[derive(Clone, Debug)]
-pub enum FullStateEventContent<C: StaticStateEventContent + RedactContent> {
+pub enum StateEventContentChange<C: StaticStateEventContent + RedactContent> {
     /// Original, unredacted content of the event.
     Original {
         /// Current content of the room state.
@@ -849,7 +848,7 @@ pub enum FullStateEventContent<C: StaticStateEventContent + RedactContent> {
     Redacted(C::Redacted),
 }
 
-impl<C: StaticStateEventContent + RedactContent> FullStateEventContent<C>
+impl<C: StaticStateEventContent + RedactContent> StateEventContentChange<C>
 where
     C::Redacted: RedactedStateEventContent,
 {
@@ -869,8 +868,8 @@ where
     /// [`RedactionRules`] has to be specified.
     pub fn redact(self, rules: &RedactionRules) -> C::Redacted {
         match self {
-            FullStateEventContent::Original { content, .. } => content.redact(rules),
-            FullStateEventContent::Redacted(content) => content,
+            Self::Original { content, .. } => content.redact(rules),
+            Self::Redacted(content) => content,
         }
     }
 }

--- a/crates/ruma-macros/src/events/event_enum/event_kind_enum.rs
+++ b/crates/ruma-macros/src/events/event_enum/event_kind_enum.rs
@@ -348,7 +348,7 @@ impl<'a> EventEnumVariation<'a> {
         if matches!(self.kind, EventEnumKind::State) && maybe_redacted {
             tokens.extend(
                 event_content_enums
-                    .full_event_content_enum()
+                    .event_content_change_enum()
                     .expand_content_accessors(&self.event_struct),
             );
         }

--- a/crates/ruma-macros/src/events/event_enum/event_kind_enum.rs
+++ b/crates/ruma-macros/src/events/event_enum/event_kind_enum.rs
@@ -340,12 +340,18 @@ impl<'a> EventEnumVariation<'a> {
         &self,
         event_content_enums: &mut EventContentEnums<'a>,
     ) -> Option<TokenStream> {
-        let event_content_enum = event_content_enums.get_or_create(self.variation)?;
-        let maybe_redacted = self.maybe_redacted();
+        let mut tokens = event_content_enums
+            .get_or_create(self.variation)?
+            .expand_content_accessors(self.variation, &self.event_struct);
 
-        let mut tokens = event_content_enum.expand_content_accessors(maybe_redacted);
-
-        if matches!(self.kind, EventEnumKind::State) && maybe_redacted {
+        // Generate the `AnyPossiblyRedactedStateEventContent` and `AnyStateEventContentChange`
+        // accessors for state enums that contain `Original` and `Redacted` variants.
+        if matches!(self.kind, EventEnumKind::State) && self.maybe_redacted() {
+            tokens.extend(event_content_enums.get_or_create(EventVariation::Stripped).map(
+                |event_content_enum| {
+                    event_content_enum.expand_content_accessors(self.variation, &self.event_struct)
+                },
+            ));
             tokens.extend(
                 event_content_enums
                     .event_content_change_enum()

--- a/crates/ruma-macros/src/lib.rs
+++ b/crates/ruma-macros/src/lib.rs
@@ -65,7 +65,7 @@ use self::{
 ///     * `AnyInitialStateEvent` for state events sent during room creation.
 ///     * `AnyStrippedStateEvent` for state events that are in room state previews when receiving
 ///       invites.
-///     * `AnyFullStateEventContent` a helper type to be able to access the `content` and
+///     * `AnyStateEventContentChange` a helper type to be able to access the `content` and
 ///       `prev_content` of a state event.
 ///
 /// This macro also implements the following traits for these enums, where it makes sense:


### PR DESCRIPTION
The first commit renames `(Any)FullStateEventContent` to `(Any)StateEventContentChange`. The name had been bugging me for a while because the `Full` prefix was unclear and made it seem like other `*EventContent` types were not "complete". `Change` reflects better the purpose of those enums to be able to track the changes between the previous and current event contents. The name change is also motivated by the fact that we need the `content()` method name available on `Any(Sync)StateEvent` for `AnyPossiblyRedactedStateEventContent`.

And the second commit reintroduces the `content()` accessor but this time it returns an `AnyPossiblyRedactedStateEventContent`.