### PR TITLE
events: Add `AnySyncTimelineEvent::is_redacted()`

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -51,6 +51,7 @@ Improvements:
 - Add support for to-device event for pushing secrets, according to MSC4385.
 - Add support for video/audio call intent according to MSC4075 as part of the 
   `RtcNotificationEventContent` new `call_intent` field.
+- Add `AnySyncTimelineEvent::is_redacted()` helper.
 
 # 0.32.1
 

--- a/crates/ruma-events/src/enums.rs
+++ b/crates/ruma-events/src/enums.rs
@@ -331,6 +331,9 @@ impl AnySyncTimelineEvent {
 
         /// Returns this event's `transaction_id` from inside `unsigned`, if there is one.
         pub fn transaction_id(&self) -> Option<&TransactionId>;
+
+        /// Returns whether this event is in its redacted form or not.
+        pub fn is_redacted(&self) -> bool;
     }
 
     /// Returns this event's `type`.


### PR DESCRIPTION
Which is what #2254 initially set out to do, but was actually applied to `AnyTimelineEvent`.