### PR TITLE
state-res: Add `EventIdSet` and `EventIdMap`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2144,7 +2144,6 @@ dependencies = [
  "criterion",
  "insta",
  "js_int",
- "maplit",
  "ruma-common",
  "ruma-events",
  "ruma-signatures",

--- a/crates/ruma-state-res/CHANGELOG.md
+++ b/crates/ruma-state-res/CHANGELOG.md
@@ -7,6 +7,9 @@ Breaking:
 - `resolve()` and `reverse_topological_power_sort()` now take
   `EventIdSet<E::Id>`s rather than `HashSet<E::Id>`. This is an opaque set type
   that will allow to optimize the backing implementation in the future.
+- `reverse_topological_power_sort()` now takes an `EventIdMap<E::Id, _>` rather
+  than a `HashMap<E::Id, _>`. This is an opaque map type that will allow to
+  optimize the backing implementation in the future.
 
 ## 0.15.0
 

--- a/crates/ruma-state-res/CHANGELOG.md
+++ b/crates/ruma-state-res/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+Breaking:
+
+- `resolve()` and `reverse_topological_power_sort()` now take
+  `EventIdSet<E::Id>`s rather than `HashSet<E::Id>`. This is an opaque set type
+  that will allow to optimize the backing implementation in the future.
+
 ## 0.15.0
 
 Breaking:

--- a/crates/ruma-state-res/Cargo.toml
+++ b/crates/ruma-state-res/Cargo.toml
@@ -34,7 +34,6 @@ criterion = { workspace = true, optional = true }
 [dev-dependencies]
 assert_matches2 = { workspace = true }
 insta = { workspace = true }
-maplit = { workspace = true }
 similar = { workspace = true }
 test-log = { version = "0.2", default-features = false, features = ["trace"] }
 

--- a/crates/ruma-state-res/benches/state_res_bench.rs
+++ b/crates/ruma-state-res/benches/state_res_bench.rs
@@ -9,7 +9,6 @@
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use js_int::{int, uint};
-use maplit::hashmap;
 use ruma_common::{
     MilliSecondsSinceUnixEpoch, RoomVersionId, owned_event_id,
     room_version_rules::{AuthorizationRules, StateResolutionV2Rules},
@@ -21,18 +20,22 @@ use ruma_state_res::{
         PublicChatInitialPdu, RoomMemberPduContent, RoomPowerLevelsPduContent, RoomTimelineFactory,
         UserFactory,
     },
-    utils::event_id_set::EventIdSet,
+    utils::{event_id_map::EventIdMap, event_id_set::EventIdSet},
 };
 
 fn reverse_topological_power_sort(c: &mut Criterion) {
     c.bench_function("reverse_topological_power_sort", |b| {
-        let graph = hashmap! {
-            owned_event_id!("$l") => EventIdSet::from([owned_event_id!("$o")]),
-            owned_event_id!("$m") => EventIdSet::from([owned_event_id!("$n"), owned_event_id!("$o")]),
-            owned_event_id!("$n") => EventIdSet::from([owned_event_id!("$o")]),
-            owned_event_id!("$o") => EventIdSet::new(), // "o" has zero outgoing edges but 4 incoming edges
-            owned_event_id!("$p") => EventIdSet::from([owned_event_id!("$o")]),
-        };
+        let graph = EventIdMap::from([
+            (owned_event_id!("$l"), EventIdSet::from([owned_event_id!("$o")])),
+            (
+                owned_event_id!("$m"),
+                EventIdSet::from([owned_event_id!("$n"), owned_event_id!("$o")]),
+            ),
+            (owned_event_id!("$n"), EventIdSet::from([owned_event_id!("$o")])),
+            (owned_event_id!("$o"), EventIdSet::new()), /* "o" has zero outgoing edges but 4
+                                                         * incoming edges */
+            (owned_event_id!("$p"), EventIdSet::from([owned_event_id!("$o")])),
+        ]);
         b.iter(|| {
             let _ = state_res::reverse_topological_power_sort(&graph, |_id| {
                 Ok((int!(0).into(), MilliSecondsSinceUnixEpoch(uint!(0))))

--- a/crates/ruma-state-res/benches/state_res_bench.rs
+++ b/crates/ruma-state-res/benches/state_res_bench.rs
@@ -9,7 +9,7 @@
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use js_int::{int, uint};
-use maplit::{hashmap, hashset};
+use maplit::hashmap;
 use ruma_common::{
     MilliSecondsSinceUnixEpoch, RoomVersionId, owned_event_id,
     room_version_rules::{AuthorizationRules, StateResolutionV2Rules},
@@ -21,16 +21,17 @@ use ruma_state_res::{
         PublicChatInitialPdu, RoomMemberPduContent, RoomPowerLevelsPduContent, RoomTimelineFactory,
         UserFactory,
     },
+    utils::event_id_set::EventIdSet,
 };
 
 fn reverse_topological_power_sort(c: &mut Criterion) {
     c.bench_function("reverse_topological_power_sort", |b| {
         let graph = hashmap! {
-            owned_event_id!("$l") => hashset![owned_event_id!("$o")],
-            owned_event_id!("$m") => hashset![owned_event_id!("$n"), owned_event_id!("$o")],
-            owned_event_id!("$n") => hashset![owned_event_id!("$o")],
-            owned_event_id!("$o") => hashset![], // "o" has zero outgoing edges but 4 incoming edges
-            owned_event_id!("$p") => hashset![owned_event_id!("$o")],
+            owned_event_id!("$l") => EventIdSet::from([owned_event_id!("$o")]),
+            owned_event_id!("$m") => EventIdSet::from([owned_event_id!("$n"), owned_event_id!("$o")]),
+            owned_event_id!("$n") => EventIdSet::from([owned_event_id!("$o")]),
+            owned_event_id!("$o") => EventIdSet::new(), // "o" has zero outgoing edges but 4 incoming edges
+            owned_event_id!("$p") => EventIdSet::from([owned_event_id!("$o")]),
         };
         b.iter(|| {
             let _ = state_res::reverse_topological_power_sort(&graph, |_id| {

--- a/crates/ruma-state-res/src/lib.rs
+++ b/crates/ruma-state-res/src/lib.rs
@@ -74,7 +74,7 @@ mod state_res;
 #[cfg(any(test, feature = "__criterion"))]
 #[doc(hidden)]
 pub mod test_utils;
-mod utils;
+pub mod utils;
 
 pub use self::{
     error::{Error, Result},

--- a/crates/ruma-state-res/src/state_res.rs
+++ b/crates/ruma-state-res/src/state_res.rs
@@ -25,7 +25,7 @@ use crate::{
         RoomCreateEvent, RoomMemberEvent, RoomPowerLevelsEvent, RoomPowerLevelsIntField,
         power_levels::RoomPowerLevelsEventOptionExt,
     },
-    utils::{RoomIdExt, event_id_set::EventIdSet},
+    utils::{RoomIdExt, event_id_map::EventIdMap, event_id_set::EventIdSet},
 };
 
 /// A mapping of event type and state_key to some value `T`, usually an `EventId`.
@@ -268,7 +268,7 @@ where
 {
     let num_sets = auth_chains.len();
 
-    let mut id_counts: HashMap<Id, usize> = HashMap::new();
+    let mut id_counts: EventIdMap<Id, usize> = EventIdMap::new();
     for id in auth_chains.into_iter().flatten() {
         *id_counts.entry(id).or_default() += 1;
     }
@@ -303,7 +303,7 @@ fn sort_power_events<E: Event>(
 
     // A representation of the DAG, a map of event ID to its list of auth events that are in the
     // full conflicted set.
-    let mut graph = HashMap::new();
+    let mut graph = EventIdMap::new();
 
     // Fill the graph.
     for event_id in conflicted_power_events {
@@ -315,7 +315,7 @@ fn sort_power_events<E: Event>(
     }
 
     // The map of event ID to the power level of the sender of the event.
-    let mut event_to_power_level = HashMap::new();
+    let mut event_to_power_level = EventIdMap::new();
     // We need to know the creator in case of missing power levels. Given that it's the same for all
     // the events in the room, we will just load it for the first event and reuse it.
     let creators_lock = OnceLock::new();
@@ -381,7 +381,7 @@ fn sort_power_events<E: Event>(
 /// Returns the ordered list of event IDs from earliest to latest.
 #[instrument(skip_all)]
 pub fn reverse_topological_power_sort<Id, F>(
-    graph: &HashMap<Id, EventIdSet<Id>>,
+    graph: &EventIdMap<Id, EventIdSet<Id>>,
     event_details_fn: F,
 ) -> Result<Vec<Id>>
 where
@@ -757,7 +757,7 @@ fn mainline_sort<E: Event>(
         .rev()
         .enumerate()
         .map(|(idx, event_id)| ((*event_id).clone(), idx))
-        .collect::<HashMap<_, _>>();
+        .collect::<EventIdMap<_, _>>();
 
     let mut order_map = HashMap::new();
     for event_id in events.iter() {
@@ -821,7 +821,7 @@ fn mainline_sort<E: Event>(
 /// chain of the event was not found.
 fn mainline_position<E: Event>(
     event: E,
-    mainline_map: &HashMap<E::Id, usize>,
+    mainline_map: &EventIdMap<E::Id, usize>,
     fetch_event: impl Fn(&EventId) -> Option<E>,
 ) -> Result<usize> {
     let mut current_event = Some(event);
@@ -856,7 +856,7 @@ fn mainline_position<E: Event>(
 /// Add the event with the given event ID and all the events in its auth chain that are in the full
 /// conflicted set to the graph.
 fn add_event_and_auth_chain_to_graph<E: Event>(
-    graph: &mut HashMap<E::Id, EventIdSet<E::Id>>,
+    graph: &mut EventIdMap<E::Id, EventIdSet<E::Id>>,
     event_id: E::Id,
     full_conflicted_set: &EventIdSet<E::Id>,
     fetch_event: impl Fn(&EventId) -> Option<E>,
@@ -878,7 +878,7 @@ fn add_event_and_auth_chain_to_graph<E: Event>(
             // If the auth event ID is in the full conflicted set…
             if full_conflicted_set.contains(auth_event_id.borrow()) {
                 // If the auth event ID is not in the graph, we need to check its auth events later.
-                if !graph.contains_key(auth_event_id.borrow()) {
+                if !graph.contains_event_id(auth_event_id.borrow()) {
                     state.push(auth_event_id.to_owned());
                 }
 

--- a/crates/ruma-state-res/src/state_res.rs
+++ b/crates/ruma-state-res/src/state_res.rs
@@ -25,7 +25,7 @@ use crate::{
         RoomCreateEvent, RoomMemberEvent, RoomPowerLevelsEvent, RoomPowerLevelsIntField,
         power_levels::RoomPowerLevelsEventOptionExt,
     },
-    utils::RoomIdExt,
+    utils::{RoomIdExt, event_id_set::EventIdSet},
 };
 
 /// A mapping of event type and state_key to some value `T`, usually an `EventId`.
@@ -71,9 +71,9 @@ pub fn resolve<'a, E, MapsIter>(
     auth_rules: &AuthorizationRules,
     state_res_rules: &StateResolutionV2Rules,
     state_maps: impl IntoIterator<IntoIter = MapsIter>,
-    auth_chains: Vec<HashSet<E::Id>>,
+    auth_chains: Vec<EventIdSet<E::Id>>,
     fetch_event: impl Fn(&EventId) -> Option<E>,
-    fetch_conflicted_state_subgraph: impl Fn(&StateMap<Vec<E::Id>>) -> Option<HashSet<E::Id>>,
+    fetch_conflicted_state_subgraph: impl Fn(&StateMap<Vec<E::Id>>) -> Option<EventIdSet<E::Id>>,
 ) -> Result<StateMap<E::Id>>
 where
     E: Event + Clone,
@@ -107,12 +107,12 @@ where
 
         conflicted_state_subgraph
     } else {
-        HashSet::new()
+        EventIdSet::new()
     };
 
     // The full conflicted set is the union of the conflicted state set and the auth difference,
     // and since v12, the conflicted state subgraph.
-    let full_conflicted_set: HashSet<_> = auth_difference(auth_chains)
+    let full_conflicted_set: EventIdSet<_> = auth_difference(auth_chains)
         .chain(conflicted_state_set.into_values().flatten())
         .chain(conflicted_state_subgraph)
         // Don't honor events we cannot "verify"
@@ -155,7 +155,7 @@ where
 
     // 3. Take all remaining events that weren’t picked in step 1 and order them by the mainline
     //    ordering based on the power level in the partially resolved state obtained in step 2.
-    let sorted_power_events_set = sorted_power_events.into_iter().collect::<HashSet<_>>();
+    let sorted_power_events_set = sorted_power_events.into_iter().collect::<EventIdSet<_>>();
     let remaining_events = full_conflicted_set
         .iter()
         .filter(|&id| !sorted_power_events_set.contains(id.borrow()))
@@ -262,9 +262,9 @@ where
 /// ## Returns
 ///
 /// Returns an iterator over all the event IDs that are not present in all the auth chains.
-fn auth_difference<Id>(auth_chains: Vec<HashSet<Id>>) -> impl Iterator<Item = Id>
+fn auth_difference<Id>(auth_chains: Vec<EventIdSet<Id>>) -> impl Iterator<Item = Id>
 where
-    Id: Eq + Hash,
+    Id: Eq + Hash + Borrow<EventId>,
 {
     let num_sets = auth_chains.len();
 
@@ -295,7 +295,7 @@ where
 #[instrument(skip_all)]
 fn sort_power_events<E: Event>(
     conflicted_power_events: Vec<E::Id>,
-    full_conflicted_set: &HashSet<E::Id>,
+    full_conflicted_set: &EventIdSet<E::Id>,
     rules: &AuthorizationRules,
     fetch_event: impl Fn(&EventId) -> Option<E>,
 ) -> Result<Vec<E::Id>> {
@@ -381,7 +381,7 @@ fn sort_power_events<E: Event>(
 /// Returns the ordered list of event IDs from earliest to latest.
 #[instrument(skip_all)]
 pub fn reverse_topological_power_sort<Id, F>(
-    graph: &HashMap<Id, HashSet<Id>>,
+    graph: &HashMap<Id, EventIdSet<Id>>,
     event_details_fn: F,
 ) -> Result<Vec<Id>>
 where
@@ -856,9 +856,9 @@ fn mainline_position<E: Event>(
 /// Add the event with the given event ID and all the events in its auth chain that are in the full
 /// conflicted set to the graph.
 fn add_event_and_auth_chain_to_graph<E: Event>(
-    graph: &mut HashMap<E::Id, HashSet<E::Id>>,
+    graph: &mut HashMap<E::Id, EventIdSet<E::Id>>,
     event_id: E::Id,
-    full_conflicted_set: &HashSet<E::Id>,
+    full_conflicted_set: &EventIdSet<E::Id>,
     fetch_event: impl Fn(&EventId) -> Option<E>,
 ) {
     let mut state = vec![event_id];

--- a/crates/ruma-state-res/src/state_res/tests.rs
+++ b/crates/ruma-state-res/src/state_res/tests.rs
@@ -1,5 +1,4 @@
 use js_int::{int, uint};
-use maplit::hashmap;
 use ruma_common::{
     MilliSecondsSinceUnixEpoch, RoomVersionId, owned_event_id,
     room_version_rules::AuthorizationRules,
@@ -8,7 +7,10 @@ use ruma_events::StateEventType;
 use test_log::test;
 
 use super::{StateMap, is_power_event};
-use crate::{test_utils::RoomTimelineFactory, utils::event_id_set::EventIdSet};
+use crate::{
+    test_utils::RoomTimelineFactory,
+    utils::{event_id_map::EventIdMap, event_id_set::EventIdSet},
+};
 
 #[test]
 fn test_sort_power_events() {
@@ -69,13 +71,14 @@ fn test_mainline_sort() {
 
 #[test]
 fn test_reverse_topological_power_sort() {
-    let graph = hashmap! {
-        owned_event_id!("$l") => EventIdSet::from([owned_event_id!("$o")]),
-        owned_event_id!("$m") => EventIdSet::from([owned_event_id!("$n"), owned_event_id!("$o")]),
-        owned_event_id!("$n") => EventIdSet::from([owned_event_id!("$o")]),
-        owned_event_id!("$o") => EventIdSet::new(), // "o" has zero outgoing edges but 4 incoming edges
-        owned_event_id!("$p") => EventIdSet::from([owned_event_id!("$o")]),
-    };
+    let graph = EventIdMap::from([
+        (owned_event_id!("$l"), EventIdSet::from([owned_event_id!("$o")])),
+        (owned_event_id!("$m"), EventIdSet::from([owned_event_id!("$n"), owned_event_id!("$o")])),
+        (owned_event_id!("$n"), EventIdSet::from([owned_event_id!("$o")])),
+        (owned_event_id!("$o"), EventIdSet::new()), /* "o" has zero outgoing edges but 4
+                                                     * incoming edges */
+        (owned_event_id!("$p"), EventIdSet::from([owned_event_id!("$o")])),
+    ]);
 
     let sorted = crate::reverse_topological_power_sort(&graph, |_id| {
         Ok((int!(0).into(), MilliSecondsSinceUnixEpoch(uint!(0))))

--- a/crates/ruma-state-res/src/state_res/tests.rs
+++ b/crates/ruma-state-res/src/state_res/tests.rs
@@ -1,5 +1,5 @@
 use js_int::{int, uint};
-use maplit::{hashmap, hashset};
+use maplit::hashmap;
 use ruma_common::{
     MilliSecondsSinceUnixEpoch, RoomVersionId, owned_event_id,
     room_version_rules::AuthorizationRules,
@@ -8,7 +8,7 @@ use ruma_events::StateEventType;
 use test_log::test;
 
 use super::{StateMap, is_power_event};
-use crate::test_utils::RoomTimelineFactory;
+use crate::{test_utils::RoomTimelineFactory, utils::event_id_set::EventIdSet};
 
 #[test]
 fn test_sort_power_events() {
@@ -70,11 +70,11 @@ fn test_mainline_sort() {
 #[test]
 fn test_reverse_topological_power_sort() {
     let graph = hashmap! {
-        owned_event_id!("$l") => hashset![owned_event_id!("$o")],
-        owned_event_id!("$m") => hashset![owned_event_id!("$n"), owned_event_id!("$o")],
-        owned_event_id!("$n") => hashset![owned_event_id!("$o")],
-        owned_event_id!("$o") => hashset![], // "o" has zero outgoing edges but 4 incoming edges
-        owned_event_id!("$p") => hashset![owned_event_id!("$o")],
+        owned_event_id!("$l") => EventIdSet::from([owned_event_id!("$o")]),
+        owned_event_id!("$m") => EventIdSet::from([owned_event_id!("$n"), owned_event_id!("$o")]),
+        owned_event_id!("$n") => EventIdSet::from([owned_event_id!("$o")]),
+        owned_event_id!("$o") => EventIdSet::new(), // "o" has zero outgoing edges but 4 incoming edges
+        owned_event_id!("$p") => EventIdSet::from([owned_event_id!("$o")]),
     };
 
     let sorted = crate::reverse_topological_power_sort(&graph, |_id| {

--- a/crates/ruma-state-res/src/test_utils/factory.rs
+++ b/crates/ruma-state-res/src/test_utils/factory.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use js_int::{UInt, uint};
 use ruma_common::{
@@ -12,7 +12,9 @@ use ruma_events::{StateEventType, TimelineEventType};
 use serde_json::{json, to_value as to_json_value};
 
 use super::{Pdu, default_room_id};
-use crate::{StateMap, auth_types_for_event, events::RoomCreateEvent};
+use crate::{
+    StateMap, auth_types_for_event, events::RoomCreateEvent, utils::event_id_set::EventIdSet,
+};
 
 /// A helper type to build a room timeline.
 ///
@@ -161,8 +163,8 @@ impl RoomTimelineFactory {
     /// Get the full auth chain for the given state map.
     ///
     /// Panics if an event in the auth chain is missing from the map of PDUs.
-    pub fn full_auth_chain(&self, state_map: &StateMap<OwnedEventId>) -> HashSet<OwnedEventId> {
-        let mut auth_chain = HashSet::new();
+    pub fn full_auth_chain(&self, state_map: &StateMap<OwnedEventId>) -> EventIdSet<OwnedEventId> {
+        let mut auth_chain = EventIdSet::new();
         let mut stack = state_map.values().cloned().collect::<Vec<_>>();
 
         while let Some(event_id) = stack.pop() {
@@ -171,7 +173,7 @@ impl RoomTimelineFactory {
             stack.extend(
                 pdu.auth_events
                     .iter()
-                    .filter(|auth_event_id| !auth_chain.contains(*auth_event_id))
+                    .filter(|auth_event_id| !auth_chain.contains(auth_event_id))
                     .cloned(),
             );
 

--- a/crates/ruma-state-res/src/test_utils/factory.rs
+++ b/crates/ruma-state-res/src/test_utils/factory.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use js_int::{UInt, uint};
 use ruma_common::{
     EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedUserId, RoomVersionId,
@@ -13,7 +11,9 @@ use serde_json::{json, to_value as to_json_value};
 
 use super::{Pdu, default_room_id};
 use crate::{
-    StateMap, auth_types_for_event, events::RoomCreateEvent, utils::event_id_set::EventIdSet,
+    StateMap, auth_types_for_event,
+    events::RoomCreateEvent,
+    utils::{event_id_map::EventIdMap, event_id_set::EventIdSet},
 };
 
 /// A helper type to build a room timeline.
@@ -42,7 +42,7 @@ pub struct RoomTimelineFactory {
     server_ts: UInt,
 
     /// The PDUs in the room.
-    pdus: HashMap<OwnedEventId, Pdu>,
+    pdus: EventIdMap<OwnedEventId, Pdu>,
 
     /// The ordered list of PDUs in the timeline.
     ///
@@ -97,7 +97,7 @@ impl RoomTimelineFactory {
     }
 
     /// Get a reference to map of PDUs.
-    pub fn pdus(&self) -> &HashMap<OwnedEventId, Pdu> {
+    pub fn pdus(&self) -> &EventIdMap<OwnedEventId, Pdu> {
         &self.pdus
     }
 
@@ -231,7 +231,7 @@ impl RoomTimelineFactory {
 
         self.timeline.push(event_id.clone());
 
-        self.pdus.entry(event_id).insert_entry(pdu).into_mut()
+        self.pdus.entry(event_id).insert_entry(pdu)
     }
 
     /// Create an `m.room.member` event prepared to be added to the timeline.

--- a/crates/ruma-state-res/src/utils.rs
+++ b/crates/ruma-state-res/src/utils.rs
@@ -2,6 +2,7 @@
 
 use ruma_common::{EventId, IdParseError, OwnedEventId, RoomId};
 
+pub mod event_id_map;
 pub mod event_id_set;
 
 /// Convenience extension trait for [`RoomId`].

--- a/crates/ruma-state-res/src/utils.rs
+++ b/crates/ruma-state-res/src/utils.rs
@@ -1,4 +1,8 @@
+//! Helper types.
+
 use ruma_common::{EventId, IdParseError, OwnedEventId, RoomId};
+
+pub mod event_id_set;
 
 /// Convenience extension trait for [`RoomId`].
 pub(crate) trait RoomIdExt {

--- a/crates/ruma-state-res/src/utils/event_id_map.rs
+++ b/crates/ruma-state-res/src/utils/event_id_map.rs
@@ -1,0 +1,412 @@
+//! A map of event IDs to a type `V`.
+
+use std::{
+    borrow::Borrow,
+    collections::{HashMap, hash_map},
+    hash::Hash,
+    iter::FusedIterator,
+    ops::Index,
+};
+
+use ruma_common::EventId;
+
+/// A map of event IDs to a type `V`.
+#[derive(Clone, Debug)]
+pub struct EventIdMap<E: Borrow<EventId>, V>(HashMap<E, V>);
+
+impl<E: Borrow<EventId>, V> EventIdMap<E, V> {
+    /// Create an empty `EventIdMap`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create an empty `EventIdMap` with the given capacity.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self(HashMap::with_capacity(capacity))
+    }
+
+    /// Clears the map, removing all key-value pairs.
+    pub fn clear(&mut self) {
+        self.0.clear();
+    }
+
+    /// Returns the number of elements in the map.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns `true` if the map contains no elements.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Gets an iterator over the entries of the map.
+    pub fn iter(&self) -> EventIdMapIter<'_, E, V> {
+        EventIdMapIter(self.0.iter())
+    }
+
+    /// Gets an iterator over the keys of the map.
+    pub fn keys(&self) -> EventIdMapKeys<'_, E, V> {
+        EventIdMapKeys(self.0.keys())
+    }
+
+    /// Gets an iterator over the keys of the map.
+    pub fn into_keys(self) -> EventIdMapIntoKeys<E, V> {
+        EventIdMapIntoKeys(self.0.into_keys())
+    }
+
+    /// Gets an iterator over the values of the map.
+    pub fn values(&self) -> EventIdMapValues<'_, E, V> {
+        EventIdMapValues(self.0.values())
+    }
+
+    /// Gets an iterator over the values of the map.
+    pub fn into_values(self) -> EventIdMapIntoValues<E, V> {
+        EventIdMapIntoValues(self.0.into_values())
+    }
+}
+
+impl<E, V> EventIdMap<E, V>
+where
+    E: Borrow<EventId> + Eq + Hash,
+{
+    /// Returns `true` if the map contains a value for the specified event ID.
+    pub fn contains_event_id(&self, event_id: &EventId) -> bool {
+        self.0.contains_key(event_id)
+    }
+
+    /// Returns a reference to the value corresponding to given event ID.
+    pub fn get(&self, event_id: &EventId) -> Option<&V> {
+        self.0.get(event_id)
+    }
+
+    /// Returns a mutable reference to the value corresponding to given event ID.
+    pub fn get_mut(&mut self, event_id: &EventId) -> Option<&mut V> {
+        self.0.get_mut(event_id)
+    }
+
+    /// Returns the key-value pair corresponding to the supplied event ID.
+    pub fn get_key_value(&self, event_id: &EventId) -> Option<(&E, &V)> {
+        self.0.get_key_value(event_id)
+    }
+
+    /// Gets the given event ID's corresponding entry in the map for in-place manipulation.
+    pub fn entry(&mut self, event_id: E) -> EventIdMapEntry<'_, E, V> {
+        EventIdMapEntry(self.0.entry(event_id))
+    }
+
+    /// Inserts a key-value pair into the map.
+    ///
+    /// If the map did not have this event ID present, `None` is returned.
+    ///
+    /// If the map did have this event ID present, the value is updated, and the old value is
+    /// returned.
+    pub fn insert(&mut self, event_id: E, value: V) -> Option<V> {
+        self.0.insert(event_id, value)
+    }
+
+    /// Removes an event ID from the map, returning the value at the event ID if the event ID was
+    /// previously in the map.
+    pub fn remove(&mut self, event_id: &EventId) -> Option<V> {
+        self.0.remove(event_id)
+    }
+
+    /// Removes an event ID from the map, returning the stored event ID and value if the event ID
+    /// was previously in the map.
+    pub fn remove_entry(&mut self, event_id: &EventId) -> Option<(E, V)> {
+        self.0.remove_entry(event_id)
+    }
+}
+
+impl<E: Borrow<EventId>, V> Default for EventIdMap<E, V> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
+impl<E, V> Index<&EventId> for EventIdMap<E, V>
+where
+    E: Borrow<EventId> + Hash + Eq,
+{
+    type Output = V;
+
+    fn index(&self, event_id: &EventId) -> &Self::Output {
+        &self.0[event_id]
+    }
+}
+
+impl<E, V, const N: usize> From<[(E, V); N]> for EventIdMap<E, V>
+where
+    E: Borrow<EventId> + Hash + Eq,
+{
+    fn from(value: [(E, V); N]) -> Self {
+        Self(value.into())
+    }
+}
+
+impl<E, V> Extend<(E, V)> for EventIdMap<E, V>
+where
+    E: Borrow<EventId> + Hash + Eq,
+{
+    fn extend<T: IntoIterator<Item = (E, V)>>(&mut self, iter: T) {
+        self.0.extend(iter);
+    }
+}
+
+impl<E, V> FromIterator<(E, V)> for EventIdMap<E, V>
+where
+    E: Borrow<EventId> + Hash + Eq,
+{
+    fn from_iter<T: IntoIterator<Item = (E, V)>>(iter: T) -> Self {
+        Self(HashMap::from_iter(iter))
+    }
+}
+
+impl<E: Borrow<EventId>, V> IntoIterator for EventIdMap<E, V> {
+    type Item = (E, V);
+    type IntoIter = EventIdMapIntoIter<E, V>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        EventIdMapIntoIter(self.0.into_iter())
+    }
+}
+
+impl<'a, E: Borrow<EventId>, V> IntoIterator for &'a EventIdMap<E, V> {
+    type Item = (&'a E, &'a V);
+    type IntoIter = EventIdMapIter<'a, E, V>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+/// An iterator over the entries of an [`EventIdMap`].
+#[derive(Clone, Debug)]
+pub struct EventIdMapIter<'a, E, V>(hash_map::Iter<'a, E, V>);
+
+impl<'a, E, V> Iterator for EventIdMapIter<'a, E, V> {
+    type Item = (&'a E, &'a V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+
+    fn count(self) -> usize {
+        self.0.len()
+    }
+
+    fn fold<B, F>(self, init: B, f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        self.0.fold(init, f)
+    }
+}
+
+impl<'a, E, V> ExactSizeIterator for EventIdMapIter<'a, E, V> {}
+
+impl<'a, E, V> FusedIterator for EventIdMapIter<'a, E, V> {}
+
+/// An iterator over the entries of an [`EventIdMap`].
+#[derive(Debug)]
+pub struct EventIdMapIntoIter<E, V>(hash_map::IntoIter<E, V>);
+
+impl<E, V> Iterator for EventIdMapIntoIter<E, V> {
+    type Item = (E, V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+
+    fn count(self) -> usize {
+        self.0.len()
+    }
+
+    fn fold<B, F>(self, init: B, f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        self.0.fold(init, f)
+    }
+}
+
+impl<E, V> ExactSizeIterator for EventIdMapIntoIter<E, V> {}
+
+impl<E, V> FusedIterator for EventIdMapIntoIter<E, V> {}
+
+/// An iterator over the keys of an [`EventIdMap`].
+#[derive(Clone, Debug)]
+pub struct EventIdMapKeys<'a, E, V>(hash_map::Keys<'a, E, V>);
+
+impl<'a, E, V> Iterator for EventIdMapKeys<'a, E, V> {
+    type Item = &'a E;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+
+    fn count(self) -> usize {
+        self.0.len()
+    }
+
+    fn fold<B, F>(self, init: B, f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        self.0.fold(init, f)
+    }
+}
+
+impl<'a, E, V> ExactSizeIterator for EventIdMapKeys<'a, E, V> {}
+
+impl<'a, E, V> FusedIterator for EventIdMapKeys<'a, E, V> {}
+
+/// An iterator over the keys of an [`EventIdMap`].
+#[derive(Debug)]
+pub struct EventIdMapIntoKeys<E, V>(hash_map::IntoKeys<E, V>);
+
+impl<E, V> Iterator for EventIdMapIntoKeys<E, V> {
+    type Item = E;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+
+    fn count(self) -> usize {
+        self.0.len()
+    }
+
+    fn fold<B, F>(self, init: B, f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        self.0.fold(init, f)
+    }
+}
+
+impl<E, V> ExactSizeIterator for EventIdMapIntoKeys<E, V> {}
+
+impl<E, V> FusedIterator for EventIdMapIntoKeys<E, V> {}
+
+/// An iterator over the values of an [`EventIdMap`].
+#[derive(Clone, Debug)]
+pub struct EventIdMapValues<'a, E, V>(hash_map::Values<'a, E, V>);
+
+impl<'a, E, V> Iterator for EventIdMapValues<'a, E, V> {
+    type Item = &'a V;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+
+    fn count(self) -> usize {
+        self.0.len()
+    }
+
+    fn fold<B, F>(self, init: B, f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        self.0.fold(init, f)
+    }
+}
+
+impl<'a, E, V> ExactSizeIterator for EventIdMapValues<'a, E, V> {}
+
+impl<'a, E, V> FusedIterator for EventIdMapValues<'a, E, V> {}
+
+/// An iterator over the values of an [`EventIdMap`].
+#[derive(Debug)]
+pub struct EventIdMapIntoValues<E, V>(hash_map::IntoValues<E, V>);
+
+impl<E, V> Iterator for EventIdMapIntoValues<E, V> {
+    type Item = V;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+
+    fn count(self) -> usize {
+        self.0.len()
+    }
+
+    fn fold<B, F>(self, init: B, f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        self.0.fold(init, f)
+    }
+}
+
+impl<E, V> ExactSizeIterator for EventIdMapIntoValues<E, V> {}
+
+impl<E, V> FusedIterator for EventIdMapIntoValues<E, V> {}
+
+/// A view into a single entry in an [`EventIdMap`].
+#[derive(Debug)]
+pub struct EventIdMapEntry<'a, E: Borrow<EventId>, V>(hash_map::Entry<'a, E, V>);
+
+impl<'a, E: Borrow<EventId>, V> EventIdMapEntry<'a, E, V> {
+    /// Ensures a value is in the entry by inserting the default if empty, and returns a mutable
+    /// reference to the value in the entry.
+    pub fn or_insert(self, default: V) -> &'a mut V {
+        self.0.or_insert(default)
+    }
+
+    /// Ensures a value is in the entry by inserting the result of the default function if empty,
+    /// and returns a mutable reference to the value in the entry.
+    pub fn or_insert_with<F: FnOnce() -> V>(self, default: F) -> &'a mut V {
+        self.0.or_insert_with(default)
+    }
+
+    /// Ensures a value is in the entry by inserting, if empty, the result of the default function.
+    ///
+    /// This method allows for generating key-derived values for insertion by providing the default
+    /// function a reference to the key that was moved during the .entry(key) method call.
+    pub fn or_insert_with_key<F: FnOnce(&E) -> V>(self, default: F) -> &'a mut V {
+        self.0.or_insert_with_key(default)
+    }
+
+    /// Sets the value of the entry, and returns a mutable reference to the value.
+    pub fn insert_entry(self, value: V) -> &'a mut V {
+        self.0.insert_entry(value).into_mut()
+    }
+}
+
+impl<'a, E: Borrow<EventId>, V: Default> EventIdMapEntry<'a, E, V> {
+    /// Ensures a value is in the entry by inserting the default value if empty, and returns a
+    /// mutable reference to the value in the entry.
+    pub fn or_default(self) -> &'a mut V {
+        self.0.or_default()
+    }
+}

--- a/crates/ruma-state-res/src/utils/event_id_set.rs
+++ b/crates/ruma-state-res/src/utils/event_id_set.rs
@@ -1,0 +1,240 @@
+//! A set of event IDs.
+
+use std::{
+    borrow::Borrow,
+    collections::{HashSet, hash_set},
+    fmt,
+    hash::{Hash, RandomState},
+    iter::FusedIterator,
+};
+
+use ruma_common::EventId;
+
+/// A set of event IDs.
+#[derive(Clone, Debug)]
+pub struct EventIdSet<E: Borrow<EventId>>(HashSet<E>);
+
+impl<E: Borrow<EventId>> EventIdSet<E> {
+    /// Create an empty `EventIdSet`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create an empty `EventIdSet` with the given capacity.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self(HashSet::with_capacity(capacity))
+    }
+
+    /// Clears the set, removing all event IDs.
+    pub fn clear(&mut self) {
+        self.0.clear();
+    }
+
+    /// Returns the number of elements in the set.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns `true` if the set contains no elements.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Gets an iterator over the elements of the set.
+    pub fn iter(&self) -> EventIdSetIter<'_, E> {
+        EventIdSetIter(self.0.iter())
+    }
+}
+
+impl<E> EventIdSet<E>
+where
+    E: Borrow<EventId> + Eq + Hash,
+{
+    /// Returns `true` if the set contains the specified event ID.
+    pub fn contains(&self, event_id: &EventId) -> bool {
+        self.0.contains(event_id)
+    }
+
+    /// Returns a reference to the event ID in the set, if any, that is equal to the given one.
+    pub fn get(&self, event_id: &EventId) -> Option<&E> {
+        self.0.get(event_id)
+    }
+
+    /// Adds an event ID to the set.
+    ///
+    /// Returns whether the ID was newly inserted.
+    pub fn insert(&mut self, event_id: E) -> bool {
+        self.0.insert(event_id)
+    }
+
+    /// Removes an event ID from the set.
+    ///
+    /// Returns whether the ID was present in the set.
+    pub fn remove(&mut self, event_id: &EventId) -> bool {
+        self.0.remove(event_id)
+    }
+
+    /// Removes and returns the event ID in the set, if any, that is equal to the given one.
+    pub fn take(&mut self, event_id: &EventId) -> Option<E> {
+        self.0.take(event_id)
+    }
+
+    /// Visits the values representing the intersection, i.e., the values that are both in self and
+    /// other.
+    pub fn intersection<'a>(&'a self, other: &'a Self) -> EventIdSetIntersection<'a, E> {
+        EventIdSetIntersection(self.0.intersection(&other.0))
+    }
+}
+
+impl<E: Borrow<EventId>> Default for EventIdSet<E> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
+impl<E, const N: usize> From<[E; N]> for EventIdSet<E>
+where
+    E: Borrow<EventId> + Hash + Eq,
+{
+    fn from(value: [E; N]) -> Self {
+        Self(value.into())
+    }
+}
+
+impl<E> Extend<E> for EventIdSet<E>
+where
+    E: Borrow<EventId> + Hash + Eq,
+{
+    fn extend<T: IntoIterator<Item = E>>(&mut self, iter: T) {
+        self.0.extend(iter);
+    }
+}
+
+impl<E> FromIterator<E> for EventIdSet<E>
+where
+    E: Borrow<EventId> + Hash + Eq,
+{
+    fn from_iter<T: IntoIterator<Item = E>>(iter: T) -> Self {
+        Self(HashSet::from_iter(iter))
+    }
+}
+
+impl<E: Borrow<EventId>> IntoIterator for EventIdSet<E> {
+    type Item = E;
+    type IntoIter = EventIdSetIntoIter<E>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        EventIdSetIntoIter(self.0.into_iter())
+    }
+}
+
+impl<'a, E: Borrow<EventId>> IntoIterator for &'a EventIdSet<E> {
+    type Item = &'a E;
+    type IntoIter = EventIdSetIter<'a, E>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+/// An iterator over the values of an [`EventIdSet`].
+#[derive(Clone, Debug)]
+pub struct EventIdSetIter<'a, E>(hash_set::Iter<'a, E>);
+
+impl<'a, E> Iterator for EventIdSetIter<'a, E> {
+    type Item = &'a E;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+
+    fn count(self) -> usize {
+        self.0.len()
+    }
+
+    fn fold<B, F>(self, init: B, f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        self.0.fold(init, f)
+    }
+}
+
+impl<'a, E> ExactSizeIterator for EventIdSetIter<'a, E> {}
+
+impl<'a, E> FusedIterator for EventIdSetIter<'a, E> {}
+
+/// An iterator over the values of an [`EventIdSet`].
+#[derive(Debug)]
+pub struct EventIdSetIntoIter<E>(hash_set::IntoIter<E>);
+
+impl<E> Iterator for EventIdSetIntoIter<E> {
+    type Item = E;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+
+    fn count(self) -> usize {
+        self.0.len()
+    }
+
+    fn fold<B, F>(self, init: B, f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        self.0.fold(init, f)
+    }
+}
+
+impl<E> ExactSizeIterator for EventIdSetIntoIter<E> {}
+
+impl<E> FusedIterator for EventIdSetIntoIter<E> {}
+
+/// A lazy iterator producing elements in the intersection of [`EventIdSet`]s.
+#[derive(Clone)]
+pub struct EventIdSetIntersection<'a, E>(hash_set::Intersection<'a, E, RandomState>);
+
+impl<'a, E> fmt::Debug for EventIdSetIntersection<'a, E>
+where
+    E: fmt::Debug + Eq + Hash,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("EventIdSetIntersection").field(&self.0).finish()
+    }
+}
+
+impl<'a, E> Iterator for EventIdSetIntersection<'a, E>
+where
+    E: Eq + Hash,
+{
+    type Item = &'a E;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+
+    fn fold<B, F>(self, init: B, f: F) -> B
+    where
+        Self: Sized,
+        F: FnMut(B, Self::Item) -> B,
+    {
+        self.0.fold(init, f)
+    }
+}
+
+impl<'a, E> FusedIterator for EventIdSetIntersection<'a, E> where E: Eq + Hash {}

--- a/crates/ruma-state-res/tests/it/resolve/macros.rs
+++ b/crates/ruma-state-res/tests/it/resolve/macros.rs
@@ -1,11 +1,5 @@
 use std::{
-    cmp::Ordering,
-    collections::{BTreeSet, HashMap},
-    error::Error,
-    fs,
-    ops::Deref,
-    path::Path,
-    sync::LazyLock,
+    cmp::Ordering, collections::BTreeSet, error::Error, fs, ops::Deref, path::Path, sync::LazyLock,
 };
 
 use ruma_common::{
@@ -14,7 +8,10 @@ use ruma_common::{
 };
 use ruma_events::{StateEventType, TimelineEventType};
 use ruma_state_res::{
-    Event, StateMap, events::RoomCreateEvent, resolve, utils::event_id_set::EventIdSet,
+    Event, StateMap,
+    events::RoomCreateEvent,
+    resolve,
+    utils::{event_id_map::EventIdMap, event_id_set::EventIdSet},
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{
@@ -148,7 +145,7 @@ pub(super) fn test_resolve_batches(pdus_paths: &[&str]) -> String {
     .expect("iterative state resolution should succeed");
 
     // Resolve PDUs in batches by file.
-    let mut pdus_map = HashMap::new();
+    let mut pdus_map = EventIdMap::new();
     let mut batched_resolved_state = None;
     for pdus in &pdu_batches {
         batched_resolved_state = Some(
@@ -170,7 +167,7 @@ pub(super) fn test_resolve_batches(pdus_paths: &[&str]) -> String {
         pdu_batches.iter().flat_map(|x| x.iter()),
         &auth_rules,
         &state_res_rules,
-        &mut HashMap::new(),
+        &mut EventIdMap::new(),
         None,
     )
     .expect("atomic state resolution should succeed");
@@ -212,7 +209,7 @@ pub(super) fn test_resolve_state_maps(state_maps_paths: &[&str], pdus_paths: &[&
     let (pdu_batches, auth_rules, state_res_rules) = load_pdus_and_room_version_rules(pdus_paths);
 
     let pdus = pdu_batches.into_iter().flat_map(|x| x.into_iter()).collect::<Vec<_>>();
-    let pdus_map: HashMap<OwnedEventId, Pdu> =
+    let pdus_map: EventIdMap<OwnedEventId, Pdu> =
         pdus.clone().into_iter().map(|pdu| (pdu.event_id().to_owned(), pdu.to_owned())).collect();
 
     let state_maps = load_state_maps(state_maps_paths, &pdus_map);
@@ -301,7 +298,7 @@ fn load_pdus_and_room_version_rules(
 ///   and `state_key`.
 fn load_state_maps(
     state_maps_paths: &[&str],
-    pdus_map: &HashMap<OwnedEventId, Pdu>,
+    pdus_map: &EventIdMap<OwnedEventId, Pdu>,
 ) -> Vec<StateMap<OwnedEventId>> {
     state_maps_paths
         .iter()
@@ -351,7 +348,7 @@ fn resolve_batch<'a, I>(
     pdus: I,
     auth_rules: &AuthorizationRules,
     state_res_rules: &StateResolutionV2Rules,
-    pdus_map: &mut HashMap<OwnedEventId, Pdu>,
+    pdus_map: &mut EventIdMap<OwnedEventId, Pdu>,
     prev_state: Option<StateMap<OwnedEventId>>,
 ) -> Result<StateMap<OwnedEventId>, Box<dyn Error>>
 where
@@ -417,7 +414,7 @@ fn resolve_iteratively<'a, I>(
 where
     I: IntoIterator<Item = &'a Pdu> + Clone,
 {
-    let mut forward_prev_events_graph: HashMap<&_, Vec<_>> = HashMap::new();
+    let mut forward_prev_events_graph: EventIdMap<&EventId, Vec<_>> = EventIdMap::new();
     let mut stack = Vec::new();
 
     for pdu in pdus.clone() {
@@ -431,8 +428,9 @@ where
         }
     }
 
-    let pdus_map: HashMap<OwnedEventId, Pdu> =
-        HashMap::from_iter(pdus.into_iter().map(|pdu| (pdu.event_id().to_owned(), pdu.to_owned())));
+    let pdus_map: EventIdMap<OwnedEventId, Pdu> = EventIdMap::from_iter(
+        pdus.into_iter().map(|pdu| (pdu.event_id().to_owned(), pdu.to_owned())),
+    );
 
     let auth_chain_from_state_map =
         |state_map: &StateMap<OwnedEventId>| -> Result<_, Box<dyn Error>> {
@@ -446,7 +444,7 @@ where
             Ok(auth_chain_sets)
         };
 
-    let mut state_at_events: HashMap<OwnedEventId, StateMap<OwnedEventId>> = HashMap::new();
+    let mut state_at_events: EventIdMap<OwnedEventId, StateMap<OwnedEventId>> = EventIdMap::new();
     let mut leaves = Vec::new();
 
     'outer: while let Some(event_id) = stack.pop() {
@@ -546,7 +544,7 @@ where
 /// # Panic
 ///
 /// Panics if `pdus_map` does not contain a PDU that appears in the auth chain of `pdu`.
-fn pdu_auth_chain(pdu: &Pdu, pdus_map: &HashMap<OwnedEventId, Pdu>) -> EventIdSet<OwnedEventId> {
+fn pdu_auth_chain(pdu: &Pdu, pdus_map: &EventIdMap<OwnedEventId, Pdu>) -> EventIdSet<OwnedEventId> {
     let mut auth_chain = EventIdSet::new();
     let mut stack = pdu.auth_events().cloned().collect::<Vec<_>>();
 
@@ -569,7 +567,7 @@ fn pdu_auth_chain(pdu: &Pdu, pdus_map: &HashMap<OwnedEventId, Pdu>) -> EventIdSe
 /// Construct the conflicted state subgraph for the given conflicted state set.
 fn conflicted_state_subgraph(
     conflicted_state_set: &StateMap<Vec<OwnedEventId>>,
-    pdus_map: &HashMap<OwnedEventId, Pdu>,
+    pdus_map: &EventIdMap<OwnedEventId, Pdu>,
 ) -> Option<EventIdSet<OwnedEventId>> {
     let conflicted_event_ids: EventIdSet<_> =
         conflicted_state_set.values().flatten().cloned().collect();
@@ -738,7 +736,7 @@ impl PartialOrd for ResolvedStateEvent<'_> {
 /// and `content` fields.
 fn state_map_to_json_string(
     state_map: StateMap<OwnedEventId>,
-    pdus_map: &HashMap<OwnedEventId, Pdu>,
+    pdus_map: &EventIdMap<OwnedEventId, Pdu>,
 ) -> String {
     let resolved_state = state_map
         .iter()

--- a/crates/ruma-state-res/tests/it/resolve/macros.rs
+++ b/crates/ruma-state-res/tests/it/resolve/macros.rs
@@ -1,6 +1,6 @@
 use std::{
     cmp::Ordering,
-    collections::{BTreeSet, HashMap, HashSet},
+    collections::{BTreeSet, HashMap},
     error::Error,
     fs,
     ops::Deref,
@@ -13,7 +13,9 @@ use ruma_common::{
     room_version_rules::{AuthorizationRules, StateResolutionV2Rules},
 };
 use ruma_events::{StateEventType, TimelineEventType};
-use ruma_state_res::{Event, StateMap, events::RoomCreateEvent, resolve};
+use ruma_state_res::{
+    Event, StateMap, events::RoomCreateEvent, resolve, utils::event_id_set::EventIdSet,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::{
     from_str as from_json_str, to_string_pretty as to_json_string_pretty,
@@ -217,7 +219,7 @@ pub(super) fn test_resolve_state_maps(state_maps_paths: &[&str], pdus_paths: &[&
 
     let mut auth_chain_sets = Vec::new();
     for state_map in &state_maps {
-        let mut auth_chain = HashSet::new();
+        let mut auth_chain = EventIdSet::new();
 
         for event_id in state_map.values() {
             let pdu = pdus_map
@@ -434,7 +436,7 @@ where
 
     let auth_chain_from_state_map =
         |state_map: &StateMap<OwnedEventId>| -> Result<_, Box<dyn Error>> {
-            let mut auth_chain_sets = HashSet::new();
+            let mut auth_chain_sets = EventIdSet::new();
 
             for event_id in state_map.values() {
                 let pdu = pdus_map.get(event_id).expect("every pdu should be available");
@@ -544,8 +546,8 @@ where
 /// # Panic
 ///
 /// Panics if `pdus_map` does not contain a PDU that appears in the auth chain of `pdu`.
-fn pdu_auth_chain(pdu: &Pdu, pdus_map: &HashMap<OwnedEventId, Pdu>) -> HashSet<OwnedEventId> {
-    let mut auth_chain = HashSet::new();
+fn pdu_auth_chain(pdu: &Pdu, pdus_map: &HashMap<OwnedEventId, Pdu>) -> EventIdSet<OwnedEventId> {
+    let mut auth_chain = EventIdSet::new();
     let mut stack = pdu.auth_events().cloned().collect::<Vec<_>>();
 
     while let Some(event_id) = stack.pop() {
@@ -568,15 +570,15 @@ fn pdu_auth_chain(pdu: &Pdu, pdus_map: &HashMap<OwnedEventId, Pdu>) -> HashSet<O
 fn conflicted_state_subgraph(
     conflicted_state_set: &StateMap<Vec<OwnedEventId>>,
     pdus_map: &HashMap<OwnedEventId, Pdu>,
-) -> Option<HashSet<OwnedEventId>> {
-    let conflicted_event_ids: HashSet<_> =
+) -> Option<EventIdSet<OwnedEventId>> {
+    let conflicted_event_ids: EventIdSet<_> =
         conflicted_state_set.values().flatten().cloned().collect();
-    let mut conflicted_state_subgraph = HashSet::new();
+    let mut conflicted_state_subgraph = EventIdSet::new();
 
     let mut stack = vec![conflicted_event_ids.iter().cloned().collect::<Vec<_>>()];
     let mut path = Vec::new();
 
-    let mut seen_events = HashSet::new();
+    let mut seen_events = EventIdSet::new();
 
     let next_event = |stack: &mut Vec<Vec<_>>, path: &mut Vec<_>| {
         while stack.last().is_some_and(|s| s.is_empty()) {


### PR DESCRIPTION
To replace the `HashSet<Id>` and `HashMap<Id, T>` types and allow to possibly use a more efficient backing implementation in the future, because event IDs are all hashes since room version 3.

Closes #2154.