### PR TITLE
events: Add `event_type()` helper to event structs

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -54,6 +54,24 @@ Improvements:
 - Add `AnySyncTimelineEvent::is_redacted()` helper.
 - Add `PossiblyRedactedSpace(Child/Parent)EventContent::is_valid()` to check the
   validity of the event content according to the Matrix specification.
+- Add a convenience `event_type()` helper on event structs which allows to
+  access the event type from the inner `*EventContent` type without requiring to
+  have a trait in scope. It is added to the following structs:
+  - `EphemeralRoomEvent`
+  - `GlobalAccountDataEvent`
+  - `InitialStateEvent`
+  - `OriginalMessageLikeEvent`
+  - `OriginalStateEvent`
+  - `OriginalSyncMessageLikeEvent`
+  - `OriginalSyncStateEvent`
+  - `RedactedMessageLikeEvent`
+  - `RedactedStateEvent`
+  - `RedactedSyncMessageLikeEvent`
+  - `RedactedSyncStateEvent`
+  - `RoomAccountDataEvent`
+  - `StrippedStateEvent`
+  - `SyncEphemeralRoomEvent`
+  - `ToDeviceEvent`
 
 # 0.32.1
 

--- a/crates/ruma-macros/src/events/common.rs
+++ b/crates/ruma-macros/src/events/common.rs
@@ -70,6 +70,11 @@ impl CommonEventKind {
             ],
         }
     }
+
+    /// Get the name of the `*EventType` enum for this kind.
+    pub(super) fn to_event_type_enum(self) -> syn::Ident {
+        format_ident!("{self}Type")
+    }
 }
 
 impl fmt::Display for CommonEventKind {

--- a/crates/ruma-macros/src/events/event.rs
+++ b/crates/ruma-macros/src/events/event.rs
@@ -15,12 +15,13 @@ use crate::util::{RumaEvents, RumaEventsReexport, to_camel_case};
 pub(crate) fn expand_event(input: syn::DeriveInput) -> syn::Result<TokenStream> {
     let event = Event::parse(input)?;
 
+    let accessors_impl = event.expand_accessors_impl();
     let deserialize_impl = event.expand_deserialize_impl();
     let sync_from_and_into_full = event.expand_sync_from_and_into_full();
-
     let eq_and_ord_impl = event.expand_eq_and_ord_impl();
 
     Ok(quote! {
+        #accessors_impl
         #deserialize_impl
         #sync_from_and_into_full
         #eq_and_ord_impl
@@ -49,6 +50,28 @@ struct Event {
 }
 
 impl Event {
+    /// Generate convenience accessors for this struct.
+    fn expand_accessors_impl(&self) -> Option<TokenStream> {
+        // Don't generate these accessors for special event types.
+        let kind = self.kind.common_kind()?;
+
+        let ruma_events = &self.ruma_events;
+        let ident = &self.ident;
+        let (impl_generics, ty_gen, where_clause) = self.generics.split_for_impl();
+
+        let event_type_enum = kind.to_event_type_enum();
+
+        Some(quote! {
+            #[automatically_derived]
+            impl #impl_generics #ident #ty_gen #where_clause {
+                /// Get the event's type.
+                pub fn event_type(&self) -> #ruma_events::#event_type_enum {
+                    self.content.event_type()
+                }
+            }
+        })
+    }
+
     /// Generate the `serde::Deserialize` implementation for this struct.
     fn expand_deserialize_impl(&self) -> TokenStream {
         let ruma_events = &self.ruma_events;

--- a/crates/ruma-macros/src/events/event_content.rs
+++ b/crates/ruma-macros/src/events/event_content.rs
@@ -911,11 +911,6 @@ impl CommonEventKind {
         Some(format_ident!("{variation}{self}"))
     }
 
-    /// Get the name of the `*EventType` enum for this kind.
-    fn to_event_type_enum(self) -> syn::Ident {
-        format_ident!("{self}Type")
-    }
-
     /// Get the name of the `[variation][kind]Content` trait for this kind and the given variation.
     fn to_content_kind_trait(self, variation: EventContentTraitVariation) -> syn::Ident {
         format_ident!("{variation}{self}Content")


### PR DESCRIPTION
It allows to access the event type from the inner `*EventContent` type without requiring to have the corresponding trait in scope.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
