### PR TITLE
client-api: Stabilize OAuth 2.0 Device Authorization Grant

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -71,6 +71,8 @@ Improvements:
   and data of the algorithm can be accessed via the `algorithm()` and
   `auth_data()` methods respectively.
 - `RegistrationKind` and `LoginType` can now represent custom values.
+- Stabilize support for the OAuth 2.0 Device Authorization Grant, according to
+  MSC4341.
 
 # 0.22.1
 

--- a/crates/ruma-client-api/src/discovery/get_authorization_server_metadata.rs
+++ b/crates/ruma-client-api/src/discovery/get_authorization_server_metadata.rs
@@ -160,7 +160,6 @@ pub mod v1 {
         /// URL of the authorization server's device authorization endpoint ([RFC 8628]).
         ///
         /// [RFC 8628]: https://datatracker.ietf.org/doc/html/rfc8628
-        #[cfg(feature = "unstable-msc4108")]
         #[serde(skip_serializing_if = "Option::is_none")]
         pub device_authorization_endpoint: Option<Url>,
 
@@ -221,7 +220,6 @@ pub mod v1 {
                 self.account_management_uri
                     .as_ref()
                     .map(|string| ("account_management_uri", string)),
-                #[cfg(feature = "unstable-msc4108")]
                 self.device_authorization_endpoint
                     .as_ref()
                     .map(|string| ("device_authorization_endpoint", string)),
@@ -431,7 +429,6 @@ pub mod v1 {
         /// The device code grant type ([RFC 8628]).
         ///
         /// [RFC 8628]: https://datatracker.ietf.org/doc/html/rfc8628
-        #[cfg(feature = "unstable-msc4108")]
         #[ruma_enum(rename = "urn:ietf:params:oauth:grant-type:device_code")]
         DeviceCode,
 
@@ -719,14 +716,11 @@ mod tests {
         metadata.validate_urls().unwrap_err();
         metadata.insecure_validate_urls().unwrap();
 
-        #[cfg(feature = "unstable-msc4108")]
-        {
-            let mut metadata = original_metadata.clone();
-            metadata.device_authorization_endpoint =
-                Some(Url::parse("http://server.local/device").unwrap());
-            metadata.validate_urls().unwrap_err();
-            metadata.insecure_validate_urls().unwrap();
-        }
+        let mut metadata = original_metadata;
+        metadata.device_authorization_endpoint =
+            Some(Url::parse("http://server.local/device").unwrap());
+        metadata.validate_urls().unwrap_err();
+        metadata.insecure_validate_urls().unwrap();
     }
 
     #[test]

--- a/crates/ruma-client-api/src/discovery/get_authorization_server_metadata/serde.rs
+++ b/crates/ruma-client-api/src/discovery/get_authorization_server_metadata/serde.rs
@@ -27,7 +27,6 @@ impl<'de> Deserialize<'de> for AuthorizationServerMetadata {
             code_challenge_methods_supported,
             account_management_uri,
             account_management_actions_supported,
-            #[cfg(feature = "unstable-msc4108")]
             device_authorization_endpoint,
             prompt_values_supported,
         } = helper;
@@ -102,7 +101,6 @@ impl<'de> Deserialize<'de> for AuthorizationServerMetadata {
             code_challenge_methods_supported,
             account_management_uri,
             account_management_actions_supported,
-            #[cfg(feature = "unstable-msc4108")]
             device_authorization_endpoint,
             prompt_values_supported,
         })
@@ -123,7 +121,6 @@ struct AuthorizationServerMetadataDeHelper {
     account_management_uri: Option<Url>,
     #[serde(default)]
     account_management_actions_supported: BTreeSet<AccountManagementAction>,
-    #[cfg(feature = "unstable-msc4108")]
     device_authorization_endpoint: Option<Url>,
     #[serde(default)]
     prompt_values_supported: Vec<Prompt>,
@@ -224,7 +221,6 @@ mod tests {
                 .contains(&AccountManagementAction::CrossSigningReset)
         );
 
-        #[cfg(feature = "unstable-msc4108")]
         assert_eq!(
             metadata.device_authorization_endpoint.as_ref().map(Url::as_str),
             Some("https://server.local/device")
@@ -267,7 +263,6 @@ mod tests {
         assert_eq!(metadata.account_management_uri, None);
         assert_eq!(metadata.account_management_actions_supported.len(), 0);
 
-        #[cfg(feature = "unstable-msc4108")]
         assert_eq!(metadata.device_authorization_endpoint, None);
     }
 
@@ -358,7 +353,6 @@ mod tests {
                 .contains(&AccountManagementAction::from("custom"))
         );
 
-        #[cfg(feature = "unstable-msc4108")]
         assert_eq!(
             metadata.device_authorization_endpoint.as_ref().map(Url::as_str),
             Some("https://server.local/device")


### PR DESCRIPTION
According to [MSC4341](https://github.com/matrix-org/matrix-spec-proposals/issues/4341) / [Spec PR](https://github.com/matrix-org/matrix-spec/pull/2320).

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
