### PR TITLE
add event definitions for secret pushing

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -29,6 +29,7 @@ Improvements:
   variants in `AnyGlobalAccountDataEvent(Content)` are now prefixed with
   `Unstable`. The new `InvitePermissionConfigEventContent` struct uses the new
   format with a `default_action` field instead of `block_all`.
+- Add support for to-device event for pushing secrets, according to MSC4385.
 
 # 0.32.1
 

--- a/crates/ruma-events/Cargo.toml
+++ b/crates/ruma-events/Cargo.toml
@@ -54,6 +54,7 @@ unstable-msc4334 = ["dep:language-tags"]
 unstable-msc4359 = []
 unstable-msc4362 = []
 unstable-msc4380 = []
+unstable-msc4385 = []
 unstable-uniffi = ["dep:uniffi"]
 
 # Allow some mandatory fields to be missing, defaulting them to an empty string

--- a/crates/ruma-events/src/enums.rs
+++ b/crates/ruma-events/src/enums.rs
@@ -239,6 +239,9 @@ event_enum! {
         "m.room.encrypted" => super::room::encrypted,
         "m.secret.request"=> super::secret::request,
         "m.secret.send" => super::secret::send,
+        #[cfg(feature = "unstable-msc4385")]
+        #[ruma_enum(alias = "m.secret.push")]
+        "io.element.msc4385.secret.push" => super::secret::push,
     }
 }
 

--- a/crates/ruma-events/src/secret.rs
+++ b/crates/ruma-events/src/secret.rs
@@ -1,4 +1,6 @@
 //! Module for events in the `m.secret` namespace.
 
+#[cfg(feature = "unstable-msc4385")]
+pub mod push;
 pub mod request;
 pub mod send;

--- a/crates/ruma-events/src/secret/push.rs
+++ b/crates/ruma-events/src/secret/push.rs
@@ -1,0 +1,42 @@
+//! Types for the [`io.element.msc4385.secret.push`] event.
+//!
+//! [`io.element.msc4385.secret.push`]: https://github.com/matrix-org/matrix-spec-proposals/pull/4385
+
+use std::fmt;
+
+use ruma_macros::EventContent;
+use serde::{Deserialize, Serialize};
+
+use super::request::SecretName;
+
+/// The content of an `m.secret.push` event.
+///
+/// An event sent by a client to push a secret with another device, without needing an
+/// `m.secret.request` event.
+///
+/// It must be encrypted as an `m.room.encrypted` event, then sent as a to-device event.
+#[derive(Clone, Deserialize, Serialize, EventContent)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+#[ruma_event(type = "io.element.msc4385.secret.push", kind = ToDevice)]
+pub struct ToDeviceSecretPushEventContent {
+    /// The name of the secret.
+    pub name: SecretName,
+
+    /// The contents of the secret.
+    pub secret: String,
+}
+
+impl ToDeviceSecretPushEventContent {
+    /// Creates a new `SecretPushEventContent` with the given name and secret.
+    pub fn new(name: SecretName, secret: String) -> Self {
+        Self { name, secret }
+    }
+}
+
+impl fmt::Debug for ToDeviceSecretPushEventContent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ToDeviceSecretPushEventContent")
+            .field("name", &self.name)
+            .finish_non_exhaustive()
+    }
+}

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -209,6 +209,7 @@ unstable-msc4334 = ["ruma-events?/unstable-msc4334", "dep:language-tags"]
 unstable-msc4359 = ["ruma-events?/unstable-msc4359"]
 unstable-msc4362 = ["ruma-events?/unstable-msc4362"]
 unstable-msc4380 = ["ruma-events?/unstable-msc4380"]
+unstable-msc4385 = ["ruma-events?/unstable-msc4385"]
 unstable-msc4388 = ["ruma-common/unstable-msc4388", "ruma-client-api?/unstable-msc4388"]
 unstable-uniffi = ["ruma-events?/unstable-uniffi"]
 


### PR DESCRIPTION
Add event definition for [MSC4385](https://github.com/matrix-org/matrix-spec-proposals/pull/4385)

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
