### PR TITLE
rtc: Support video and audio call intent in rtc notifications

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -30,6 +30,8 @@ Improvements:
   `Unstable`. The new `InvitePermissionConfigEventContent` struct uses the new
   format with a `default_action` field instead of `block_all`.
 - Add support for to-device event for pushing secrets, according to MSC4385.
+- Add support for video/audio call intent according to MSC4075 as part of the 
+  `RtcNotificationEventContent` new `call_intent` field.
 
 # 0.32.1
 

--- a/crates/ruma-events/src/rtc/notification.rs
+++ b/crates/ruma-events/src/rtc/notification.rs
@@ -45,6 +45,7 @@ pub struct RtcNotificationEventContent {
     pub notification_type: NotificationType,
 
     /// Gives a soft indication of whether the call is a "audio" or "video" (+audio) call.
+    ///
     /// This is just to indicate between trusted callers that they can start with audio or video
     /// off, but the actual call semantics remain the same, and they may switch at will.
     #[serde(rename = "m.call.intent", skip_serializing_if = "Option::is_none")]
@@ -132,9 +133,11 @@ pub enum NotificationType {
 pub enum CallIntent {
     /// Soft indication from the sender that the call is intended for audio.
     Audio,
+
     /// Soft indication from the sender that the call is intended for video.
     /// Hence that the receiver should start with camera enabled.
     Video,
+
     #[doc(hidden)]
     _Custom(PrivOwnedStr),
 }
@@ -219,6 +222,7 @@ mod tests {
         assert_eq!(serde_json::to_string(&CallIntent::Audio).unwrap(), r#""audio""#);
         assert_eq!(serde_json::to_string(&CallIntent::Video).unwrap(), r#""video""#);
     }
+
     #[test]
     fn notification_event_deserialization() {
         let json_data = json!({

--- a/crates/ruma-events/src/rtc/notification.rs
+++ b/crates/ruma-events/src/rtc/notification.rs
@@ -207,7 +207,7 @@ mod tests {
                 "event_id": "$IACrEkEKgDa-n4cMk-lEJ3vqLLUL9zX1nVyAnpmFaec",
                 "rel_type": "m.reference"
             },
-            "sender_ts": 17709890710_u64,
+            "sender_ts": 17_709_890_710_u64,
             "lifetime": 30000,
         });
         let content: RtcNotificationEventContent = from_json_value(raw_content).unwrap();


### PR DESCRIPTION
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->

Support for reading the intent from the notification event (m.call.intent in notification event as per [MSC4075](https://github.com/matrix-org/matrix-spec-proposals/pull/4075))

Parity with js-sdk implementation
https://github.com/matrix-org/matrix-js-sdk/blob/bd6547c0814e11b41e79de3cc9d0d4ecf7648272/src/matrixrtc/types.ts#L150