### PR TITLE
Define wildmatch as a workspace dep and upgrade it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3205,9 +3205,9 @@ dependencies = [
 
 [[package]]
 name = "wildmatch"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39b7d07a236abaef6607536ccfaf19b396dbe3f5110ddb73d39f4562902ed382"
+checksum = "29333c3ea1ba8b17211763463ff24ee84e41c78224c16b001cd907e663a38c68"
 
 [[package]]
 name = "winapi-util"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ tracing = { version = "0.1.37", default-features = false, features = ["std"] }
 uniffi = { git = "https://github.com/mozilla/uniffi-rs.git", rev = "e5f4821410bea19e71984ea5e06a7bc8b11ed9e5", version = "0.31.0", default-features = false, features = ["wasm-unstable-single-threaded"] }
 url = { version = "2.5.0" }
 web-time = "1.1.0"
+wildmatch = "2.6.1"
 zeroize = "1.8.1"
 
 [workspace.lints.rust]

--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -79,7 +79,7 @@ tracing = { workspace = true, features = ["attributes"] }
 url = { workspace = true }
 uuid = { version = "1.0.0", optional = true, features = ["v4"] }
 web-time = { workspace = true }
-wildmatch = "2.0.0"
+wildmatch = { workspace = true }
 zeroize = { workspace = true }
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]

--- a/crates/ruma-events/Cargo.toml
+++ b/crates/ruma-events/Cargo.toml
@@ -102,7 +102,7 @@ tracing = { workspace = true, features = ["attributes"] }
 uniffi = { workspace = true, optional = true }
 url = { workspace = true }
 web-time = { workspace = true }
-wildmatch = "2.0.0"
+wildmatch = { workspace = true }
 zeroize = { workspace = true }
 
 # dev-dependencies can't be optional, so this is a regular dependency

--- a/crates/ruma-html/Cargo.toml
+++ b/crates/ruma-html/Cargo.toml
@@ -22,7 +22,7 @@ as_variant = { workspace = true }
 html5ever = "0.35.0"
 ruma-common = { workspace = true, optional = true }
 tracing = { workspace = true, features = ["attributes"] }
-wildmatch = "2.0.0"
+wildmatch = { workspace = true }
 
 [dev-dependencies]
 assert_matches2 = { workspace = true }


### PR DESCRIPTION
`WildMatch::new_case_insensitive()` (used since #2358) was only added in version 2.4.0 so we need to update the version that we depend on. This sets it to the latest release.
