### PR TITLE
client-api: Remove the `score` field from the `report_content` endpoint

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -34,6 +34,9 @@ Breaking changes:
   - `UnknownToken`
   - `WrongRoomKeysVersion`, and its `current_version` field is now required and
     its serialization was fixed.
+- Remove the `score` field from `report_content::v3::Request` according to
+  MSC4277. `report_content::v3::Request::new()` now only takes a room ID and an
+  event ID.
 
 Bug fixes:
 

--- a/crates/ruma-client-api/src/room/report_content.rs
+++ b/crates/ruma-client-api/src/room/report_content.rs
@@ -7,7 +7,6 @@ pub mod v3 {
     //!
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidreporteventid
 
-    use js_int::Int;
     use ruma_common::{
         OwnedEventId, OwnedRoomId,
         api::{auth_scheme::AccessToken, request, response},
@@ -35,10 +34,6 @@ pub mod v3 {
         #[ruma_api(path)]
         pub event_id: OwnedEventId,
 
-        /// Integer between -100 and 0 rating offensivness.
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub score: Option<Int>,
-
         /// Reason to report content.
         #[serde(skip_serializing_if = "Option::is_none")]
         pub reason: Option<String>,
@@ -50,14 +45,9 @@ pub mod v3 {
     pub struct Response {}
 
     impl Request {
-        /// Creates a new `Request` with the given room ID, event ID, score and reason.
-        pub fn new(
-            room_id: OwnedRoomId,
-            event_id: OwnedEventId,
-            score: Option<Int>,
-            reason: Option<String>,
-        ) -> Self {
-            Self { room_id, event_id, score, reason }
+        /// Creates a new `Request` with the given room ID ad event ID.
+        pub fn new(room_id: OwnedRoomId, event_id: OwnedEventId) -> Self {
+            Self { room_id, event_id, reason: None }
         }
     }
 


### PR DESCRIPTION
According to [MSC4277](https://github.com/matrix-org/matrix-spec-proposals/pull/4277) / [Spec PR](https://github.com/matrix-org/matrix-spec/issues/2311).

I used this occasion to remove the other optional field from the `Request` constructor, because we usually don't include them in constructors.