### PR TITLE
state-res: Use `EventIdMap` and `EventIdSet` in `reverse_topological_power_sort`

### DIFF
--- a/crates/ruma-state-res/src/state_res.rs
+++ b/crates/ruma-state-res/src/state_res.rs
@@ -428,7 +428,8 @@ where
     let mut incoming_edges_map: HashMap<_, HashSet<_>> = HashMap::new();
 
     // Vec of events that have an outdegree of zero (no outgoing edges), i.e. the oldest events.
-    let mut zero_outdegrees = Vec::new();
+    // Use a BinaryHeap to keep the events sorted.
+    let mut heap = BinaryHeap::new();
 
     // Populate the list of events with an outdegree of zero, and the maps of incoming and outgoing
     // edges with the graph.
@@ -438,7 +439,7 @@ where
 
             // `Reverse` because `BinaryHeap` sorts largest -> smallest and we need
             // smallest -> largest.
-            zero_outdegrees.push(Reverse(TieBreaker {
+            heap.push(Reverse(TieBreaker {
                 power_level,
                 origin_server_ts,
                 event_id: event_id.clone(),
@@ -453,8 +454,6 @@ where
         }
     }
 
-    // Use a BinaryHeap to keep the events with an outdegree of zero sorted.
-    let mut heap = BinaryHeap::from(zero_outdegrees);
     let mut sorted = vec![];
 
     // Apply Kahn's algorithm.

--- a/crates/ruma-state-res/src/state_res.rs
+++ b/crates/ruma-state-res/src/state_res.rs
@@ -422,7 +422,7 @@ where
     // an incoming edge to its auth events.
 
     // Map of event to the list of events in its auth events.
-    let mut outgoing_edges_map = graph.clone();
+    let mut outgoing_edges_map: HashMap<_, HashSet<_>> = HashMap::new();
 
     // Map of event to the list of events that reference it in its auth events.
     let mut incoming_edges_map: HashMap<_, HashSet<_>> = HashMap::new();
@@ -430,7 +430,8 @@ where
     // Vec of events that have an outdegree of zero (no outgoing edges), i.e. the oldest events.
     let mut zero_outdegrees = Vec::new();
 
-    // Populate the list of events with an outdegree of zero, and the map of incoming edges.
+    // Populate the list of events with an outdegree of zero, and the maps of incoming and outgoing
+    // edges with the graph.
     for (event_id, outgoing_edges) in graph {
         if outgoing_edges.is_empty() {
             let (power_level, origin_server_ts) = event_details_fn(event_id.borrow())?;
@@ -442,6 +443,9 @@ where
             for auth_event_id in outgoing_edges {
                 incoming_edges_map.entry(auth_event_id).or_default().insert(event_id);
             }
+
+            outgoing_edges_map
+                .insert(event_id.clone(), outgoing_edges.iter().map(Borrow::borrow).collect());
         }
     }
 

--- a/crates/ruma-state-res/src/state_res.rs
+++ b/crates/ruma-state-res/src/state_res.rs
@@ -389,13 +389,13 @@ where
     Id: Clone + Eq + Ord + Hash + Borrow<EventId>,
 {
     #[derive(PartialEq, Eq)]
-    struct TieBreaker<'a, Id> {
+    struct TieBreaker<Id> {
         power_level: UserPowerLevel,
         origin_server_ts: MilliSecondsSinceUnixEpoch,
-        event_id: &'a Id,
+        event_id: Id,
     }
 
-    impl<Id> Ord for TieBreaker<'_, Id>
+    impl<Id> Ord for TieBreaker<Id>
     where
         Id: Ord,
     {
@@ -405,11 +405,11 @@ where
                 .power_level
                 .cmp(&self.power_level)
                 .then(self.origin_server_ts.cmp(&other.origin_server_ts))
-                .then(self.event_id.cmp(other.event_id))
+                .then(self.event_id.cmp(&other.event_id))
         }
     }
 
-    impl<Id> PartialOrd for TieBreaker<'_, Id>
+    impl<Id> PartialOrd for TieBreaker<Id>
     where
         Id: Ord,
     {
@@ -438,7 +438,11 @@ where
 
             // `Reverse` because `BinaryHeap` sorts largest -> smallest and we need
             // smallest -> largest.
-            zero_outdegrees.push(Reverse(TieBreaker { power_level, origin_server_ts, event_id }));
+            zero_outdegrees.push(Reverse(TieBreaker {
+                power_level,
+                origin_server_ts,
+                event_id: event_id.clone(),
+            }));
         } else {
             for auth_event_id in outgoing_edges {
                 incoming_edges_map.entry(auth_event_id).or_default().insert(event_id);
@@ -455,19 +459,26 @@ where
 
     // Apply Kahn's algorithm.
     // https://en.wikipedia.org/wiki/Topological_sorting#Kahn's_algorithm
-    while let Some(Reverse(item)) = heap.pop() {
-        let event_id = item.event_id;
+    while let Some(Reverse(TieBreaker { event_id, .. })) = heap.pop() {
+        for &parent_id in incoming_edges_map.get(&event_id).into_iter().flatten() {
+            let parent_has_zero_outdegrees = {
+                let outgoing_edges = outgoing_edges_map.get_mut(parent_id.borrow()).expect(
+                    "outgoing edges map should have a key for all event IDs with outgoing edges",
+                );
 
-        for &parent_id in incoming_edges_map.get(event_id).into_iter().flatten() {
-            let outgoing_edges = outgoing_edges_map
-                .get_mut(parent_id.borrow())
-                .expect("outgoing edges map should have a key for all event IDs");
-
-            outgoing_edges.remove(event_id.borrow());
+                outgoing_edges.remove(event_id.borrow());
+                outgoing_edges.is_empty()
+            };
 
             // Push on the heap once all the outgoing edges have been removed.
-            if outgoing_edges.is_empty() {
+            if parent_has_zero_outdegrees {
                 let (power_level, origin_server_ts) = event_details_fn(parent_id.borrow())?;
+                // Because the parent has no more outgoing edges, we can remove its entry from the
+                // outgoing edges map to get the owned event ID used for the key.
+                let (parent_id, _) = outgoing_edges_map
+                    .remove_entry(parent_id.borrow())
+                    .expect("outgoing edges map should have a key for all event IDs");
+
                 heap.push(Reverse(TieBreaker {
                     power_level,
                     origin_server_ts,
@@ -476,7 +487,7 @@ where
             }
         }
 
-        sorted.push(event_id.clone());
+        sorted.push(event_id);
     }
 
     Ok(sorted)

--- a/crates/ruma-state-res/src/state_res.rs
+++ b/crates/ruma-state-res/src/state_res.rs
@@ -422,10 +422,10 @@ where
     // an incoming edge to its auth events.
 
     // Map of event to the list of events in its auth events.
-    let mut outgoing_edges_map: HashMap<_, HashSet<_>> = HashMap::new();
+    let mut outgoing_edges_map: EventIdMap<_, EventIdSet<_>> = EventIdMap::new();
 
     // Map of event to the list of events that reference it in its auth events.
-    let mut incoming_edges_map: HashMap<_, HashSet<_>> = HashMap::new();
+    let mut incoming_edges_map: EventIdMap<_, EventIdSet<_>> = EventIdMap::new();
 
     // Vec of events that have an outdegree of zero (no outgoing edges), i.e. the oldest events.
     // Use a BinaryHeap to keep the events sorted.
@@ -446,7 +446,10 @@ where
             }));
         } else {
             for auth_event_id in outgoing_edges {
-                incoming_edges_map.entry(auth_event_id).or_default().insert(event_id);
+                incoming_edges_map
+                    .entry(auth_event_id.borrow())
+                    .or_default()
+                    .insert(event_id.borrow());
             }
 
             outgoing_edges_map
@@ -459,9 +462,9 @@ where
     // Apply Kahn's algorithm.
     // https://en.wikipedia.org/wiki/Topological_sorting#Kahn's_algorithm
     while let Some(Reverse(TieBreaker { event_id, .. })) = heap.pop() {
-        for &parent_id in incoming_edges_map.get(&event_id).into_iter().flatten() {
+        for &parent_id in incoming_edges_map.get(event_id.borrow()).into_iter().flatten() {
             let parent_has_zero_outdegrees = {
-                let outgoing_edges = outgoing_edges_map.get_mut(parent_id.borrow()).expect(
+                let outgoing_edges = outgoing_edges_map.get_mut(parent_id).expect(
                     "outgoing edges map should have a key for all event IDs with outgoing edges",
                 );
 
@@ -471,11 +474,11 @@ where
 
             // Push on the heap once all the outgoing edges have been removed.
             if parent_has_zero_outdegrees {
-                let (power_level, origin_server_ts) = event_details_fn(parent_id.borrow())?;
+                let (power_level, origin_server_ts) = event_details_fn(parent_id)?;
                 // Because the parent has no more outgoing edges, we can remove its entry from the
                 // outgoing edges map to get the owned event ID used for the key.
                 let (parent_id, _) = outgoing_edges_map
-                    .remove_entry(parent_id.borrow())
+                    .remove_entry(parent_id)
                     .expect("outgoing edges map should have a key for all event IDs");
 
                 heap.push(Reverse(TieBreaker {

--- a/crates/ruma-state-res/src/state_res.rs
+++ b/crates/ruma-state-res/src/state_res.rs
@@ -438,12 +438,10 @@ where
             // `Reverse` because `BinaryHeap` sorts largest -> smallest and we need
             // smallest -> largest.
             zero_outdegrees.push(Reverse(TieBreaker { power_level, origin_server_ts, event_id }));
-        }
-
-        incoming_edges_map.entry(event_id).or_default();
-
-        for auth_event_id in outgoing_edges {
-            incoming_edges_map.entry(auth_event_id).or_default().insert(event_id);
+        } else {
+            for auth_event_id in outgoing_edges {
+                incoming_edges_map.entry(auth_event_id).or_default().insert(event_id);
+            }
         }
     }
 
@@ -456,10 +454,7 @@ where
     while let Some(Reverse(item)) = heap.pop() {
         let event_id = item.event_id;
 
-        for &parent_id in incoming_edges_map
-            .get(event_id)
-            .expect("event ID in heap should also be in incoming edges map")
-        {
+        for &parent_id in incoming_edges_map.get(event_id).into_iter().flatten() {
             let outgoing_edges = outgoing_edges_map
                 .get_mut(parent_id.borrow())
                 .expect("outgoing edges map should have a key for all event IDs");


### PR DESCRIPTION
This requires to work only with `Id`s or `&EventId`s (not `&Id`s) for the bounds on those types to work, so we use this opportunity to ensure we only make a single clone of each `Id` used as a key in the input `graph` and forward it all the way to the output without extra clones.