### PR TITLE
identifiers: Rely on inner type's `Eq` and `Ord` implementations for Owned* IDs

### DIFF
--- a/crates/ruma-macros/src/identifiers/id_dst.rs
+++ b/crates/ruma-macros/src/identifiers/id_dst.rs
@@ -313,7 +313,7 @@ impl IdDst {
             #[automatically_derived]
             impl #impl_generics ::std::cmp::PartialEq for #owned_id {
                 fn eq(&self, other: &Self) -> bool {
-                    self.as_inner_str() == other.as_inner_str()
+                    self.inner.eq(&other.inner)
                 }
             }
 
@@ -330,7 +330,7 @@ impl IdDst {
             #[automatically_derived]
             impl #impl_generics ::std::cmp::Ord for #owned_id {
                 fn cmp(&self, other: &Self) -> ::std::cmp::Ordering {
-                    self.as_inner_str().cmp(other.as_inner_str())
+                    self.inner.cmp(&other.inner)
                 }
             }
 


### PR DESCRIPTION
Some inner representations might have more efficient implementations than string comparison.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
