### PR TITLE
Update rendezvous discovery mechanism for MSC4388

### DIFF
--- a/crates/ruma-client-api/Cargo.toml
+++ b/crates/ruma-client-api/Cargo.toml
@@ -52,7 +52,7 @@ unstable-msc4195 = ["unstable-msc4143"]
 # Thread subscription support.
 unstable-msc4306 = []
 unstable-msc4308 = []
-unstable-msc4388 = ["ruma-common/unstable-msc4388"]
+unstable-msc4388 = []
 
 [dependencies]
 as_variant = { workspace = true }

--- a/crates/ruma-client-api/src/rendezvous.rs
+++ b/crates/ruma-client-api/src/rendezvous.rs
@@ -4,6 +4,8 @@ pub mod create_rendezvous_session;
 #[cfg(feature = "unstable-msc4388")]
 pub mod delete_rendezvous_session;
 #[cfg(feature = "unstable-msc4388")]
+pub mod discover_rendezvous;
+#[cfg(feature = "unstable-msc4388")]
 pub mod get_rendezvous_session;
 #[cfg(feature = "unstable-msc4388")]
 pub mod update_rendezvous_session;

--- a/crates/ruma-client-api/src/rendezvous/create_rendezvous_session.rs
+++ b/crates/ruma-client-api/src/rendezvous/create_rendezvous_session.rs
@@ -222,7 +222,7 @@ pub mod unstable_msc4388 {
         rate_limited: true,
         authentication: AccessTokenOptional,
         history: {
-            unstable("io.element.msc4388") => "/_matrix/client/unstable/io.element.msc4388/rendezvous",
+            unstable => "/_matrix/client/unstable/io.element.msc4388/rendezvous",
         }
     }
 

--- a/crates/ruma-client-api/src/rendezvous/delete_rendezvous_session.rs
+++ b/crates/ruma-client-api/src/rendezvous/delete_rendezvous_session.rs
@@ -17,7 +17,7 @@ pub mod unstable {
         rate_limited: true,
         authentication: NoAuthentication,
         history: {
-            unstable("io.element.msc4388") => "/_matrix/client/unstable/io.element.msc4388/rendezvous/{id}",
+            unstable => "/_matrix/client/unstable/io.element.msc4388/rendezvous/{id}",
         }
     }
 

--- a/crates/ruma-client-api/src/rendezvous/discover_rendezvous.rs
+++ b/crates/ruma-client-api/src/rendezvous/discover_rendezvous.rs
@@ -1,0 +1,45 @@
+//! `GET /_matrix/client/*/rendezvous`
+//!
+//! Discover if the rendezvous API is available.
+
+pub mod unstable {
+    //! `unstable/io.element.msc4388` ([MSC])
+    //!
+    //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/4388
+
+    use ruma_common::{
+        api::{auth_scheme::AccessTokenOptional, request, response},
+        metadata,
+    };
+
+    metadata! {
+        method: GET,
+        rate_limited: true,
+        authentication: AccessTokenOptional,
+        history: {
+            unstable("io.element.msc4388") => "/_matrix/client/unstable/io.element.msc4388/rendezvous",
+        }
+    }
+
+    /// Request type for the `GET` `rendezvous` endpoint.
+    #[request(error = crate::Error)]
+    pub struct Request {}
+
+    impl Request {
+        /// Creates a new `Request`.
+        pub fn new() -> Self {
+            Self {}
+        }
+    }
+
+    #[response(error = crate::Error)]
+    /// Response type for the `GET` `rendezvous` endpoint.
+    pub struct Response {}
+
+    impl Response {
+        /// Creates a new `Response`.
+        pub fn new() -> Self {
+            Self {}
+        }
+    }
+}

--- a/crates/ruma-client-api/src/rendezvous/discover_rendezvous.rs
+++ b/crates/ruma-client-api/src/rendezvous/discover_rendezvous.rs
@@ -17,7 +17,7 @@ pub mod unstable {
         rate_limited: true,
         authentication: AccessTokenOptional,
         history: {
-            unstable("io.element.msc4388") => "/_matrix/client/unstable/io.element.msc4388/rendezvous",
+            unstable => "/_matrix/client/unstable/io.element.msc4388/rendezvous",
         }
     }
 

--- a/crates/ruma-client-api/src/rendezvous/get_rendezvous_session.rs
+++ b/crates/ruma-client-api/src/rendezvous/get_rendezvous_session.rs
@@ -19,7 +19,7 @@ pub mod unstable {
         rate_limited: true,
         authentication: NoAuthentication,
         history: {
-            unstable("io.element.msc4388") => "/_matrix/client/unstable/io.element.msc4388/rendezvous/{id}",
+            unstable => "/_matrix/client/unstable/io.element.msc4388/rendezvous/{id}",
         }
     }
 

--- a/crates/ruma-client-api/src/rendezvous/update_rendezvous_session.rs
+++ b/crates/ruma-client-api/src/rendezvous/update_rendezvous_session.rs
@@ -17,7 +17,7 @@ pub mod unstable {
         rate_limited: true,
         authentication: NoAuthentication,
         history: {
-            unstable("io.element.msc4388") => "/_matrix/client/unstable/io.element.msc4388/rendezvous/{id}",
+            unstable => "/_matrix/client/unstable/io.element.msc4388/rendezvous/{id}",
         }
     }
 

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -24,7 +24,6 @@ Improvements:
   `to_canonical_value()`.
 - Add the `assert_to_canonical_json_eq!` macro that can be used in tests to
   check the canonical JSON serialization of a type against its expected value.
-- Add `io.element.msc4388` unstable feature support to `/versions`.
 - Add crate-internal into_raw() / from_raw() helpers for IdDst owned IDs and
   use them in OwnedRoomId / OwnedRoomAliasId <-> OwnedRoomOrAliasId
   conversions.

--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -41,7 +41,6 @@ unstable-msc4140 = []
 unstable-msc4186 = []
 # Thread subscriptions.
 unstable-msc4306 = []
-unstable-msc4388 = []
 
 # Allow IDs to exceed 255 bytes.
 compat-arbitrary-length-ids = ["ruma-identifiers-validation/compat-arbitrary-length-ids"]

--- a/crates/ruma-common/src/api/metadata.rs
+++ b/crates/ruma-common/src/api/metadata.rs
@@ -778,17 +778,6 @@ pub enum FeatureFlag {
     #[ruma_enum(rename = "org.matrix.msc4380")]
     Msc4380,
 
-    /// `io.element.msc4388` ([MSC])
-    ///
-    /// Secure out-of-band channel for sign in with QR. This is part of the
-    /// 2025 version of [MSC4108].
-    ///
-    /// [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/4388
-    /// [MSC4108]: https://github.com/matrix-org/matrix-spec-proposals/pull/4108
-    #[cfg(feature = "unstable-msc4388")]
-    #[ruma_enum(rename = "io.element.msc4388")]
-    Msc4388,
-
     #[doc(hidden)]
     _Custom(PrivOwnedStr),
 }

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -200,7 +200,7 @@ unstable-msc4359 = ["ruma-events?/unstable-msc4359"]
 unstable-msc4362 = ["ruma-events?/unstable-msc4362"]
 unstable-msc4380 = ["ruma-events?/unstable-msc4380"]
 unstable-msc4385 = ["ruma-events?/unstable-msc4385"]
-unstable-msc4388 = ["ruma-common/unstable-msc4388", "ruma-client-api?/unstable-msc4388"]
+unstable-msc4388 = ["ruma-client-api?/unstable-msc4388"]
 unstable-uniffi = ["ruma-events?/unstable-uniffi"]
 
 [dependencies]


### PR DESCRIPTION
This implements support for the latest changes in https://github.com/matrix-org/matrix-spec-proposals/commit/f07df05dd3d8bfd2dd0e503f8d5f331ae82fe15d

It remove the unstable_features support from ruma-common and adds the discovery endpoint to ruma-client-api.

If you would prefer separate changelog entries then let me know. Otherwise, it looked like the existing ones could be reused/deleted.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
