### PR TITLE
common: Remove direct dependency on js-sys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install cargo-sort
         uses: taiki-e/cache-cargo-install-action@v3
         with:
-          tool: cargo-sort
+          tool: cargo-sort@2.0.2
 
       - name: Get xtask
         uses: actions/cache@v5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1943,7 +1943,6 @@ dependencies = [
  "getrandom 0.2.16",
  "http",
  "indexmap",
- "js-sys",
  "js_int",
  "konst",
  "macro_rules_attribute",

--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -21,7 +21,7 @@ client = []
 server = []
 
 api = ["dep:http", "dep:konst"]
-js = ["dep:js-sys", "getrandom?/js", "uuid?/js"]
+js = ["getrandom?/js", "uuid?/js"]
 rand = ["dep:rand", "dep:getrandom", "dep:uuid"]
 
 unstable-msc2666 = []
@@ -81,9 +81,6 @@ uuid = { version = "1.0.0", optional = true, features = ["v4"] }
 web-time = { workspace = true }
 wildmatch = { workspace = true }
 zeroize = { workspace = true }
-
-[target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
-js-sys = { version = "0.3", optional = true }
 
 [dev-dependencies]
 assert_matches2 = { workspace = true }

--- a/crates/ruma-common/src/time.rs
+++ b/crates/ruma-common/src/time.rs
@@ -22,11 +22,7 @@ impl MilliSecondsSinceUnixEpoch {
 
     /// The current system time in milliseconds since the unix epoch.
     pub fn now() -> Self {
-        #[cfg(not(all(target_family = "wasm", target_os = "unknown", feature = "js")))]
-        return Self::from_system_time(SystemTime::now()).expect("date out of range");
-
-        #[cfg(all(target_family = "wasm", target_os = "unknown", feature = "js"))]
-        return Self(f64_to_uint(js_sys::Date::now()));
+        Self::from_system_time(SystemTime::now()).expect("date out of range")
     }
 
     /// Creates a new `SystemTime` from `self`, if it can be represented.
@@ -89,11 +85,7 @@ impl SecondsSinceUnixEpoch {
 
     /// The current system-time as seconds since the unix epoch.
     pub fn now() -> Self {
-        #[cfg(not(all(target_family = "wasm", target_os = "unknown", feature = "js")))]
-        return Self::from_system_time(SystemTime::now()).expect("date out of range");
-
-        #[cfg(all(target_family = "wasm", target_os = "unknown", feature = "js"))]
-        return Self(f64_to_uint(js_sys::Date::now() / 1000.0));
+        Self::from_system_time(SystemTime::now()).expect("date out of range")
     }
 
     /// Creates a new `SystemTime` from `self`, if it can be represented.
@@ -130,13 +122,6 @@ impl fmt::Debug for SecondsSinceUnixEpoch {
             }
         }
     }
-}
-
-#[cfg(all(target_family = "wasm", target_os = "unknown", feature = "js"))]
-fn f64_to_uint(val: f64) -> UInt {
-    // UInt::MAX milliseconds is ~285 616 years, we do not account for that
-    // (or for dates before the unix epoch which would have to be negative)
-    UInt::try_from(val as u64).expect("date out of range")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Since we use `web-time`, we can use its `SystemTime` implementation under wasm32 too.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
