### PR TITLE
signatures: Ignore signatures from keys missing from the key map

### DIFF
--- a/crates/ruma-signatures/CHANGELOG.md
+++ b/crates/ruma-signatures/CHANGELOG.md
@@ -35,6 +35,9 @@ Breaking changes:
   - `verify_canonical_json_bytes()`
   - `verify_event()`
   - `verify_json()`
+- When verifying the signatures on a JSON object, signatures of keys that are
+  not in the key map are ignored rather than returning an error. The
+  `VerificationError::PublicKeyNotFound` variant was removed.
 
 Improvements:
 

--- a/crates/ruma-signatures/src/error.rs
+++ b/crates/ruma-signatures/src/error.rs
@@ -95,16 +95,6 @@ pub enum VerificationError {
     #[error("Could not find public keys for entity {0:?}")]
     NoPublicKeysForEntity(String),
 
-    /// The public key with the given identifier cannot be found for the given entity.
-    #[error("Could not find public key {key_id:?} for entity {entity:?}")]
-    PublicKeyNotFound {
-        /// The entity for which the key is missing.
-        entity: String,
-
-        /// The identifier of the key that is missing.
-        key_id: String,
-    },
-
     /// No signature with a supported algorithm was found for the given entity.
     #[error("Could not find supported signature for entity {0:?}")]
     NoSupportedSignatureForEntity(String),

--- a/crates/ruma-signatures/src/functions.rs
+++ b/crates/ruma-signatures/src/functions.rs
@@ -297,6 +297,11 @@ fn verify_canonical_json_for_entity(
 
     let mut checked = false;
     for (key_id, signature) in signature_set {
+        // If the key is not in the map of public keys, ignore.
+        let Some(public_key) = public_keys.get(key_id) else {
+            continue;
+        };
+
         // If we cannot parse the key ID, ignore.
         let Ok(parsed_key_id) = <&SigningKeyId<AnyKeyName>>::try_from(key_id.as_str()) else {
             continue;
@@ -305,13 +310,6 @@ fn verify_canonical_json_for_entity(
         // If the signature uses an unknown algorithm, ignore.
         let Some(verifier) = verifier_from_algorithm(&parsed_key_id.algorithm()) else {
             continue;
-        };
-
-        let Some(public_key) = public_keys.get(key_id) else {
-            return Err(VerificationError::PublicKeyNotFound {
-                entity: entity_id.to_owned(),
-                key_id: key_id.clone(),
-            });
         };
 
         let CanonicalJsonValue::String(signature) = signature else {

--- a/crates/ruma-signatures/src/functions/tests.rs
+++ b/crates/ruma-signatures/src/functions/tests.rs
@@ -353,7 +353,7 @@ fn verify_event_check_signatures_for_sender_is_allowed_with_unknown_algorithms_i
 }
 
 #[test]
-fn verify_event_fails_with_missing_key_when_event_is_signed_multiple_times_by_same_entity() {
+fn verify_event_succeeds_when_missing_key_and_event_is_signed_multiple_times_by_same_entity() {
     let key_pair_sender = generate_key_pair("1");
     let secondary_key_pair_sender = generate_key_pair("2");
     let mut signed_event = serde_json::from_str(
@@ -382,14 +382,45 @@ fn verify_event_fails_with_missing_key_when_event_is_signed_multiple_times_by_sa
     let mut public_key_map = BTreeMap::new();
     add_key_to_map(&mut public_key_map, "domain-sender", &key_pair_sender);
 
-    let verification_result = verify_event(&public_key_map, &signed_event, &RoomVersionRules::V6);
+    let verification = verify_event(&public_key_map, &signed_event, &RoomVersionRules::V6).unwrap();
+    assert_eq!(verification, Verified::Signatures);
+}
 
+#[test]
+fn verify_event_fails_when_missing_key_and_event_is_signed_once_by_entity() {
+    let key_pair_sender = generate_key_pair("1");
+    let secondary_key_pair_sender = generate_key_pair("2");
+    let mut signed_event = serde_json::from_str(
+        r#"{
+                "auth_events": [],
+                "content": {},
+                "depth": 3,
+                "hashes": {
+                    "sha256": "5jM4wQpv6lnBo7CLIghJuHdW+s2CMBJPUOGOC89ncos"
+                },
+                "origin": "domain",
+                "origin_server_ts": 1000000,
+                "prev_events": [],
+                "room_id": "!x:domain",
+                "sender": "@name:domain-sender",
+                "type": "X",
+                "unsigned": {
+                    "age_ts": 1000000
+                }
+            }"#,
+    )
+    .unwrap();
+    sign_json("domain-sender", &secondary_key_pair_sender, &mut signed_event).unwrap();
+
+    let mut public_key_map = BTreeMap::new();
+    add_key_to_map(&mut public_key_map, "domain-sender", &key_pair_sender);
+
+    let verification_result = verify_event(&public_key_map, &signed_event, &RoomVersionRules::V6);
     assert_matches!(
         verification_result,
-        Err(VerificationError::PublicKeyNotFound { entity, key_id })
+        Err(VerificationError::NoSupportedSignatureForEntity(entity))
     );
     assert_eq!(entity, "domain-sender");
-    assert_eq!(key_id, "ed25519:2");
 }
 
 #[test]


### PR DESCRIPTION
I believe this was a misinterpretation of [the spec](https://spec.matrix.org/v1.17/appendices/#checking-for-a-signature):

> If it cannot find a verification key then the check fails.

This formulation is confusing, it could mean:

> If it cannot find **one of** the verification keys then the check fails.

which is what was implemented. It could also mean:

> If it cannot find **any** verification key then the check fails.

Which is what this change does. This also matches the behavior of Synapse (https://github.com/element-hq/synapse/blob/e30001883c30f38818d8ef6239145f9b42f89dd7/synapse/crypto/keyring.py#L356).

cc @jevolk 

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
