### PR TITLE
Improve/room or alias id no alloc

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -20,6 +20,9 @@ Improvements:
 - Add the `assert_to_canonical_json_eq!` macro that can be used in tests to
   check the canonical JSON serialization of a type against its expected value.
 - Add `io.element.msc4388` unstable feature support to `/versions`.
+- Avoid extra allocations when converting between `OwnedRoomId` /
+  `OwnedRoomAliasId` and `OwnedRoomOrAliasId` in the default `Box` storage
+  path.
 
 # 0.17.1
 

--- a/crates/ruma-common/src/identifiers/room_or_alias_id.rs
+++ b/crates/ruma-common/src/identifiers/room_or_alias_id.rs
@@ -92,6 +92,7 @@ impl<'a> From<&'a RoomAliasId> for &'a RoomOrAliasId {
 
 impl From<OwnedRoomId> for OwnedRoomOrAliasId {
     fn from(room_id: OwnedRoomId) -> Self {
+        // FIXME: Arc storage still allocates here.
         let room_id: Box<RoomId> = room_id.into();
         RoomOrAliasId::from_box(room_id.into()).into()
     }
@@ -99,6 +100,7 @@ impl From<OwnedRoomId> for OwnedRoomOrAliasId {
 
 impl From<OwnedRoomAliasId> for OwnedRoomOrAliasId {
     fn from(room_alias_id: OwnedRoomAliasId) -> Self {
+        // FIXME: Arc storage still allocates here.
         let room_alias_id: Box<RoomAliasId> = room_alias_id.into();
         RoomOrAliasId::from_box(room_alias_id.into()).into()
     }
@@ -130,6 +132,7 @@ impl TryFrom<OwnedRoomOrAliasId> for OwnedRoomId {
     type Error = OwnedRoomAliasId;
 
     fn try_from(id: OwnedRoomOrAliasId) -> Result<OwnedRoomId, OwnedRoomAliasId> {
+        // FIXME: Arc storage still allocates here.
         let variant = id.variant();
         let id: Box<RoomOrAliasId> = id.into();
 
@@ -144,6 +147,7 @@ impl TryFrom<OwnedRoomOrAliasId> for OwnedRoomAliasId {
     type Error = OwnedRoomId;
 
     fn try_from(id: OwnedRoomOrAliasId) -> Result<OwnedRoomAliasId, OwnedRoomId> {
+        // FIXME: Arc storage still allocates here.
         let variant = id.variant();
         let id: Box<RoomOrAliasId> = id.into();
 

--- a/crates/ruma-common/src/identifiers/room_or_alias_id.rs
+++ b/crates/ruma-common/src/identifiers/room_or_alias_id.rs
@@ -92,15 +92,15 @@ impl<'a> From<&'a RoomAliasId> for &'a RoomOrAliasId {
 
 impl From<OwnedRoomId> for OwnedRoomOrAliasId {
     fn from(room_id: OwnedRoomId) -> Self {
-        // FIXME: Don't allocate
-        RoomOrAliasId::from_borrowed(room_id.as_str()).to_owned()
+        let room_id: Box<RoomId> = room_id.into();
+        RoomOrAliasId::from_box(room_id.into()).into()
     }
 }
 
 impl From<OwnedRoomAliasId> for OwnedRoomOrAliasId {
     fn from(room_alias_id: OwnedRoomAliasId) -> Self {
-        // FIXME: Don't allocate
-        RoomOrAliasId::from_borrowed(room_alias_id.as_str()).to_owned()
+        let room_alias_id: Box<RoomAliasId> = room_alias_id.into();
+        RoomOrAliasId::from_box(room_alias_id.into()).into()
     }
 }
 
@@ -130,10 +130,12 @@ impl TryFrom<OwnedRoomOrAliasId> for OwnedRoomId {
     type Error = OwnedRoomAliasId;
 
     fn try_from(id: OwnedRoomOrAliasId) -> Result<OwnedRoomId, OwnedRoomAliasId> {
-        // FIXME: Don't allocate
-        match id.variant() {
-            Variant::RoomId => Ok(RoomId::from_borrowed(id.as_str()).to_owned()),
-            Variant::RoomAliasId => Err(RoomAliasId::from_borrowed(id.as_str()).to_owned()),
+        let variant = id.variant();
+        let id: Box<RoomOrAliasId> = id.into();
+
+        match variant {
+            Variant::RoomId => Ok(RoomId::from_box(id.into()).into()),
+            Variant::RoomAliasId => Err(RoomAliasId::from_box(id.into()).into()),
         }
     }
 }
@@ -142,10 +144,12 @@ impl TryFrom<OwnedRoomOrAliasId> for OwnedRoomAliasId {
     type Error = OwnedRoomId;
 
     fn try_from(id: OwnedRoomOrAliasId) -> Result<OwnedRoomAliasId, OwnedRoomId> {
-        // FIXME: Don't allocate
-        match id.variant() {
-            Variant::RoomAliasId => Ok(RoomAliasId::from_borrowed(id.as_str()).to_owned()),
-            Variant::RoomId => Err(RoomId::from_borrowed(id.as_str()).to_owned()),
+        let variant = id.variant();
+        let id: Box<RoomOrAliasId> = id.into();
+
+        match variant {
+            Variant::RoomAliasId => Ok(RoomAliasId::from_box(id.into()).into()),
+            Variant::RoomId => Err(RoomId::from_box(id.into()).into()),
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/ruma/ruma/issues/2364

This change is scoped to the default `Box` storage path and removes the current extra allocation in those conversions. We can revisit `direct inner moves` approach later after identifier internals are unified in issue 2313.
