### PR TITLE
identifiers: Reject server names with empty host

### DIFF
--- a/crates/ruma-identifiers-validation/CHANGELOG.md
+++ b/crates/ruma-identifiers-validation/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [unreleased]
 
+Bug fixes:
+
+- Reject server names with an empty host and only a port in
+  `server_name::validate()` (e.g. `:8448`).
+
 # 0.12.0
 
 - Bump MSRV to 1.88

--- a/crates/ruma-identifiers-validation/src/server_name.rs
+++ b/crates/ruma-identifiers-validation/src/server_name.rs
@@ -21,6 +21,10 @@ pub fn validate(server_name: &str) -> Result<(), Error> {
         #[allow(clippy::unnecessary_lazy_evaluations)]
         let end_of_host = server_name.find(':').unwrap_or_else(|| server_name.len());
 
+        if end_of_host == 0 {
+            return Err(Error::InvalidServerName);
+        }
+
         if server_name[..end_of_host]
             .bytes()
             .any(|byte| !(byte.is_ascii_alphanumeric() || byte == b'-' || byte == b'.'))
@@ -42,5 +46,21 @@ pub fn validate(server_name: &str) -> Result<(), Error> {
         Err(Error::InvalidServerName)
     } else {
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate;
+    use crate::user_id;
+
+    #[test]
+    fn rejects_hostless_server_name_with_port() {
+        assert!(validate(":8448").is_err());
+    }
+
+    #[test]
+    fn rejects_user_id_with_hostless_server_name() {
+        assert!(user_id::validate("@alice::8448").is_err());
     }
 }


### PR DESCRIPTION
Fixes https://github.com/ruma/ruma/issues/2362

- Fixed server-name validation to reject empty-host server names.
- Added explicit empty-host check in server_name.rs

I also added two test to confirm this.

rejects_hostless_server_name_with_port - server_name.rs (line 58)
rejects_user_id_with_hostless_server_name - server_name.rs (line 63)