### PR TITLE
identifiers: Use `Box<str>` or `Arc<str>` as inner representation

### DIFF
--- a/crates/ruma-common/src/identifiers/base64_public_key_or_device_id.rs
+++ b/crates/ruma-common/src/identifiers/base64_public_key_or_device_id.rs
@@ -48,7 +48,7 @@ impl<'a> From<&'a DeviceId> for &'a Base64PublicKeyOrDeviceId {
 
 impl From<OwnedDeviceId> for OwnedBase64PublicKeyOrDeviceId {
     fn from(value: OwnedDeviceId) -> Self {
-        unsafe { Self::from_raw(value.into_raw() as *const Base64PublicKeyOrDeviceId) }
+        unsafe { Self::from_inner_unchecked(value.into_inner()) }
     }
 }
 
@@ -60,7 +60,7 @@ impl<'a> From<&'a Base64PublicKey> for &'a Base64PublicKeyOrDeviceId {
 
 impl From<OwnedBase64PublicKey> for OwnedBase64PublicKeyOrDeviceId {
     fn from(value: OwnedBase64PublicKey) -> Self {
-        unsafe { Self::from_raw(value.into_raw() as *const Base64PublicKeyOrDeviceId) }
+        unsafe { Self::from_inner_unchecked(value.into_inner()) }
     }
 }
 

--- a/crates/ruma-common/src/identifiers/room_or_alias_id.rs
+++ b/crates/ruma-common/src/identifiers/room_or_alias_id.rs
@@ -92,13 +92,13 @@ impl<'a> From<&'a RoomAliasId> for &'a RoomOrAliasId {
 
 impl From<OwnedRoomId> for OwnedRoomOrAliasId {
     fn from(room_id: OwnedRoomId) -> Self {
-        unsafe { Self::from_raw(room_id.into_raw() as *const RoomOrAliasId) }
+        unsafe { Self::from_inner_unchecked(room_id.into_inner()) }
     }
 }
 
 impl From<OwnedRoomAliasId> for OwnedRoomOrAliasId {
     fn from(room_alias_id: OwnedRoomAliasId) -> Self {
-        unsafe { Self::from_raw(room_alias_id.into_raw() as *const RoomOrAliasId) }
+        unsafe { Self::from_inner_unchecked(room_alias_id.into_inner()) }
     }
 }
 
@@ -129,12 +129,12 @@ impl TryFrom<OwnedRoomOrAliasId> for OwnedRoomId {
 
     fn try_from(id: OwnedRoomOrAliasId) -> Result<OwnedRoomId, OwnedRoomAliasId> {
         let variant = id.variant();
-        let ptr = id.into_raw();
+        let inner = id.into_inner();
 
         unsafe {
             match variant {
-                Variant::RoomId => Ok(Self::from_raw(ptr as *const RoomId)),
-                Variant::RoomAliasId => Err(OwnedRoomAliasId::from_raw(ptr as *const RoomAliasId)),
+                Variant::RoomId => Ok(Self::from_inner_unchecked(inner)),
+                Variant::RoomAliasId => Err(OwnedRoomAliasId::from_inner_unchecked(inner)),
             }
         }
     }
@@ -145,12 +145,12 @@ impl TryFrom<OwnedRoomOrAliasId> for OwnedRoomAliasId {
 
     fn try_from(id: OwnedRoomOrAliasId) -> Result<OwnedRoomAliasId, OwnedRoomId> {
         let variant = id.variant();
-        let ptr = id.into_raw();
+        let inner = id.into_inner();
 
         unsafe {
             match variant {
-                Variant::RoomAliasId => Ok(Self::from_raw(ptr as *const RoomAliasId)),
-                Variant::RoomId => Err(OwnedRoomId::from_raw(ptr as *const RoomId)),
+                Variant::RoomAliasId => Ok(Self::from_inner_unchecked(inner)),
+                Variant::RoomId => Err(OwnedRoomId::from_inner_unchecked(inner)),
             }
         }
     }

--- a/crates/ruma/src/lib.rs
+++ b/crates/ruma/src/lib.rs
@@ -102,10 +102,10 @@
 //!
 //! * `ruma_identifiers_storage` -- Choose the inner representation of the identifier types
 //!   generated with the `ruma_id` attribute macro. If the setting is not set or has an unknown
-//!   value, the owned identifiers use a [`Box`] around the borrowed type internally. The following
-//!   values are also supported:
+//!   value, the owned identifiers use a `Box<str>` internally. The following values are also
+//!   supported:
 //!
-//!   * `Arc` -- Use an [`Arc`](std::sync::Arc) around the borrowed type.
+//!   * `Arc` -- Use an `Arc<str>`.
 //!
 //!   This setting can also be configured by setting the `RUMA_IDENTIFIERS_STORAGE` environment
 //!   variable.


### PR DESCRIPTION
Instead of `Box<{id}>` or `Arc<{id}>`. This should make it easier to test alternate inner representations that can't rely on the borrowed identifier type to handle generics.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
