### PR TITLE
events: Add `m.room.policy` event

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -88,6 +88,8 @@ Improvements:
   see `MembershipData::call_intent()`.
 - Stabilize the `is_animated` flag for image messages and sticker events,
   according to MSC4230 / Matrix 1.18.
+- Add support for the `m.room.policy` state event, according to MSC4284 / Matrix
+  1.18.
 
 # 0.32.1
 

--- a/crates/ruma-events/src/enums.rs
+++ b/crates/ruma-events/src/enums.rs
@@ -197,6 +197,7 @@ event_enum! {
         "m.room.member" => super::room::member,
         "m.room.name" => super::room::name,
         "m.room.pinned_events" => super::room::pinned_events,
+        "m.room.policy" => super::room::policy,
         "m.room.power_levels" => super::room::power_levels,
         "m.room.server_acl" => super::room::server_acl,
         "m.room.third_party_invite" => super::room::third_party_invite,

--- a/crates/ruma-events/src/room.rs
+++ b/crates/ruma-events/src/room.rs
@@ -39,6 +39,7 @@ pub mod member;
 pub mod message;
 pub mod name;
 pub mod pinned_events;
+pub mod policy;
 pub mod power_levels;
 pub mod redaction;
 pub mod server_acl;

--- a/crates/ruma-events/src/room/policy.rs
+++ b/crates/ruma-events/src/room/policy.rs
@@ -1,0 +1,41 @@
+//! Types for the [`m.room.policy`] event.
+//!
+//! [`m.room.policy`]: https://spec.matrix.org/latest/client-server-api/#mroompolicy
+
+use std::collections::BTreeMap;
+
+use ruma_common::{OwnedServerName, SigningKeyAlgorithm, serde::Base64};
+use ruma_macros::EventContent;
+use serde::{Deserialize, Serialize};
+
+use crate::EmptyStateKey;
+
+/// The content of an [`m.room.policy`] event.
+///
+/// A [Policy Server] configuration.
+///
+/// If invalid or not set, the room does not use a Policy Server.
+///
+/// [`m.room.policy`]: https://spec.matrix.org/latest/client-server-api/#mroompolicy
+/// [Policy Server]: https://spec.matrix.org/latest/client-server-api/#policy-servers
+#[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+#[ruma_event(type = "m.room.policy", kind = State, state_key_type = EmptyStateKey)]
+pub struct RoomPolicyEventContent {
+    /// The server name to use as a Policy Server.
+    ///
+    /// MUST have a joined user in the room.
+    pub via: OwnedServerName,
+
+    /// The public keys for the Policy Server.
+    ///
+    /// MUST contain at least `ed25519`.
+    pub public_keys: BTreeMap<SigningKeyAlgorithm, Base64>,
+}
+
+impl RoomPolicyEventContent {
+    /// Creates a new `RoomPolicyEventContent` with the given server name and ed25519 public key.
+    pub fn new(via: OwnedServerName, ed25519_public_key: Base64) -> Self {
+        Self { via, public_keys: [(SigningKeyAlgorithm::Ed25519, ed25519_public_key)].into() }
+    }
+}


### PR DESCRIPTION
According to [MSC4284](https://github.com/matrix-org/matrix-spec-proposals/pull/4284) / [Spec PR](https://github.com/matrix-org/matrix-spec/issues/2332).

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
