### PR TITLE
Use assert_let over assert_matches in some tests

### DIFF
--- a/crates/ruma-appservice-api/src/event/push_events.rs
+++ b/crates/ruma-appservice-api/src/event/push_events.rs
@@ -326,7 +326,7 @@ pub mod v1 {
 
     #[cfg(test)]
     mod tests {
-        use assert_matches2::assert_matches;
+        use assert_matches2::assert_let;
         use js_int::uint;
         use ruma_common::{
             MilliSecondsSinceUnixEpoch, canonical_json::assert_to_canonical_json_eq, event_id,
@@ -391,7 +391,7 @@ pub mod v1 {
             });
 
             let data = from_json_value::<EphemeralData>(typing_json.clone()).unwrap();
-            assert_matches!(&data, EphemeralData::Typing(typing));
+            assert_let!(EphemeralData::Typing(typing) = &data);
             assert_eq!(typing.room_id, room_id);
             assert_eq!(typing.content.user_ids, &[user_id.to_owned()]);
 
@@ -413,7 +413,7 @@ pub mod v1 {
             });
 
             let data = from_json_value::<EphemeralData>(receipt_json.clone()).unwrap();
-            assert_matches!(&data, EphemeralData::Receipt(receipt));
+            assert_let!(EphemeralData::Receipt(receipt) = &data);
             assert_eq!(receipt.room_id, room_id);
             let event_receipts = receipt.content.get(event_id).unwrap();
             let event_read_receipts = event_receipts.get(&ReceiptType::Read).unwrap();
@@ -436,7 +436,7 @@ pub mod v1 {
             });
 
             let data = from_json_value::<EphemeralData>(presence_json.clone()).unwrap();
-            assert_matches!(&data, EphemeralData::Presence(presence));
+            assert_let!(EphemeralData::Presence(presence) = &data);
             assert_eq!(presence.sender, user_id);
             assert_eq!(presence.content.currently_active, Some(false));
 

--- a/crates/ruma-appservice-api/tests/it/appservice_registration.rs
+++ b/crates/ruma-appservice-api/tests/it/appservice_registration.rs
@@ -1,4 +1,4 @@
-use assert_matches2::assert_matches;
+use assert_matches2::assert_let;
 use ruma_appservice_api::Registration;
 
 #[test]
@@ -58,7 +58,7 @@ fn registration_with_optional_url() {
           aliases: []
           rooms: []
         "#;
-    assert_matches!(serde_yaml::from_str(registration_config).unwrap(), Registration { url, .. });
+    assert_let!(Registration { url, .. } = serde_yaml::from_str(registration_config).unwrap());
     assert_eq!(url, None);
 }
 

--- a/crates/ruma-client-api/src/backup.rs
+++ b/crates/ruma-client-api/src/backup.rs
@@ -210,7 +210,7 @@ impl From<EncryptedSessionDataInit> for EncryptedSessionData {
 mod tests {
     use std::borrow::Cow;
 
-    use assert_matches2::assert_matches;
+    use assert_matches2::{assert_let, assert_matches};
     use ruma_common::{
         SigningKeyAlgorithm, SigningKeyId, canonical_json::assert_to_canonical_json_eq,
         owned_user_id, serde::Base64,
@@ -242,18 +242,15 @@ mod tests {
         );
         assert_to_canonical_json_eq!(BackupAlgorithm::from(backup_algorithm), json.clone());
 
-        assert_matches!(
-            from_json_value(json),
-            Ok(BackupAlgorithm::MegolmBackupV1Curve25519AesSha2(auth_data))
+        assert_let!(
+            Ok(BackupAlgorithm::MegolmBackupV1Curve25519AesSha2(auth_data)) = from_json_value(json)
         );
         assert_eq!(auth_data.public_key.as_bytes(), b"abcdef");
-        assert_matches!(
-            auth_data.signatures.get(&owned_user_id!("@alice:example.org")),
-            Some(user_signatures)
-        );
+        let user_signatures =
+            auth_data.signatures.get(&owned_user_id!("@alice:example.org")).unwrap();
 
         let mut user_signatures_iter = user_signatures.iter();
-        assert_matches!(user_signatures_iter.next(), Some((key_id, signature)));
+        let (key_id, signature) = user_signatures_iter.next().unwrap();
         assert_eq!(key_id, "ed25519:DEVICEID");
         assert_eq!(signature, "signature");
         assert_matches!(user_signatures_iter.next(), None);
@@ -271,14 +268,14 @@ mod tests {
             },
         });
 
-        assert_matches!(from_json_value::<BackupAlgorithm>(json.clone()), Ok(backup_algorithm));
+        assert_let!(Ok(backup_algorithm) = from_json_value::<BackupAlgorithm>(json.clone()));
         assert_eq!(backup_algorithm.algorithm(), "local.dev.unknown_algorithm");
-        assert_matches!(backup_algorithm.auth_data(), Cow::Borrowed(auth_data));
+        assert_let!(Cow::Borrowed(auth_data) = backup_algorithm.auth_data());
 
-        assert_matches!(auth_data.get("foo"), Some(JsonValue::String(foo)));
+        assert_let!(Some(JsonValue::String(foo)) = auth_data.get("foo"));
         assert_eq!(foo, "bar");
-        assert_matches!(auth_data.get("signatures"), Some(JsonValue::Object(signatures)));
-        assert_matches!(signatures.get("ed25519:DEVICEID"), Some(JsonValue::String(signature)));
+        assert_let!(Some(JsonValue::Object(signatures)) = auth_data.get("signatures"));
+        assert_let!(Some(JsonValue::String(signature)) = signatures.get("ed25519:DEVICEID"));
         assert_eq!(signature, "signature");
 
         assert_to_canonical_json_eq!(backup_algorithm, json);

--- a/crates/ruma-client-api/src/discovery/discover_homeserver.rs
+++ b/crates/ruma-client-api/src/discovery/discover_homeserver.rs
@@ -233,7 +233,7 @@ pub struct CustomRtcFocusInfo {
 #[cfg(test)]
 mod tests {
     #[cfg(feature = "unstable-msc4143")]
-    use assert_matches2::assert_matches;
+    use assert_matches2::assert_let;
     #[cfg(feature = "unstable-msc4143")]
     use ruma_common::canonical_json::assert_to_canonical_json_eq;
     #[cfg(feature = "unstable-msc4143")]
@@ -255,7 +255,7 @@ mod tests {
         let focus: RtcFocusInfo = from_json_value(json).unwrap();
 
         // Then it should be recognized as a LiveKit focus with the correct service URL.
-        assert_matches!(focus, RtcFocusInfo::LiveKit(info));
+        assert_let!(RtcFocusInfo::LiveKit(info) = focus);
         assert_eq!(info.service_url, "https://livekit.example.com");
     }
 

--- a/crates/ruma-client-api/src/membership/invite_user.rs
+++ b/crates/ruma-client-api/src/membership/invite_user.rs
@@ -107,7 +107,7 @@ pub mod v3 {
 
     #[cfg(test)]
     mod tests {
-        use assert_matches2::assert_matches;
+        use assert_matches2::assert_let;
         use ruma_common::thirdparty::Medium;
         use serde_json::{from_value as from_json_value, json};
 
@@ -119,9 +119,8 @@ pub mod v3 {
                 from_json_value::<InvitationRecipient>(json!({ "user_id": "@carl:example.org" }))
                     .unwrap();
 
-            assert_matches!(
-                incoming,
-                InvitationRecipient::UserId(InviteUserId { user_id, reason: None })
+            assert_let!(
+                InvitationRecipient::UserId(InviteUserId { user_id, reason: None }) = incoming
             );
             assert_eq!(user_id, "@carl:example.org");
         }
@@ -136,7 +135,7 @@ pub mod v3 {
             }))
             .unwrap();
 
-            assert_matches!(incoming, InvitationRecipient::ThirdPartyId(third_party_id));
+            assert_let!(InvitationRecipient::ThirdPartyId(third_party_id) = incoming);
 
             assert_eq!(third_party_id.id_server, "example.org");
             assert_eq!(third_party_id.id_access_token, "abcdefghijklmnop");

--- a/crates/ruma-client-api/src/profile/set_profile_field.rs
+++ b/crates/ruma-client-api/src/profile/set_profile_field.rs
@@ -277,7 +277,7 @@ mod tests_client {
 
 #[cfg(all(test, feature = "server"))]
 mod tests_server {
-    use assert_matches2::assert_matches;
+    use assert_matches2::assert_let;
     use ruma_common::api::IncomingRequest;
     use serde_json::{json, to_vec as to_json_vec};
 
@@ -302,7 +302,7 @@ mod tests_server {
         .unwrap();
 
         assert_eq!(request.user_id, "@alice:localhost");
-        assert_matches!(request.value, ProfileFieldValue::DisplayName(display_name));
+        assert_let!(ProfileFieldValue::DisplayName(display_name) = request.value);
         assert_eq!(display_name, "Alice");
     }
 

--- a/crates/ruma-client-api/src/push/pusher_serde.rs
+++ b/crates/ruma-client-api/src/push/pusher_serde.rs
@@ -79,7 +79,7 @@ impl<'de> Deserialize<'de> for PusherKind {
 
 #[cfg(test)]
 mod tests {
-    use assert_matches2::assert_matches;
+    use assert_matches2::assert_let;
     use ruma_common::{
         canonical_json::assert_to_canonical_json_eq, push::HttpPusherData, serde::JsonObject,
     };
@@ -172,7 +172,7 @@ mod tests {
             "data": {},
         });
 
-        assert_matches!(from_json_value(json).unwrap(), PusherKind::Email(data));
+        assert_let!(PusherKind::Email(data) = from_json_value(json).unwrap());
         assert!(data.data.is_empty());
 
         // With custom data fields.
@@ -183,9 +183,9 @@ mod tests {
             },
         });
 
-        assert_matches!(from_json_value(json).unwrap(), PusherKind::Email(data));
+        assert_let!(PusherKind::Email(data) = from_json_value(json).unwrap());
         assert_eq!(data.data.len(), 1);
-        assert_matches!(data.data.get("custom_key"), Some(JsonValue::String(custom_value)));
+        assert_let!(Some(JsonValue::String(custom_value)) = data.data.get("custom_key"));
         assert_eq!(custom_value, "value");
     }
 
@@ -199,7 +199,7 @@ mod tests {
             },
         });
 
-        assert_matches!(from_json_value(json).unwrap(), PusherKind::Http(data));
+        assert_let!(PusherKind::Http(data) = from_json_value(json).unwrap());
         assert_eq!(data.url, "http://localhost");
         assert_eq!(data.format, None);
         assert!(data.data.is_empty());
@@ -213,9 +213,9 @@ mod tests {
             },
         });
 
-        assert_matches!(from_json_value(json).unwrap(), PusherKind::Http(data));
+        assert_let!(PusherKind::Http(data) = from_json_value(json).unwrap());
         assert_eq!(data.data.len(), 1);
-        assert_matches!(data.data.get("custom_key"), Some(JsonValue::String(custom_value)));
+        assert_let!(Some(JsonValue::String(custom_value)) = data.data.get("custom_key"));
         assert_eq!(custom_value, "value");
     }
 
@@ -226,7 +226,7 @@ mod tests {
             "data": {}
         });
 
-        assert_matches!(from_json_value(json).unwrap(), PusherKind::_Custom(custom));
+        assert_let!(PusherKind::_Custom(custom) = from_json_value(json).unwrap());
         assert_eq!(custom.kind, "my.custom.kind");
         assert!(custom.data.is_empty());
     }

--- a/crates/ruma-client-api/src/push/set_pusher/set_pusher_serde.rs
+++ b/crates/ruma-client-api/src/push/set_pusher/set_pusher_serde.rs
@@ -67,7 +67,7 @@ impl<'de> Deserialize<'de> for PusherAction {
 
 #[cfg(test)]
 mod tests {
-    use assert_matches2::assert_matches;
+    use assert_matches2::{assert_let, assert_matches};
     use ruma_common::canonical_json::assert_to_canonical_json_eq;
     use serde_json::{from_value as from_json_value, json};
 
@@ -131,7 +131,7 @@ mod tests {
             "data": {}
         });
 
-        assert_matches!(from_json_value(json).unwrap(), PusherAction::Post(post_data));
+        assert_let!(PusherAction::Post(post_data) = from_json_value(json).unwrap());
         assert!(!post_data.append);
 
         let pusher = post_data.pusher;
@@ -152,7 +152,7 @@ mod tests {
             "kind": null,
         });
 
-        assert_matches!(from_json_value(json).unwrap(), PusherAction::Delete(ids));
+        assert_let!(PusherAction::Delete(ids) = from_json_value(json).unwrap());
         assert_eq!(ids.pushkey, "abcdef");
         assert_eq!(ids.app_id, "my.matrix.app");
     }

--- a/crates/ruma-client-api/src/rtc/transports.rs
+++ b/crates/ruma-client-api/src/rtc/transports.rs
@@ -184,7 +184,7 @@ pub mod v1 {
 
 #[cfg(test)]
 mod tests {
-    use assert_matches2::assert_matches;
+    use assert_matches2::assert_let;
     use ruma_common::canonical_json::assert_to_canonical_json_eq;
     use serde_json::{Value as JsonValue, from_value as from_json_value, json};
 
@@ -193,12 +193,11 @@ mod tests {
     #[test]
     fn serialize_roundtrip_custom_rtc_transport() {
         let transport_type = "local.custom.transport";
-        assert_matches!(
-            json!({
+        assert_let!(
+            JsonValue::Object(transport_data) = json!({
                 "foo": "bar",
                 "baz": true,
-            }),
-            JsonValue::Object(transport_data)
+            })
         );
         let transport =
             RtcTransport::new(transport_type.to_owned(), transport_data.clone()).unwrap();

--- a/crates/ruma-common/src/push.rs
+++ b/crates/ruma-common/src/push.rs
@@ -1031,7 +1031,7 @@ pub enum RemovePushRuleError {
 mod tests {
     use std::{collections::BTreeMap, sync::LazyLock};
 
-    use assert_matches2::assert_matches;
+    use assert_matches2::{assert_let, assert_matches};
     use js_int::{int, uint};
     use macro_rules_attribute::apply;
     use serde_json::{
@@ -1132,26 +1132,17 @@ mod tests {
 
         let rule_opt = iter.next();
         assert!(rule_opt.is_some());
-        assert_matches!(
-            rule_opt.unwrap(),
-            AnyPushRule::Override(ConditionalPushRule { rule_id, .. })
-        );
+        assert_let!(AnyPushRule::Override(ConditionalPushRule { rule_id, .. }) = rule_opt.unwrap());
         assert_eq!(rule_id, ".m.rule.call");
 
         let rule_opt = iter.next();
         assert!(rule_opt.is_some());
-        assert_matches!(
-            rule_opt.unwrap(),
-            AnyPushRule::Override(ConditionalPushRule { rule_id, .. })
-        );
+        assert_let!(AnyPushRule::Override(ConditionalPushRule { rule_id, .. }) = rule_opt.unwrap());
         assert_eq!(rule_id, "!roomid:matrix.org");
 
         let rule_opt = iter.next();
         assert!(rule_opt.is_some());
-        assert_matches!(
-            rule_opt.unwrap(),
-            AnyPushRule::Override(ConditionalPushRule { rule_id, .. })
-        );
+        assert_let!(AnyPushRule::Override(ConditionalPushRule { rule_id, .. }) = rule_opt.unwrap());
         assert_eq!(rule_id, ".m.rule.suppress_notices");
 
         assert_matches!(iter.next(), None);
@@ -1397,7 +1388,7 @@ mod tests {
 
         let mut iter = rule.actions.iter();
         assert_matches!(iter.next(), Some(Action::Notify));
-        assert_matches!(iter.next(), Some(Action::SetTweak(Tweak::Sound(sound))));
+        assert_let!(Some(Action::SetTweak(Tweak::Sound(sound))) = iter.next());
         assert_eq!(sound, "default");
         assert_matches!(iter.next(), Some(Action::SetTweak(Tweak::Highlight(true))));
         assert_matches!(iter.next(), None);
@@ -1463,40 +1454,33 @@ mod tests {
 
         let rule_opt = iter.next();
         assert!(rule_opt.is_some());
-        assert_matches!(
-            rule_opt.unwrap(),
-            AnyPushRule::Override(ConditionalPushRule { rule_id, .. })
-        );
+        assert_let!(AnyPushRule::Override(ConditionalPushRule { rule_id, .. }) = rule_opt.unwrap());
         assert_eq!(rule_id, "!roomid:server.name");
 
         let rule_opt = iter.next();
         assert!(rule_opt.is_some());
-        assert_matches!(
-            rule_opt.unwrap(),
-            AnyPushRule::Override(ConditionalPushRule { rule_id, .. })
-        );
+        assert_let!(AnyPushRule::Override(ConditionalPushRule { rule_id, .. }) = rule_opt.unwrap());
         assert_eq!(rule_id, ".m.rule.call");
 
         let rule_opt = iter.next();
         assert!(rule_opt.is_some());
-        assert_matches!(rule_opt.unwrap(), AnyPushRule::Content(PatternedPushRule { rule_id, .. }));
+        assert_let!(AnyPushRule::Content(PatternedPushRule { rule_id, .. }) = rule_opt.unwrap());
         assert_eq!(rule_id, ".m.rule.contains_user_name");
 
         let rule_opt = iter.next();
         assert!(rule_opt.is_some());
-        assert_matches!(rule_opt.unwrap(), AnyPushRule::Content(PatternedPushRule { rule_id, .. }));
+        assert_let!(AnyPushRule::Content(PatternedPushRule { rule_id, .. }) = rule_opt.unwrap());
         assert_eq!(rule_id, "ruma");
 
         let rule_opt = iter.next();
         assert!(rule_opt.is_some());
-        assert_matches!(rule_opt.unwrap(), AnyPushRule::Room(SimplePushRule { rule_id, .. }));
+        assert_let!(AnyPushRule::Room(SimplePushRule { rule_id, .. }) = rule_opt.unwrap());
         assert_eq!(rule_id, "!roomid:server.name");
 
         let rule_opt = iter.next();
         assert!(rule_opt.is_some());
-        assert_matches!(
-            rule_opt.unwrap(),
-            AnyPushRule::Underride(ConditionalPushRule { rule_id, .. })
+        assert_let!(
+            AnyPushRule::Underride(ConditionalPushRule { rule_id, .. }) = rule_opt.unwrap()
         );
         assert_eq!(rule_id, ".m.rule.room_one_to_one");
 
@@ -1585,7 +1569,7 @@ mod tests {
 
         assert_matches!(
             set.get_actions(&room_mention, &CONTEXT_PUBLIC_ROOM).await,
-            [Action::Notify, Action::SetTweak(Tweak::Highlight(true)),]
+            [Action::Notify, Action::SetTweak(Tweak::Highlight(true))]
         );
 
         let empty = serde_json::from_str::<Raw<JsonValue>>(r#"{}"#).unwrap();

--- a/crates/ruma-events/tests/it/encrypted.rs
+++ b/crates/ruma-events/tests/it/encrypted.rs
@@ -1,4 +1,4 @@
-use assert_matches2::assert_matches;
+use assert_matches2::{assert_let, assert_matches};
 use ruma_common::{
     canonical_json::assert_to_canonical_json_eq, owned_device_id, owned_event_id, serde::Raw,
 };
@@ -67,7 +67,7 @@ fn content_no_relation_deserialization() {
 
     let content = from_json_value::<RoomEncryptedEventContent>(json).unwrap();
 
-    assert_matches!(content.scheme, EncryptedEventScheme::MegolmV1AesSha2(encrypted_content));
+    assert_let!(EncryptedEventScheme::MegolmV1AesSha2(encrypted_content) = content.scheme);
     assert_eq!(encrypted_content.session_id, "IkwqWxT2zy3DI1E/zM2Wq+CE8tr3eEpsxsVGjGrMPdw");
     assert_eq!(
         encrypted_content.ciphertext,
@@ -144,7 +144,7 @@ fn content_reply_deserialization() {
 
     let content = from_json_value::<RoomEncryptedEventContent>(json).unwrap();
 
-    assert_matches!(content.scheme, EncryptedEventScheme::MegolmV1AesSha2(encrypted_content));
+    assert_let!(EncryptedEventScheme::MegolmV1AesSha2(encrypted_content) = content.scheme);
     assert_eq!(encrypted_content.session_id, "IkwqWxT2zy3DI1E/zM2Wq+CE8tr3eEpsxsVGjGrMPdw");
     assert_eq!(
         encrypted_content.ciphertext,
@@ -156,7 +156,7 @@ fn content_reply_deserialization() {
         lDl5mzVO3tPnJMKZ0hn+AF"
     );
 
-    assert_matches!(content.relates_to, Some(Relation::Reply(reply)));
+    assert_let!(Some(Relation::Reply(reply)) = content.relates_to);
     assert_eq!(reply.in_reply_to.event_id, "$replied_to_event");
 }
 
@@ -172,7 +172,7 @@ fn content_reply_serialization_roundtrip() {
     let deser_content = json_content.deserialize().unwrap();
 
     assert_matches!(deser_content.scheme, EncryptedEventScheme::MegolmV1AesSha2(_));
-    assert_matches!(deser_content.relates_to, Some(Relation::Reply(reply)));
+    assert_let!(Some(Relation::Reply(reply)) = deser_content.relates_to);
     assert_eq!(reply.in_reply_to.event_id, event_id);
 }
 
@@ -225,7 +225,7 @@ fn content_replacement_deserialization() {
 
     let content = from_json_value::<RoomEncryptedEventContent>(json).unwrap();
 
-    assert_matches!(content.scheme, EncryptedEventScheme::MegolmV1AesSha2(encrypted_content));
+    assert_let!(EncryptedEventScheme::MegolmV1AesSha2(encrypted_content) = content.scheme);
     assert_eq!(encrypted_content.session_id, "IkwqWxT2zy3DI1E/zM2Wq+CE8tr3eEpsxsVGjGrMPdw");
     assert_eq!(
         encrypted_content.ciphertext,
@@ -237,7 +237,7 @@ fn content_replacement_deserialization() {
         lDl5mzVO3tPnJMKZ0hn+AF"
     );
 
-    assert_matches!(content.relates_to, Some(Relation::Replacement(replacement)));
+    assert_let!(Some(Relation::Replacement(replacement)) = content.relates_to);
     assert_eq!(replacement.event_id, "$replaced_event");
 }
 
@@ -253,7 +253,7 @@ fn content_replacement_serialization_roundtrip() {
     let deser_content = json_content.deserialize().unwrap();
 
     assert_matches!(deser_content.scheme, EncryptedEventScheme::MegolmV1AesSha2(_));
-    assert_matches!(deser_content.relates_to, Some(Relation::Replacement(deser_replacement)));
+    assert_let!(Some(Relation::Replacement(deser_replacement)) = deser_content.relates_to);
     assert_eq!(deser_replacement.event_id, replacement.event_id);
 }
 
@@ -306,7 +306,7 @@ fn content_reference_deserialization() {
 
     let content = from_json_value::<RoomEncryptedEventContent>(json).unwrap();
 
-    assert_matches!(content.scheme, EncryptedEventScheme::MegolmV1AesSha2(encrypted_content));
+    assert_let!(EncryptedEventScheme::MegolmV1AesSha2(encrypted_content) = content.scheme);
     assert_eq!(encrypted_content.session_id, "IkwqWxT2zy3DI1E/zM2Wq+CE8tr3eEpsxsVGjGrMPdw");
     assert_eq!(
         encrypted_content.ciphertext,
@@ -318,7 +318,7 @@ fn content_reference_deserialization() {
         lDl5mzVO3tPnJMKZ0hn+AF"
     );
 
-    assert_matches!(content.relates_to, Some(Relation::Reference(reference)));
+    assert_let!(Some(Relation::Reference(reference)) = content.relates_to);
     assert_eq!(reference.event_id, "$referenced_event");
 }
 
@@ -334,7 +334,7 @@ fn content_reference_serialization_roundtrip() {
     let deser_content = json_content.deserialize().unwrap();
 
     assert_matches!(deser_content.scheme, EncryptedEventScheme::MegolmV1AesSha2(_));
-    assert_matches!(deser_content.relates_to, Some(Relation::Reference(deser_reference)));
+    assert_let!(Some(Relation::Reference(deser_reference)) = deser_content.relates_to);
     assert_eq!(deser_reference.event_id, reference.event_id);
 }
 
@@ -397,7 +397,7 @@ fn content_thread_deserialization() {
 
     let content = from_json_value::<RoomEncryptedEventContent>(json).unwrap();
 
-    assert_matches!(content.scheme, EncryptedEventScheme::MegolmV1AesSha2(encrypted_content));
+    assert_let!(EncryptedEventScheme::MegolmV1AesSha2(encrypted_content) = content.scheme);
     assert_eq!(encrypted_content.session_id, "IkwqWxT2zy3DI1E/zM2Wq+CE8tr3eEpsxsVGjGrMPdw");
     assert_eq!(
         encrypted_content.ciphertext,
@@ -409,7 +409,7 @@ fn content_thread_deserialization() {
         lDl5mzVO3tPnJMKZ0hn+AF"
     );
 
-    assert_matches!(content.relates_to, Some(Relation::Thread(thread)));
+    assert_let!(Some(Relation::Thread(thread)) = content.relates_to);
     assert_eq!(thread.event_id, "$thread_root");
     assert_eq!(thread.in_reply_to.unwrap().event_id, "$prev_event");
     assert!(!thread.is_falling_back);
@@ -425,7 +425,7 @@ fn content_thread_serialization_roundtrip() {
     let deser_content = json_content.deserialize().unwrap();
 
     assert_matches!(deser_content.scheme, EncryptedEventScheme::MegolmV1AesSha2(_));
-    assert_matches!(deser_content.relates_to, Some(Relation::Thread(deser_thread)));
+    assert_let!(Some(Relation::Thread(deser_thread)) = deser_content.relates_to);
     assert_eq!(deser_thread.event_id, thread.event_id);
     assert_eq!(deser_thread.in_reply_to.unwrap().event_id, thread.in_reply_to.unwrap().event_id);
     assert_eq!(deser_thread.is_falling_back, thread.is_falling_back);
@@ -485,7 +485,7 @@ fn content_annotation_deserialization() {
 
     let content = from_json_value::<RoomEncryptedEventContent>(json).unwrap();
 
-    assert_matches!(content.scheme, EncryptedEventScheme::MegolmV1AesSha2(encrypted_content));
+    assert_let!(EncryptedEventScheme::MegolmV1AesSha2(encrypted_content) = content.scheme);
     assert_eq!(encrypted_content.session_id, "IkwqWxT2zy3DI1E/zM2Wq+CE8tr3eEpsxsVGjGrMPdw");
     assert_eq!(
         encrypted_content.ciphertext,
@@ -497,7 +497,7 @@ fn content_annotation_deserialization() {
         lDl5mzVO3tPnJMKZ0hn+AF"
     );
 
-    assert_matches!(content.relates_to, Some(Relation::Annotation(annotation)));
+    assert_let!(Some(Relation::Annotation(annotation)) = content.relates_to);
     assert_eq!(annotation.event_id, "$annotated_event");
     assert_eq!(annotation.key, "some_key");
 }
@@ -514,7 +514,7 @@ fn content_annotation_serialization_roundtrip() {
     let deser_content = json_content.deserialize().unwrap();
 
     assert_matches!(deser_content.scheme, EncryptedEventScheme::MegolmV1AesSha2(_));
-    assert_matches!(deser_content.relates_to, Some(Relation::Annotation(deser_annotation)));
+    assert_let!(Some(Relation::Annotation(deser_annotation)) = deser_content.relates_to);
     assert_eq!(deser_annotation.event_id, annotation.event_id);
     assert_eq!(deser_annotation.key, annotation.key);
 }
@@ -542,7 +542,7 @@ fn custom_relation_deserialization() {
 
     let content = from_json_value::<RoomEncryptedEventContent>(content_json).unwrap();
 
-    assert_matches!(content.scheme, EncryptedEventScheme::MegolmV1AesSha2(encrypted_content));
+    assert_let!(EncryptedEventScheme::MegolmV1AesSha2(encrypted_content) = content.scheme);
     assert_eq!(encrypted_content.session_id, "IkwqWxT2zy3DI1E/zM2Wq+CE8tr3eEpsxsVGjGrMPdw");
     assert_eq!(
         encrypted_content.ciphertext,


### PR DESCRIPTION
It's less obvious that assert_matches2::assert_matches can introduce new bindings.

I thought this would be easy with Rust-Analyzer's structural search & replace, but unfortunately that introduced extra parentheses that rustc would warn about, but mostly not emit structural suggestions (for `cargo fix`) for. So I stopped after a couple files. Might submit more PRs like this some other time.