### PR TITLE
federation-api: Add support for extended profile fields to `get_profile_information`

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -45,6 +45,8 @@ Breaking changes:
 - `UserIdentifier` can now represent an identifier with a custom type, and its
   variants were changed to tuple variants containing a non-exhaustive struct.
   - `UserIdentifier::UserIdOrLocalpart` was renamed to `UserIdentifier::Matrix`.
+- The `ProfileFieldName` and `ProfileFieldValue` enums were moved to
+  `ruma_common::profile`.
 
 Bug fixes:
 

--- a/crates/ruma-client-api/src/discovery/get_capabilities.rs
+++ b/crates/ruma-client-api/src/discovery/get_capabilities.rs
@@ -17,6 +17,7 @@ pub mod v3 {
         RoomVersionId,
         api::{auth_scheme::AccessToken, request, response},
         metadata,
+        profile::ProfileFieldName,
         serde::StringEnum,
     };
     use serde::{Deserialize, Serialize};
@@ -24,7 +25,7 @@ pub mod v3 {
         Value as JsonValue, from_value as from_json_value, to_value as to_json_value,
     };
 
-    use crate::{PrivOwnedStr, profile::ProfileFieldName};
+    use crate::PrivOwnedStr;
 
     metadata! {
         method: GET,

--- a/crates/ruma-client-api/src/profile.rs
+++ b/crates/ruma-client-api/src/profile.rs
@@ -1,21 +1,20 @@
 //! Endpoints for user profiles.
 
-use std::borrow::Cow;
-
 #[cfg(feature = "client")]
-use ruma_common::api::{
-    MatrixVersion,
-    path_builder::{StablePathSelector, VersionHistory},
+use ruma_common::{
+    api::{
+        MatrixVersion,
+        path_builder::{StablePathSelector, VersionHistory},
+    },
+    profile::ProfileFieldName,
 };
-use ruma_common::{OwnedMxcUri, serde::StringEnum};
-use serde::Serialize;
-use serde_json::{Value as JsonValue, from_value as from_json_value, to_value as to_json_value};
 
 pub mod delete_profile_field;
 pub mod get_avatar_url;
 pub mod get_display_name;
 pub mod get_profile;
 pub mod get_profile_field;
+#[cfg(feature = "client")]
 mod profile_field_serde;
 pub mod set_avatar_url;
 pub mod set_display_name;
@@ -23,122 +22,6 @@ pub mod set_profile_field;
 mod static_profile_field;
 
 pub use self::static_profile_field::*;
-
-/// The possible fields of a user's [profile].
-///
-/// [profile]: https://spec.matrix.org/latest/client-server-api/#profiles
-#[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
-#[derive(Clone, StringEnum)]
-#[ruma_enum(rename_all = "snake_case")]
-#[non_exhaustive]
-pub enum ProfileFieldName {
-    /// The user's avatar URL.
-    AvatarUrl,
-
-    /// The user's display name.
-    #[ruma_enum(rename = "displayname")]
-    DisplayName,
-
-    /// The user's time zone.
-    #[ruma_enum(rename = "m.tz")]
-    TimeZone,
-
-    #[doc(hidden)]
-    _Custom(crate::PrivOwnedStr),
-}
-
-impl ProfileFieldName {
-    /// Whether this field name existed already before custom fields were officially supported in
-    /// profiles.
-    #[cfg(feature = "client")]
-    fn existed_before_extended_profiles(&self) -> bool {
-        matches!(self, Self::AvatarUrl | Self::DisplayName)
-    }
-}
-
-/// The possible values of a field of a user's [profile].
-///
-/// [profile]: https://spec.matrix.org/latest/client-server-api/#profiles
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "snake_case")]
-#[non_exhaustive]
-pub enum ProfileFieldValue {
-    /// The user's avatar URL.
-    AvatarUrl(OwnedMxcUri),
-
-    /// The user's display name.
-    #[serde(rename = "displayname")]
-    DisplayName(String),
-
-    /// The user's time zone.
-    #[serde(rename = "m.tz")]
-    TimeZone(String),
-
-    #[doc(hidden)]
-    #[serde(untagged)]
-    _Custom(CustomProfileFieldValue),
-}
-
-impl ProfileFieldValue {
-    /// Construct a new `ProfileFieldValue` with the given field and value.
-    ///
-    /// Prefer to use the public variants of `ProfileFieldValue` where possible; this constructor is
-    /// meant to be used for unsupported fields only and does not allow setting arbitrary data for
-    /// supported ones.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the `field` is known and serialization of `value` to the corresponding
-    /// `ProfileFieldValue` variant fails.
-    pub fn new(field: &str, value: JsonValue) -> serde_json::Result<Self> {
-        Ok(match field {
-            "avatar_url" => Self::AvatarUrl(from_json_value(value)?),
-            "displayname" => Self::DisplayName(from_json_value(value)?),
-            "m.tz" => Self::TimeZone(from_json_value(value)?),
-            _ => Self::_Custom(CustomProfileFieldValue { field: field.to_owned(), value }),
-        })
-    }
-
-    /// The name of the field for this value.
-    pub fn field_name(&self) -> ProfileFieldName {
-        match self {
-            Self::AvatarUrl(_) => ProfileFieldName::AvatarUrl,
-            Self::DisplayName(_) => ProfileFieldName::DisplayName,
-            Self::TimeZone(_) => ProfileFieldName::TimeZone,
-            Self::_Custom(CustomProfileFieldValue { field, .. }) => field.as_str().into(),
-        }
-    }
-
-    /// Returns the value of the field.
-    ///
-    /// Prefer to use the public variants of `ProfileFieldValue` where possible; this method is
-    /// meant to be used for custom fields only.
-    pub fn value(&self) -> Cow<'_, JsonValue> {
-        match self {
-            Self::AvatarUrl(value) => {
-                Cow::Owned(to_json_value(value).expect("value should serialize successfully"))
-            }
-            Self::DisplayName(value) => {
-                Cow::Owned(to_json_value(value).expect("value should serialize successfully"))
-            }
-            Self::TimeZone(value) => {
-                Cow::Owned(to_json_value(value).expect("value should serialize successfully"))
-            }
-            Self::_Custom(c) => Cow::Borrowed(&c.value),
-        }
-    }
-}
-
-/// A custom value for a user's profile field.
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[doc(hidden)]
-pub struct CustomProfileFieldValue {
-    /// The name of the field.
-    field: String,
-
-    /// The value of the field
-    value: JsonValue,
-}
 
 /// Endpoint version history valid only for profile fields that didn't exist before Matrix 1.16.
 #[cfg(feature = "client")]
@@ -155,52 +38,9 @@ const EXTENDED_PROFILE_FIELD_HISTORY: VersionHistory = VersionHistory::new(
     None,
 );
 
-#[cfg(test)]
-mod tests {
-    use ruma_common::{canonical_json::assert_to_canonical_json_eq, owned_mxc_uri};
-    use serde_json::{from_value as from_json_value, json};
-
-    use super::ProfileFieldValue;
-
-    #[test]
-    fn serialize_profile_field_value() {
-        // Avatar URL.
-        let value = ProfileFieldValue::AvatarUrl(owned_mxc_uri!("mxc://localhost/abcdef"));
-        assert_to_canonical_json_eq!(value, json!({ "avatar_url": "mxc://localhost/abcdef" }));
-
-        // Display name.
-        let value = ProfileFieldValue::DisplayName("Alice".to_owned());
-        assert_to_canonical_json_eq!(value, json!({ "displayname": "Alice" }));
-
-        // Custom field.
-        let value = ProfileFieldValue::new("custom_field", "value".into()).unwrap();
-        assert_to_canonical_json_eq!(value, json!({ "custom_field": "value" }));
-    }
-
-    #[test]
-    fn deserialize_any_profile_field_value() {
-        // Avatar URL.
-        let json = json!({ "avatar_url": "mxc://localhost/abcdef" });
-        assert_eq!(
-            from_json_value::<ProfileFieldValue>(json).unwrap(),
-            ProfileFieldValue::AvatarUrl(owned_mxc_uri!("mxc://localhost/abcdef"))
-        );
-
-        // Display name.
-        let json = json!({ "displayname": "Alice" });
-        assert_eq!(
-            from_json_value::<ProfileFieldValue>(json).unwrap(),
-            ProfileFieldValue::DisplayName("Alice".to_owned())
-        );
-
-        // Custom field.
-        let json = json!({ "custom_field": "value" });
-        let value = from_json_value::<ProfileFieldValue>(json).unwrap();
-        assert_eq!(value.field_name().as_str(), "custom_field");
-        assert_eq!(value.value().as_str(), Some("value"));
-
-        // Error if the object is empty.
-        let json = json!({});
-        from_json_value::<ProfileFieldValue>(json).unwrap_err();
-    }
+/// Whether the given field name existed already before custom fields were officially supported in
+/// profiles.
+#[cfg(feature = "client")]
+fn field_existed_before_extended_profiles(field_name: &ProfileFieldName) -> bool {
+    matches!(field_name, ProfileFieldName::AvatarUrl | ProfileFieldName::DisplayName)
 }

--- a/crates/ruma-client-api/src/profile/delete_profile_field.rs
+++ b/crates/ruma-client-api/src/profile/delete_profile_field.rs
@@ -11,9 +11,8 @@ pub mod v3 {
         OwnedUserId,
         api::{auth_scheme::AccessToken, request, response},
         metadata,
+        profile::ProfileFieldName,
     };
-
-    use crate::profile::ProfileFieldName;
 
     metadata! {
         method: DELETE,

--- a/crates/ruma-client-api/src/profile/get_profile.rs
+++ b/crates/ruma-client-api/src/profile/get_profile.rs
@@ -13,10 +13,11 @@ pub mod v3 {
         OwnedUserId,
         api::{auth_scheme::NoAccessToken, request, response},
         metadata,
+        profile::{ProfileFieldName, ProfileFieldValue},
     };
     use serde_json::Value as JsonValue;
 
-    use crate::profile::{ProfileFieldName, ProfileFieldValue, StaticProfileField};
+    use crate::profile::StaticProfileField;
 
     metadata! {
         method: GET,
@@ -58,7 +59,7 @@ pub mod v3 {
             Self::default()
         }
 
-        /// Returns the value of the given capability.
+        /// Returns the value of the given profile field.
         pub fn get(&self, field: &str) -> Option<&JsonValue> {
             self.data.get(field)
         }
@@ -142,10 +143,8 @@ mod tests {
     #[test]
     #[cfg(feature = "server")]
     fn serialize_response() {
-        use ruma_common::{api::OutgoingResponse, owned_mxc_uri};
+        use ruma_common::{api::OutgoingResponse, owned_mxc_uri, profile::ProfileFieldValue};
         use serde_json::{Value as JsonValue, from_slice as from_json_slice};
-
-        use crate::profile::ProfileFieldValue;
 
         let response = [
             ProfileFieldValue::AvatarUrl(owned_mxc_uri!("mxc://localhost/abcdef")),

--- a/crates/ruma-client-api/src/profile/get_profile_field.rs
+++ b/crates/ruma-client-api/src/profile/get_profile_field.rs
@@ -19,9 +19,10 @@ pub mod v3 {
         OwnedUserId,
         api::{Metadata, auth_scheme::NoAccessToken, path_builder::VersionHistory},
         metadata,
+        profile::{ProfileFieldName, ProfileFieldValue},
     };
 
-    use crate::profile::{ProfileFieldName, ProfileFieldValue, StaticProfileField};
+    use crate::profile::StaticProfileField;
 
     metadata! {
         method: GET,
@@ -71,7 +72,9 @@ pub mod v3 {
         ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
             use ruma_common::api::{auth_scheme::AuthScheme, path_builder::PathBuilder};
 
-            let url = if self.field.existed_before_extended_profiles() {
+            use crate::profile::field_existed_before_extended_profiles;
+
+            let url = if field_existed_before_extended_profiles(&self.field) {
                 Self::make_endpoint_url(considering, base_url, &[&self.user_id, &self.field], "")?
             } else {
                 crate::profile::EXTENDED_PROFILE_FIELD_HISTORY.make_endpoint_url(
@@ -192,9 +195,8 @@ pub mod v3 {
             response: http::Response<T>,
         ) -> Result<Self, ruma_common::api::error::FromHttpResponseError<Self::EndpointError>>
         {
-            use ruma_common::api::EndpointError;
-
-            use crate::profile::profile_field_serde::deserialize_profile_field_value_option;
+            use ruma_common::{api::EndpointError, profile::ProfileFieldValueVisitor};
+            use serde::Deserializer;
 
             if response.status().as_u16() >= 400 {
                 return Err(ruma_common::api::error::FromHttpResponseError::Server(
@@ -203,7 +205,7 @@ pub mod v3 {
             }
 
             let mut de = serde_json::Deserializer::from_slice(response.body().as_ref());
-            let value = deserialize_profile_field_value_option(&mut de)?;
+            let value = de.deserialize_map(ProfileFieldValueVisitor::new(None))?;
             de.end()?;
 
             Ok(Self { value })
@@ -278,11 +280,13 @@ pub mod v3 {
 
 #[cfg(all(test, feature = "client"))]
 mod tests_client {
-    use ruma_common::{owned_mxc_uri, owned_user_id};
+    use ruma_common::{
+        owned_mxc_uri, owned_user_id,
+        profile::{ProfileFieldName, ProfileFieldValue},
+    };
     use serde_json::{json, to_vec as to_json_vec};
 
     use super::v3::{Request, RequestStatic, Response};
-    use crate::profile::{ProfileFieldName, ProfileFieldValue};
 
     #[test]
     fn serialize_request() {
@@ -425,11 +429,13 @@ mod tests_client {
 
 #[cfg(all(test, feature = "server"))]
 mod tests_server {
-    use ruma_common::owned_mxc_uri;
+    use ruma_common::{
+        owned_mxc_uri,
+        profile::{ProfileFieldName, ProfileFieldValue},
+    };
     use serde_json::{Value as JsonValue, from_slice as from_json_slice, json};
 
     use super::v3::{Request, Response};
-    use crate::profile::{ProfileFieldName, ProfileFieldValue};
 
     #[test]
     fn deserialize_request() {

--- a/crates/ruma-client-api/src/profile/profile_field_serde.rs
+++ b/crates/ruma-client-api/src/profile/profile_field_serde.rs
@@ -1,16 +1,12 @@
 use std::fmt;
 
-use serde::{Deserialize, Serialize, Serializer, de, ser::SerializeMap};
-
-use super::{CustomProfileFieldValue, ProfileFieldName, ProfileFieldValue};
+use serde::de;
 
 /// Helper type to deserialize any type that implements [`StaticProfileField`].
-#[cfg(feature = "client")]
 pub(super) struct StaticProfileFieldVisitor<F: super::StaticProfileField>(
     pub(super) std::marker::PhantomData<F>,
 );
 
-#[cfg(feature = "client")]
 impl<'de, F: super::StaticProfileField> de::Visitor<'de> for StaticProfileFieldVisitor<F> {
     type Value = Option<F::Value>;
 
@@ -38,89 +34,5 @@ impl<'de, F: super::StaticProfileField> de::Visitor<'de> for StaticProfileFieldV
         }
 
         Ok(Some(map.next_value()?))
-    }
-}
-
-impl Serialize for CustomProfileFieldValue {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut map = serializer.serialize_map(Some(1))?;
-        map.serialize_entry(&self.field, &self.value)?;
-        map.end()
-    }
-}
-
-/// Helper type to deserialize [`ProfileFieldValue`].
-///
-/// If the inner value is set, this will try to deserialize a map entry using this key, otherwise
-/// this will deserialize the first key-value pair encountered.
-pub(super) struct ProfileFieldValueVisitor(pub(super) Option<ProfileFieldName>);
-
-impl<'de> de::Visitor<'de> for ProfileFieldValueVisitor {
-    type Value = Option<ProfileFieldValue>;
-
-    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str("enum ProfileFieldValue")
-    }
-
-    fn visit_map<V>(self, mut map: V) -> Result<Self::Value, V::Error>
-    where
-        V: de::MapAccess<'de>,
-    {
-        let field = if let Some(field) = self.0 {
-            let mut found = false;
-
-            while let Some(key) = map.next_key::<ProfileFieldName>()? {
-                if key == field {
-                    found = true;
-                    break;
-                }
-            }
-
-            if !found {
-                return Ok(None);
-            }
-
-            field
-        } else {
-            let Some(field) = map.next_key()? else {
-                return Ok(None);
-            };
-
-            field
-        };
-
-        Ok(Some(match field {
-            ProfileFieldName::AvatarUrl => ProfileFieldValue::AvatarUrl(map.next_value()?),
-            ProfileFieldName::DisplayName => ProfileFieldValue::DisplayName(map.next_value()?),
-            ProfileFieldName::TimeZone => ProfileFieldValue::TimeZone(map.next_value()?),
-            ProfileFieldName::_Custom(field) => {
-                ProfileFieldValue::_Custom(CustomProfileFieldValue {
-                    field: field.0.into(),
-                    value: map.next_value()?,
-                })
-            }
-        }))
-    }
-}
-
-pub(super) fn deserialize_profile_field_value_option<'de, D>(
-    deserializer: D,
-) -> Result<Option<ProfileFieldValue>, D::Error>
-where
-    D: de::Deserializer<'de>,
-{
-    deserializer.deserialize_map(ProfileFieldValueVisitor(None))
-}
-
-impl<'de> Deserialize<'de> for ProfileFieldValue {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        deserialize_profile_field_value_option(deserializer)?
-            .ok_or_else(|| de::Error::invalid_length(0, &"at least one key-value pair"))
     }
 }

--- a/crates/ruma-client-api/src/profile/set_profile_field.rs
+++ b/crates/ruma-client-api/src/profile/set_profile_field.rs
@@ -17,9 +17,8 @@ pub mod v3 {
         OwnedUserId,
         api::{auth_scheme::AccessToken, response},
         metadata,
+        profile::ProfileFieldValue,
     };
-
-    use crate::profile::ProfileFieldValue;
 
     metadata! {
         method: PUT,
@@ -64,9 +63,11 @@ pub mod v3 {
         ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
             use ruma_common::api::{Metadata, auth_scheme::AuthScheme, path_builder::PathBuilder};
 
+            use crate::profile::field_existed_before_extended_profiles;
+
             let field = self.value.field_name();
 
-            let url = if field.existed_before_extended_profiles() {
+            let url = if field_existed_before_extended_profiles(&field) {
                 Self::make_endpoint_url(considering, base_url, &[&self.user_id, &field], "")?
             } else {
                 crate::profile::EXTENDED_PROFILE_FIELD_HISTORY.make_endpoint_url(
@@ -104,9 +105,8 @@ pub mod v3 {
             B: AsRef<[u8]>,
             S: AsRef<str>,
         {
+            use ruma_common::profile::{ProfileFieldName, ProfileFieldValueVisitor};
             use serde::de::{Deserializer, Error as _};
-
-            use crate::profile::{ProfileFieldName, profile_field_serde::ProfileFieldValueVisitor};
 
             Self::check_request_method(request.method())?;
 
@@ -119,7 +119,7 @@ pub mod v3 {
                 ))?;
 
             let value = serde_json::Deserializer::from_slice(request.body().as_ref())
-                .deserialize_map(ProfileFieldValueVisitor(Some(field.clone())))?
+                .deserialize_map(ProfileFieldValueVisitor::new(Some(field.clone())))?
                 .ok_or_else(|| serde_json::Error::custom(format!("missing field `{field}`")))?;
 
             Ok(Request { user_id, value })
@@ -147,11 +147,11 @@ mod tests_client {
     use ruma_common::{
         api::{OutgoingRequest, SupportedVersions, auth_scheme::SendAccessToken},
         owned_mxc_uri, owned_user_id,
+        profile::ProfileFieldValue,
     };
     use serde_json::{Value as JsonValue, from_slice as from_json_slice, json};
 
     use super::v3::Request;
-    use crate::profile::ProfileFieldValue;
 
     #[test]
     fn serialize_request() {
@@ -278,11 +278,10 @@ mod tests_client {
 #[cfg(all(test, feature = "server"))]
 mod tests_server {
     use assert_matches2::assert_let;
-    use ruma_common::api::IncomingRequest;
+    use ruma_common::{api::IncomingRequest, profile::ProfileFieldValue};
     use serde_json::{json, to_vec as to_json_vec};
 
     use super::v3::Request;
-    use crate::profile::ProfileFieldValue;
 
     #[test]
     fn deserialize_request_valid_field() {

--- a/crates/ruma-common/src/lib.rs
+++ b/crates/ruma-common/src/lib.rs
@@ -31,6 +31,7 @@ mod percent_encode;
 pub mod power_levels;
 pub mod presence;
 mod priv_owned_str;
+pub mod profile;
 pub mod push;
 pub mod room;
 pub mod room_version_rules;

--- a/crates/ruma-common/src/profile.rs
+++ b/crates/ruma-common/src/profile.rs
@@ -1,0 +1,171 @@
+//! Common types for user profile endpoints.
+
+use std::borrow::Cow;
+
+use ruma_macros::StringEnum;
+use serde::Serialize;
+use serde_json::{Value as JsonValue, from_value as from_json_value, to_value as to_json_value};
+
+use crate::{OwnedMxcUri, PrivOwnedStr};
+
+mod profile_field_value_serde;
+
+#[doc(hidden)]
+pub use self::profile_field_value_serde::ProfileFieldValueVisitor;
+
+/// The possible fields of a user's [profile].
+///
+/// [profile]: https://spec.matrix.org/latest/client-server-api/#profiles
+#[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
+#[derive(Clone, StringEnum)]
+#[ruma_enum(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ProfileFieldName {
+    /// The user's avatar URL.
+    AvatarUrl,
+
+    /// The user's display name.
+    #[ruma_enum(rename = "displayname")]
+    DisplayName,
+
+    /// The user's time zone.
+    #[ruma_enum(rename = "m.tz")]
+    TimeZone,
+
+    #[doc(hidden)]
+    _Custom(PrivOwnedStr),
+}
+
+/// The possible values of a field of a user's [profile].
+///
+/// [profile]: https://spec.matrix.org/latest/client-server-api/#profiles
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ProfileFieldValue {
+    /// The user's avatar URL.
+    AvatarUrl(OwnedMxcUri),
+
+    /// The user's display name.
+    #[serde(rename = "displayname")]
+    DisplayName(String),
+
+    /// The user's time zone.
+    #[serde(rename = "m.tz")]
+    TimeZone(String),
+
+    #[doc(hidden)]
+    #[serde(untagged)]
+    _Custom(CustomProfileFieldValue),
+}
+
+impl ProfileFieldValue {
+    /// Construct a new `ProfileFieldValue` with the given field and value.
+    ///
+    /// Prefer to use the public variants of `ProfileFieldValue` where possible; this constructor is
+    /// meant to be used for unsupported fields only and does not allow setting arbitrary data for
+    /// supported ones.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the `field` is known and serialization of `value` to the corresponding
+    /// `ProfileFieldValue` variant fails.
+    pub fn new(field: &str, value: JsonValue) -> serde_json::Result<Self> {
+        Ok(match field {
+            "avatar_url" => Self::AvatarUrl(from_json_value(value)?),
+            "displayname" => Self::DisplayName(from_json_value(value)?),
+            "m.tz" => Self::TimeZone(from_json_value(value)?),
+            _ => Self::_Custom(CustomProfileFieldValue { field: field.to_owned(), value }),
+        })
+    }
+
+    /// The name of the field for this value.
+    pub fn field_name(&self) -> ProfileFieldName {
+        match self {
+            Self::AvatarUrl(_) => ProfileFieldName::AvatarUrl,
+            Self::DisplayName(_) => ProfileFieldName::DisplayName,
+            Self::TimeZone(_) => ProfileFieldName::TimeZone,
+            Self::_Custom(CustomProfileFieldValue { field, .. }) => field.as_str().into(),
+        }
+    }
+
+    /// Returns the value of the field.
+    ///
+    /// Prefer to use the public variants of `ProfileFieldValue` where possible; this method is
+    /// meant to be used for custom fields only.
+    pub fn value(&self) -> Cow<'_, JsonValue> {
+        match self {
+            Self::AvatarUrl(value) => {
+                Cow::Owned(to_json_value(value).expect("value should serialize successfully"))
+            }
+            Self::DisplayName(value) => {
+                Cow::Owned(to_json_value(value).expect("value should serialize successfully"))
+            }
+            Self::TimeZone(value) => {
+                Cow::Owned(to_json_value(value).expect("value should serialize successfully"))
+            }
+            Self::_Custom(c) => Cow::Borrowed(&c.value),
+        }
+    }
+}
+
+/// A custom value for a user's profile field.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[doc(hidden)]
+pub struct CustomProfileFieldValue {
+    /// The name of the field.
+    field: String,
+
+    /// The value of the field
+    value: JsonValue,
+}
+
+#[cfg(test)]
+mod tests {
+    use ruma_common::{canonical_json::assert_to_canonical_json_eq, owned_mxc_uri};
+    use serde_json::{from_value as from_json_value, json};
+
+    use super::ProfileFieldValue;
+
+    #[test]
+    fn serialize_profile_field_value() {
+        // Avatar URL.
+        let value = ProfileFieldValue::AvatarUrl(owned_mxc_uri!("mxc://localhost/abcdef"));
+        assert_to_canonical_json_eq!(value, json!({ "avatar_url": "mxc://localhost/abcdef" }));
+
+        // Display name.
+        let value = ProfileFieldValue::DisplayName("Alice".to_owned());
+        assert_to_canonical_json_eq!(value, json!({ "displayname": "Alice" }));
+
+        // Custom field.
+        let value = ProfileFieldValue::new("custom_field", "value".into()).unwrap();
+        assert_to_canonical_json_eq!(value, json!({ "custom_field": "value" }));
+    }
+
+    #[test]
+    fn deserialize_profile_field_value() {
+        // Avatar URL.
+        let json = json!({ "avatar_url": "mxc://localhost/abcdef" });
+        assert_eq!(
+            from_json_value::<ProfileFieldValue>(json).unwrap(),
+            ProfileFieldValue::AvatarUrl(owned_mxc_uri!("mxc://localhost/abcdef"))
+        );
+
+        // Display name.
+        let json = json!({ "displayname": "Alice" });
+        assert_eq!(
+            from_json_value::<ProfileFieldValue>(json).unwrap(),
+            ProfileFieldValue::DisplayName("Alice".to_owned())
+        );
+
+        // Custom field.
+        let json = json!({ "custom_field": "value" });
+        let value = from_json_value::<ProfileFieldValue>(json).unwrap();
+        assert_eq!(value.field_name().as_str(), "custom_field");
+        assert_eq!(value.value().as_str(), Some("value"));
+
+        // Error if the object is empty.
+        let json = json!({});
+        from_json_value::<ProfileFieldValue>(json).unwrap_err();
+    }
+}

--- a/crates/ruma-common/src/profile/profile_field_value_serde.rs
+++ b/crates/ruma-common/src/profile/profile_field_value_serde.rs
@@ -1,0 +1,87 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize, Serializer, de, ser::SerializeMap};
+
+use super::{CustomProfileFieldValue, ProfileFieldName, ProfileFieldValue};
+
+/// Helper type to deserialize [`ProfileFieldValue`].
+///
+/// If the field name is set, this will try to deserialize a map entry using this key, otherwise
+/// this will deserialize the first key-value pair encountered.
+pub struct ProfileFieldValueVisitor(Option<ProfileFieldName>);
+
+impl ProfileFieldValueVisitor {
+    /// Construct a `ProfileFieldValueVisitor` for the given optional field name.
+    pub fn new(field: Option<ProfileFieldName>) -> Self {
+        Self(field)
+    }
+
+    /// Try to find the key in the map matching the proper field name if it is set, or return the
+    /// first key if it is not set.
+    ///
+    /// Returns `Ok(Some(_))` if the field name was found, `Ok(None)` if it wasn't found, and
+    /// `Err(_)` if deserialization of a key failed.
+    fn find_field_name<'de, V>(self, map: &mut V) -> Result<Option<ProfileFieldName>, V::Error>
+    where
+        V: de::MapAccess<'de>,
+    {
+        while let Some(key) = map.next_key::<ProfileFieldName>()? {
+            if self.0.as_ref().is_none_or(|field| key == *field) {
+                return Ok(Some(key));
+            }
+        }
+
+        Ok(None)
+    }
+}
+
+impl<'de> de::Visitor<'de> for ProfileFieldValueVisitor {
+    type Value = Option<ProfileFieldValue>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("enum ProfileFieldValue")
+    }
+
+    fn visit_map<V>(self, mut map: V) -> Result<Self::Value, V::Error>
+    where
+        V: de::MapAccess<'de>,
+    {
+        let Some(field) = self.find_field_name(&mut map)? else {
+            return Ok(None);
+        };
+
+        Ok(Some(match field {
+            ProfileFieldName::AvatarUrl => ProfileFieldValue::AvatarUrl(map.next_value()?),
+            ProfileFieldName::DisplayName => ProfileFieldValue::DisplayName(map.next_value()?),
+            ProfileFieldName::TimeZone => ProfileFieldValue::TimeZone(map.next_value()?),
+            ProfileFieldName::_Custom(field) => {
+                ProfileFieldValue::_Custom(CustomProfileFieldValue {
+                    field: field.0.into(),
+                    value: map.next_value()?,
+                })
+            }
+        }))
+    }
+}
+
+impl<'de> Deserialize<'de> for ProfileFieldValue {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        deserializer
+            .deserialize_map(ProfileFieldValueVisitor(None))?
+            .ok_or_else(|| de::Error::invalid_length(0, &"at least one key-value pair"))
+    }
+}
+
+impl Serialize for CustomProfileFieldValue {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(1))?;
+        map.serialize_entry(&self.field, &self.value)?;
+        map.end()
+    }
+}

--- a/crates/ruma-federation-api/CHANGELOG.md
+++ b/crates/ruma-federation-api/CHANGELOG.md
@@ -1,5 +1,16 @@
 # [unreleased]
 
+Breaking changes:
+
+- Add support for extended profile fields to `get_profile_information` endpoint.
+  - The `field` field of `Request` takes a `ProfileFieldName` rather than a
+    custom enum.
+  - `Response` has no public fields anymore but stores all profile fields. The
+    fields can be accessed with `.get()`, `.iter()` or `.into_iter()`.
+    `Response::new()` takes no arguments and creates an empty response. Fields
+    can be added using `.set()`, or the `FromIterator` and `Extend`
+    implementations.
+
 Improvements:
 
 - Add the Policy Server event signing endpoint, according to MSC4284 / Matrix

--- a/crates/ruma-federation-api/CHANGELOG.md
+++ b/crates/ruma-federation-api/CHANGELOG.md
@@ -10,6 +10,8 @@ Breaking changes:
     `Response::new()` takes no arguments and creates an empty response. Fields
     can be added using `.set()`, or the `FromIterator` and `Extend`
     implementations.
+- The `compat-empty-string-null` cargo feature was removed because it is now
+  unused.
 
 Improvements:
 

--- a/crates/ruma-federation-api/Cargo.toml
+++ b/crates/ruma-federation-api/Cargo.toml
@@ -15,10 +15,6 @@ rust-version = { workspace = true }
 all-features = true
 
 [features]
-# Allow some mandatory fields in requests / responses to be missing, defaulting
-# them to an empty string in deserialization.
-compat-empty-string-null = []
-
 # Allow the `pdus` field in a transaction request to be missing, defaulting to
 # an empty `Vec` in deserialization.
 compat-optional-txn-pdus = []

--- a/crates/ruma-federation-api/Cargo.toml
+++ b/crates/ruma-federation-api/Cargo.toml
@@ -25,7 +25,6 @@ compat-optional-txn-pdus = []
 
 client = ["dep:httparse", "dep:memchr"]
 server = ["dep:bytes", "dep:rand"]
-unstable-msc2448 = []
 unstable-msc3618 = []
 unstable-msc3723 = []
 unstable-msc3843 = []

--- a/crates/ruma-federation-api/src/query/get_profile_information.rs
+++ b/crates/ruma-federation-api/src/query/get_profile_information.rs
@@ -7,14 +7,17 @@ pub mod v1 {
     //!
     //! [spec]: https://spec.matrix.org/latest/server-server-api/#get_matrixfederationv1queryprofile
 
+    use std::collections::{BTreeMap, btree_map};
+
     use ruma_common::{
-        OwnedMxcUri, OwnedUserId,
+        OwnedUserId,
         api::{request, response},
         metadata,
-        serde::StringEnum,
+        profile::{ProfileFieldName, ProfileFieldValue},
     };
+    use serde_json::Value as JsonValue;
 
-    use crate::{PrivOwnedStr, authentication::ServerSignatures};
+    use crate::authentication::ServerSignatures;
 
     metadata! {
         method: GET,
@@ -33,35 +36,7 @@ pub mod v1 {
         /// Profile field to query.
         #[serde(skip_serializing_if = "Option::is_none")]
         #[ruma_api(query)]
-        pub field: Option<ProfileField>,
-    }
-
-    /// Response type for the `get_profile_information` endpoint.
-    #[response]
-    #[derive(Default)]
-    pub struct Response {
-        /// Display name of the user.
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub displayname: Option<String>,
-
-        /// Avatar URL for the user's avatar.
-        ///
-        /// If you activate the `compat-empty-string-null` feature, this field being an empty
-        /// string in JSON will result in `None` here during deserialization.
-        #[serde(skip_serializing_if = "Option::is_none")]
-        #[cfg_attr(
-            feature = "compat-empty-string-null",
-            serde(default, deserialize_with = "ruma_common::serde::empty_string_as_none")
-        )]
-        pub avatar_url: Option<OwnedMxcUri>,
-
-        /// The [BlurHash](https://blurha.sh) for the avatar pointed to by `avatar_url`.
-        ///
-        /// This uses the unstable prefix in
-        /// [MSC2448](https://github.com/matrix-org/matrix-spec-proposals/pull/2448).
-        #[cfg(feature = "unstable-msc2448")]
-        #[serde(rename = "xyz.amorgan.blurhash", skip_serializing_if = "Option::is_none")]
-        pub blurhash: Option<String>,
+        pub field: Option<ProfileFieldName>,
     }
 
     impl Request {
@@ -71,31 +46,81 @@ pub mod v1 {
         }
     }
 
+    /// Response type for the `get_profile_information` endpoint.
+    #[response]
+    #[derive(Default)]
+    pub struct Response {
+        /// The profile data.
+        #[ruma_api(body)]
+        data: BTreeMap<String, JsonValue>,
+    }
+
     impl Response {
-        /// Creates an empty `Response`.
+        /// Creates a new empty `Response`.
         pub fn new() -> Self {
-            Default::default()
+            Self::default()
+        }
+
+        /// Returns the value of the given profile field.
+        pub fn get(&self, field: &str) -> Option<&JsonValue> {
+            self.data.get(field)
+        }
+
+        /// Gets an iterator over the fields of the profile.
+        pub fn iter(&self) -> btree_map::Iter<'_, String, JsonValue> {
+            self.data.iter()
+        }
+
+        /// Sets a field to the given value.
+        pub fn set(&mut self, field: String, value: JsonValue) {
+            self.data.insert(field, value);
         }
     }
 
-    /// Profile fields to specify in query.
-    ///
-    /// This type can hold an arbitrary string. To build this with a custom value, convert it from a
-    /// string with `::from()` / `.into()`. To check for values that are not available as a
-    /// documented variant here, use its string representation, obtained through
-    /// [`.as_str()`](Self::as_str()).
-    #[derive(Clone, StringEnum)]
-    #[non_exhaustive]
-    pub enum ProfileField {
-        /// Display name of the user.
-        #[ruma_enum(rename = "displayname")]
-        DisplayName,
+    impl FromIterator<(String, JsonValue)> for Response {
+        fn from_iter<T: IntoIterator<Item = (String, JsonValue)>>(iter: T) -> Self {
+            Self { data: iter.into_iter().collect() }
+        }
+    }
 
-        /// Avatar URL for the user's avatar.
-        #[ruma_enum(rename = "avatar_url")]
-        AvatarUrl,
+    impl FromIterator<(ProfileFieldName, JsonValue)> for Response {
+        fn from_iter<T: IntoIterator<Item = (ProfileFieldName, JsonValue)>>(iter: T) -> Self {
+            iter.into_iter().map(|(field, value)| (field.as_str().to_owned(), value)).collect()
+        }
+    }
 
-        #[doc(hidden)]
-        _Custom(PrivOwnedStr),
+    impl FromIterator<ProfileFieldValue> for Response {
+        fn from_iter<T: IntoIterator<Item = ProfileFieldValue>>(iter: T) -> Self {
+            iter.into_iter().map(|value| (value.field_name(), value.value().into_owned())).collect()
+        }
+    }
+
+    impl Extend<(String, JsonValue)> for Response {
+        fn extend<T: IntoIterator<Item = (String, JsonValue)>>(&mut self, iter: T) {
+            self.data.extend(iter);
+        }
+    }
+
+    impl Extend<(ProfileFieldName, JsonValue)> for Response {
+        fn extend<T: IntoIterator<Item = (ProfileFieldName, JsonValue)>>(&mut self, iter: T) {
+            self.extend(iter.into_iter().map(|(field, value)| (field.as_str().to_owned(), value)));
+        }
+    }
+
+    impl Extend<ProfileFieldValue> for Response {
+        fn extend<T: IntoIterator<Item = ProfileFieldValue>>(&mut self, iter: T) {
+            self.extend(
+                iter.into_iter().map(|value| (value.field_name(), value.value().into_owned())),
+            );
+        }
+    }
+
+    impl IntoIterator for Response {
+        type Item = (String, JsonValue);
+        type IntoIter = btree_map::IntoIter<String, JsonValue>;
+
+        fn into_iter(self) -> Self::IntoIter {
+            self.data.into_iter()
+        }
     }
 }

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -133,11 +133,7 @@ unstable-extensible-events = [
     "unstable-msc3955",
 ]
 unstable-msc1767 = ["ruma-events?/unstable-msc1767"]
-unstable-msc2448 = [
-    "ruma-client-api?/unstable-msc2448",
-    "ruma-events?/unstable-msc2448",
-    "ruma-federation-api?/unstable-msc2448",
-]
+unstable-msc2448 = ["ruma-client-api?/unstable-msc2448", "ruma-events?/unstable-msc2448"]
 unstable-msc2545 = ["ruma-events?/unstable-msc2545"]
 unstable-msc2654 = ["ruma-client-api?/unstable-msc2654"]
 unstable-msc2666 = ["ruma-common/unstable-msc2666", "ruma-client-api?/unstable-msc2666"]

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -78,7 +78,6 @@ compat-empty-string-null = [
     "ruma-common/compat-empty-string-null",
     "ruma-client-api?/compat-empty-string-null",
     "ruma-events?/compat-empty-string-null",
-    "ruma-federation-api?/compat-empty-string-null",
 ]
 
 # Allow certain fields to be `null` for compatibility, treating that the same as


### PR DESCRIPTION
We share `ProfileFieldName` with ruma-client-api, and we use a map in the  response to keep all profile fields.
