### PR TITLE
client-api: Make InvitationRecipient::UserId non-exhaustive

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -15,6 +15,9 @@ Breaking changes:
   `ResultGroupMapsByGroupingKey`. This is a wrapper around a map that ensure
   that each `ResultGroupMap` uses the appropriate key type for their
   `GroupingKey`. As a result, the `OwnedRoomIdOrUserId` enum was removed.
+- `InvitationRecipient::UserId` is now a tuple variant containing a
+  non-exhaustive struct, and the `reason` field of `invite_user::v3::Request`
+  was moved to `InviteUserId`, because it is not available for third-party IDs.
 
 Bug fixes:
 


### PR DESCRIPTION
And move the `reason` field from the parent `Request` to its new inner struct, because it is not available for third-party IDs.

Part of #1083.