### PR TITLE
docs: Document supported room versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ You can also find a small number of examples in our dedicated
 
 Ruma 0.14.0 supports all events and REST endpoints of Matrix 1.16.
 
+Only room versions enforcing canonical JSON (introduced with room version 6) are
+supported. Room versions 1 through 5 are supported on a best effort basis, but a
+missing feature or an incompatibility with a homeserver implementation are not
+considered bugs. Clients should be able to work with those room versions,
+granted parts of the room might break in some unconventional cases, but
+homeservers based on Ruma **should not** advertise support for them.
+
 Various changes from in-progress or finished MSCs are also implemented, gated
 behind the `unstable-mscXXXX` (where `XXXX` is the MSC number) Cargo features.
 

--- a/crates/ruma-signatures/src/lib.rs
+++ b/crates/ruma-signatures/src/lib.rs
@@ -24,6 +24,14 @@
 //! In JSON representations, both signatures and hashes appear as base64-encoded strings, usually
 //! using the standard character set, without padding.
 //!
+//! # Supported room versions
+//!
+//! Only room versions enforcing [canonical JSON] (introduced with [room version 6]) are supported.
+//!
+//! Room versions 1 through 5 are unsupported because the rules for the JSON encoding of events
+//! before signing or hashing them is unspecified. Homeservers using this crate **should not**
+//! advertise support for those room versions.
+//!
 //! # Signing and hashing
 //!
 //! To sign an arbitrary JSON object, use the [`sign_json()`] function. See the documentation of
@@ -45,6 +53,9 @@
 //! To verify a signature on arbitrary JSON, use the [`verify_json()`] function. To verify the
 //! signatures and hashes on an event, use the [`verify_event()`] function. See the documentation
 //! for these respective functions for more details and full examples of use.
+//!
+//! [canonical JSON]: https://spec.matrix.org/v1.18/appendices/#canonical-json
+//! [room version 6]: https://spec.matrix.org/v1.18/rooms/v6/
 
 #![warn(missing_docs)]
 

--- a/crates/ruma-state-res/src/lib.rs
+++ b/crates/ruma-state-res/src/lib.rs
@@ -5,6 +5,18 @@
 //! When creating or receiving a PDU (or event), a server must check whether it is valid and how it
 //! affects the room state. The purpose of this crate is to provide functions that solve that.
 //!
+//! # Supported room versions
+//!
+//! Only room versions enforcing [canonical JSON] (introduced with [room version 6]) are supported.
+//!
+//! Room versions 1 through 5 are supported on a best effort basis:
+//!
+//! * The authorization rules should work for most events but some unconventional JSON encoding of
+//!   values might fail to deserialize while still considered to be valid by other implementations.
+//! * The [state resolution algorithm from room version 1][state-res-v1] is not implemented.
+//!
+//! Homeservers using this crate **should not** advertise support for those room versions.
+//!
 //! # Checks performed on receipt of a PDU
 //!
 //! This crate used with [ruma-signatures] should allow to perform all the [necessary checks on
@@ -45,6 +57,9 @@
 //! The types from ruma-events are still appropriate to be used to create a new event, or to
 //! validate an event received from a client.
 //!
+//! [canonical JSON]: https://spec.matrix.org/v1.18/appendices/#canonical-json
+//! [room version 6]: https://spec.matrix.org/v1.18/rooms/v6/
+//! [state-res-v1]: https://spec.matrix.org/v1.18/rooms/v1/#state-resolution
 //! [ruma-signatures]: https://crates.io/crates/ruma-signatures
 //! [necessary checks on receipt of a PDU]: https://spec.matrix.org/v1.18/server-server-api/#checks-performed-on-receipt-of-a-pdu
 //! [ruma-events]: https://crates.io/crates/ruma-events

--- a/crates/ruma/src/lib.rs
+++ b/crates/ruma/src/lib.rs
@@ -2,8 +2,40 @@
 #![doc(html_logo_url = "https://ruma.dev/images/logo.png")]
 //! Types and traits for working with the [Matrix](https://matrix.org) protocol.
 //!
-//! This crate re-exports things from all of the other ruma crates so you don't
-//! have to manually keep all the versions in sync.
+//! # Getting started
+//!
+//! If you want to build a Matrix client or bot, have a look at [matrix-rust-sdk](https://github.com/matrix-org/matrix-rust-sdk#readme).
+//! It builds on Ruma and includes handling of state storage, end-to-end encryption and many other
+//! useful things.
+//!
+//! For homeservers, bridges and harder-to-categorize software that works with Matrix, you're at the
+//! right place. To get started, add `ruma` to your dependencies:
+//!
+//! ```toml
+//! # crates.io release
+//! ruma = { version = "0.17.0", features = ["..."] }
+//! # git dependency
+//! ruma = { git = "https://github.com/ruma/ruma", branch = "main", features = ["..."] }
+//! ```
+//!
+//! You can find a low level Matrix client in the [ruma-client repository](https://github.com/ruma/ruma-client).
+//!
+//! You can also find a small number of examples in our dedicated [ruma-examples repository](https://github.com/ruma/ruma-examples).
+//!
+//! # Status
+//!
+//! Ruma supports all events and REST endpoints of Matrix 1.17.
+//!
+//! Only room versions enforcing canonical JSON (introduced with room version 6) are supported. Room
+//! versions 1 through 5 are supported on a best effort basis, but a missing feature or an
+//! incompatibility with a homeserver implementation are not considered bugs. Clients should be able
+//! to work with those room versions, granted parts of the room might break in some unconventional
+//! cases, but homeservers based on Ruma **should not** advertise support for them.
+//!
+//! # Features
+//!
+//! This crate re-exports things from all of the other ruma crates so you don't have to manually
+//! keep all the versions in sync.
 //!
 //! Which crates are re-exported can be configured through cargo features.
 //!
@@ -14,7 +46,7 @@
 //! > in the serialized representation, as the Matrix specification has a mix of British and
 //! > American English.
 //!
-//! # API features
+//! ## API features
 //!
 //! Depending on which parts of Matrix are relevant to you, activate the following features:
 //!
@@ -29,7 +61,7 @@
 //!   * `client-api-c` -- The Client-Server API optimized for the client side.
 //!   * `client-api-s` -- The Client-Server API optimized for the server side.
 //!
-//! # Compatibility features
+//! ## Compatibility features
 //!
 //! By default, the ruma crates are only able to handle strictly spec-compliant data and behaviour.
 //! However, due to the fact that Matrix is federated, that it is used by various implementations
@@ -44,7 +76,7 @@
 //! Each cargo feature is documented briefly in the cargo manifest of the crate, and more thoroughly
 //! where the feature applies.
 //!
-//! # Convenience features
+//! ## Convenience features
 //!
 //! These features are only useful if you want to use a method that requires it:
 //!
@@ -54,7 +86,7 @@
 //!   * `html-matrix` -- Enables the `matrix` feature of `ruma-html` to parse HTML elements data to
 //!     typed data as suggested by the Matrix Specification.
 //!
-//! # Unstable features
+//! ## Unstable features
 //!
 //! By using these features, you opt out of all semver guarantees Ruma otherwise provides:
 //!
@@ -63,7 +95,7 @@
 //! * `unstable-uniffi` -- Enables UniFFI bindings by adding conditional `uniffi` derives to _some_
 //!   types. This feature is currently a work in progress and, thus, unstable.
 //!
-//! # Common features
+//! ## Common features
 //!
 //! These submodules are usually activated by the API features when needed:
 //!


### PR DESCRIPTION
This mostly concerns homeservers, but we also add a warning for clients.

While we're at it, I also copied more helpful docs from the README to the intro of the ruma crate.

Closes #877.