### PR TITLE
api: Add `NoAccessToken` authentication scheme

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -40,6 +40,8 @@ Breaking changes:
 - `Typing::Yes` now holds a non-exhaustive struct rather than a `Duration`, to
   potentially allow to add more fields in the future without it being a breaking
   change.
+- The endpoints that were using the `NoAuthentication` authentication scheme now
+  use `NoAccessToken`.
 
 Bug fixes:
 

--- a/crates/ruma-client-api/src/account/check_registration_token_validity.rs
+++ b/crates/ruma-client-api/src/account/check_registration_token_validity.rs
@@ -8,14 +8,14 @@ pub mod v1 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv1registermloginregistration_tokenvalidity
 
     use ruma_common::{
-        api::{auth_scheme::NoAuthentication, request, response},
+        api::{auth_scheme::NoAccessToken, request, response},
         metadata,
     };
 
     metadata! {
         method: GET,
         rate_limited: true,
-        authentication: NoAuthentication,
+        authentication: NoAccessToken,
         history: {
             unstable => "/_matrix/client/unstable/org.matrix.msc3231/register/org.matrix.msc3231.login.registration_token/validity",
             1.2 => "/_matrix/client/v1/register/m.login.registration_token/validity",

--- a/crates/ruma-client-api/src/account/get_username_availability.rs
+++ b/crates/ruma-client-api/src/account/get_username_availability.rs
@@ -8,14 +8,14 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3registeravailable
 
     use ruma_common::{
-        api::{auth_scheme::NoAuthentication, request, response},
+        api::{auth_scheme::NoAccessToken, request, response},
         metadata,
     };
 
     metadata! {
         method: GET,
         rate_limited: true,
-        authentication: NoAuthentication,
+        authentication: NoAccessToken,
         history: {
             1.0 => "/_matrix/client/r0/register/available",
             1.1 => "/_matrix/client/v3/register/available",

--- a/crates/ruma-client-api/src/account/request_3pid_management_token_via_email.rs
+++ b/crates/ruma-client-api/src/account/request_3pid_management_token_via_email.rs
@@ -10,7 +10,7 @@ pub mod v3 {
     use js_int::UInt;
     use ruma_common::{
         OwnedClientSecret, OwnedSessionId,
-        api::{auth_scheme::NoAuthentication, request, response},
+        api::{auth_scheme::NoAccessToken, request, response},
         metadata,
     };
 
@@ -19,7 +19,7 @@ pub mod v3 {
     metadata! {
         method: POST,
         rate_limited: false,
-        authentication: NoAuthentication,
+        authentication: NoAccessToken,
         history: {
             1.0 => "/_matrix/client/r0/account/3pid/email/requestToken",
             1.1 => "/_matrix/client/v3/account/3pid/email/requestToken",

--- a/crates/ruma-client-api/src/account/request_3pid_management_token_via_msisdn.rs
+++ b/crates/ruma-client-api/src/account/request_3pid_management_token_via_msisdn.rs
@@ -10,7 +10,7 @@ pub mod v3 {
     use js_int::UInt;
     use ruma_common::{
         OwnedClientSecret, OwnedSessionId,
-        api::{auth_scheme::NoAuthentication, request, response},
+        api::{auth_scheme::NoAccessToken, request, response},
         metadata,
     };
 
@@ -19,7 +19,7 @@ pub mod v3 {
     metadata! {
         method: POST,
         rate_limited: false,
-        authentication: NoAuthentication,
+        authentication: NoAccessToken,
         history: {
             1.0 => "/_matrix/client/r0/account/3pid/msisdn/requestToken",
             1.1 => "/_matrix/client/v3/account/3pid/msisdn/requestToken",

--- a/crates/ruma-client-api/src/account/request_password_change_token_via_email.rs
+++ b/crates/ruma-client-api/src/account/request_password_change_token_via_email.rs
@@ -10,7 +10,7 @@ pub mod v3 {
     use js_int::UInt;
     use ruma_common::{
         OwnedClientSecret, OwnedSessionId,
-        api::{auth_scheme::NoAuthentication, request, response},
+        api::{auth_scheme::NoAccessToken, request, response},
         metadata,
     };
 
@@ -19,7 +19,7 @@ pub mod v3 {
     metadata! {
         method: POST,
         rate_limited: false,
-        authentication: NoAuthentication,
+        authentication: NoAccessToken,
         history: {
             1.0 => "/_matrix/client/r0/account/password/email/requestToken",
             1.1 => "/_matrix/client/v3/account/password/email/requestToken",

--- a/crates/ruma-client-api/src/account/request_password_change_token_via_msisdn.rs
+++ b/crates/ruma-client-api/src/account/request_password_change_token_via_msisdn.rs
@@ -10,14 +10,14 @@ pub mod v3 {
     use js_int::UInt;
     use ruma_common::{
         OwnedClientSecret, OwnedSessionId,
-        api::{auth_scheme::NoAuthentication, request, response},
+        api::{auth_scheme::NoAccessToken, request, response},
         metadata,
     };
 
     metadata! {
         method: POST,
         rate_limited: false,
-        authentication: NoAuthentication,
+        authentication: NoAccessToken,
         history: {
             1.0 => "/_matrix/client/r0/account/password/msisdn/requestToken",
             1.1 => "/_matrix/client/v3/account/password/msisdn/requestToken",

--- a/crates/ruma-client-api/src/account/request_registration_token_via_email.rs
+++ b/crates/ruma-client-api/src/account/request_registration_token_via_email.rs
@@ -10,7 +10,7 @@ pub mod v3 {
     use js_int::UInt;
     use ruma_common::{
         OwnedClientSecret, OwnedSessionId,
-        api::{auth_scheme::NoAuthentication, request, response},
+        api::{auth_scheme::NoAccessToken, request, response},
         metadata,
     };
 
@@ -19,7 +19,7 @@ pub mod v3 {
     metadata! {
         method: POST,
         rate_limited: false,
-        authentication: NoAuthentication,
+        authentication: NoAccessToken,
         history: {
             1.0 => "/_matrix/client/r0/register/email/requestToken",
             1.1 => "/_matrix/client/v3/register/email/requestToken",

--- a/crates/ruma-client-api/src/account/request_registration_token_via_msisdn.rs
+++ b/crates/ruma-client-api/src/account/request_registration_token_via_msisdn.rs
@@ -10,7 +10,7 @@ pub mod v3 {
     use js_int::UInt;
     use ruma_common::{
         OwnedClientSecret, OwnedSessionId,
-        api::{auth_scheme::NoAuthentication, request, response},
+        api::{auth_scheme::NoAccessToken, request, response},
         metadata,
     };
 
@@ -19,7 +19,7 @@ pub mod v3 {
     metadata! {
         method: POST,
         rate_limited: false,
-        authentication: NoAuthentication,
+        authentication: NoAccessToken,
         history: {
             1.0 => "/_matrix/client/r0/register/msisdn/requestToken",
             1.1 => "/_matrix/client/v3/register/msisdn/requestToken",

--- a/crates/ruma-client-api/src/alias/get_alias.rs
+++ b/crates/ruma-client-api/src/alias/get_alias.rs
@@ -9,14 +9,14 @@ pub mod v3 {
 
     use ruma_common::{
         OwnedRoomAliasId, OwnedRoomId, OwnedServerName,
-        api::{auth_scheme::NoAuthentication, request, response},
+        api::{auth_scheme::NoAccessToken, request, response},
         metadata,
     };
 
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: NoAuthentication,
+        authentication: NoAccessToken,
         history: {
             1.0 => "/_matrix/client/r0/directory/room/{room_alias}",
             1.1 => "/_matrix/client/v3/directory/room/{room_alias}",

--- a/crates/ruma-client-api/src/directory/get_public_rooms.rs
+++ b/crates/ruma-client-api/src/directory/get_public_rooms.rs
@@ -10,7 +10,7 @@ pub mod v3 {
     use js_int::UInt;
     use ruma_common::{
         OwnedServerName,
-        api::{auth_scheme::NoAuthentication, request, response},
+        api::{auth_scheme::NoAccessToken, request, response},
         directory::PublicRoomsChunk,
         metadata,
     };
@@ -18,7 +18,7 @@ pub mod v3 {
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: NoAuthentication,
+        authentication: NoAccessToken,
         history: {
             1.0 => "/_matrix/client/r0/publicRooms",
             1.1 => "/_matrix/client/v3/publicRooms",

--- a/crates/ruma-client-api/src/directory/get_room_visibility.rs
+++ b/crates/ruma-client-api/src/directory/get_room_visibility.rs
@@ -9,7 +9,7 @@ pub mod v3 {
 
     use ruma_common::{
         OwnedRoomId,
-        api::{auth_scheme::NoAuthentication, request, response},
+        api::{auth_scheme::NoAccessToken, request, response},
         metadata,
     };
 
@@ -18,7 +18,7 @@ pub mod v3 {
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: NoAuthentication,
+        authentication: NoAccessToken,
         history: {
             1.0 => "/_matrix/client/r0/directory/list/room/{room_id}",
             1.1 => "/_matrix/client/v3/directory/list/room/{room_id}",

--- a/crates/ruma-client-api/src/discovery/discover_homeserver.rs
+++ b/crates/ruma-client-api/src/discovery/discover_homeserver.rs
@@ -10,7 +10,7 @@ use std::borrow::Cow;
 #[cfg(feature = "unstable-msc4143")]
 use ruma_common::serde::JsonObject;
 use ruma_common::{
-    api::{auth_scheme::NoAuthentication, request, response},
+    api::{auth_scheme::NoAccessToken, request, response},
     metadata,
 };
 #[cfg(feature = "unstable-msc4143")]
@@ -22,7 +22,7 @@ use serde_json::Value as JsonValue;
 metadata! {
     method: GET,
     rate_limited: false,
-    authentication: NoAuthentication,
+    authentication: NoAccessToken,
     path: "/.well-known/matrix/client",
 }
 

--- a/crates/ruma-client-api/src/discovery/discover_support.rs
+++ b/crates/ruma-client-api/src/discovery/discover_support.rs
@@ -6,7 +6,7 @@
 
 use ruma_common::{
     OwnedUserId,
-    api::{auth_scheme::NoAuthentication, request, response},
+    api::{auth_scheme::NoAccessToken, request, response},
     metadata,
     serde::StringEnum,
 };
@@ -17,7 +17,7 @@ use crate::PrivOwnedStr;
 metadata! {
     method: GET,
     rate_limited: false,
-    authentication: NoAuthentication,
+    authentication: NoAccessToken,
     path: "/.well-known/matrix/support",
 }
 

--- a/crates/ruma-client-api/src/discovery/get_authorization_server_metadata.rs
+++ b/crates/ruma-client-api/src/discovery/get_authorization_server_metadata.rs
@@ -13,7 +13,7 @@ pub mod v1 {
 
     use ruma_common::{
         DeviceId,
-        api::{auth_scheme::NoAuthentication, request, response},
+        api::{auth_scheme::NoAccessToken, request, response},
         metadata,
         serde::{Raw, StringEnum},
     };
@@ -25,7 +25,7 @@ pub mod v1 {
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: NoAuthentication,
+        authentication: NoAccessToken,
         history: {
             unstable => "/_matrix/client/unstable/org.matrix.msc2965/auth_metadata",
             1.15 => "/_matrix/client/v1/auth_metadata",

--- a/crates/ruma-client-api/src/media/get_content.rs
+++ b/crates/ruma-client-api/src/media/get_content.rs
@@ -12,7 +12,7 @@ pub mod v3 {
     use http::header::{CONTENT_DISPOSITION, CONTENT_TYPE};
     use ruma_common::{
         IdParseError, MxcUri, OwnedServerName,
-        api::{auth_scheme::NoAuthentication, request, response},
+        api::{auth_scheme::NoAccessToken, request, response},
         http_headers::ContentDisposition,
         metadata,
     };
@@ -22,7 +22,7 @@ pub mod v3 {
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: NoAuthentication,
+        authentication: NoAccessToken,
         history: {
             1.0 => "/_matrix/media/r0/download/{server_name}/{media_id}",
             1.1 => "/_matrix/media/v3/download/{server_name}/{media_id}",

--- a/crates/ruma-client-api/src/media/get_content_as_filename.rs
+++ b/crates/ruma-client-api/src/media/get_content_as_filename.rs
@@ -12,7 +12,7 @@ pub mod v3 {
     use http::header::{CONTENT_DISPOSITION, CONTENT_TYPE};
     use ruma_common::{
         IdParseError, MxcUri, OwnedServerName,
-        api::{auth_scheme::NoAuthentication, request, response},
+        api::{auth_scheme::NoAccessToken, request, response},
         http_headers::ContentDisposition,
         metadata,
     };
@@ -22,7 +22,7 @@ pub mod v3 {
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: NoAuthentication,
+        authentication: NoAccessToken,
         history: {
             1.0 => "/_matrix/media/r0/download/{server_name}/{media_id}/{filename}",
             1.1 => "/_matrix/media/v3/download/{server_name}/{media_id}/{filename}",

--- a/crates/ruma-client-api/src/media/get_content_thumbnail.rs
+++ b/crates/ruma-client-api/src/media/get_content_thumbnail.rs
@@ -14,7 +14,7 @@ pub mod v3 {
     pub use ruma_common::media::Method;
     use ruma_common::{
         IdParseError, MxcUri, OwnedServerName,
-        api::{auth_scheme::NoAuthentication, request, response},
+        api::{auth_scheme::NoAccessToken, request, response},
         http_headers::ContentDisposition,
         metadata,
     };
@@ -24,7 +24,7 @@ pub mod v3 {
     metadata! {
         method: GET,
         rate_limited: true,
-        authentication: NoAuthentication,
+        authentication: NoAccessToken,
         history: {
             1.0 => "/_matrix/media/r0/thumbnail/{server_name}/{media_id}",
             1.1 => "/_matrix/media/v3/thumbnail/{server_name}/{media_id}",

--- a/crates/ruma-client-api/src/profile/get_avatar_url.rs
+++ b/crates/ruma-client-api/src/profile/get_avatar_url.rs
@@ -9,14 +9,14 @@ pub mod v3 {
 
     use ruma_common::{
         OwnedMxcUri, OwnedUserId,
-        api::{auth_scheme::NoAuthentication, request, response},
+        api::{auth_scheme::NoAccessToken, request, response},
         metadata,
     };
 
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: NoAuthentication,
+        authentication: NoAccessToken,
         history: {
             1.0 => "/_matrix/client/r0/profile/{user_id}/avatar_url",
             1.1 => "/_matrix/client/v3/profile/{user_id}/avatar_url",

--- a/crates/ruma-client-api/src/profile/get_display_name.rs
+++ b/crates/ruma-client-api/src/profile/get_display_name.rs
@@ -9,14 +9,14 @@ pub mod v3 {
 
     use ruma_common::{
         OwnedUserId,
-        api::{auth_scheme::NoAuthentication, request, response},
+        api::{auth_scheme::NoAccessToken, request, response},
         metadata,
     };
 
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: NoAuthentication,
+        authentication: NoAccessToken,
         history: {
             1.0 => "/_matrix/client/r0/profile/{user_id}/displayname",
             1.1 => "/_matrix/client/v3/profile/{user_id}/displayname",

--- a/crates/ruma-client-api/src/profile/get_profile.rs
+++ b/crates/ruma-client-api/src/profile/get_profile.rs
@@ -11,7 +11,7 @@ pub mod v3 {
 
     use ruma_common::{
         OwnedUserId,
-        api::{auth_scheme::NoAuthentication, request, response},
+        api::{auth_scheme::NoAccessToken, request, response},
         metadata,
     };
     use serde_json::Value as JsonValue;
@@ -21,7 +21,7 @@ pub mod v3 {
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: NoAuthentication,
+        authentication: NoAccessToken,
         history: {
             1.0 => "/_matrix/client/r0/profile/{user_id}",
             1.1 => "/_matrix/client/v3/profile/{user_id}",

--- a/crates/ruma-client-api/src/profile/get_profile_field.rs
+++ b/crates/ruma-client-api/src/profile/get_profile_field.rs
@@ -17,7 +17,7 @@ pub mod v3 {
 
     use ruma_common::{
         OwnedUserId,
-        api::{Metadata, auth_scheme::NoAuthentication, path_builder::VersionHistory},
+        api::{Metadata, auth_scheme::NoAccessToken, path_builder::VersionHistory},
         metadata,
     };
 
@@ -26,7 +26,7 @@ pub mod v3 {
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: NoAuthentication,
+        authentication: NoAccessToken,
         // History valid for fields that existed in Matrix 1.0, i.e. `displayname` and `avatar_url`.
         history: {
             unstable("uk.tcpip.msc4133") => "/_matrix/client/unstable/uk.tcpip.msc4133/profile/{user_id}/{field}",

--- a/crates/ruma-client-api/src/rendezvous/create_rendezvous_session.rs
+++ b/crates/ruma-client-api/src/rendezvous/create_rendezvous_session.rs
@@ -12,7 +12,7 @@ pub mod unstable_msc4108 {
     #[cfg(feature = "client")]
     use ruma_common::api::error::FromHttpResponseError;
     use ruma_common::{
-        api::{auth_scheme::NoAuthentication, error::HeaderDeserializationError},
+        api::{auth_scheme::NoAccessToken, error::HeaderDeserializationError},
         metadata,
     };
     use serde::{Deserialize, Serialize};
@@ -22,7 +22,7 @@ pub mod unstable_msc4108 {
     metadata! {
         method: POST,
         rate_limited: true,
-        authentication: NoAuthentication,
+        authentication: NoAccessToken,
         history: {
             unstable("org.matrix.msc4108") => "/_matrix/client/unstable/org.matrix.msc4108/rendezvous",
         }

--- a/crates/ruma-client-api/src/rendezvous/delete_rendezvous_session.rs
+++ b/crates/ruma-client-api/src/rendezvous/delete_rendezvous_session.rs
@@ -8,14 +8,14 @@ pub mod unstable {
     //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/4388
 
     use ruma_common::{
-        api::{auth_scheme::NoAuthentication, request, response},
+        api::{auth_scheme::NoAccessToken, request, response},
         metadata,
     };
 
     metadata! {
         method: DELETE,
         rate_limited: true,
-        authentication: NoAuthentication,
+        authentication: NoAccessToken,
         history: {
             unstable => "/_matrix/client/unstable/io.element.msc4388/rendezvous/{id}",
         }

--- a/crates/ruma-client-api/src/rendezvous/get_rendezvous_session.rs
+++ b/crates/ruma-client-api/src/rendezvous/get_rendezvous_session.rs
@@ -10,14 +10,14 @@ pub mod unstable {
     use std::time::Duration;
 
     use ruma_common::{
-        api::{auth_scheme::NoAuthentication, request, response},
+        api::{auth_scheme::NoAccessToken, request, response},
         metadata,
     };
 
     metadata! {
         method: GET,
         rate_limited: true,
-        authentication: NoAuthentication,
+        authentication: NoAccessToken,
         history: {
             unstable => "/_matrix/client/unstable/io.element.msc4388/rendezvous/{id}",
         }

--- a/crates/ruma-client-api/src/rendezvous/update_rendezvous_session.rs
+++ b/crates/ruma-client-api/src/rendezvous/update_rendezvous_session.rs
@@ -8,14 +8,14 @@ pub mod unstable {
     //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/4388
 
     use ruma_common::{
-        api::{auth_scheme::NoAuthentication, request, response},
+        api::{auth_scheme::NoAccessToken, request, response},
         metadata,
     };
 
     metadata! {
         method: PUT,
         rate_limited: true,
-        authentication: NoAuthentication,
+        authentication: NoAccessToken,
         history: {
             unstable => "/_matrix/client/unstable/io.element.msc4388/rendezvous/{id}",
         }

--- a/crates/ruma-client-api/src/session/get_login_types.rs
+++ b/crates/ruma-client-api/src/session/get_login_types.rs
@@ -12,7 +12,7 @@ pub mod v3 {
 
     use ruma_common::{
         OwnedMxcUri,
-        api::{auth_scheme::NoAuthentication, request, response},
+        api::{auth_scheme::NoAccessToken, request, response},
         metadata,
         serde::{JsonObject, StringEnum},
     };
@@ -24,7 +24,7 @@ pub mod v3 {
     metadata! {
         method: GET,
         rate_limited: true,
-        authentication: NoAuthentication,
+        authentication: NoAccessToken,
         history: {
             1.0 => "/_matrix/client/r0/login",
             1.1 => "/_matrix/client/v3/login",

--- a/crates/ruma-client-api/src/session/login_fallback.rs
+++ b/crates/ruma-client-api/src/session/login_fallback.rs
@@ -6,14 +6,14 @@
 
 use ruma_common::{
     OwnedDeviceId,
-    api::{auth_scheme::NoAuthentication, request},
+    api::{auth_scheme::NoAccessToken, request},
     metadata,
 };
 
 metadata! {
     method: GET,
     rate_limited: false,
-    authentication: NoAuthentication,
+    authentication: NoAccessToken,
     path: "/_matrix/static/client/login/",
 }
 

--- a/crates/ruma-client-api/src/session/refresh_token.rs
+++ b/crates/ruma-client-api/src/session/refresh_token.rs
@@ -28,14 +28,14 @@ pub mod v3 {
     use std::time::Duration;
 
     use ruma_common::{
-        api::{auth_scheme::NoAuthentication, request, response},
+        api::{auth_scheme::NoAccessToken, request, response},
         metadata,
     };
 
     metadata! {
         method: POST,
         rate_limited: true,
-        authentication: NoAuthentication,
+        authentication: NoAccessToken,
         history: {
             unstable => "/_matrix/client/unstable/org.matrix.msc2918/refresh",
             1.3 => "/_matrix/client/v3/refresh",

--- a/crates/ruma-client-api/src/session/sso_login.rs
+++ b/crates/ruma-client-api/src/session/sso_login.rs
@@ -7,7 +7,7 @@ pub mod v3 {
 
     use http::header::{LOCATION, SET_COOKIE};
     use ruma_common::{
-        api::{auth_scheme::NoAuthentication, request, response},
+        api::{auth_scheme::NoAccessToken, request, response},
         metadata,
     };
 
@@ -16,7 +16,7 @@ pub mod v3 {
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: NoAuthentication,
+        authentication: NoAccessToken,
         history: {
             1.0 => "/_matrix/client/r0/login/sso/redirect",
             1.1 => "/_matrix/client/v3/login/sso/redirect",

--- a/crates/ruma-client-api/src/session/sso_login_with_provider.rs
+++ b/crates/ruma-client-api/src/session/sso_login_with_provider.rs
@@ -9,7 +9,7 @@ pub mod v3 {
 
     use http::header::{LOCATION, SET_COOKIE};
     use ruma_common::{
-        api::{auth_scheme::NoAuthentication, request, response},
+        api::{auth_scheme::NoAccessToken, request, response},
         metadata,
     };
 
@@ -18,7 +18,7 @@ pub mod v3 {
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: NoAuthentication,
+        authentication: NoAccessToken,
         history: {
             unstable => "/_matrix/client/unstable/org.matrix.msc2858/login/sso/redirect/{idp_id}",
             1.1 => "/_matrix/client/v3/login/sso/redirect/{idp_id}",

--- a/crates/ruma-client-api/src/uiaa/get_uiaa_fallback_page.rs
+++ b/crates/ruma-client-api/src/uiaa/get_uiaa_fallback_page.rs
@@ -8,7 +8,7 @@ pub mod v3 {
     //! [spec]: https://spec.matrix.org/latest/client-server-api/#fallback
 
     use ruma_common::{
-        api::{auth_scheme::NoAuthentication, request},
+        api::{auth_scheme::NoAccessToken, request},
         metadata,
     };
 
@@ -17,7 +17,7 @@ pub mod v3 {
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: NoAuthentication,
+        authentication: NoAccessToken,
         history: {
             1.0 => "/_matrix/client/r0/auth/{auth_type}/fallback/web",
             1.1 => "/_matrix/client/v3/auth/{auth_type}/fallback/web",

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -15,6 +15,11 @@ Breaking changes:
   preferred.
 - `EventId::new()` was renamed to `EventId::new_v1()`, since it works only for
   the first format of event IDs.
+- The `NoAuthentication` authentication scheme doesn't take a `SendAccessToken`
+  as input anymore, because it doesn't make sense to be able to send access
+  tokens for APIs that don't use them as a form of authentication. The new
+  `NoAccessToken` authentication scheme should be used instead for APIs that
+  rely on access tokens as a form of authentication.
 
 Improvements:
 

--- a/crates/ruma-common/src/api/auth_scheme.rs
+++ b/crates/ruma-common/src/api/auth_scheme.rs
@@ -40,13 +40,38 @@ pub trait AuthScheme: Sized {
 }
 
 /// No authentication is performed.
-///
-/// This type accepts a [`SendAccessToken`] as input to be able to send it regardless of whether it
-/// is required.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct NoAuthentication;
 
 impl AuthScheme for NoAuthentication {
+    type Input<'a> = ();
+    type AddAuthenticationError = std::convert::Infallible;
+    type Output = ();
+    type ExtractAuthenticationError = std::convert::Infallible;
+
+    fn add_authentication<T: AsRef<[u8]>>(
+        _request: &mut http::Request<T>,
+        _input: (),
+    ) -> Result<(), Self::AddAuthenticationError> {
+        Ok(())
+    }
+
+    /// Since this endpoint doesn't expect any authentication, this is a noop.
+    fn extract_authentication<T: AsRef<[u8]>>(
+        _request: &http::Request<T>,
+    ) -> Result<(), Self::ExtractAuthenticationError> {
+        Ok(())
+    }
+}
+
+/// No authentication is performed on an API that usually relies on access tokens.
+///
+/// Contrary to [`NoAuthentication`], this type accepts a [`SendAccessToken`] as input to be able to
+/// send it regardless of whether it is required.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NoAccessToken;
+
+impl AuthScheme for NoAccessToken {
     type Input<'a> = SendAccessToken<'a>;
     type AddAuthenticationError = header::InvalidHeaderValue;
     type Output = ();

--- a/crates/ruma-common/tests/it/api/auth_scheme.rs
+++ b/crates/ruma-common/tests/it/api/auth_scheme.rs
@@ -2,7 +2,7 @@ use assert_matches2::assert_matches;
 use http::header;
 use ruma_common::api::auth_scheme::{
     AccessToken, AccessTokenOptional, AppserviceToken, AppserviceTokenOptional, AuthScheme,
-    NoAuthentication, SendAccessToken,
+    NoAccessToken, NoAuthentication, SendAccessToken,
 };
 
 const TOKEN: &str = "token";
@@ -21,7 +21,10 @@ fn send_access_token_none() {
     let input = SendAccessToken::None;
     let mut request = http_request();
 
-    NoAuthentication::add_authentication(&mut request, input).unwrap();
+    NoAuthentication::add_authentication(&mut request, ()).unwrap();
+    assert_eq!(request.headers_mut().remove(header::AUTHORIZATION), None);
+
+    NoAccessToken::add_authentication(&mut request, input).unwrap();
     assert_eq!(request.headers_mut().remove(header::AUTHORIZATION), None);
 
     AccessToken::add_authentication(&mut request, input).unwrap_err();
@@ -40,7 +43,10 @@ fn send_access_token_if_required() {
     let input = SendAccessToken::IfRequired(TOKEN);
     let mut request = http_request();
 
-    NoAuthentication::add_authentication(&mut request, input).unwrap();
+    NoAuthentication::add_authentication(&mut request, ()).unwrap();
+    assert_eq!(request.headers_mut().remove(header::AUTHORIZATION), None);
+
+    NoAccessToken::add_authentication(&mut request, input).unwrap();
     assert_eq!(request.headers_mut().remove(header::AUTHORIZATION), None);
 
     AccessToken::add_authentication(&mut request, input).unwrap();
@@ -62,7 +68,10 @@ fn send_access_token_always() {
     let input = SendAccessToken::Always(TOKEN);
     let mut request = http_request();
 
-    NoAuthentication::add_authentication(&mut request, input).unwrap();
+    NoAuthentication::add_authentication(&mut request, ()).unwrap();
+    assert_eq!(request.headers_mut().remove(header::AUTHORIZATION), None);
+
+    NoAccessToken::add_authentication(&mut request, input).unwrap();
     assert_matches!(request.headers_mut().remove(header::AUTHORIZATION), Some(value));
     assert_eq!(value, HEADER_VALUE);
 
@@ -88,7 +97,10 @@ fn send_access_token_appservice() {
     let input = SendAccessToken::Appservice(TOKEN);
     let mut request = http_request();
 
-    NoAuthentication::add_authentication(&mut request, input).unwrap();
+    NoAuthentication::add_authentication(&mut request, ()).unwrap();
+    assert_eq!(request.headers_mut().remove(header::AUTHORIZATION), None);
+
+    NoAccessToken::add_authentication(&mut request, input).unwrap();
     assert_eq!(request.headers_mut().remove(header::AUTHORIZATION), None);
 
     AccessToken::add_authentication(&mut request, input).unwrap();
@@ -126,6 +138,11 @@ fn extract_authentication_bearer() {
     NoAuthentication::extract_authentication(&request_with_valid_header).unwrap();
     NoAuthentication::extract_authentication(&request_with_invalid_scheme).unwrap();
     NoAuthentication::extract_authentication(&request_with_query).unwrap();
+
+    NoAccessToken::extract_authentication(&request_without_token).unwrap();
+    NoAccessToken::extract_authentication(&request_with_valid_header).unwrap();
+    NoAccessToken::extract_authentication(&request_with_invalid_scheme).unwrap();
+    NoAccessToken::extract_authentication(&request_with_query).unwrap();
 
     AccessToken::extract_authentication(&request_without_token).unwrap_err();
     let token = AccessToken::extract_authentication(&request_with_valid_header).unwrap();

--- a/crates/ruma-common/tests/it/api/conversions.rs
+++ b/crates/ruma-common/tests/it/api/conversions.rs
@@ -8,7 +8,7 @@ use ruma_common::{
     api::{
         AppserviceUserIdentity, IncomingRequest as _, MatrixVersion, OutgoingRequest as _,
         OutgoingRequestAppserviceExt, SupportedVersions,
-        auth_scheme::{NoAuthentication, SendAccessToken},
+        auth_scheme::{NoAccessToken, SendAccessToken},
         request, response,
     },
     metadata, owned_user_id, user_id,
@@ -17,7 +17,7 @@ use ruma_common::{
 metadata! {
     method: POST,
     rate_limited: false,
-    authentication: NoAuthentication,
+    authentication: NoAccessToken,
     history: {
         unstable => "/_matrix/foo/{bar}/{user}",
     }
@@ -147,7 +147,7 @@ mod without_query {
         OwnedUserId,
         api::{
             AppserviceUserIdentity, MatrixVersion, OutgoingRequestAppserviceExt, SupportedVersions,
-            auth_scheme::{NoAuthentication, SendAccessToken},
+            auth_scheme::{NoAccessToken, SendAccessToken},
             request, response,
         },
         metadata, owned_user_id, user_id,
@@ -156,7 +156,7 @@ mod without_query {
     metadata! {
         method: POST,
         rate_limited: false,
-        authentication: NoAuthentication,
+        authentication: NoAccessToken,
         history: {
             unstable => "/_matrix/foo/{bar}/{user}",
         }

--- a/crates/ruma-common/tests/it/api/header_override.rs
+++ b/crates/ruma-common/tests/it/api/header_override.rs
@@ -6,8 +6,7 @@ use http::header::{CONTENT_TYPE, Entry, LOCATION};
 use ruma_common::{
     api::{
         MatrixVersion, OutgoingRequest as _, OutgoingResponse as _, SupportedVersions,
-        auth_scheme::{NoAuthentication, SendAccessToken},
-        request, response,
+        auth_scheme::NoAuthentication, request, response,
     },
     metadata,
 };
@@ -62,11 +61,7 @@ fn request_content_type_override() {
         SupportedVersions { versions: [MatrixVersion::V1_1].into(), features: Default::default() };
 
     let mut http_req = req
-        .try_into_http_request::<Vec<u8>>(
-            "https://homeserver.tld",
-            SendAccessToken::None,
-            Cow::Owned(supported),
-        )
+        .try_into_http_request::<Vec<u8>>("https://homeserver.tld", (), Cow::Owned(supported))
         .unwrap();
 
     assert_eq!(

--- a/crates/ruma-common/tests/it/api/manual_endpoint_impl.rs
+++ b/crates/ruma-common/tests/it/api/manual_endpoint_impl.rs
@@ -12,7 +12,7 @@ use ruma_common::{
     api::{
         EndpointError, IncomingRequest, IncomingResponse, MatrixVersion, Metadata, OutgoingRequest,
         OutgoingResponse, SupportedVersions,
-        auth_scheme::{NoAuthentication, SendAccessToken},
+        auth_scheme::NoAuthentication,
         error::{FromHttpRequestError, FromHttpResponseError, IntoHttpError, MatrixError},
         path_builder::{StablePathSelector, VersionHistory},
     },
@@ -64,7 +64,7 @@ impl OutgoingRequest for Request {
     fn try_into_http_request<T: Default + BufMut>(
         self,
         base_url: &str,
-        _access_token: SendAccessToken<'_>,
+        _input: (),
         considering: Cow<'_, SupportedVersions>,
     ) -> Result<http::Request<T>, IntoHttpError> {
         let url = Self::make_endpoint_url(considering, base_url, &[&self.room_alias], "")?;

--- a/crates/ruma-common/tests/it/api/no_fields.rs
+++ b/crates/ruma-common/tests/it/api/no_fields.rs
@@ -2,7 +2,6 @@ use std::borrow::Cow;
 
 use ruma_common::api::{
     MatrixVersion, OutgoingRequest as _, OutgoingResponse as _, SupportedVersions,
-    auth_scheme::SendAccessToken,
 };
 
 mod get {
@@ -60,11 +59,7 @@ fn empty_post_request_http_repr() {
         SupportedVersions { versions: [MatrixVersion::V1_1].into(), features: Default::default() };
 
     let http_req = req
-        .try_into_http_request::<Vec<u8>>(
-            "https://homeserver.tld",
-            SendAccessToken::None,
-            Cow::Owned(supported),
-        )
+        .try_into_http_request::<Vec<u8>>("https://homeserver.tld", (), Cow::Owned(supported))
         .unwrap();
 
     // Empty POST requests should contain an empty dictionary as a body...
@@ -77,11 +72,7 @@ fn empty_get_request_http_repr() {
         SupportedVersions { versions: [MatrixVersion::V1_1].into(), features: Default::default() };
 
     let http_req = req
-        .try_into_http_request::<Vec<u8>>(
-            "https://homeserver.tld",
-            SendAccessToken::None,
-            Cow::Owned(supported),
-        )
+        .try_into_http_request::<Vec<u8>>("https://homeserver.tld", (), Cow::Owned(supported))
         .unwrap();
 
     // ... but GET requests' bodies should be empty.

--- a/crates/ruma-common/tests/it/api/optional_headers.rs
+++ b/crates/ruma-common/tests/it/api/optional_headers.rs
@@ -5,9 +5,7 @@ use http::header::{CONTENT_DISPOSITION, LOCATION};
 use ruma_common::{
     api::{
         IncomingRequest, IncomingResponse, MatrixVersion, OutgoingRequest, OutgoingResponse,
-        SupportedVersions,
-        auth_scheme::{NoAuthentication, SendAccessToken},
-        request, response,
+        SupportedVersions, auth_scheme::NoAuthentication, request, response,
     },
     http_headers::{ContentDisposition, ContentDispositionType},
     metadata,
@@ -48,11 +46,7 @@ fn request_serde_no_header() {
 
     let http_req = req
         .clone()
-        .try_into_http_request::<Vec<u8>>(
-            "https://homeserver.tld",
-            SendAccessToken::None,
-            Cow::Owned(supported),
-        )
+        .try_into_http_request::<Vec<u8>>("https://homeserver.tld", (), Cow::Owned(supported))
         .unwrap();
     assert_matches!(http_req.headers().get(LOCATION), None);
     assert_matches!(http_req.headers().get(CONTENT_DISPOSITION), None);
@@ -76,11 +70,7 @@ fn request_serde_with_header() {
 
     let mut http_req = req
         .clone()
-        .try_into_http_request::<Vec<u8>>(
-            "https://homeserver.tld",
-            SendAccessToken::None,
-            Cow::Owned(supported),
-        )
+        .try_into_http_request::<Vec<u8>>("https://homeserver.tld", (), Cow::Owned(supported))
         .unwrap();
     assert_matches!(http_req.headers().get(LOCATION), Some(_));
     assert_matches!(http_req.headers().get(CONTENT_DISPOSITION), Some(_));

--- a/crates/ruma-common/tests/it/api/required_headers.rs
+++ b/crates/ruma-common/tests/it/api/required_headers.rs
@@ -6,7 +6,7 @@ use ruma_common::{
     api::{
         IncomingRequest, IncomingResponse, MatrixVersion, OutgoingRequest, OutgoingResponse,
         SupportedVersions,
-        auth_scheme::{NoAuthentication, SendAccessToken},
+        auth_scheme::NoAuthentication,
         error::{
             DeserializationError, FromHttpRequestError, FromHttpResponseError,
             HeaderDeserializationError,
@@ -56,11 +56,7 @@ fn request_serde() {
 
     let mut http_req = req
         .clone()
-        .try_into_http_request::<Vec<u8>>(
-            "https://homeserver.tld",
-            SendAccessToken::None,
-            Cow::Owned(supported),
-        )
+        .try_into_http_request::<Vec<u8>>("https://homeserver.tld", (), Cow::Owned(supported))
         .unwrap();
     assert_matches!(http_req.headers().get(LOCATION), Some(_));
     assert_matches!(http_req.headers().get(CONTENT_DISPOSITION), Some(_));

--- a/crates/ruma-identity-service-api/CHANGELOG.md
+++ b/crates/ruma-identity-service-api/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [unreleased]
 
+Breaking changes:
+
+- The endpoints that were using the `NoAuthentication` authentication scheme now
+  use `NoAccessToken`.
+
 # 0.13.0
 
 Breaking changes:

--- a/crates/ruma-identity-service-api/src/authentication/register.rs
+++ b/crates/ruma-identity-service-api/src/authentication/register.rs
@@ -11,7 +11,7 @@ pub mod v2 {
 
     use ruma_common::{
         OwnedServerName,
-        api::{auth_scheme::NoAuthentication, request, response},
+        api::{auth_scheme::NoAccessToken, request, response},
         authentication::TokenType,
         metadata,
     };
@@ -19,7 +19,7 @@ pub mod v2 {
     metadata! {
         method: POST,
         rate_limited: false,
-        authentication: NoAuthentication,
+        authentication: NoAccessToken,
         history: {
             1.0 => "/_matrix/identity/v2/account/register",
         }

--- a/crates/ruma-identity-service-api/src/discovery/get_server_status.rs
+++ b/crates/ruma-identity-service-api/src/discovery/get_server_status.rs
@@ -8,14 +8,14 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/identity-service-api/#get_matrixidentityv2
 
     use ruma_common::{
-        api::{auth_scheme::NoAuthentication, request, response},
+        api::{auth_scheme::NoAccessToken, request, response},
         metadata,
     };
 
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: NoAuthentication,
+        authentication: NoAccessToken,
         history: {
             1.0 => "/_matrix/identity/v2",
         }

--- a/crates/ruma-identity-service-api/src/discovery/get_supported_versions.rs
+++ b/crates/ruma-identity-service-api/src/discovery/get_supported_versions.rs
@@ -13,14 +13,14 @@
 use std::collections::BTreeMap;
 
 use ruma_common::{
-    api::{SupportedVersions, auth_scheme::NoAuthentication, request, response},
+    api::{SupportedVersions, auth_scheme::NoAccessToken, request, response},
     metadata,
 };
 
 metadata! {
     method: GET,
     rate_limited: false,
-    authentication: NoAuthentication,
+    authentication: NoAccessToken,
     path: "/_matrix/identity/versions",
 }
 

--- a/crates/ruma-identity-service-api/src/keys/check_public_key_validity.rs
+++ b/crates/ruma-identity-service-api/src/keys/check_public_key_validity.rs
@@ -9,7 +9,7 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/identity-service-api/#get_matrixidentityv2pubkeyisvalid
 
     use ruma_common::{
-        api::{auth_scheme::NoAuthentication, request, response},
+        api::{auth_scheme::NoAccessToken, request, response},
         metadata,
         third_party_invite::IdentityServerBase64PublicKey,
     };
@@ -17,7 +17,7 @@ pub mod v2 {
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: NoAuthentication,
+        authentication: NoAccessToken,
         history: {
             1.0 => "/_matrix/identity/v2/pubkey/isvalid",
         }

--- a/crates/ruma-identity-service-api/src/keys/get_public_key.rs
+++ b/crates/ruma-identity-service-api/src/keys/get_public_key.rs
@@ -9,7 +9,7 @@ pub mod v2 {
 
     use ruma_common::{
         OwnedServerSigningKeyId,
-        api::{auth_scheme::NoAuthentication, request, response},
+        api::{auth_scheme::NoAccessToken, request, response},
         metadata,
         third_party_invite::IdentityServerBase64PublicKey,
     };
@@ -17,7 +17,7 @@ pub mod v2 {
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: NoAuthentication,
+        authentication: NoAccessToken,
         history: {
             1.0 => "/_matrix/identity/v2/pubkey/{key_id}",
         }

--- a/crates/ruma-identity-service-api/src/keys/validate_ephemeral_key.rs
+++ b/crates/ruma-identity-service-api/src/keys/validate_ephemeral_key.rs
@@ -8,7 +8,7 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/latest/identity-service-api/#get_matrixidentityv2pubkeyephemeralisvalid
 
     use ruma_common::{
-        api::{auth_scheme::NoAuthentication, request, response},
+        api::{auth_scheme::NoAccessToken, request, response},
         metadata,
         third_party_invite::IdentityServerBase64PublicKey,
     };
@@ -16,7 +16,7 @@ pub mod v2 {
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: NoAuthentication,
+        authentication: NoAccessToken,
         history: {
             1.0 => "/_matrix/identity/v2/pubkey/ephemeral/isvalid",
         }

--- a/crates/ruma-identity-service-api/src/tos/get_terms_of_service.rs
+++ b/crates/ruma-identity-service-api/src/tos/get_terms_of_service.rs
@@ -10,7 +10,7 @@ pub mod v2 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{auth_scheme::NoAuthentication, request, response},
+        api::{auth_scheme::NoAccessToken, request, response},
         metadata,
     };
     use serde::{Deserialize, Serialize};
@@ -18,7 +18,7 @@ pub mod v2 {
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: NoAuthentication,
+        authentication: NoAccessToken,
         history: {
             1.0 => "/_matrix/identity/v2/terms",
         }


### PR DESCRIPTION
Because in some APIs it doesn't make sense to be able to provide a `SendAccessToken`, we create a separate type for this and `NoAuthentication` doesn't accept any input anymore.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
