### PR TITLE
Use owned_id! macro instead of using `ToOwned` manually

### DIFF
--- a/crates/ruma-client-api/src/directory/get_public_rooms.rs
+++ b/crates/ruma-client-api/src/directory/get_public_rooms.rs
@@ -94,7 +94,7 @@ pub mod v3 {
                     MatrixVersion, OutgoingRequest as _, SupportedVersions,
                     auth_scheme::SendAccessToken,
                 },
-                server_name,
+                owned_server_name,
             };
 
             let supported = SupportedVersions {
@@ -105,7 +105,7 @@ pub mod v3 {
             let req = super::Request {
                 limit: Some(uint!(10)),
                 since: Some("hello".to_owned()),
-                server: Some(server_name!("test.tld").to_owned()),
+                server: Some(owned_server_name!("test.tld")),
             }
             .try_into_http_request::<Vec<u8>>(
                 "https://homeserver.tld",

--- a/crates/ruma-client-api/src/message/get_message_events.rs
+++ b/crates/ruma-client-api/src/message/get_message_events.rs
@@ -190,7 +190,7 @@ pub mod v3 {
         #[test]
         fn serialize_some_room_event_filter() {
             let room_id = owned_room_id!("!roomid:example.org");
-            let rooms = vec![room_id.to_owned()];
+            let rooms = vec![room_id.clone()];
             let filter = RoomEventFilter {
                 lazy_load_options: LazyLoadOptions::Enabled { include_redundant_members: true },
                 rooms: Some(rooms),

--- a/crates/ruma-client-api/src/room/create_room.rs
+++ b/crates/ruma-client-api/src/room/create_room.rs
@@ -334,7 +334,8 @@ mod tests {
     use js_int::int;
     use maplit::btreemap;
     use ruma_common::{
-        canonical_json::assert_to_canonical_json_eq, power_levels::NotificationPowerLevels, user_id,
+        canonical_json::assert_to_canonical_json_eq, owned_user_id,
+        power_levels::NotificationPowerLevels,
     };
     use serde_json::json;
 
@@ -360,7 +361,7 @@ mod tests {
 
     #[test]
     fn serialization_of_power_levels_overridden_values_with_all_fields() {
-        let user = user_id!("@carl:example.com");
+        let user = owned_user_id!("@carl:example.com");
         let power_levels_event = RoomPowerLevelsContentOverride {
             ban: Some(int!(23)),
             events: btreemap! {
@@ -372,7 +373,7 @@ mod tests {
             redact: Some(int!(23)),
             state_default: Some(int!(23)),
             users: btreemap! {
-                user.to_owned() => int!(23)
+                user => int!(23)
             },
             users_default: Some(int!(23)),
             notifications: assign!(NotificationPowerLevels::new(), { room: int!(23) }),

--- a/crates/ruma-client-api/src/sync/sync_events/v5.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v5.rs
@@ -265,7 +265,7 @@ pub mod request {
         {
             match deserialize_cow_str(deserializer)?.as_ref() {
                 "*" => Ok(Self::AllSubscribed),
-                other => Ok(Self::Room(RoomId::parse(other).map_err(D::Error::custom)?.to_owned())),
+                other => Ok(Self::Room(RoomId::parse(other).map_err(D::Error::custom)?)),
             }
         }
     }

--- a/crates/ruma-common/src/identifiers/base64_public_key_or_device_id.rs
+++ b/crates/ruma-common/src/identifiers/base64_public_key_or_device_id.rs
@@ -67,7 +67,7 @@ impl From<OwnedBase64PublicKey> for OwnedBase64PublicKeyOrDeviceId {
 #[cfg(test)]
 mod tests {
     use super::OwnedBase64PublicKeyOrDeviceId;
-    use crate::{Base64PublicKey, OwnedBase64PublicKey, OwnedDeviceId};
+    use crate::{OwnedBase64PublicKey, OwnedDeviceId};
 
     #[test]
     fn convert_owned_device_id_to_owned_base64_public_key_or_device_id() {
@@ -80,7 +80,7 @@ mod tests {
     #[test]
     fn convert_owned_base64_public_key_to_owned_base64_public_key_or_device_id() {
         let base64_public_key: OwnedBase64PublicKey =
-            <&Base64PublicKey>::try_from("base64+master+public+key").unwrap().to_owned();
+            "base64+master+public+key".try_into().unwrap();
         let mixed: OwnedBase64PublicKeyOrDeviceId = base64_public_key.into();
 
         assert_eq!(mixed.as_str(), "base64+master+public+key");

--- a/crates/ruma-common/src/identifiers/matrix_uri.rs
+++ b/crates/ruma-common/src/identifiers/matrix_uri.rs
@@ -553,8 +553,8 @@ mod tests {
 
     use super::{MatrixId, MatrixToUri, MatrixUri};
     use crate::{
-        RoomOrAliasId, event_id, matrix_uri::UriAction, room_alias_id, room_id, server_name,
-        user_id,
+        RoomOrAliasId, event_id, matrix_uri::UriAction, owned_server_name, room_alias_id, room_id,
+        server_name, user_id,
     };
 
     #[test]
@@ -743,7 +743,7 @@ mod tests {
         assert_eq!(matrix_to.id(), &room_id!("!ruma:notareal.hs").into());
         assert_eq!(
             matrix_to.via(),
-            &[server_name!("notareal.hs").to_owned(), server_name!("anotherunreal.hs").to_owned(),]
+            &[owned_server_name!("notareal.hs"), owned_server_name!("anotherunreal.hs"),]
         );
 
         let matrix_to =
@@ -777,7 +777,7 @@ mod tests {
         let matrix_to = MatrixToUri::parse("https://matrix.to/#/!ruma:notareal.hs?via=notareal.hs")
             .expect("Failed to create MatrixToUri.");
         assert_eq!(matrix_to.id(), &room_id!("!ruma:notareal.hs").into());
-        assert_eq!(matrix_to.via(), &[server_name!("notareal.hs").to_owned()]);
+        assert_eq!(matrix_to.via(), &[owned_server_name!("notareal.hs")]);
 
         let matrix_to =
             MatrixToUri::parse("https://matrix.to/#/#ruma:notareal.hs/$event:notareal.hs")
@@ -1022,7 +1022,7 @@ mod tests {
         let matrix_uri = MatrixUri::parse("matrix:roomid/ruma:notareal.hs?via=notareal.hs")
             .expect("Failed to create MatrixToUri.");
         assert_eq!(matrix_uri.id(), &room_id!("!ruma:notareal.hs").into());
-        assert_eq!(matrix_uri.via(), &[server_name!("notareal.hs").to_owned()]);
+        assert_eq!(matrix_uri.via(), &[owned_server_name!("notareal.hs")]);
         assert_eq!(matrix_uri.action(), None);
 
         let matrix_uri = MatrixUri::parse("matrix:r/ruma:notareal.hs/e/event:notareal.hs")
@@ -1050,10 +1050,7 @@ mod tests {
         );
         assert_eq!(
             matrix_uri.via(),
-            &vec![
-                server_name!("notareal.hs").to_owned(),
-                server_name!("anotherinexistant.hs").to_owned()
-            ]
+            &vec![owned_server_name!("notareal.hs"), owned_server_name!("anotherinexistant.hs")]
         );
         assert_eq!(matrix_uri.action(), Some(&UriAction::Join));
     }

--- a/crates/ruma-common/tests/it/serde/empty_strings.rs
+++ b/crates/ruma-common/tests/it/serde/empty_strings.rs
@@ -48,14 +48,14 @@ mod string {
 }
 
 mod user {
-    use ruma_common::{OwnedUserId, UserId, canonical_json::assert_to_canonical_json_eq, user_id};
+    use ruma_common::{OwnedUserId, canonical_json::assert_to_canonical_json_eq, owned_user_id};
     use serde::{Deserialize, Serialize};
     use serde_json::{from_value as from_json_value, json};
 
     const CARL: &str = "@carl:example.com";
 
-    fn carl() -> &'static UserId {
-        user_id!("@carl:example.com")
+    fn carl() -> OwnedUserId {
+        owned_user_id!("@carl:example.com")
     }
 
     #[derive(Serialize, Deserialize, PartialEq, Debug)]
@@ -76,7 +76,7 @@ mod user {
 
     #[test]
     fn some_se() {
-        let decoded = User { x: Some(carl().to_owned()) };
+        let decoded = User { x: Some(carl()) };
         assert_to_canonical_json_eq!(decoded, json!({ "x": CARL }));
     }
 
@@ -97,7 +97,7 @@ mod user {
     #[test]
     fn some_de() {
         let encoded = json!({ "x": CARL });
-        let decoded = User { x: Some(carl().to_owned()) };
+        let decoded = User { x: Some(carl()) };
         assert_eq!(from_json_value::<User>(encoded).unwrap(), decoded);
     }
 }

--- a/crates/ruma-events/src/call/member/member_state_key.rs
+++ b/crates/ruma-events/src/call/member/member_state_key.rs
@@ -202,7 +202,7 @@ impl de::Expected for KeyParseError {
 mod tests {
     use std::str::FromStr;
 
-    use ruma_common::user_id;
+    use ruma_common::owned_user_id;
 
     use crate::call::member::{CallMemberStateKey, member_state_key::CallMemberStateKeyEnum};
 
@@ -216,7 +216,7 @@ mod tests {
         assert_eq!(state_key.as_ref(), key);
         // Compare to the from string without `CallMemberStateKeyEnum` step.
         let state_key_direct = CallMemberStateKey::new(
-            user_id!("@user:domain.org").to_owned(),
+            owned_user_id!("@user:domain.org"),
             Some("ABC".to_owned()),
             true,
         );
@@ -233,7 +233,7 @@ mod tests {
         assert_eq!(state_key.as_ref(), key);
         // Compare to the from string without `CallMemberStateKeyEnum` step.
         let state_key_direct =
-            CallMemberStateKey::new(user_id!("@user:domain.org").to_owned(), None, false);
+            CallMemberStateKey::new(owned_user_id!("@user:domain.org"), None, false);
         assert_eq!(state_key, state_key_direct);
     }
 
@@ -247,7 +247,7 @@ mod tests {
         assert_eq!(state_key.as_ref(), key);
         // Compare to the from string without `CallMemberStateKeyEnum` step.
         let state_key_direct = CallMemberStateKey::new(
-            user_id!("@user:domain.org").to_owned(),
+            owned_user_id!("@user:domain.org"),
             Some("ABC_m.callTestId".to_owned()),
             false,
         );

--- a/crates/ruma-events/src/presence.rs
+++ b/crates/ruma-events/src/presence.rs
@@ -73,7 +73,8 @@ impl PresenceEventContent {
 mod tests {
     use js_int::uint;
     use ruma_common::{
-        canonical_json::assert_to_canonical_json_eq, mxc_uri, presence::PresenceState,
+        canonical_json::assert_to_canonical_json_eq, mxc_uri, owned_mxc_uri,
+        presence::PresenceState,
     };
     use serde_json::{from_value as from_json_value, json};
 
@@ -82,7 +83,7 @@ mod tests {
     #[test]
     fn serialization() {
         let content = PresenceEventContent {
-            avatar_url: Some(mxc_uri!("mxc://localhost/wefuiwegh8742w").to_owned()),
+            avatar_url: Some(owned_mxc_uri!("mxc://localhost/wefuiwegh8742w")),
             currently_active: Some(false),
             displayname: None,
             last_active_ago: Some(uint!(2_478_593)),

--- a/crates/ruma-events/src/room.rs
+++ b/crates/ruma-events/src/room.rs
@@ -325,7 +325,7 @@ mod tests {
     use std::collections::BTreeMap;
 
     use assert_matches2::assert_matches;
-    use ruma_common::{mxc_uri, serde::Base64};
+    use ruma_common::{owned_mxc_uri, serde::Base64};
     use serde::Deserialize;
     use serde_json::{from_value as from_json_value, json};
 
@@ -351,7 +351,7 @@ mod tests {
 
     fn encrypted_file() -> EncryptedFile {
         EncryptedFile {
-            url: mxc_uri!("mxc://localhost/encryptedfile").to_owned(),
+            url: owned_mxc_uri!("mxc://localhost/encryptedfile"),
             key: dummy_jwt(),
             iv: Base64::new(vec![0; 64]),
             hashes: BTreeMap::new(),

--- a/crates/ruma-events/src/room/power_levels.rs
+++ b/crates/ruma-events/src/room/power_levels.rs
@@ -992,7 +992,7 @@ mod tests {
 
     #[test]
     fn serialization_with_all_fields() {
-        let user = user_id!("@carl:example.com");
+        let user = owned_user_id!("@carl:example.com");
         let power_levels_event = RoomPowerLevelsEventContent {
             ban: int!(23),
             events: btreemap! {
@@ -1004,7 +1004,7 @@ mod tests {
             redact: int!(23),
             state_default: int!(23),
             users: btreemap! {
-                user.to_owned() => int!(23)
+                user => int!(23)
             },
             users_default: int!(23),
             notifications: assign!(NotificationPowerLevels::new(), { room: int!(23) }),

--- a/crates/ruma-events/src/room/thumbnail_source_serde.rs
+++ b/crates/ruma-events/src/room/thumbnail_source_serde.rs
@@ -51,7 +51,7 @@ where
 #[cfg(test)]
 mod tests {
     use assert_matches2::assert_matches;
-    use ruma_common::{mxc_uri, serde::Base64};
+    use ruma_common::{owned_mxc_uri, serde::Base64};
     use serde::{Deserialize, Serialize};
     use serde_json::json;
 
@@ -134,7 +134,7 @@ mod tests {
     #[test]
     fn serialize_plain() {
         let request = ThumbnailSourceTest {
-            source: Some(MediaSource::Plain(mxc_uri!("mxc://notareal.hs/abcdef").into())),
+            source: Some(MediaSource::Plain(owned_mxc_uri!("mxc://notareal.hs/abcdef"))),
         };
         assert_eq!(
             serde_json::to_value(&request).unwrap(),
@@ -147,7 +147,7 @@ mod tests {
         let request = ThumbnailSourceTest {
             source: Some(MediaSource::Encrypted(Box::new(
                 EncryptedFileInit {
-                    url: mxc_uri!("mxc://notareal.hs/abcdef").to_owned(),
+                    url: owned_mxc_uri!("mxc://notareal.hs/abcdef"),
                     key: JsonWebKeyInit {
                         kty: "oct".to_owned(),
                         key_ops: vec!["encrypt".to_owned(), "decrypt".to_owned()],

--- a/crates/ruma-events/src/space/child.rs
+++ b/crates/ruma-events/src/space/child.rs
@@ -291,9 +291,9 @@ mod tests {
 
     use js_int::{UInt, uint};
     use ruma_common::{
-        MilliSecondsSinceUnixEpoch, RoomId, SpaceChildOrder,
-        canonical_json::assert_to_canonical_json_eq, owned_server_name, owned_user_id, room_id,
-        server_name,
+        MilliSecondsSinceUnixEpoch, OwnedRoomId, SpaceChildOrder,
+        canonical_json::assert_to_canonical_json_eq, owned_room_id, owned_server_name,
+        owned_user_id, server_name,
     };
     use serde_json::{from_value as from_json_value, json};
 
@@ -304,7 +304,7 @@ mod tests {
     #[test]
     fn space_child_serialization() {
         let content = SpaceChildEventContent {
-            via: vec![server_name!("example.com").to_owned()],
+            via: vec![owned_server_name!("example.com")],
             order: Some(SpaceChildOrder::parse("uwu").unwrap()),
             suggested: false,
         };
@@ -406,7 +406,7 @@ mod tests {
 
     /// Construct a [`HierarchySpaceChildEvent`] with the given state key, order and timestamp.
     fn hierarchy_space_child_event(
-        state_key: &RoomId,
+        state_key: OwnedRoomId,
         order: Option<&str>,
         origin_server_ts: UInt,
     ) -> HierarchySpaceChildEvent {
@@ -416,7 +416,7 @@ mod tests {
         HierarchySpaceChildEvent {
             content,
             sender: owned_user_id!("@alice:example.org"),
-            state_key: state_key.to_owned(),
+            state_key,
             origin_server_ts: MilliSecondsSinceUnixEpoch(origin_server_ts),
         }
     }
@@ -425,24 +425,30 @@ mod tests {
     fn space_child_ord_spec_example() {
         // Reproduce the example from the spec.
         let child_a = hierarchy_space_child_event(
-            room_id!("!a:example.org"),
+            owned_room_id!("!a:example.org"),
             Some("aaaa"),
             uint!(1_640_141_000),
         );
         let child_b = hierarchy_space_child_event(
-            room_id!("!b:example.org"),
+            owned_room_id!("!b:example.org"),
             Some(" "),
             uint!(1_640_341_000),
         );
         let child_c = hierarchy_space_child_event(
-            room_id!("!c:example.org"),
+            owned_room_id!("!c:example.org"),
             Some("first"),
             uint!(1_640_841_000),
         );
-        let child_d =
-            hierarchy_space_child_event(room_id!("!d:example.org"), None, uint!(1_640_741_000));
-        let child_e =
-            hierarchy_space_child_event(room_id!("!e:example.org"), None, uint!(1_640_641_000));
+        let child_d = hierarchy_space_child_event(
+            owned_room_id!("!d:example.org"),
+            None,
+            uint!(1_640_741_000),
+        );
+        let child_e = hierarchy_space_child_event(
+            owned_room_id!("!e:example.org"),
+            None,
+            uint!(1_640_641_000),
+        );
 
         let events =
             [child_a.clone(), child_b.clone(), child_c.clone(), child_d.clone(), child_e.clone()];
@@ -479,21 +485,30 @@ mod tests {
     fn space_child_ord_other_example() {
         // We also check invalid order and state key comparison here.
         let child_a = hierarchy_space_child_event(
-            room_id!("!a:example.org"),
+            owned_room_id!("!a:example.org"),
             Some("🔝"),
             uint!(1_640_141_000),
         );
         let child_b = hierarchy_space_child_event(
-            room_id!("!b:example.org"),
+            owned_room_id!("!b:example.org"),
             Some(" "),
             uint!(1_640_341_000),
         );
-        let child_c =
-            hierarchy_space_child_event(room_id!("!c:example.org"), None, uint!(1_640_841_000));
-        let child_d =
-            hierarchy_space_child_event(room_id!("!d:example.org"), None, uint!(1_640_741_000));
-        let child_e =
-            hierarchy_space_child_event(room_id!("!e:example.org"), None, uint!(1_640_741_000));
+        let child_c = hierarchy_space_child_event(
+            owned_room_id!("!c:example.org"),
+            None,
+            uint!(1_640_841_000),
+        );
+        let child_d = hierarchy_space_child_event(
+            owned_room_id!("!d:example.org"),
+            None,
+            uint!(1_640_741_000),
+        );
+        let child_e = hierarchy_space_child_event(
+            owned_room_id!("!e:example.org"),
+            None,
+            uint!(1_640_741_000),
+        );
 
         let mut events =
             [child_a.clone(), child_b.clone(), child_c.clone(), child_d.clone(), child_e.clone()];

--- a/crates/ruma-events/src/space/parent.rs
+++ b/crates/ruma-events/src/space/parent.rs
@@ -42,7 +42,7 @@ impl SpaceParentEventContent {
 
 #[cfg(test)]
 mod tests {
-    use ruma_common::{canonical_json::assert_to_canonical_json_eq, server_name};
+    use ruma_common::{canonical_json::assert_to_canonical_json_eq, owned_server_name};
     use serde_json::json;
 
     use super::SpaceParentEventContent;
@@ -50,7 +50,7 @@ mod tests {
     #[test]
     fn space_parent_serialization() {
         let content = SpaceParentEventContent {
-            via: vec![server_name!("example.com").to_owned()],
+            via: vec![owned_server_name!("example.com")],
             canonical: true,
         };
 

--- a/crates/ruma-events/tests/it/audio.rs
+++ b/crates/ruma-events/tests/it/audio.rs
@@ -7,7 +7,7 @@ use js_int::uint;
 use ruma_common::{
     MilliSecondsSinceUnixEpoch,
     canonical_json::assert_to_canonical_json_eq,
-    mxc_uri, owned_event_id,
+    owned_event_id, owned_mxc_uri,
     serde::{Base64, CanBeEmpty},
 };
 #[cfg(feature = "unstable-msc3246")]
@@ -36,7 +36,7 @@ fn plain_content_serialization() {
     let event_content = AudioEventContent::with_plain_text(
         "Upload: my_sound.ogg",
         FileContentBlock::plain(
-            mxc_uri!("mxc://notareal.hs/abcdef").to_owned(),
+            owned_mxc_uri!("mxc://notareal.hs/abcdef"),
             "my_sound.ogg".to_owned(),
         ),
     );
@@ -60,7 +60,7 @@ fn encrypted_content_serialization() {
     let event_content = AudioEventContent::with_plain_text(
         "Upload: my_sound.ogg",
         FileContentBlock::encrypted(
-            mxc_uri!("mxc://notareal.hs/abcdef").to_owned(),
+            owned_mxc_uri!("mxc://notareal.hs/abcdef"),
             "my_sound.ogg".to_owned(),
             EncryptedContentInit {
                 key: JsonWebKeyInit {
@@ -114,7 +114,7 @@ fn event_serialization() {
     let mut content = AudioEventContent::new(
         TextContentBlock::html("Upload: my_mix.mp3", "Upload: <strong>my_mix.mp3</strong>"),
         FileContentBlock::plain(
-            mxc_uri!("mxc://notareal.hs/abcdef").to_owned(),
+            owned_mxc_uri!("mxc://notareal.hs/abcdef"),
             "my_mix.mp3".to_owned(),
         ),
     );

--- a/crates/ruma-events/tests/it/call.rs
+++ b/crates/ruma-events/tests/it/call.rs
@@ -4,7 +4,7 @@ use assign::assign;
 use js_int::uint;
 use ruma_common::{
     MilliSecondsSinceUnixEpoch, VoipVersionId, canonical_json::assert_to_canonical_json_eq,
-    room_id, serde::CanBeEmpty,
+    owned_room_id, serde::CanBeEmpty,
 };
 #[cfg(feature = "unstable-msc2747")]
 use ruma_events::call::CallCapabilities;
@@ -99,7 +99,6 @@ fn answer_v0_event_deserialization() {
 
 #[test]
 fn answer_v0_event_deserialization_then_convert_to_full() {
-    let rid = room_id!("!roomid:room.com");
     let json_data = json!({
         "content": {
             "answer": {
@@ -118,7 +117,7 @@ fn answer_v0_event_deserialization_then_convert_to_full() {
     let sync_ev: AnySyncMessageLikeEvent = from_json_value(json_data).unwrap();
 
     assert_matches!(
-        sync_ev.into_full_event(rid.to_owned()),
+        sync_ev.into_full_event(owned_room_id!("!roomid:room.com")),
         AnyMessageLikeEvent::CallAnswer(MessageLikeEvent::Original(message_event))
     );
     assert_eq!(message_event.event_id, "$h29iv0s8:example.com");

--- a/crates/ruma-events/tests/it/file.rs
+++ b/crates/ruma-events/tests/it/file.rs
@@ -5,7 +5,7 @@ use js_int::uint;
 use ruma_common::{
     MilliSecondsSinceUnixEpoch,
     canonical_json::assert_to_canonical_json_eq,
-    mxc_uri, owned_event_id,
+    owned_event_id, owned_mxc_uri,
     serde::{Base64, CanBeEmpty},
 };
 use ruma_events::{
@@ -21,7 +21,7 @@ use serde_json::{from_value as from_json_value, json};
 fn plain_content_serialization() {
     let event_content = FileEventContent::plain_with_plain_text(
         "Upload: my_file.txt",
-        mxc_uri!("mxc://notareal.hs/abcdef").to_owned(),
+        owned_mxc_uri!("mxc://notareal.hs/abcdef"),
         "my_file.txt".to_owned(),
     );
 
@@ -43,7 +43,7 @@ fn plain_content_serialization() {
 fn encrypted_content_serialization() {
     let event_content = FileEventContent::encrypted_with_plain_text(
         "Upload: my_file.txt",
-        mxc_uri!("mxc://notareal.hs/abcdef").to_owned(),
+        owned_mxc_uri!("mxc://notareal.hs/abcdef"),
         "my_file.txt".to_owned(),
         EncryptedContentInit {
             key: JsonWebKeyInit {
@@ -95,7 +95,7 @@ fn encrypted_content_serialization() {
 fn file_event_serialization() {
     let mut content = FileEventContent::plain(
         TextContentBlock::html("Upload: my_file.txt", "Upload: <strong>my_file.txt</strong>"),
-        mxc_uri!("mxc://notareal.hs/abcdef").to_owned(),
+        owned_mxc_uri!("mxc://notareal.hs/abcdef"),
         "my_file.txt".to_owned(),
     );
     content.file.mimetype = Some("text/plain".to_owned());

--- a/crates/ruma-events/tests/it/image.rs
+++ b/crates/ruma-events/tests/it/image.rs
@@ -5,7 +5,7 @@ use js_int::uint;
 use ruma_common::{
     MilliSecondsSinceUnixEpoch,
     canonical_json::assert_to_canonical_json_eq,
-    mxc_uri, owned_event_id,
+    owned_event_id, owned_mxc_uri,
     serde::{Base64, CanBeEmpty},
 };
 use ruma_events::{
@@ -26,7 +26,7 @@ fn plain_content_serialization() {
     let event_content = ImageEventContent::with_plain_text(
         "Upload: my_image.jpg",
         FileContentBlock::plain(
-            mxc_uri!("mxc://notareal.hs/abcdef").to_owned(),
+            owned_mxc_uri!("mxc://notareal.hs/abcdef"),
             "my_image.jpg".to_owned(),
         ),
     );
@@ -50,7 +50,7 @@ fn encrypted_content_serialization() {
     let event_content = ImageEventContent::with_plain_text(
         "Upload: my_image.jpg",
         FileContentBlock::encrypted(
-            mxc_uri!("mxc://notareal.hs/abcdef").to_owned(),
+            owned_mxc_uri!("mxc://notareal.hs/abcdef"),
             "my_image.jpg".to_owned(),
             EncryptedContentInit {
                 key: JsonWebKeyInit {
@@ -104,7 +104,7 @@ fn image_event_serialization() {
     let mut content = ImageEventContent::new(
         TextContentBlock::html("Upload: my_house.jpg", "Upload: <strong>my_house.jpg</strong>"),
         FileContentBlock::plain(
-            mxc_uri!("mxc://notareal.hs/abcdef").to_owned(),
+            owned_mxc_uri!("mxc://notareal.hs/abcdef"),
             "my_house.jpg".to_owned(),
         ),
     );
@@ -114,7 +114,7 @@ fn image_event_serialization() {
     content.image_details = Some(ImageDetailsContentBlock::new(uint!(1920), uint!(1080)));
     let mut thumbnail = Thumbnail::new(
         ThumbnailFileContentBlock::plain(
-            mxc_uri!("mxc://notareal.hs/thumbnail").to_owned(),
+            owned_mxc_uri!("mxc://notareal.hs/thumbnail"),
             "image/jpeg".to_owned(),
         ),
         ThumbnailImageDetailsContentBlock::new(uint!(560), uint!(480)),

--- a/crates/ruma-events/tests/it/room_message.rs
+++ b/crates/ruma-events/tests/it/room_message.rs
@@ -4,7 +4,7 @@ use assert_matches2::assert_matches;
 use ruma_common::{
     OwnedDeviceId,
     canonical_json::assert_to_canonical_json_eq,
-    mxc_uri, owned_device_id, owned_user_id,
+    owned_device_id, owned_mxc_uri, owned_user_id,
     serde::{Base64, Raw},
     user_id,
 };
@@ -490,7 +490,7 @@ fn audio_msgtype_serialization() {
     let message_event_content =
         RoomMessageEventContent::new(MessageType::Audio(AudioMessageEventContent::plain(
             "Upload: my_song.mp3".to_owned(),
-            mxc_uri!("mxc://notareal.hs/file").to_owned(),
+            owned_mxc_uri!("mxc://notareal.hs/file"),
         )));
 
     assert_to_canonical_json_eq!(
@@ -524,7 +524,7 @@ fn file_msgtype_plain_content_serialization() {
     let message_event_content =
         RoomMessageEventContent::new(MessageType::File(FileMessageEventContent::plain(
             "Upload: my_file.txt".to_owned(),
-            mxc_uri!("mxc://notareal.hs/file").to_owned(),
+            owned_mxc_uri!("mxc://notareal.hs/file"),
         )));
 
     assert_to_canonical_json_eq!(
@@ -543,7 +543,7 @@ fn file_msgtype_encrypted_content_serialization() {
         RoomMessageEventContent::new(MessageType::File(FileMessageEventContent::encrypted(
             "Upload: my_file.txt".to_owned(),
             EncryptedFileInit {
-                url: mxc_uri!("mxc://notareal.hs/file").to_owned(),
+                url: owned_mxc_uri!("mxc://notareal.hs/file"),
                 key: JsonWebKeyInit {
                     kty: "oct".to_owned(),
                     key_ops: vec!["encrypt".to_owned(), "decrypt".to_owned()],
@@ -643,7 +643,7 @@ fn gallery_msgtype_serialization_with_image() {
             )),
             vec![GalleryItemType::Image(ImageMessageEventContent::plain(
                 "my_image.jpg".to_owned(),
-                mxc_uri!("mxc://notareal.hs/file").to_owned(),
+                owned_mxc_uri!("mxc://notareal.hs/file"),
             ))],
         )));
 
@@ -772,7 +772,7 @@ fn image_msgtype_serialization() {
     let message_event_content =
         RoomMessageEventContent::new(MessageType::Image(ImageMessageEventContent::plain(
             "Upload: my_image.jpg".to_owned(),
-            mxc_uri!("mxc://notareal.hs/file").to_owned(),
+            owned_mxc_uri!("mxc://notareal.hs/file"),
         )));
 
     assert_to_canonical_json_eq!(
@@ -958,7 +958,7 @@ fn video_msgtype_serialization() {
     let message_event_content =
         RoomMessageEventContent::new(MessageType::Video(VideoMessageEventContent::plain(
             "Upload: my_video.mp4".to_owned(),
-            mxc_uri!("mxc://notareal.hs/file").to_owned(),
+            owned_mxc_uri!("mxc://notareal.hs/file"),
         )));
 
     assert_to_canonical_json_eq!(
@@ -1137,7 +1137,7 @@ fn invalid_replacement() {
 fn test_audio_filename() {
     let mut content = AudioMessageEventContent::plain(
         "my_sound.ogg".to_owned(),
-        mxc_uri!("mxc://notareal.hs/abcdef").to_owned(),
+        owned_mxc_uri!("mxc://notareal.hs/abcdef"),
     );
     assert_eq!(content.filename(), "my_sound.ogg");
 
@@ -1150,7 +1150,7 @@ fn test_audio_filename() {
 fn test_audio_caption() {
     let mut content = AudioMessageEventContent::plain(
         "my_sound.ogg".to_owned(),
-        mxc_uri!("mxc://notareal.hs/abcdef").to_owned(),
+        owned_mxc_uri!("mxc://notareal.hs/abcdef"),
     );
     assert!(content.caption().is_none());
     assert!(content.formatted_caption().is_none());
@@ -1176,7 +1176,7 @@ fn test_audio_caption() {
 fn test_file_filename() {
     let mut content = FileMessageEventContent::plain(
         "my_file.txt".to_owned(),
-        mxc_uri!("mxc://notareal.hs/abcdef").to_owned(),
+        owned_mxc_uri!("mxc://notareal.hs/abcdef"),
     );
     assert_eq!(content.filename(), "my_file.txt");
 
@@ -1189,7 +1189,7 @@ fn test_file_filename() {
 fn test_file_caption() {
     let mut content = FileMessageEventContent::plain(
         "my_file.txt".to_owned(),
-        mxc_uri!("mxc://notareal.hs/abcdef").to_owned(),
+        owned_mxc_uri!("mxc://notareal.hs/abcdef"),
     );
     assert!(content.caption().is_none());
     assert!(content.formatted_caption().is_none());
@@ -1215,7 +1215,7 @@ fn test_file_caption() {
 fn test_image_filename() {
     let mut content = ImageMessageEventContent::plain(
         "my_image.jpg".to_owned(),
-        mxc_uri!("mxc://notareal.hs/abcdef").to_owned(),
+        owned_mxc_uri!("mxc://notareal.hs/abcdef"),
     );
     assert_eq!(content.filename(), "my_image.jpg");
 
@@ -1228,7 +1228,7 @@ fn test_image_filename() {
 fn test_image_caption() {
     let mut content = ImageMessageEventContent::plain(
         "my_image.jpg".to_owned(),
-        mxc_uri!("mxc://notareal.hs/abcdef").to_owned(),
+        owned_mxc_uri!("mxc://notareal.hs/abcdef"),
     );
     assert!(content.caption().is_none());
     assert!(content.formatted_caption().is_none());
@@ -1253,7 +1253,7 @@ fn test_image_caption() {
 fn test_video_filename() {
     let mut content = VideoMessageEventContent::plain(
         "my_video.mp4".to_owned(),
-        mxc_uri!("mxc://notareal.hs/abcdef").to_owned(),
+        owned_mxc_uri!("mxc://notareal.hs/abcdef"),
     );
     assert_eq!(content.filename(), "my_video.mp4");
 
@@ -1266,7 +1266,7 @@ fn test_video_filename() {
 fn test_video_caption() {
     let mut content = VideoMessageEventContent::plain(
         "my_video.mp4".to_owned(),
-        mxc_uri!("mxc://notareal.hs/abcdef").to_owned(),
+        owned_mxc_uri!("mxc://notareal.hs/abcdef"),
     );
     assert!(content.caption().is_none());
     assert!(content.formatted_caption().is_none());

--- a/crates/ruma-events/tests/it/sticker.rs
+++ b/crates/ruma-events/tests/it/sticker.rs
@@ -2,8 +2,8 @@ use assert_matches2::assert_matches;
 use assign::assign;
 use js_int::{UInt, uint};
 use ruma_common::{
-    MilliSecondsSinceUnixEpoch, canonical_json::assert_to_canonical_json_eq, mxc_uri,
-    owned_event_id, serde::CanBeEmpty,
+    MilliSecondsSinceUnixEpoch, canonical_json::assert_to_canonical_json_eq, owned_event_id,
+    owned_mxc_uri, serde::CanBeEmpty,
 };
 use ruma_events::{
     AnyMessageLikeEvent, MessageLikeEvent,
@@ -18,7 +18,7 @@ fn content_serialization() {
     let message_event_content = StickerEventContent::new(
         "Upload: my_image.jpg".to_owned(),
         ImageInfo::new(),
-        mxc_uri!("mxc://notareal.hs/file").to_owned(),
+        owned_mxc_uri!("mxc://notareal.hs/file"),
     );
 
     assert_to_canonical_json_eq!(
@@ -36,13 +36,13 @@ fn replace_content_serialization() {
     let mut message_event_content = StickerEventContent::new(
         "* Upload: my_image.jpg".to_owned(),
         ImageInfo::new(),
-        mxc_uri!("mxc://notareal.hs/file").to_owned(),
+        owned_mxc_uri!("mxc://notareal.hs/file"),
     );
     let old_event_id = owned_event_id!("$15827405538098VGFWH:example.com");
     let new_message_event_content = StickerEventContent::new(
         "Upload: my_image.jpg".to_owned(),
         ImageInfo::new(),
-        mxc_uri!("mxc://notareal.hs/file").to_owned(),
+        owned_mxc_uri!("mxc://notareal.hs/file"),
     );
     let new_content = StickerEventContentWithoutRelation::from(new_message_event_content);
     let replacement = Replacement::new(old_event_id.clone(), new_content);
@@ -83,9 +83,9 @@ fn event_serialization() {
                 mimetype: Some("image/png".into()),
                 size: UInt::new(82595),
             }))),
-            thumbnail_source: Some(MediaSource::Plain(mxc_uri!("mxc://matrix.org/irsns989Rrsn").to_owned())),
+            thumbnail_source: Some(MediaSource::Plain(owned_mxc_uri!("mxc://matrix.org/irsns989Rrsn"))),
         }),
-        mxc_uri!("mxc://matrix.org/rnsldl8srs98IRrs").to_owned(),
+        owned_mxc_uri!("mxc://matrix.org/rnsldl8srs98IRrs"),
     );
 
     assert_to_canonical_json_eq!(

--- a/crates/ruma-events/tests/it/video.rs
+++ b/crates/ruma-events/tests/it/video.rs
@@ -7,7 +7,7 @@ use js_int::uint;
 use ruma_common::{
     MilliSecondsSinceUnixEpoch,
     canonical_json::assert_to_canonical_json_eq,
-    mxc_uri, owned_event_id,
+    owned_event_id, owned_mxc_uri,
     serde::{Base64, CanBeEmpty},
 };
 use ruma_events::{
@@ -26,7 +26,7 @@ fn plain_content_serialization() {
     let event_content = VideoEventContent::with_plain_text(
         "Upload: my_video.webm",
         FileContentBlock::plain(
-            mxc_uri!("mxc://notareal.hs/abcdef").to_owned(),
+            owned_mxc_uri!("mxc://notareal.hs/abcdef"),
             "my_video.webm".to_owned(),
         ),
     );
@@ -50,7 +50,7 @@ fn encrypted_content_serialization() {
     let event_content = VideoEventContent::with_plain_text(
         "Upload: my_video.webm",
         FileContentBlock::encrypted(
-            mxc_uri!("mxc://notareal.hs/abcdef").to_owned(),
+            owned_mxc_uri!("mxc://notareal.hs/abcdef"),
             "my_video.webm".to_owned(),
             EncryptedContentInit {
                 key: JsonWebKeyInit {
@@ -107,7 +107,7 @@ fn event_serialization() {
             "Upload: <strong>my_lava_lamp.webm</strong>",
         ),
         FileContentBlock::plain(
-            mxc_uri!("mxc://notareal.hs/abcdef").to_owned(),
+            owned_mxc_uri!("mxc://notareal.hs/abcdef"),
             "my_lava_lamp.webm".to_owned(),
         ),
     );
@@ -119,7 +119,7 @@ fn event_serialization() {
     content.video_details = Some(video_details);
     let mut thumbnail = Thumbnail::new(
         ThumbnailFileContentBlock::plain(
-            mxc_uri!("mxc://notareal.hs/thumbnail").to_owned(),
+            owned_mxc_uri!("mxc://notareal.hs/thumbnail"),
             "image/jpeg".to_owned(),
         ),
         ThumbnailImageDetailsContentBlock::new(uint!(560), uint!(480)),

--- a/crates/ruma-events/tests/it/voice.rs
+++ b/crates/ruma-events/tests/it/voice.rs
@@ -5,8 +5,8 @@ use std::time::Duration;
 use assert_matches2::assert_matches;
 use js_int::uint;
 use ruma_common::{
-    MilliSecondsSinceUnixEpoch, canonical_json::assert_to_canonical_json_eq, mxc_uri,
-    owned_event_id, serde::CanBeEmpty,
+    MilliSecondsSinceUnixEpoch, canonical_json::assert_to_canonical_json_eq, owned_event_id,
+    owned_mxc_uri, serde::CanBeEmpty,
 };
 use ruma_events::{
     AnyMessageLikeEvent, MessageLikeEvent,
@@ -23,7 +23,7 @@ fn event_serialization() {
     let mut content = VoiceEventContent::with_plain_text(
         "Voice message",
         FileContentBlock::plain(
-            mxc_uri!("mxc://notareal.hs/abcdef").to_owned(),
+            owned_mxc_uri!("mxc://notareal.hs/abcdef"),
             "voice_message.ogg".to_owned(),
         ),
         VoiceAudioDetailsContentBlock::new(


### PR DESCRIPTION
This is a bit of refactoring which should reduce the diff for other PRs like #2371/#2372.
