### PR TITLE
identifiers: Add constructor for V2 and V3 event ID formats

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -13,6 +13,8 @@ Breaking changes:
 - The `IdDst` macro doesn't generate methods and trait implementations anymore
   for `Box{id}`, `Arc<id>` and `Rc<{id}>`. Using `Owned{id}` should be
   preferred.
+- `EventId::new()` was renamed to `EventId::new_v1()`, since it works only for
+  the first format of event IDs.
 
 Improvements:
 
@@ -31,6 +33,8 @@ Improvements:
 - Identifier types implement `(Try)From<Box<str>>`, `(Try)From<Cow<'a, str>>`
   and `PartialEq<Cow<'a, str>>` and conversions between owned types try not to
   reallocate when possible.
+- Add `EventId::new_v2_or_v3()` to construct event IDs formats which are based
+  on the event reference hash.
 
 # 0.17.1
 

--- a/crates/ruma-common/src/identifiers/event_id.rs
+++ b/crates/ruma-common/src/identifiers/event_id.rs
@@ -2,7 +2,7 @@
 
 use ruma_macros::IdDst;
 
-use super::ServerName;
+use super::{IdParseError, ServerName};
 
 /// A Matrix [event ID].
 ///
@@ -18,17 +18,35 @@ use super::ServerName;
 /// `EventId` are only relevant to the original event format.
 ///
 /// ```
-/// # use ruma_common::EventId;
-/// // Original format
+/// # use ruma_common::{server_name, EventId};
+/// // Room versions 1 and 2
 /// assert_eq!(<&EventId>::try_from("$h29iv0s8:example.com").unwrap(), "$h29iv0s8:example.com");
-/// // Room version 3 format
+///
+/// # #[cfg(feature = "rand")]
+/// # {
+/// let server_name = server_name!("example.com");
+/// let event_id = EventId::new_v1(server_name);
+/// assert_eq!(event_id.localpart().len(), 18);
+/// assert_eq!(event_id.server_name(), Some(server_name));
+/// # }
+///
+/// // Room version 3
 /// assert_eq!(
 ///     <&EventId>::try_from("$acR1l0raoZnm60CBwAVgqbZqoO/mYU81xysh1u7XcJk").unwrap(),
 ///     "$acR1l0raoZnm60CBwAVgqbZqoO/mYU81xysh1u7XcJk"
 /// );
-/// // Room version 4 format
+/// assert_eq!(
+///     EventId::new_v2_or_v3("acR1l0raoZnm60CBwAVgqbZqoO/mYU81xysh1u7XcJk").unwrap(),
+///     "$acR1l0raoZnm60CBwAVgqbZqoO/mYU81xysh1u7XcJk"
+/// );
+///
+/// // Room version 4 and later
 /// assert_eq!(
 ///     <&EventId>::try_from("$Rqnc-F-dvnEYJTyHq_iKxU2bZ1CI92-kuZq3a5lr5Zg").unwrap(),
+///     "$Rqnc-F-dvnEYJTyHq_iKxU2bZ1CI92-kuZq3a5lr5Zg"
+/// );
+/// assert_eq!(
+///     EventId::new_v2_or_v3("Rqnc-F-dvnEYJTyHq_iKxU2bZ1CI92-kuZq3a5lr5Zg").unwrap(),
 ///     "$Rqnc-F-dvnEYJTyHq_iKxU2bZ1CI92-kuZq3a5lr5Zg"
 /// );
 /// ```
@@ -41,18 +59,42 @@ use super::ServerName;
 pub struct EventId(str);
 
 impl EventId {
-    /// Attempts to generate an `EventId` for the given origin server with a localpart consisting
-    /// of 18 random ASCII characters.
+    /// Attempts to generate an `OwnedEventId` for the given origin server with a localpart
+    /// consisting of 18 random ASCII characters.
     ///
-    /// This should only be used for events in the original format  as used by Matrix room versions
-    /// 1 and 2.
+    /// This generates an event ID matching the [`EventIdFormatVersion::V1`] variant of the
+    /// `event_id_format` field of [`RoomVersionRules`]. To construct an event ID matching the
+    /// [`EventIdFormatVersion::V2`] or [`EventIdFormatVersion::V3`] variants, use
+    /// [`EventId::new_v2_or_v3()`] instead.
+    ///
+    /// [`EventIdFormatVersion::V1`]: crate::room_version_rules::EventIdFormatVersion::V1
+    /// [`EventIdFormatVersion::V2`]: crate::room_version_rules::EventIdFormatVersion::V2
+    /// [`EventIdFormatVersion::V3`]: crate::room_version_rules::EventIdFormatVersion::V3
+    /// [`RoomVersionRules`]: crate::room_version_rules::RoomVersionRules
     #[cfg(feature = "rand")]
     #[allow(clippy::new_ret_no_self)]
-    pub fn new(server_name: &ServerName) -> OwnedEventId {
+    pub fn new_v1(server_name: &ServerName) -> OwnedEventId {
         OwnedEventId::from_string_unchecked(format!(
             "${}:{server_name}",
             super::generate_localpart(18)
         ))
+    }
+
+    /// Construct an `OwnedEventId` using the reference hash of the event.
+    ///
+    /// This generates a room ID matching the [`EventIdFormatVersion::V2`] or
+    /// [`EventIdFormatVersion::V3`] variants of the `event_id_format` field of
+    /// [`RoomVersionRules`]. To construct an event ID matching the [`EventIdFormatVersion::V1`]
+    /// variant, use [`EventId::new_v1()`] instead.
+    ///
+    /// Returns an error if the given string contains a NUL byte or is too long.
+    ///
+    /// [`EventIdFormatVersion::V1`]: crate::room_version_rules::EventIdFormatVersion::V1
+    /// [`EventIdFormatVersion::V2`]: crate::room_version_rules::EventIdFormatVersion::V2
+    /// [`EventIdFormatVersion::V3`]: crate::room_version_rules::EventIdFormatVersion::V3
+    /// [`RoomVersionRules`]: crate::room_version_rules::RoomVersionRules
+    pub fn new_v2_or_v3(reference_hash: &str) -> Result<OwnedEventId, IdParseError> {
+        OwnedEventId::try_from(format!("${reference_hash}"))
     }
 
     /// Returns the event's unique ID.
@@ -113,11 +155,13 @@ mod tests {
     fn generate_random_valid_event_id() {
         use crate::server_name;
 
-        let event_id = EventId::new(server_name!("example.com"));
+        let server_name = server_name!("example.com");
+        let event_id = EventId::new_v1(server_name);
         let id_str = event_id.as_str();
 
         assert!(id_str.starts_with('$'));
         assert_eq!(id_str.len(), 31);
+        assert_eq!(event_id.server_name(), Some(server_name));
     }
 
     #[test]
@@ -244,6 +288,14 @@ mod tests {
         assert_eq!(
             <&EventId>::try_from("$39hvsi03hlne:example.com:notaport").unwrap_err(),
             IdParseError::InvalidServerName
+        );
+    }
+
+    #[test]
+    fn construct_v2_or_v3_event_id() {
+        assert_eq!(
+            EventId::new_v2_or_v3("Rqnc-F-dvnEYJTyHq_iKxU2bZ1CI92-kuZq3a5lr5Zg").unwrap(),
+            "$Rqnc-F-dvnEYJTyHq_iKxU2bZ1CI92-kuZq3a5lr5Zg"
         );
     }
 }


### PR DESCRIPTION
Like we have for room ID formats. And rename `new()` to `new_v1()`.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
