### PR TITLE
Upgrade bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,9 +211,9 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cast"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ as_variant = "1.2.0"
 assert_matches2 = "0.1.0"
 assign = "1.1.1"
 base64 = "0.22.0"
-bytes = "1.0.1"
+bytes = "1.11.1"
 criterion = "0.7.0"
 http = "1.1.0"
 insta = { version = "1.41.1", features = ["json"] }


### PR DESCRIPTION
To get rid of the error in CI due to a CVE. Downstream can upgrade it themselves in their `Cargo.lock` so there is no need for a release.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
