### PR TITLE
client-api: Improve non-exhaustiveness of `BackupAlgorithm`

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -9,6 +9,8 @@ Breaking changes:
 - The `server` module was renamed to `admin`, to make it easier to find since it
   contains all the administration endpoints, and it matches the namespace in the
   spec.
+- `BackupAlgorithm::MegolmBackupV1Curve25519AesSha2` is now a tuple variant
+  containing a non-exhaustive struct.
 
 Improvements:
 

--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -30,6 +30,9 @@ Improvements:
 - Stabilize support for the `M_INVITE_BLOCKED` error code, according to MSC4380.
 - Stabilize support for OAuth 2.0 aware clients, according to MSC3824. Unstable
   support was dropped entirely.
+- `BackupAlgorithm` can be deserialized from unsupported algorithms. The name
+  and data of the algorithm can be accessed via the `algorithm()` and
+  `auth_data()` methods respectively.
 
 # 0.22.1
 


### PR DESCRIPTION
1. Use a non-exhaustive struct for its only variant's data.
2. Allow to deserialize custom algorithms.

Part of #1083.