### PR TITLE
events: Use stricter types in `EncryptedFile`

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -41,6 +41,9 @@ Improvements:
   on the event reference hash.
 - Add `RoomType::Call` & `RoomTypeFilter::Call` to support MSC3417 behind
   `unstable-msc3417`
+- It is now possible to use `Base64::parse` when the inner `B` "bytes" type is
+  an array, and the inner bytes can be accessed without consuming the wrapper
+  type with `Base64::as_inner()`.
 
 # 0.17.1
 

--- a/crates/ruma-common/src/serde/base64.rs
+++ b/crates/ruma-common/src/serde/base64.rs
@@ -91,6 +91,11 @@ impl<C: Base64Config, B: AsRef<[u8]>> Base64<C, B> {
 }
 
 impl<C, B> Base64<C, B> {
+    /// Get a reference to the raw bytes held by this `Base64` instance.
+    pub fn as_inner(&self) -> &B {
+        &self.bytes
+    }
+
     /// Get the raw bytes held by this `Base64` instance.
     pub fn into_inner(self) -> B {
         self.bytes
@@ -102,10 +107,13 @@ impl<C: Base64Config> Base64<C> {
     pub fn empty() -> Self {
         Self::new(Vec::new())
     }
+}
 
+impl<C: Base64Config, B: TryFromBase64DecodedBytes> Base64<C, B> {
     /// Parse some base64-encoded data to create a `Base64` instance.
     pub fn parse(encoded: impl AsRef<[u8]>) -> Result<Self, Base64DecodeError> {
-        Self::ENGINE.decode(encoded).map(Self::new).map_err(Base64DecodeError)
+        let decoded = Self::ENGINE.decode(encoded).map_err(Base64DecodeError::base64)?;
+        B::try_from_bytes(decoded).map(Self::new)
     }
 }
 
@@ -121,7 +129,7 @@ impl<C: Base64Config, B: AsRef<[u8]>> fmt::Display for Base64<C, B> {
     }
 }
 
-impl<'de, C: Base64Config> Deserialize<'de> for Base64<C> {
+impl<'de, C: Base64Config, B: TryFromBase64DecodedBytes> Deserialize<'de> for Base64<C, B> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -140,9 +148,45 @@ impl<C: Base64Config, B: AsRef<[u8]>> Serialize for Base64<C, B> {
     }
 }
 
+/// Marker trait for indicating which inner `B` "bytes" type can be converted from decoded base64
+/// bytes.
+///
+/// This is used as a bound in [`Base64::parse()`] to provide a more helpful error message than
+/// using a `TryFrom<Vec<u8>>` implementation.
+pub trait TryFromBase64DecodedBytes: Sized + AsRef<[u8]> {
+    /// Convert the given bytes to this type.
+    #[doc(hidden)]
+    fn try_from_bytes(bytes: Vec<u8>) -> Result<Self, Base64DecodeError>;
+}
+
+impl TryFromBase64DecodedBytes for Vec<u8> {
+    fn try_from_bytes(bytes: Vec<u8>) -> Result<Self, Base64DecodeError> {
+        Ok(bytes)
+    }
+}
+
+impl<const N: usize> TryFromBase64DecodedBytes for [u8; N] {
+    fn try_from_bytes(bytes: Vec<u8>) -> Result<Self, Base64DecodeError> {
+        Self::try_from(bytes)
+            .map_err(|bytes| Base64DecodeError::invalid_decoded_length(bytes.len(), N))
+    }
+}
+
 /// An error that occurred while decoding a base64 string.
 #[derive(Clone)]
-pub struct Base64DecodeError(base64::DecodeError);
+pub struct Base64DecodeError(Base64DecodeErrorInner);
+
+impl Base64DecodeError {
+    /// Construct a `Base64DecodeError` from an invalid base64 encoding error.
+    fn base64(error: base64::DecodeError) -> Self {
+        Self(Base64DecodeErrorInner::Base64(error))
+    }
+
+    /// Construct a `Base64DecodeError` from an invalid decoded bytes length error.
+    fn invalid_decoded_length(len: usize, expected: usize) -> Self {
+        Self(Base64DecodeErrorInner::InvalidDecodedLength { len, expected })
+    }
+}
 
 impl fmt::Debug for Base64DecodeError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -152,18 +196,38 @@ impl fmt::Debug for Base64DecodeError {
 
 impl fmt::Display for Base64DecodeError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
+        match &self.0 {
+            Base64DecodeErrorInner::Base64(error) => write!(f, "invalid base64 encoding: {error}"),
+            Base64DecodeErrorInner::InvalidDecodedLength { len, expected } => {
+                write!(f, "invalid decoded base64 bytes length: {len}, expected {expected}")
+            }
+        }
     }
 }
 
 impl std::error::Error for Base64DecodeError {}
+
+/// An error that occurred while decoding a base64 string.
+#[derive(Debug, Clone)]
+enum Base64DecodeErrorInner {
+    /// The base64 encoding is invalid.
+    Base64(base64::DecodeError),
+
+    /// The decoded bytes have the wrong length to fit into an array of fixed length.
+    InvalidDecodedLength {
+        /// The length of the input.
+        len: usize,
+        /// The expected length.
+        expected: usize,
+    },
+}
 
 #[cfg(test)]
 mod tests {
     use super::{Base64, Standard};
 
     #[test]
-    fn slightly_malformed_base64() {
+    fn parse_base64() {
         const INPUT: &str = "3UmJnEIzUr2xWyaUnJg5fXwRybwG5FVC6Gq\
             MHverEUn0ztuIsvVxX89JXX2pvdTsOBbLQx+4TVL02l4Cp5wPCm";
         const INPUT_WITH_PADDING: &str = "im9+knCkMNQNh9o6sbdcZw==";
@@ -171,5 +235,11 @@ mod tests {
         Base64::<Standard>::parse(INPUT).unwrap();
         Base64::<Standard>::parse(INPUT_WITH_PADDING)
             .expect("We should be able to decode padded Base64");
+
+        // Check that we can parse with the correct length.
+        Base64::<Standard, [u8; 32]>::parse(INPUT).unwrap_err();
+        Base64::<Standard, [u8; 64]>::parse(INPUT).unwrap();
+        Base64::<Standard, [u8; 32]>::parse(INPUT_WITH_PADDING).unwrap_err();
+        Base64::<Standard, [u8; 16]>::parse(INPUT_WITH_PADDING).unwrap();
     }
 }

--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -32,6 +32,9 @@ Breaking changes:
   and to hide fields that should be set to a constant value to have a stricter
   validation during construction and deserialization. Now that there are fewer
   fields, this type can be constructed with `EncryptedFile::new()`.
+  - Similarly, the `hashes` field uses a stricter `EncryptedFileHashes` map type
+    to ensure that a decoded hash has the appropriate format for the algorithm
+    in the key.
   - `EncryptedFileInit`, `JsonWebKey` and `JsonWebKeyInit` were removed.
   - The same changes were applied to the unstable `EncryptedContent`.
   

--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -27,6 +27,14 @@ Breaking changes:
   deserialization when more algorithms are added. This type should be `.cast()`
   from and to other types when the algorithm is known from external data. The
   previous `AesHmacSha2EncryptedData` variant is now a separate struct.
+- Some fields of `EncryptedFile` are now grouped by version in a new
+  `EncryptedFileInfo` enum. This allows to support custom encryption algorithms
+  and to hide fields that should be set to a constant value to have a stricter
+  validation during construction and deserialization. Now that there are fewer
+  fields, this type can be constructed with `EncryptedFile::new()`.
+  - `EncryptedFileInit`, `JsonWebKey` and `JsonWebKeyInit` were removed.
+  - The same changes were applied to the unstable `EncryptedContent`.
+  
 
 Bug fixes:
 

--- a/crates/ruma-events/src/file.rs
+++ b/crates/ruma-events/src/file.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 
 use super::{
     message::TextContentBlock,
-    room::{EncryptedFile, JsonWebKey, message::Relation},
+    room::{EncryptedFile, EncryptedFileInfo, message::Relation},
 };
 
 /// The payload for an extensible file message.
@@ -172,64 +172,30 @@ impl FileContentBlock {
 }
 
 /// The encryption info of a file sent to a room with end-to-end encryption enabled.
-///
-/// To create an instance of this type, first create a `EncryptedContentInit` and convert it via
-/// `EncryptedContent::from` / `.into()`.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct EncryptedContent {
-    /// A [JSON Web Key](https://tools.ietf.org/html/rfc7517#appendix-A.3) object.
-    pub key: JsonWebKey,
+    /// Information about the encryption of the file.
+    #[serde(flatten)]
+    pub info: EncryptedFileInfo,
 
-    /// The 128-bit unique counter block used by AES-CTR, encoded as unpadded base64.
-    pub iv: Base64,
-
-    /// A map from an algorithm name to a hash of the ciphertext, encoded as unpadded base64.
+    /// A map from an algorithm name to a hash of the ciphertext.
     ///
     /// Clients should support the SHA-256 hash, which uses the key sha256.
     pub hashes: BTreeMap<String, Base64>,
-
-    /// Version of the encrypted attachments protocol.
-    ///
-    /// Must be `v2`.
-    pub v: String,
 }
 
-/// Initial set of fields of `EncryptedContent`.
-///
-/// This struct will not be updated even if additional fields are added to `EncryptedContent` in a
-/// new (non-breaking) release of the Matrix specification.
-#[derive(Debug)]
-#[allow(clippy::exhaustive_structs)]
-pub struct EncryptedContentInit {
-    /// A [JSON Web Key](https://tools.ietf.org/html/rfc7517#appendix-A.3) object.
-    pub key: JsonWebKey,
-
-    /// The 128-bit unique counter block used by AES-CTR, encoded as unpadded base64.
-    pub iv: Base64,
-
-    /// A map from an algorithm name to a hash of the ciphertext, encoded as unpadded base64.
-    ///
-    /// Clients should support the SHA-256 hash, which uses the key sha256.
-    pub hashes: BTreeMap<String, Base64>,
-
-    /// Version of the encrypted attachments protocol.
-    ///
-    /// Must be `v2`.
-    pub v: String,
-}
-
-impl From<EncryptedContentInit> for EncryptedContent {
-    fn from(init: EncryptedContentInit) -> Self {
-        let EncryptedContentInit { key, iv, hashes, v } = init;
-        Self { key, iv, hashes, v }
+impl EncryptedContent {
+    /// Construct a new `EncryptedContent` with the given encryption info and hashes.
+    pub fn new(info: EncryptedFileInfo, hashes: BTreeMap<String, Base64>) -> Self {
+        Self { info, hashes }
     }
 }
 
 impl From<&EncryptedFile> for EncryptedContent {
     fn from(encrypted: &EncryptedFile) -> Self {
-        let EncryptedFile { key, iv, hashes, v, .. } = encrypted;
-        Self { key: key.to_owned(), iv: iv.to_owned(), hashes: hashes.to_owned(), v: v.to_owned() }
+        let EncryptedFile { info, hashes, .. } = encrypted;
+        Self { info: info.to_owned(), hashes: hashes.to_owned() }
     }
 }
 

--- a/crates/ruma-events/src/file.rs
+++ b/crates/ruma-events/src/file.rs
@@ -2,16 +2,14 @@
 //!
 //! [MSC3551]: https://github.com/matrix-org/matrix-spec-proposals/pull/3551
 
-use std::collections::BTreeMap;
-
 use js_int::UInt;
-use ruma_common::{OwnedMxcUri, serde::Base64};
+use ruma_common::OwnedMxcUri;
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};
 
 use super::{
     message::TextContentBlock,
-    room::{EncryptedFile, EncryptedFileInfo, message::Relation},
+    room::{EncryptedFile, EncryptedFileHashes, EncryptedFileInfo, message::Relation},
 };
 
 /// The payload for an extensible file message.
@@ -182,12 +180,12 @@ pub struct EncryptedContent {
     /// A map from an algorithm name to a hash of the ciphertext.
     ///
     /// Clients should support the SHA-256 hash, which uses the key sha256.
-    pub hashes: BTreeMap<String, Base64>,
+    pub hashes: EncryptedFileHashes,
 }
 
 impl EncryptedContent {
     /// Construct a new `EncryptedContent` with the given encryption info and hashes.
-    pub fn new(info: EncryptedFileInfo, hashes: BTreeMap<String, Base64>) -> Self {
+    pub fn new(info: EncryptedFileInfo, hashes: EncryptedFileHashes) -> Self {
         Self { info, hashes }
     }
 }

--- a/crates/ruma-events/src/room.rs
+++ b/crates/ruma-events/src/room.rs
@@ -2,7 +2,11 @@
 //!
 //! This module also contains types shared by events in its child namespaces.
 
-use std::{collections::BTreeMap, fmt};
+use std::{
+    collections::{BTreeMap, btree_map},
+    fmt,
+    ops::Deref,
+};
 
 use as_variant::as_variant;
 use js_int::UInt;
@@ -13,8 +17,11 @@ use ruma_common::{
         base64::{Standard, UrlSafe},
     },
 };
+use ruma_macros::StringEnum;
 use serde::{Deserialize, Serialize, de};
 use zeroize::Zeroize;
+
+use crate::PrivOwnedStr;
 
 pub mod aliases;
 pub mod avatar;
@@ -181,17 +188,13 @@ pub struct EncryptedFile {
 
     /// A map from an algorithm name to a hash of the ciphertext.
     ///
-    /// Clients should support the SHA-256 hash, which uses the key sha256.
-    pub hashes: BTreeMap<String, Base64>,
+    /// Clients should support the SHA-256 hash.
+    pub hashes: EncryptedFileHashes,
 }
 
 impl EncryptedFile {
     /// Construct a new `EncryptedFile` with the given URL, encryption info and hashes.
-    pub fn new(
-        url: OwnedMxcUri,
-        info: EncryptedFileInfo,
-        hashes: BTreeMap<String, Base64>,
-    ) -> Self {
+    pub fn new(url: OwnedMxcUri, info: EncryptedFileInfo, hashes: EncryptedFileHashes) -> Self {
         Self { url, info, hashes }
     }
 }
@@ -281,16 +284,132 @@ pub struct CustomEncryptedFileInfo {
     data: JsonObject,
 }
 
+/// A map of [`EncryptedFileHashAlgorithm`] to the associated [`EncryptedFileHash`].
+///
+/// This type is used to ensure that a supported [`EncryptedFileHash`] always matches the
+/// appropriate [`EncryptedFileHashAlgorithm`].
+#[derive(Clone, Debug, Default)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+pub struct EncryptedFileHashes(BTreeMap<EncryptedFileHashAlgorithm, EncryptedFileHash>);
+
+impl EncryptedFileHashes {
+    /// Construct an empty `EncryptedFileHashes`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Construct an `EncryptedFileHashes` that includes the given SHA-256 hash.
+    pub fn with_sha256(hash: [u8; 32]) -> Self {
+        std::iter::once(EncryptedFileHash::Sha256(Base64::new(hash))).collect()
+    }
+
+    /// Insert the given [`EncryptedFileHash`].
+    ///
+    /// If a map with the same [`EncryptedFileHashAlgorithm`] was already present, it is returned.
+    pub fn insert(&mut self, hash: EncryptedFileHash) -> Option<EncryptedFileHash> {
+        self.0.insert(hash.algorithm(), hash)
+    }
+}
+
+impl Deref for EncryptedFileHashes {
+    type Target = BTreeMap<EncryptedFileHashAlgorithm, EncryptedFileHash>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl FromIterator<EncryptedFileHash> for EncryptedFileHashes {
+    fn from_iter<T: IntoIterator<Item = EncryptedFileHash>>(iter: T) -> Self {
+        Self(iter.into_iter().map(|hash| (hash.algorithm(), hash)).collect())
+    }
+}
+
+impl Extend<EncryptedFileHash> for EncryptedFileHashes {
+    fn extend<T: IntoIterator<Item = EncryptedFileHash>>(&mut self, iter: T) {
+        self.0.extend(iter.into_iter().map(|hash| (hash.algorithm(), hash)));
+    }
+}
+
+impl IntoIterator for EncryptedFileHashes {
+    type Item = EncryptedFileHash;
+    type IntoIter = btree_map::IntoValues<EncryptedFileHashAlgorithm, EncryptedFileHash>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_values()
+    }
+}
+
+/// An algorithm used to generate the hash of an [`EncryptedFile`].
+#[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
+#[derive(Clone, StringEnum)]
+#[ruma_enum(rename_all = "lowercase")]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+pub enum EncryptedFileHashAlgorithm {
+    /// The SHA-256 algorithm
+    Sha256,
+
+    #[doc(hidden)]
+    _Custom(PrivOwnedStr),
+}
+
+/// The hash of an encrypted file's ciphertext.
+#[derive(Clone, Debug)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+pub enum EncryptedFileHash {
+    /// A hash computed with the SHA-256 algorithm.
+    Sha256(Base64<Standard, [u8; 32]>),
+
+    #[doc(hidden)]
+    _Custom(CustomEncryptedFileHash),
+}
+
+impl EncryptedFileHash {
+    /// The key that was used to group this map.
+    pub fn algorithm(&self) -> EncryptedFileHashAlgorithm {
+        match self {
+            Self::Sha256(_) => EncryptedFileHashAlgorithm::Sha256,
+            Self::_Custom(custom) => custom.algorithm.as_str().into(),
+        }
+    }
+
+    /// Get a reference to the decoded bytes of the hash.
+    pub fn as_bytes(&self) -> &[u8] {
+        match self {
+            Self::Sha256(hash) => hash.as_bytes(),
+            Self::_Custom(custom) => custom.hash.as_bytes(),
+        }
+    }
+
+    /// Get the decoded bytes of the hash.
+    pub fn into_bytes(self) -> Vec<u8> {
+        match self {
+            Self::Sha256(hash) => hash.into_inner().into(),
+            Self::_Custom(custom) => custom.hash.into_inner(),
+        }
+    }
+}
+
+/// A map of results grouped by custom key type.
+#[doc(hidden)]
+#[derive(Clone, Debug)]
+pub struct CustomEncryptedFileHash {
+    /// The algorithm that was used to generate the hash.
+    algorithm: String,
+
+    /// The hash.
+    hash: Base64,
+}
+
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
-
     use assert_matches2::assert_matches;
     use ruma_common::owned_mxc_uri;
     use serde::Deserialize;
     use serde_json::{from_value as from_json_value, json};
 
     use super::{EncryptedFile, MediaSource, V2EncryptedFileInfo};
+    use crate::room::EncryptedFileHashes;
 
     #[derive(Deserialize)]
     struct MsgWithAttachment {
@@ -307,7 +426,7 @@ mod tests {
             "file": EncryptedFile::new(
                 owned_mxc_uri!("mxc://localhost/encryptedfile"),
                 V2EncryptedFileInfo::encode([0;32], [1;16]).into(),
-                BTreeMap::new(),
+                EncryptedFileHashes::new(),
             ),
             "url": "mxc://localhost/file",
         }))

--- a/crates/ruma-events/src/room.rs
+++ b/crates/ruma-events/src/room.rs
@@ -2,12 +2,16 @@
 //!
 //! This module also contains types shared by events in its child namespaces.
 
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, fmt};
 
+use as_variant::as_variant;
 use js_int::UInt;
 use ruma_common::{
     OwnedMxcUri,
-    serde::{Base64, base64::UrlSafe},
+    serde::{
+        Base64, JsonObject,
+        base64::{Standard, UrlSafe},
+    },
 };
 use serde::{Deserialize, Serialize, de};
 use zeroize::Zeroize;
@@ -17,6 +21,7 @@ pub mod avatar;
 pub mod canonical_alias;
 pub mod create;
 pub mod encrypted;
+mod encrypted_file_serde;
 pub mod encryption;
 pub mod guest_access;
 pub mod history_visibility;
@@ -164,162 +169,116 @@ impl ThumbnailInfo {
 }
 
 /// A file sent to a room with end-to-end encryption enabled.
-///
-/// To create an instance of this type, first create a `EncryptedFileInit` and convert it via
-/// `EncryptedFile::from` / `.into()`.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct EncryptedFile {
     /// The URL to the file.
     pub url: OwnedMxcUri,
 
-    /// A [JSON Web Key](https://tools.ietf.org/html/rfc7517#appendix-A.3) object.
-    pub key: JsonWebKey,
+    /// Information about the encryption of the file.
+    #[serde(flatten)]
+    pub info: EncryptedFileInfo,
 
-    /// The 128-bit unique counter block used by AES-CTR, encoded as unpadded base64.
-    pub iv: Base64,
-
-    /// A map from an algorithm name to a hash of the ciphertext, encoded as unpadded base64.
+    /// A map from an algorithm name to a hash of the ciphertext.
     ///
     /// Clients should support the SHA-256 hash, which uses the key sha256.
     pub hashes: BTreeMap<String, Base64>,
-
-    /// Version of the encrypted attachments protocol.
-    ///
-    /// Must be `v2`.
-    pub v: String,
 }
 
-/// Initial set of fields of `EncryptedFile`.
-///
-/// This struct will not be updated even if additional fields are added to `EncryptedFile` in a new
-/// (non-breaking) release of the Matrix specification.
-#[derive(Debug)]
-#[allow(clippy::exhaustive_structs)]
-pub struct EncryptedFileInit {
-    /// The URL to the file.
-    pub url: OwnedMxcUri,
-
-    /// A [JSON Web Key](https://tools.ietf.org/html/rfc7517#appendix-A.3) object.
-    pub key: JsonWebKey,
-
-    /// The 128-bit unique counter block used by AES-CTR, encoded as unpadded base64.
-    pub iv: Base64,
-
-    /// A map from an algorithm name to a hash of the ciphertext, encoded as unpadded base64.
-    ///
-    /// Clients should support the SHA-256 hash, which uses the key sha256.
-    pub hashes: BTreeMap<String, Base64>,
-
-    /// Version of the encrypted attachments protocol.
-    ///
-    /// Must be `v2`.
-    pub v: String,
-}
-
-impl From<EncryptedFileInit> for EncryptedFile {
-    fn from(init: EncryptedFileInit) -> Self {
-        let EncryptedFileInit { url, key, iv, hashes, v } = init;
-        Self { url, key, iv, hashes, v }
+impl EncryptedFile {
+    /// Construct a new `EncryptedFile` with the given URL, encryption info and hashes.
+    pub fn new(
+        url: OwnedMxcUri,
+        info: EncryptedFileInfo,
+        hashes: BTreeMap<String, Base64>,
+    ) -> Self {
+        Self { url, info, hashes }
     }
 }
 
-/// A [JSON Web Key](https://tools.ietf.org/html/rfc7517#appendix-A.3) object.
-///
-/// To create an instance of this type, first create a `JsonWebKeyInit` and convert it via
-/// `JsonWebKey::from` / `.into()`.
-#[derive(Clone, Deserialize, Serialize)]
+/// Information about the encryption of a file.
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
-pub struct JsonWebKey {
-    /// Key type.
-    ///
-    /// Must be `oct`.
-    pub kty: String,
+#[serde(tag = "v", rename_all = "lowercase")]
+pub enum EncryptedFileInfo {
+    /// Information about a file encrypted using version 2 of the attachment encryption protocol.
+    V2(V2EncryptedFileInfo),
 
-    /// Key operations.
-    ///
-    /// Must at least contain `encrypt` and `decrypt`.
-    pub key_ops: Vec<String>,
-
-    /// Algorithm.
-    ///
-    /// Must be `A256CTR`.
-    pub alg: String,
-
-    /// The key, encoded as url-safe unpadded base64.
-    pub k: Base64<UrlSafe>,
-
-    /// Extractable.
-    ///
-    /// Must be `true`. This is a
-    /// [W3C extension](https://w3c.github.io/webcrypto/#iana-section-jwk).
-    pub ext: bool,
+    #[doc(hidden)]
+    #[serde(untagged)]
+    _Custom(CustomEncryptedFileInfo),
 }
 
-impl std::fmt::Debug for JsonWebKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("JsonWebKey")
-            .field("kty", &self.kty)
-            .field("key_ops", &self.key_ops)
-            .field("alg", &self.alg)
-            .field("ext", &self.ext)
-            .finish_non_exhaustive()
+impl EncryptedFileInfo {
+    /// Get the version of the attachment encryption protocol.
+    ///
+    /// This matches the `v` field in the serialized data.
+    pub fn version(&self) -> &str {
+        match self {
+            Self::V2(_) => "v2",
+            Self::_Custom(info) => &info.v,
+        }
+    }
+
+    /// Get the data of the attachment encryption protocol, if it doesn't match one of the known
+    /// variants.
+    pub fn custom_data(&self) -> Option<&JsonObject> {
+        as_variant!(self, Self::_Custom(info) => &info.data)
     }
 }
 
-impl Drop for JsonWebKey {
+impl From<V2EncryptedFileInfo> for EncryptedFileInfo {
+    fn from(value: V2EncryptedFileInfo) -> Self {
+        Self::V2(value)
+    }
+}
+
+/// A file encrypted with the AES-CTR algorithm with a 256-bit key.
+#[derive(Clone)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+pub struct V2EncryptedFileInfo {
+    /// The 256-bit key used to encrypt or decrypt the file.
+    pub k: Base64<UrlSafe, [u8; 32]>,
+
+    /// The 128-bit unique counter block used by AES-CTR.
+    pub iv: Base64<Standard, [u8; 16]>,
+}
+
+impl V2EncryptedFileInfo {
+    /// Construct a new `V2EncryptedFileInfo` with the given encoded key and initialization vector.
+    pub fn new(k: Base64<UrlSafe, [u8; 32]>, iv: Base64<Standard, [u8; 16]>) -> Self {
+        Self { k, iv }
+    }
+
+    /// Construct a new `V2EncryptedFileInfo` by base64-encoding the given key and initialization
+    /// vector bytes.
+    pub fn encode(k: [u8; 32], iv: [u8; 16]) -> Self {
+        Self::new(Base64::new(k), Base64::new(iv))
+    }
+}
+
+impl fmt::Debug for V2EncryptedFileInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("V2EncryptedFileInfo").finish_non_exhaustive()
+    }
+}
+
+impl Drop for V2EncryptedFileInfo {
     fn drop(&mut self) {
         self.k.zeroize();
     }
 }
 
-/// Initial set of fields of `JsonWebKey`.
-///
-/// This struct will not be updated even if additional fields are added to `JsonWebKey` in a new
-/// (non-breaking) release of the Matrix specification.
-#[allow(clippy::exhaustive_structs)]
-pub struct JsonWebKeyInit {
-    /// Key type.
-    ///
-    /// Must be `oct`.
-    pub kty: String,
+/// Information about a file encrypted using a custom version of the attachment encryption protocol.
+#[doc(hidden)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CustomEncryptedFileInfo {
+    /// The version of the protocol.
+    v: String,
 
-    /// Key operations.
-    ///
-    /// Must at least contain `encrypt` and `decrypt`.
-    pub key_ops: Vec<String>,
-
-    /// Algorithm.
-    ///
-    /// Must be `A256CTR`.
-    pub alg: String,
-
-    /// The key, encoded as url-safe unpadded base64.
-    pub k: Base64<UrlSafe>,
-
-    /// Extractable.
-    ///
-    /// Must be `true`. This is a
-    /// [W3C extension](https://w3c.github.io/webcrypto/#iana-section-jwk).
-    pub ext: bool,
-}
-
-impl std::fmt::Debug for JsonWebKeyInit {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("JsonWebKeyInit")
-            .field("kty", &self.kty)
-            .field("key_ops", &self.key_ops)
-            .field("alg", &self.alg)
-            .field("ext", &self.ext)
-            .finish_non_exhaustive()
-    }
-}
-
-impl From<JsonWebKeyInit> for JsonWebKey {
-    fn from(init: JsonWebKeyInit) -> Self {
-        let JsonWebKeyInit { kty, key_ops, alg, k, ext } = init;
-        Self { kty, key_ops, alg, k, ext }
-    }
+    /// Extra data about the encryption.
+    #[serde(flatten)]
+    data: JsonObject,
 }
 
 #[cfg(test)]
@@ -327,11 +286,11 @@ mod tests {
     use std::collections::BTreeMap;
 
     use assert_matches2::assert_matches;
-    use ruma_common::{owned_mxc_uri, serde::Base64};
+    use ruma_common::owned_mxc_uri;
     use serde::Deserialize;
     use serde_json::{from_value as from_json_value, json};
 
-    use super::{EncryptedFile, JsonWebKey, MediaSource};
+    use super::{EncryptedFile, MediaSource, V2EncryptedFileInfo};
 
     #[derive(Deserialize)]
     struct MsgWithAttachment {
@@ -341,41 +300,15 @@ mod tests {
         source: MediaSource,
     }
 
-    fn dummy_jwt() -> JsonWebKey {
-        JsonWebKey {
-            kty: "oct".to_owned(),
-            key_ops: vec!["encrypt".to_owned(), "decrypt".to_owned()],
-            alg: "A256CTR".to_owned(),
-            k: Base64::new(vec![0; 64]),
-            ext: true,
-        }
-    }
-
-    fn encrypted_file() -> EncryptedFile {
-        EncryptedFile {
-            url: owned_mxc_uri!("mxc://localhost/encryptedfile"),
-            key: dummy_jwt(),
-            iv: Base64::new(vec![0; 64]),
-            hashes: BTreeMap::new(),
-            v: "v2".to_owned(),
-        }
-    }
-
     #[test]
     fn prefer_encrypted_attachment_over_plain() {
         let msg: MsgWithAttachment = from_json_value(json!({
             "body": "",
-            "url": "mxc://localhost/file",
-            "file": encrypted_file(),
-        }))
-        .unwrap();
-
-        assert_matches!(msg.source, MediaSource::Encrypted(_));
-
-        // As above, but with the file field before the url field
-        let msg: MsgWithAttachment = from_json_value(json!({
-            "body": "",
-            "file": encrypted_file(),
+            "file": EncryptedFile::new(
+                owned_mxc_uri!("mxc://localhost/encryptedfile"),
+                V2EncryptedFileInfo::encode([0;32], [1;16]).into(),
+                BTreeMap::new(),
+            ),
             "url": "mxc://localhost/file",
         }))
         .unwrap();

--- a/crates/ruma-events/src/room/encrypted_file_serde.rs
+++ b/crates/ruma-events/src/room/encrypted_file_serde.rs
@@ -1,9 +1,12 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, collections::BTreeMap};
 
 use ruma_common::serde::Base64;
-use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de, ser::SerializeMap};
 
-use super::V2EncryptedFileInfo;
+use super::{
+    CustomEncryptedFileHash, EncryptedFileHash, EncryptedFileHashAlgorithm, EncryptedFileHashes,
+    V2EncryptedFileInfo,
+};
 
 impl<'de> Deserialize<'de> for V2EncryptedFileInfo {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -111,4 +114,52 @@ struct JsonWebKey<'a> {
     /// Must be `true`. This is a
     /// [W3C extension](https://w3c.github.io/webcrypto/#iana-section-jwk).
     ext: bool,
+}
+
+impl Serialize for EncryptedFileHashes {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut s = serializer.serialize_map(Some(self.len()))?;
+
+        for hash in self.values() {
+            match hash {
+                EncryptedFileHash::Sha256(hash) => {
+                    s.serialize_entry(&EncryptedFileHashAlgorithm::Sha256, hash)?;
+                }
+                EncryptedFileHash::_Custom(CustomEncryptedFileHash { algorithm, hash }) => {
+                    s.serialize_entry(algorithm, hash)?;
+                }
+            }
+        }
+
+        s.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for EncryptedFileHashes {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let map_by_key = BTreeMap::<EncryptedFileHashAlgorithm, String>::deserialize(deserializer)?;
+
+        map_by_key
+            .into_iter()
+            .map(|(algorithm, hash)| {
+                Ok(match algorithm {
+                    EncryptedFileHashAlgorithm::Sha256 => {
+                        EncryptedFileHash::Sha256(Base64::parse(hash).map_err(de::Error::custom)?)
+                    }
+                    EncryptedFileHashAlgorithm::_Custom(s) => {
+                        EncryptedFileHash::_Custom(CustomEncryptedFileHash {
+                            algorithm: s.0.into(),
+                            hash: Base64::parse(hash).map_err(de::Error::custom)?,
+                        })
+                    }
+                })
+            })
+            .collect()
+    }
 }

--- a/crates/ruma-events/src/room/encrypted_file_serde.rs
+++ b/crates/ruma-events/src/room/encrypted_file_serde.rs
@@ -1,0 +1,114 @@
+use std::borrow::Cow;
+
+use ruma_common::serde::Base64;
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
+
+use super::V2EncryptedFileInfo;
+
+impl<'de> Deserialize<'de> for V2EncryptedFileInfo {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let V2EncryptedFileInfoSerdeHelper { key: JsonWebKey { kty, key_ops, alg, k, ext }, iv } =
+            V2EncryptedFileInfoSerdeHelper::deserialize(deserializer)?;
+
+        if kty != "oct" {
+            return Err(de::Error::custom(format!(
+                "invalid value in `kty` field: `{kty}` , expected `oct`"
+            )));
+        }
+
+        if alg != "A256CTR" {
+            return Err(de::Error::custom(format!(
+                "invalid value in `alg` field: `{alg}` , expected `A256CTR`"
+            )));
+        }
+
+        if !key_ops.iter().any(|key_op| key_op == "encrypt") {
+            return Err(de::Error::custom("missing value `encrypt` in `key_ops` field"));
+        }
+
+        if !key_ops.iter().any(|key_op| key_op == "decrypt") {
+            return Err(de::Error::custom("missing value `decrypt` in `key_ops` field"));
+        }
+
+        if !ext {
+            return Err(de::Error::custom(
+                "invalid value in `ext` field: `false` , expected `true`",
+            ));
+        }
+
+        let k = Base64::parse(k.as_ref())
+            .map_err(|error| de::Error::custom(format!("invalid value in `k` field: {error}")))?;
+        let iv = Base64::parse(iv.as_ref())
+            .map_err(|error| de::Error::custom(format!("invalid value in `iv` field: {error}")))?;
+
+        Ok(Self { k, iv })
+    }
+}
+
+impl Serialize for V2EncryptedFileInfo {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let Self { k, iv } = self;
+
+        let info = V2EncryptedFileInfoSerdeHelper {
+            key: JsonWebKey {
+                kty: Cow::Borrowed("oct"),
+                key_ops: vec![Cow::Borrowed("decrypt"), Cow::Borrowed("encrypt")],
+                alg: Cow::Borrowed("A256CTR"),
+                k: Cow::Owned(k.encode()),
+                ext: true,
+            },
+            iv: Cow::Owned(iv.encode()),
+        };
+
+        info.serialize(serializer)
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+struct V2EncryptedFileInfoSerdeHelper<'a> {
+    /// The key.
+    #[serde(borrow)]
+    key: JsonWebKey<'a>,
+
+    /// The 128-bit unique counter block used by AES-CTR, encoded as unpadded base64.
+    #[serde(borrow)]
+    iv: Cow<'a, str>,
+}
+
+/// A [JSON Web Key](https://tools.ietf.org/html/rfc7517#appendix-A.3) object.
+#[derive(Deserialize, Serialize)]
+struct JsonWebKey<'a> {
+    /// Key type.
+    ///
+    /// Must be `oct`.
+    #[serde(borrow)]
+    kty: Cow<'a, str>,
+
+    /// Key operations.
+    ///
+    /// Must at least contain `encrypt` and `decrypt`.
+    #[serde(borrow)]
+    key_ops: Vec<Cow<'a, str>>,
+
+    /// Algorithm.
+    ///
+    /// Must be `A256CTR`.
+    #[serde(borrow)]
+    alg: Cow<'a, str>,
+
+    /// The key, encoded as url-safe unpadded base64.
+    #[serde(borrow)]
+    k: Cow<'a, str>,
+
+    /// Extractable.
+    ///
+    /// Must be `true`. This is a
+    /// [W3C extension](https://w3c.github.io/webcrypto/#iana-section-jwk).
+    ext: bool,
+}

--- a/crates/ruma-events/src/room/message/url_preview.rs
+++ b/crates/ruma-events/src/room/message/url_preview.rs
@@ -123,8 +123,6 @@ impl UrlPreview {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
-
     use assert_matches2::assert_matches;
     use assign::assign;
     use js_int::uint;
@@ -133,28 +131,14 @@ mod tests {
     use serde_json::{from_value as from_json_value, json};
 
     use super::{super::text::TextMessageEventContent, *};
-    use crate::room::{EncryptedFile, JsonWebKey};
-
-    fn dummy_jwt() -> JsonWebKey {
-        JsonWebKey {
-            kty: "oct".to_owned(),
-            key_ops: vec!["encrypt".to_owned(), "decrypt".to_owned()],
-            alg: "A256CTR".to_owned(),
-            k: Base64::new(vec![0; 64]),
-            ext: true,
-        }
-    }
+    use crate::room::{EncryptedFile, V2EncryptedFileInfo};
 
     fn encrypted_file() -> EncryptedFile {
-        let mut hashes: BTreeMap<String, Base64> = BTreeMap::new();
-        hashes.insert("sha256".to_owned(), Base64::new(vec![1; 10]));
-        EncryptedFile {
-            url: owned_mxc_uri!("mxc://localhost/encryptedfile"),
-            key: dummy_jwt(),
-            iv: Base64::new(vec![1; 12]),
-            hashes,
-            v: "v2".to_owned(),
-        }
+        EncryptedFile::new(
+            owned_mxc_uri!("mxc://localhost/encryptedfile"),
+            V2EncryptedFileInfo::encode([0; 32], [1; 16]).into(),
+            [("sha256".to_owned(), Base64::new(vec![2; 32]))].into(),
+        )
     }
 
     #[test]
@@ -176,17 +160,14 @@ mod tests {
             json!({
                 "beeper:image:encryption": {
                     "hashes" : {
-                        "sha256": "AQEBAQEBAQEBAQ",
+                        "sha256": "AgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI",
                     },
-                    "iv": "AQEBAQEBAQEBAQEB",
+                    "iv": "AQEBAQEBAQEBAQEBAQEBAQ",
                     "key": {
                         "alg": "A256CTR",
                         "ext": true,
-                        "k": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                        "key_ops": [
-                            "encrypt",
-                            "decrypt"
-                        ],
+                        "k": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                        "key_ops": ["decrypt", "encrypt"],
                         "kty": "oct",
                     },
                     "v": "v2",
@@ -241,17 +222,14 @@ mod tests {
                         "matched_url": "https://matrix.org/",
                         "beeper:image:encryption": {
                             "hashes" : {
-                                "sha256": "AQEBAQEBAQEBAQ",
+                                "sha256": "AgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI",
                             },
-                            "iv": "AQEBAQEBAQEBAQEB",
+                            "iv": "AQEBAQEBAQEBAQEBAQEBAQ",
                             "key": {
                                 "alg": "A256CTR",
                                 "ext": true,
-                                "k": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                                "key_ops": [
-                                    "encrypt",
-                                    "decrypt"
-                                ],
+                                "k": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                                "key_ops": ["decrypt", "encrypt"],
                                 "kty": "oct",
                             },
                             "v": "v2",
@@ -448,7 +426,7 @@ mod tests {
                     "og:image:width": 800,
                     "beeper:image:encryption": {
                         "key": {
-                            "k": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                            "k": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                             "alg": "A256CTR",
                             "ext": true,
                             "kty": "oct",
@@ -457,9 +435,9 @@ mod tests {
                                 "decrypt"
                             ]
                         },
-                        "iv": "AQEBAQEBAQEBAQEB",
+                        "iv": "AQEBAQEBAQEBAQEBAQEBAQ",
                         "hashes": {
-                            "sha256": "AQEBAQEBAQEBAQ"
+                            "sha256": "AgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI",
                         },
                         "v": "v2",
                         "url": "mxc://beeper.com/53207ac52ce3e2c722bb638987064bfdc0cc257b"

--- a/crates/ruma-events/src/room/message/url_preview.rs
+++ b/crates/ruma-events/src/room/message/url_preview.rs
@@ -126,18 +126,18 @@ mod tests {
     use assert_matches2::assert_matches;
     use assign::assign;
     use js_int::uint;
-    use ruma_common::{canonical_json::assert_to_canonical_json_eq, owned_mxc_uri, serde::Base64};
+    use ruma_common::{canonical_json::assert_to_canonical_json_eq, owned_mxc_uri};
     use ruma_events::room::message::{MessageType, RoomMessageEventContent};
     use serde_json::{from_value as from_json_value, json};
 
     use super::{super::text::TextMessageEventContent, *};
-    use crate::room::{EncryptedFile, V2EncryptedFileInfo};
+    use crate::room::{EncryptedFile, EncryptedFileHashes, V2EncryptedFileInfo};
 
     fn encrypted_file() -> EncryptedFile {
         EncryptedFile::new(
             owned_mxc_uri!("mxc://localhost/encryptedfile"),
             V2EncryptedFileInfo::encode([0; 32], [1; 16]).into(),
-            [("sha256".to_owned(), Base64::new(vec![2; 32]))].into(),
+            EncryptedFileHashes::with_sha256([2; 32]),
         )
     }
 

--- a/crates/ruma-events/src/room/thumbnail_source_serde.rs
+++ b/crates/ruma-events/src/room/thumbnail_source_serde.rs
@@ -51,11 +51,11 @@ where
 #[cfg(test)]
 mod tests {
     use assert_matches2::assert_matches;
-    use ruma_common::{owned_mxc_uri, serde::Base64};
+    use ruma_common::{canonical_json::assert_to_canonical_json_eq, owned_mxc_uri, serde::Base64};
     use serde::{Deserialize, Serialize};
     use serde_json::json;
 
-    use crate::room::{EncryptedFileInit, JsonWebKeyInit, MediaSource};
+    use crate::room::{EncryptedFile, MediaSource, V2EncryptedFileInfo};
 
     #[derive(Clone, Debug, Deserialize, Serialize)]
     struct ThumbnailSourceTest {
@@ -145,36 +145,29 @@ mod tests {
     #[test]
     fn serialize_encrypted() {
         let request = ThumbnailSourceTest {
-            source: Some(MediaSource::Encrypted(Box::new(
-                EncryptedFileInit {
-                    url: owned_mxc_uri!("mxc://notareal.hs/abcdef"),
-                    key: JsonWebKeyInit {
-                        kty: "oct".to_owned(),
-                        key_ops: vec!["encrypt".to_owned(), "decrypt".to_owned()],
-                        alg: "A256CTR".to_owned(),
-                        k: Base64::parse("TLlG_OpX807zzQuuwv4QZGJ21_u7weemFGYJFszMn9A").unwrap(),
-                        ext: true,
-                    }
-                    .into(),
-                    iv: Base64::parse("S22dq3NAX8wAAAAAAAAAAA").unwrap(),
-                    hashes: [(
-                        "sha256".to_owned(),
-                        Base64::parse("aWOHudBnDkJ9IwaR1Nd8XKoI7DOrqDTwt6xDPfVGN6Q").unwrap(),
-                    )]
-                    .into(),
-                    v: "v2".to_owned(),
-                }
+            source: Some(MediaSource::Encrypted(Box::new(EncryptedFile::new(
+                owned_mxc_uri!("mxc://notareal.hs/abcdef"),
+                V2EncryptedFileInfo::new(
+                    Base64::parse("TLlG_OpX807zzQuuwv4QZGJ21_u7weemFGYJFszMn9A").unwrap(),
+                    Base64::parse("S22dq3NAX8wAAAAAAAAAAA").unwrap(),
+                )
                 .into(),
-            ))),
+                [(
+                    "sha256".to_owned(),
+                    Base64::parse("aWOHudBnDkJ9IwaR1Nd8XKoI7DOrqDTwt6xDPfVGN6Q").unwrap(),
+                )]
+                .into(),
+            )))),
         };
-        assert_eq!(
-            serde_json::to_value(&request).unwrap(),
+
+        assert_to_canonical_json_eq!(
+            request,
             json!({
                 "thumbnail_file": {
                     "url": "mxc://notareal.hs/abcdef",
                     "key": {
                         "kty": "oct",
-                        "key_ops": ["encrypt", "decrypt"],
+                        "key_ops": ["decrypt", "encrypt"],
                         "alg": "A256CTR",
                         "k": "TLlG_OpX807zzQuuwv4QZGJ21_u7weemFGYJFszMn9A",
                         "ext": true

--- a/crates/ruma-events/src/room/thumbnail_source_serde.rs
+++ b/crates/ruma-events/src/room/thumbnail_source_serde.rs
@@ -55,7 +55,7 @@ mod tests {
     use serde::{Deserialize, Serialize};
     use serde_json::json;
 
-    use crate::room::{EncryptedFile, MediaSource, V2EncryptedFileInfo};
+    use crate::room::{EncryptedFile, EncryptedFileHash, MediaSource, V2EncryptedFileInfo};
 
     #[derive(Clone, Debug, Deserialize, Serialize)]
     struct ThumbnailSourceTest {
@@ -152,11 +152,10 @@ mod tests {
                     Base64::parse("S22dq3NAX8wAAAAAAAAAAA").unwrap(),
                 )
                 .into(),
-                [(
-                    "sha256".to_owned(),
+                std::iter::once(EncryptedFileHash::Sha256(
                     Base64::parse("aWOHudBnDkJ9IwaR1Nd8XKoI7DOrqDTwt6xDPfVGN6Q").unwrap(),
-                )]
-                .into(),
+                ))
+                .collect(),
             )))),
         };
 

--- a/crates/ruma-events/src/room_key_bundle.rs
+++ b/crates/ruma-events/src/room_key_bundle.rs
@@ -34,40 +34,35 @@ impl ToDeviceRoomKeyBundleEventContent {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
-
-    use ruma_common::{owned_mxc_uri, owned_room_id, serde::Base64};
+    use ruma_common::{
+        canonical_json::assert_to_canonical_json_eq, owned_mxc_uri, owned_room_id, serde::Base64,
+    };
     use serde_json::json;
 
     use super::ToDeviceRoomKeyBundleEventContent;
-    use crate::room::{EncryptedFile, JsonWebKey};
+    use crate::room::{EncryptedFile, V2EncryptedFileInfo};
 
     #[test]
     fn serialization() {
         let content = ToDeviceRoomKeyBundleEventContent {
             room_id: owned_room_id!("!testroomid:example.org"),
-            file: EncryptedFile {
-                url: owned_mxc_uri!("mxc://example.org/FHyPlCeYUSFFxlgbQYZmoEoe"),
-                key: JsonWebKey {
-                    kty: "A256CTR".to_owned(),
-                    key_ops: vec!["encrypt".to_owned(), "decrypt".to_owned()],
-                    alg: "A256CTR".to_owned(),
-                    k: Base64::parse("aWF6-32KGYaC3A_FEUCk1Bt0JA37zP0wrStgmdCaW-0").unwrap(),
-                    ext: true,
-                },
-                iv: Base64::parse("w+sE15fzSc0AAAAAAAAAAA").unwrap(),
-                hashes: BTreeMap::from([(
+            file: EncryptedFile::new(
+                owned_mxc_uri!("mxc://example.org/FHyPlCeYUSFFxlgbQYZmoEoe"),
+                V2EncryptedFileInfo::new(
+                    Base64::parse("aWF6-32KGYaC3A_FEUCk1Bt0JA37zP0wrStgmdCaW-0").unwrap(),
+                    Base64::parse("w+sE15fzSc0AAAAAAAAAAA").unwrap(),
+                )
+                .into(),
+                [(
                     "sha256".to_owned(),
                     Base64::parse("fdSLu/YkRx3Wyh3KQabP3rd6+SFiKg5lsJZQHtkSAYA").unwrap(),
-                )]),
-                v: "v2".to_owned(),
-            },
+                )]
+                .into(),
+            ),
         };
 
-        let serialized = serde_json::to_value(content).unwrap();
-
-        assert_eq!(
-            serialized,
+        assert_to_canonical_json_eq!(
+            content,
             json!({
                 "room_id": "!testroomid:example.org",
                 "file": {
@@ -77,8 +72,8 @@ mod tests {
                         "alg": "A256CTR",
                         "ext": true,
                         "k": "aWF6-32KGYaC3A_FEUCk1Bt0JA37zP0wrStgmdCaW-0",
-                        "key_ops": ["encrypt","decrypt"],
-                        "kty": "A256CTR"
+                        "key_ops": ["decrypt", "encrypt"],
+                        "kty": "oct"
                     },
                     "iv": "w+sE15fzSc0AAAAAAAAAAA",
                     "hashes": {
@@ -86,7 +81,6 @@ mod tests {
                     }
                 }
             }),
-            "The serialized value should match the declared JSON Value"
         );
     }
 }

--- a/crates/ruma-events/src/room_key_bundle.rs
+++ b/crates/ruma-events/src/room_key_bundle.rs
@@ -40,7 +40,7 @@ mod tests {
     use serde_json::json;
 
     use super::ToDeviceRoomKeyBundleEventContent;
-    use crate::room::{EncryptedFile, V2EncryptedFileInfo};
+    use crate::room::{EncryptedFile, EncryptedFileHash, V2EncryptedFileInfo};
 
     #[test]
     fn serialization() {
@@ -53,11 +53,10 @@ mod tests {
                     Base64::parse("w+sE15fzSc0AAAAAAAAAAA").unwrap(),
                 )
                 .into(),
-                [(
-                    "sha256".to_owned(),
+                std::iter::once(EncryptedFileHash::Sha256(
                     Base64::parse("fdSLu/YkRx3Wyh3KQabP3rd6+SFiKg5lsJZQHtkSAYA").unwrap(),
-                )]
-                .into(),
+                ))
+                .collect(),
             ),
         };
 

--- a/crates/ruma-events/tests/it/audio.rs
+++ b/crates/ruma-events/tests/it/audio.rs
@@ -18,7 +18,7 @@ use ruma_events::{
     file::{EncryptedContent, FileContentBlock},
     message::TextContentBlock,
     relation::Reply,
-    room::{V2EncryptedFileInfo, message::Relation},
+    room::{EncryptedFileHash, V2EncryptedFileInfo, message::Relation},
 };
 use serde_json::{from_value as from_json_value, json};
 
@@ -68,11 +68,10 @@ fn encrypted_content_serialization() {
                     Base64::parse("S22dq3NAX8wAAAAAAAAAAA").unwrap(),
                 )
                 .into(),
-                [(
-                    "sha256".to_owned(),
+                std::iter::once(EncryptedFileHash::Sha256(
                     Base64::parse("aWOHudBnDkJ9IwaR1Nd8XKoI7DOrqDTwt6xDPfVGN6Q").unwrap(),
-                )]
-                .into(),
+                ))
+                .collect(),
             ),
         ),
     );

--- a/crates/ruma-events/tests/it/audio.rs
+++ b/crates/ruma-events/tests/it/audio.rs
@@ -15,10 +15,10 @@ use ruma_events::audio::Amplitude;
 use ruma_events::{
     AnyMessageLikeEvent, MessageLikeEvent,
     audio::{AudioDetailsContentBlock, AudioEventContent},
-    file::{EncryptedContentInit, FileContentBlock},
+    file::{EncryptedContent, FileContentBlock},
     message::TextContentBlock,
     relation::Reply,
-    room::{JsonWebKeyInit, message::Relation},
+    room::{V2EncryptedFileInfo, message::Relation},
 };
 use serde_json::{from_value as from_json_value, json};
 
@@ -62,24 +62,18 @@ fn encrypted_content_serialization() {
         FileContentBlock::encrypted(
             owned_mxc_uri!("mxc://notareal.hs/abcdef"),
             "my_sound.ogg".to_owned(),
-            EncryptedContentInit {
-                key: JsonWebKeyInit {
-                    kty: "oct".to_owned(),
-                    key_ops: vec!["encrypt".to_owned(), "decrypt".to_owned()],
-                    alg: "A256CTR".to_owned(),
-                    k: Base64::parse("TLlG_OpX807zzQuuwv4QZGJ21_u7weemFGYJFszMn9A").unwrap(),
-                    ext: true,
-                }
+            EncryptedContent::new(
+                V2EncryptedFileInfo::new(
+                    Base64::parse("TLlG_OpX807zzQuuwv4QZGJ21_u7weemFGYJFszMn9A").unwrap(),
+                    Base64::parse("S22dq3NAX8wAAAAAAAAAAA").unwrap(),
+                )
                 .into(),
-                iv: Base64::parse("S22dq3NAX8wAAAAAAAAAAA").unwrap(),
-                hashes: [(
+                [(
                     "sha256".to_owned(),
                     Base64::parse("aWOHudBnDkJ9IwaR1Nd8XKoI7DOrqDTwt6xDPfVGN6Q").unwrap(),
                 )]
                 .into(),
-                v: "v2".to_owned(),
-            }
-            .into(),
+            ),
         ),
     );
 
@@ -94,7 +88,7 @@ fn encrypted_content_serialization() {
                 "name": "my_sound.ogg",
                 "key": {
                     "kty": "oct",
-                    "key_ops": ["encrypt", "decrypt"],
+                    "key_ops": ["decrypt", "encrypt"],
                     "alg": "A256CTR",
                     "k": "TLlG_OpX807zzQuuwv4QZGJ21_u7weemFGYJFszMn9A",
                     "ext": true

--- a/crates/ruma-events/tests/it/file.rs
+++ b/crates/ruma-events/tests/it/file.rs
@@ -13,7 +13,7 @@ use ruma_events::{
     file::{EncryptedContent, FileEventContent},
     message::TextContentBlock,
     relation::Reply,
-    room::{V2EncryptedFileInfo, message::Relation},
+    room::{EncryptedFileHash, V2EncryptedFileInfo, message::Relation},
 };
 use serde_json::{from_value as from_json_value, json};
 
@@ -51,11 +51,10 @@ fn encrypted_content_serialization() {
                 Base64::parse("S22dq3NAX8wAAAAAAAAAAA").unwrap(),
             )
             .into(),
-            [(
-                "sha256".to_owned(),
+            std::iter::once(EncryptedFileHash::Sha256(
                 Base64::parse("aWOHudBnDkJ9IwaR1Nd8XKoI7DOrqDTwt6xDPfVGN6Q").unwrap(),
-            )]
-            .into(),
+            ))
+            .collect(),
         ),
     );
 

--- a/crates/ruma-events/tests/it/file.rs
+++ b/crates/ruma-events/tests/it/file.rs
@@ -10,10 +10,10 @@ use ruma_common::{
 };
 use ruma_events::{
     AnyMessageLikeEvent, MessageLikeEvent,
-    file::{EncryptedContentInit, FileEventContent},
+    file::{EncryptedContent, FileEventContent},
     message::TextContentBlock,
     relation::Reply,
-    room::{JsonWebKeyInit, message::Relation},
+    room::{V2EncryptedFileInfo, message::Relation},
 };
 use serde_json::{from_value as from_json_value, json};
 
@@ -45,24 +45,18 @@ fn encrypted_content_serialization() {
         "Upload: my_file.txt",
         owned_mxc_uri!("mxc://notareal.hs/abcdef"),
         "my_file.txt".to_owned(),
-        EncryptedContentInit {
-            key: JsonWebKeyInit {
-                kty: "oct".to_owned(),
-                key_ops: vec!["encrypt".to_owned(), "decrypt".to_owned()],
-                alg: "A256CTR".to_owned(),
-                k: Base64::parse("TLlG_OpX807zzQuuwv4QZGJ21_u7weemFGYJFszMn9A").unwrap(),
-                ext: true,
-            }
+        EncryptedContent::new(
+            V2EncryptedFileInfo::new(
+                Base64::parse("TLlG_OpX807zzQuuwv4QZGJ21_u7weemFGYJFszMn9A").unwrap(),
+                Base64::parse("S22dq3NAX8wAAAAAAAAAAA").unwrap(),
+            )
             .into(),
-            iv: Base64::parse("S22dq3NAX8wAAAAAAAAAAA").unwrap(),
-            hashes: [(
+            [(
                 "sha256".to_owned(),
                 Base64::parse("aWOHudBnDkJ9IwaR1Nd8XKoI7DOrqDTwt6xDPfVGN6Q").unwrap(),
             )]
             .into(),
-            v: "v2".to_owned(),
-        }
-        .into(),
+        ),
     );
 
     assert_to_canonical_json_eq!(
@@ -76,7 +70,7 @@ fn encrypted_content_serialization() {
                 "name": "my_file.txt",
                 "key": {
                     "kty": "oct",
-                    "key_ops": ["encrypt", "decrypt"],
+                    "key_ops": ["decrypt", "encrypt"],
                     "alg": "A256CTR",
                     "k": "TLlG_OpX807zzQuuwv4QZGJ21_u7weemFGYJFszMn9A",
                     "ext": true

--- a/crates/ruma-events/tests/it/image.rs
+++ b/crates/ruma-events/tests/it/image.rs
@@ -17,7 +17,7 @@ use ruma_events::{
     },
     message::TextContentBlock,
     relation::Reply,
-    room::{V2EncryptedFileInfo, message::Relation},
+    room::{EncryptedFileHash, V2EncryptedFileInfo, message::Relation},
 };
 use serde_json::{from_value as from_json_value, json};
 
@@ -58,11 +58,10 @@ fn encrypted_content_serialization() {
                     Base64::parse("S22dq3NAX8wAAAAAAAAAAA").unwrap(),
                 )
                 .into(),
-                [(
-                    "sha256".to_owned(),
+                std::iter::once(EncryptedFileHash::Sha256(
                     Base64::parse("aWOHudBnDkJ9IwaR1Nd8XKoI7DOrqDTwt6xDPfVGN6Q").unwrap(),
-                )]
-                .into(),
+                ))
+                .collect(),
             ),
         ),
     );

--- a/crates/ruma-events/tests/it/image.rs
+++ b/crates/ruma-events/tests/it/image.rs
@@ -10,14 +10,14 @@ use ruma_common::{
 };
 use ruma_events::{
     AnyMessageLikeEvent, MessageLikeEvent,
-    file::{CaptionContentBlock, EncryptedContentInit, FileContentBlock},
+    file::{CaptionContentBlock, EncryptedContent, FileContentBlock},
     image::{
         ImageDetailsContentBlock, ImageEventContent, Thumbnail, ThumbnailFileContentBlock,
         ThumbnailImageDetailsContentBlock,
     },
     message::TextContentBlock,
     relation::Reply,
-    room::{JsonWebKeyInit, message::Relation},
+    room::{V2EncryptedFileInfo, message::Relation},
 };
 use serde_json::{from_value as from_json_value, json};
 
@@ -52,24 +52,18 @@ fn encrypted_content_serialization() {
         FileContentBlock::encrypted(
             owned_mxc_uri!("mxc://notareal.hs/abcdef"),
             "my_image.jpg".to_owned(),
-            EncryptedContentInit {
-                key: JsonWebKeyInit {
-                    kty: "oct".to_owned(),
-                    key_ops: vec!["encrypt".to_owned(), "decrypt".to_owned()],
-                    alg: "A256CTR".to_owned(),
-                    k: Base64::parse("TLlG_OpX807zzQuuwv4QZGJ21_u7weemFGYJFszMn9A").unwrap(),
-                    ext: true,
-                }
+            EncryptedContent::new(
+                V2EncryptedFileInfo::new(
+                    Base64::parse("TLlG_OpX807zzQuuwv4QZGJ21_u7weemFGYJFszMn9A").unwrap(),
+                    Base64::parse("S22dq3NAX8wAAAAAAAAAAA").unwrap(),
+                )
                 .into(),
-                iv: Base64::parse("S22dq3NAX8wAAAAAAAAAAA").unwrap(),
-                hashes: [(
+                [(
                     "sha256".to_owned(),
                     Base64::parse("aWOHudBnDkJ9IwaR1Nd8XKoI7DOrqDTwt6xDPfVGN6Q").unwrap(),
                 )]
                 .into(),
-                v: "v2".to_owned(),
-            }
-            .into(),
+            ),
         ),
     );
 
@@ -84,7 +78,7 @@ fn encrypted_content_serialization() {
                 "name": "my_image.jpg",
                 "key": {
                     "kty": "oct",
-                    "key_ops": ["encrypt", "decrypt"],
+                    "key_ops": ["decrypt", "encrypt"],
                     "alg": "A256CTR",
                     "k": "TLlG_OpX807zzQuuwv4QZGJ21_u7weemFGYJFszMn9A",
                     "ext": true

--- a/crates/ruma-events/tests/it/room_message.rs
+++ b/crates/ruma-events/tests/it/room_message.rs
@@ -14,7 +14,7 @@ use ruma_events::{
     Mentions,
     key::verification::VerificationMethod,
     room::{
-        EncryptedFile, EncryptedFileInfo, MediaSource, V2EncryptedFileInfo,
+        EncryptedFile, EncryptedFileHash, EncryptedFileInfo, MediaSource, V2EncryptedFileInfo,
         message::{
             AddMentions, AudioMessageEventContent, EmoteMessageEventContent,
             FileMessageEventContent, FormattedBody, ForwardThread, ImageMessageEventContent,
@@ -549,11 +549,10 @@ fn file_msgtype_encrypted_content_serialization() {
                     Base64::parse("S22dq3NAX8wAAAAAAAAAAA").unwrap(),
                 )
                 .into(),
-                [(
-                    "sha256".to_owned(),
+                std::iter::once(EncryptedFileHash::Sha256(
                     Base64::parse("aWOHudBnDkJ9IwaR1Nd8XKoI7DOrqDTwt6xDPfVGN6Q").unwrap(),
-                )]
-                .into(),
+                ))
+                .collect(),
             ),
         )));
 

--- a/crates/ruma-events/tests/it/room_message.rs
+++ b/crates/ruma-events/tests/it/room_message.rs
@@ -14,7 +14,7 @@ use ruma_events::{
     Mentions,
     key::verification::VerificationMethod,
     room::{
-        EncryptedFileInit, JsonWebKeyInit, MediaSource,
+        EncryptedFile, EncryptedFileInfo, MediaSource, V2EncryptedFileInfo,
         message::{
             AddMentions, AudioMessageEventContent, EmoteMessageEventContent,
             FileMessageEventContent, FormattedBody, ForwardThread, ImageMessageEventContent,
@@ -542,25 +542,19 @@ fn file_msgtype_encrypted_content_serialization() {
     let message_event_content =
         RoomMessageEventContent::new(MessageType::File(FileMessageEventContent::encrypted(
             "Upload: my_file.txt".to_owned(),
-            EncryptedFileInit {
-                url: owned_mxc_uri!("mxc://notareal.hs/file"),
-                key: JsonWebKeyInit {
-                    kty: "oct".to_owned(),
-                    key_ops: vec!["encrypt".to_owned(), "decrypt".to_owned()],
-                    alg: "A256CTR".to_owned(),
-                    k: Base64::parse("TLlG_OpX807zzQuuwv4QZGJ21_u7weemFGYJFszMn9A").unwrap(),
-                    ext: true,
-                }
+            EncryptedFile::new(
+                owned_mxc_uri!("mxc://notareal.hs/file"),
+                V2EncryptedFileInfo::new(
+                    Base64::parse("TLlG_OpX807zzQuuwv4QZGJ21_u7weemFGYJFszMn9A").unwrap(),
+                    Base64::parse("S22dq3NAX8wAAAAAAAAAAA").unwrap(),
+                )
                 .into(),
-                iv: Base64::parse("S22dq3NAX8wAAAAAAAAAAA").unwrap(),
-                hashes: [(
+                [(
                     "sha256".to_owned(),
                     Base64::parse("aWOHudBnDkJ9IwaR1Nd8XKoI7DOrqDTwt6xDPfVGN6Q").unwrap(),
                 )]
                 .into(),
-                v: "v2".to_owned(),
-            }
-            .into(),
+            ),
         )));
 
     assert_to_canonical_json_eq!(
@@ -571,7 +565,7 @@ fn file_msgtype_encrypted_content_serialization() {
                 "url": "mxc://notareal.hs/file",
                 "key": {
                     "kty": "oct",
-                    "key_ops": ["encrypt", "decrypt"],
+                    "key_ops": ["decrypt", "encrypt"],
                     "alg": "A256CTR",
                     "k": "TLlG_OpX807zzQuuwv4QZGJ21_u7weemFGYJFszMn9A",
                     "ext": true
@@ -611,7 +605,7 @@ fn file_msgtype_encrypted_content_deserialization() {
             "url": "mxc://notareal.hs/file",
             "key": {
                 "kty": "oct",
-                "key_ops": ["encrypt", "decrypt"],
+                "key_ops": ["decrypt", "encrypt"],
                 "alg": "A256CTR",
                 "k": "TLlG_OpX807zzQuuwv4QZGJ21_u7weemFGYJFszMn9A",
                 "ext": true
@@ -630,6 +624,36 @@ fn file_msgtype_encrypted_content_deserialization() {
     assert_eq!(content.body, "Upload: my_file.txt");
     assert_matches!(content.source, MediaSource::Encrypted(encrypted_file));
     assert_eq!(encrypted_file.url, "mxc://notareal.hs/file");
+    assert_matches!(encrypted_file.info, EncryptedFileInfo::V2(_));
+}
+
+#[test]
+fn file_msgtype_custom_encrypted_content_deserialization() {
+    let json_data = json!({
+        "body": "Upload: my_file.txt",
+        "file": {
+            "url": "mxc://notareal.hs/file",
+            "key": "TLlG_OpX807zzQuuwv4QZGJ21_u7weemFGYJFszMn9A",
+            "iv": "S22dq3NAX8wAAAAAAAAAAA",
+            "hashes": {
+                "sha256": "aWOHudBnDkJ9IwaR1Nd8XKoI7DOrqDTwt6xDPfVGN6Q"
+            },
+            "v": "local.custom.version",
+        },
+        "msgtype": "m.file",
+    });
+
+    let event_content = from_json_value::<RoomMessageEventContent>(json_data).unwrap();
+    assert_matches!(event_content.msgtype, MessageType::File(content));
+    assert_eq!(content.body, "Upload: my_file.txt");
+    assert_matches!(content.source, MediaSource::Encrypted(encrypted_file));
+    assert_eq!(encrypted_file.url, "mxc://notareal.hs/file");
+    assert_eq!(encrypted_file.info.version(), "local.custom.version");
+    let encryption_data = encrypted_file.info.custom_data().unwrap();
+    assert_eq!(
+        encryption_data.get("key").unwrap().as_str(),
+        Some("TLlG_OpX807zzQuuwv4QZGJ21_u7weemFGYJFszMn9A")
+    );
 }
 
 #[test]

--- a/crates/ruma-events/tests/it/video.rs
+++ b/crates/ruma-events/tests/it/video.rs
@@ -12,11 +12,11 @@ use ruma_common::{
 };
 use ruma_events::{
     AnyMessageLikeEvent, MessageLikeEvent,
-    file::{CaptionContentBlock, EncryptedContentInit, FileContentBlock},
+    file::{CaptionContentBlock, EncryptedContent, FileContentBlock},
     image::{Thumbnail, ThumbnailFileContentBlock, ThumbnailImageDetailsContentBlock},
     message::TextContentBlock,
     relation::Reply,
-    room::{JsonWebKeyInit, message::Relation},
+    room::{V2EncryptedFileInfo, message::Relation},
     video::{VideoDetailsContentBlock, VideoEventContent},
 };
 use serde_json::{from_value as from_json_value, json};
@@ -52,24 +52,18 @@ fn encrypted_content_serialization() {
         FileContentBlock::encrypted(
             owned_mxc_uri!("mxc://notareal.hs/abcdef"),
             "my_video.webm".to_owned(),
-            EncryptedContentInit {
-                key: JsonWebKeyInit {
-                    kty: "oct".to_owned(),
-                    key_ops: vec!["encrypt".to_owned(), "decrypt".to_owned()],
-                    alg: "A256CTR".to_owned(),
-                    k: Base64::parse("TLlG_OpX807zzQuuwv4QZGJ21_u7weemFGYJFszMn9A").unwrap(),
-                    ext: true,
-                }
+            EncryptedContent::new(
+                V2EncryptedFileInfo::new(
+                    Base64::parse("TLlG_OpX807zzQuuwv4QZGJ21_u7weemFGYJFszMn9A").unwrap(),
+                    Base64::parse("S22dq3NAX8wAAAAAAAAAAA").unwrap(),
+                )
                 .into(),
-                iv: Base64::parse("S22dq3NAX8wAAAAAAAAAAA").unwrap(),
-                hashes: [(
+                [(
                     "sha256".to_owned(),
                     Base64::parse("aWOHudBnDkJ9IwaR1Nd8XKoI7DOrqDTwt6xDPfVGN6Q").unwrap(),
                 )]
                 .into(),
-                v: "v2".to_owned(),
-            }
-            .into(),
+            ),
         ),
     );
 
@@ -84,7 +78,7 @@ fn encrypted_content_serialization() {
                 "name": "my_video.webm",
                 "key": {
                     "kty": "oct",
-                    "key_ops": ["encrypt", "decrypt"],
+                    "key_ops": ["decrypt", "encrypt"],
                     "alg": "A256CTR",
                     "k": "TLlG_OpX807zzQuuwv4QZGJ21_u7weemFGYJFszMn9A",
                     "ext": true

--- a/crates/ruma-events/tests/it/video.rs
+++ b/crates/ruma-events/tests/it/video.rs
@@ -16,7 +16,7 @@ use ruma_events::{
     image::{Thumbnail, ThumbnailFileContentBlock, ThumbnailImageDetailsContentBlock},
     message::TextContentBlock,
     relation::Reply,
-    room::{V2EncryptedFileInfo, message::Relation},
+    room::{EncryptedFileHash, V2EncryptedFileInfo, message::Relation},
     video::{VideoDetailsContentBlock, VideoEventContent},
 };
 use serde_json::{from_value as from_json_value, json};
@@ -58,11 +58,10 @@ fn encrypted_content_serialization() {
                     Base64::parse("S22dq3NAX8wAAAAAAAAAAA").unwrap(),
                 )
                 .into(),
-                [(
-                    "sha256".to_owned(),
+                std::iter::once(EncryptedFileHash::Sha256(
                     Base64::parse("aWOHudBnDkJ9IwaR1Nd8XKoI7DOrqDTwt6xDPfVGN6Q").unwrap(),
-                )]
-                .into(),
+                ))
+                .collect(),
             ),
         ),
     );


### PR DESCRIPTION
Like we do in other places, we join the fields by version of the algorithm that is used inside an `EncryptedFileInfo` enum. We also add a strong `EncryptedFileHashes` map type that ensures that the decoded hash has the appropriate format (namely the length of the hash in bytes for SHA-256).

It has several advantages:

1. Clients are less likely to send invalid events.
2. Deserialization is stricter so we can discard invalid events earlier.
3. The new type improves forward-compatibility by allowing to use new versions of the algorithms.

I believe that this is the first place where we enforce the length of the decoded data by using an array type in `Base64`. If this is unwanted we could just use a `Vec` like always and leave the validation to clients.

~~If we keep this validation, we could probably simplify the code here by implementing `Base64::<C, B>::parse()` and `Deserialize` where `B` implements `TryFrom<Vec<u8>>`.~~ This was implemented albeit with another marker trait to get proper error messages.