### PR TITLE
client-api: add create_available field to MSC4388 discovery response

### DIFF
--- a/crates/ruma-client-api/src/rendezvous/discover_rendezvous.rs
+++ b/crates/ruma-client-api/src/rendezvous/discover_rendezvous.rs
@@ -34,12 +34,15 @@ pub mod unstable {
 
     #[response(error = crate::Error)]
     /// Response type for the `GET` `rendezvous` endpoint.
-    pub struct Response {}
+    pub struct Response {
+        /// True if the requester is able to use the create session endpoint, false otherwise.
+        pub create_available: bool,
+    }
 
     impl Response {
         /// Creates a new `Response`.
-        pub fn new() -> Self {
-            Self {}
+        pub fn new(create_available: bool) -> Self {
+            Self { create_available }
         }
     }
 }


### PR DESCRIPTION
No changelog as covered by existing unreleased changes.

The corresponding MSC changes are: https://github.com/matrix-org/matrix-spec-proposals/compare/d638bdd3950491d09c1090f3a33e0420fc3f48ab...62672cfc7bb84863bf1157e99836bc5086c8f761

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
