### PR TITLE
identifiers: Test alternate inner representation types for `IdDst`

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -18,6 +18,7 @@ version = 2
 allow = [
     "Apache-2.0",
     "BSD-3-Clause",
+    "CC0-1.0",
     "ISC",
     "MIT",
     "MPL-2.0",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,9 @@ jobs:
           - name: Check Owned IDs with SmallVec
             cmd: msrv-owned-id-smallvec
 
+          - name: Check Owned IDs with CompactString
+            cmd: msrv-owned-id-compactstring
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,9 @@ jobs:
           - name: Check Owned IDs with ArcStr
             cmd: msrv-owned-id-arcstr
 
+          - name: Check Owned IDs with SmallVec
+            cmd: msrv-owned-id-smallvec
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,9 @@ jobs:
           - name: Check Owned IDs with Arc
             cmd: msrv-owned-id-arc
 
+          - name: Check Owned IDs with ArcStr
+            cmd: msrv-owned-id-arcstr
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,9 @@ jobs:
           - name: Check Owned IDs with CompactString
             cmd: msrv-owned-id-compactstring
 
+          - name: Check Owned IDs with ArcIntern
+            cmd: msrv-owned-id-arcintern
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,8 +76,11 @@ jobs:
           - name: Check Owned IDs with CompactString
             cmd: msrv-owned-id-compactstring
 
-          - name: Check Owned IDs with ArcIntern
+          - name: Check Owned IDs with ArcIntern from arc-interner
             cmd: msrv-owned-id-arcintern
+
+          - name: Check Owned IDs with ArcIntern from internment
+            cmd: msrv-owned-id-arcinternment
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install cargo-sort
         uses: taiki-e/cache-cargo-install-action@v3
         with:
-          tool: cargo-sort
+          tool: cargo-sort@2.0.2
 
       - name: Get xtask
         uses: actions/cache@v5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
+dependencies = [
+ "const-random",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,6 +96,18 @@ name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
+name = "arc-interner"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "655ae79d4a7661f2f9a8f6daf95af32897eafdea938df06aeb127cea02b5f4ac"
+dependencies = [
+ "ahash",
+ "dashmap",
+ "once_cell",
+ "serde",
+]
 
 [[package]]
 name = "arcstr"
@@ -379,6 +400,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.16",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "const_panic"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -511,6 +552,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dashmap"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
+dependencies = [
+ "cfg-if",
+ "num_cpus",
 ]
 
 [[package]]
@@ -1457,6 +1508,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1963,6 +2024,7 @@ dependencies = [
 name = "ruma-common"
 version = "0.17.1"
 dependencies = [
+ "arc-interner",
  "arcstr",
  "as_variant",
  "assert_matches2",
@@ -2682,6 +2744,15 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
 
 [[package]]
 name = "tinystr"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,6 +240,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,6 +336,20 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "compact_str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -1946,6 +1969,7 @@ dependencies = [
  "assign",
  "base64",
  "bytes",
+ "compact_str",
  "form_urlencoded",
  "getrandom 0.2.16",
  "http",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "arcstr"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
+
+[[package]]
 name = "as_variant"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1934,6 +1940,7 @@ dependencies = [
 name = "ruma-common"
 version = "0.17.1"
 dependencies = [
+ "arcstr",
  "as_variant",
  "assert_matches2",
  "assign",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1963,6 +1963,7 @@ dependencies = [
  "serde",
  "serde_html_form",
  "serde_json",
+ "smallvec",
  "smol-macros",
  "thiserror",
  "time",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.3",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -34,6 +47,12 @@ checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anes"
@@ -103,8 +122,8 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "655ae79d4a7661f2f9a8f6daf95af32897eafdea938df06aeb127cea02b5f4ac"
 dependencies = [
- "ahash",
- "dashmap",
+ "ahash 0.3.8",
+ "dashmap 4.0.2",
  "once_cell",
  "serde",
 ]
@@ -565,6 +584,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "date_header"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -718,6 +750,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -853,9 +891,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasi 0.14.7+wasi-0.2.4",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -901,9 +941,20 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "headers"
@@ -1210,7 +1261,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92119844f513ffa41556430369ab02c295a3578af21cf945caa3e9e0c2481ac3"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.5",
  "serde",
  "serde_core",
 ]
@@ -1225,6 +1276,18 @@ dependencies = [
  "once_cell",
  "serde",
  "similar",
+]
+
+[[package]]
+name = "internment"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "636d4b0f6a39fd684effe2a73f5310df16a3fa7954c26d36833e98f44d1977a2"
+dependencies = [
+ "ahash 0.8.12",
+ "dashmap 5.5.3",
+ "hashbrown 0.15.5",
+ "once_cell",
 ]
 
 [[package]]
@@ -2034,8 +2097,10 @@ dependencies = [
  "compact_str",
  "form_urlencoded",
  "getrandom 0.2.16",
+ "getrandom 0.3.3",
  "http",
  "indexmap",
+ "internment",
  "js-sys",
  "js_int",
  "konst",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ zeroize = "1.8.1"
 rust_2018_idioms = { level = "warn", priority = -1 }
 semicolon_in_expressions_from_macros = "warn"
 unexpected_cfgs = { level = "warn", check-cfg = [
-    'cfg(ruma_identifiers_storage, values("Arc"))', # used by the IdDst macro
+    'cfg(ruma_identifiers_storage, values("Arc", "ArcStr"))', # used by the IdDst macro
     'cfg(ruma_unstable_exhaustive_types)', # set all types as exhaustive
 ] }
 unreachable_pub = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ zeroize = "1.8.1"
 rust_2018_idioms = { level = "warn", priority = -1 }
 semicolon_in_expressions_from_macros = "warn"
 unexpected_cfgs = { level = "warn", check-cfg = [
-    'cfg(ruma_identifiers_storage, values("Arc", "ArcStr", "SmallVec", "CompactString"))', # used by the IdDst macro
+    'cfg(ruma_identifiers_storage, values("Arc", "ArcStr", "SmallVec", "CompactString", "ArcIntern"))', # used by the IdDst macro
     'cfg(ruma_unstable_exhaustive_types)', # set all types as exhaustive
 ] }
 unreachable_pub = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ zeroize = "1.8.1"
 rust_2018_idioms = { level = "warn", priority = -1 }
 semicolon_in_expressions_from_macros = "warn"
 unexpected_cfgs = { level = "warn", check-cfg = [
-    'cfg(ruma_identifiers_storage, values("Arc", "ArcStr"))', # used by the IdDst macro
+    'cfg(ruma_identifiers_storage, values("Arc", "ArcStr", "SmallVec"))', # used by the IdDst macro
     'cfg(ruma_unstable_exhaustive_types)', # set all types as exhaustive
 ] }
 unreachable_pub = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ zeroize = "1.8.1"
 rust_2018_idioms = { level = "warn", priority = -1 }
 semicolon_in_expressions_from_macros = "warn"
 unexpected_cfgs = { level = "warn", check-cfg = [
-    'cfg(ruma_identifiers_storage, values("Arc", "ArcStr", "SmallVec"))', # used by the IdDst macro
+    'cfg(ruma_identifiers_storage, values("Arc", "ArcStr", "SmallVec", "CompactString"))', # used by the IdDst macro
     'cfg(ruma_unstable_exhaustive_types)', # set all types as exhaustive
 ] }
 unreachable_pub = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ zeroize = "1.8.1"
 rust_2018_idioms = { level = "warn", priority = -1 }
 semicolon_in_expressions_from_macros = "warn"
 unexpected_cfgs = { level = "warn", check-cfg = [
-    'cfg(ruma_identifiers_storage, values("Arc", "ArcStr", "SmallVec", "CompactString", "ArcIntern"))', # used by the IdDst macro
+    'cfg(ruma_identifiers_storage, values("Arc", "ArcStr", "SmallVec", "CompactString", "ArcIntern", "ArcInternment"))', # used by the IdDst macro
     'cfg(ruma_unstable_exhaustive_types)', # set all types as exhaustive
 ] }
 unreachable_pub = "warn"

--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -74,6 +74,7 @@ ruma-macros = { workspace = true }
 serde = { workspace = true }
 serde_html_form = { workspace = true }
 serde_json = { workspace = true, features = ["raw_value"] }
+smallvec = "1.15.1"
 thiserror = { workspace = true }
 time = "0.3.47"
 tracing = { workspace = true, features = ["attributes"] }

--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -60,6 +60,7 @@ arcstr = { version = "1.2.0", default-features = false }
 as_variant = { workspace = true }
 base64 = { workspace = true }
 bytes = { workspace = true }
+compact_str = "0.9.0"
 form_urlencoded = "1.0.0"
 getrandom = { version = "0.2.6", optional = true }
 http = { workspace = true, optional = true }

--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -56,6 +56,7 @@ compat-null = []
 compat-optional = []
 
 [dependencies]
+arcstr = { version = "1.2.0", default-features = false }
 as_variant = { workspace = true }
 base64 = { workspace = true }
 bytes = { workspace = true }

--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -56,6 +56,7 @@ compat-null = []
 compat-optional = []
 
 [dependencies]
+arc-interner = "0.7.0"
 arcstr = { version = "1.2.0", default-features = false }
 as_variant = { workspace = true }
 base64 = { workspace = true }

--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -21,8 +21,8 @@ client = []
 server = []
 
 api = ["dep:http", "dep:konst"]
-js = ["dep:js-sys", "getrandom?/js", "uuid?/js"]
-rand = ["dep:rand", "dep:getrandom", "dep:uuid"]
+js = ["dep:js-sys", "getrandom_0_2?/js", "getrandom_0_3/wasm_js", "uuid?/js"]
+rand = ["dep:rand", "dep:getrandom_0_2", "dep:uuid"]
 
 unstable-msc2666 = []
 unstable-msc2870 = []
@@ -63,9 +63,11 @@ base64 = { workspace = true }
 bytes = { workspace = true }
 compact_str = "0.9.0"
 form_urlencoded = "1.0.0"
-getrandom = { version = "0.2.6", optional = true }
+getrandom_0_2 = { version = "0.2.6", optional = true, package = "getrandom" }
+getrandom_0_3 = { version = "0.3.3", package = "getrandom" }
 http = { workspace = true, optional = true }
 indexmap = { version = "2.0.0", features = ["serde"] }
+internment = { version = "0.8.6", default-features = false, features = ["arc"] }
 js_int = { workspace = true, features = ["serde"] }
 konst = { version = "0.3.5", default-features = false, features = ["cmp", "iter", "parsing"], optional = true }
 percent-encoding = "2.1.0"

--- a/crates/ruma-common/src/identifiers/event_id.rs
+++ b/crates/ruma-common/src/identifiers/event_id.rs
@@ -55,7 +55,7 @@ use super::{IdParseError, ServerName};
 /// [room versions]: https://spec.matrix.org/latest/rooms/#complete-list-of-room-versions
 #[repr(transparent)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
-#[ruma_id(validate = ruma_identifiers_validation::event_id::validate)]
+#[ruma_id(validate = ruma_identifiers_validation::event_id::validate, inline_bytes = 48)]
 pub struct EventId(str);
 
 impl EventId {

--- a/crates/ruma-common/src/identifiers/room_alias_id.rs
+++ b/crates/ruma-common/src/identifiers/room_alias_id.rs
@@ -17,7 +17,7 @@ use super::{MatrixToUri, MatrixUri, OwnedEventId, matrix_uri::UriAction, server_
 /// [room alias ID]: https://spec.matrix.org/latest/appendices/#room-aliases
 #[repr(transparent)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
-#[ruma_id(validate = ruma_identifiers_validation::room_alias_id::validate)]
+#[ruma_id(validate = ruma_identifiers_validation::room_alias_id::validate, inline_bytes = 48)]
 pub struct RoomAliasId(str);
 
 impl RoomAliasId {

--- a/crates/ruma-common/src/identifiers/room_id.rs
+++ b/crates/ruma-common/src/identifiers/room_id.rs
@@ -21,7 +21,7 @@ use crate::RoomOrAliasId;
 /// [room ID]: https://spec.matrix.org/latest/appendices/#room-ids
 #[repr(transparent)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
-#[ruma_id(validate = ruma_identifiers_validation::room_id::validate)]
+#[ruma_id(validate = ruma_identifiers_validation::room_id::validate, inline_bytes = 48)]
 pub struct RoomId(str);
 
 impl RoomId {

--- a/crates/ruma-common/src/identifiers/room_or_alias_id.rs
+++ b/crates/ruma-common/src/identifiers/room_or_alias_id.rs
@@ -31,7 +31,7 @@ use super::{OwnedRoomAliasId, OwnedRoomId, RoomAliasId, RoomId, server_name::Ser
 /// [room alias ID]: https://spec.matrix.org/latest/appendices/#room-aliases
 #[repr(transparent)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
-#[ruma_id(validate = ruma_identifiers_validation::room_id_or_alias_id::validate)]
+#[ruma_id(validate = ruma_identifiers_validation::room_id_or_alias_id::validate, inline_bytes = 48)]
 pub struct RoomOrAliasId(str);
 
 impl RoomOrAliasId {

--- a/crates/ruma-common/src/identifiers/server_signing_key_version.rs
+++ b/crates/ruma-common/src/identifiers/server_signing_key_version.rs
@@ -15,6 +15,7 @@ use super::{IdParseError, KeyName};
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
 #[ruma_id(
     validate = ruma_identifiers_validation::server_signing_key_version::validate,
+    inline_bytes = 16,
 )]
 pub struct ServerSigningKeyVersion(str);
 

--- a/crates/ruma-common/src/identifiers/space_child_order.rs
+++ b/crates/ruma-common/src/identifiers/space_child_order.rs
@@ -11,7 +11,7 @@ use ruma_macros::IdDst;
 /// [`m.space.child`]: https://spec.matrix.org/latest/client-server-api/#mspacechild
 #[repr(transparent)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
-#[ruma_id(validate = ruma_identifiers_validation::space_child_order::validate)]
+#[ruma_id(validate = ruma_identifiers_validation::space_child_order::validate, inline_bytes = 50)]
 pub struct SpaceChildOrder(str);
 
 #[cfg(test)]

--- a/crates/ruma-common/src/identifiers/user_id.rs
+++ b/crates/ruma-common/src/identifiers/user_id.rs
@@ -19,7 +19,7 @@ use super::{IdParseError, MatrixToUri, MatrixUri, ServerName, matrix_uri::UriAct
 /// [user ID]: https://spec.matrix.org/latest/appendices/#user-identifiers
 #[repr(transparent)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
-#[ruma_id(validate = ruma_identifiers_validation::user_id::validate)]
+#[ruma_id(validate = ruma_identifiers_validation::user_id::validate, inline_bytes = 40)]
 pub struct UserId(str);
 
 impl UserId {

--- a/crates/ruma-common/src/lib.rs
+++ b/crates/ruma-common/src/lib.rs
@@ -60,6 +60,7 @@ pub mod exports {
     pub use compact_str;
     #[cfg(feature = "api")]
     pub use http;
+    pub use internment;
     pub use ruma_macros;
     pub use serde;
     pub use serde_html_form;

--- a/crates/ruma-common/src/lib.rs
+++ b/crates/ruma-common/src/lib.rs
@@ -53,6 +53,7 @@ priv_owned_str!();
 /// It is not considered part of this module's public API.
 #[doc(hidden)]
 pub mod exports {
+    pub use arcstr;
     #[cfg(feature = "api")]
     pub use bytes;
     #[cfg(feature = "api")]

--- a/crates/ruma-common/src/lib.rs
+++ b/crates/ruma-common/src/lib.rs
@@ -53,6 +53,7 @@ priv_owned_str!();
 /// It is not considered part of this module's public API.
 #[doc(hidden)]
 pub mod exports {
+    pub use arc_interner;
     pub use arcstr;
     #[cfg(feature = "api")]
     pub use bytes;

--- a/crates/ruma-common/src/lib.rs
+++ b/crates/ruma-common/src/lib.rs
@@ -56,6 +56,7 @@ pub mod exports {
     pub use arcstr;
     #[cfg(feature = "api")]
     pub use bytes;
+    pub use compact_str;
     #[cfg(feature = "api")]
     pub use http;
     pub use ruma_macros;

--- a/crates/ruma-common/src/lib.rs
+++ b/crates/ruma-common/src/lib.rs
@@ -62,4 +62,5 @@ pub mod exports {
     pub use serde;
     pub use serde_html_form;
     pub use serde_json;
+    pub use smallvec;
 }

--- a/crates/ruma-macros/src/identifiers/id_dst.rs
+++ b/crates/ruma-macros/src/identifiers/id_dst.rs
@@ -163,6 +163,7 @@ impl IdDst {
         let smallvec = &self.types.smallvec;
         let compactstring = &self.types.compactstring;
         let arcintern = &self.types.arcintern;
+        let arcinternment = &self.types.arcinternment;
         let id = &self.types.id;
         let owned_id = &self.types.owned_id;
 
@@ -172,6 +173,7 @@ impl IdDst {
         let smallvec_cfg = &self.storage_cfg.smallvec;
         let compactstring_cfg = &self.storage_cfg.compactstring;
         let arcintern_cfg = &self.storage_cfg.arcintern;
+        let arcinternment_cfg = &self.storage_cfg.arcinternment;
 
         let (phantom_decl, phantom_ctor) = if self.generics.params.is_empty() {
             None
@@ -226,6 +228,7 @@ impl IdDst {
             (smallvec_cfg, smallvec),
             (compactstring_cfg, compactstring),
             (arcintern_cfg, arcintern),
+            (arcinternment_cfg, arcinternment),
         ]
         .into_iter()
         .map(|(cfg, inner)| from_into_inner_cfg_impl(cfg, inner));
@@ -244,6 +247,7 @@ impl IdDst {
             /// * `CompactString` -- Use a `CompactString` from the [`compact_str`](https://crates.io/crates/compact_str) crate.
             /// * `ArcIntern` -- Use an `ArcIntern<str>` from the [`arc-interner`](https://crates.io/crates/arc-interner)
             ///   crate.
+            /// * `ArcInternment` -- Use an `ArcIntern<str>` from the [`internment`](https://crates.io/crates/internment) crate.
             ///
             /// The selected value can be set by using the `ruma_identifiers_storage` compile-time `cfg` setting.
             /// This setting can be configured using the `RUSTFLAGS` environment variable at build time, like this:
@@ -284,6 +288,8 @@ impl IdDst {
                 inner: #compactstring,
                 #arcintern_cfg
                 inner: #arcintern,
+                #arcinternment_cfg
+                inner: #arcinternment,
                 #phantom_decl
             }
 
@@ -303,6 +309,8 @@ impl IdDst {
                         inner: s.into(),
                         #arcintern_cfg
                         inner: s.into(),
+                        #arcinternment_cfg
+                        inner: s.into(),
                         #phantom_ctor
                     }
                 }
@@ -320,6 +328,8 @@ impl IdDst {
                         #compactstring_cfg
                         inner: s.into(),
                         #arcintern_cfg
+                        inner: s.into(),
+                        #arcinternment_cfg
                         inner: s.into(),
                         #phantom_ctor
                     }
@@ -339,6 +349,8 @@ impl IdDst {
                         inner: s.into(),
                         #arcintern_cfg
                         inner: s.into_boxed_str().into(),
+                        #arcinternment_cfg
+                        inner: s.into(),
                         #phantom_ctor
                     }
                 }
@@ -357,6 +369,8 @@ impl IdDst {
                     { &self.inner }
                     #arcintern_cfg
                     { &self.inner }
+                    #arcinternment_cfg
+                    { &self.inner }
                 }
 
                 /// Access the inner bytes without going through the borrowed type.
@@ -373,6 +387,8 @@ impl IdDst {
                     { self.inner.as_bytes() }
                     #arcintern_cfg
                     { self.inner.as_bytes() }
+                    #arcinternment_cfg
+                    { &self.inner.as_bytes() }
                 }
 
                 #( #from_into_inner_impls )*
@@ -489,6 +505,8 @@ impl IdDst {
                     { id.inner.into() }
                     #arcintern_cfg
                     { id.as_inner_str().into() }
+                    #arcinternment_cfg
+                    { id.as_inner_str().into() }
                 }
             }
 
@@ -506,6 +524,8 @@ impl IdDst {
                     #compactstring_cfg
                     { id.inner.into() }
                     #arcintern_cfg
+                    { id.as_inner_str().into() }
+                    #arcinternment_cfg
                     { id.as_inner_str().into() }
                 }
             }
@@ -826,8 +846,11 @@ struct Types {
     /// `CompactString`.
     compactstring: syn::Type,
 
-    /// `ArcIntern<str>`.
+    /// `ArcIntern<str>` from the `arc-interner` crate.
     arcintern: syn::Type,
+
+    /// `ArcIntern<str>` from the `internment` crate.
+    arcinternment: syn::Type,
 
     /// `{id}`, the identifier type with generics, if any.
     id: syn::Type,
@@ -848,6 +871,7 @@ impl Types {
         let smallvec_crate = ruma_common.reexported(RumaCommonReexport::Smallvec);
         let compact_str = ruma_common.reexported(RumaCommonReexport::CompactStr);
         let arc_interner = ruma_common.reexported(RumaCommonReexport::ArcInterner);
+        let internment = ruma_common.reexported(RumaCommonReexport::Internment);
 
         let str = parse_quote! { ::std::primitive::str };
         let cow = parse_quote! { ::std::borrow::Cow };
@@ -865,6 +889,7 @@ impl Types {
             smallvec: parse_quote! { #smallvec_crate::SmallVec<[#byte; #inline_bytes]> },
             compactstring: parse_quote! { #compact_str::CompactString },
             arcintern: parse_quote! { #arc_interner::ArcIntern<#str> },
+            arcinternment: parse_quote! { #internment::ArcIntern<#str> },
             str,
             cow,
             id,
@@ -890,8 +915,11 @@ struct StorageCfg {
     /// Attribute for the `CompactString` internal representation.
     compactstring: syn::Attribute,
 
-    /// Attribute for the `ArcIntern` internal representation.
+    /// Attribute for the `ArcIntern<str>` internal representation from the `arc-interner` crate.
     arcintern: syn::Attribute,
+
+    /// Attribute for the `ArcIntern<str>` internal representation from the `internment` crate.
+    arcinternment: syn::Attribute,
 }
 
 impl StorageCfg {
@@ -903,12 +931,14 @@ impl StorageCfg {
         let smallvec_value = quote! { "SmallVec" };
         let compactstring_value = quote! { "CompactString" };
         let arcintern_value = quote! { "ArcIntern" };
+        let arcinternment_value = quote! { "ArcInternment" };
         let all_values = &[
             &arc_str_value,
             &arcstr_value,
             &smallvec_value,
             &compactstring_value,
             &arcintern_value,
+            &arcinternment_value,
         ];
 
         Self {
@@ -918,6 +948,7 @@ impl StorageCfg {
             smallvec: parse_quote! { #[cfg(#key = #smallvec_value)] },
             compactstring: parse_quote! { #[cfg(#key = #compactstring_value)] },
             arcintern: parse_quote! { #[cfg(#key = #arcintern_value)] },
+            arcinternment: parse_quote! { #[cfg(#key = #arcinternment_value)] },
         }
     }
 }

--- a/crates/ruma-macros/src/identifiers/id_dst/parse.rs
+++ b/crates/ruma-macros/src/identifiers/id_dst/parse.rs
@@ -21,7 +21,7 @@ impl IdDst {
             attr.parse_nested_meta(|meta| id_dst_attrs.try_merge(meta, attr))?;
         }
 
-        let IdDstAttrs { validate } = id_dst_attrs;
+        let IdDstAttrs { validate, inline_bytes } = id_dst_attrs;
 
         if validate.is_none() && !input.generics.params.is_empty() {
             return Err(syn::Error::new(
@@ -59,7 +59,8 @@ impl IdDst {
         let ruma_common = RumaCommon::new();
         let ident = input.ident;
         let owned_ident = format_ident!("Owned{ident}");
-        let types = Types::new(&ident, &owned_ident, type_generics, &ruma_common);
+        let inline_bytes = inline_bytes.unwrap_or(32);
+        let types = Types::new(&ident, &owned_ident, type_generics, inline_bytes, &ruma_common);
 
         Ok(Self {
             ident,
@@ -67,6 +68,7 @@ impl IdDst {
             generics,
             impl_generics,
             validate,
+            inline_bytes,
             str_field_index,
             types,
             storage_cfg: StorageCfg::new(),
@@ -80,6 +82,9 @@ impl IdDst {
 struct IdDstAttrs {
     /// The path to the function to use to validate the identifier.
     validate: Option<syn::Path>,
+
+    /// The size of the inline array for the `SmallVec` inner representation.
+    inline_bytes: Option<usize>,
 }
 
 impl IdDstAttrs {
@@ -98,6 +103,21 @@ impl IdDstAttrs {
         Ok(())
     }
 
+    /// Set the size of the inline array for the `SmallVec` inner representation.
+    ///
+    /// Returns an error if it is already set.
+    fn set_inline_bytes(&mut self, inline_bytes: usize, attr: &syn::Attribute) -> syn::Result<()> {
+        if self.inline_bytes.is_some() {
+            return Err(syn::Error::new_spanned(
+                attr,
+                "cannot have multiple values for `inline_bytes` attribute",
+            ));
+        }
+
+        self.inline_bytes = Some(inline_bytes);
+        Ok(())
+    }
+
     /// Try to parse the given meta item and merge it into this `IdDstAttrs`.
     ///
     /// Returns an error if an unknown `ruma_id` attribute is encountered, or if an attribute
@@ -105,6 +125,11 @@ impl IdDstAttrs {
     fn try_merge(&mut self, meta: ParseNestedMeta<'_>, attr: &syn::Attribute) -> syn::Result<()> {
         if meta.path.is_ident("validate") {
             return self.set_validate(meta.value()?.parse()?, attr);
+        }
+
+        if meta.path.is_ident("inline_bytes") {
+            return self
+                .set_inline_bytes(meta.value()?.parse::<syn::LitInt>()?.base10_parse()?, attr);
         }
 
         Err(meta.error("unsupported `ruma_id` attribute"))

--- a/crates/ruma-macros/src/identifiers/id_dst/parse.rs
+++ b/crates/ruma-macros/src/identifiers/id_dst/parse.rs
@@ -56,9 +56,10 @@ impl IdDst {
         let (impl_generics, type_generics, _where_clause) = generics.split_for_impl();
         let impl_generics = quote! { #impl_generics };
 
+        let ruma_common = RumaCommon::new();
         let ident = input.ident;
         let owned_ident = format_ident!("Owned{ident}");
-        let types = Types::new(&ident, &owned_ident, type_generics);
+        let types = Types::new(&ident, &owned_ident, type_generics, &ruma_common);
 
         Ok(Self {
             ident,
@@ -69,7 +70,7 @@ impl IdDst {
             str_field_index,
             types,
             storage_cfg: StorageCfg::new(),
-            ruma_common: RumaCommon::new(),
+            ruma_common,
         })
     }
 }

--- a/crates/ruma-macros/src/lib.rs
+++ b/crates/ruma-macros/src/lib.rs
@@ -465,6 +465,8 @@ pub fn derive_from_event_to_enum(input: TokenStream) -> TokenStream {
 /// * `#[ruma_api(validate = PATH)]`: the path to a function to validate the string during parsing
 ///   and deserialization. By default, the types implement `From` string types, when this is set
 ///   they implement `TryFrom`.
+/// * `#[ruma_api(inline_bytes = USIZE)]`: the size of the bytes array when using the `SmallVec<[u8;
+///   N]>` inner representation. Defaults to `32`.
 ///
 /// # Examples
 ///

--- a/crates/ruma-macros/src/util.rs
+++ b/crates/ruma-macros/src/util.rs
@@ -64,6 +64,9 @@ pub(crate) enum RumaCommonReexport {
 
     /// The arcstr crate.
     Arcstr,
+
+    /// The smallvec crate.
+    Smallvec,
 }
 
 impl ToTokens for RumaCommonReexport {
@@ -76,6 +79,7 @@ impl ToTokens for RumaCommonReexport {
             Self::Http => "http",
             Self::Bytes => "bytes",
             Self::Arcstr => "arcstr",
+            Self::Smallvec => "smallvec",
         };
 
         tokens.append(Ident::new(crate_name, Span::call_site()));

--- a/crates/ruma-macros/src/util.rs
+++ b/crates/ruma-macros/src/util.rs
@@ -70,6 +70,9 @@ pub(crate) enum RumaCommonReexport {
 
     /// The compact_str crate.
     CompactStr,
+
+    /// The arc-interner crate.
+    ArcInterner,
 }
 
 impl ToTokens for RumaCommonReexport {
@@ -84,6 +87,7 @@ impl ToTokens for RumaCommonReexport {
             Self::Arcstr => "arcstr",
             Self::Smallvec => "smallvec",
             Self::CompactStr => "compact_str",
+            Self::ArcInterner => "arc_interner",
         };
 
         tokens.append(Ident::new(crate_name, Span::call_site()));

--- a/crates/ruma-macros/src/util.rs
+++ b/crates/ruma-macros/src/util.rs
@@ -67,6 +67,9 @@ pub(crate) enum RumaCommonReexport {
 
     /// The smallvec crate.
     Smallvec,
+
+    /// The compact_str crate.
+    CompactStr,
 }
 
 impl ToTokens for RumaCommonReexport {
@@ -80,6 +83,7 @@ impl ToTokens for RumaCommonReexport {
             Self::Bytes => "bytes",
             Self::Arcstr => "arcstr",
             Self::Smallvec => "smallvec",
+            Self::CompactStr => "compact_str",
         };
 
         tokens.append(Ident::new(crate_name, Span::call_site()));

--- a/crates/ruma-macros/src/util.rs
+++ b/crates/ruma-macros/src/util.rs
@@ -61,6 +61,9 @@ pub(crate) enum RumaCommonReexport {
 
     /// The bytes crate.
     Bytes,
+
+    /// The arcstr crate.
+    Arcstr,
 }
 
 impl ToTokens for RumaCommonReexport {
@@ -72,6 +75,7 @@ impl ToTokens for RumaCommonReexport {
             Self::SerdeJson => "serde_json",
             Self::Http => "http",
             Self::Bytes => "bytes",
+            Self::Arcstr => "arcstr",
         };
 
         tokens.append(Ident::new(crate_name, Span::call_site()));

--- a/crates/ruma-macros/src/util.rs
+++ b/crates/ruma-macros/src/util.rs
@@ -73,6 +73,9 @@ pub(crate) enum RumaCommonReexport {
 
     /// The arc-interner crate.
     ArcInterner,
+
+    /// The internment crate.
+    Internment,
 }
 
 impl ToTokens for RumaCommonReexport {
@@ -88,6 +91,7 @@ impl ToTokens for RumaCommonReexport {
             Self::Smallvec => "smallvec",
             Self::CompactStr => "compact_str",
             Self::ArcInterner => "arc_interner",
+            Self::Internment => "internment",
         };
 
         tokens.append(Ident::new(crate_name, Span::call_site()));

--- a/crates/ruma/src/lib.rs
+++ b/crates/ruma/src/lib.rs
@@ -107,6 +107,8 @@
 //!
 //!   * `Arc` -- Use an `Arc<str>`.
 //!   * `ArcStr` -- Use an `ArcStr` from the [`arcstr`](https://crates.io/crates/arcstr) crate.
+//!   * `SmallVec` -- Use a `SmallVec<[u8; N]>` from the [`smallvec`](https://crates.io/crates/smallvec)
+//!     crate. The size of the array is variable depending on the identifier type.
 //!
 //!   This setting can also be configured by setting the `RUMA_IDENTIFIERS_STORAGE` environment
 //!   variable.

--- a/crates/ruma/src/lib.rs
+++ b/crates/ruma/src/lib.rs
@@ -109,6 +109,8 @@
 //!   * `ArcStr` -- Use an `ArcStr` from the [`arcstr`](https://crates.io/crates/arcstr) crate.
 //!   * `SmallVec` -- Use a `SmallVec<[u8; N]>` from the [`smallvec`](https://crates.io/crates/smallvec)
 //!     crate. The size of the array is variable depending on the identifier type.
+//!   * `CompactString` -- Use a `CompactString` from the [`compact_str`](https://crates.io/crates/compact_str)
+//!     crate.
 //!
 //!   This setting can also be configured by setting the `RUMA_IDENTIFIERS_STORAGE` environment
 //!   variable.

--- a/crates/ruma/src/lib.rs
+++ b/crates/ruma/src/lib.rs
@@ -106,6 +106,7 @@
 //!   supported:
 //!
 //!   * `Arc` -- Use an `Arc<str>`.
+//!   * `ArcStr` -- Use an `ArcStr` from the [`arcstr`](https://crates.io/crates/arcstr) crate.
 //!
 //!   This setting can also be configured by setting the `RUMA_IDENTIFIERS_STORAGE` environment
 //!   variable.

--- a/crates/ruma/src/lib.rs
+++ b/crates/ruma/src/lib.rs
@@ -111,6 +111,8 @@
 //!     crate. The size of the array is variable depending on the identifier type.
 //!   * `CompactString` -- Use a `CompactString` from the [`compact_str`](https://crates.io/crates/compact_str)
 //!     crate.
+//!   * `ArcIntern` -- Use an `ArcIntern<str>` from the [`arc-interner`](https://crates.io/crates/arc-interner)
+//!     crate.
 //!
 //!   This setting can also be configured by setting the `RUMA_IDENTIFIERS_STORAGE` environment
 //!   variable.

--- a/crates/ruma/src/lib.rs
+++ b/crates/ruma/src/lib.rs
@@ -113,6 +113,8 @@
 //!     crate.
 //!   * `ArcIntern` -- Use an `ArcIntern<str>` from the [`arc-interner`](https://crates.io/crates/arc-interner)
 //!     crate.
+//!   * `ArcInternment` -- Use an `ArcIntern<str>` from the [`internment`](https://crates.io/crates/internment)
+//!     crate.
 //!
 //!   This setting can also be configured by setting the `RUMA_IDENTIFIERS_STORAGE` environment
 //!   variable.

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -39,6 +39,8 @@ pub enum CiCmd {
     MsrvOwnedIdArc,
     /// Check ruma-identifiers with `ruma_identifiers_storage="ArcStr"`
     MsrvOwnedIdArcstr,
+    /// Check ruma-identifiers with `ruma_identifiers_storage="SmallVec"`
+    MsrvOwnedIdSmallvec,
     /// Run all the tasks that use the stable version
     Stable,
     /// Check all crates with all features (stable)
@@ -120,6 +122,7 @@ impl CiTask {
             Some(CiCmd::MsrvOwnedIdBox) => self.msrv_owned_id_cfg("Box")?,
             Some(CiCmd::MsrvOwnedIdArc) => self.msrv_owned_id_cfg("Arc")?,
             Some(CiCmd::MsrvOwnedIdArcstr) => self.msrv_owned_id_cfg("ArcStr")?,
+            Some(CiCmd::MsrvOwnedIdSmallvec) => self.msrv_owned_id_cfg("SmallVec")?,
             Some(CiCmd::Stable) => self.stable()?,
             Some(CiCmd::StableAll) => self.stable_all()?,
             Some(CiCmd::StableCommon) => self.stable_common()?,

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -43,6 +43,8 @@ pub enum CiCmd {
     MsrvOwnedIdSmallvec,
     /// Check ruma-identifiers with `ruma_identifiers_storage="CompactString"`
     MsrvOwnedIdCompactstring,
+    /// Check ruma-identifiers with `ruma_identifiers_storage="ArcIntern"`
+    MsrvOwnedIdArcintern,
     /// Run all the tasks that use the stable version
     Stable,
     /// Check all crates with all features (stable)
@@ -126,6 +128,7 @@ impl CiTask {
             Some(CiCmd::MsrvOwnedIdArcstr) => self.msrv_owned_id_cfg("ArcStr")?,
             Some(CiCmd::MsrvOwnedIdSmallvec) => self.msrv_owned_id_cfg("SmallVec")?,
             Some(CiCmd::MsrvOwnedIdCompactstring) => self.msrv_owned_id_cfg("CompactString")?,
+            Some(CiCmd::MsrvOwnedIdArcintern) => self.msrv_owned_id_cfg("ArcIntern")?,
             Some(CiCmd::Stable) => self.stable()?,
             Some(CiCmd::StableAll) => self.stable_all()?,
             Some(CiCmd::StableCommon) => self.stable_common()?,

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -41,6 +41,8 @@ pub enum CiCmd {
     MsrvOwnedIdArcstr,
     /// Check ruma-identifiers with `ruma_identifiers_storage="SmallVec"`
     MsrvOwnedIdSmallvec,
+    /// Check ruma-identifiers with `ruma_identifiers_storage="CompactString"`
+    MsrvOwnedIdCompactstring,
     /// Run all the tasks that use the stable version
     Stable,
     /// Check all crates with all features (stable)
@@ -123,6 +125,7 @@ impl CiTask {
             Some(CiCmd::MsrvOwnedIdArc) => self.msrv_owned_id_cfg("Arc")?,
             Some(CiCmd::MsrvOwnedIdArcstr) => self.msrv_owned_id_cfg("ArcStr")?,
             Some(CiCmd::MsrvOwnedIdSmallvec) => self.msrv_owned_id_cfg("SmallVec")?,
+            Some(CiCmd::MsrvOwnedIdCompactstring) => self.msrv_owned_id_cfg("CompactString")?,
             Some(CiCmd::Stable) => self.stable()?,
             Some(CiCmd::StableAll) => self.stable_all()?,
             Some(CiCmd::StableCommon) => self.stable_common()?,

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -37,6 +37,8 @@ pub enum CiCmd {
     MsrvOwnedIdBox,
     /// Check ruma-identifiers with `ruma_identifiers_storage="Arc"`
     MsrvOwnedIdArc,
+    /// Check ruma-identifiers with `ruma_identifiers_storage="ArcStr"`
+    MsrvOwnedIdArcstr,
     /// Run all the tasks that use the stable version
     Stable,
     /// Check all crates with all features (stable)
@@ -115,8 +117,9 @@ impl CiTask {
             Some(CiCmd::Msrv) => self.msrv()?,
             Some(CiCmd::MsrvAll) => self.msrv_all()?,
             Some(CiCmd::MsrvRuma) => self.msrv_ruma()?,
-            Some(CiCmd::MsrvOwnedIdBox) => self.msrv_owned_id_box()?,
-            Some(CiCmd::MsrvOwnedIdArc) => self.msrv_owned_id_arc()?,
+            Some(CiCmd::MsrvOwnedIdBox) => self.msrv_owned_id_cfg("Box")?,
+            Some(CiCmd::MsrvOwnedIdArc) => self.msrv_owned_id_cfg("Arc")?,
+            Some(CiCmd::MsrvOwnedIdArcstr) => self.msrv_owned_id_cfg("ArcStr")?,
             Some(CiCmd::Stable) => self.stable()?,
             Some(CiCmd::StableAll) => self.stable_all()?,
             Some(CiCmd::StableCommon) => self.stable_common()?,
@@ -300,18 +303,10 @@ impl CiTask {
         .map_err(Into::into)
     }
 
-    /// Check ruma-common with `ruma_identifiers_storage="Box"`
-    fn msrv_owned_id_box(&self) -> Result<()> {
+    /// Check ruma-common with `ruma_identifiers_storage="value"`
+    fn msrv_owned_id_cfg(&self, value: &str) -> Result<()> {
         cmd!(&self.sh, "rustup run {MSRV} cargo check -p ruma-common")
-            .env("RUSTFLAGS", "--cfg=ruma_identifiers_storage=\"Box\"")
-            .run()
-            .map_err(Into::into)
-    }
-
-    /// Check ruma-common with `ruma_identifiers_storage="Arc"`
-    fn msrv_owned_id_arc(&self) -> Result<()> {
-        cmd!(&self.sh, "rustup run {MSRV} cargo check -p ruma-common")
-            .env("RUSTFLAGS", "--cfg=ruma_identifiers_storage=\"Arc\"")
+            .env("RUSTFLAGS", format!("--cfg=ruma_identifiers_storage={value:?}"))
             .run()
             .map_err(Into::into)
     }

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -45,6 +45,8 @@ pub enum CiCmd {
     MsrvOwnedIdCompactstring,
     /// Check ruma-identifiers with `ruma_identifiers_storage="ArcIntern"`
     MsrvOwnedIdArcintern,
+    /// Check ruma-identifiers with `ruma_identifiers_storage="ArcInternment"`
+    MsrvOwnedIdArcinternment,
     /// Run all the tasks that use the stable version
     Stable,
     /// Check all crates with all features (stable)
@@ -129,6 +131,7 @@ impl CiTask {
             Some(CiCmd::MsrvOwnedIdSmallvec) => self.msrv_owned_id_cfg("SmallVec")?,
             Some(CiCmd::MsrvOwnedIdCompactstring) => self.msrv_owned_id_cfg("CompactString")?,
             Some(CiCmd::MsrvOwnedIdArcintern) => self.msrv_owned_id_cfg("ArcIntern")?,
+            Some(CiCmd::MsrvOwnedIdArcinternment) => self.msrv_owned_id_cfg("ArcInternment")?,
             Some(CiCmd::Stable) => self.stable()?,
             Some(CiCmd::StableAll) => self.stable_all()?,
             Some(CiCmd::StableCommon) => self.stable_common()?,
@@ -345,6 +348,7 @@ impl CiTask {
             "
         )
         .env("CLIPPY_CONF_DIR", ".wasm")
+        .env("RUSTFLAGS", "--cfg getrandom_backend=\"wasm_js\"")
         .run()
         .map_err(Into::into)
     }


### PR DESCRIPTION
`ruma_identifiers_storage` values added:

- `ArcStr`: `ArcStr` from [`arcstr`](https://crates.io/crates/arcstr)
- `SmallVec`: `SmallVec<[u8; N]>` from [`smallvec`](https://crates.io/crates/smallvec)
- `CompactString`: `CompactString` from [`compact_str`](https://crates.io/crates/compact_str) (#1199)
- `ArcIntern`: `ArcIntern<str>` from [`arc-interner`](https://crates.io/crates/arc-interner) (#1198)
- ~~`EcoString`: `EcoString` from [`ecow`](https://crates.io/crates/ecow)~~ Removed because it didn't bring anything in the first batch of benchmarks
- `ArcInternment`: `ArcIntern<str>` from [`internment`](https://crates.io/crates/internment) (seems better maintained than `arc-interner`)
