### PR TITLE
common: use raw transfer for base64-or-device owned conversions

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -23,6 +23,8 @@ Improvements:
 - Add crate-internal into_raw() / from_raw() helpers for IdDst owned IDs and
   use them in OwnedRoomId / OwnedRoomAliasId <-> OwnedRoomOrAliasId
   conversions.
+- Use raw ownership transfer for conversions from OwnedDeviceId and
+  OwnedBase64PublicKey to OwnedBase64PublicKeyOrDeviceId.
 
 # 0.17.1
 

--- a/crates/ruma-common/src/identifiers/base64_public_key_or_device_id.rs
+++ b/crates/ruma-common/src/identifiers/base64_public_key_or_device_id.rs
@@ -48,7 +48,7 @@ impl<'a> From<&'a DeviceId> for &'a Base64PublicKeyOrDeviceId {
 
 impl From<OwnedDeviceId> for OwnedBase64PublicKeyOrDeviceId {
     fn from(value: OwnedDeviceId) -> Self {
-        Self::from(value.as_str())
+        unsafe { Self::from_raw(value.into_raw() as *const Base64PublicKeyOrDeviceId) }
     }
 }
 
@@ -60,6 +60,29 @@ impl<'a> From<&'a Base64PublicKey> for &'a Base64PublicKeyOrDeviceId {
 
 impl From<OwnedBase64PublicKey> for OwnedBase64PublicKeyOrDeviceId {
     fn from(value: OwnedBase64PublicKey) -> Self {
-        Self::from(value.as_str())
+        unsafe { Self::from_raw(value.into_raw() as *const Base64PublicKeyOrDeviceId) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::OwnedBase64PublicKeyOrDeviceId;
+    use crate::{Base64PublicKey, OwnedBase64PublicKey, OwnedDeviceId};
+
+    #[test]
+    fn convert_owned_device_id_to_owned_base64_public_key_or_device_id() {
+        let device_id: OwnedDeviceId = "MYDEVICE".into();
+        let mixed: OwnedBase64PublicKeyOrDeviceId = device_id.into();
+
+        assert_eq!(mixed.as_str(), "MYDEVICE");
+    }
+
+    #[test]
+    fn convert_owned_base64_public_key_to_owned_base64_public_key_or_device_id() {
+        let base64_public_key: OwnedBase64PublicKey =
+            <&Base64PublicKey>::try_from("base64+master+public+key").unwrap().to_owned();
+        let mixed: OwnedBase64PublicKeyOrDeviceId = base64_public_key.into();
+
+        assert_eq!(mixed.as_str(), "base64+master+public+key");
     }
 }


### PR DESCRIPTION
Fixes https://github.com/ruma/ruma/issues/2369

The raw ownership-transfer approach for Owned -> Owned identifier conversions in crates/ruma-common/src/identifiers/base64_public_key_or_device_id.rs.

Please review on changes.