### PR TITLE
signatures: Refactor error types

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -35,6 +35,8 @@ Breaking changes:
 - Refactor and improve the variants of `RedactionError`:
   - `NotOfType` was renamed to `InvalidType` and provides more details about the
     invalid field.
+  - `JsonFieldMissingFromObject` was renamed to `MissingField` an provides the
+    full path of the missing field.
 
 Improvements:
 

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -32,6 +32,9 @@ Breaking changes:
 - `JsonType` was renamed to `CanonicalJsonType` to reflect that it only
   represents the possible types of a `CanonicalJsonValue`. It can also be
   accessed with `CanonicalJsonValue::json_type()`.
+- Refactor and improve the variants of `RedactionError`:
+  - `NotOfType` was renamed to `InvalidType` and provides more details about the
+    invalid field.
 
 Improvements:
 

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -29,6 +29,9 @@ Breaking changes:
   `Tweak::set_tweak()` and `Tweak::custom_value()`.
 - The struct variants of `PushCondition` are now tuple variants containing a
   non-exhaustive struct.
+- `JsonType` was renamed to `CanonicalJsonType` to reflect that it only
+  represents the possible types of a `CanonicalJsonValue`. It can also be
+  accessed with `CanonicalJsonValue::json_type()`.
 
 Improvements:
 
@@ -54,6 +57,7 @@ Improvements:
   an array, and the inner bytes can be accessed without consuming the wrapper
   type with `Base64::as_inner()`.
 - Add `MatrixVersion::V1_18`.
+- `CanonicalJsonValue::json_type()` allows to get the `JsonType` of a value.
 
 # 0.17.1
 

--- a/crates/ruma-common/src/canonical_json.rs
+++ b/crates/ruma-common/src/canonical_json.rs
@@ -84,8 +84,11 @@ pub enum RedactionError {
         found: CanonicalJsonType,
     },
 
-    /// The given required field is missing from a JSON object.
-    JsonFieldMissingFromObject(String),
+    /// A required field is missing from a JSON object.
+    MissingField {
+        /// The path of the missing field.
+        path: String,
+    },
 }
 
 impl fmt::Display for RedactionError {
@@ -94,8 +97,8 @@ impl fmt::Display for RedactionError {
             RedactionError::InvalidType { path, expected, found } => {
                 write!(f, "invalid type at `{path}`: expected {expected:?}, found {found:?}")
             }
-            RedactionError::JsonFieldMissingFromObject(field) => {
-                write!(f, "JSON object must contain the field {field:?}")
+            RedactionError::MissingField { path } => {
+                write!(f, "missing field: `{path}`")
             }
         }
     }
@@ -103,10 +106,27 @@ impl fmt::Display for RedactionError {
 
 impl std::error::Error for RedactionError {}
 
-impl RedactionError {
-    fn field_missing_from_object(target: &str) -> Self {
-        Self::JsonFieldMissingFromObject(target.to_owned())
-    }
+/// The possible types of a JSON value.
+#[derive(Debug)]
+#[allow(clippy::exhaustive_enums)]
+pub enum JsonType {
+    /// A JSON Object.
+    Object,
+
+    /// A JSON String.
+    String,
+
+    /// A JSON Integer.
+    Integer,
+
+    /// A JSON Array.
+    Array,
+
+    /// A JSON Boolean.
+    Boolean,
+
+    /// JSON Null.
+    Null,
 }
 
 /// Fallible conversion from a `serde_json::Map` to a `CanonicalJsonObject`.
@@ -208,7 +228,7 @@ pub fn redact_in_place(
                 found: value.json_type(),
             });
         }
-        None => return Err(RedactionError::field_missing_from_object("type")),
+        None => return Err(RedactionError::MissingField { path: "type".to_owned() }),
     };
 
     if let Some(content_value) = event.get_mut("content") {

--- a/crates/ruma-common/src/canonical_json.rs
+++ b/crates/ruma-common/src/canonical_json.rs
@@ -72,13 +72,16 @@ impl serde::ser::Error for CanonicalJsonError {
 #[derive(Debug)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub enum RedactionError {
-    /// The field `field` is not of the correct type `of_type` ([`JsonType`]).
-    #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
-    NotOfType {
-        /// The field name.
-        field: String,
-        /// The expected JSON type.
-        of_type: CanonicalJsonType,
+    /// The field at `path` was expected to be of type `expected`, but was received as `found`.
+    InvalidType {
+        /// The path of the invalid field.
+        path: String,
+
+        /// The type that was expected.
+        expected: CanonicalJsonType,
+
+        /// The type that was found.
+        found: CanonicalJsonType,
     },
 
     /// The given required field is missing from a JSON object.
@@ -88,8 +91,8 @@ pub enum RedactionError {
 impl fmt::Display for RedactionError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            RedactionError::NotOfType { field, of_type } => {
-                write!(f, "Value in {field:?} must be a JSON {of_type:?}")
+            RedactionError::InvalidType { path, expected, found } => {
+                write!(f, "invalid type at `{path}`: expected {expected:?}, found {found:?}")
             }
             RedactionError::JsonFieldMissingFromObject(field) => {
                 write!(f, "JSON object must contain the field {field:?}")
@@ -101,10 +104,6 @@ impl fmt::Display for RedactionError {
 impl std::error::Error for RedactionError {}
 
 impl RedactionError {
-    fn not_of_type(target: &str, of_type: CanonicalJsonType) -> Self {
-        Self::NotOfType { field: target.to_owned(), of_type }
-    }
-
     fn field_missing_from_object(target: &str) -> Self {
         Self::JsonFieldMissingFromObject(target.to_owned())
     }
@@ -202,13 +201,23 @@ pub fn redact_in_place(
         Some(CanonicalJsonValue::String(event_type)) => {
             retained_event_content_keys(event_type.as_ref(), rules)
         }
-        Some(_) => return Err(RedactionError::not_of_type("type", CanonicalJsonType::String)),
+        Some(value) => {
+            return Err(RedactionError::InvalidType {
+                path: "type".to_owned(),
+                expected: CanonicalJsonType::String,
+                found: value.json_type(),
+            });
+        }
         None => return Err(RedactionError::field_missing_from_object("type")),
     };
 
     if let Some(content_value) = event.get_mut("content") {
         let CanonicalJsonValue::Object(content) = content_value else {
-            return Err(RedactionError::not_of_type("content", CanonicalJsonType::Object));
+            return Err(RedactionError::InvalidType {
+                path: "content".to_owned(),
+                expected: CanonicalJsonType::Object,
+                found: content_value.json_type(),
+            });
         };
 
         retained_event_content_keys.apply(rules, content)?;
@@ -339,10 +348,11 @@ fn is_room_member_content_key_retained(
         }
         "third_party_invite" if rules.keep_room_member_third_party_invite_signed => {
             let Some(third_party_invite) = value.as_object_mut() else {
-                return Err(RedactionError::not_of_type(
-                    "third_party_invite",
-                    CanonicalJsonType::Object,
-                ));
+                return Err(RedactionError::InvalidType {
+                    path: "content.third_party_invite".to_owned(),
+                    expected: CanonicalJsonType::Object,
+                    found: value.json_type(),
+                });
             };
 
             third_party_invite.retain(|key, _| key == "signed");

--- a/crates/ruma-common/src/canonical_json.rs
+++ b/crates/ruma-common/src/canonical_json.rs
@@ -11,7 +11,7 @@ mod value;
 
 pub use self::{
     serializer::Serializer,
-    value::{CanonicalJsonObject, CanonicalJsonValue},
+    value::{CanonicalJsonObject, CanonicalJsonType, CanonicalJsonValue},
 };
 #[doc(inline)]
 pub use crate::assert_to_canonical_json_eq;
@@ -78,7 +78,7 @@ pub enum RedactionError {
         /// The field name.
         field: String,
         /// The expected JSON type.
-        of_type: JsonType,
+        of_type: CanonicalJsonType,
     },
 
     /// The given required field is missing from a JSON object.
@@ -101,36 +101,13 @@ impl fmt::Display for RedactionError {
 impl std::error::Error for RedactionError {}
 
 impl RedactionError {
-    fn not_of_type(target: &str, of_type: JsonType) -> Self {
+    fn not_of_type(target: &str, of_type: CanonicalJsonType) -> Self {
         Self::NotOfType { field: target.to_owned(), of_type }
     }
 
     fn field_missing_from_object(target: &str) -> Self {
         Self::JsonFieldMissingFromObject(target.to_owned())
     }
-}
-
-/// A JSON type enum for [`RedactionError`] variants.
-#[derive(Debug)]
-#[allow(clippy::exhaustive_enums)]
-pub enum JsonType {
-    /// A JSON Object.
-    Object,
-
-    /// A JSON String.
-    String,
-
-    /// A JSON Integer.
-    Integer,
-
-    /// A JSON Array.
-    Array,
-
-    /// A JSON Boolean.
-    Boolean,
-
-    /// JSON Null.
-    Null,
 }
 
 /// Fallible conversion from a `serde_json::Map` to a `CanonicalJsonObject`.
@@ -225,13 +202,13 @@ pub fn redact_in_place(
         Some(CanonicalJsonValue::String(event_type)) => {
             retained_event_content_keys(event_type.as_ref(), rules)
         }
-        Some(_) => return Err(RedactionError::not_of_type("type", JsonType::String)),
+        Some(_) => return Err(RedactionError::not_of_type("type", CanonicalJsonType::String)),
         None => return Err(RedactionError::field_missing_from_object("type")),
     };
 
     if let Some(content_value) = event.get_mut("content") {
         let CanonicalJsonValue::Object(content) = content_value else {
-            return Err(RedactionError::not_of_type("content", JsonType::Object));
+            return Err(RedactionError::not_of_type("content", CanonicalJsonType::Object));
         };
 
         retained_event_content_keys.apply(rules, content)?;
@@ -362,7 +339,10 @@ fn is_room_member_content_key_retained(
         }
         "third_party_invite" if rules.keep_room_member_third_party_invite_signed => {
             let Some(third_party_invite) = value.as_object_mut() else {
-                return Err(RedactionError::not_of_type("third_party_invite", JsonType::Object));
+                return Err(RedactionError::not_of_type(
+                    "third_party_invite",
+                    CanonicalJsonType::Object,
+                ));
             };
 
             third_party_invite.retain(|key, _| key == "signed");

--- a/crates/ruma-common/src/canonical_json/value.rs
+++ b/crates/ruma-common/src/canonical_json/value.rs
@@ -76,6 +76,18 @@ pub enum CanonicalJsonValue {
 }
 
 impl CanonicalJsonValue {
+    /// The type of this value.
+    pub fn json_type(&self) -> CanonicalJsonType {
+        match self {
+            Self::Null => CanonicalJsonType::Null,
+            Self::Bool(_) => CanonicalJsonType::Boolean,
+            Self::Integer(_) => CanonicalJsonType::Integer,
+            Self::String(_) => CanonicalJsonType::String,
+            Self::Array(_) => CanonicalJsonType::Array,
+            Self::Object(_) => CanonicalJsonType::Object,
+        }
+    }
+
     /// If the `CanonicalJsonValue` is a `Bool`, return the inner value.
     pub fn as_bool(&self) -> Option<bool> {
         as_variant!(self, Self::Bool).copied()
@@ -300,6 +312,29 @@ impl<'de> Deserialize<'de> for CanonicalJsonValue {
         let val = JsonValue::deserialize(deserializer)?;
         val.try_into().map_err(serde::de::Error::custom)
     }
+}
+
+/// The possible types of a [`CanonicalJsonValue`].
+#[derive(Debug)]
+#[allow(clippy::exhaustive_enums)]
+pub enum CanonicalJsonType {
+    /// A JSON Object.
+    Object,
+
+    /// A JSON String.
+    String,
+
+    /// A JSON Integer.
+    Integer,
+
+    /// A JSON Array.
+    Array,
+
+    /// A JSON Boolean.
+    Boolean,
+
+    /// JSON Null.
+    Null,
 }
 
 #[cfg(test)]

--- a/crates/ruma-federation-api/src/authentication.rs
+++ b/crates/ruma-federation-api/src/authentication.rs
@@ -235,7 +235,7 @@ impl XMatrix {
         }
 
         let mut request_object = Self::request_object(request, &self.origin, destination)
-            .map_err(|error| ruma_signatures::Error::Json(error.into()))?;
+            .map_err(|error| ruma_signatures::VerificationError::Json(error.into()))?;
         let entity_signature =
             CanonicalJsonObject::from([(self.key.to_string(), self.sig.encode().into())]);
         let signatures =
@@ -385,7 +385,7 @@ pub enum XMatrixVerificationError {
 
     /// The signature verification failed.
     #[error("signature verification failed: {0}")]
-    Signature(#[from] ruma_signatures::Error),
+    Signature(#[from] ruma_signatures::VerificationError),
 }
 
 #[cfg(test)]

--- a/crates/ruma-signatures/CHANGELOG.md
+++ b/crates/ruma-signatures/CHANGELOG.md
@@ -23,6 +23,13 @@ Breaking changes:
     `Ed25519VerificationError::InvalidSignatureLength`.
   - `VerificationError::Signature` is now
     `Ed25519VerificationError::SignatureVerification`.
+- `Error::PduSize` is now `JsonError::PduTooLarge` allowing the following
+  functions to return `JsonError` as an error type:
+  - `canonical_json()`
+  - `reference_hash()`
+  - `content_hash()`
+  - `sign_json()`
+  - `hash_and_sign_event()`
 
 Improvements:
 

--- a/crates/ruma-signatures/CHANGELOG.md
+++ b/crates/ruma-signatures/CHANGELOG.md
@@ -1,5 +1,11 @@
 # [unreleased]
 
+Breaking changes:
+
+- Refactor and improve the variants of `JsonError`:
+  - `NotOfType` and `NotMultiplesOfType` were merged into a single `InvalidType`
+    variant and provide more details about the invalid field.
+
 Improvements:
 
 - Get a better error message when verifying a signature with a public key that

--- a/crates/ruma-signatures/CHANGELOG.md
+++ b/crates/ruma-signatures/CHANGELOG.md
@@ -7,6 +7,13 @@ Breaking changes:
     variant and provide more details about the invalid field.
   - `JsonFieldMissingFromObject` was renamed to `MissingField` an provides the
     full path of the missing field.
+- The methods on `Ed25519KeyPair` use a separate error enum named
+  `Ed25519KeyPairParseError`.
+  - `Error::DerParse` is now `Ed25519KeyPairParseError::Pkcs8`.
+  - `ParseError::DerivedPublicKeyDoesNotMatchParsedKey` is now
+    `Ed25519KeyPairParseError::PublicKeyMismatch`.
+  - `ParseError::Oid` is now `Ed25519KeyPairParseError::InvalidOid`.
+  - `ParseError::SecretKey` is now `Ed25519KeyPairParseError::InvalidSecretKey`.
 
 Improvements:
 

--- a/crates/ruma-signatures/CHANGELOG.md
+++ b/crates/ruma-signatures/CHANGELOG.md
@@ -14,6 +14,15 @@ Breaking changes:
     `Ed25519KeyPairParseError::PublicKeyMismatch`.
   - `ParseError::Oid` is now `Ed25519KeyPairParseError::InvalidOid`.
   - `ParseError::SecretKey` is now `Ed25519KeyPairParseError::InvalidSecretKey`.
+- The error variants returned specifically when verifying an ed25519 signature
+  use a separate error enum named `Ed25519VerificationError`, which is exposed
+  as `VerificationError::Ed25519`.
+  - `ParseError::PublicKey` is now
+    `Ed25519VerificationError::InvalidPublicKey`.
+  - `ParseError::Signature` is now
+    `Ed25519VerificationError::InvalidSignatureLength`.
+  - `VerificationError::Signature` is now
+    `Ed25519VerificationError::SignatureVerification`.
 
 Improvements:
 

--- a/crates/ruma-signatures/CHANGELOG.md
+++ b/crates/ruma-signatures/CHANGELOG.md
@@ -30,6 +30,11 @@ Breaking changes:
   - `content_hash()`
   - `sign_json()`
   - `hash_and_sign_event()`
+- The remaining variants of `Error` and `ParseError` were merged into
+  `VerificationError`. This is now the error type returned by:
+  - `verify_canonical_json_bytes()`
+  - `verify_event()`
+  - `verify_json()`
 
 Improvements:
 

--- a/crates/ruma-signatures/CHANGELOG.md
+++ b/crates/ruma-signatures/CHANGELOG.md
@@ -5,6 +5,8 @@ Breaking changes:
 - Refactor and improve the variants of `JsonError`:
   - `NotOfType` and `NotMultiplesOfType` were merged into a single `InvalidType`
     variant and provide more details about the invalid field.
+  - `JsonFieldMissingFromObject` was renamed to `MissingField` an provides the
+    full path of the missing field.
 
 Improvements:
 

--- a/crates/ruma-signatures/src/error.rs
+++ b/crates/ruma-signatures/src/error.rs
@@ -5,6 +5,8 @@ use ruma_common::{
 };
 use thiserror::Error;
 
+use crate::Ed25519VerificationError;
+
 /// `ruma-signature`'s error type, wraps a number of other error types.
 #[derive(Debug, Error)]
 #[non_exhaustive]
@@ -99,9 +101,9 @@ pub enum VerificationError {
     #[error("Could not find supported signature for entity {0:?}")]
     NoSupportedSignatureForEntity(String),
 
-    /// The signature verification failed.
-    #[error("Could not verify signature: {0}")]
-    Signature(#[source] ed25519_dalek::SignatureError),
+    /// Error verifying an ed25519 signature.
+    #[error(transparent)]
+    Ed25519(#[from] Ed25519VerificationError),
 }
 
 /// Errors relating to parsing of all sorts.
@@ -120,14 +122,6 @@ pub enum ParseError {
     /// embedded.
     #[error("Event ID {0:?} should have a server name for the given room version")]
     ServerNameFromEventId(OwnedEventId),
-
-    /// For when [`ed25519_dalek`] cannot parse a public key.
-    #[error("Could not parse public key: {0}")]
-    PublicKey(#[source] ed25519_dalek::SignatureError),
-
-    /// For when [`ed25519_dalek`] cannot parse a signature.
-    #[error("Could not parse signature: {0}")]
-    Signature(#[source] ed25519_dalek::SignatureError),
 
     /// For when parsing base64 gives an error.
     #[error("Could not parse {of_type} base64 string {string:?}: {source}")]

--- a/crates/ruma-signatures/src/error.rs
+++ b/crates/ruma-signatures/src/error.rs
@@ -1,29 +1,11 @@
 use ruma_common::{
-    OwnedEventId,
+    IdParseError,
     canonical_json::{CanonicalJsonType, RedactionError},
     serde::Base64DecodeError,
 };
 use thiserror::Error;
 
 use crate::Ed25519VerificationError;
-
-/// `ruma-signature`'s error type, wraps a number of other error types.
-#[derive(Debug, Error)]
-#[non_exhaustive]
-#[allow(clippy::enum_variant_names)]
-pub enum Error {
-    /// [`JsonError`] wrapper.
-    #[error("JSON error: {0}")]
-    Json(#[from] JsonError),
-
-    /// [`VerificationError`] wrapper.
-    #[error("Verification error: {0}")]
-    Verification(#[from] VerificationError),
-
-    /// [`ParseError`] wrapper.
-    #[error("Parse error: {0}")]
-    Parse(#[from] ParseError),
-}
 
 /// All errors related to JSON validation/parsing.
 #[derive(Debug, Error)]
@@ -75,6 +57,32 @@ impl From<RedactionError> for JsonError {
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum VerificationError {
+    /// The JSON to check is invalid.
+    #[error("Invalid JSON: {0}")]
+    Json(#[from] JsonError),
+
+    /// Parsing a base64-encoded signature failed.
+    #[error("Could not parse base64-encoded signature at `path`: {source}")]
+    InvalidBase64Signature {
+        /// The full path to the signature.
+        path: String,
+
+        /// The originating error.
+        #[source]
+        source: Base64DecodeError,
+    },
+
+    /// Parsing a Matrix identifier failed.
+    #[error("Could not parse {identifier_type}: {source}")]
+    ParseIdentifier {
+        /// The type of identifier that was parsed.
+        identifier_type: &'static str,
+
+        /// The error when parsing the identifier.
+        #[source]
+        source: IdParseError,
+    },
+
     /// The signature uses an unsupported algorithm.
     #[error("signature uses an unsupported algorithm")]
     UnsupportedAlgorithm,
@@ -104,48 +112,4 @@ pub enum VerificationError {
     /// Error verifying an ed25519 signature.
     #[error(transparent)]
     Ed25519(#[from] Ed25519VerificationError),
-}
-
-/// Errors relating to parsing of all sorts.
-#[derive(Debug, Error)]
-#[non_exhaustive]
-pub enum ParseError {
-    /// For user ID parsing errors.
-    #[error("Could not parse User ID: {0}")]
-    UserId(#[source] ruma_common::IdParseError),
-
-    /// For event ID parsing errors.
-    #[error("Could not parse Event ID: {0}")]
-    EventId(#[source] ruma_common::IdParseError),
-
-    /// For when an event ID, coupled with a specific room version, doesn't have a server name
-    /// embedded.
-    #[error("Event ID {0:?} should have a server name for the given room version")]
-    ServerNameFromEventId(OwnedEventId),
-
-    /// For when parsing base64 gives an error.
-    #[error("Could not parse {of_type} base64 string {string:?}: {source}")]
-    Base64 {
-        /// The "type"/name of the base64 string
-        of_type: String,
-        /// The string itself.
-        string: String,
-        /// The originating error.
-        #[source]
-        source: Base64DecodeError,
-    },
-}
-
-impl ParseError {
-    pub(crate) fn server_name_from_event_id(event_id: OwnedEventId) -> Error {
-        Self::ServerNameFromEventId(event_id).into()
-    }
-
-    pub(crate) fn base64<T1: Into<String>, T2: Into<String>>(
-        of_type: T1,
-        string: T2,
-        source: Base64DecodeError,
-    ) -> Error {
-        Self::Base64 { of_type: of_type.into(), string: string.into(), source }.into()
-    }
 }

--- a/crates/ruma-signatures/src/error.rs
+++ b/crates/ruma-signatures/src/error.rs
@@ -22,10 +22,6 @@ pub enum Error {
     #[error("Parse error: {0}")]
     Parse(#[from] ParseError),
 
-    /// Wrapper for [`pkcs8::Error`].
-    #[error("DER Parse error: {0}")]
-    DerParse(pkcs8::Error),
-
     /// PDU was too large
     #[error("PDU is larger than maximum of 65535 bytes")]
     PduSize,
@@ -125,31 +121,6 @@ pub enum ParseError {
     #[error("Event ID {0:?} should have a server name for the given room version")]
     ServerNameFromEventId(OwnedEventId),
 
-    /// For when the extracted/"parsed" public key from a PKCS#8 v2 document doesn't match the
-    /// public key derived from it's private key.
-    #[error("PKCS#8 Document public key does not match public key derived from private key; derived: {0:X?} (len {}), parsed: {1:X?} (len {})", .derived_key.len(), .parsed_key.len())]
-    DerivedPublicKeyDoesNotMatchParsedKey {
-        /// The parsed key.
-        parsed_key: Vec<u8>,
-        /// The derived key.
-        derived_key: Vec<u8>,
-    },
-
-    /// For when the ASN.1 Object Identifier on a PKCS#8 document doesn't match the expected one.
-    ///
-    /// e.g. the document describes a RSA key, while an ed25519 key was expected.
-    #[error("Algorithm OID does not match ed25519, expected {expected}, found {found}")]
-    Oid {
-        /// The expected OID.
-        expected: pkcs8::ObjectIdentifier,
-        /// The OID that was found instead.
-        found: pkcs8::ObjectIdentifier,
-    },
-
-    /// For when [`ed25519_dalek`] cannot parse a secret/private key.
-    #[error("Could not parse secret key")]
-    SecretKey,
-
     /// For when [`ed25519_dalek`] cannot parse a public key.
     #[error("Could not parse public key: {0}")]
     PublicKey(#[source] ed25519_dalek::SignatureError),
@@ -174,17 +145,6 @@ pub enum ParseError {
 impl ParseError {
     pub(crate) fn server_name_from_event_id(event_id: OwnedEventId) -> Error {
         Self::ServerNameFromEventId(event_id).into()
-    }
-
-    pub(crate) fn derived_vs_parsed_mismatch<P: Into<Vec<u8>>, D: Into<Vec<u8>>>(
-        parsed: P,
-        derived: D,
-    ) -> Error {
-        Self::DerivedPublicKeyDoesNotMatchParsedKey {
-            parsed_key: parsed.into(),
-            derived_key: derived.into(),
-        }
-        .into()
     }
 
     pub(crate) fn base64<T1: Into<String>, T2: Into<String>>(

--- a/crates/ruma-signatures/src/error.rs
+++ b/crates/ruma-signatures/src/error.rs
@@ -1,6 +1,6 @@
 use ruma_common::{
     OwnedEventId,
-    canonical_json::{JsonType, RedactionError},
+    canonical_json::{CanonicalJsonType, RedactionError},
     serde::Base64DecodeError,
 };
 use thiserror::Error;
@@ -56,7 +56,7 @@ pub enum JsonError {
         /// An arbitrary "target" that doesn't have the required type.
         target: String,
         /// The JSON type the target was expected to be.
-        of_type: JsonType,
+        of_type: CanonicalJsonType,
     },
 
     /// Like [`JsonError::NotOfType`], only called when the `target` is a multiple;
@@ -67,7 +67,7 @@ pub enum JsonError {
         /// each or one of it's elements doesn't have the required type.
         target: String,
         /// The JSON type the element was expected to be.
-        of_type: JsonType,
+        of_type: CanonicalJsonType,
     },
 
     /// The given required field is missing from a JSON object.
@@ -81,11 +81,14 @@ pub enum JsonError {
 
 // TODO: make macro for this
 impl JsonError {
-    pub(crate) fn not_of_type<T: Into<String>>(target: T, of_type: JsonType) -> Error {
+    pub(crate) fn not_of_type<T: Into<String>>(target: T, of_type: CanonicalJsonType) -> Error {
         Self::NotOfType { target: target.into(), of_type }.into()
     }
 
-    pub(crate) fn not_multiples_of_type<T: Into<String>>(target: T, of_type: JsonType) -> Error {
+    pub(crate) fn not_multiples_of_type<T: Into<String>>(
+        target: T,
+        of_type: CanonicalJsonType,
+    ) -> Error {
         Self::NotMultiplesOfType { target: target.into(), of_type }.into()
     }
 

--- a/crates/ruma-signatures/src/error.rs
+++ b/crates/ruma-signatures/src/error.rs
@@ -37,9 +37,7 @@ impl From<RedactionError> for Error {
             RedactionError::InvalidType { path, expected, found } => {
                 JsonError::InvalidType { path, expected, found }.into()
             }
-            RedactionError::JsonFieldMissingFromObject(field) => {
-                JsonError::JsonFieldMissingFromObject(field).into()
-            }
+            RedactionError::MissingField { path } => JsonError::MissingField { path }.into(),
             #[allow(unreachable_patterns)]
             _ => unreachable!(),
         }
@@ -63,19 +61,16 @@ pub enum JsonError {
         found: CanonicalJsonType,
     },
 
-    /// The given required field is missing from a JSON object.
-    #[error("JSON object must contain the field {0:?}")]
-    JsonFieldMissingFromObject(String),
+    /// A required field is missing from a JSON object.
+    #[error("missing field: `{path}`")]
+    MissingField {
+        /// The path of the missing field.
+        path: String,
+    },
 
     /// A more generic JSON error from [`serde_json`].
     #[error(transparent)]
     Serde(#[from] serde_json::Error),
-}
-
-impl JsonError {
-    pub(crate) fn field_missing_from_object<T: Into<String>>(target: T) -> Error {
-        Self::JsonFieldMissingFromObject(target.into()).into()
-    }
 }
 
 /// Errors relating to verification of signatures.

--- a/crates/ruma-signatures/src/error.rs
+++ b/crates/ruma-signatures/src/error.rs
@@ -23,29 +23,16 @@ pub enum Error {
     /// [`ParseError`] wrapper.
     #[error("Parse error: {0}")]
     Parse(#[from] ParseError),
-
-    /// PDU was too large
-    #[error("PDU is larger than maximum of 65535 bytes")]
-    PduSize,
-}
-
-impl From<RedactionError> for Error {
-    fn from(err: RedactionError) -> Self {
-        match err {
-            RedactionError::InvalidType { path, expected, found } => {
-                JsonError::InvalidType { path, expected, found }.into()
-            }
-            RedactionError::MissingField { path } => JsonError::MissingField { path }.into(),
-            #[allow(unreachable_patterns)]
-            _ => unreachable!(),
-        }
-    }
 }
 
 /// All errors related to JSON validation/parsing.
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum JsonError {
+    /// The PDU is too large.
+    #[error("PDU is larger than maximum of 65535 bytes")]
+    PduTooLarge,
+
     /// The field at `path` was expected to be of type `expected`, but was received as `found`.
     #[error("invalid type at `{path}`: expected {expected:?}, found {found:?}")]
     InvalidType {
@@ -69,6 +56,19 @@ pub enum JsonError {
     /// A more generic JSON error from [`serde_json`].
     #[error(transparent)]
     Serde(#[from] serde_json::Error),
+}
+
+impl From<RedactionError> for JsonError {
+    fn from(err: RedactionError) -> Self {
+        match err {
+            RedactionError::InvalidType { path, expected, found } => {
+                JsonError::InvalidType { path, expected, found }
+            }
+            RedactionError::MissingField { path } => JsonError::MissingField { path },
+            #[allow(unreachable_patterns)]
+            _ => unreachable!(),
+        }
+    }
 }
 
 /// Errors relating to verification of signatures.

--- a/crates/ruma-signatures/src/error.rs
+++ b/crates/ruma-signatures/src/error.rs
@@ -34,8 +34,8 @@ pub enum Error {
 impl From<RedactionError> for Error {
     fn from(err: RedactionError) -> Self {
         match err {
-            RedactionError::NotOfType { field: target, of_type, .. } => {
-                JsonError::NotOfType { target, of_type }.into()
+            RedactionError::InvalidType { path, expected, found } => {
+                JsonError::InvalidType { path, expected, found }.into()
             }
             RedactionError::JsonFieldMissingFromObject(field) => {
                 JsonError::JsonFieldMissingFromObject(field).into()
@@ -50,24 +50,17 @@ impl From<RedactionError> for Error {
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum JsonError {
-    /// `target` is not of the correct type `of_type` ([`JsonType`]).
-    #[error("Value in {target:?} must be a JSON {of_type:?}")]
-    NotOfType {
-        /// An arbitrary "target" that doesn't have the required type.
-        target: String,
-        /// The JSON type the target was expected to be.
-        of_type: CanonicalJsonType,
-    },
+    /// The field at `path` was expected to be of type `expected`, but was received as `found`.
+    #[error("invalid type at `{path}`: expected {expected:?}, found {found:?}")]
+    InvalidType {
+        /// The path of the invalid field.
+        path: String,
 
-    /// Like [`JsonError::NotOfType`], only called when the `target` is a multiple;
-    /// array, set, etc.
-    #[error("Values in {target:?} must be JSON {of_type:?}s")]
-    NotMultiplesOfType {
-        /// An arbitrary "target" where
-        /// each or one of it's elements doesn't have the required type.
-        target: String,
-        /// The JSON type the element was expected to be.
-        of_type: CanonicalJsonType,
+        /// The type that was expected.
+        expected: CanonicalJsonType,
+
+        /// The type that was found.
+        found: CanonicalJsonType,
     },
 
     /// The given required field is missing from a JSON object.
@@ -79,19 +72,7 @@ pub enum JsonError {
     Serde(#[from] serde_json::Error),
 }
 
-// TODO: make macro for this
 impl JsonError {
-    pub(crate) fn not_of_type<T: Into<String>>(target: T, of_type: CanonicalJsonType) -> Error {
-        Self::NotOfType { target: target.into(), of_type }.into()
-    }
-
-    pub(crate) fn not_multiples_of_type<T: Into<String>>(
-        target: T,
-        of_type: CanonicalJsonType,
-    ) -> Error {
-        Self::NotMultiplesOfType { target: target.into(), of_type }.into()
-    }
-
     pub(crate) fn field_missing_from_object<T: Into<String>>(target: T) -> Error {
         Self::JsonFieldMissingFromObject(target.into()).into()
     }

--- a/crates/ruma-signatures/src/functions.rs
+++ b/crates/ruma-signatures/src/functions.rs
@@ -8,8 +8,8 @@ use std::{
 
 use base64::{Engine, alphabet};
 use ruma_common::{
-    AnyKeyName, CanonicalJsonObject, CanonicalJsonValue, OwnedEventId, OwnedServerName,
-    SigningKeyAlgorithm, SigningKeyId, UserId,
+    AnyKeyName, CanonicalJsonObject, CanonicalJsonValue, IdParseError, OwnedEventId,
+    OwnedServerName, SigningKeyAlgorithm, SigningKeyId, UserId,
     canonical_json::{CanonicalJsonType, redact},
     room_version_rules::{EventIdFormatVersion, RedactionRules, RoomVersionRules, SignaturesRules},
     serde::{Base64, base64::Standard},
@@ -21,7 +21,7 @@ use sha2::{Sha256, digest::Digest};
 mod tests;
 
 use crate::{
-    Error, JsonError, ParseError, VerificationError,
+    JsonError, VerificationError,
     keys::{KeyPair, PublicKeyMap},
     verification::{Verified, Verifier, verifier_from_algorithm},
 };
@@ -227,7 +227,7 @@ pub fn canonical_json(object: &CanonicalJsonObject) -> Result<String, JsonError>
 pub fn verify_json(
     public_key_map: &PublicKeyMap,
     object: &CanonicalJsonObject,
-) -> Result<(), Error> {
+) -> Result<(), VerificationError> {
     let signature_map = match object.get("signatures") {
         Some(CanonicalJsonValue::Object(signatures)) => signatures,
         Some(value) => {
@@ -277,7 +277,7 @@ fn verify_canonical_json_for_entity(
     public_key_map: &PublicKeyMap,
     signature_map: &CanonicalJsonObject,
     canonical_json: &[u8],
-) -> Result<(), Error> {
+) -> Result<(), VerificationError> {
     let signature_set = match signature_map.get(entity_id) {
         Some(CanonicalJsonValue::Object(set)) => set,
         Some(value) => {
@@ -288,7 +288,7 @@ fn verify_canonical_json_for_entity(
             }
             .into());
         }
-        None => return Err(VerificationError::NoSignaturesForEntity(entity_id.to_owned()).into()),
+        None => return Err(VerificationError::NoSignaturesForEntity(entity_id.to_owned())),
     };
 
     let public_keys = public_key_map
@@ -311,8 +311,7 @@ fn verify_canonical_json_for_entity(
             return Err(VerificationError::PublicKeyNotFound {
                 entity: entity_id.to_owned(),
                 key_id: key_id.clone(),
-            }
-            .into());
+            });
         };
 
         let CanonicalJsonValue::String(signature) = signature else {
@@ -324,8 +323,12 @@ fn verify_canonical_json_for_entity(
             .into());
         };
 
-        let signature = Base64::<Standard>::parse(signature)
-            .map_err(|e| ParseError::base64("signature", signature, e))?;
+        let signature = Base64::<Standard>::parse(signature).map_err(|error| {
+            VerificationError::InvalidBase64Signature {
+                path: format!("signatures.{entity_id}.{key_id}"),
+                source: error,
+            }
+        })?;
 
         verify_canonical_json_with(
             &verifier,
@@ -337,7 +340,7 @@ fn verify_canonical_json_for_entity(
     }
 
     if !checked {
-        return Err(VerificationError::NoSupportedSignatureForEntity(entity_id.to_owned()).into());
+        return Err(VerificationError::NoSupportedSignatureForEntity(entity_id.to_owned()));
     }
 
     Ok(())
@@ -365,11 +368,11 @@ pub fn verify_canonical_json_bytes(
     public_key: &[u8],
     signature: &[u8],
     canonical_json: &[u8],
-) -> Result<(), Error> {
+) -> Result<(), VerificationError> {
     let verifier =
         verifier_from_algorithm(algorithm).ok_or(VerificationError::UnsupportedAlgorithm)?;
 
-    verify_canonical_json_with(&verifier, public_key, signature, canonical_json).map_err(Into::into)
+    verify_canonical_json_with(&verifier, public_key, signature, canonical_json)
 }
 
 /// Uses a public key to verify signed canonical JSON bytes.
@@ -684,7 +687,7 @@ pub fn verify_event(
     public_key_map: &PublicKeyMap,
     object: &CanonicalJsonObject,
     rules: &RoomVersionRules,
-) -> Result<Verified, Error> {
+) -> Result<Verified, VerificationError> {
     let redacted = redact(object.clone(), &rules.redaction, None).map_err(JsonError::from)?;
 
     let hashes = match object.get("hashes") {
@@ -779,14 +782,15 @@ fn canonical_json_with_fields_to_remove(
 fn servers_to_check_signatures(
     object: &CanonicalJsonObject,
     rules: &SignaturesRules,
-) -> Result<BTreeSet<OwnedServerName>, Error> {
+) -> Result<BTreeSet<OwnedServerName>, VerificationError> {
     let mut servers_to_check = BTreeSet::new();
 
     if !is_invite_via_third_party_id(object)? {
         match object.get("sender") {
             Some(CanonicalJsonValue::String(raw_sender)) => {
-                let user_id = <&UserId>::try_from(raw_sender.as_str())
-                    .map_err(|e| Error::from(ParseError::UserId(e)))?;
+                let user_id = <&UserId>::try_from(raw_sender.as_str()).map_err(|source| {
+                    VerificationError::ParseIdentifier { identifier_type: "user ID", source }
+                })?;
 
                 servers_to_check.insert(user_id.server_name().to_owned());
             }
@@ -805,13 +809,17 @@ fn servers_to_check_signatures(
     if rules.check_event_id_server {
         match object.get("event_id") {
             Some(CanonicalJsonValue::String(raw_event_id)) => {
-                let event_id: OwnedEventId =
-                    raw_event_id.parse().map_err(|e| Error::from(ParseError::EventId(e)))?;
+                let event_id: OwnedEventId = raw_event_id.parse().map_err(|source| {
+                    VerificationError::ParseIdentifier { identifier_type: "event ID", source }
+                })?;
 
-                let server_name = event_id
-                    .server_name()
-                    .map(ToOwned::to_owned)
-                    .ok_or_else(|| ParseError::server_name_from_event_id(event_id))?;
+                let server_name =
+                    event_id.server_name().map(ToOwned::to_owned).ok_or_else(|| {
+                        VerificationError::ParseIdentifier {
+                            identifier_type: "event ID",
+                            source: IdParseError::InvalidServerName,
+                        }
+                    })?;
 
                 servers_to_check.insert(server_name);
             }
@@ -840,8 +848,9 @@ fn servers_to_check_signatures(
             expected: CanonicalJsonType::String,
             found: authorized_user.json_type(),
         })?;
-        let authorized_user =
-            <&UserId>::try_from(authorized_user).map_err(|e| Error::from(ParseError::UserId(e)))?;
+        let authorized_user = <&UserId>::try_from(authorized_user).map_err(|source| {
+            VerificationError::ParseIdentifier { identifier_type: "user ID", source }
+        })?;
 
         servers_to_check.insert(authorized_user.server_name().to_owned());
     }

--- a/crates/ruma-signatures/src/functions.rs
+++ b/crates/ruma-signatures/src/functions.rs
@@ -10,7 +10,7 @@ use base64::{Engine, alphabet};
 use ruma_common::{
     AnyKeyName, CanonicalJsonObject, CanonicalJsonValue, OwnedEventId, OwnedServerName,
     SigningKeyAlgorithm, SigningKeyId, UserId,
-    canonical_json::{JsonType, redact},
+    canonical_json::{CanonicalJsonType, redact},
     room_version_rules::{EventIdFormatVersion, RedactionRules, RoomVersionRules, SignaturesRules},
     serde::{Base64, base64::Standard},
 };
@@ -106,7 +106,7 @@ where
 {
     let (signatures_key, mut signature_map) = match object.remove_entry("signatures") {
         Some((key, CanonicalJsonValue::Object(signatures))) => (Cow::Owned(key), signatures),
-        Some(_) => return Err(JsonError::not_of_type("signatures", JsonType::Object)),
+        Some(_) => return Err(JsonError::not_of_type("signatures", CanonicalJsonType::Object)),
         None => (Cow::Borrowed("signatures"), BTreeMap::new()),
     };
 
@@ -124,7 +124,7 @@ where
         .or_insert_with(|| CanonicalJsonValue::Object(BTreeMap::new()));
 
     let CanonicalJsonValue::Object(signature_set) = signature_set else {
-        return Err(JsonError::not_multiples_of_type("signatures", JsonType::Object));
+        return Err(JsonError::not_multiples_of_type("signatures", CanonicalJsonType::Object));
     };
 
     signature_set.insert(signature.id(), CanonicalJsonValue::String(signature.base64()));
@@ -220,7 +220,7 @@ pub fn verify_json(
 ) -> Result<(), Error> {
     let signature_map = match object.get("signatures") {
         Some(CanonicalJsonValue::Object(signatures)) => signatures,
-        Some(_) => return Err(JsonError::not_of_type("signatures", JsonType::Object)),
+        Some(_) => return Err(JsonError::not_of_type("signatures", CanonicalJsonType::Object)),
         None => return Err(JsonError::field_missing_from_object("signatures")),
     };
 
@@ -264,7 +264,10 @@ fn verify_canonical_json_for_entity(
     let signature_set = match signature_map.get(entity_id) {
         Some(CanonicalJsonValue::Object(set)) => set,
         Some(_) => {
-            return Err(JsonError::not_multiples_of_type("signature sets", JsonType::Object));
+            return Err(JsonError::not_multiples_of_type(
+                "signature sets",
+                CanonicalJsonType::Object,
+            ));
         }
         None => return Err(VerificationError::NoSignaturesForEntity(entity_id.to_owned()).into()),
     };
@@ -294,7 +297,7 @@ fn verify_canonical_json_for_entity(
         };
 
         let CanonicalJsonValue::String(signature) = signature else {
-            return Err(JsonError::not_of_type("signature", JsonType::String));
+            return Err(JsonError::not_of_type("signature", CanonicalJsonType::String));
         };
 
         let signature = Base64::<Standard>::parse(signature)
@@ -562,7 +565,7 @@ where
         CanonicalJsonValue::Object(hashes) => {
             hashes.insert("sha256".into(), CanonicalJsonValue::String(hash.encode()))
         }
-        _ => return Err(JsonError::not_of_type("hashes", JsonType::Object)),
+        _ => return Err(JsonError::not_of_type("hashes", CanonicalJsonType::Object)),
     };
 
     let mut redacted = redact(object.clone(), redaction_rules, None)?;
@@ -657,9 +660,14 @@ pub fn verify_event(
             CanonicalJsonValue::Object(hashes) => match hashes.get("sha256") {
                 Some(hash_value) => match hash_value {
                     CanonicalJsonValue::String(hash) => hash,
-                    _ => return Err(JsonError::not_of_type("sha256 hash", JsonType::String)),
+                    _ => {
+                        return Err(JsonError::not_of_type(
+                            "sha256 hash",
+                            CanonicalJsonType::String,
+                        ));
+                    }
                 },
-                None => return Err(JsonError::not_of_type("hashes", JsonType::Object)),
+                None => return Err(JsonError::not_of_type("hashes", CanonicalJsonType::Object)),
             },
             _ => return Err(JsonError::field_missing_from_object("sha256")),
         },
@@ -668,7 +676,7 @@ pub fn verify_event(
 
     let signature_map = match object.get("signatures") {
         Some(CanonicalJsonValue::Object(signatures)) => signatures,
-        Some(_) => return Err(JsonError::not_of_type("signatures", JsonType::Object)),
+        Some(_) => return Err(JsonError::not_of_type("signatures", CanonicalJsonType::Object)),
         None => return Err(JsonError::field_missing_from_object("signatures")),
     };
 
@@ -736,7 +744,7 @@ fn servers_to_check_signatures(
 
                 servers_to_check.insert(user_id.server_name().to_owned());
             }
-            Some(_) => return Err(JsonError::not_of_type("sender", JsonType::String)),
+            Some(_) => return Err(JsonError::not_of_type("sender", CanonicalJsonType::String)),
             _ => return Err(JsonError::field_missing_from_object("sender")),
         }
     }
@@ -754,7 +762,7 @@ fn servers_to_check_signatures(
 
                 servers_to_check.insert(server_name);
             }
-            Some(_) => return Err(JsonError::not_of_type("event_id", JsonType::String)),
+            Some(_) => return Err(JsonError::not_of_type("event_id", CanonicalJsonType::String)),
             _ => {
                 return Err(JsonError::field_missing_from_object("event_id"));
             }
@@ -768,7 +776,7 @@ fn servers_to_check_signatures(
             .and_then(|c| c.get("join_authorised_via_users_server"))
     {
         let authorized_user = authorized_user.as_str().ok_or_else(|| {
-            JsonError::not_of_type("join_authorised_via_users_server", JsonType::String)
+            JsonError::not_of_type("join_authorised_via_users_server", CanonicalJsonType::String)
         })?;
         let authorized_user =
             <&UserId>::try_from(authorized_user).map_err(|e| Error::from(ParseError::UserId(e)))?;
@@ -785,7 +793,7 @@ fn servers_to_check_signatures(
 /// Returns an error if the object has not the expected format of an `m.room.member` event.
 fn is_invite_via_third_party_id(object: &CanonicalJsonObject) -> Result<bool, Error> {
     let Some(CanonicalJsonValue::String(raw_type)) = object.get("type") else {
-        return Err(JsonError::not_of_type("type", JsonType::String));
+        return Err(JsonError::not_of_type("type", CanonicalJsonType::String));
     };
 
     if raw_type != "m.room.member" {
@@ -793,11 +801,11 @@ fn is_invite_via_third_party_id(object: &CanonicalJsonObject) -> Result<bool, Er
     }
 
     let Some(CanonicalJsonValue::Object(content)) = object.get("content") else {
-        return Err(JsonError::not_of_type("content", JsonType::Object));
+        return Err(JsonError::not_of_type("content", CanonicalJsonType::Object));
     };
 
     let Some(CanonicalJsonValue::String(membership)) = content.get("membership") else {
-        return Err(JsonError::not_of_type("membership", JsonType::String));
+        return Err(JsonError::not_of_type("membership", CanonicalJsonType::String));
     };
 
     if membership != "invite" {
@@ -807,6 +815,6 @@ fn is_invite_via_third_party_id(object: &CanonicalJsonObject) -> Result<bool, Er
     match content.get("third_party_invite") {
         Some(CanonicalJsonValue::Object(_)) => Ok(true),
         None => Ok(false),
-        _ => Err(JsonError::not_of_type("third_party_invite", JsonType::Object)),
+        _ => Err(JsonError::not_of_type("third_party_invite", CanonicalJsonType::Object)),
     }
 }

--- a/crates/ruma-signatures/src/functions.rs
+++ b/crates/ruma-signatures/src/functions.rs
@@ -106,7 +106,14 @@ where
 {
     let (signatures_key, mut signature_map) = match object.remove_entry("signatures") {
         Some((key, CanonicalJsonValue::Object(signatures))) => (Cow::Owned(key), signatures),
-        Some(_) => return Err(JsonError::not_of_type("signatures", CanonicalJsonType::Object)),
+        Some((_, value)) => {
+            return Err(JsonError::InvalidType {
+                path: "signatures".to_owned(),
+                expected: CanonicalJsonType::Object,
+                found: value.json_type(),
+            }
+            .into());
+        }
         None => (Cow::Borrowed("signatures"), BTreeMap::new()),
     };
 
@@ -124,7 +131,12 @@ where
         .or_insert_with(|| CanonicalJsonValue::Object(BTreeMap::new()));
 
     let CanonicalJsonValue::Object(signature_set) = signature_set else {
-        return Err(JsonError::not_multiples_of_type("signatures", CanonicalJsonType::Object));
+        return Err(JsonError::InvalidType {
+            path: format!("signatures.{entity_id}"),
+            expected: CanonicalJsonType::Object,
+            found: signature_set.json_type(),
+        }
+        .into());
     };
 
     signature_set.insert(signature.id(), CanonicalJsonValue::String(signature.base64()));
@@ -220,7 +232,14 @@ pub fn verify_json(
 ) -> Result<(), Error> {
     let signature_map = match object.get("signatures") {
         Some(CanonicalJsonValue::Object(signatures)) => signatures,
-        Some(_) => return Err(JsonError::not_of_type("signatures", CanonicalJsonType::Object)),
+        Some(value) => {
+            return Err(JsonError::InvalidType {
+                path: "signatures".to_owned(),
+                expected: CanonicalJsonType::Object,
+                found: value.json_type(),
+            }
+            .into());
+        }
         None => return Err(JsonError::field_missing_from_object("signatures")),
     };
 
@@ -263,11 +282,13 @@ fn verify_canonical_json_for_entity(
 ) -> Result<(), Error> {
     let signature_set = match signature_map.get(entity_id) {
         Some(CanonicalJsonValue::Object(set)) => set,
-        Some(_) => {
-            return Err(JsonError::not_multiples_of_type(
-                "signature sets",
-                CanonicalJsonType::Object,
-            ));
+        Some(value) => {
+            return Err(JsonError::InvalidType {
+                path: format!("signatures.{entity_id}"),
+                expected: CanonicalJsonType::Object,
+                found: value.json_type(),
+            }
+            .into());
         }
         None => return Err(VerificationError::NoSignaturesForEntity(entity_id.to_owned()).into()),
     };
@@ -297,7 +318,12 @@ fn verify_canonical_json_for_entity(
         };
 
         let CanonicalJsonValue::String(signature) = signature else {
-            return Err(JsonError::not_of_type("signature", CanonicalJsonType::String));
+            return Err(JsonError::InvalidType {
+                path: format!("signatures.{entity_id}.{key_id}"),
+                expected: CanonicalJsonType::String,
+                found: signature.json_type(),
+            }
+            .into());
         };
 
         let signature = Base64::<Standard>::parse(signature)
@@ -565,7 +591,14 @@ where
         CanonicalJsonValue::Object(hashes) => {
             hashes.insert("sha256".into(), CanonicalJsonValue::String(hash.encode()))
         }
-        _ => return Err(JsonError::not_of_type("hashes", CanonicalJsonType::Object)),
+        _ => {
+            return Err(JsonError::InvalidType {
+                path: "hashes".to_owned(),
+                expected: CanonicalJsonType::Object,
+                found: hashes_value.json_type(),
+            }
+            .into());
+        }
     };
 
     let mut redacted = redact(object.clone(), redaction_rules, None)?;
@@ -655,28 +688,42 @@ pub fn verify_event(
 ) -> Result<Verified, Error> {
     let redacted = redact(object.clone(), &rules.redaction, None)?;
 
-    let hash = match object.get("hashes") {
-        Some(hashes_value) => match hashes_value {
-            CanonicalJsonValue::Object(hashes) => match hashes.get("sha256") {
-                Some(hash_value) => match hash_value {
-                    CanonicalJsonValue::String(hash) => hash,
-                    _ => {
-                        return Err(JsonError::not_of_type(
-                            "sha256 hash",
-                            CanonicalJsonType::String,
-                        ));
-                    }
-                },
-                None => return Err(JsonError::not_of_type("hashes", CanonicalJsonType::Object)),
-            },
-            _ => return Err(JsonError::field_missing_from_object("sha256")),
-        },
+    let hashes = match object.get("hashes") {
+        Some(CanonicalJsonValue::Object(hashes)) => hashes,
+        Some(value) => {
+            return Err(JsonError::InvalidType {
+                path: "hashes".to_owned(),
+                expected: CanonicalJsonType::Object,
+                found: value.json_type(),
+            }
+            .into());
+        }
         None => return Err(JsonError::field_missing_from_object("hashes")),
+    };
+
+    let hash = match hashes.get("sha256") {
+        Some(CanonicalJsonValue::String(hash)) => hash,
+        Some(value) => {
+            return Err(JsonError::InvalidType {
+                path: "hashes.sha256".to_owned(),
+                expected: CanonicalJsonType::String,
+                found: value.json_type(),
+            }
+            .into());
+        }
+        None => return Err(JsonError::field_missing_from_object("sha256")),
     };
 
     let signature_map = match object.get("signatures") {
         Some(CanonicalJsonValue::Object(signatures)) => signatures,
-        Some(_) => return Err(JsonError::not_of_type("signatures", CanonicalJsonType::Object)),
+        Some(value) => {
+            return Err(JsonError::InvalidType {
+                path: "signatures".to_owned(),
+                expected: CanonicalJsonType::Object,
+                found: value.json_type(),
+            }
+            .into());
+        }
         None => return Err(JsonError::field_missing_from_object("signatures")),
     };
 
@@ -744,7 +791,14 @@ fn servers_to_check_signatures(
 
                 servers_to_check.insert(user_id.server_name().to_owned());
             }
-            Some(_) => return Err(JsonError::not_of_type("sender", CanonicalJsonType::String)),
+            Some(value) => {
+                return Err(JsonError::InvalidType {
+                    path: "sender".to_owned(),
+                    expected: CanonicalJsonType::String,
+                    found: value.json_type(),
+                }
+                .into());
+            }
             _ => return Err(JsonError::field_missing_from_object("sender")),
         }
     }
@@ -762,7 +816,14 @@ fn servers_to_check_signatures(
 
                 servers_to_check.insert(server_name);
             }
-            Some(_) => return Err(JsonError::not_of_type("event_id", CanonicalJsonType::String)),
+            Some(value) => {
+                return Err(JsonError::InvalidType {
+                    path: "event_id".to_owned(),
+                    expected: CanonicalJsonType::String,
+                    found: value.json_type(),
+                }
+                .into());
+            }
             _ => {
                 return Err(JsonError::field_missing_from_object("event_id"));
             }
@@ -775,8 +836,10 @@ fn servers_to_check_signatures(
             .and_then(|c| c.as_object())
             .and_then(|c| c.get("join_authorised_via_users_server"))
     {
-        let authorized_user = authorized_user.as_str().ok_or_else(|| {
-            JsonError::not_of_type("join_authorised_via_users_server", CanonicalJsonType::String)
+        let authorized_user = authorized_user.as_str().ok_or_else(|| JsonError::InvalidType {
+            path: "content.join_authorised_via_users_server".to_owned(),
+            expected: CanonicalJsonType::String,
+            found: authorized_user.json_type(),
         })?;
         let authorized_user =
             <&UserId>::try_from(authorized_user).map_err(|e| Error::from(ParseError::UserId(e)))?;
@@ -792,20 +855,51 @@ fn servers_to_check_signatures(
 ///
 /// Returns an error if the object has not the expected format of an `m.room.member` event.
 fn is_invite_via_third_party_id(object: &CanonicalJsonObject) -> Result<bool, Error> {
-    let Some(CanonicalJsonValue::String(raw_type)) = object.get("type") else {
-        return Err(JsonError::not_of_type("type", CanonicalJsonType::String));
+    let raw_type = match object.get("type") {
+        Some(CanonicalJsonValue::String(raw_type)) => raw_type,
+        Some(value) => {
+            return Err(JsonError::InvalidType {
+                path: "type".to_owned(),
+                expected: CanonicalJsonType::String,
+                found: value.json_type(),
+            }
+            .into());
+        }
+        None => return Err(JsonError::JsonFieldMissingFromObject("type".to_owned()).into()),
     };
 
     if raw_type != "m.room.member" {
         return Ok(false);
     }
 
-    let Some(CanonicalJsonValue::Object(content)) = object.get("content") else {
-        return Err(JsonError::not_of_type("content", CanonicalJsonType::Object));
+    let content = match object.get("content") {
+        Some(CanonicalJsonValue::Object(content)) => content,
+        Some(value) => {
+            return Err(JsonError::InvalidType {
+                path: "content".to_owned(),
+                expected: CanonicalJsonType::Object,
+                found: value.json_type(),
+            }
+            .into());
+        }
+        None => return Err(JsonError::JsonFieldMissingFromObject("content".to_owned()).into()),
     };
 
-    let Some(CanonicalJsonValue::String(membership)) = content.get("membership") else {
-        return Err(JsonError::not_of_type("membership", CanonicalJsonType::String));
+    let membership = match content.get("membership") {
+        Some(CanonicalJsonValue::String(membership)) => membership,
+        Some(value) => {
+            return Err(JsonError::InvalidType {
+                path: "content.membership".to_owned(),
+                expected: CanonicalJsonType::String,
+                found: value.json_type(),
+            }
+            .into());
+        }
+        None => {
+            return Err(
+                JsonError::JsonFieldMissingFromObject("content.membership".to_owned()).into()
+            );
+        }
     };
 
     if membership != "invite" {
@@ -814,7 +908,12 @@ fn is_invite_via_third_party_id(object: &CanonicalJsonObject) -> Result<bool, Er
 
     match content.get("third_party_invite") {
         Some(CanonicalJsonValue::Object(_)) => Ok(true),
+        Some(value) => Err(JsonError::InvalidType {
+            path: "content.third_party_invite".to_owned(),
+            expected: CanonicalJsonType::Object,
+            found: value.json_type(),
+        }
+        .into()),
         None => Ok(false),
-        _ => Err(JsonError::not_of_type("third_party_invite", CanonicalJsonType::Object)),
     }
 }

--- a/crates/ruma-signatures/src/functions.rs
+++ b/crates/ruma-signatures/src/functions.rs
@@ -100,7 +100,7 @@ pub fn sign_json<K>(
     entity_id: &str,
     key_pair: &K,
     object: &mut CanonicalJsonObject,
-) -> Result<(), Error>
+) -> Result<(), JsonError>
 where
     K: KeyPair,
 {
@@ -111,8 +111,7 @@ where
                 path: "signatures".to_owned(),
                 expected: CanonicalJsonType::Object,
                 found: value.json_type(),
-            }
-            .into());
+            });
         }
         None => (Cow::Borrowed("signatures"), BTreeMap::new()),
     };
@@ -135,8 +134,7 @@ where
             path: format!("signatures.{entity_id}"),
             expected: CanonicalJsonType::Object,
             found: signature_set.json_type(),
-        }
-        .into());
+        });
     };
 
     signature_set.insert(signature.id(), CanonicalJsonValue::String(signature.base64()));
@@ -172,7 +170,7 @@ where
 ///
 /// assert_eq!(canonical, r#"{"日":1,"本":2}"#);
 /// ```
-pub fn canonical_json(object: &CanonicalJsonObject) -> Result<String, Error> {
+pub fn canonical_json(object: &CanonicalJsonObject) -> Result<String, JsonError> {
     canonical_json_with_fields_to_remove(object, CANONICAL_JSON_FIELDS_TO_REMOVE)
 }
 
@@ -411,10 +409,11 @@ where
 /// # Errors
 ///
 /// Returns an error if the event is too large.
-pub fn content_hash(object: &CanonicalJsonObject) -> Result<Base64<Standard, [u8; 32]>, Error> {
+pub fn content_hash(object: &CanonicalJsonObject) -> Result<Base64<Standard, [u8; 32]>, JsonError> {
     let json = canonical_json_with_fields_to_remove(object, CONTENT_HASH_FIELDS_TO_REMOVE)?;
+
     if json.len() > MAX_PDU_BYTES {
-        return Err(Error::PduSize);
+        return Err(JsonError::PduTooLarge);
     }
 
     let hash = Sha256::digest(json.as_bytes());
@@ -448,13 +447,14 @@ pub fn content_hash(object: &CanonicalJsonObject) -> Result<Base64<Standard, [u8
 pub fn reference_hash(
     object: &CanonicalJsonObject,
     rules: &RoomVersionRules,
-) -> Result<String, Error> {
+) -> Result<String, JsonError> {
     let redacted_value = redact(object.clone(), &rules.redaction, None)?;
 
     let json =
         canonical_json_with_fields_to_remove(&redacted_value, REFERENCE_HASH_FIELDS_TO_REMOVE)?;
+
     if json.len() > MAX_PDU_BYTES {
-        return Err(Error::PduSize);
+        return Err(JsonError::PduTooLarge);
     }
 
     let hash = Sha256::digest(json.as_bytes());
@@ -577,7 +577,7 @@ pub fn hash_and_sign_event<K>(
     key_pair: &K,
     object: &mut CanonicalJsonObject,
     redaction_rules: &RedactionRules,
-) -> Result<(), Error>
+) -> Result<(), JsonError>
 where
     K: KeyPair,
 {
@@ -596,12 +596,11 @@ where
                 path: "hashes".to_owned(),
                 expected: CanonicalJsonType::Object,
                 found: hashes_value.json_type(),
-            }
-            .into());
+            });
         }
     };
 
-    let mut redacted = redact(object.clone(), redaction_rules, None)?;
+    let mut redacted = redact(object.clone(), redaction_rules, None).map_err(JsonError::from)?;
 
     sign_json(entity_id, key_pair, &mut redacted)?;
 
@@ -686,7 +685,7 @@ pub fn verify_event(
     object: &CanonicalJsonObject,
     rules: &RoomVersionRules,
 ) -> Result<Verified, Error> {
-    let redacted = redact(object.clone(), &rules.redaction, None)?;
+    let redacted = redact(object.clone(), &rules.redaction, None).map_err(JsonError::from)?;
 
     let hashes = match object.get("hashes") {
         Some(CanonicalJsonValue::Object(hashes)) => hashes,
@@ -756,14 +755,14 @@ pub fn verify_event(
 fn canonical_json_with_fields_to_remove(
     object: &CanonicalJsonObject,
     fields: &[&str],
-) -> Result<String, Error> {
+) -> Result<String, JsonError> {
     let mut owned_object = object.clone();
 
     for field in fields {
         owned_object.remove(*field);
     }
 
-    to_json_string(&owned_object).map_err(|e| Error::Json(e.into()))
+    to_json_string(&owned_object).map_err(Into::into)
 }
 
 /// Extracts the server names to check signatures for given event.
@@ -854,7 +853,7 @@ fn servers_to_check_signatures(
 /// third-party invite.
 ///
 /// Returns an error if the object has not the expected format of an `m.room.member` event.
-fn is_invite_via_third_party_id(object: &CanonicalJsonObject) -> Result<bool, Error> {
+fn is_invite_via_third_party_id(object: &CanonicalJsonObject) -> Result<bool, JsonError> {
     let raw_type = match object.get("type") {
         Some(CanonicalJsonValue::String(raw_type)) => raw_type,
         Some(value) => {
@@ -862,10 +861,9 @@ fn is_invite_via_third_party_id(object: &CanonicalJsonObject) -> Result<bool, Er
                 path: "type".to_owned(),
                 expected: CanonicalJsonType::String,
                 found: value.json_type(),
-            }
-            .into());
+            });
         }
-        None => return Err(JsonError::MissingField { path: "type".to_owned() }.into()),
+        None => return Err(JsonError::MissingField { path: "type".to_owned() }),
     };
 
     if raw_type != "m.room.member" {
@@ -879,10 +877,9 @@ fn is_invite_via_third_party_id(object: &CanonicalJsonObject) -> Result<bool, Er
                 path: "content".to_owned(),
                 expected: CanonicalJsonType::Object,
                 found: value.json_type(),
-            }
-            .into());
+            });
         }
-        None => return Err(JsonError::MissingField { path: "content".to_owned() }.into()),
+        None => return Err(JsonError::MissingField { path: "content".to_owned() }),
     };
 
     let membership = match content.get("membership") {
@@ -892,11 +889,10 @@ fn is_invite_via_third_party_id(object: &CanonicalJsonObject) -> Result<bool, Er
                 path: "content.membership".to_owned(),
                 expected: CanonicalJsonType::String,
                 found: value.json_type(),
-            }
-            .into());
+            });
         }
         None => {
-            return Err(JsonError::MissingField { path: "content.membership".to_owned() }.into());
+            return Err(JsonError::MissingField { path: "content.membership".to_owned() });
         }
     };
 
@@ -910,8 +906,7 @@ fn is_invite_via_third_party_id(object: &CanonicalJsonObject) -> Result<bool, Er
             path: "content.third_party_invite".to_owned(),
             expected: CanonicalJsonType::Object,
             found: value.json_type(),
-        }
-        .into()),
+        }),
         None => Ok(false),
     }
 }

--- a/crates/ruma-signatures/src/functions.rs
+++ b/crates/ruma-signatures/src/functions.rs
@@ -240,7 +240,7 @@ pub fn verify_json(
             }
             .into());
         }
-        None => return Err(JsonError::field_missing_from_object("signatures")),
+        None => return Err(JsonError::MissingField { path: "signatures".to_owned() }.into()),
     };
 
     let canonical_json = canonical_json(object)?;
@@ -698,7 +698,7 @@ pub fn verify_event(
             }
             .into());
         }
-        None => return Err(JsonError::field_missing_from_object("hashes")),
+        None => return Err(JsonError::MissingField { path: "hashes".to_owned() }.into()),
     };
 
     let hash = match hashes.get("sha256") {
@@ -711,7 +711,7 @@ pub fn verify_event(
             }
             .into());
         }
-        None => return Err(JsonError::field_missing_from_object("sha256")),
+        None => return Err(JsonError::MissingField { path: "hashes.sha256".to_owned() }.into()),
     };
 
     let signature_map = match object.get("signatures") {
@@ -724,7 +724,7 @@ pub fn verify_event(
             }
             .into());
         }
-        None => return Err(JsonError::field_missing_from_object("signatures")),
+        None => return Err(JsonError::MissingField { path: "signatures".to_owned() }.into()),
     };
 
     let servers_to_check = servers_to_check_signatures(object, &rules.signatures)?;
@@ -799,7 +799,7 @@ fn servers_to_check_signatures(
                 }
                 .into());
             }
-            _ => return Err(JsonError::field_missing_from_object("sender")),
+            _ => return Err(JsonError::MissingField { path: "sender".to_owned() }.into()),
         }
     }
 
@@ -825,7 +825,7 @@ fn servers_to_check_signatures(
                 .into());
             }
             _ => {
-                return Err(JsonError::field_missing_from_object("event_id"));
+                return Err(JsonError::MissingField { path: "event_id".to_owned() }.into());
             }
         }
     }
@@ -865,7 +865,7 @@ fn is_invite_via_third_party_id(object: &CanonicalJsonObject) -> Result<bool, Er
             }
             .into());
         }
-        None => return Err(JsonError::JsonFieldMissingFromObject("type".to_owned()).into()),
+        None => return Err(JsonError::MissingField { path: "type".to_owned() }.into()),
     };
 
     if raw_type != "m.room.member" {
@@ -882,7 +882,7 @@ fn is_invite_via_third_party_id(object: &CanonicalJsonObject) -> Result<bool, Er
             }
             .into());
         }
-        None => return Err(JsonError::JsonFieldMissingFromObject("content".to_owned()).into()),
+        None => return Err(JsonError::MissingField { path: "content".to_owned() }.into()),
     };
 
     let membership = match content.get("membership") {
@@ -896,9 +896,7 @@ fn is_invite_via_third_party_id(object: &CanonicalJsonObject) -> Result<bool, Er
             .into());
         }
         None => {
-            return Err(
-                JsonError::JsonFieldMissingFromObject("content.membership".to_owned()).into()
-            );
+            return Err(JsonError::MissingField { path: "content.membership".to_owned() }.into());
         }
     };
 

--- a/crates/ruma-signatures/src/functions.rs
+++ b/crates/ruma-signatures/src/functions.rs
@@ -371,7 +371,7 @@ pub fn verify_canonical_json_bytes(
     let verifier =
         verifier_from_algorithm(algorithm).ok_or(VerificationError::UnsupportedAlgorithm)?;
 
-    verify_canonical_json_with(&verifier, public_key, signature, canonical_json)
+    verify_canonical_json_with(&verifier, public_key, signature, canonical_json).map_err(Into::into)
 }
 
 /// Uses a public key to verify signed canonical JSON bytes.
@@ -392,11 +392,11 @@ fn verify_canonical_json_with<V>(
     public_key: &[u8],
     signature: &[u8],
     canonical_json: &[u8],
-) -> Result<(), Error>
+) -> Result<(), VerificationError>
 where
     V: Verifier,
 {
-    verifier.verify_json(public_key, signature, canonical_json)
+    verifier.verify_json(public_key, signature, canonical_json).map_err(Into::into)
 }
 
 /// Creates a *content hash* for an event.

--- a/crates/ruma-signatures/src/functions/tests.rs
+++ b/crates/ruma-signatures/src/functions/tests.rs
@@ -14,7 +14,7 @@ use super::{
     verify_event,
 };
 use crate::{
-    Ed25519KeyPair, Ed25519VerificationError, Error, KeyPair, PublicKeyMap, PublicKeySet,
+    Ed25519KeyPair, Ed25519VerificationError, KeyPair, PublicKeyMap, PublicKeySet,
     VerificationError, Verified,
 };
 
@@ -232,10 +232,7 @@ fn verification_fails_if_missing_signatures_for_authorized_user() {
 
     let verification_result = verify_event(&public_key_map, &signed_event, &RoomVersionRules::V9);
 
-    assert_matches!(
-        verification_result,
-        Err(Error::Verification(VerificationError::NoSignaturesForEntity(server)))
-    );
+    assert_matches!(verification_result, Err(VerificationError::NoSignaturesForEntity(server)));
     assert_eq!(server, "domain-authorized");
 }
 
@@ -269,10 +266,7 @@ fn verification_fails_if_required_keys_are_not_given() {
     let public_key_map = BTreeMap::new();
     let verification_result = verify_event(&public_key_map, &signed_event, &RoomVersionRules::V6);
 
-    assert_matches!(
-        verification_result,
-        Err(Error::Verification(VerificationError::NoPublicKeysForEntity(entity)))
-    );
+    assert_matches!(verification_result, Err(VerificationError::NoPublicKeysForEntity(entity)));
     assert_eq!(entity, "domain-sender");
 }
 
@@ -317,9 +311,7 @@ fn verify_event_fails_if_public_key_is_invalid() {
 
     assert_matches!(
         verification_result,
-        Err(Error::Verification(VerificationError::Ed25519(
-            Ed25519VerificationError::SignatureVerification(error)
-        )))
+        Err(VerificationError::Ed25519(Ed25519VerificationError::SignatureVerification(error)))
     );
     // dalek doesn't expose InternalError :(
     // https://github.com/dalek-cryptography/ed25519-dalek/issues/174
@@ -394,7 +386,7 @@ fn verify_event_fails_with_missing_key_when_event_is_signed_multiple_times_by_sa
 
     assert_matches!(
         verification_result,
-        Err(Error::Verification(VerificationError::PublicKeyNotFound { entity, key_id }))
+        Err(VerificationError::PublicKeyNotFound { entity, key_id })
     );
     assert_eq!(entity, "domain-sender");
     assert_eq!(key_id, "ed25519:2");
@@ -471,7 +463,7 @@ fn verify_event_with_single_key_with_unknown_algorithm_should_not_accept_event()
     let verification_result = verify_event(&public_key_map, &signed_event, &RoomVersionRules::V6);
     assert_matches!(
         verification_result,
-        Err(Error::Verification(VerificationError::NoSupportedSignatureForEntity(entity)))
+        Err(VerificationError::NoSupportedSignatureForEntity(entity))
     );
     assert_eq!(entity, "domain-sender");
 }
@@ -651,7 +643,7 @@ fn verify_canonical_json_bytes_unsupported_algorithm() {
         canonical_json.as_bytes(),
     )
     .unwrap_err();
-    assert_matches!(err, Error::Verification(VerificationError::UnsupportedAlgorithm));
+    assert_matches!(err, VerificationError::UnsupportedAlgorithm);
 }
 
 #[test]
@@ -677,8 +669,6 @@ fn verify_canonical_json_bytes_wrong_key() {
     .unwrap_err();
     assert_matches!(
         err,
-        Error::Verification(VerificationError::Ed25519(
-            Ed25519VerificationError::SignatureVerification(_)
-        ))
+        VerificationError::Ed25519(Ed25519VerificationError::SignatureVerification(_))
     );
 }

--- a/crates/ruma-signatures/src/functions/tests.rs
+++ b/crates/ruma-signatures/src/functions/tests.rs
@@ -14,7 +14,8 @@ use super::{
     verify_event,
 };
 use crate::{
-    Ed25519KeyPair, Error, KeyPair, PublicKeyMap, PublicKeySet, VerificationError, Verified,
+    Ed25519KeyPair, Ed25519VerificationError, Error, KeyPair, PublicKeyMap, PublicKeySet,
+    VerificationError, Verified,
 };
 
 fn generate_key_pair(name: &str) -> Ed25519KeyPair {
@@ -316,7 +317,9 @@ fn verify_event_fails_if_public_key_is_invalid() {
 
     assert_matches!(
         verification_result,
-        Err(Error::Verification(VerificationError::Signature(error)))
+        Err(Error::Verification(VerificationError::Ed25519(
+            Ed25519VerificationError::SignatureVerification(error)
+        )))
     );
     // dalek doesn't expose InternalError :(
     // https://github.com/dalek-cryptography/ed25519-dalek/issues/174
@@ -672,5 +675,10 @@ fn verify_canonical_json_bytes_wrong_key() {
         canonical_json.as_bytes(),
     )
     .unwrap_err();
-    assert_matches!(err, Error::Verification(VerificationError::Signature(_)));
+    assert_matches!(
+        err,
+        Error::Verification(VerificationError::Ed25519(
+            Ed25519VerificationError::SignatureVerification(_)
+        ))
+    );
 }

--- a/crates/ruma-signatures/src/keys.rs
+++ b/crates/ruma-signatures/src/keys.rs
@@ -10,8 +10,9 @@ use pkcs8::{
     DecodePrivateKey, EncodePrivateKey, ObjectIdentifier, PrivateKeyInfo, der::zeroize::Zeroizing,
 };
 use ruma_common::{SigningKeyAlgorithm, SigningKeyId, serde::Base64};
+use thiserror::Error;
 
-use crate::{Error, ParseError, signatures::Signature};
+use crate::signatures::Signature;
 
 #[cfg(feature = "ring-compat")]
 mod compat;
@@ -40,9 +41,12 @@ impl Ed25519KeyPair {
         privkey: &[u8],
         pubkey: Option<&[u8]>,
         version: String,
-    ) -> Result<Self, Error> {
+    ) -> Result<Self, Ed25519KeyPairParseError> {
         if oid != ALGORITHM_OID {
-            return Err(ParseError::Oid { expected: ALGORITHM_OID, found: oid }.into());
+            return Err(Ed25519KeyPairParseError::InvalidOid {
+                expected: ALGORITHM_OID,
+                found: oid,
+            });
         }
 
         let secret_key = Self::correct_privkey_from_octolet(privkey)?;
@@ -53,10 +57,10 @@ impl Ed25519KeyPair {
             let verifying_key = signing_key.verifying_key();
 
             if oak_key != verifying_key.as_bytes() {
-                return Err(ParseError::derived_vs_parsed_mismatch(
-                    oak_key,
-                    verifying_key.as_bytes().to_vec(),
-                ));
+                return Err(Ed25519KeyPairParseError::PublicKeyMismatch {
+                    derived: verifying_key.as_bytes().to_vec(),
+                    parsed: oak_key.to_owned(),
+                });
             }
         }
 
@@ -81,7 +85,7 @@ impl Ed25519KeyPair {
     /// Returns an error when the PKCS#8 document had a public key, but it doesn't match the one
     /// generated from the private key. This is a fallback and extra validation against
     /// corruption or
-    pub fn from_der(document: &[u8], version: String) -> Result<Self, Error> {
+    pub fn from_der(document: &[u8], version: String) -> Result<Self, Ed25519KeyPairParseError> {
         #[cfg(feature = "ring-compat")]
         use self::compat::CompatibleDocument;
 
@@ -90,29 +94,31 @@ impl Ed25519KeyPair {
         #[cfg(feature = "ring-compat")]
         {
             signing_key = match CompatibleDocument::from_bytes(document) {
-                CompatibleDocument::WellFormed(bytes) => {
-                    SigningKey::from_pkcs8_der(bytes).map_err(Error::DerParse)?
-                }
-                CompatibleDocument::CleanedFromRing(vec) => {
-                    SigningKey::from_pkcs8_der(&vec).map_err(Error::DerParse)?
-                }
+                CompatibleDocument::WellFormed(bytes) => SigningKey::from_pkcs8_der(bytes)?,
+                CompatibleDocument::CleanedFromRing(vec) => SigningKey::from_pkcs8_der(&vec)?,
             }
         }
         #[cfg(not(feature = "ring-compat"))]
         {
-            signing_key = SigningKey::from_pkcs8_der(document).map_err(Error::DerParse)?;
+            signing_key = SigningKey::from_pkcs8_der(document)?;
         }
 
         Ok(Self { signing_key, version })
     }
 
     /// Constructs a key pair from [`pkcs8::PrivateKeyInfo`].
-    pub fn from_pkcs8_oak(oak: PrivateKeyInfo<'_>, version: String) -> Result<Self, Error> {
+    pub fn from_pkcs8_oak(
+        oak: PrivateKeyInfo<'_>,
+        version: String,
+    ) -> Result<Self, Ed25519KeyPairParseError> {
         Self::new(oak.algorithm.oid, oak.private_key, oak.public_key, version)
     }
 
     /// Constructs a key pair from [`pkcs8::PrivateKeyInfo`].
-    pub fn from_pkcs8_pki(oak: PrivateKeyInfo<'_>, version: String) -> Result<Self, Error> {
+    pub fn from_pkcs8_pki(
+        oak: PrivateKeyInfo<'_>,
+        version: String,
+    ) -> Result<Self, Ed25519KeyPairParseError> {
         Self::new(oak.algorithm.oid, oak.private_key, None, version)
     }
 
@@ -120,11 +126,14 @@ impl Ed25519KeyPair {
     /// so convert it if it is wrongly formatted.
     ///
     /// See [RFC 8310 10.3](https://datatracker.ietf.org/doc/html/rfc8410#section-10.3) for more details
-    fn correct_privkey_from_octolet(key: &[u8]) -> Result<&SecretKey, ParseError> {
+    fn correct_privkey_from_octolet(key: &[u8]) -> Result<&SecretKey, Ed25519KeyPairParseError> {
         if key.len() == 34 && key[..2] == [0x04, 0x20] {
             Ok(key[2..].try_into().unwrap())
         } else {
-            key.try_into().map_err(|_| ParseError::SecretKey)
+            key.try_into().map_err(|_| Ed25519KeyPairParseError::InvalidSecretKeyLength {
+                expected: ed25519_dalek::SECRET_KEY_LENGTH,
+                found: key.len(),
+            })
         }
     }
 
@@ -137,9 +146,9 @@ impl Ed25519KeyPair {
     /// # Errors
     ///
     /// Returns an error if the generation failed.
-    pub fn generate() -> Result<Zeroizing<Vec<u8>>, Error> {
+    pub fn generate() -> Result<Zeroizing<Vec<u8>>, Ed25519KeyPairParseError> {
         let signing_key = SigningKey::generate(&mut rand::rngs::OsRng);
-        Ok(signing_key.to_pkcs8_der().map_err(Error::DerParse)?.to_bytes())
+        Ok(signing_key.to_pkcs8_der()?.to_bytes())
     }
 
     /// Returns the version string for this keypair.
@@ -173,6 +182,48 @@ impl Debug for Ed25519KeyPair {
             .field("version", &self.version)
             .finish()
     }
+}
+
+/// An error encountered when constructing an [`Ed25519KeyPair`] from its constituent parts.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum Ed25519KeyPairParseError {
+    /// The ASN.1 Object Identifier on a PKCS#8 document doesn't match the expected one.
+    ///
+    /// This can happen when the document describes a RSA key, while an ed25519 key was expected.
+    #[error("algorithm OID does not match ed25519 algorithm: expected {expected}, found {found}")]
+    InvalidOid {
+        /// The expected OID.
+        expected: ObjectIdentifier,
+
+        /// The OID that was found instead.
+        found: ObjectIdentifier,
+    },
+
+    /// The length of the ed25519 secret key is invalid.
+    #[error("invalid ed25519 secret key length: expected {expected}, found {found}")]
+    InvalidSecretKeyLength {
+        /// The expected length of the secret key.
+        expected: usize,
+
+        /// The actual size of the secret key.
+        found: usize,
+    },
+
+    /// The public key found in a PKCS#8 v2 document doesn't match the public key derived from its
+    /// private key.
+    #[error("PKCS#8 Document public key does not match public key derived from private key: derived {0:X?} (len {}), parsed {1:X?} (len {})", .derived.len(), .parsed.len())]
+    PublicKeyMismatch {
+        /// The key derived from the private key.
+        derived: Vec<u8>,
+
+        /// The key found in the document.
+        parsed: Vec<u8>,
+    },
+
+    /// An error occurred when parsing a PKCS#8 document.
+    #[error("invalid PKCS#8 document: {0}")]
+    Pkcs8(#[from] pkcs8::Error),
 }
 
 /// A map from entity names to sets of public keys for that entity.

--- a/crates/ruma-signatures/src/lib.rs
+++ b/crates/ruma-signatures/src/lib.rs
@@ -58,7 +58,7 @@ pub use self::{
     },
     keys::{Ed25519KeyPair, Ed25519KeyPairParseError, KeyPair, PublicKeyMap, PublicKeySet},
     signatures::Signature,
-    verification::Verified,
+    verification::{Ed25519VerificationError, Verified},
 };
 
 mod error;

--- a/crates/ruma-signatures/src/lib.rs
+++ b/crates/ruma-signatures/src/lib.rs
@@ -51,7 +51,7 @@
 pub use ruma_common::{IdParseError, SigningKeyAlgorithm};
 
 pub use self::{
-    error::{Error, JsonError, ParseError, VerificationError},
+    error::{JsonError, VerificationError},
     functions::{
         canonical_json, content_hash, hash_and_sign_event, reference_hash, sign_json,
         verify_canonical_json_bytes, verify_event, verify_json,

--- a/crates/ruma-signatures/src/lib.rs
+++ b/crates/ruma-signatures/src/lib.rs
@@ -56,7 +56,7 @@ pub use self::{
         canonical_json, content_hash, hash_and_sign_event, reference_hash, sign_json,
         verify_canonical_json_bytes, verify_event, verify_json,
     },
-    keys::{Ed25519KeyPair, KeyPair, PublicKeyMap, PublicKeySet},
+    keys::{Ed25519KeyPair, Ed25519KeyPairParseError, KeyPair, PublicKeyMap, PublicKeySet},
     signatures::Signature,
     verification::Verified,
 };

--- a/crates/ruma-signatures/src/verification.rs
+++ b/crates/ruma-signatures/src/verification.rs
@@ -1,12 +1,18 @@
 //! Verification of digital signatures.
 
-use ed25519_dalek::{Verifier as _, VerifyingKey};
+use ed25519_dalek::{
+    Verifier as _, VerifyingKey as Ed25519VerifyingKey, ed25519::Signature as Ed25519Signature,
+};
 use ruma_common::SigningKeyAlgorithm;
+use thiserror::Error;
 
-use crate::{Error, ParseError, VerificationError};
+use crate::VerificationError;
 
 /// A digital signature verifier.
 pub(crate) trait Verifier {
+    /// The error type returned by the verifier.
+    type Error: std::error::Error + Into<VerificationError>;
+
     /// Use a public key to verify a signature against the JSON object that was signed.
     ///
     /// # Parameters
@@ -18,8 +24,12 @@ pub(crate) trait Verifier {
     /// # Errors
     ///
     /// Returns an error if verification fails.
-    fn verify_json(&self, public_key: &[u8], signature: &[u8], message: &[u8])
-    -> Result<(), Error>;
+    fn verify_json(
+        &self,
+        public_key: &[u8],
+        signature: &[u8],
+        message: &[u8],
+    ) -> Result<(), Self::Error>;
 }
 
 /// A verifier for Ed25519 digital signatures.
@@ -27,18 +37,50 @@ pub(crate) trait Verifier {
 pub(crate) struct Ed25519Verifier;
 
 impl Verifier for Ed25519Verifier {
+    type Error = Ed25519VerificationError;
+
     fn verify_json(
         &self,
         public_key: &[u8],
         signature: &[u8],
         message: &[u8],
-    ) -> Result<(), Error> {
-        VerifyingKey::try_from(public_key)
-            .map_err(ParseError::PublicKey)?
-            .verify(message, &signature.try_into().map_err(ParseError::Signature)?)
-            .map_err(VerificationError::Signature)
-            .map_err(Error::from)
+    ) -> Result<(), Self::Error> {
+        Ed25519VerifyingKey::try_from(public_key)
+            .map_err(Ed25519VerificationError::InvalidPublicKey)?
+            .verify(
+                message,
+                &Ed25519Signature::from_bytes(&signature.try_into().map_err(|_| {
+                    Ed25519VerificationError::InvalidSignatureLength {
+                        expected: Ed25519Signature::BYTE_SIZE,
+                        found: signature.len(),
+                    }
+                })?),
+            )
+            .map_err(Ed25519VerificationError::SignatureVerification)
     }
+}
+
+/// Errors relating to the verification of ed25519 signatures.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum Ed25519VerificationError {
+    /// The provided ed25519 public key is invalid.
+    #[error("Invalid ed25519 public key: {0}")]
+    InvalidPublicKey(#[source] ed25519_dalek::SignatureError),
+
+    /// The provided signature has an invalid length.
+    #[error("Invalid ed25519 signature length: expected {expected}, found {found}")]
+    InvalidSignatureLength {
+        /// The expected length of the signature.
+        expected: usize,
+
+        /// The actual length of the signature.
+        found: usize,
+    },
+
+    /// The signature verification failed.
+    #[error("ed25519 signature verification failed: {0}")]
+    SignatureVerification(#[source] ed25519_dalek::SignatureError),
 }
 
 /// A value returned when an event is successfully verified.


### PR DESCRIPTION
Closes #1216.

This tries to have a better organization of the errors, in particular:

- We try to merge error variants that are very similar.
- We try to provide more context on JSON errors.
- Functions return the most specific error type possible, instead of always returning `Error`. We end up with signing functions only requiring `JsonError`, so we merge everything else in `VerificationError`.
- ed25519-specific error types have their own enums, in case more algorithms are added in the future.

This can be reviewed commit by commit.