### PR TITLE
client-api: Add support for the Policy Server public key information endpoint

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -75,6 +75,8 @@ Improvements:
 - `RegistrationKind` and `LoginType` can now represent custom values.
 - Stabilize support for the OAuth 2.0 Device Authorization Grant, according to
   MSC4341 / Matrix 1.18.
+- Add support for the Policy Server public key information endpoint, according
+  to MSC4284 / Matrix 1.18.
 
 # 0.22.1
 

--- a/crates/ruma-client-api/src/discovery.rs
+++ b/crates/ruma-client-api/src/discovery.rs
@@ -1,6 +1,7 @@
 //! Server discovery endpoints.
 
 pub mod discover_homeserver;
+pub mod discover_policy_server;
 pub mod discover_support;
 pub mod get_authorization_server_metadata;
 pub mod get_capabilities;

--- a/crates/ruma-client-api/src/discovery/discover_policy_server.rs
+++ b/crates/ruma-client-api/src/discovery/discover_policy_server.rs
@@ -1,0 +1,53 @@
+//! `GET /.well-known/matrix/policy_server` ([spec])
+//!
+//! Gets public key information for a [Policy Server].
+//!
+//! Note that this endpoint is not necessarily handled by the homeserver or Policy Server. It may be
+//! served by another webserver.
+//!
+//! [spec]: https://spec.matrix.org/latest/client-server-api/#getwell-knownmatrixpolicy_server
+//! [Policy Server]: https://spec.matrix.org/latest/client-server-api/#policy-servers
+
+use std::collections::BTreeMap;
+
+use ruma_common::{
+    SigningKeyAlgorithm,
+    api::{auth_scheme::NoAccessToken, request, response},
+    metadata,
+    serde::Base64,
+};
+
+metadata! {
+    method: GET,
+    rate_limited: false,
+    authentication: NoAccessToken,
+    path: "/.well-known/matrix/policy_server",
+}
+
+/// Request type for the `discover_policy_server` endpoint.
+#[request(error = crate::Error)]
+#[derive(Default)]
+pub struct Request {}
+
+/// Response type for the `discover_policy_server` endpoint.
+#[response(error = crate::Error)]
+pub struct Response {
+    /// The public keys for the Policy Server.
+    ///
+    /// MUST contain at least `ed25519`.
+    pub public_keys: BTreeMap<SigningKeyAlgorithm, Base64>,
+}
+
+impl Request {
+    /// Creates an empty `Request`.
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Response {
+    /// Creates a new `Response` with the given ed25519 public key.
+    pub fn new(ed25519_public_key: Base64) -> Self {
+        Self { public_keys: [(SigningKeyAlgorithm::Ed25519, ed25519_public_key)].into() }
+    }
+}


### PR DESCRIPTION
According to [MSC4284](https://github.com/matrix-org/matrix-spec-proposals/pull/4284) / [Spec PR](https://github.com/matrix-org/matrix-spec/issues/2332).

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
