### PR TITLE
push: Disallow to construct custom `Action`s and `Tweak`s directly

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -20,6 +20,9 @@ Breaking changes:
   tokens for APIs that don't use them as a form of authentication. The new
   `NoAccessToken` authentication scheme should be used instead for APIs that
   rely on access tokens as a form of authentication.
+- It is no longer possible to construct custom `Action` types directly through
+  the hidden `_Custom` variant. They should be constructed with `Action::new()`
+  and their data should be accessed with `Action::custom_data()`.
 
 Improvements:
 

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -23,6 +23,10 @@ Breaking changes:
 - It is no longer possible to construct custom `Action` types directly through
   the hidden `_Custom` variant. They should be constructed with `Action::new()`
   and their data should be accessed with `Action::custom_data()`.
+- The `Tweak` type uses stronger enum types for its variants, and the `Custom`
+  variant is now hidden and cannot be constructed directly. It should be
+  constructed with `Tweak::new()` and its data should be accessed with
+  `Tweak::set_tweak()` and `Tweak::custom_value()`.
 
 Improvements:
 

--- a/crates/ruma-common/src/push.rs
+++ b/crates/ruma-common/src/push.rs
@@ -1500,16 +1500,9 @@ mod tests {
 
         assert_matches!(
             set.get_actions(&message, &CONTEXT_ONE_TO_ONE).await,
-            [
-                Action::Notify,
-                Action::SetTweak(Tweak::Sound(_)),
-                Action::SetTweak(Tweak::Highlight(false))
-            ]
+            [Action::Notify, Action::SetTweak(Tweak::Sound(_)),]
         );
-        assert_matches!(
-            set.get_actions(&message, &CONTEXT_PUBLIC_ROOM).await,
-            [Action::Notify, Action::SetTweak(Tweak::Highlight(false))]
-        );
+        assert_matches!(set.get_actions(&message, &CONTEXT_PUBLIC_ROOM).await, [Action::Notify]);
 
         let user_mention = serde_json::from_str::<Raw<JsonValue>>(
             r#"{

--- a/crates/ruma-common/src/push.rs
+++ b/crates/ruma-common/src/push.rs
@@ -34,7 +34,7 @@ mod predefined;
 #[cfg(feature = "unstable-msc3932")]
 pub use self::condition::RoomVersionFeature;
 pub use self::{
-    action::{Action, Tweak},
+    action::{Action, HighlightTweakValue, SoundTweakValue, Tweak},
     condition::{
         _CustomPushCondition, ComparisonOperator, FlattenedJson, FlattenedJsonValue, PushCondition,
         PushConditionPowerLevelsCtx, PushConditionRoomCtx, RoomMemberCountIs, ScalarJsonValue,
@@ -1049,7 +1049,9 @@ mod tests {
     use crate::{
         assert_to_canonical_json_eq, owned_room_id, owned_user_id,
         power_levels::NotificationPowerLevels,
-        push::{PredefinedContentRuleId, PredefinedOverrideRuleId},
+        push::{
+            HighlightTweakValue, PredefinedContentRuleId, PredefinedOverrideRuleId, SoundTweakValue,
+        },
         room_version_rules::{AuthorizationRules, RoomPowerLevelsRules},
         serde::Raw,
         user_id,
@@ -1063,7 +1065,10 @@ mod tests {
                 key: "type".into(),
                 pattern: "m.call.invite".into(),
             }],
-            actions: vec![Action::Notify, Action::SetTweak(Tweak::Highlight(true))],
+            actions: vec![
+                Action::Notify,
+                Action::SetTweak(Tweak::Highlight(HighlightTweakValue::Yes)),
+            ],
             rule_id: ".m.rule.call".into(),
             enabled: true,
             default: true,
@@ -1151,7 +1156,10 @@ mod tests {
     #[test]
     fn serialize_conditional_push_rule() {
         let rule = ConditionalPushRule {
-            actions: vec![Action::Notify, Action::SetTweak(Tweak::Highlight(true))],
+            actions: vec![
+                Action::Notify,
+                Action::SetTweak(Tweak::Highlight(HighlightTweakValue::Yes)),
+            ],
             default: true,
             enabled: true,
             rule_id: ".m.rule.call".into(),
@@ -1225,11 +1233,14 @@ mod tests {
         let rule = PatternedPushRule {
             actions: vec![
                 Action::Notify,
-                Action::SetTweak(Tweak::Sound("default".into())),
-                Action::SetTweak(Tweak::Custom {
-                    name: "dance".into(),
-                    value: RawJsonValue::from_string("true".into()).unwrap(),
-                }),
+                Action::SetTweak(Tweak::Sound(SoundTweakValue::Default)),
+                Action::SetTweak(
+                    Tweak::new(
+                        "dance".into(),
+                        Some(RawJsonValue::from_string("true".into()).unwrap()),
+                    )
+                    .unwrap(),
+                ),
             ],
             default: true,
             enabled: true,
@@ -1270,8 +1281,8 @@ mod tests {
             ],
             actions: vec![
                 Action::Notify,
-                Action::SetTweak(Tweak::Sound("default".into())),
-                Action::SetTweak(Tweak::Highlight(false)),
+                Action::SetTweak(Tweak::Sound(SoundTweakValue::Default)),
+                Action::SetTweak(Tweak::Highlight(HighlightTweakValue::No)),
             ],
             rule_id: ".m.rule.room_one_to_one".into(),
             enabled: true,
@@ -1280,8 +1291,8 @@ mod tests {
         set.content.insert(PatternedPushRule {
             actions: vec![
                 Action::Notify,
-                Action::SetTweak(Tweak::Sound("default".into())),
-                Action::SetTweak(Tweak::Highlight(true)),
+                Action::SetTweak(Tweak::Sound(SoundTweakValue::Default)),
+                Action::SetTweak(Tweak::Highlight(HighlightTweakValue::Yes)),
             ],
             rule_id: ".m.rule.contains_user_name".into(),
             pattern: "user_id".into(),
@@ -1388,9 +1399,14 @@ mod tests {
 
         let mut iter = rule.actions.iter();
         assert_matches!(iter.next(), Some(Action::Notify));
-        assert_let!(Some(Action::SetTweak(Tweak::Sound(sound))) = iter.next());
-        assert_eq!(sound, "default");
-        assert_matches!(iter.next(), Some(Action::SetTweak(Tweak::Highlight(true))));
+        assert_matches!(
+            iter.next(),
+            Some(Action::SetTweak(Tweak::Sound(SoundTweakValue::Default)))
+        );
+        assert_matches!(
+            iter.next(),
+            Some(Action::SetTweak(Tweak::Highlight(HighlightTweakValue::Yes)))
+        );
         assert_matches!(iter.next(), None);
     }
 
@@ -1522,7 +1538,7 @@ mod tests {
             [
                 Action::Notify,
                 Action::SetTweak(Tweak::Sound(_)),
-                Action::SetTweak(Tweak::Highlight(true)),
+                Action::SetTweak(Tweak::Highlight(HighlightTweakValue::Yes)),
             ]
         );
         assert_matches!(
@@ -1530,7 +1546,7 @@ mod tests {
             [
                 Action::Notify,
                 Action::SetTweak(Tweak::Sound(_)),
-                Action::SetTweak(Tweak::Highlight(true)),
+                Action::SetTweak(Tweak::Highlight(HighlightTweakValue::Yes)),
             ]
         );
 
@@ -1562,7 +1578,7 @@ mod tests {
 
         assert_matches!(
             set.get_actions(&room_mention, &CONTEXT_PUBLIC_ROOM).await,
-            [Action::Notify, Action::SetTweak(Tweak::Highlight(true))]
+            [Action::Notify, Action::SetTweak(Tweak::Highlight(HighlightTweakValue::Yes))]
         );
 
         let empty = serde_json::from_str::<Raw<JsonValue>>(r#"{}"#).unwrap();
@@ -1599,7 +1615,7 @@ mod tests {
         assert_matches!(test_set.get_actions(&message, &CONTEXT_ONE_TO_ONE).await, []);
 
         let no_conditions = ConditionalPushRule {
-            actions: vec![Action::SetTweak(Tweak::Highlight(true))],
+            actions: vec![Action::SetTweak(Tweak::Highlight(HighlightTweakValue::Yes))],
             default: false,
             enabled: true,
             rule_id: "no.conditions".into(),
@@ -1610,7 +1626,7 @@ mod tests {
         let test_set = set.clone();
         assert_matches!(
             test_set.get_actions(&message, &CONTEXT_ONE_TO_ONE).await,
-            [Action::SetTweak(Tweak::Highlight(true))]
+            [Action::SetTweak(Tweak::Highlight(HighlightTweakValue::Yes))]
         );
 
         let sender = SimplePushRule {
@@ -1628,7 +1644,7 @@ mod tests {
         );
 
         let room = SimplePushRule {
-            actions: vec![Action::SetTweak(Tweak::Highlight(true))],
+            actions: vec![Action::SetTweak(Tweak::Highlight(HighlightTweakValue::Yes))],
             default: false,
             enabled: true,
             rule_id: owned_room_id!("!dm:server.name"),
@@ -1638,7 +1654,7 @@ mod tests {
         let test_set = set.clone();
         assert_matches!(
             test_set.get_actions(&message, &CONTEXT_ONE_TO_ONE).await,
-            [Action::SetTweak(Tweak::Highlight(true))]
+            [Action::SetTweak(Tweak::Highlight(HighlightTweakValue::Yes))]
         );
 
         let content = PatternedPushRule {
@@ -1655,7 +1671,7 @@ mod tests {
             test_set.get_actions(&message, &CONTEXT_ONE_TO_ONE).await,
             [Action::SetTweak(Tweak::Sound(sound))]
         );
-        assert_eq!(sound, "content");
+        assert_eq!(sound.as_str(), "content");
 
         let three_conditions = ConditionalPushRule {
             actions: vec![Action::SetTweak(Tweak::Sound("three".into()))],
@@ -1678,7 +1694,7 @@ mod tests {
             set.get_actions(&message, &CONTEXT_ONE_TO_ONE).await,
             [Action::SetTweak(Tweak::Sound(sound))]
         );
-        assert_eq!(sound, "content");
+        assert_eq!(sound.as_str(), "content");
 
         let new_message = serde_json::from_str::<Raw<JsonValue>>(
             r#"{
@@ -1696,7 +1712,7 @@ mod tests {
             set.get_actions(&new_message, &CONTEXT_ONE_TO_ONE).await,
             [Action::SetTweak(Tweak::Sound(sound))]
         );
-        assert_eq!(sound, "three");
+        assert_eq!(sound.as_str(), "three");
     }
 
     #[apply(test!)]
@@ -1710,16 +1726,16 @@ mod tests {
             pattern: "jolly_jumper".to_owned(),
             actions: vec![
                 Action::Notify,
-                Action::SetTweak(Tweak::Sound("default".into())),
-                Action::SetTweak(Tweak::Highlight(true)),
+                Action::SetTweak(Tweak::Sound(SoundTweakValue::Default)),
+                Action::SetTweak(Tweak::Highlight(HighlightTweakValue::Yes)),
             ],
         });
         set.override_.extend([
             ConditionalPushRule {
                 actions: vec![
                     Action::Notify,
-                    Action::SetTweak(Tweak::Sound("default".into())),
-                    Action::SetTweak(Tweak::Highlight(true)),
+                    Action::SetTweak(Tweak::Sound(SoundTweakValue::Default)),
+                    Action::SetTweak(Tweak::Highlight(HighlightTweakValue::Yes)),
                 ],
                 default: true,
                 enabled: true,
@@ -1727,7 +1743,10 @@ mod tests {
                 conditions: vec![PushCondition::ContainsDisplayName],
             },
             ConditionalPushRule {
-                actions: vec![Action::Notify, Action::SetTweak(Tweak::Highlight(true))],
+                actions: vec![
+                    Action::Notify,
+                    Action::SetTweak(Tweak::Highlight(HighlightTweakValue::Yes)),
+                ],
                 default: true,
                 enabled: true,
                 rule_id: PredefinedOverrideRuleId::RoomNotif.to_string(),

--- a/crates/ruma-common/src/push/action/action_serde.rs
+++ b/crates/ruma-common/src/push/action/action_serde.rs
@@ -1,0 +1,96 @@
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::value::RawValue as RawJsonValue;
+
+use super::{Action, CustomAction, Tweak};
+use crate::serde::from_raw_json_value;
+
+impl<'de> Deserialize<'de> for Action {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let json = Box::<RawJsonValue>::deserialize(deserializer)?;
+        let custom: CustomAction = from_raw_json_value(&json)?;
+
+        match &custom {
+            CustomAction::String(s) => match s.as_str() {
+                "notify" => Ok(Action::Notify),
+                #[cfg(feature = "unstable-msc3768")]
+                "org.matrix.msc3768.notify_in_app" => Ok(Action::NotifyInApp),
+                _ => Ok(Action::_Custom(custom)),
+            },
+            CustomAction::Object(o) => {
+                if o.get("set_tweak").is_some() {
+                    Ok(Action::SetTweak(from_raw_json_value(&json)?))
+                } else {
+                    Ok(Action::_Custom(custom))
+                }
+            }
+        }
+    }
+}
+
+impl Serialize for Action {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Action::Notify => serializer.serialize_unit_variant("Action", 0, "notify"),
+            #[cfg(feature = "unstable-msc3768")]
+            Action::NotifyInApp => {
+                serializer.serialize_unit_variant("Action", 0, "org.matrix.msc3768.notify_in_app")
+            }
+            Action::SetTweak(kind) => kind.serialize(serializer),
+            Action::_Custom(custom) => custom.serialize(serializer),
+        }
+    }
+}
+
+/// Values for the `set_tweak` action.
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(untagged)]
+pub(super) enum TweakSerdeHelper {
+    Sound(SoundTweakSerdeHelper),
+    Highlight(HighlightTweakSerdeHelper),
+    Custom {
+        #[serde(rename = "set_tweak")]
+        name: String,
+        value: Box<RawJsonValue>,
+    },
+}
+
+#[derive(Clone, PartialEq, Deserialize, Serialize)]
+#[serde(tag = "set_tweak", rename = "sound")]
+pub(super) struct SoundTweakSerdeHelper {
+    value: String,
+}
+
+#[derive(Clone, PartialEq, Deserialize, Serialize)]
+#[serde(tag = "set_tweak", rename = "highlight")]
+pub(super) struct HighlightTweakSerdeHelper {
+    #[serde(default = "crate::serde::default_true", skip_serializing_if = "crate::serde::is_true")]
+    value: bool,
+}
+
+impl From<Tweak> for TweakSerdeHelper {
+    fn from(tweak: Tweak) -> Self {
+        match tweak {
+            Tweak::Sound(value) => Self::Sound(SoundTweakSerdeHelper { value }),
+            Tweak::Highlight(value) => Self::Highlight(HighlightTweakSerdeHelper { value }),
+            Tweak::Custom { name, value } => Self::Custom { name, value },
+        }
+    }
+}
+
+impl From<TweakSerdeHelper> for Tweak {
+    fn from(tweak: TweakSerdeHelper) -> Self {
+        match tweak {
+            TweakSerdeHelper::Sound(SoundTweakSerdeHelper { value }) => Self::Sound(value),
+            TweakSerdeHelper::Highlight(HighlightTweakSerdeHelper { value }) => {
+                Self::Highlight(value)
+            }
+            TweakSerdeHelper::Custom { name, value } => Self::Custom { name, value },
+        }
+    }
+}

--- a/crates/ruma-common/src/push/iter.rs
+++ b/crates/ruma-common/src/push/iter.rs
@@ -4,7 +4,7 @@ use super::{
     Action, ConditionalPushRule, FlattenedJson, PatternedPushRule, PushConditionRoomCtx, Ruleset,
     SimplePushRule, condition,
 };
-use crate::{OwnedRoomId, OwnedUserId};
+use crate::{OwnedRoomId, OwnedUserId, push::action::SoundTweakValue};
 
 /// The kinds of push rules that are available.
 #[derive(Clone, Debug)]
@@ -72,7 +72,7 @@ impl AnyPushRule {
     }
 
     /// The sound that should be played when an event matches the push rule, if any.
-    pub fn triggers_sound(&self) -> Option<&str> {
+    pub fn triggers_sound(&self) -> Option<&SoundTweakValue> {
         self.as_ref().triggers_sound()
     }
 
@@ -227,7 +227,7 @@ impl<'a> AnyPushRuleRef<'a> {
     }
 
     /// The sound that should be played when an event matches the push rule, if any.
-    pub fn triggers_sound(self) -> Option<&'a str> {
+    pub fn triggers_sound(self) -> Option<&'a SoundTweakValue> {
         self.actions().iter().find_map(|a| a.sound())
     }
 

--- a/crates/ruma-common/src/push/predefined.rs
+++ b/crates/ruma-common/src/push/predefined.rs
@@ -159,11 +159,7 @@ impl ConditionalPushRule {
     /// Matches any invites to a new room for this user.
     pub fn invite_for_me(user_id: &UserId) -> Self {
         Self {
-            actions: vec![
-                Notify,
-                SetTweak(Tweak::Sound("default".into())),
-                SetTweak(Tweak::Highlight(false)),
-            ],
+            actions: vec![Notify, SetTweak(Tweak::Sound("default".into()))],
             default: true,
             enabled: true,
             rule_id: PredefinedOverrideRuleId::InviteForMe.to_string(),
@@ -311,11 +307,7 @@ impl ConditionalPushRule {
             default: true,
             enabled: true,
             conditions: vec![EventMatch { key: "type".into(), pattern: "m.call.invite".into() }],
-            actions: vec![
-                Notify,
-                SetTweak(Tweak::Sound("ring".into())),
-                SetTweak(Tweak::Highlight(false)),
-            ],
+            actions: vec![Notify, SetTweak(Tweak::Sound("ring".into()))],
         }
     }
 
@@ -333,11 +325,7 @@ impl ConditionalPushRule {
                 RoomMemberCount { is: RoomMemberCountIs::from(js_int::uint!(2)) },
                 EventMatch { key: "type".into(), pattern: "m.room.encrypted".into() },
             ],
-            actions: vec![
-                Notify,
-                SetTweak(Tweak::Sound("default".into())),
-                SetTweak(Tweak::Highlight(false)),
-            ],
+            actions: vec![Notify, SetTweak(Tweak::Sound("default".into()))],
         }
     }
 
@@ -351,11 +339,7 @@ impl ConditionalPushRule {
                 RoomMemberCount { is: RoomMemberCountIs::from(js_int::uint!(2)) },
                 EventMatch { key: "type".into(), pattern: "m.room.message".into() },
             ],
-            actions: vec![
-                Notify,
-                SetTweak(Tweak::Sound("default".into())),
-                SetTweak(Tweak::Highlight(false)),
-            ],
+            actions: vec![Notify, SetTweak(Tweak::Sound("default".into()))],
         }
     }
 
@@ -366,7 +350,7 @@ impl ConditionalPushRule {
             default: true,
             enabled: true,
             conditions: vec![EventMatch { key: "type".into(), pattern: "m.room.message".into() }],
-            actions: vec![Notify, SetTweak(Tweak::Highlight(false))],
+            actions: vec![Notify],
         }
     }
 
@@ -381,7 +365,7 @@ impl ConditionalPushRule {
             default: true,
             enabled: true,
             conditions: vec![EventMatch { key: "type".into(), pattern: "m.room.encrypted".into() }],
-            actions: vec![Notify, SetTweak(Tweak::Highlight(false))],
+            actions: vec![Notify],
         }
     }
 

--- a/crates/ruma-common/src/push/predefined.rs
+++ b/crates/ruma-common/src/push/predefined.rs
@@ -5,7 +5,8 @@
 use ruma_macros::StringEnum;
 
 use super::{
-    Action::*, ConditionalPushRule, PushCondition::*, RoomMemberCountIs, RuleKind, Ruleset, Tweak,
+    Action::*, ConditionalPushRule, HighlightTweakValue, PushCondition::*, RoomMemberCountIs,
+    RuleKind, Ruleset, SoundTweakValue, Tweak,
 };
 use crate::{PrivOwnedStr, UserId, power_levels::NotificationPowerLevelsKey};
 
@@ -159,7 +160,7 @@ impl ConditionalPushRule {
     /// Matches any invites to a new room for this user.
     pub fn invite_for_me(user_id: &UserId) -> Self {
         Self {
-            actions: vec![Notify, SetTweak(Tweak::Sound("default".into()))],
+            actions: vec![Notify, SetTweak(Tweak::Sound(SoundTweakValue::Default))],
             default: true,
             enabled: true,
             rule_id: PredefinedOverrideRuleId::InviteForMe.to_string(),
@@ -188,8 +189,8 @@ impl ConditionalPushRule {
         Self {
             actions: vec![
                 Notify,
-                SetTweak(Tweak::Sound("default".to_owned())),
-                SetTweak(Tweak::Highlight(true)),
+                SetTweak(Tweak::Sound(SoundTweakValue::Default)),
+                SetTweak(Tweak::Highlight(HighlightTweakValue::Yes)),
             ],
             default: true,
             enabled: true,
@@ -206,7 +207,7 @@ impl ConditionalPushRule {
     /// similar to what an `@room` notification would accomplish.
     pub fn tombstone() -> Self {
         Self {
-            actions: vec![Notify, SetTweak(Tweak::Highlight(true))],
+            actions: vec![Notify, SetTweak(Tweak::Highlight(HighlightTweakValue::Yes))],
             default: true,
             enabled: true,
             rule_id: PredefinedOverrideRuleId::Tombstone.to_string(),
@@ -221,7 +222,7 @@ impl ConditionalPushRule {
     /// the `m.mentions` property set to `true`.
     pub fn is_room_mention() -> Self {
         Self {
-            actions: vec![Notify, SetTweak(Tweak::Highlight(true))],
+            actions: vec![Notify, SetTweak(Tweak::Highlight(HighlightTweakValue::Yes))],
             default: true,
             enabled: true,
             rule_id: PredefinedOverrideRuleId::IsRoomMention.to_string(),
@@ -325,7 +326,7 @@ impl ConditionalPushRule {
                 RoomMemberCount { is: RoomMemberCountIs::from(js_int::uint!(2)) },
                 EventMatch { key: "type".into(), pattern: "m.room.encrypted".into() },
             ],
-            actions: vec![Notify, SetTweak(Tweak::Sound("default".into()))],
+            actions: vec![Notify, SetTweak(Tweak::Sound(SoundTweakValue::Default))],
         }
     }
 
@@ -339,7 +340,7 @@ impl ConditionalPushRule {
                 RoomMemberCount { is: RoomMemberCountIs::from(js_int::uint!(2)) },
                 EventMatch { key: "type".into(), pattern: "m.room.message".into() },
             ],
-            actions: vec![Notify, SetTweak(Tweak::Sound("default".into()))],
+            actions: vec![Notify, SetTweak(Tweak::Sound(SoundTweakValue::Default))],
         }
     }
 
@@ -388,7 +389,7 @@ impl ConditionalPushRule {
                     value: "org.matrix.msc3381.poll.start".into(),
                 },
             ],
-            actions: vec![Notify, SetTweak(Tweak::Sound("default".into()))],
+            actions: vec![Notify, SetTweak(Tweak::Sound(SoundTweakValue::Default))],
         }
     }
 
@@ -431,7 +432,7 @@ impl ConditionalPushRule {
                     value: "org.matrix.msc3381.poll.end".into(),
                 },
             ],
-            actions: vec![Notify, SetTweak(Tweak::Sound("default".into()))],
+            actions: vec![Notify, SetTweak(Tweak::Sound(SoundTweakValue::Default))],
         }
     }
 
@@ -483,7 +484,7 @@ impl ConditionalPushRule {
             default: true,
             enabled: true,
             conditions: vec![ThreadSubscription { subscribed: true }],
-            actions: vec![Notify, SetTweak(Tweak::Sound("default".into()))],
+            actions: vec![Notify, SetTweak(Tweak::Sound(SoundTweakValue::Default))],
         }
     }
 }


### PR DESCRIPTION
Otherwise they could match known variants. We also use stronger enum types for the `Tweak` values.

Part of #1083.