### PR TITLE
ci: Upgrade actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Check spelling
-        uses: crate-ci/typos@v1.42.1
+        uses: crate-ci/typos@v1.44.0
 
       - name: Install cargo-sort
         uses: taiki-e/cache-cargo-install-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,10 +242,11 @@ jobs:
 
       - name: Upload docs as artifact
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: docs
           path: docs.tar.zstd
+          archive: false
 
       - name: Upload docs as pages artifact
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/semver-comment.yml
+++ b/.github/workflows/semver-comment.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download results
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
-          name: breaking-changes-results
+          name: breaking-changes-results.json
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ github.token }}
 

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -115,10 +115,10 @@ jobs:
           echo "$BREAKING_CHANGES_RESULTS" >> breaking-changes-results.json
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
-          name: breaking-changes-results
           path: breaking-changes-results.json
+          archive: false
 
   xtask:
     needs: changes

--- a/.typos.toml
+++ b/.typos.toml
@@ -2,6 +2,7 @@
 # Remove this once base64 gets correctly ignored by typos
 # Or if we're able to ignore certain lines.
 Hd = "Hd"
+Iz = "Iz"
 NAX = "NAX"
 Nd = "Nd"
 Pn = "Pn"


### PR DESCRIPTION
Based on #2406 for CI to pass.

This upgrades all actions to their latest version (except cargo-sort which is locked for now).