### PR TITLE
client-api: Remove `non_exhaustive` attribute on `ErrorKind::Forbidden`

### DIFF
--- a/crates/ruma-client-api/src/error.rs
+++ b/crates/ruma-client-api/src/error.rs
@@ -130,7 +130,6 @@ pub enum ErrorKind {
     /// `M_FORBIDDEN`
     ///
     /// Forbidden access, e.g. joining a room without permission, failed login.
-    #[non_exhaustive]
     Forbidden,
 
     /// `M_GUEST_ACCESS_FORBIDDEN`

--- a/crates/ruma-client-api/tests/it/uiaa.rs
+++ b/crates/ruma-client-api/tests/it/uiaa.rs
@@ -131,7 +131,7 @@ fn deserialize_uiaa_info() {
     assert_eq!(info.flows[1].stages, vec![AuthType::EmailIdentity, AuthType::Msisdn]);
     assert_eq!(info.session.as_deref(), Some("xxxxxx"));
     let auth_error = info.auth_error.unwrap();
-    assert_matches!(auth_error.kind, ErrorKind::Forbidden { .. });
+    assert_matches!(auth_error.kind, ErrorKind::Forbidden);
     assert_eq!(auth_error.message, "Invalid password");
     assert_eq!(
         from_json_str::<JsonValue>(info.params.unwrap().get()).unwrap(),
@@ -214,7 +214,7 @@ fn try_uiaa_response_from_http_response() {
     assert_eq!(info.flows[1].stages, vec![AuthType::EmailIdentity, AuthType::Msisdn]);
     assert_eq!(info.session.as_deref(), Some("xxxxxx"));
     let auth_error = info.auth_error.unwrap();
-    assert_matches!(auth_error.kind, ErrorKind::Forbidden { .. });
+    assert_matches!(auth_error.kind, ErrorKind::Forbidden);
     assert_eq!(auth_error.message, "Invalid password");
     assert_eq!(
         from_json_str::<JsonValue>(info.params.unwrap().get()).unwrap(),


### PR DESCRIPTION
It was supposed to be removed when its field was removed in #2389.
