### PR TITLE
federation-api: Add unstable support for MSC4447

### DIFF
--- a/crates/ruma-federation-api/CHANGELOG.md
+++ b/crates/ruma-federation-api/CHANGELOG.md
@@ -21,6 +21,7 @@ Improvements:
 
 - Add the Policy Server event signing endpoint, according to MSC4284 / Matrix
   1.18.
+- Add unstable support for MSC4447.
 
 ## 0.13.1
 

--- a/crates/ruma-federation-api/Cargo.toml
+++ b/crates/ruma-federation-api/Cargo.toml
@@ -25,6 +25,7 @@ unstable-msc3618 = []
 unstable-msc3723 = []
 unstable-msc3843 = ["ruma-common/unstable-msc3843"]
 unstable-msc4125 = []
+unstable-msc4447 = []
 
 [dependencies]
 bytes = { workspace = true, optional = true }

--- a/crates/ruma-federation-api/src/openid.rs
+++ b/crates/ruma-federation-api/src/openid.rs
@@ -1,3 +1,5 @@
 //! OpenID endpoints.
 
 pub mod get_openid_userinfo;
+#[cfg(feature = "unstable-msc4447")]
+pub mod openid_userinfo;

--- a/crates/ruma-federation-api/src/openid/openid_userinfo.rs
+++ b/crates/ruma-federation-api/src/openid/openid_userinfo.rs
@@ -1,0 +1,51 @@
+//! `GET /_matrix/openid/*/userinfo`
+//!
+//! Exchange an OpenID access token for information about the user who generated the token.
+
+pub mod v1 {
+    //! `/v1/` ([MSC])
+    //!
+    //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/4447/
+
+    use ruma_common::{
+        OwnedUserId,
+        api::{auth_scheme::NoAuthentication, request, response},
+        metadata,
+    };
+
+    metadata! {
+        method: GET,
+        rate_limited: false,
+        authentication: NoAuthentication,
+        path: "/_matrix/openid/v1/userinfo",
+    }
+
+    /// Request type for the `openid_userinfo` endpoint.
+    #[request]
+    pub struct Request {
+        /// The OpenID access token to get information about the owner for.
+        #[ruma_api(query)]
+        pub access_token: String,
+    }
+
+    /// Response type for the `openid_userinfo` endpoint.
+    #[response]
+    pub struct Response {
+        /// The Matrix User ID who generated the token.
+        pub sub: OwnedUserId,
+    }
+
+    impl Request {
+        /// Creates a new `Request` with the given access token.
+        pub fn new(access_token: String) -> Self {
+            Self { access_token }
+        }
+    }
+
+    impl Response {
+        /// Creates a new `Response` with the given user id.
+        pub fn new(sub: OwnedUserId) -> Self {
+            Self { sub }
+        }
+    }
+}

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -197,6 +197,7 @@ unstable-msc4380 = ["ruma-events?/unstable-msc4380"]
 unstable-msc4385 = ["ruma-events?/unstable-msc4385"]
 unstable-msc4388 = ["ruma-client-api?/unstable-msc4388"]
 unstable-msc4439 = ["ruma-client-api?/unstable-msc4439"]
+unstable-msc4447 = ["ruma-federation-api?/unstable-msc4447"]
 unstable-uniffi = ["ruma-events?/unstable-uniffi"]
 
 [dependencies]


### PR DESCRIPTION
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
This is almost an exact copy of the existing OpenID endpoint, just with a different name.