### PR TITLE
identifiers: Improve conversions around `MatrixId`

### DIFF
--- a/crates/ruma-common/src/identifiers/matrix_uri.rs
+++ b/crates/ruma-common/src/identifiers/matrix_uri.rs
@@ -548,8 +548,8 @@ mod tests {
 
     use super::{MatrixId, MatrixToUri, MatrixUri};
     use crate::{
-        RoomOrAliasId, event_id, matrix_uri::UriAction, owned_server_name, room_alias_id, room_id,
-        server_name, user_id,
+        matrix_uri::UriAction, owned_event_id, owned_room_alias_id, owned_room_id,
+        owned_server_name, owned_user_id, room_alias_id, room_id, user_id,
     };
 
     #[test]
@@ -568,26 +568,26 @@ mod tests {
         );
         assert_eq!(
             room_id!("!ruma:notareal.hs")
-                .matrix_to_uri_via(vec![server_name!("notareal.hs")])
+                .matrix_to_uri_via(vec![owned_server_name!("notareal.hs")])
                 .to_string(),
             "https://matrix.to/#/!ruma:notareal.hs?via=notareal.hs"
         );
         #[allow(deprecated)]
         let uri = room_alias_id!("#ruma:notareal.hs")
-            .matrix_to_event_uri(event_id!("$event:notareal.hs"))
+            .matrix_to_event_uri(owned_event_id!("$event:notareal.hs"))
             .to_string();
         assert_eq!(uri, "https://matrix.to/#/%23ruma:notareal.hs/$event:notareal.hs");
         assert_eq!(
             room_id!("!ruma:notareal.hs")
-                .matrix_to_event_uri(event_id!("$event:notareal.hs"))
+                .matrix_to_event_uri(owned_event_id!("$event:notareal.hs"))
                 .to_string(),
             "https://matrix.to/#/!ruma:notareal.hs/$event:notareal.hs"
         );
         assert_eq!(
             room_id!("!ruma:notareal.hs")
                 .matrix_to_event_uri_via(
-                    event_id!("$event:notareal.hs"),
-                    vec![server_name!("notareal.hs")]
+                    owned_event_id!("$event:notareal.hs"),
+                    vec![owned_server_name!("notareal.hs")]
                 )
                 .to_string(),
             "https://matrix.to/#/!ruma:notareal.hs/$event:notareal.hs?via=notareal.hs"
@@ -598,31 +598,31 @@ mod tests {
     fn parse_valid_matrixid_with_sigil() {
         assert_eq!(
             MatrixId::parse_with_sigil("@user:imaginary.hs").expect("Failed to create MatrixId."),
-            MatrixId::User(user_id!("@user:imaginary.hs").into())
+            MatrixId::User(owned_user_id!("@user:imaginary.hs"))
         );
         assert_eq!(
             MatrixId::parse_with_sigil("!roomid:imaginary.hs").expect("Failed to create MatrixId."),
-            MatrixId::Room(room_id!("!roomid:imaginary.hs").into())
+            MatrixId::Room(owned_room_id!("!roomid:imaginary.hs"))
         );
         assert_eq!(
             MatrixId::parse_with_sigil("#roomalias:imaginary.hs")
                 .expect("Failed to create MatrixId."),
-            MatrixId::RoomAlias(room_alias_id!("#roomalias:imaginary.hs").into())
+            MatrixId::RoomAlias(owned_room_alias_id!("#roomalias:imaginary.hs"))
         );
         assert_eq!(
             MatrixId::parse_with_sigil("!roomid:imaginary.hs/$event:imaginary.hs")
                 .expect("Failed to create MatrixId."),
             MatrixId::Event(
-                <&RoomOrAliasId>::from(room_id!("!roomid:imaginary.hs")).into(),
-                event_id!("$event:imaginary.hs").into()
+                owned_room_id!("!roomid:imaginary.hs").into(),
+                owned_event_id!("$event:imaginary.hs")
             )
         );
         assert_eq!(
             MatrixId::parse_with_sigil("#roomalias:imaginary.hs/$event:imaginary.hs")
                 .expect("Failed to create MatrixId."),
             MatrixId::Event(
-                <&RoomOrAliasId>::from(room_alias_id!("#roomalias:imaginary.hs")).into(),
-                event_id!("$event:imaginary.hs").into()
+                owned_room_alias_id!("#roomalias:imaginary.hs").into(),
+                owned_event_id!("$event:imaginary.hs")
             )
         );
         // Invert the order of the event and the room.
@@ -630,34 +630,34 @@ mod tests {
             MatrixId::parse_with_sigil("$event:imaginary.hs/!roomid:imaginary.hs")
                 .expect("Failed to create MatrixId."),
             MatrixId::Event(
-                <&RoomOrAliasId>::from(room_id!("!roomid:imaginary.hs")).into(),
-                event_id!("$event:imaginary.hs").into()
+                owned_room_id!("!roomid:imaginary.hs").into(),
+                owned_event_id!("$event:imaginary.hs")
             )
         );
         assert_eq!(
             MatrixId::parse_with_sigil("$event:imaginary.hs/#roomalias:imaginary.hs")
                 .expect("Failed to create MatrixId."),
             MatrixId::Event(
-                <&RoomOrAliasId>::from(room_alias_id!("#roomalias:imaginary.hs")).into(),
-                event_id!("$event:imaginary.hs").into()
+                owned_room_alias_id!("#roomalias:imaginary.hs").into(),
+                owned_event_id!("$event:imaginary.hs")
             )
         );
         // Starting with a slash
         assert_eq!(
             MatrixId::parse_with_sigil("/@user:imaginary.hs").expect("Failed to create MatrixId."),
-            MatrixId::User(user_id!("@user:imaginary.hs").into())
+            MatrixId::User(owned_user_id!("@user:imaginary.hs"))
         );
         // Ending with a slash
         assert_eq!(
             MatrixId::parse_with_sigil("!roomid:imaginary.hs/")
                 .expect("Failed to create MatrixId."),
-            MatrixId::Room(room_id!("!roomid:imaginary.hs").into())
+            MatrixId::Room(owned_room_id!("!roomid:imaginary.hs"))
         );
         // Starting and ending with a slash
         assert_eq!(
             MatrixId::parse_with_sigil("/#roomalias:imaginary.hs/")
                 .expect("Failed to create MatrixId."),
-            MatrixId::RoomAlias(room_alias_id!("#roomalias:imaginary.hs").into())
+            MatrixId::RoomAlias(owned_room_alias_id!("#roomalias:imaginary.hs"))
         );
     }
 
@@ -725,17 +725,17 @@ mod tests {
     fn parse_matrixtouri_valid_uris() {
         let matrix_to = MatrixToUri::parse("https://matrix.to/#/%40jplatte%3Anotareal.hs")
             .expect("Failed to create MatrixToUri.");
-        assert_eq!(matrix_to.id(), &user_id!("@jplatte:notareal.hs").into());
+        assert_eq!(*matrix_to.id(), owned_user_id!("@jplatte:notareal.hs").into());
 
         let matrix_to = MatrixToUri::parse("https://matrix.to/#/%23ruma%3Anotareal.hs")
             .expect("Failed to create MatrixToUri.");
-        assert_eq!(matrix_to.id(), &room_alias_id!("#ruma:notareal.hs").into());
+        assert_eq!(*matrix_to.id(), owned_room_alias_id!("#ruma:notareal.hs").into());
 
         let matrix_to = MatrixToUri::parse(
             "https://matrix.to/#/%21ruma%3Anotareal.hs?via=notareal.hs&via=anotherunreal.hs",
         )
         .expect("Failed to create MatrixToUri.");
-        assert_eq!(matrix_to.id(), &room_id!("!ruma:notareal.hs").into());
+        assert_eq!(*matrix_to.id(), owned_room_id!("!ruma:notareal.hs").into());
         assert_eq!(
             matrix_to.via(),
             &[owned_server_name!("notareal.hs"), owned_server_name!("anotherunreal.hs"),]
@@ -745,16 +745,17 @@ mod tests {
             MatrixToUri::parse("https://matrix.to/#/%23ruma%3Anotareal.hs/%24event%3Anotareal.hs")
                 .expect("Failed to create MatrixToUri.");
         assert_eq!(
-            matrix_to.id(),
-            &(room_alias_id!("#ruma:notareal.hs"), event_id!("$event:notareal.hs")).into()
+            *matrix_to.id(),
+            (owned_room_alias_id!("#ruma:notareal.hs"), owned_event_id!("$event:notareal.hs"))
+                .into()
         );
 
         let matrix_to =
             MatrixToUri::parse("https://matrix.to/#/%21ruma%3Anotareal.hs/%24event%3Anotareal.hs")
                 .expect("Failed to create MatrixToUri.");
         assert_eq!(
-            matrix_to.id(),
-            &(room_id!("!ruma:notareal.hs"), event_id!("$event:notareal.hs")).into()
+            *matrix_to.id(),
+            (owned_room_id!("!ruma:notareal.hs"), owned_event_id!("$event:notareal.hs")).into()
         );
         assert_eq!(matrix_to.via().len(), 0);
     }
@@ -763,31 +764,32 @@ mod tests {
     fn parse_matrixtouri_valid_uris_not_urlencoded() {
         let matrix_to = MatrixToUri::parse("https://matrix.to/#/@jplatte:notareal.hs")
             .expect("Failed to create MatrixToUri.");
-        assert_eq!(matrix_to.id(), &user_id!("@jplatte:notareal.hs").into());
+        assert_eq!(*matrix_to.id(), owned_user_id!("@jplatte:notareal.hs").into());
 
         let matrix_to = MatrixToUri::parse("https://matrix.to/#/#ruma:notareal.hs")
             .expect("Failed to create MatrixToUri.");
-        assert_eq!(matrix_to.id(), &room_alias_id!("#ruma:notareal.hs").into());
+        assert_eq!(*matrix_to.id(), owned_room_alias_id!("#ruma:notareal.hs").into());
 
         let matrix_to = MatrixToUri::parse("https://matrix.to/#/!ruma:notareal.hs?via=notareal.hs")
             .expect("Failed to create MatrixToUri.");
-        assert_eq!(matrix_to.id(), &room_id!("!ruma:notareal.hs").into());
+        assert_eq!(*matrix_to.id(), owned_room_id!("!ruma:notareal.hs").into());
         assert_eq!(matrix_to.via(), &[owned_server_name!("notareal.hs")]);
 
         let matrix_to =
             MatrixToUri::parse("https://matrix.to/#/#ruma:notareal.hs/$event:notareal.hs")
                 .expect("Failed to create MatrixToUri.");
         assert_eq!(
-            matrix_to.id(),
-            &(room_alias_id!("#ruma:notareal.hs"), event_id!("$event:notareal.hs")).into()
+            *matrix_to.id(),
+            (owned_room_alias_id!("#ruma:notareal.hs"), owned_event_id!("$event:notareal.hs"))
+                .into()
         );
 
         let matrix_to =
             MatrixToUri::parse("https://matrix.to/#/!ruma:notareal.hs/$event:notareal.hs")
                 .expect("Failed to create MatrixToUri.");
         assert_eq!(
-            matrix_to.id(),
-            &(room_id!("!ruma:notareal.hs"), event_id!("$event:notareal.hs")).into()
+            *matrix_to.id(),
+            (owned_room_id!("!ruma:notareal.hs"), owned_event_id!("$event:notareal.hs")).into()
         );
         assert_eq!(matrix_to.via().len(), 0);
     }
@@ -855,14 +857,14 @@ mod tests {
         );
         assert_eq!(
             room_id!("!ruma:notareal.hs")
-                .matrix_uri_via(vec![server_name!("notareal.hs")], false)
+                .matrix_uri_via(vec![owned_server_name!("notareal.hs")], false)
                 .to_string(),
             "matrix:roomid/ruma:notareal.hs?via=notareal.hs"
         );
         assert_eq!(
             room_id!("!ruma:notareal.hs")
                 .matrix_uri_via(
-                    vec![server_name!("notareal.hs"), server_name!("anotherunreal.hs")],
+                    vec![owned_server_name!("notareal.hs"), owned_server_name!("anotherunreal.hs")],
                     true
                 )
                 .to_string(),
@@ -870,20 +872,20 @@ mod tests {
         );
         #[allow(deprecated)]
         let uri = room_alias_id!("#ruma:notareal.hs")
-            .matrix_event_uri(event_id!("$event:notareal.hs"))
+            .matrix_event_uri(owned_event_id!("$event:notareal.hs"))
             .to_string();
         assert_eq!(uri, "matrix:r/ruma:notareal.hs/e/event:notareal.hs");
         assert_eq!(
             room_id!("!ruma:notareal.hs")
-                .matrix_event_uri(event_id!("$event:notareal.hs"))
+                .matrix_event_uri(owned_event_id!("$event:notareal.hs"))
                 .to_string(),
             "matrix:roomid/ruma:notareal.hs/e/event:notareal.hs"
         );
         assert_eq!(
             room_id!("!ruma:notareal.hs")
                 .matrix_event_uri_via(
-                    event_id!("$event:notareal.hs"),
-                    vec![server_name!("notareal.hs")]
+                    owned_event_id!("$event:notareal.hs"),
+                    vec![owned_server_name!("notareal.hs")]
                 )
                 .to_string(),
             "matrix:roomid/ruma:notareal.hs/e/event:notareal.hs?via=notareal.hs"
@@ -894,50 +896,50 @@ mod tests {
     fn parse_valid_matrixid_with_type() {
         assert_eq!(
             MatrixId::parse_with_type("u/user:imaginary.hs").expect("Failed to create MatrixId."),
-            MatrixId::User(user_id!("@user:imaginary.hs").into())
+            MatrixId::User(owned_user_id!("@user:imaginary.hs"))
         );
         assert_eq!(
             MatrixId::parse_with_type("user/user:imaginary.hs")
                 .expect("Failed to create MatrixId."),
-            MatrixId::User(user_id!("@user:imaginary.hs").into())
+            MatrixId::User(owned_user_id!("@user:imaginary.hs"))
         );
         assert_eq!(
             MatrixId::parse_with_type("roomid/roomid:imaginary.hs")
                 .expect("Failed to create MatrixId."),
-            MatrixId::Room(room_id!("!roomid:imaginary.hs").into())
+            MatrixId::Room(owned_room_id!("!roomid:imaginary.hs"))
         );
         assert_eq!(
             MatrixId::parse_with_type("r/roomalias:imaginary.hs")
                 .expect("Failed to create MatrixId."),
-            MatrixId::RoomAlias(room_alias_id!("#roomalias:imaginary.hs").into())
+            MatrixId::RoomAlias(owned_room_alias_id!("#roomalias:imaginary.hs"))
         );
         assert_eq!(
             MatrixId::parse_with_type("room/roomalias:imaginary.hs")
                 .expect("Failed to create MatrixId."),
-            MatrixId::RoomAlias(room_alias_id!("#roomalias:imaginary.hs").into())
+            MatrixId::RoomAlias(owned_room_alias_id!("#roomalias:imaginary.hs"))
         );
         assert_eq!(
             MatrixId::parse_with_type("roomid/roomid:imaginary.hs/e/event:imaginary.hs")
                 .expect("Failed to create MatrixId."),
             MatrixId::Event(
-                <&RoomOrAliasId>::from(room_id!("!roomid:imaginary.hs")).into(),
-                event_id!("$event:imaginary.hs").into()
+                owned_room_id!("!roomid:imaginary.hs").into(),
+                owned_event_id!("$event:imaginary.hs")
             )
         );
         assert_eq!(
             MatrixId::parse_with_type("r/roomalias:imaginary.hs/e/event:imaginary.hs")
                 .expect("Failed to create MatrixId."),
             MatrixId::Event(
-                <&RoomOrAliasId>::from(room_alias_id!("#roomalias:imaginary.hs")).into(),
-                event_id!("$event:imaginary.hs").into()
+                owned_room_alias_id!("#roomalias:imaginary.hs").into(),
+                owned_event_id!("$event:imaginary.hs")
             )
         );
         assert_eq!(
             MatrixId::parse_with_type("room/roomalias:imaginary.hs/event/event:imaginary.hs")
                 .expect("Failed to create MatrixId."),
             MatrixId::Event(
-                <&RoomOrAliasId>::from(room_alias_id!("#roomalias:imaginary.hs")).into(),
-                event_id!("$event:imaginary.hs").into()
+                owned_room_alias_id!("#roomalias:imaginary.hs").into(),
+                owned_event_id!("$event:imaginary.hs")
             )
         );
         // Invert the order of the event and the room.
@@ -945,34 +947,34 @@ mod tests {
             MatrixId::parse_with_type("e/event:imaginary.hs/roomid/roomid:imaginary.hs")
                 .expect("Failed to create MatrixId."),
             MatrixId::Event(
-                <&RoomOrAliasId>::from(room_id!("!roomid:imaginary.hs")).into(),
-                event_id!("$event:imaginary.hs").into()
+                owned_room_id!("!roomid:imaginary.hs").into(),
+                owned_event_id!("$event:imaginary.hs")
             )
         );
         assert_eq!(
             MatrixId::parse_with_type("e/event:imaginary.hs/r/roomalias:imaginary.hs")
                 .expect("Failed to create MatrixId."),
             MatrixId::Event(
-                <&RoomOrAliasId>::from(room_alias_id!("#roomalias:imaginary.hs")).into(),
-                event_id!("$event:imaginary.hs").into()
+                owned_room_alias_id!("#roomalias:imaginary.hs").into(),
+                owned_event_id!("$event:imaginary.hs")
             )
         );
         // Starting with a slash
         assert_eq!(
             MatrixId::parse_with_type("/u/user:imaginary.hs").expect("Failed to create MatrixId."),
-            MatrixId::User(user_id!("@user:imaginary.hs").into())
+            MatrixId::User(owned_user_id!("@user:imaginary.hs"))
         );
         // Ending with a slash
         assert_eq!(
             MatrixId::parse_with_type("roomid/roomid:imaginary.hs/")
                 .expect("Failed to create MatrixId."),
-            MatrixId::Room(room_id!("!roomid:imaginary.hs").into())
+            MatrixId::Room(owned_room_id!("!roomid:imaginary.hs"))
         );
         // Starting and ending with a slash
         assert_eq!(
             MatrixId::parse_with_type("/r/roomalias:imaginary.hs/")
                 .expect("Failed to create MatrixId."),
-            MatrixId::RoomAlias(room_alias_id!("#roomalias:imaginary.hs").into())
+            MatrixId::RoomAlias(owned_room_alias_id!("#roomalias:imaginary.hs"))
         );
     }
 
@@ -1002,36 +1004,37 @@ mod tests {
     fn parse_matrixuri_valid_uris() {
         let matrix_uri =
             MatrixUri::parse("matrix:u/jplatte:notareal.hs").expect("Failed to create MatrixUri.");
-        assert_eq!(matrix_uri.id(), &user_id!("@jplatte:notareal.hs").into());
+        assert_eq!(*matrix_uri.id(), owned_user_id!("@jplatte:notareal.hs").into());
         assert_eq!(matrix_uri.action(), None);
 
         let matrix_uri = MatrixUri::parse("matrix:u/jplatte:notareal.hs?action=chat")
             .expect("Failed to create MatrixUri.");
-        assert_eq!(matrix_uri.id(), &user_id!("@jplatte:notareal.hs").into());
+        assert_eq!(*matrix_uri.id(), owned_user_id!("@jplatte:notareal.hs").into());
         assert_eq!(matrix_uri.action(), Some(&UriAction::Chat));
 
         let matrix_uri =
             MatrixUri::parse("matrix:r/ruma:notareal.hs").expect("Failed to create MatrixToUri.");
-        assert_eq!(matrix_uri.id(), &room_alias_id!("#ruma:notareal.hs").into());
+        assert_eq!(*matrix_uri.id(), owned_room_alias_id!("#ruma:notareal.hs").into());
 
         let matrix_uri = MatrixUri::parse("matrix:roomid/ruma:notareal.hs?via=notareal.hs")
             .expect("Failed to create MatrixToUri.");
-        assert_eq!(matrix_uri.id(), &room_id!("!ruma:notareal.hs").into());
+        assert_eq!(*matrix_uri.id(), owned_room_id!("!ruma:notareal.hs").into());
         assert_eq!(matrix_uri.via(), &[owned_server_name!("notareal.hs")]);
         assert_eq!(matrix_uri.action(), None);
 
         let matrix_uri = MatrixUri::parse("matrix:r/ruma:notareal.hs/e/event:notareal.hs")
             .expect("Failed to create MatrixToUri.");
         assert_eq!(
-            matrix_uri.id(),
-            &(room_alias_id!("#ruma:notareal.hs"), event_id!("$event:notareal.hs")).into()
+            *matrix_uri.id(),
+            (owned_room_alias_id!("#ruma:notareal.hs"), owned_event_id!("$event:notareal.hs"))
+                .into()
         );
 
         let matrix_uri = MatrixUri::parse("matrix:roomid/ruma:notareal.hs/e/event:notareal.hs")
             .expect("Failed to create MatrixToUri.");
         assert_eq!(
-            matrix_uri.id(),
-            &(room_id!("!ruma:notareal.hs"), event_id!("$event:notareal.hs")).into()
+            *matrix_uri.id(),
+            (owned_room_id!("!ruma:notareal.hs"), owned_event_id!("$event:notareal.hs")).into()
         );
         assert_eq!(matrix_uri.via().len(), 0);
         assert_eq!(matrix_uri.action(), None);
@@ -1040,8 +1043,8 @@ mod tests {
             MatrixUri::parse("matrix:roomid/ruma:notareal.hs/e/event:notareal.hs?via=notareal.hs&action=join&via=anotherinexistant.hs")
                 .expect("Failed to create MatrixToUri.");
         assert_eq!(
-            matrix_uri.id(),
-            &(room_id!("!ruma:notareal.hs"), event_id!("$event:notareal.hs")).into()
+            *matrix_uri.id(),
+            (owned_room_id!("!ruma:notareal.hs"), owned_event_id!("$event:notareal.hs")).into()
         );
         assert_eq!(
             matrix_uri.via(),

--- a/crates/ruma-common/src/identifiers/matrix_uri.rs
+++ b/crates/ruma-common/src/identifiers/matrix_uri.rs
@@ -415,8 +415,7 @@ impl AsRef<str> for UriAction {
 
 impl fmt::Display for UriAction {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.as_ref())?;
-        Ok(())
+        self.as_str().fmt(f)
     }
 }
 


### PR DESCRIPTION
~~The first commit improves `(Try)From` conversions between owned string types and owned identifier types by avoiding to reallocate when possible, and adds support for converting from `Cow<'a, str>`.~~

**The previous first commit is now part of #2376, which this is now based on, so only the 3 last commits are part of this PR.**

Then we use the new conversions when constructing `MatrixId` from parsed Matrix URIs.

And finally, similarly to  #2373, we prefer the use of the `owned_id!()` macros in tests, rather than relying on `id!()` + `.into()`.