### PR TITLE
client-api: Add a `new` method to `delete_3pid::v3::response`

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -60,6 +60,7 @@ Bug fixes:
 - In the `search::search_events::v3` module, fix the deserialization of:
   - `Criteria` when the `filter` field is omitted.
   - `SearchResult` when the `context` field is omitted.
+- Add a `new()` method to `account::delete_3pid::v3::Response`, allowing it to be constructed.
 
 Improvements:
 

--- a/crates/ruma-client-api/src/account/delete_3pid.rs
+++ b/crates/ruma-client-api/src/account/delete_3pid.rs
@@ -52,4 +52,11 @@ pub mod v3 {
             Self { id_server: None, medium, address }
         }
     }
+
+    impl Response {
+        /// Creates a new `Response` with the given unbind result.
+        pub fn new(id_server_unbind_result: ThirdPartyIdRemovalStatus) -> Self {
+            Self { id_server_unbind_result }
+        }
+    }
 }


### PR DESCRIPTION
This is necessary to allow the struct to be created in consuming crates.