### PR TITLE
identifiers: Fix using `RUMA_IDENTIFIERS_STORAGE` environment variable

### DIFF
--- a/crates/ruma-common/build.rs
+++ b/crates/ruma-common/build.rs
@@ -3,7 +3,7 @@ use std::env;
 fn main() {
     // Set the `ruma_identifiers_storage` configuration from an environment variable.
     if let Ok(value) = env::var("RUMA_IDENTIFIERS_STORAGE") {
-        println!("cargo:rustc-cfg=ruma_identifiers_storage={value}");
+        println!("cargo:rustc-cfg=ruma_identifiers_storage={value:?}");
     }
 
     println!("cargo:rerun-if-env-changed=RUMA_IDENTIFIERS_STORAGE");

--- a/crates/ruma-events/build.rs
+++ b/crates/ruma-events/build.rs
@@ -3,7 +3,7 @@ use std::env;
 fn main() {
     // Set the `ruma_identifiers_storage` configuration from an environment variable.
     if let Ok(value) = env::var("RUMA_IDENTIFIERS_STORAGE") {
-        println!("cargo:rustc-cfg=ruma_identifiers_storage={value}");
+        println!("cargo:rustc-cfg=ruma_identifiers_storage={value:?}");
     }
 
     println!("cargo:rerun-if-env-changed=RUMA_IDENTIFIERS_STORAGE");


### PR DESCRIPTION
The value of the `cfg` setting must be between double quotes, so we use the `Debug` implementation of `String` to do just that.
