### PR TITLE
events: Add `PossiblyRedactedSpace(Child/Parent)EventContent::is_valid`

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -52,6 +52,8 @@ Improvements:
 - Add support for video/audio call intent according to MSC4075 as part of the 
   `RtcNotificationEventContent` new `call_intent` field.
 - Add `AnySyncTimelineEvent::is_redacted()` helper.
+- Add `PossiblyRedactedSpace(Child/Parent)EventContent::is_valid()` to check the
+  validity of the event content according to the Matrix specification.
 
 # 0.32.1
 

--- a/crates/ruma-events/src/space/child.rs
+++ b/crates/ruma-events/src/space/child.rs
@@ -65,6 +65,19 @@ impl SpaceChildEventContent {
     }
 }
 
+impl PossiblyRedactedSpaceChildEventContent {
+    /// Whether this `PossiblyRedactedSpaceChildEventContent` is valid according to the Matrix
+    /// specification.
+    ///
+    /// The room in the state key of the event should only be considered a child of this space
+    /// if this returns `true`.
+    ///
+    /// Returns `false` if the `via` field is `None`.
+    pub fn is_valid(&self) -> bool {
+        self.via.is_some()
+    }
+}
+
 /// An `m.space.child` event represented as a Stripped State Event with an added `origin_server_ts`
 /// key.
 #[derive(Clone, Debug, Event)]

--- a/crates/ruma-events/src/space/parent.rs
+++ b/crates/ruma-events/src/space/parent.rs
@@ -40,6 +40,19 @@ impl SpaceParentEventContent {
     }
 }
 
+impl PossiblyRedactedSpaceParentEventContent {
+    /// Whether this `PossiblyRedactedSpaceParentEventContent` is valid according to the Matrix
+    /// specification.
+    ///
+    /// The room in the state key of the event should only be considered a parent space of this room
+    /// if this returns `true`.
+    ///
+    /// Returns `false` if the `via` field is `None`.
+    pub fn is_valid(&self) -> bool {
+        self.via.is_some()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use ruma_common::{canonical_json::assert_to_canonical_json_eq, owned_server_name};


### PR DESCRIPTION
A helper to check the validity of the content according to the specification.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
