### PR TITLE
client-api: Improve non-exhaustiveness of `UserIdentifier`

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -42,6 +42,9 @@ Breaking changes:
   change.
 - The endpoints that were using the `NoAuthentication` authentication scheme now
   use `NoAccessToken`.
+- The variants of `UserIdentifier` were changed to tuple variants containing a
+  non-exhaustive struct.
+  - `UserIdentifier::UserIdOrLocalpart` was renamed to `UserIdentifier::Matrix`.
 
 Bug fixes:
 

--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -42,8 +42,8 @@ Breaking changes:
   change.
 - The endpoints that were using the `NoAuthentication` authentication scheme now
   use `NoAccessToken`.
-- The variants of `UserIdentifier` were changed to tuple variants containing a
-  non-exhaustive struct.
+- `UserIdentifier` can now represent an identifier with a custom type, and its
+  variants were changed to tuple variants containing a non-exhaustive struct.
   - `UserIdentifier::UserIdOrLocalpart` was renamed to `UserIdentifier::Matrix`.
 
 Bug fixes:

--- a/crates/ruma-client-api/src/session/login.rs
+++ b/crates/ruma-client-api/src/session/login.rs
@@ -443,7 +443,7 @@ pub mod v3 {
             use serde_json::Value as JsonValue;
 
             use super::{LoginInfo, Password, Request, Token};
-            use crate::uiaa::UserIdentifier;
+            use crate::uiaa::{EmailUserIdentifier, UserIdentifier};
 
             let supported = SupportedVersions {
                 versions: [MatrixVersion::V1_1].into(),
@@ -476,9 +476,9 @@ pub mod v3 {
             let req: http::Request<Vec<u8>> = Request {
                 #[allow(deprecated)]
                 login_info: LoginInfo::Password(Password {
-                    identifier: Some(UserIdentifier::Email {
-                        address: "hello@example.com".to_owned(),
-                    }),
+                    identifier: Some(UserIdentifier::Email(EmailUserIdentifier::new(
+                        "hello@example.com".to_owned(),
+                    ))),
                     password: "deadbeef".to_owned(),
                     user: None,
                     address: None,

--- a/crates/ruma-client-api/src/session/login.rs
+++ b/crates/ruma-client-api/src/session/login.rs
@@ -417,8 +417,8 @@ pub mod v3 {
                 .unwrap(),
                 LoginInfo::Password(login)
             );
-            assert_matches!(login.identifier, Some(UserIdentifier::UserIdOrLocalpart(user)));
-            assert_eq!(user, "cheeky_monkey");
+            assert_matches!(login.identifier, Some(UserIdentifier::Matrix(id)));
+            assert_eq!(id.user, "cheeky_monkey");
             assert_eq!(login.password, "ilovebananas");
 
             assert_matches!(

--- a/crates/ruma-client-api/src/uiaa/auth_data.rs
+++ b/crates/ruma-client-api/src/uiaa/auth_data.rs
@@ -471,7 +471,7 @@ pub enum UserIdentifier {
 
     /// Unsupported `m.id.thirdpartyid`.
     #[doc(hidden)]
-    _CustomThirdParty(CustomThirdPartyId),
+    _CustomThirdParty(CustomThirdPartyUserIdentifier),
 }
 
 impl UserIdentifier {
@@ -480,7 +480,7 @@ impl UserIdentifier {
         match medium {
             Medium::Email => Self::Email { address },
             Medium::Msisdn => Self::Msisdn { number: address },
-            _ => Self::_CustomThirdParty(CustomThirdPartyId { medium, address }),
+            _ => Self::_CustomThirdParty(CustomThirdPartyUserIdentifier { medium, address }),
         }
     }
 
@@ -489,7 +489,7 @@ impl UserIdentifier {
         match self {
             Self::Email { address } => Some((&Medium::Email, address)),
             Self::Msisdn { number } => Some((&Medium::Msisdn, number)),
-            Self::_CustomThirdParty(CustomThirdPartyId { medium, address }) => {
+            Self::_CustomThirdParty(CustomThirdPartyUserIdentifier { medium, address }) => {
                 Some((medium, address))
             }
             _ => None,
@@ -545,8 +545,9 @@ impl From<&OwnedUserId> for MatrixUserIdentifier {
 
 /// Data for an unsupported third-party ID.
 #[doc(hidden)]
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct CustomThirdPartyId {
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(tag = "type", rename = "m.id.thirdparty")]
+pub struct CustomThirdPartyUserIdentifier {
     /// The kind of the third-party ID.
     medium: Medium,
 

--- a/crates/ruma-client-api/src/uiaa/auth_data.rs
+++ b/crates/ruma-client-api/src/uiaa/auth_data.rs
@@ -447,19 +447,7 @@ pub enum UserIdentifier {
     Msisdn(MsisdnUserIdentifier),
 
     /// A phone number as a separate country code and phone number.
-    ///
-    /// The homeserver will be responsible for canonicalizing this to the MSISDN format.
-    PhoneNumber {
-        /// The country that the phone number is from.
-        ///
-        /// This is a two-letter uppercase [ISO-3166-1 alpha-2] country code.
-        ///
-        /// [ISO-3166-1 alpha-2]: https://www.iso.org/iso-3166-country-codes.html
-        country: String,
-
-        /// The phone number.
-        phone: String,
-    },
+    PhoneNumber(PhoneNumberUserIdentifier),
 
     /// Unsupported `m.id.thirdpartyid`.
     #[doc(hidden)]
@@ -516,6 +504,12 @@ impl From<EmailUserIdentifier> for UserIdentifier {
 impl From<MsisdnUserIdentifier> for UserIdentifier {
     fn from(id: MsisdnUserIdentifier) -> Self {
         Self::Msisdn(id)
+    }
+}
+
+impl From<PhoneNumberUserIdentifier> for UserIdentifier {
+    fn from(id: PhoneNumberUserIdentifier) -> Self {
+        Self::PhoneNumber(id)
     }
 }
 
@@ -576,6 +570,31 @@ impl MsisdnUserIdentifier {
     /// Construct a new `MsisdnUserIdentifier` with the given phone number.
     pub fn new(number: String) -> Self {
         Self { number }
+    }
+}
+
+/// Data for a phone number identifier as a separate country code and phone number.
+///
+/// The homeserver is responsible for canonicalizing this to the MSISDN format.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+#[serde(tag = "type", rename = "m.id.phone")]
+pub struct PhoneNumberUserIdentifier {
+    /// The country that the phone number is from.
+    ///
+    /// This is a two-letter uppercase [ISO-3166-1 alpha-2] country code.
+    ///
+    /// [ISO-3166-1 alpha-2]: https://www.iso.org/iso-3166-country-codes.html
+    pub country: String,
+
+    /// The phone number.
+    pub phone: String,
+}
+
+impl PhoneNumberUserIdentifier {
+    /// Construct a new `PhoneNumberUserIdentifier` with the given country code and phone number.
+    pub fn new(country: String, phone: String) -> Self {
+        Self { country, phone }
     }
 }
 

--- a/crates/ruma-client-api/src/uiaa/auth_data.rs
+++ b/crates/ruma-client-api/src/uiaa/auth_data.rs
@@ -441,10 +441,7 @@ pub enum UserIdentifier {
     Matrix(MatrixUserIdentifier),
 
     /// An email address.
-    Email {
-        /// The email address.
-        address: String,
-    },
+    Email(EmailUserIdentifier),
 
     /// A phone number in the MSISDN format.
     Msisdn {
@@ -478,7 +475,7 @@ impl UserIdentifier {
     /// Creates a new `UserIdentifier` from the given third party identifier.
     pub fn third_party_id(medium: Medium, address: String) -> Self {
         match medium {
-            Medium::Email => Self::Email { address },
+            Medium::Email => Self::Email(EmailUserIdentifier { address }),
             Medium::Msisdn => Self::Msisdn { number: address },
             _ => Self::_CustomThirdParty(CustomThirdPartyUserIdentifier { medium, address }),
         }
@@ -487,7 +484,7 @@ impl UserIdentifier {
     /// Get this `UserIdentifier` as a third party identifier if it is one.
     pub fn as_third_party_id(&self) -> Option<(&Medium, &str)> {
         match self {
-            Self::Email { address } => Some((&Medium::Email, address)),
+            Self::Email(EmailUserIdentifier { address }) => Some((&Medium::Email, address)),
             Self::Msisdn { number } => Some((&Medium::Msisdn, number)),
             Self::_CustomThirdParty(CustomThirdPartyUserIdentifier { medium, address }) => {
                 Some((medium, address))
@@ -512,6 +509,12 @@ impl From<&OwnedUserId> for UserIdentifier {
 impl From<MatrixUserIdentifier> for UserIdentifier {
     fn from(id: MatrixUserIdentifier) -> Self {
         Self::Matrix(id)
+    }
+}
+
+impl From<EmailUserIdentifier> for UserIdentifier {
+    fn from(id: EmailUserIdentifier) -> Self {
+        Self::Email(id)
     }
 }
 
@@ -540,6 +543,21 @@ impl From<OwnedUserId> for MatrixUserIdentifier {
 impl From<&OwnedUserId> for MatrixUserIdentifier {
     fn from(id: &OwnedUserId) -> Self {
         Self::new(id.as_str().to_owned())
+    }
+}
+
+/// Data for a email third-party identifier.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+pub struct EmailUserIdentifier {
+    /// The email address.
+    pub address: String,
+}
+
+impl EmailUserIdentifier {
+    /// Construct a new `EmailUserIdentifier` with the given email address.
+    pub fn new(address: String) -> Self {
+        Self { address }
     }
 }
 

--- a/crates/ruma-client-api/src/uiaa/auth_data.rs
+++ b/crates/ruma-client-api/src/uiaa/auth_data.rs
@@ -444,12 +444,7 @@ pub enum UserIdentifier {
     Email(EmailUserIdentifier),
 
     /// A phone number in the MSISDN format.
-    Msisdn {
-        /// The phone number according to the [E.164] numbering plan.
-        ///
-        /// [E.164]: https://www.itu.int/rec/T-REC-E.164-201011-I/en
-        number: String,
-    },
+    Msisdn(MsisdnUserIdentifier),
 
     /// A phone number as a separate country code and phone number.
     ///
@@ -476,7 +471,7 @@ impl UserIdentifier {
     pub fn third_party_id(medium: Medium, address: String) -> Self {
         match medium {
             Medium::Email => Self::Email(EmailUserIdentifier { address }),
-            Medium::Msisdn => Self::Msisdn { number: address },
+            Medium::Msisdn => Self::Msisdn(MsisdnUserIdentifier { number: address }),
             _ => Self::_CustomThirdParty(CustomThirdPartyUserIdentifier { medium, address }),
         }
     }
@@ -485,7 +480,7 @@ impl UserIdentifier {
     pub fn as_third_party_id(&self) -> Option<(&Medium, &str)> {
         match self {
             Self::Email(EmailUserIdentifier { address }) => Some((&Medium::Email, address)),
-            Self::Msisdn { number } => Some((&Medium::Msisdn, number)),
+            Self::Msisdn(MsisdnUserIdentifier { number }) => Some((&Medium::Msisdn, number)),
             Self::_CustomThirdParty(CustomThirdPartyUserIdentifier { medium, address }) => {
                 Some((medium, address))
             }
@@ -515,6 +510,12 @@ impl From<MatrixUserIdentifier> for UserIdentifier {
 impl From<EmailUserIdentifier> for UserIdentifier {
     fn from(id: EmailUserIdentifier) -> Self {
         Self::Email(id)
+    }
+}
+
+impl From<MsisdnUserIdentifier> for UserIdentifier {
+    fn from(id: MsisdnUserIdentifier) -> Self {
+        Self::Msisdn(id)
     }
 }
 
@@ -558,6 +559,23 @@ impl EmailUserIdentifier {
     /// Construct a new `EmailUserIdentifier` with the given email address.
     pub fn new(address: String) -> Self {
         Self { address }
+    }
+}
+
+/// Data for a phone number third-party identifier in the MSISDN format.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+pub struct MsisdnUserIdentifier {
+    /// The phone number according to the [E.164] numbering plan.
+    ///
+    /// [E.164]: https://www.itu.int/rec/T-REC-E.164-201011-I/en
+    pub number: String,
+}
+
+impl MsisdnUserIdentifier {
+    /// Construct a new `MsisdnUserIdentifier` with the given phone number.
+    pub fn new(number: String) -> Self {
+        Self { number }
     }
 }
 

--- a/crates/ruma-client-api/src/uiaa/auth_data/data_serde.rs
+++ b/crates/ruma-client-api/src/uiaa/auth_data/data_serde.rs
@@ -49,39 +49,37 @@ impl Serialize for UserIdentifier {
     where
         S: serde::Serializer,
     {
-        let mut id;
         match self {
-            Self::UserIdOrLocalpart(user) => {
-                id = serializer.serialize_struct("UserIdentifier", 2)?;
-                id.serialize_field("type", "m.id.user")?;
-                id.serialize_field("user", user)?;
-            }
+            Self::Matrix(id) => id.serialize(serializer),
             Self::PhoneNumber { country, phone } => {
-                id = serializer.serialize_struct("UserIdentifier", 3)?;
+                let mut id = serializer.serialize_struct("UserIdentifier", 3)?;
                 id.serialize_field("type", "m.id.phone")?;
                 id.serialize_field("country", country)?;
                 id.serialize_field("phone", phone)?;
+                id.end()
             }
             Self::Email { address } => {
-                id = serializer.serialize_struct("UserIdentifier", 3)?;
+                let mut id = serializer.serialize_struct("UserIdentifier", 3)?;
                 id.serialize_field("type", "m.id.thirdparty")?;
                 id.serialize_field("medium", &Medium::Email)?;
                 id.serialize_field("address", address)?;
+                id.end()
             }
             Self::Msisdn { number } => {
-                id = serializer.serialize_struct("UserIdentifier", 3)?;
+                let mut id = serializer.serialize_struct("UserIdentifier", 3)?;
                 id.serialize_field("type", "m.id.thirdparty")?;
                 id.serialize_field("medium", &Medium::Msisdn)?;
                 id.serialize_field("address", number)?;
+                id.end()
             }
             Self::_CustomThirdParty(CustomThirdPartyId { medium, address }) => {
-                id = serializer.serialize_struct("UserIdentifier", 3)?;
+                let mut id = serializer.serialize_struct("UserIdentifier", 3)?;
                 id.serialize_field("type", "m.id.thirdparty")?;
                 id.serialize_field("medium", &medium)?;
                 id.serialize_field("address", address)?;
+                id.end()
             }
         }
-        id.end()
     }
 }
 
@@ -104,11 +102,6 @@ impl<'de> Deserialize<'de> for UserIdentifier {
         }
 
         #[derive(Deserialize)]
-        struct UserIdOrLocalpart {
-            user: String,
-        }
-
-        #[derive(Deserialize)]
         struct ThirdPartyId {
             medium: Medium,
             address: String,
@@ -123,8 +116,7 @@ impl<'de> Deserialize<'de> for UserIdentifier {
         let id_type = serde_json::from_str::<ExtractType>(json.get()).map_err(de::Error::custom)?;
 
         match id_type {
-            ExtractType::User => from_raw_json_value(&json)
-                .map(|user_id: UserIdOrLocalpart| Self::UserIdOrLocalpart(user_id.user)),
+            ExtractType::User => from_raw_json_value(&json).map(Self::Matrix),
             ExtractType::Phone => from_raw_json_value(&json)
                 .map(|nb: PhoneNumber| Self::PhoneNumber { country: nb.country, phone: nb.phone }),
             ExtractType::ThirdParty => {
@@ -145,12 +137,12 @@ mod tests {
     use ruma_common::canonical_json::assert_to_canonical_json_eq;
     use serde_json::{from_value as from_json_value, json};
 
-    use crate::uiaa::UserIdentifier;
+    use crate::uiaa::{MatrixUserIdentifier, UserIdentifier};
 
     #[test]
     fn serialize() {
         assert_to_canonical_json_eq!(
-            UserIdentifier::UserIdOrLocalpart("@user:notareal.hs".to_owned()),
+            UserIdentifier::Matrix(MatrixUserIdentifier::new("@user:notareal.hs".to_owned())),
             json!({
                 "type": "m.id.user",
                 "user": "@user:notareal.hs",
@@ -203,8 +195,8 @@ mod tests {
             "type": "m.id.user",
             "user": "@user:notareal.hs",
         });
-        assert_let!(Ok(UserIdentifier::UserIdOrLocalpart(user)) = from_json_value(json));
-        assert_eq!(user, "@user:notareal.hs");
+        assert_let!(Ok(UserIdentifier::Matrix(id)) = from_json_value(json));
+        assert_eq!(id.user, "@user:notareal.hs");
 
         let json = json!({
             "type": "m.id.phone",

--- a/crates/ruma-client-api/src/uiaa/auth_data/data_serde.rs
+++ b/crates/ruma-client-api/src/uiaa/auth_data/data_serde.rs
@@ -47,45 +47,25 @@ impl<'de> Deserialize<'de> for AuthData {
     }
 }
 
-impl Serialize for UserIdentifier {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        match self {
-            Self::Matrix(id) => id.serialize(serializer),
-            Self::PhoneNumber(id) => id.serialize(serializer),
-            Self::Email(id) => id.serialize(serializer),
-            Self::Msisdn(id) => id.serialize(serializer),
-            Self::_CustomThirdParty(id) => id.serialize(serializer),
-        }
-    }
-}
-
 impl<'de> Deserialize<'de> for UserIdentifier {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
-        let json = Box::<RawJsonValue>::deserialize(deserializer)?;
-
         #[derive(Deserialize)]
-        #[serde(tag = "type")]
-        enum ExtractType {
-            #[serde(rename = "m.id.user")]
-            User,
-            #[serde(rename = "m.id.phone")]
-            Phone,
-            #[serde(rename = "m.id.thirdparty")]
-            ThirdParty,
+        struct ExtractType<'a> {
+            #[serde(borrow, rename = "type")]
+            identifier_type: Cow<'a, str>,
         }
 
-        let id_type = serde_json::from_str::<ExtractType>(json.get()).map_err(de::Error::custom)?;
+        let json = Box::<RawJsonValue>::deserialize(deserializer)?;
+        let ExtractType { identifier_type } =
+            serde_json::from_str(json.get()).map_err(de::Error::custom)?;
 
-        match id_type {
-            ExtractType::User => from_raw_json_value(&json).map(Self::Matrix),
-            ExtractType::Phone => from_raw_json_value(&json).map(Self::PhoneNumber),
-            ExtractType::ThirdParty => {
+        match identifier_type.as_ref() {
+            "m.id.user" => from_raw_json_value(&json).map(Self::Matrix),
+            "m.id.phone" => from_raw_json_value(&json).map(Self::PhoneNumber),
+            "m.id.thirdparty" => {
                 let id: CustomThirdPartyUserIdentifier = from_raw_json_value(&json)?;
                 match &id.medium {
                     Medium::Email => Ok(Self::Email(EmailUserIdentifier { address: id.address })),
@@ -93,6 +73,7 @@ impl<'de> Deserialize<'de> for UserIdentifier {
                     _ => Ok(Self::_CustomThirdParty(id)),
                 }
             }
+            _ => from_raw_json_value(&json).map(Self::_Custom),
         }
     }
 }
@@ -163,7 +144,7 @@ impl<'de> Deserialize<'de> for MsisdnUserIdentifier {
 mod tests {
     use assert_matches2::assert_let;
     use ruma_common::canonical_json::assert_to_canonical_json_eq;
-    use serde_json::{from_value as from_json_value, json};
+    use serde_json::{Value as JsonValue, from_value as from_json_value, json};
 
     use crate::uiaa::{
         EmailUserIdentifier, MatrixUserIdentifier, MsisdnUserIdentifier, PhoneNumberUserIdentifier,
@@ -266,5 +247,21 @@ mod tests {
         let (medium, address) = id.as_third_party_id().unwrap();
         assert_eq!(medium.as_str(), "robot");
         assert_eq!(address, "01110010");
+    }
+
+    #[test]
+    fn custom_identifier_roundtrip() {
+        let json = json!({
+            "type": "local.dev.identifier",
+            "foo": "bar",
+        });
+
+        let id = from_json_value::<UserIdentifier>(json.clone()).unwrap();
+        assert_eq!(id.identifier_type(), "local.dev.identifier");
+        let data = id.custom_identifier_data().unwrap();
+        assert_let!(Some(JsonValue::String(foo)) = data.get("foo"));
+        assert_eq!(foo, "bar");
+
+        assert_to_canonical_json_eq!(id, json);
     }
 }

--- a/crates/ruma-client-api/src/uiaa/auth_data/data_serde.rs
+++ b/crates/ruma-client-api/src/uiaa/auth_data/data_serde.rs
@@ -3,7 +3,7 @@
 use std::borrow::Cow;
 
 use ruma_common::{serde::from_raw_json_value, thirdparty::Medium};
-use serde::{Deserialize, Deserializer, Serialize, de, ser::SerializeStruct};
+use serde::{Deserialize, Deserializer, Serialize, de};
 use serde_json::value::RawValue as RawJsonValue;
 
 use super::{
@@ -54,13 +54,7 @@ impl Serialize for UserIdentifier {
     {
         match self {
             Self::Matrix(id) => id.serialize(serializer),
-            Self::PhoneNumber { country, phone } => {
-                let mut id = serializer.serialize_struct("UserIdentifier", 3)?;
-                id.serialize_field("type", "m.id.phone")?;
-                id.serialize_field("country", country)?;
-                id.serialize_field("phone", phone)?;
-                id.end()
-            }
+            Self::PhoneNumber(id) => id.serialize(serializer),
             Self::Email(id) => id.serialize(serializer),
             Self::Msisdn(id) => id.serialize(serializer),
             Self::_CustomThirdParty(id) => id.serialize(serializer),
@@ -86,18 +80,11 @@ impl<'de> Deserialize<'de> for UserIdentifier {
             ThirdParty,
         }
 
-        #[derive(Deserialize)]
-        struct PhoneNumber {
-            country: String,
-            phone: String,
-        }
-
         let id_type = serde_json::from_str::<ExtractType>(json.get()).map_err(de::Error::custom)?;
 
         match id_type {
             ExtractType::User => from_raw_json_value(&json).map(Self::Matrix),
-            ExtractType::Phone => from_raw_json_value(&json)
-                .map(|nb: PhoneNumber| Self::PhoneNumber { country: nb.country, phone: nb.phone }),
+            ExtractType::Phone => from_raw_json_value(&json).map(Self::PhoneNumber),
             ExtractType::ThirdParty => {
                 let id: CustomThirdPartyUserIdentifier = from_raw_json_value(&json)?;
                 match &id.medium {
@@ -179,7 +166,8 @@ mod tests {
     use serde_json::{from_value as from_json_value, json};
 
     use crate::uiaa::{
-        EmailUserIdentifier, MatrixUserIdentifier, MsisdnUserIdentifier, UserIdentifier,
+        EmailUserIdentifier, MatrixUserIdentifier, MsisdnUserIdentifier, PhoneNumberUserIdentifier,
+        UserIdentifier,
     };
 
     #[test]
@@ -193,10 +181,10 @@ mod tests {
         );
 
         assert_to_canonical_json_eq!(
-            UserIdentifier::PhoneNumber {
-                country: "33".to_owned(),
-                phone: "0102030405".to_owned()
-            },
+            UserIdentifier::PhoneNumber(PhoneNumberUserIdentifier::new(
+                "33".to_owned(),
+                "0102030405".to_owned()
+            )),
             json!({
                 "type": "m.id.phone",
                 "country": "33",
@@ -246,7 +234,10 @@ mod tests {
             "country": "33",
             "phone": "0102030405",
         });
-        assert_let!(Ok(UserIdentifier::PhoneNumber { country, phone }) = from_json_value(json));
+        assert_let!(
+            Ok(UserIdentifier::PhoneNumber(PhoneNumberUserIdentifier { country, phone })) =
+                from_json_value(json)
+        );
         assert_eq!(country, "33");
         assert_eq!(phone, "0102030405");
 

--- a/crates/ruma-client-api/src/uiaa/auth_data/data_serde.rs
+++ b/crates/ruma-client-api/src/uiaa/auth_data/data_serde.rs
@@ -6,7 +6,10 @@ use ruma_common::{serde::from_raw_json_value, thirdparty::Medium};
 use serde::{Deserialize, Deserializer, Serialize, de, ser::SerializeStruct};
 use serde_json::value::RawValue as RawJsonValue;
 
-use super::{AuthData, CustomThirdPartyUserIdentifier, EmailUserIdentifier, UserIdentifier};
+use super::{
+    AuthData, CustomThirdPartyUserIdentifier, EmailUserIdentifier, MsisdnUserIdentifier,
+    UserIdentifier,
+};
 
 impl<'de> Deserialize<'de> for AuthData {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -59,13 +62,7 @@ impl Serialize for UserIdentifier {
                 id.end()
             }
             Self::Email(id) => id.serialize(serializer),
-            Self::Msisdn { number } => {
-                let mut id = serializer.serialize_struct("UserIdentifier", 3)?;
-                id.serialize_field("type", "m.id.thirdparty")?;
-                id.serialize_field("medium", &Medium::Msisdn)?;
-                id.serialize_field("address", number)?;
-                id.end()
-            }
+            Self::Msisdn(id) => id.serialize(serializer),
             Self::_CustomThirdParty(id) => id.serialize(serializer),
         }
     }
@@ -105,7 +102,7 @@ impl<'de> Deserialize<'de> for UserIdentifier {
                 let id: CustomThirdPartyUserIdentifier = from_raw_json_value(&json)?;
                 match &id.medium {
                     Medium::Email => Ok(Self::Email(EmailUserIdentifier { address: id.address })),
-                    Medium::Msisdn => Ok(Self::Msisdn { number: id.address }),
+                    Medium::Msisdn => Ok(Self::Msisdn(MsisdnUserIdentifier { number: id.address })),
                     _ => Ok(Self::_CustomThirdParty(id)),
                 }
             }
@@ -144,13 +141,46 @@ impl<'de> Deserialize<'de> for EmailUserIdentifier {
     }
 }
 
+impl Serialize for MsisdnUserIdentifier {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let Self { number } = self;
+
+        CustomThirdPartyUserIdentifier { medium: Medium::Msisdn, address: number.clone() }
+            .serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for MsisdnUserIdentifier {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let CustomThirdPartyUserIdentifier { medium, address } =
+            CustomThirdPartyUserIdentifier::deserialize(deserializer)?;
+
+        if medium != Medium::Msisdn {
+            return Err(de::Error::invalid_value(
+                de::Unexpected::Str(medium.as_str()),
+                &Medium::Msisdn.as_str(),
+            ));
+        }
+
+        Ok(Self { number: address })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use assert_matches2::assert_let;
     use ruma_common::canonical_json::assert_to_canonical_json_eq;
     use serde_json::{from_value as from_json_value, json};
 
-    use crate::uiaa::{EmailUserIdentifier, MatrixUserIdentifier, UserIdentifier};
+    use crate::uiaa::{
+        EmailUserIdentifier, MatrixUserIdentifier, MsisdnUserIdentifier, UserIdentifier,
+    };
 
     #[test]
     fn serialize() {
@@ -184,7 +214,7 @@ mod tests {
         );
 
         assert_to_canonical_json_eq!(
-            UserIdentifier::Msisdn { number: "330102030405".to_owned() },
+            UserIdentifier::Msisdn(MsisdnUserIdentifier::new("330102030405".to_owned())),
             json!({
                 "type": "m.id.thirdparty",
                 "medium": "msisdn",
@@ -233,8 +263,8 @@ mod tests {
             "medium": "msisdn",
             "address": "330102030405",
         });
-        assert_let!(Ok(UserIdentifier::Msisdn { number }) = from_json_value(json));
-        assert_eq!(number, "330102030405");
+        assert_let!(Ok(UserIdentifier::Msisdn(id)) = from_json_value(json));
+        assert_eq!(id.number, "330102030405");
 
         let json = json!({
             "type": "m.id.thirdparty",

--- a/crates/ruma-client-api/src/uiaa/auth_data/data_serde.rs
+++ b/crates/ruma-client-api/src/uiaa/auth_data/data_serde.rs
@@ -6,7 +6,7 @@ use ruma_common::{serde::from_raw_json_value, thirdparty::Medium};
 use serde::{Deserialize, Deserializer, Serialize, de, ser::SerializeStruct};
 use serde_json::value::RawValue as RawJsonValue;
 
-use super::{AuthData, CustomThirdPartyUserIdentifier, UserIdentifier};
+use super::{AuthData, CustomThirdPartyUserIdentifier, EmailUserIdentifier, UserIdentifier};
 
 impl<'de> Deserialize<'de> for AuthData {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -58,13 +58,7 @@ impl Serialize for UserIdentifier {
                 id.serialize_field("phone", phone)?;
                 id.end()
             }
-            Self::Email { address } => {
-                let mut id = serializer.serialize_struct("UserIdentifier", 3)?;
-                id.serialize_field("type", "m.id.thirdparty")?;
-                id.serialize_field("medium", &Medium::Email)?;
-                id.serialize_field("address", address)?;
-                id.end()
-            }
+            Self::Email(id) => id.serialize(serializer),
             Self::Msisdn { number } => {
                 let mut id = serializer.serialize_struct("UserIdentifier", 3)?;
                 id.serialize_field("type", "m.id.thirdparty")?;
@@ -110,12 +104,43 @@ impl<'de> Deserialize<'de> for UserIdentifier {
             ExtractType::ThirdParty => {
                 let id: CustomThirdPartyUserIdentifier = from_raw_json_value(&json)?;
                 match &id.medium {
-                    Medium::Email => Ok(Self::Email { address: id.address }),
+                    Medium::Email => Ok(Self::Email(EmailUserIdentifier { address: id.address })),
                     Medium::Msisdn => Ok(Self::Msisdn { number: id.address }),
                     _ => Ok(Self::_CustomThirdParty(id)),
                 }
             }
         }
+    }
+}
+
+impl Serialize for EmailUserIdentifier {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let Self { address } = self;
+
+        CustomThirdPartyUserIdentifier { medium: Medium::Email, address: address.clone() }
+            .serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for EmailUserIdentifier {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let CustomThirdPartyUserIdentifier { medium, address } =
+            CustomThirdPartyUserIdentifier::deserialize(deserializer)?;
+
+        if medium != Medium::Email {
+            return Err(de::Error::invalid_value(
+                de::Unexpected::Str(medium.as_str()),
+                &Medium::Email.as_str(),
+            ));
+        }
+
+        Ok(Self { address })
     }
 }
 
@@ -125,7 +150,7 @@ mod tests {
     use ruma_common::canonical_json::assert_to_canonical_json_eq;
     use serde_json::{from_value as from_json_value, json};
 
-    use crate::uiaa::{MatrixUserIdentifier, UserIdentifier};
+    use crate::uiaa::{EmailUserIdentifier, MatrixUserIdentifier, UserIdentifier};
 
     #[test]
     fn serialize() {
@@ -150,7 +175,7 @@ mod tests {
         );
 
         assert_to_canonical_json_eq!(
-            UserIdentifier::Email { address: "me@myprovider.net".to_owned() },
+            UserIdentifier::Email(EmailUserIdentifier::new("me@myprovider.net".to_owned())),
             json!({
                 "type": "m.id.thirdparty",
                 "medium": "email",
@@ -200,8 +225,8 @@ mod tests {
             "medium": "email",
             "address": "me@myprovider.net",
         });
-        assert_let!(Ok(UserIdentifier::Email { address }) = from_json_value(json));
-        assert_eq!(address, "me@myprovider.net");
+        assert_let!(Ok(UserIdentifier::Email(id)) = from_json_value(json));
+        assert_eq!(id.address, "me@myprovider.net");
 
         let json = json!({
             "type": "m.id.thirdparty",

--- a/crates/ruma-client-api/tests/it/uiaa.rs
+++ b/crates/ruma-client-api/tests/it/uiaa.rs
@@ -16,16 +16,16 @@ use serde_json::{
 };
 
 #[test]
-fn deserialize_user_identifier() {
+fn deserialize_matrix_user_identifier() {
     assert_matches!(
         from_json_value(json!({
             "type": "m.id.user",
             "user": "cheeky_monkey"
         }))
         .unwrap(),
-        UserIdentifier::UserIdOrLocalpart(id)
+        UserIdentifier::Matrix(id)
     );
-    assert_eq!(id, "cheeky_monkey");
+    assert_eq!(id.user, "cheeky_monkey");
 }
 
 #[test]


### PR DESCRIPTION
Make its variants contain non-exhaustive structs and allow custom identifier types.

Part of #1083.