### PR TITLE
client-api: Add `M_USER_LIMIT_EXCEEDED` error code

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -82,6 +82,7 @@ Improvements:
   MSC4341 / Matrix 1.18.
 - Add support for the Policy Server public key information endpoint, according
   to MSC4284 / Matrix 1.18.
+- Add `M_USER_LIMIT_EXCEEDED` error code according to MSC4335.
 
 # 0.22.1
 

--- a/crates/ruma-client-api/src/error.rs
+++ b/crates/ruma-client-api/src/error.rs
@@ -366,6 +366,14 @@ pub enum ErrorKind {
     /// The desired user ID is already taken.
     UserInUse,
 
+    /// `M_USER_LIMIT_EXCEEDED`
+    ///
+    /// The request cannot be completed because the user has exceeded (or the request would cause
+    /// them to exceed) a limit associated with their account. For example, a user may have reached
+    /// their allocated storage quota, reached a maximum number of allowed rooms, devices, or other
+    /// account-scoped resources, or exceeded usage limits for specific features.
+    UserLimitExceeded(UserLimitExceededErrorData),
+
     /// `M_USER_LOCKED`
     ///
     /// The account has been [locked] and cannot be used at this time.
@@ -457,6 +465,7 @@ impl ErrorKind {
             ErrorKind::UrlNotSet => ErrorCode::UrlNotSet,
             ErrorKind::UserDeactivated => ErrorCode::UserDeactivated,
             ErrorKind::UserInUse => ErrorCode::UserInUse,
+            ErrorKind::UserLimitExceeded(_) => ErrorCode::UserLimitExceeded,
             ErrorKind::UserLocked => ErrorCode::UserLocked,
             ErrorKind::UserSuspended => ErrorCode::UserSuspended,
             ErrorKind::WeakPassword => ErrorCode::WeakPassword,
@@ -550,6 +559,33 @@ impl UnknownTokenErrorData {
     /// Construct a new `UnknownTokenErrorData` with `soft_logout` set to `false`.
     pub fn new() -> Self {
         Self::default()
+    }
+}
+
+/// Data for the `M_USER_LIMIT_EXCEEDED` [`ErrorKind`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+pub struct UserLimitExceededErrorData {
+    /// A URI that the client can present to the user to provide more context on the encountered
+    /// limit and, if applicable, guidance on how to increase the limit.
+    ///
+    /// The homeserver MAY return different values depending on the type of limit reached.
+    pub info_uri: String,
+
+    /// Whether the specific limit encountered can be increased.
+    ///
+    /// If `true`, it indicates that the specific limit encountered can be increased, for example
+    /// by upgrading the user’s account tier. If `false`, the limit is a hard limit that cannot be
+    /// increased.
+    ///
+    /// Defaults to `false`.
+    pub can_upgrade: bool,
+}
+
+impl UserLimitExceededErrorData {
+    /// Construct a new `UserLimitExceededErrorData` with the given URI.
+    pub fn new(info_uri: String) -> Self {
+        Self { info_uri, can_upgrade: false }
     }
 }
 
@@ -920,6 +956,14 @@ pub enum ErrorCode {
     ///
     /// The desired user ID is already taken.
     UserInUse,
+
+    /// `M_USER_LIMIT_EXCEEDED`
+    ///
+    /// The request cannot be completed because the user has exceeded (or the request would cause
+    /// them to exceed) a limit associated with their account. For example, a user may have reached
+    /// their allocated storage quota, reached a maximum number of allowed rooms, devices, or other
+    /// account-scoped resources, or exceeded usage limits for specific features.
+    UserLimitExceeded,
 
     /// `M_USER_LOCKED`
     ///

--- a/crates/ruma-client-api/src/error/kind_serde.rs
+++ b/crates/ruma-client-api/src/error/kind_serde.rs
@@ -13,6 +13,7 @@ use super::{
     LimitExceededErrorData, ResourceLimitExceededErrorData, RetryAfter, UnknownTokenErrorData,
     WrongRoomKeysVersionErrorData,
 };
+use crate::error::UserLimitExceededErrorData;
 
 enum Field<'de> {
     ErrorCode,
@@ -23,6 +24,8 @@ enum Field<'de> {
     Status,
     Body,
     CurrentVersion,
+    InfoUri,
+    CanUpgrade,
     Other(Cow<'de, str>),
 }
 
@@ -37,6 +40,8 @@ impl<'de> Field<'de> {
             "status" => Self::Status,
             "body" => Self::Body,
             "current_version" => Self::CurrentVersion,
+            "info_uri" => Self::InfoUri,
+            "can_upgrade" => Self::CanUpgrade,
             _ => Self::Other(s),
         }
     }
@@ -103,6 +108,8 @@ impl<'de> Visitor<'de> for ErrorKindVisitor {
         let mut status = None;
         let mut body = None;
         let mut current_version = None;
+        let mut info_uri = None;
+        let mut can_upgrade = None;
         let mut data = JsonObject::new();
 
         macro_rules! set_field {
@@ -128,6 +135,8 @@ impl<'de> Visitor<'de> for ErrorKindVisitor {
             (@variant_containing status) => { ErrorCode::BadStatus };
             (@variant_containing body) => { ErrorCode::BadStatus };
             (@variant_containing current_version) => { ErrorCode::WrongRoomKeysVersion };
+            (@variant_containing info_uri) => { ErrorCode::UserLimitExceeded };
+            (@variant_containing can_upgrade) => { ErrorCode::UserLimitExceeded };
             (@inner $field:ident) => {
                 {
                     if $field.is_some() {
@@ -148,6 +157,8 @@ impl<'de> Visitor<'de> for ErrorKindVisitor {
                 Field::Status => set_field!(status),
                 Field::Body => set_field!(body),
                 Field::CurrentVersion => set_field!(current_version),
+                Field::InfoUri => set_field!(info_uri),
+                Field::CanUpgrade => set_field!(can_upgrade),
                 Field::Other(other) => match data.entry(other.into_owned()) {
                     Entry::Vacant(v) => {
                         v.insert(map.next_value()?);
@@ -254,6 +265,19 @@ impl<'de> Visitor<'de> for ErrorKindVisitor {
             ErrorCode::UrlNotSet => ErrorKind::UrlNotSet,
             ErrorCode::UserDeactivated => ErrorKind::UserDeactivated,
             ErrorCode::UserInUse => ErrorKind::UserInUse,
+            ErrorCode::UserLimitExceeded => {
+                ErrorKind::UserLimitExceeded(UserLimitExceededErrorData {
+                    info_uri: from_json_value(
+                        info_uri.ok_or_else(|| de::Error::missing_field("info_uri"))?,
+                    )
+                    .map_err(de::Error::custom)?,
+                    can_upgrade: can_upgrade
+                        .map(from_json_value)
+                        .transpose()
+                        .map_err(de::Error::custom)?
+                        .unwrap_or_default(),
+                })
+            }
             ErrorCode::UserLocked => ErrorKind::UserLocked,
             ErrorCode::UserSuspended => ErrorKind::UserSuspended,
             ErrorCode::WeakPassword => ErrorKind::WeakPassword,
@@ -315,6 +339,13 @@ impl Serialize for ErrorKind {
             Self::UnknownToken(UnknownTokenErrorData { soft_logout: true }) | Self::UserLocked => {
                 st.serialize_entry("soft_logout", &true)?;
             }
+            Self::UserLimitExceeded(UserLimitExceededErrorData { info_uri, can_upgrade }) => {
+                st.serialize_entry("info_uri", info_uri)?;
+
+                if *can_upgrade {
+                    st.serialize_entry("can_upgrade", can_upgrade)?;
+                }
+            }
             Self::WrongRoomKeysVersion(WrongRoomKeysVersionErrorData { current_version }) => {
                 st.serialize_entry("current_version", current_version)?;
             }
@@ -323,7 +354,61 @@ impl Serialize for ErrorKind {
                     st.serialize_entry(k, v)?;
                 }
             }
-            _ => {}
+            Self::AppserviceLoginUnsupported
+            | Self::BadAlias
+            | Self::BadJson
+            | Self::BadState
+            | Self::CannotLeaveServerNoticeRoom
+            | Self::CannotOverwriteMedia
+            | Self::CaptchaInvalid
+            | Self::CaptchaNeeded
+            | Self::ConnectionFailed
+            | Self::ConnectionTimeout
+            | Self::DuplicateAnnotation
+            | Self::Exclusive
+            | Self::Forbidden
+            | Self::GuestAccessForbidden
+            | Self::InvalidParam
+            | Self::InvalidRoomState
+            | Self::InvalidUsername
+            | Self::InviteBlocked
+            | Self::LimitExceeded(LimitExceededErrorData {
+                retry_after: None | Some(RetryAfter::DateTime(_)),
+            })
+            | Self::MissingParam
+            | Self::MissingToken
+            | Self::NotFound
+            | Self::NotJson
+            | Self::NotYetUploaded
+            | Self::RoomInUse
+            | Self::ServerNotTrusted
+            | Self::ThreepidAuthFailed
+            | Self::ThreepidDenied
+            | Self::ThreepidInUse
+            | Self::ThreepidMediumNotSupported
+            | Self::ThreepidNotFound
+            | Self::TokenIncorrect
+            | Self::TooLarge
+            | Self::UnableToAuthorizeJoin
+            | Self::UnableToGrantJoin
+            | Self::Unauthorized
+            | Self::Unknown
+            | Self::UnknownToken(UnknownTokenErrorData { soft_logout: false })
+            | Self::Unrecognized
+            | Self::UnsupportedRoomVersion
+            | Self::UrlNotSet
+            | Self::UserDeactivated
+            | Self::UserInUse
+            | Self::UserSuspended
+            | Self::WeakPassword => {}
+            #[cfg(feature = "unstable-msc4306")]
+            Self::ConflictingUnsubscription => {}
+            #[cfg(feature = "unstable-msc4306")]
+            Self::NotInThread => {}
+            #[cfg(feature = "unstable-msc3843")]
+            Self::Unactionable => {}
+            #[cfg(feature = "unstable-msc4186")]
+            Self::UnknownPos => {}
         }
         st.end()
     }


### PR DESCRIPTION
According to [MSC4335](https://github.com/matrix-org/matrix-spec-proposals/pull/4335) / [Spec PR](https://github.com/matrix-org/matrix-spec/pull/2315).

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
