### PR TITLE
Add initial support for Matrix 1.18

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -35,8 +35,8 @@ Breaking changes:
   - `WrongRoomKeysVersion`, and its `current_version` field is now required and
     its serialization was fixed.
 - Remove the `score` field from `report_content::v3::Request` according to
-  MSC4277. `report_content::v3::Request::new()` now only takes a room ID and an
-  event ID.
+  MSC4277 / Matrix 1.18. `report_content::v3::Request::new()` now only takes a
+  room ID and an event ID.
 - `Typing::Yes` now holds a non-exhaustive struct rather than a `Duration`, to
   potentially allow to add more fields in the future without it being a breaking
   change.
@@ -51,11 +51,12 @@ Bug fixes:
 
 Improvements:
 
-- Add the `M_TOKEN_INCORRECT` error code according to MSC4183.
-- Add the `m.forget_forced_upon_leave` capability, according to MSC4267.
+- Add the `M_TOKEN_INCORRECT` error code according to MSC4183 / Matrix 1.18.
+- Add the `m.forget_forced_upon_leave` capability, according to MSC4267 / Matrix
+  1.18.
 - Stabilize support for the OAuth 2.0 account management URL, according to
-  MSC4191. The `AccountManagementAction` variants that were replaced when the
-  MSC was stabilized now have an `Unstable` prefix.
+  MSC4191 / Matrix 1.18. The `AccountManagementAction` variants that were
+  replaced when the MSC was stabilized now have an `Unstable` prefix.
   - `AuthorizationServerMetadata` has helper methods to work with both stable
     and unstable account management actions:
     `is_account_management_action_supported()` allows to check whether either of
@@ -64,15 +65,16 @@ Improvements:
     URL including the proper version of the action, depending on what the server
     advertises.
 - Add support for updated rendezvous session from MSC4388 behind `unstable-msc4388`.
-- Stabilize support for the `M_INVITE_BLOCKED` error code, according to MSC4380.
-- Stabilize support for OAuth 2.0 aware clients, according to MSC3824. Unstable
-  support was dropped entirely.
+- Stabilize support for the `M_INVITE_BLOCKED` error code, according to MSC4380
+  / Matrix 1.18.
+- Stabilize support for OAuth 2.0 aware clients, according to MSC3824 / Matrix
+  1.18. Unstable support was dropped entirely.
 - `BackupAlgorithm` can be deserialized from unsupported algorithms. The name
   and data of the algorithm can be accessed via the `algorithm()` and
   `auth_data()` methods respectively.
 - `RegistrationKind` and `LoginType` can now represent custom values.
 - Stabilize support for the OAuth 2.0 Device Authorization Grant, according to
-  MSC4341.
+  MSC4341 / Matrix 1.18.
 
 # 0.22.1
 

--- a/crates/ruma-client-api/src/discovery/get_authorization_server_metadata.rs
+++ b/crates/ruma-client-api/src/discovery/get_authorization_server_metadata.rs
@@ -145,15 +145,15 @@ pub mod v1 {
         pub code_challenge_methods_supported: BTreeSet<CodeChallengeMethod>,
 
         /// URL where the user is able to access the account management capabilities of the
-        /// authorization server ([MSC4191]).
+        /// authorization server ([spec]).
         ///
-        /// [MSC4191]: https://github.com/matrix-org/matrix-spec-proposals/pull/4191
+        /// [spec]: https://spec.matrix.org/latest/client-server-api/#account-management-url-discovery
         #[serde(skip_serializing_if = "Option::is_none")]
         pub account_management_uri: Option<Url>,
 
-        /// List of actions that the account management URL supports ([MSC4191]).
+        /// List of actions that the account management URL supports ([spec]).
         ///
-        /// [MSC4191]: https://github.com/matrix-org/matrix-spec-proposals/pull/4191
+        /// [spec]: https://spec.matrix.org/latest/client-server-api/#account-management-url-discovery
         #[serde(skip_serializing_if = "BTreeSet::is_empty")]
         pub account_management_actions_supported: BTreeSet<AccountManagementAction>,
 
@@ -450,14 +450,15 @@ pub mod v1 {
         _Custom(PrivOwnedStr),
     }
 
-    /// The action that the user wishes to do at the account management URL.
+    /// The [action] that the user wishes to do at the account management URL.
     ///
     /// This enum supports both the values that were first specified in [MSC4191] and the values
-    /// that replaced them in the Matrix specification, for backwards compatibility with unstable
+    /// that replaced them in the [Matrix specification], for backwards compatibility with unstable
     /// implementations. The variants that were replaced all use an `Unstable` prefix.
     #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
     ///
     /// [MSC4191]: https://github.com/matrix-org/matrix-spec-proposals/pull/4191
+    /// [action]: https://spec.matrix.org/latest/client-server-api/#account-management-url-actions
     #[derive(Clone, StringEnum)]
     #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
     pub enum AccountManagementAction {
@@ -520,10 +521,10 @@ pub mod v1 {
         _Custom(PrivOwnedStr),
     }
 
-    /// The action that the user wishes to do at the account management URL with its associated
+    /// The [action] that the user wishes to do at the account management URL with its associated
     /// data.
     ///
-    /// [MSC 4191]: https://github.com/matrix-org/matrix-spec-proposals/pull/4191
+    /// [action]: https://spec.matrix.org/latest/client-server-api/#account-management-url-actions
     #[derive(Debug, Clone)]
     #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
     pub enum AccountManagementActionData<'a> {

--- a/crates/ruma-client-api/src/discovery/get_capabilities.rs
+++ b/crates/ruma-client-api/src/discovery/get_capabilities.rs
@@ -435,7 +435,9 @@ pub mod v3 {
         }
     }
 
-    /// Information about the `m.forget_forced_upon_leave` capability.
+    /// Information about the [`m.forget_forced_upon_leave`] capability.
+    ///
+    /// [`m.forget_forced_upon_leave`]: https://spec.matrix.org/latest/client-server-api/#mforget_forced_upon_leave-capability
     #[derive(Clone, Debug, Default, Serialize, Deserialize)]
     #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
     pub struct ForgetForcedUponLeaveCapability {

--- a/crates/ruma-client-api/src/session/get_login_types.rs
+++ b/crates/ruma-client-api/src/session/get_login_types.rs
@@ -175,9 +175,9 @@ pub mod v3 {
 
         /// Whether this flow is preferred over other flows.
         ///
-        /// If this is `true`, [OAuth 2.0 aware] clients must only offer this flow to the user.
+        /// If this is `true`, [OAuth 2.0 aware clients] must only offer this flow to the user.
         ///
-        /// [OAuth 2.0 aware]: https://github.com/matrix-org/matrix-spec-proposals/pull/3824
+        /// [OAuth 2.0 aware clients]: https://spec.matrix.org/latest/client-server-api/#oauth-20-aware-clients
         #[serde(default, skip_serializing_if = "ruma_common::serde::is_default")]
         pub oauth_aware_preferred: bool,
     }

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -29,11 +29,11 @@ Improvements:
   `to_canonical_value()`.
 - Add the `assert_to_canonical_json_eq!` macro that can be used in tests to
   check the canonical JSON serialization of a type against its expected value.
-- Add crate-internal into_raw() / from_raw() helpers for IdDst owned IDs and
-  use them in OwnedRoomId / OwnedRoomAliasId <-> OwnedRoomOrAliasId
+- Add crate-internal `into_raw()` / `from_raw()` helpers for `IdDst` owned IDs
+  and use them in `OwnedRoomId` / `OwnedRoomAliasId` <-> `OwnedRoomOrAliasId`
   conversions.
-- Use raw ownership transfer for conversions from OwnedDeviceId and
-  OwnedBase64PublicKey to OwnedBase64PublicKeyOrDeviceId.
+- Use raw ownership transfer for conversions from `OwnedDeviceId` and
+  `OwnedBase64PublicKey` to `OwnedBase64PublicKeyOrDeviceId`.
 - Identifier types implement `(Try)From<Box<str>>`, `(Try)From<Cow<'a, str>>`
   and `PartialEq<Cow<'a, str>>` and conversions between owned types try not to
   reallocate when possible.

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -44,6 +44,7 @@ Improvements:
 - It is now possible to use `Base64::parse` when the inner `B` "bytes" type is
   an array, and the inner bytes can be accessed without consuming the wrapper
   type with `Base64::as_inner()`.
+- Add `MatrixVersion::V1_18`.
 
 # 0.17.1
 

--- a/crates/ruma-common/src/api/metadata.rs
+++ b/crates/ruma-common/src/api/metadata.rs
@@ -383,6 +383,11 @@ pub enum MatrixVersion {
     ///
     /// See <https://spec.matrix.org/v1.17/>.
     V1_17,
+
+    /// Version 1.18 of the Matrix specification, released in Q1 2026.
+    ///
+    /// See <https://spec.matrix.org/v1.18/>.
+    V1_18,
 }
 
 impl TryFrom<&str> for MatrixVersion {
@@ -414,6 +419,7 @@ impl TryFrom<&str> for MatrixVersion {
             "v1.15" => V1_15,
             "v1.16" => V1_16,
             "v1.17" => V1_17,
+            "v1.18" => V1_18,
             _ => return Err(UnknownVersionError),
         })
     }
@@ -467,6 +473,7 @@ impl MatrixVersion {
             MatrixVersion::V1_15 => "v1.15",
             MatrixVersion::V1_16 => "v1.16",
             MatrixVersion::V1_17 => "v1.17",
+            MatrixVersion::V1_18 => "v1.18",
         };
 
         Some(string)
@@ -493,6 +500,7 @@ impl MatrixVersion {
             MatrixVersion::V1_15 => (1, 15),
             MatrixVersion::V1_16 => (1, 16),
             MatrixVersion::V1_17 => (1, 17),
+            MatrixVersion::V1_18 => (1, 18),
         }
     }
 
@@ -517,6 +525,7 @@ impl MatrixVersion {
             (1, 15) => Ok(MatrixVersion::V1_15),
             (1, 16) => Ok(MatrixVersion::V1_16),
             (1, 17) => Ok(MatrixVersion::V1_17),
+            (1, 18) => Ok(MatrixVersion::V1_18),
             _ => Err(UnknownVersionError),
         }
     }
@@ -609,7 +618,9 @@ impl MatrixVersion {
             // <https://spec.matrix.org/v1.16/rooms/#complete-list-of-room-versions>
             MatrixVersion::V1_16
             // <https://spec.matrix.org/v1.17/rooms/#complete-list-of-room-versions>
-            | MatrixVersion::V1_17 => RoomVersionId::V12,
+            | MatrixVersion::V1_17
+            // <https://spec.matrix.org/v1.18/rooms/#complete-list-of-room-versions>
+            | MatrixVersion::V1_18 => RoomVersionId::V12,
         }
     }
 }

--- a/crates/ruma-common/src/push/condition.rs
+++ b/crates/ruma-common/src/push/condition.rs
@@ -759,7 +759,7 @@ mod tests {
         assert!(!"m".matches_word("[[:alpha:]]?"));
         assert!("[[:alpha:]]!".matches_word("[[:alpha:]]?"));
 
-        // From the spec: <https://spec.matrix.org/v1.17/client-server-api/#conditions-1>
+        // From the spec: <https://spec.matrix.org/v1.18/client-server-api/#conditions-1>
         assert!("An example event.".matches_word("ex*ple"));
         assert!("exple".matches_word("ex*ple"));
         assert!("An exciting triple-whammy".matches_word("ex*ple"));
@@ -808,7 +808,7 @@ mod tests {
         assert!("".matches_pattern("*", false));
         assert!(!"foo".matches_pattern("", false));
 
-        // From the spec: <https://spec.matrix.org/v1.17/client-server-api/#conditions-1>
+        // From the spec: <https://spec.matrix.org/v1.18/client-server-api/#conditions-1>
         assert!("Lunch plans".matches_pattern("lunc?*", false));
         assert!("LUNCH".matches_pattern("lunc?*", false));
         assert!(!" lunch".matches_pattern("lunc?*", false));

--- a/crates/ruma-common/src/room_version_rules.rs
+++ b/crates/ruma-common/src/room_version_rules.rs
@@ -347,7 +347,7 @@ pub struct AuthorizationRules {
     /// Whether the room creator should be determined using the `m.room.create` event's `sender`,
     /// instead of the event content's `creator` field ([spec]), introduced in room version 11.
     ///
-    /// [spec]: https://spec.matrix.org/v1.17/rooms/v11/#event-format
+    /// [spec]: https://spec.matrix.org/v1.18/rooms/v11/#event-format
     pub use_room_create_sender: bool,
 
     /// Whether room creators should always be considered to have "infinite" power level,
@@ -439,56 +439,56 @@ pub struct RedactionRules {
     /// Whether to keep the `aliases` field in the `content` of `m.room.aliases` events ([spec]),
     /// disabled since room version 6.
     ///
-    /// [spec]: https://spec.matrix.org/v1.17/rooms/v6/#redactions
+    /// [spec]: https://spec.matrix.org/v1.18/rooms/v6/#redactions
     pub keep_room_aliases_aliases: bool,
 
     /// Whether to keep the `allow` field in the `content` of `m.room.join_rules` events ([spec]),
     /// introduced in room version 8.
     ///
-    /// [spec]: https://spec.matrix.org/v1.17/rooms/v8/#redactions
+    /// [spec]: https://spec.matrix.org/v1.18/rooms/v8/#redactions
     pub keep_room_join_rules_allow: bool,
 
     /// Whether to keep the `join_authorised_via_users_server` field in the `content` of
     /// `m.room.member` events ([spec]), introduced in room version 9.
     ///
-    /// [spec]: https://spec.matrix.org/v1.17/rooms/v9/#redactions
+    /// [spec]: https://spec.matrix.org/v1.18/rooms/v9/#redactions
     pub keep_room_member_join_authorised_via_users_server: bool,
 
     /// Whether to keep the `origin`, `membership` and `prev_state` fields a the top-level of all
     /// events ([spec]), disabled since room version 11.
     ///
-    /// [spec]: https://spec.matrix.org/v1.17/rooms/v11/#redactions
+    /// [spec]: https://spec.matrix.org/v1.18/rooms/v11/#redactions
     pub keep_origin_membership_prev_state: bool,
 
     /// Whether to keep the entire `content` of `m.room.create` events ([spec]), introduced in room
     /// version 11.
     ///
-    /// [spec]: https://spec.matrix.org/v1.17/rooms/v11/#redactions
+    /// [spec]: https://spec.matrix.org/v1.18/rooms/v11/#redactions
     pub keep_room_create_content: bool,
 
     /// Whether to keep the `redacts` field in the `content` of `m.room.redaction` events ([spec]),
     /// introduced in room version 11.
     ///
-    /// [spec]: https://spec.matrix.org/v1.17/rooms/v11/#redactions
+    /// [spec]: https://spec.matrix.org/v1.18/rooms/v11/#redactions
     pub keep_room_redaction_redacts: bool,
 
     /// Whether to keep the `invite` field in the `content` of `m.room.power_levels` events
     /// ([spec]), introduced in room version 11.
     ///
-    /// [spec]: https://spec.matrix.org/v1.17/rooms/v11/#redactions
+    /// [spec]: https://spec.matrix.org/v1.18/rooms/v11/#redactions
     pub keep_room_power_levels_invite: bool,
 
     /// Whether to keep the `signed` field in `third_party_invite` of the `content` of
     /// `m.room.member` events ([spec]), introduced in room version 11.
     ///
-    /// [spec]: https://spec.matrix.org/v1.17/rooms/v11/#redactions
+    /// [spec]: https://spec.matrix.org/v1.18/rooms/v11/#redactions
     pub keep_room_member_third_party_invite_signed: bool,
 
     /// Whether the `content.redacts` field should be used to determine the event an event
     /// redacts, as opposed to the top-level `redacts` field ([spec]), introduced in room version
     /// 11.
     ///
-    /// [spec]: https://spec.matrix.org/v1.17/rooms/v11/#redactions
+    /// [spec]: https://spec.matrix.org/v1.18/rooms/v11/#redactions
     pub content_field_redacts: bool,
 
     /// Whether to keep the `allow`, `deny` and `allow_ip_literals` in the `content` of
@@ -502,7 +502,7 @@ pub struct RedactionRules {
 impl RedactionRules {
     /// Redaction rules as introduced in room version 1 ([spec]).
     ///
-    /// [spec]: https://spec.matrix.org/v1.17/rooms/v1/#redactions
+    /// [spec]: https://spec.matrix.org/v1.18/rooms/v1/#redactions
     pub const V1: Self = Self {
         keep_room_aliases_aliases: true,
         keep_room_join_rules_allow: false,
@@ -519,23 +519,23 @@ impl RedactionRules {
 
     /// Redaction rules with tweaks introduced in room version 6 ([spec]).
     ///
-    /// [spec]: https://spec.matrix.org/v1.17/rooms/v6/#redactions
+    /// [spec]: https://spec.matrix.org/v1.18/rooms/v6/#redactions
     pub const V6: Self = Self { keep_room_aliases_aliases: false, ..Self::V1 };
 
     /// Redaction rules with tweaks introduced in room version 8 ([spec]).
     ///
-    /// [spec]: https://spec.matrix.org/v1.17/rooms/v8/#redactions
+    /// [spec]: https://spec.matrix.org/v1.18/rooms/v8/#redactions
     pub const V8: Self = Self { keep_room_join_rules_allow: true, ..Self::V6 };
 
     /// Redaction rules with tweaks introduced in room version 9 ([spec]).
     ///
-    /// [spec]: https://spec.matrix.org/v1.17/rooms/v9/#redactions
+    /// [spec]: https://spec.matrix.org/v1.18/rooms/v9/#redactions
     pub const V9: Self =
         Self { keep_room_member_join_authorised_via_users_server: true, ..Self::V8 };
 
     /// Redaction rules with tweaks introduced in room version 11 ([spec]).
     ///
-    /// [spec]: https://spec.matrix.org/v1.17/rooms/v11/#redactions
+    /// [spec]: https://spec.matrix.org/v1.18/rooms/v11/#redactions
     pub const V11: Self = Self {
         keep_origin_membership_prev_state: false,
         keep_room_create_content: true,

--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -53,12 +53,13 @@ Improvements:
   for all state events.
 - Implement `RedactContent for PossiblyRedacted*EventContent` for all state
   events. 
-- Add support for the recently used emoji account data, according to MSC4356.
-- Stabilize support for invite blocking, according to MSC4380. Since the format
-  of the account data changed, the previous event content struct as well as its
-  variants in `AnyGlobalAccountDataEvent(Content)` are now prefixed with
-  `Unstable`. The new `InvitePermissionConfigEventContent` struct uses the new
-  format with a `default_action` field instead of `block_all`.
+- Add support for the recently used emoji account data, according to MSC4356 /
+  Matrix 1.18.
+- Stabilize support for invite blocking, according to MSC4380 / Matrix 1.18.
+  Since the format of the account data changed, the previous event content
+  struct as well as its variants in `AnyGlobalAccountDataEvent(Content)` are now
+  prefixed with `Unstable`. The new `InvitePermissionConfigEventContent` struct
+  uses the new format with a `default_action` field instead of `block_all`.
 - Add support for to-device event for pushing secrets, according to MSC4385.
 - Add support for video/audio call intent according to MSC4075 as part of the 
   `RtcNotificationEventContent` new `call_intent` field.
@@ -86,7 +87,7 @@ Improvements:
 - Add support for reading `m.call.intent` inside rtc membership events, 
   see `MembershipData::call_intent()`.
 - Stabilize the `is_animated` flag for image messages and sticker events,
-  according to MSC4230.
+  according to MSC4230 / Matrix 1.18.
 
 # 0.32.1
 

--- a/crates/ruma-events/src/enums.rs
+++ b/crates/ruma-events/src/enums.rs
@@ -30,7 +30,7 @@ pub const RECOMMENDED_STRIPPED_STATE_EVENT_TYPES: &[StateEventType] = &[
 /// Event types that servers should transfer upon [room upgrade]. The exact details for what is
 /// transferred is left as an implementation detail.
 ///
-/// [room upgrade]: https://spec.matrix.org/v1.17/client-server-api/#server-behaviour-19
+/// [room upgrade]: https://spec.matrix.org/v1.18/client-server-api/#server-behaviour-21
 pub const RECOMMENDED_TRANSFERABLE_STATE_EVENT_TYPES: &[StateEventType] = &[
     StateEventType::RoomServerAcl,
     StateEventType::RoomEncryption,

--- a/crates/ruma-events/src/invite_permission_config.rs
+++ b/crates/ruma-events/src/invite_permission_config.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.invite_permission_config`] account data.
 //!
-//! [`m.invite_permission_config`]: https://github.com/matrix-org/matrix-spec-proposals/pull/4380
+//! [`m.invite_permission_config`]: https://spec.matrix.org/latest/client-server-api/#minvite_permission_config
 
 use ruma_macros::{EventContent, StringEnum};
 use serde::{Deserialize, Serialize};
@@ -11,7 +11,7 @@ use crate::PrivOwnedStr;
 ///
 /// Controls whether invites to this account are permitted.
 ///
-/// [`m.invite_permission_config`]: https://github.com/matrix-org/matrix-spec-proposals/pull/4380
+/// [`m.invite_permission_config`]: https://spec.matrix.org/latest/client-server-api/#minvite_permission_config
 #[derive(Clone, Debug, Default, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 #[ruma_event(

--- a/crates/ruma-events/src/recent_emoji.rs
+++ b/crates/ruma-events/src/recent_emoji.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.recent_emoji`] account data event.
 //!
-//! [`m.recent_emoji`]: https://github.com/matrix-org/matrix-spec-proposals/pull/4356
+//! [`m.recent_emoji`]: https://spec.matrix.org/latest/client-server-api/#mrecent_emoji
 
 use js_int::{UInt, uint};
 use ruma_macros::EventContent;
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 /// The content of an [`m.recent_emoji`] event.
 ///
-/// [`m.recent_emoji`]: https://github.com/matrix-org/matrix-spec-proposals/pull/4356
+/// [`m.recent_emoji`]: https://spec.matrix.org/latest/client-server-api/#mrecent_emoji
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 #[ruma_event(type = "m.recent_emoji", kind = GlobalAccountData)]

--- a/crates/ruma-events/src/secret_storage/key.rs
+++ b/crates/ruma-events/src/secret_storage/key.rs
@@ -57,7 +57,7 @@ fn is_default_bits(val: &UInt) -> bool {
 ///
 /// The only algorithm currently specified is `m.secret_storage.v1.aes-hmac-sha2`, so this
 /// essentially represents `AesHmacSha2KeyDescription` in the
-/// [spec](https://spec.matrix.org/v1.17/client-server-api/#msecret_storagev1aes-hmac-sha2).
+/// [spec](https://spec.matrix.org/v1.18/client-server-api/#msecret_storagev1aes-hmac-sha2).
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 #[derive(Clone, Debug, Serialize, EventContent)]
 #[ruma_event(type = "m.secret_storage.key.*", kind = GlobalAccountData)]
@@ -137,7 +137,7 @@ impl SecretStorageEncryptionAlgorithm {
 /// The key properties for the `m.secret_storage.v1.aes-hmac-sha2` algorithm.
 ///
 /// Corresponds to the AES-specific properties of `AesHmacSha2KeyDescription` in the
-/// [spec](https://spec.matrix.org/v1.17/client-server-api/#msecret_storagev1aes-hmac-sha2).
+/// [spec](https://spec.matrix.org/v1.18/client-server-api/#msecret_storagev1aes-hmac-sha2).
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct SecretStorageV1AesHmacSha2Properties {

--- a/crates/ruma-federation-api/src/membership/create_join_event/v1.rs
+++ b/crates/ruma-federation-api/src/membership/create_join_event/v1.rs
@@ -1,6 +1,6 @@
 //! `/v1/` ([spec])
 //!
-//! [spec]: https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv1send_joinroomideventid
+//! [spec]: https://spec.matrix.org/v1.17/server-server-api/#put_matrixfederationv1send_joinroomideventid
 
 use ruma_common::{
     OwnedEventId, OwnedRoomId,

--- a/crates/ruma-federation-api/src/membership/create_leave_event/v1.rs
+++ b/crates/ruma-federation-api/src/membership/create_leave_event/v1.rs
@@ -1,6 +1,6 @@
 //! `/v1/` ([spec])
 //!
-//! [spec]: https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv1send_leaveroomideventid
+//! [spec]: https://spec.matrix.org/v1.17/server-server-api/#put_matrixfederationv1send_leaveroomideventid
 
 use ruma_common::{
     OwnedEventId, OwnedRoomId,

--- a/crates/ruma-federation-api/src/serde/v1_pdu.rs
+++ b/crates/ruma-federation-api/src/serde/v1_pdu.rs
@@ -1,8 +1,8 @@
 //! A module to deserialize a response from incorrectly specified endpoint:
 //!
-//! - [PUT /_matrix/federation/v1/send_join/{roomId}/{eventId}](https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv1send_joinroomideventid)
+//! - [PUT /_matrix/federation/v1/send_join/{roomId}/{eventId}](https://spec.matrix.org/v1.17/server-server-api/#put_matrixfederationv1send_joinroomideventid)
 //! - [PUT /_matrix/federation/v1/invite/{roomId}/{eventId}](https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv1inviteroomideventid)
-//! - [PUT /_matrix/federation/v1/send_leave/{roomId}/{eventId}](https://spec.matrix.org/latest/server-server-api/#put_matrixfederationv1send_leaveroomideventid)
+//! - [PUT /_matrix/federation/v1/send_leave/{roomId}/{eventId}](https://spec.matrix.org/v1.17/server-server-api/#put_matrixfederationv1send_leaveroomideventid)
 //!
 //! For more information, see this [GitHub issue][issue].
 //!

--- a/crates/ruma-identifiers-validation/src/error.rs
+++ b/crates/ruma-identifiers-validation/src/error.rs
@@ -77,7 +77,7 @@ pub enum MxcUriError {
     /// Media identifier malformed due to invalid characters detected.
     ///
     /// Valid characters are (in regex notation) `[A-Za-z0-9_-]+`.
-    /// See [here](https://spec.matrix.org/v1.17/client-server-api/#security-considerations-5) for more details.
+    /// See [here](https://spec.matrix.org/v1.18/client-server-api/#security-considerations-5) for more details.
     #[error("Media Identifier malformed, invalid characters")]
     MediaIdMalformed,
 

--- a/crates/ruma-identifiers-validation/src/mxc_uri.rs
+++ b/crates/ruma-identifiers-validation/src/mxc_uri.rs
@@ -15,7 +15,7 @@ pub fn validate(uri: &str) -> Result<NonZeroU8, MxcUriError> {
 
     let server_name = &uri[..index];
     let media_id = &uri[index + 1..];
-    // See: https://spec.matrix.org/v1.17/client-server-api/#security-considerations-5
+    // See: https://spec.matrix.org/v1.18/client-server-api/#security-considerations-5
     let media_id_is_valid = media_id
         .bytes()
         .all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'z' | b'A'..=b'Z' | b'-' | b'_' ));

--- a/xtask/src/ci/spec_links.rs
+++ b/xtask/src/ci/spec_links.rs
@@ -18,7 +18,7 @@ const OLD_URL_WHITELIST: &[&str] =
 /// Authorized versions in URLs pointing to the new specs.
 const NEW_VERSION_WHITELIST: &[&str] = &[
     "v1.1", "v1.2", "v1.3", "v1.4", "v1.5", "v1.6", "v1.7", "v1.8", "v1.9", "v1.10", "v1.11",
-    "v1.12", "v1.13", "v1.14", "v1.15", "v1.16", "v1.17",
+    "v1.12", "v1.13", "v1.14", "v1.15", "v1.16", "v1.17", "v1.18",
     "latest",
     // This should only be enabled if a legitimate use case is found.
     // "unstable",


### PR DESCRIPTION
First we add support for parsing the Matrix 1.18 version and then we update the docs with links to the latest version of the spec.