### PR TITLE
common: Add hidden macro to generate `PrivOwnedStr` structs

### DIFF
--- a/crates/ruma-client-api/src/lib.rs
+++ b/crates/ruma-client-api/src/lib.rs
@@ -60,19 +60,6 @@ pub mod uiaa;
 pub mod user_directory;
 pub mod voip;
 
-use std::fmt;
-
 pub use error::Error;
 
-// Wrapper around `Box<str>` that cannot be used in a meaningful way outside of
-// this crate. Used for string enums because their `_Custom` variant can't be
-// truly private (only `#[doc(hidden)]`).
-#[doc(hidden)]
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct PrivOwnedStr(Box<str>);
-
-impl fmt::Debug for PrivOwnedStr {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
+ruma_common::priv_owned_str!();

--- a/crates/ruma-common/src/lib.rs
+++ b/crates/ruma-common/src/lib.rs
@@ -30,6 +30,7 @@ pub mod media;
 mod percent_encode;
 pub mod power_levels;
 pub mod presence;
+mod priv_owned_str;
 pub mod push;
 pub mod room;
 pub mod room_version_rules;
@@ -39,26 +40,13 @@ pub mod thirdparty;
 mod time;
 pub mod to_device;
 
-use std::fmt;
-
 pub use self::{
     canonical_json::{CanonicalJsonError, CanonicalJsonObject, CanonicalJsonValue},
     identifiers::*,
     time::{MilliSecondsSinceUnixEpoch, SecondsSinceUnixEpoch},
 };
 
-// Wrapper around `Box<str>` that cannot be used in a meaningful way outside of
-// this crate. Used for string enums because their `_Custom` variant can't be
-// truly private (only `#[doc(hidden)]`).
-#[doc(hidden)]
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct PrivOwnedStr(Box<str>);
-
-impl fmt::Debug for PrivOwnedStr {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
+priv_owned_str!();
 
 /// Re-exports used by macro-generated code.
 ///

--- a/crates/ruma-common/src/priv_owned_str.rs
+++ b/crates/ruma-common/src/priv_owned_str.rs
@@ -1,0 +1,65 @@
+/// Convenience macro to declare a struct named `PrivOwnedStr`.
+///
+/// The generated struct is a wrapper around `Box<str>` that cannot be used in a meaningful way
+/// outside of the crate where it is defined. It is usually used for string enums because their
+/// `_Custom` variant can't be truly private (only `#[doc(hidden)]`).
+///
+/// The struct implements `Clone`, `Debug`, `PartialEq`, `Eq`, `PartialOrd`, `Ord` and `Hash`.
+///
+/// ## Arguments
+///
+/// This macro can be called without any arguments, it will only generate the struct and its basic
+/// implementations.
+///
+/// The following keywords can also be used as a comma-separated list to add more implementations to
+/// the struct:
+///
+/// - `uniffi` - Expose the struct as an object named `PrivateString` to foreign languages via
+///   [`uniffi`], behind an `unstable-uniffi` cargo feature. This is necessary to expose an enum or
+///   record using `PrivOwnedStr` to foreign languages. Requires the crate calling the macro to have
+///   an `unstable-uniffi` cargo feature and [`uniffi` must be set up][uniffi-setup].
+///
+/// ## Example
+///
+/// ```
+/// ruma_common::priv_owned_str!(uniffi);
+/// ```
+///
+/// [uniffi]: https://crates.io/crates/uniffi
+/// [uniffi-setup]: https://mozilla.github.io/uniffi-rs/latest/tutorial/Rust_scaffolding.html
+#[doc(hidden)]
+#[macro_export]
+macro_rules! priv_owned_str {
+    () => {
+        #[doc(hidden)]
+        #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        pub struct PrivOwnedStr(std::boxed::Box<std::primitive::str>);
+
+        impl std::fmt::Debug for PrivOwnedStr {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                self.0.fmt(f)
+            }
+        }
+    };
+
+    ( $( $keyword:ident ),+ ) => {
+        $crate::priv_owned_str!();
+        $( $crate::priv_owned_str!(@keyword $keyword); )+
+    };
+
+    ( @keyword uniffi ) => {
+        // Wrapper around `Box<str>` for transferring `PrivOwnedStr` over UniFFI.
+        // We cannot derive `PrivOwnedStr` from `uniffi::Object` directly because
+        // that would require wrapping it in an `Arc` inside the `_Custom` variants.
+        #[cfg(feature = "unstable-uniffi")]
+        #[derive(uniffi::Object)]
+        #[doc(hidden)]
+        pub struct PrivateString(std::boxed::Box<std::primitive::str>);
+
+        #[cfg(feature = "unstable-uniffi")]
+        uniffi::custom_type!(PrivOwnedStr, std::sync::Arc<PrivateString> , {
+            lower: |value| std::sync::Arc::new(PrivateString(value.0)),
+            try_lift: |value| Ok(PrivOwnedStr(value.0.clone())),
+        });
+    };
+}

--- a/crates/ruma-common/tests/it/serde/enum_derive.rs
+++ b/crates/ruma-common/tests/it/serde/enum_derive.rs
@@ -1,8 +1,7 @@
 use ruma_common::serde::StringEnum;
 use serde_json::{from_value as from_json_value, json};
 
-#[derive(Debug, PartialEq)]
-struct PrivOwnedStr(Box<str>);
+ruma_common::priv_owned_str!();
 
 #[derive(StringEnum)]
 #[ruma_enum(rename_all = "snake_case")]

--- a/crates/ruma-events/src/lib.rs
+++ b/crates/ruma-events/src/lib.rs
@@ -107,7 +107,7 @@
 #[cfg(feature = "unstable-uniffi")]
 uniffi::setup_scaffolding!();
 
-use std::{collections::BTreeSet, fmt};
+use std::collections::BTreeSet;
 
 use ruma_common::{EventEncryptionAlgorithm, OwnedUserId, room_version_rules::RedactionRules};
 use serde::{Deserialize, Serialize, Serializer, de::IgnoredAny};
@@ -302,29 +302,4 @@ impl Mentions {
     }
 }
 
-// Wrapper around `Box<str>` that cannot be used in a meaningful way outside of
-// this crate. Used for string enums because their `_Custom` variant can't be
-// truly private (only `#[doc(hidden)]`).
-#[doc(hidden)]
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct PrivOwnedStr(Box<str>);
-
-impl fmt::Debug for PrivOwnedStr {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
-// Wrapper around `Box<str>` for transferring `PrivOwnedStr` over UniFFI.
-// We cannot derive `PrivOwnedStr` from `uniffi::Object` directly because
-// that would require wrapping it in an `Arc` inside the `_Custom` variants.
-#[cfg_attr(feature = "unstable-uniffi", derive(uniffi::Object))]
-#[doc(hidden)]
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct PrivateString(Box<str>);
-
-#[cfg(feature = "unstable-uniffi")]
-uniffi::custom_type!(PrivOwnedStr, std::sync::Arc<PrivateString> , {
-    lower: |value| std::sync::Arc::new(PrivateString(value.0)),
-    try_lift: |value| Ok(PrivOwnedStr(value.0.clone())),
-});
+ruma_common::priv_owned_str!(uniffi);

--- a/crates/ruma-events/tests/it/ui/07-enum-sanity-check.rs
+++ b/crates/ruma-events/tests/it/ui/07-enum-sanity-check.rs
@@ -40,17 +40,4 @@ fn main() {
     assert_eq!(GlobalAccountDataEventType::IdentityServer.to_cow_str(), "io.ruma.identity_server");
 }
 
-#[doc(hidden)]
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct PrivOwnedStr(Box<str>);
-
-#[cfg_attr(feature = "unstable-uniffi", derive(uniffi::Object))]
-#[doc(hidden)]
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct PrivateString(Box<str>);
-
-#[cfg(feature = "unstable-uniffi")]
-uniffi::custom_type!(PrivOwnedStr, std::sync::Arc<PrivateString> , {
-    lower: |value| std::sync::Arc::new(PrivateString(value.0)),
-    try_lift: |value| Ok(PrivOwnedStr(value.0.clone())),
-});
+ruma_common::priv_owned_str!(uniffi);

--- a/crates/ruma-events/tests/it/ui/08-enum-invalid-path.rs
+++ b/crates/ruma-events/tests/it/ui/08-enum-invalid-path.rs
@@ -13,17 +13,4 @@ event_enum! {
 
 fn main() {}
 
-#[doc(hidden)]
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct PrivOwnedStr(Box<str>);
-
-#[cfg_attr(feature = "unstable-uniffi", derive(uniffi::Object))]
-#[doc(hidden)]
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct PrivateString(Box<str>);
-
-#[cfg(feature = "unstable-uniffi")]
-uniffi::custom_type!(PrivOwnedStr, std::sync::Arc<PrivateString> , {
-    lower: |value| std::sync::Arc::new(PrivateString(value.0)),
-    try_lift: |value| Ok(PrivOwnedStr(value.0.clone())),
-});
+ruma_common::priv_owned_str!(uniffi);

--- a/crates/ruma-events/tests/it/ui/14-enum-content-double-kind.rs
+++ b/crates/ruma-events/tests/it/ui/14-enum-content-double-kind.rs
@@ -50,17 +50,4 @@ fn main() {
     assert_eq!(RoomAccountDataEventType::MacroTest.to_string(), "m.macro.test");
 }
 
-#[doc(hidden)]
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct PrivOwnedStr(Box<str>);
-
-#[cfg_attr(feature = "unstable-uniffi", derive(uniffi::Object))]
-#[doc(hidden)]
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct PrivateString(Box<str>);
-
-#[cfg(feature = "unstable-uniffi")]
-uniffi::custom_type!(PrivOwnedStr, std::sync::Arc<PrivateString> , {
-    lower: |value| std::sync::Arc::new(PrivateString(value.0)),
-    try_lift: |value| Ok(PrivOwnedStr(value.0.clone())),
-});
+ruma_common::priv_owned_str!(uniffi);

--- a/crates/ruma-federation-api/src/lib.rs
+++ b/crates/ruma-federation-api/src/lib.rs
@@ -8,8 +8,6 @@
 #![warn(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-use std::fmt;
-
 mod serde;
 
 pub mod authenticated_media;
@@ -29,15 +27,4 @@ pub mod space;
 pub mod thirdparty;
 pub mod transactions;
 
-// Wrapper around `Box<str>` that cannot be used in a meaningful way outside of
-// this crate. Used for string enums because their `_Custom` variant can't be
-// truly private (only `#[doc(hidden)]`).
-#[doc(hidden)]
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct PrivOwnedStr(Box<str>);
-
-impl fmt::Debug for PrivOwnedStr {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
+ruma_common::priv_owned_str!();

--- a/crates/ruma-identity-service-api/src/lib.rs
+++ b/crates/ruma-identity-service-api/src/lib.rs
@@ -7,8 +7,6 @@
 
 #![warn(missing_docs)]
 
-use std::fmt;
-
 pub mod association;
 pub mod authentication;
 pub mod discovery;
@@ -17,15 +15,4 @@ pub mod keys;
 pub mod lookup;
 pub mod tos;
 
-// Wrapper around `Box<str>` that cannot be used in a meaningful way outside of
-// this crate. Used for string enums because their `_Custom` variant can't be
-// truly private (only `#[doc(hidden)]`).
-#[doc(hidden)]
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct PrivOwnedStr(Box<str>);
-
-impl fmt::Debug for PrivOwnedStr {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
+ruma_common::priv_owned_str!();

--- a/crates/ruma-push-gateway-api/src/lib.rs
+++ b/crates/ruma-push-gateway-api/src/lib.rs
@@ -7,19 +7,6 @@
 
 #![warn(missing_docs)]
 
-use std::fmt;
-
 pub mod send_event_notification;
 
-// Wrapper around `Box<str>` that cannot be used in a meaningful way outside of
-// this crate. Used for string enums because their `_Custom` variant can't be
-// truly private (only `#[doc(hidden)]`).
-#[doc(hidden)]
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct PrivOwnedStr(Box<str>);
-
-impl fmt::Debug for PrivOwnedStr {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
+ruma_common::priv_owned_str!();


### PR DESCRIPTION
This avoids to duplicate the boilerplate between crates, especially when exposing the struct via uniffi.

@Johennes, could you check that I didn't break anything for uniffi downstream with this?