### PR TITLE
Implement Eq for CrossSigningKey

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -76,6 +76,7 @@ Improvements:
   and locking endpoints, according to MSC4323.
 - Add unstable support for MSC4406.
 - Add `rule_type()` and `data()` methods to `AllowRule`.
+- Implement `PartialEq` and `Eq` on `CrossSigningKey` and `Signatures`.
 
 ## 0.17.1
 

--- a/crates/ruma-common/src/encryption.rs
+++ b/crates/ruma-common/src/encryption.rs
@@ -118,7 +118,7 @@ pub enum OneTimeKey {
 /// A [cross-signing] key.
 ///
 /// [cross-signing]: https://spec.matrix.org/v1.18/client-server-api/#cross-signing
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct CrossSigningKey {
     /// The ID of the user the key belongs to.

--- a/crates/ruma-common/src/identifiers/signatures.rs
+++ b/crates/ruma-common/src/identifiers/signatures.rs
@@ -27,7 +27,7 @@ pub type EntitySignatures<K> = BTreeMap<OwnedSigningKeyId<K>, String>;
 ///     "YbJva03ihSj5mPk+CHMJKUKlCXCPFXjXOK6VqBnN9nA2evksQcTGn6hwQfrgRHIDDXO2le49x7jnWJHMJrJoBQ";
 /// signatures.insert_signature(server_name, key_identifier, signature.into());
 /// ```
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(
     transparent,
     bound(serialize = "E: Serialize", deserialize = "E: serde::de::DeserializeOwned")


### PR DESCRIPTION
This is necessary to implement the restriction on [`/v3/keys/device_signing/upload`](https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3keysdevice_signingupload) requiring UIAA if the supplied keys aren't equal to the existing keys.