### PR TITLE
Prevent hidden `_Custom` variant types to be deserialized

### DIFF
--- a/crates/ruma-client-api/src/backup.rs
+++ b/crates/ruma-client-api/src/backup.rs
@@ -20,10 +20,10 @@ use std::{borrow::Cow, collections::BTreeMap};
 use js_int::UInt;
 use ruma_common::{
     CrossSigningOrDeviceSignatures,
-    serde::{Base64, JsonObject, Raw},
+    serde::{Base64, JsonObject, Raw, from_raw_json_value},
 };
-use serde::{Deserialize, Serialize};
-use serde_json::Value as JsonValue;
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::{Value as JsonValue, value::RawValue as RawJsonValue};
 
 /// A wrapper around a mapping of session IDs to key data.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -41,7 +41,7 @@ impl RoomKeyBackup {
 }
 
 /// The algorithm used for storing backups.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize)]
 #[serde(tag = "algorithm", content = "auth_data")]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub enum BackupAlgorithm {
@@ -82,6 +82,32 @@ impl BackupAlgorithm {
     }
 }
 
+impl<'de> Deserialize<'de> for BackupAlgorithm {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct BackupAlgorithmDeHelper {
+            algorithm: String,
+            auth_data: Box<RawJsonValue>,
+        }
+
+        let BackupAlgorithmDeHelper { algorithm, auth_data } =
+            BackupAlgorithmDeHelper::deserialize(deserializer)?;
+
+        Ok(match algorithm.as_ref() {
+            "m.megolm_backup.v1.curve25519-aes-sha2" => {
+                Self::MegolmBackupV1Curve25519AesSha2(from_raw_json_value(&auth_data)?)
+            }
+            _ => Self::_Custom(CustomBackupAlgorithm {
+                algorithm,
+                auth_data: from_raw_json_value(&auth_data)?,
+            }),
+        })
+    }
+}
+
 impl From<MegolmBackupV1Curve25519AesSha2AuthData> for BackupAlgorithm {
     fn from(value: MegolmBackupV1Curve25519AesSha2AuthData) -> Self {
         Self::MegolmBackupV1Curve25519AesSha2(value)
@@ -108,7 +134,7 @@ impl MegolmBackupV1Curve25519AesSha2AuthData {
 
 /// The payload for a custom backup algorithm.
 #[doc(hidden)]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct CustomBackupAlgorithm {
     /// The backup algorithm.
     algorithm: String,

--- a/crates/ruma-client-api/src/discovery/discover_homeserver.rs
+++ b/crates/ruma-client-api/src/discovery/discover_homeserver.rs
@@ -8,16 +8,18 @@
 use std::borrow::Cow;
 
 #[cfg(feature = "unstable-msc4143")]
-use ruma_common::serde::JsonObject;
+use ruma_common::serde::{JsonObject, from_raw_json_value};
 use ruma_common::{
     api::{auth_scheme::NoAccessToken, request, response},
     metadata,
 };
-#[cfg(feature = "unstable-msc4143")]
-use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "unstable-msc4143")]
+use serde::{Deserializer, de::DeserializeOwned};
+#[cfg(feature = "unstable-msc4143")]
 use serde_json::Value as JsonValue;
+#[cfg(feature = "unstable-msc4143")]
+use serde_json::value::RawValue as RawJsonValue;
 
 metadata! {
     method: GET,
@@ -134,7 +136,7 @@ impl TileServerInfo {
 
 /// Information about a specific MatrixRTC focus.
 #[cfg(feature = "unstable-msc4143")]
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 #[serde(tag = "type")]
 pub enum RtcFocusInfo {
@@ -206,6 +208,33 @@ impl RtcFocusInfo {
     }
 }
 
+#[cfg(feature = "unstable-msc4143")]
+impl<'de> Deserialize<'de> for RtcFocusInfo {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct RtcFocusInfoDeHelper {
+            #[serde(rename = "type")]
+            focus_type: String,
+        }
+
+        let json = Box::<RawJsonValue>::deserialize(deserializer)?;
+        let RtcFocusInfoDeHelper { focus_type } = from_raw_json_value(&json)?;
+
+        Ok(match focus_type.as_ref() {
+            "livekit" => Self::LiveKit(from_raw_json_value(&json)?),
+            _ => {
+                let mut data = from_raw_json_value::<JsonObject, _>(&json)?;
+                data.remove("type");
+
+                Self::_Custom(CustomRtcFocusInfo { focus_type, data })
+            }
+        })
+    }
+}
+
 /// Information about a LiveKit RTC focus.
 #[cfg(feature = "unstable-msc4143")]
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
@@ -219,7 +248,7 @@ pub struct LiveKitRtcFocusInfo {
 /// Information about a custom RTC focus type.
 #[doc(hidden)]
 #[cfg(feature = "unstable-msc4143")]
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
 pub struct CustomRtcFocusInfo {
     /// The type of RTC focus.
     #[serde(rename = "type")]

--- a/crates/ruma-client-api/src/push.rs
+++ b/crates/ruma-client-api/src/push.rs
@@ -303,7 +303,7 @@ impl EmailPusherData {
 }
 
 #[doc(hidden)]
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct CustomPusherData {
     kind: String,

--- a/crates/ruma-client-api/src/push/pusher_serde.rs
+++ b/crates/ruma-client-api/src/push/pusher_serde.rs
@@ -2,7 +2,7 @@ use ruma_common::serde::from_raw_json_value;
 use serde::{Deserialize, Serialize, de, ser::SerializeStruct};
 use serde_json::value::RawValue as RawJsonValue;
 
-use super::{Pusher, PusherIds, PusherKind};
+use super::{CustomPusherData, Pusher, PusherIds, PusherKind};
 
 #[derive(Debug, Deserialize)]
 struct PusherDeHelper {
@@ -72,7 +72,7 @@ impl<'de> Deserialize<'de> for PusherKind {
         match kind.as_ref() {
             "http" => from_raw_json_value(&data).map(Self::Http),
             "email" => from_raw_json_value(&data).map(Self::Email),
-            _ => from_raw_json_value(&json).map(Self::_Custom),
+            _ => Ok(Self::_Custom(CustomPusherData { kind, data: from_raw_json_value(&data)? })),
         }
     }
 }

--- a/crates/ruma-client-api/src/rtc/transports.rs
+++ b/crates/ruma-client-api/src/rtc/transports.rs
@@ -9,13 +9,15 @@ pub mod v1 {
 
     use std::borrow::Cow;
 
+    #[cfg(feature = "unstable-msc4195")]
+    use ruma_common::serde::from_raw_json_value;
     use ruma_common::{
         api::{auth_scheme::AccessToken, request, response},
         metadata,
         serde::JsonObject,
     };
-    use serde::{Deserialize, Serialize, de::DeserializeOwned};
-    use serde_json::Value as JsonValue;
+    use serde::{Deserialize, Deserializer, Serialize, de::DeserializeOwned};
+    use serde_json::{Value as JsonValue, value::RawValue as RawJsonValue};
 
     metadata! {
         method: GET,
@@ -57,7 +59,7 @@ pub mod v1 {
     ///
     /// This type can hold arbitrary RTC transports. Their data can be accessed with
     /// [`transport_type()`](Self::transport_type) and [`data()`](Self::data()).
-    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+    #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
     #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
     #[serde(tag = "type")]
     pub enum RtcTransport {
@@ -128,6 +130,33 @@ pub mod v1 {
         }
     }
 
+    impl<'de> Deserialize<'de> for RtcTransport {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            #[derive(Deserialize)]
+            struct RtcTransportDeHelper {
+                #[serde(rename = "type")]
+                transport_type: String,
+            }
+
+            let json = Box::<RawJsonValue>::deserialize(deserializer)?;
+            let RtcTransportDeHelper { transport_type } = from_raw_json_value(&json)?;
+
+            Ok(match transport_type.as_ref() {
+                #[cfg(feature = "unstable-msc4195")]
+                "livekit_multi_sfu" => Self::LivekitMultiSfu(from_raw_json_value(&json)?),
+                _ => {
+                    let mut data = from_raw_json_value::<JsonObject, _>(&json)?;
+                    data.remove("type");
+
+                    Self::_Custom(CustomRtcTransport { transport_type, data })
+                }
+            })
+        }
+    }
+
     /// A LiveKit multi-SFU transport.
     #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
     #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
@@ -170,7 +199,7 @@ pub mod v1 {
 
     /// Information about an unsupported RTC transport.
     #[doc(hidden)]
-    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+    #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
     pub struct CustomRtcTransport {
         /// The type of RTC transport.
         #[serde(rename = "type")]

--- a/crates/ruma-client-api/src/session/get_login_types.rs
+++ b/crates/ruma-client-api/src/session/get_login_types.rs
@@ -95,9 +95,10 @@ pub mod v3 {
                 "m.login.token" => Self::Token(from_json_object(data)?),
                 "m.login.sso" => Self::Sso(from_json_object(data)?),
                 "m.login.application_service" => Self::ApplicationService(from_json_object(data)?),
-                _ => {
-                    Self::_Custom(Box::new(CustomLoginType { type_: login_type.to_owned(), data }))
-                }
+                _ => Self::_Custom(Box::new(CustomLoginType {
+                    login_type: login_type.to_owned(),
+                    data,
+                })),
             })
         }
 
@@ -108,7 +109,7 @@ pub mod v3 {
                 Self::Token(_) => "m.login.token",
                 Self::Sso(_) => "m.login.sso",
                 Self::ApplicationService(_) => "m.login.application_service",
-                Self::_Custom(c) => &c.type_,
+                Self::_Custom(c) => &c.login_type,
             }
         }
 
@@ -266,34 +267,31 @@ pub mod v3 {
 
     /// A custom login payload.
     #[doc(hidden)]
-    #[derive(Clone, Debug, Deserialize, Serialize)]
+    #[derive(Clone, Debug, Serialize)]
     #[allow(clippy::exhaustive_structs)]
     pub struct CustomLoginType {
-        /// A custom type
-        ///
-        /// This field is named `type_` instead of `type` because the latter is a reserved
-        /// keyword in Rust.
+        /// The custom type.
         #[serde(rename = "type")]
-        pub type_: String,
+        login_type: String,
 
-        /// Remaining type content
+        /// Remaining content.
         #[serde(flatten)]
-        pub data: JsonObject,
+        data: JsonObject,
     }
 
     mod login_type_serde {
-        use ruma_common::serde::from_raw_json_value;
+        use ruma_common::serde::{JsonObject, from_raw_json_value};
         use serde::{Deserialize, de};
         use serde_json::value::RawValue as RawJsonValue;
 
-        use super::LoginType;
+        use super::{CustomLoginType, LoginType};
 
         /// Helper struct to determine the type from a `serde_json::value::RawValue`
         #[derive(Debug, Deserialize)]
         struct LoginTypeDeHelper {
             /// The login type field
             #[serde(rename = "type")]
-            type_: String,
+            login_type: String,
         }
 
         impl<'de> Deserialize<'de> for LoginType {
@@ -302,16 +300,21 @@ pub mod v3 {
                 D: de::Deserializer<'de>,
             {
                 let json = Box::<RawJsonValue>::deserialize(deserializer)?;
-                let LoginTypeDeHelper { type_ } = from_raw_json_value(&json)?;
+                let LoginTypeDeHelper { login_type } = from_raw_json_value(&json)?;
 
-                Ok(match type_.as_ref() {
+                Ok(match login_type.as_ref() {
                     "m.login.password" => Self::Password(from_raw_json_value(&json)?),
                     "m.login.token" => Self::Token(from_raw_json_value(&json)?),
                     "m.login.sso" => Self::Sso(from_raw_json_value(&json)?),
                     "m.login.application_service" => {
                         Self::ApplicationService(from_raw_json_value(&json)?)
                     }
-                    _ => Self::_Custom(from_raw_json_value(&json)?),
+                    _ => {
+                        let mut data = from_raw_json_value::<JsonObject, _>(&json)?;
+                        data.remove("type");
+
+                        Self::_Custom(CustomLoginType { login_type, data }.into())
+                    }
                 })
             }
         }
@@ -346,21 +349,24 @@ pub mod v3 {
         }
 
         #[test]
-        fn deserialize_custom_login_type() {
-            let wrapper = from_json_value::<Wrapper>(json!({
+        fn custom_login_type_serialize_roundtrip() {
+            let json = json!({
                 "flows": [
                     {
                         "type": "io.ruma.custom",
                         "color": "green",
                     }
                 ],
-            }))
-            .unwrap();
+            });
+
+            let wrapper = from_json_value::<Wrapper>(json.clone()).unwrap();
             assert_eq!(wrapper.flows.len(), 1);
             assert_let!(LoginType::_Custom(custom) = &wrapper.flows[0]);
-            assert_eq!(custom.type_, "io.ruma.custom");
+            assert_eq!(custom.login_type, "io.ruma.custom");
             assert_eq!(custom.data.len(), 1);
             assert_eq!(custom.data.get("color"), Some(&JsonValue::from("green")));
+
+            assert_to_canonical_json_eq!(wrapper, json);
         }
 
         #[test]

--- a/crates/ruma-client-api/src/session/login.rs
+++ b/crates/ruma-client-api/src/session/login.rs
@@ -7,8 +7,9 @@ pub mod v3 {
     //!
     //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3login
 
-    use std::{fmt, time::Duration};
+    use std::{borrow::Cow, fmt, time::Duration};
 
+    use as_variant::as_variant;
     use ruma_common::{
         OwnedDeviceId, OwnedServerName, OwnedUserId,
         api::{auth_scheme::AppserviceTokenOptional, request, response},
@@ -177,8 +178,38 @@ pub mod v3 {
                 "m.login.application_service" => {
                     Self::ApplicationService(serde_json::from_value(JsonValue::Object(data))?)
                 }
-                _ => Self::_Custom(CustomLoginInfo { login_type: login_type.into(), extra: data }),
+                _ => Self::_Custom(CustomLoginInfo { login_type: login_type.into(), data }),
             })
+        }
+
+        /// The type of this `LoginInfo`.
+        pub fn login_type(&self) -> &str {
+            match self {
+                LoginInfo::Password(_) => "m.login.password",
+                LoginInfo::Token(_) => "m.login.token",
+                LoginInfo::ApplicationService(_) => "m.login.application_service",
+                LoginInfo::_Custom(c) => &c.login_type,
+            }
+        }
+
+        /// The data of this `LoginInfo`.
+        ///
+        /// Prefer to use the public variants of `LoginInfo` where possible; this method is meant to
+        /// be used for unsupported login types only.
+        pub fn data(&self) -> Cow<'_, JsonObject> {
+            fn serialize<T: Serialize>(obj: &T) -> JsonObject {
+                match serde_json::to_value(obj).expect("login info serialization to succeed") {
+                    JsonValue::Object(obj) => obj,
+                    _ => panic!("all login info variants must serialize to objects"),
+                }
+            }
+
+            match self {
+                Self::Password(d) => Cow::Owned(serialize(d)),
+                Self::Token(d) => Cow::Owned(serialize(d)),
+                Self::ApplicationService(d) => Cow::Owned(serialize(d)),
+                Self::_Custom(c) => Cow::Borrowed(&c.data),
+            }
         }
     }
 
@@ -205,17 +236,25 @@ pub mod v3 {
 
             // FIXME: Would be better to use serde_json::value::RawValue, but that would require
             // implementing Deserialize manually for Request, bc. `#[serde(flatten)]` breaks things.
-            let json = JsonValue::deserialize(deserializer)?;
+            let mut data = JsonObject::deserialize(deserializer)?;
 
             let login_type =
-                json["type"].as_str().ok_or_else(|| de::Error::missing_field("type"))?;
+                data["type"].as_str().ok_or_else(|| de::Error::missing_field("type"))?;
             match login_type {
-                "m.login.password" => from_json_value(json).map(Self::Password),
-                "m.login.token" => from_json_value(json).map(Self::Token),
+                "m.login.password" => from_json_value(data.into()).map(Self::Password),
+                "m.login.token" => from_json_value(data.into()).map(Self::Token),
                 "m.login.application_service" => {
-                    from_json_value(json).map(Self::ApplicationService)
+                    from_json_value(data.into()).map(Self::ApplicationService)
                 }
-                _ => from_json_value(json).map(Self::_Custom),
+                _ => {
+                    let login_type = as_variant!(
+                        data.remove("type")
+                            .expect("we already checked that the object has a type field"),
+                        JsonValue::String
+                    )
+                    .expect("we already checked that the type field is a string");
+                    Ok(Self::_Custom(CustomLoginInfo { login_type, data }))
+                }
             }
         }
     }
@@ -327,18 +366,18 @@ pub mod v3 {
     }
 
     #[doc(hidden)]
-    #[derive(Clone, Deserialize, Serialize)]
+    #[derive(Clone, Serialize)]
     #[non_exhaustive]
     pub struct CustomLoginInfo {
         #[serde(rename = "type")]
         login_type: String,
         #[serde(flatten)]
-        extra: JsonObject,
+        data: JsonObject,
     }
 
     impl fmt::Debug for CustomLoginInfo {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            let Self { login_type, extra: _ } = self;
+            let Self { login_type, data: _ } = self;
             f.debug_struct("CustomLoginInfo")
                 .field("login_type", login_type)
                 .finish_non_exhaustive()
@@ -398,6 +437,7 @@ pub mod v3 {
     #[cfg(test)]
     mod tests {
         use assert_matches2::assert_matches;
+        use ruma_common::canonical_json::assert_to_canonical_json_eq;
         use serde_json::{from_value as from_json_value, json};
 
         use super::{LoginInfo, Token};
@@ -430,6 +470,23 @@ pub mod v3 {
                 LoginInfo::Token(Token { token })
             );
             assert_eq!(token, "1234567890abcdef");
+        }
+
+        #[test]
+        fn login_info_serialize_roundtrip() {
+            let json = json!({
+                "type": "local.dev.custom",
+                "identifier": "dGhpcy5pcy5tZQ",
+            });
+
+            let login_info = from_json_value::<LoginInfo>(json.clone()).unwrap();
+
+            assert_eq!(login_info.login_type(), "local.dev.custom");
+            let data = login_info.data();
+            assert_eq!(data.len(), 1);
+            assert_eq!(data.get("identifier").unwrap().as_str(), Some("dGhpcy5pcy5tZQ"));
+
+            assert_to_canonical_json_eq!(login_info, json);
         }
 
         #[test]

--- a/crates/ruma-client-api/src/uiaa/auth_data.rs
+++ b/crates/ruma-client-api/src/uiaa/auth_data.rs
@@ -2,7 +2,6 @@
 
 use std::{borrow::Cow, fmt};
 
-use as_variant::as_variant;
 use ruma_common::{
     OwnedClientSecret, OwnedSessionId, OwnedUserId, serde::JsonObject, thirdparty::Medium,
 };
@@ -93,9 +92,7 @@ impl AuthData {
             "m.oauth" | "org.matrix.cross_signing_reset" => {
                 Self::OAuth(deserialize_variant(session, data)?)
             }
-            _ => {
-                Self::_Custom(CustomAuthData { auth_type: auth_type.into(), session, extra: data })
-            }
+            _ => Self::_Custom(CustomAuthData { auth_type: auth_type.into(), session, data }),
         })
     }
 
@@ -175,7 +172,7 @@ impl AuthData {
             Self::Dummy(_) | Self::FallbackAcknowledgement(_) | Self::Terms(_) | Self::OAuth(_) => {
                 Cow::Owned(JsonObject::default())
             }
-            Self::_Custom(c) => Cow::Borrowed(&c.extra),
+            Self::_Custom(c) => Cow::Borrowed(&c.data),
         }
     }
 }
@@ -409,7 +406,7 @@ impl OAuth {
 
 /// Data for an unsupported authentication type.
 #[doc(hidden)]
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone, Serialize)]
 #[non_exhaustive]
 pub struct CustomAuthData {
     /// The type of authentication.
@@ -421,12 +418,12 @@ pub struct CustomAuthData {
 
     /// Extra data.
     #[serde(flatten)]
-    extra: JsonObject,
+    data: JsonObject,
 }
 
 impl fmt::Debug for CustomAuthData {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let Self { auth_type, session, extra: _ } = self;
+        let Self { auth_type, session, data: _ } = self;
         f.debug_struct("CustomAuthData")
             .field("auth_type", auth_type)
             .field("session", session)
@@ -494,12 +491,32 @@ impl UserIdentifier {
         }
     }
 
-    /// Returns the associated data if this is a custom identifier type.
+    /// Returns the associated data of the identifier.
     ///
     /// The returned JSON object won't contain the `type` field, use
     /// [`.identifier_type()`][Self::identifier_type] to access it.
-    pub fn custom_identifier_data(&self) -> Option<&JsonObject> {
-        as_variant!(self, Self::_Custom).map(|id| &id.data)
+    ///
+    /// Prefer to use the public variants of `UserIdentifier` where possible; this method is meant
+    /// to be used for custom identifier types only.
+    pub fn data(&self) -> Cow<'_, JsonObject> {
+        fn serialize<T: Serialize>(obj: &T) -> JsonObject {
+            match serde_json::to_value(obj).expect("user identifier serialization to succeed") {
+                JsonValue::Object(mut obj) => {
+                    obj.remove("type");
+                    obj
+                }
+                _ => panic!("all user identifiers must serialize to objects"),
+            }
+        }
+
+        match self {
+            Self::Matrix(i) => Cow::Owned(serialize(i)),
+            Self::Email(i) => Cow::Owned(serialize(i)),
+            Self::Msisdn(i) => Cow::Owned(serialize(i)),
+            Self::PhoneNumber(i) => Cow::Owned(serialize(i)),
+            Self::_CustomThirdParty(i) => Cow::Owned(serialize(i)),
+            Self::_Custom(i) => Cow::Borrowed(&i.data),
+        }
     }
 }
 
@@ -638,7 +655,7 @@ pub struct CustomThirdPartyUserIdentifier {
 
 /// Data for a custom identifier type.
 #[doc(hidden)]
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct CustomUserIdentifier {
     /// The type of the identifier.
     #[serde(rename = "type")]

--- a/crates/ruma-client-api/src/uiaa/auth_data/data_serde.rs
+++ b/crates/ruma-client-api/src/uiaa/auth_data/data_serde.rs
@@ -2,14 +2,19 @@
 
 use std::borrow::Cow;
 
-use ruma_common::{serde::from_raw_json_value, thirdparty::Medium};
+use as_variant::as_variant;
+use ruma_common::{
+    serde::{JsonObject, from_raw_json_value},
+    thirdparty::Medium,
+};
 use serde::{Deserialize, Deserializer, Serialize, de};
-use serde_json::value::RawValue as RawJsonValue;
+use serde_json::{Value as JsonValue, value::RawValue as RawJsonValue};
 
 use super::{
     AuthData, CustomThirdPartyUserIdentifier, EmailUserIdentifier, MsisdnUserIdentifier,
     UserIdentifier,
 };
+use crate::uiaa::{CustomAuthData, CustomUserIdentifier};
 
 impl<'de> Deserialize<'de> for AuthData {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -24,9 +29,7 @@ impl<'de> Deserialize<'de> for AuthData {
             auth_type: Option<Cow<'a, str>>,
         }
 
-        let auth_type = serde_json::from_str::<ExtractType<'_>>(json.get())
-            .map_err(de::Error::custom)?
-            .auth_type;
+        let ExtractType { auth_type } = from_raw_json_value(&json)?;
 
         match auth_type.as_deref() {
             Some("m.login.password") => from_raw_json_value(&json).map(Self::Password),
@@ -42,7 +45,19 @@ impl<'de> Deserialize<'de> for AuthData {
                 from_raw_json_value(&json).map(Self::OAuth)
             }
             None => from_raw_json_value(&json).map(Self::FallbackAcknowledgement),
-            Some(_) => from_raw_json_value(&json).map(Self::_Custom),
+            Some(_) => {
+                let mut data = from_raw_json_value::<JsonObject, _>(&json)?;
+                let auth_type = as_variant!(
+                    data.remove("type").expect("we already checked that the type field is present"),
+                    JsonValue::String
+                )
+                .expect("we already checked that the type is a string");
+                let session = data
+                    .remove("session")
+                    .and_then(|session| as_variant!(session, JsonValue::String));
+
+                Ok(Self::_Custom(CustomAuthData { auth_type, session, data }))
+            }
         }
     }
 }
@@ -73,7 +88,16 @@ impl<'de> Deserialize<'de> for UserIdentifier {
                     _ => Ok(Self::_CustomThirdParty(id)),
                 }
             }
-            _ => from_raw_json_value(&json).map(Self::_Custom),
+            _ => {
+                let mut data = from_raw_json_value::<JsonObject, _>(&json)?;
+                let identifier_type = as_variant!(
+                    data.remove("type").expect("we already checked that the type field is present"),
+                    JsonValue::String
+                )
+                .expect("we already checked that the type is a string");
+
+                Ok(Self::_Custom(CustomUserIdentifier { identifier_type, data }))
+            }
         }
     }
 }
@@ -147,12 +171,12 @@ mod tests {
     use serde_json::{Value as JsonValue, from_value as from_json_value, json};
 
     use crate::uiaa::{
-        EmailUserIdentifier, MatrixUserIdentifier, MsisdnUserIdentifier, PhoneNumberUserIdentifier,
-        UserIdentifier,
+        AuthData, EmailUserIdentifier, MatrixUserIdentifier, MsisdnUserIdentifier,
+        PhoneNumberUserIdentifier, UserIdentifier,
     };
 
     #[test]
-    fn serialize() {
+    fn serialize_user_identifier() {
         assert_to_canonical_json_eq!(
             UserIdentifier::Matrix(MatrixUserIdentifier::new("@user:notareal.hs".to_owned())),
             json!({
@@ -202,7 +226,7 @@ mod tests {
     }
 
     #[test]
-    fn deserialize() {
+    fn deserialize_user_identifier() {
         let json = json!({
             "type": "m.id.user",
             "user": "@user:notareal.hs",
@@ -250,7 +274,7 @@ mod tests {
     }
 
     #[test]
-    fn custom_identifier_roundtrip() {
+    fn custom_user_identifier_roundtrip() {
         let json = json!({
             "type": "local.dev.identifier",
             "foo": "bar",
@@ -258,10 +282,29 @@ mod tests {
 
         let id = from_json_value::<UserIdentifier>(json.clone()).unwrap();
         assert_eq!(id.identifier_type(), "local.dev.identifier");
-        let data = id.custom_identifier_data().unwrap();
+        let data = &*id.data();
         assert_let!(Some(JsonValue::String(foo)) = data.get("foo"));
         assert_eq!(foo, "bar");
 
         assert_to_canonical_json_eq!(id, json);
+    }
+
+    #[test]
+    fn custom_auth_data_roundtrip() {
+        let json = json!({
+            "type": "local.dev.auth",
+            "session": "abcdef",
+            "foo": "bar",
+        });
+
+        let auth_data = from_json_value::<AuthData>(json.clone()).unwrap();
+        assert_eq!(auth_data.auth_type().unwrap().as_str(), "local.dev.auth");
+        assert_eq!(auth_data.session(), Some("abcdef"));
+        let data = auth_data.data();
+        assert_eq!(data.len(), 1);
+        assert_let!(Some(JsonValue::String(foo)) = data.get("foo"));
+        assert_eq!(foo, "bar");
+
+        assert_to_canonical_json_eq!(auth_data, json);
     }
 }

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -24,11 +24,11 @@ Breaking changes:
   rely on access tokens as a form of authentication.
 - It is no longer possible to construct custom `Action` types directly through
   the hidden `_Custom` variant. They should be constructed with `Action::new()`
-  and their data should be accessed with `Action::custom_data()`.
+  and their data should be accessed with `Action::data()`.
 - The `Tweak` type uses stronger enum types for its variants, and the `Custom`
   variant is now hidden and cannot be constructed directly. It should be
   constructed with `Tweak::new()` and its data should be accessed with
-  `Tweak::set_tweak()` and `Tweak::custom_value()`.
+  `Tweak::set_tweak()` and `Tweak::value()`.
 - The struct variants of `PushCondition` are now tuple variants containing a
   non-exhaustive struct.
 - `JsonType` was renamed to `CanonicalJsonType` to reflect that it only

--- a/crates/ruma-common/src/http_headers/content_disposition.rs
+++ b/crates/ruma-common/src/http_headers/content_disposition.rs
@@ -8,6 +8,7 @@ use super::{
     is_tchar, is_token, quote_ascii_string_if_required, rfc8187, sanitize_for_ascii_quoted_string,
     unescape_string,
 };
+use crate::PrivOwnedStr;
 
 /// The value of a `Content-Disposition` HTTP header.
 ///
@@ -348,7 +349,7 @@ pub enum ContentDispositionType {
     Attachment,
 
     #[doc(hidden)]
-    _Custom(TokenString),
+    _Custom(PrivOwnedStr),
 }
 
 impl ContentDispositionType {
@@ -365,7 +366,7 @@ impl From<TokenString> for ContentDispositionType {
         } else if value.eq_ignore_ascii_case("attachment") {
             Self::Attachment
         } else {
-            Self::_Custom(value)
+            Self::_Custom(PrivOwnedStr(value.0))
         }
     }
 }
@@ -379,7 +380,7 @@ impl<'a> TryFrom<&'a [u8]> for ContentDispositionType {
         } else if value.eq_ignore_ascii_case(b"attachment") {
             Ok(Self::Attachment)
         } else {
-            TokenString::try_from(value).map(Self::_Custom)
+            TokenString::try_from(value).map(Into::into)
         }
     }
 }

--- a/crates/ruma-common/src/push/action.rs
+++ b/crates/ruma-common/src/push/action.rs
@@ -1,7 +1,9 @@
+use std::borrow::Cow;
+
 use as_variant::as_variant;
 use ruma_macros::StringEnum;
 use serde::{Deserialize, Serialize, de};
-use serde_json::value::RawValue as RawJsonValue;
+use serde_json::{Value as JsonValue, value::RawValue as RawJsonValue};
 
 mod action_serde;
 
@@ -88,15 +90,30 @@ impl Action {
         as_variant!(self, Action::SetTweak(Tweak::Sound(sound)) => sound)
     }
 
-    /// Access the data if this is a custom action.
-    pub fn custom_data(&self) -> Option<&CustomActionData> {
-        as_variant!(self, Self::_Custom).map(|action| &action.0)
+    /// Access the data of this action.
+    pub fn data(&self) -> Cow<'_, CustomActionData> {
+        fn serialize<T: Serialize>(obj: T) -> JsonObject {
+            match serde_json::to_value(obj).expect("action serialization to succeed") {
+                JsonValue::Object(obj) => obj,
+                _ => panic!("action variant must serialize to object"),
+            }
+        }
+
+        match self {
+            Self::Notify => Cow::Owned(CustomActionData::String("notify".to_owned())),
+            #[cfg(feature = "unstable-msc3768")]
+            Self::NotifyInApp => {
+                Cow::Owned(CustomActionData::String("org.matrix.msc3768.notify_in_app".to_owned()))
+            }
+            Self::SetTweak(t) => Cow::Owned(CustomActionData::Object(serialize(t))),
+            Self::_Custom(c) => Cow::Borrowed(&c.0),
+        }
     }
 }
 
 /// A custom action.
 #[doc(hidden)]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(transparent)]
 pub struct CustomAction(CustomActionData);
 
@@ -169,9 +186,25 @@ impl Tweak {
         }
     }
 
-    /// Access the value, if it is a custom tweak.
-    pub fn custom_value(&self) -> Option<&RawJsonValue> {
-        as_variant!(self, Self::_Custom).and_then(|tweak| tweak.value.as_deref())
+    /// Access the value of this tweak.
+    ///
+    /// Prefer to use the public variants of `Tweak` where possible; this method is meant to
+    /// be used for custom tweaks only.
+    pub fn value(&self) -> Option<Cow<'_, RawJsonValue>> {
+        fn serialize<T: Serialize>(val: &T) -> Box<RawJsonValue> {
+            RawJsonValue::from_string(
+                serde_json::to_string(val).expect("tweak serialization to succeed"),
+            )
+            .expect("serialized tweak should be valid JSON")
+        }
+
+        match self {
+            Tweak::Sound(s) => Some(Cow::Owned(serialize(s))),
+            Tweak::Highlight(h) => {
+                Some(Cow::Owned(serialize(&matches!(h, HighlightTweakValue::Yes))))
+            }
+            Tweak::_Custom(c) => c.value.as_deref().map(Cow::Borrowed),
+        }
     }
 }
 
@@ -224,7 +257,7 @@ impl From<bool> for HighlightTweakValue {
 
 /// A custom tweak.
 #[doc(hidden)]
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct CustomTweak {
     /// The kind of the custom tweak.
     set_tweak: String,
@@ -236,11 +269,11 @@ pub struct CustomTweak {
 
 #[cfg(test)]
 mod tests {
-    use assert_matches2::assert_matches;
-    use serde_json::{from_value as from_json_value, json};
+    use assert_matches2::{assert_let, assert_matches};
+    use serde_json::{Value as JsonValue, from_value as from_json_value, json};
 
     use super::{Action, HighlightTweakValue, SoundTweakValue, Tweak};
-    use crate::assert_to_canonical_json_eq;
+    use crate::{assert_to_canonical_json_eq, push::action::CustomActionData};
 
     #[test]
     fn serialize_notify() {
@@ -332,5 +365,35 @@ mod tests {
             from_json_value::<Action>(json!({ "set_tweak": "highlight" })),
             Ok(Action::SetTweak(Tweak::Highlight(HighlightTweakValue::Yes)))
         );
+    }
+
+    #[test]
+    fn custom_tweak_serialize_roundtrip() {
+        let json = json!({ "set_tweak": "dev.local.tweak", "value": "rainbow" });
+        let tweak = from_json_value::<Tweak>(json.clone()).unwrap();
+
+        assert_eq!(tweak.set_tweak(), "dev.local.tweak");
+        assert_eq!(tweak.value().unwrap().get(), r#""rainbow""#);
+
+        assert_to_canonical_json_eq!(tweak, json);
+    }
+
+    #[test]
+    fn custom_action_serialize_roundtrip() {
+        // String action.
+        let json = json!("dev.local.action");
+        let action = from_json_value::<Action>(json.clone()).unwrap();
+        assert_let!(CustomActionData::String(value) = &*action.data());
+        assert_eq!(value, "dev.local.action");
+        assert_to_canonical_json_eq!(action, json);
+
+        // Object action.
+        let json = json!({ "dev.local.action": "rainbow" });
+        let action = from_json_value::<Action>(json.clone()).unwrap();
+        assert_let!(CustomActionData::Object(value) = &*action.data());
+        assert_eq!(value.len(), 1);
+        assert_let!(Some(JsonValue::String(s)) = value.get("dev.local.action"));
+        assert_eq!(s, "rainbow");
+        assert_to_canonical_json_eq!(action, json);
     }
 }

--- a/crates/ruma-common/src/push/action/action_serde.rs
+++ b/crates/ruma-common/src/push/action/action_serde.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de, ser::SerializeStruct};
+use serde_json::value::RawValue as RawJsonValue;
 
-use super::{Action, CustomActionData, CustomTweak, HighlightTweakValue, Tweak};
+use super::{Action, CustomActionData, HighlightTweakValue, Tweak};
 
 impl<'de> Deserialize<'de> for Action {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -31,7 +32,13 @@ impl<'de> Deserialize<'de> for Tweak {
     where
         D: Deserializer<'de>,
     {
-        let CustomTweak { set_tweak, value } = CustomTweak::deserialize(deserializer)?;
+        #[derive(Deserialize)]
+        struct TweakDeHelper {
+            set_tweak: String,
+            value: Option<Box<RawJsonValue>>,
+        }
+
+        let TweakDeHelper { set_tweak, value } = TweakDeHelper::deserialize(deserializer)?;
         Self::new(set_tweak, value).map_err(de::Error::custom)
     }
 }

--- a/crates/ruma-common/src/push/condition.rs
+++ b/crates/ruma-common/src/push/condition.rs
@@ -1,13 +1,14 @@
 use std::{
-    collections::BTreeMap, future::Future, ops::RangeBounds, pin::Pin, str::FromStr, sync::Arc,
+    borrow::Cow, collections::BTreeMap, future::Future, ops::RangeBounds, pin::Pin, str::FromStr,
+    sync::Arc,
 };
 
-use as_variant::as_variant;
 use js_int::{Int, UInt};
 use regex::bytes::Regex;
 #[cfg(feature = "unstable-msc3931")]
 use ruma_macros::StringEnum;
 use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
 use wildmatch::WildMatch;
 
 use crate::{
@@ -19,6 +20,7 @@ use crate::{
 #[cfg(feature = "unstable-msc3931")]
 use crate::{PrivOwnedStr, RoomVersionId};
 
+mod condition_serde;
 mod flattened_json;
 mod room_member_count_is;
 
@@ -28,7 +30,7 @@ pub use self::{
 };
 
 /// A condition that must apply for an associated push rule's action to be taken.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum PushCondition {
@@ -90,9 +92,35 @@ impl PushCondition {
         }
     }
 
-    /// The data, if this is a custom condition.
-    pub fn custom_data(&self) -> Option<&JsonObject> {
-        as_variant!(self, Self::_Custom).map(|condition| &condition.data)
+    /// The data of this `PushCondition`.
+    ///
+    /// The returned JSON object won't contain the `kind` field, use [`.kind()`][Self::kind] to
+    /// access it.
+    ///
+    /// Prefer to use the public variants of `PushCondition` where possible; this method is meant to
+    /// be used for custom conditions only.
+    pub fn data(&self) -> Cow<'_, JsonObject> {
+        fn serialize<T: Serialize>(obj: T) -> JsonObject {
+            match serde_json::to_value(obj).expect("push condition serialization to succeed") {
+                JsonValue::Object(obj) => obj,
+                _ => panic!("all push condition variants must serialize to objects"),
+            }
+        }
+
+        match self {
+            Self::EventMatch(c) => Cow::Owned(serialize(c)),
+            #[allow(deprecated)]
+            Self::ContainsDisplayName => Cow::Owned(JsonObject::new()),
+            Self::RoomMemberCount(c) => Cow::Owned(serialize(c)),
+            Self::SenderNotificationPermission(c) => Cow::Owned(serialize(c)),
+            #[cfg(feature = "unstable-msc3931")]
+            Self::RoomVersionSupports(c) => Cow::Owned(serialize(c)),
+            Self::EventPropertyIs(c) => Cow::Owned(serialize(c)),
+            Self::EventPropertyContains(c) => Cow::Owned(serialize(c)),
+            #[cfg(feature = "unstable-msc4306")]
+            Self::ThreadSubscription(c) => Cow::Owned(serialize(c)),
+            Self::_Custom(c) => Cow::Borrowed(&c.data),
+        }
     }
 
     /// Check if this condition applies to the event.
@@ -455,7 +483,7 @@ impl ThreadSubscriptionConditionData {
 
 /// An unknown push condition.
 #[doc(hidden)]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 #[allow(clippy::exhaustive_structs)]
 pub struct _CustomPushCondition {
     /// The kind of the condition.
@@ -1445,15 +1473,18 @@ mod tests {
 
     #[test]
     fn custom_condition_roundtrip() {
-        let json_data = json!({
+        let json = json!({
             "kind": "local_dev_custom",
             "foo": "bar"
         });
 
-        let condition = from_json_value::<PushCondition>(json_data).unwrap();
+        let condition = from_json_value::<PushCondition>(json.clone()).unwrap();
         assert_eq!(condition.kind(), "local_dev_custom");
-        assert_matches!(condition.custom_data(), Some(data));
+        let data = condition.data();
+        assert_eq!(data.len(), 1);
         assert_matches!(data.get("foo"), Some(JsonValue::String(foo)));
         assert_eq!(foo, "bar");
+
+        assert_to_canonical_json_eq!(condition, json);
     }
 }

--- a/crates/ruma-common/src/push/condition/condition_serde.rs
+++ b/crates/ruma-common/src/push/condition/condition_serde.rs
@@ -1,0 +1,51 @@
+use serde::{Deserialize, Deserializer};
+use serde_json::value::RawValue as RawJsonValue;
+
+use super::PushCondition;
+use crate::{
+    push::_CustomPushCondition,
+    serde::{JsonObject, from_raw_json_value},
+};
+
+impl<'de> Deserialize<'de> for PushCondition {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct ConditionDeHelper {
+            kind: String,
+        }
+
+        let json = Box::<RawJsonValue>::deserialize(deserializer)?;
+        let ConditionDeHelper { kind } = from_raw_json_value(&json)?;
+
+        match kind.as_ref() {
+            "event_match" => from_raw_json_value(&json).map(Self::EventMatch),
+            #[allow(deprecated)]
+            "contains_display_name" => Ok(Self::ContainsDisplayName),
+            "room_member_count" => from_raw_json_value(&json).map(Self::RoomMemberCount),
+            "sender_notification_permission" => {
+                from_raw_json_value(&json).map(Self::SenderNotificationPermission)
+            }
+            #[cfg(feature = "unstable-msc3931")]
+            "org.matrix.msc3931.room_version_supports" => {
+                from_raw_json_value(&json).map(Self::RoomVersionSupports)
+            }
+            "event_property_is" => from_raw_json_value(&json).map(Self::EventPropertyIs),
+            "event_property_contains" => {
+                from_raw_json_value(&json).map(Self::EventPropertyContains)
+            }
+            #[cfg(feature = "unstable-msc4306")]
+            "io.element.msc4306.thread_subscription" => {
+                from_raw_json_value(&json).map(Self::ThreadSubscription)
+            }
+            _ => {
+                let mut data = from_raw_json_value::<JsonObject, _>(&json)?;
+                data.remove("kind");
+
+                Ok(Self::_Custom(_CustomPushCondition { kind, data }))
+            }
+        }
+    }
+}

--- a/crates/ruma-common/src/room.rs
+++ b/crates/ruma-common/src/room.rs
@@ -68,6 +68,7 @@ pub enum JoinRule {
     Public,
 
     #[doc(hidden)]
+    #[serde(untagged)]
     _Custom(CustomJoinRule),
 }
 
@@ -140,13 +141,10 @@ impl<'de> Deserialize<'de> for JoinRule {
         #[derive(Deserialize)]
         struct ExtractType<'a> {
             #[serde(borrow)]
-            join_rule: Option<Cow<'a, str>>,
+            join_rule: Cow<'a, str>,
         }
 
-        let join_rule = serde_json::from_str::<ExtractType<'_>>(json.get())
-            .map_err(de::Error::custom)?
-            .join_rule
-            .ok_or_else(|| de::Error::missing_field("join_rule"))?;
+        let ExtractType { join_rule } = from_raw_json_value(&json)?;
 
         match join_rule.as_ref() {
             "invite" => Ok(Self::Invite),
@@ -155,14 +153,24 @@ impl<'de> Deserialize<'de> for JoinRule {
             "restricted" => from_raw_json_value(&json).map(Self::Restricted),
             "knock_restricted" => from_raw_json_value(&json).map(Self::KnockRestricted),
             "public" => Ok(Self::Public),
-            _ => from_raw_json_value(&json).map(Self::_Custom),
+            _ => {
+                let mut data = from_raw_json_value::<JsonObject, _>(&json)?;
+                let join_rule = as_variant!(
+                    data.remove("join_rule")
+                        .expect("we already checked that the join_rule field is present"),
+                    JsonValue::String
+                )
+                .expect("we already checked that the join rule is a string");
+
+                Ok(Self::_Custom(CustomJoinRule { join_rule, data }))
+            }
         }
     }
 }
 
 /// The payload for an unsupported join rule.
 #[doc(hidden)]
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct CustomJoinRule {
     /// The kind of join rule.
     join_rule: String,
@@ -253,7 +261,7 @@ impl RoomMembership {
 }
 
 #[doc(hidden)]
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct CustomAllowRule {
     /// The type of the allow rule.
@@ -276,18 +284,24 @@ impl<'de> Deserialize<'de> for AllowRule {
         #[derive(Deserialize)]
         struct ExtractType<'a> {
             #[serde(borrow, rename = "type")]
-            rule_type: Option<Cow<'a, str>>,
+            rule_type: Cow<'a, str>,
         }
 
         // Get the value of `type` if present.
-        let rule_type = serde_json::from_str::<ExtractType<'_>>(json.get())
-            .map_err(de::Error::custom)?
-            .rule_type;
+        let ExtractType { rule_type } = from_raw_json_value(&json)?;
 
-        match rule_type.as_deref() {
-            Some("m.room_membership") => from_raw_json_value(&json).map(Self::RoomMembership),
-            Some(_) => from_raw_json_value(&json).map(Self::_Custom),
-            None => Err(de::Error::missing_field("type")),
+        match rule_type.as_ref() {
+            "m.room_membership" => from_raw_json_value(&json).map(Self::RoomMembership),
+            _ => {
+                let mut data = from_raw_json_value::<JsonObject, _>(&json)?;
+                let rule_type = as_variant!(
+                    data.remove("type").expect("we already checked that the type field is present"),
+                    JsonValue::String
+                )
+                .expect("we already checked that the type is a string");
+
+                Ok(Self::_Custom(CustomAllowRule { rule_type, data }))
+            }
         }
     }
 }
@@ -641,10 +655,10 @@ impl From<Restricted> for RestrictedSummary {
 
 #[cfg(test)]
 mod tests {
-    use assert_matches2::assert_matches;
+    use assert_matches2::{assert_let, assert_matches};
     use js_int::uint;
     use ruma_common::{OwnedRoomId, owned_room_id};
-    use serde_json::{from_value as from_json_value, json};
+    use serde_json::{Value as JsonValue, from_value as from_json_value, json};
 
     use super::{
         AllowRule, CustomAllowRule, JoinRule, JoinRuleSummary, Restricted, RestrictedSummary,
@@ -774,6 +788,23 @@ mod tests {
     }
 
     #[test]
+    fn custom_join_rule_serialize_roundtrip() {
+        let json = json!({
+            "join_rule": "local.dev.unicorns",
+            "rainbows": true,
+        });
+
+        let join_rule = from_json_value::<JoinRule>(json.clone()).unwrap();
+        assert_eq!(join_rule.kind().as_str(), "local.dev.unicorns");
+        let data = &*join_rule.data();
+        assert_eq!(data.len(), 1);
+        assert_let!(Some(JsonValue::Bool(value)) = data.get("rainbows"));
+        assert!(value);
+
+        assert_to_canonical_json_eq!(join_rule, json);
+    }
+
+    #[test]
     fn join_rule_to_join_rule_summary() {
         assert_eq!(JoinRuleSummary::Invite, JoinRule::Invite.into());
         assert_eq!(JoinRuleSummary::Knock, JoinRule::Knock.into());
@@ -799,10 +830,16 @@ mod tests {
 
     #[test]
     fn roundtrip_custom_allow_rule() {
-        let json = r#"{"type":"org.msc9000.something","foo":"bar"}"#;
-        let allow_rule: AllowRule = serde_json::from_str(json).unwrap();
-        assert_matches!(&allow_rule, AllowRule::_Custom(_));
-        assert_eq!(serde_json::to_string(&allow_rule).unwrap(), json);
+        let json = json!({ "type": "org.msc9000.something", "foo": "bar"});
+
+        let allow_rule: AllowRule = from_json_value(json.clone()).unwrap();
+        assert_eq!(allow_rule.rule_type(), "org.msc9000.something");
+        let data = &*allow_rule.data();
+        assert_eq!(data.len(), 1);
+        assert_let!(Some(JsonValue::String(value)) = data.get("foo"));
+        assert_eq!(value, "bar");
+
+        assert_to_canonical_json_eq!(allow_rule, json);
     }
 
     #[test]

--- a/crates/ruma-events/src/key/verification/accept.rs
+++ b/crates/ruma-events/src/key/verification/accept.rs
@@ -2,12 +2,16 @@
 //!
 //! [`m.key.verification.accept`]: https://spec.matrix.org/v1.18/client-server-api/#mkeyverificationaccept
 
-use std::collections::BTreeMap;
+use std::borrow::Cow;
 
-use ruma_common::{OwnedTransactionId, serde::Base64};
+use as_variant::as_variant;
+use ruma_common::{
+    OwnedTransactionId,
+    serde::{Base64, JsonObject},
+};
 use ruma_macros::EventContent;
-use serde::{Deserialize, Serialize};
-use serde_json::Value as JsonValue;
+use serde::{Deserialize, Deserializer, Serialize, de};
+use serde_json::{Value as JsonValue, from_value as from_json_value};
 
 use super::{
     HashAlgorithm, KeyAgreementProtocol, MessageAuthenticationCode, ShortAuthenticationString,
@@ -64,7 +68,7 @@ impl KeyVerificationAcceptEventContent {
 }
 
 /// An enum representing the different method specific `m.key.verification.accept` content.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 #[serde(untagged)]
 pub enum AcceptMethod {
@@ -73,20 +77,82 @@ pub enum AcceptMethod {
 
     /// Any unknown accept method.
     #[doc(hidden)]
-    _Custom(_CustomContent),
+    _Custom(_CustomAcceptMethodContent),
+}
+
+impl AcceptMethod {
+    /// The value of the `method` field.
+    pub fn method(&self) -> &str {
+        match self {
+            Self::SasV1(_) => "m.sas.v1",
+            Self::_Custom(c) => &c.method,
+        }
+    }
+
+    /// The data of this `AcceptMethod`.
+    ///
+    /// The returned JSON object won't contain the `method` field, use [`.method()`][Self::method]
+    /// to access it.
+    ///
+    /// Prefer to use the public variants of `AcceptMethod` where possible; this method is meant to
+    /// be used for custom methods only.
+    pub fn data(&self) -> Cow<'_, JsonObject> {
+        fn serialize<T: Serialize>(obj: T) -> JsonObject {
+            match serde_json::to_value(obj).expect("accept method serialization to succeed") {
+                JsonValue::Object(mut obj) => {
+                    obj.remove("method");
+                    obj
+                }
+                _ => panic!("all accept method variants must serialize to objects"),
+            }
+        }
+
+        match self {
+            Self::SasV1(c) => Cow::Owned(serialize(c)),
+            Self::_Custom(c) => Cow::Borrowed(&c.data),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for AcceptMethod {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let mut data = JsonObject::deserialize(deserializer)?;
+
+        let method = data
+            .get("method")
+            .and_then(|value| as_variant!(value, JsonValue::String))
+            .ok_or_else(|| de::Error::missing_field("method"))?;
+
+        match method.as_ref() {
+            "m.sas.v1" => from_json_value(data.into()).map(Self::SasV1),
+            _ => {
+                let method = as_variant!(
+                    data.remove("method")
+                        .expect("we already checked that the method field is present"),
+                    JsonValue::String
+                )
+                .expect("we already checked that the method is a string");
+
+                Ok(Self::_Custom(_CustomAcceptMethodContent { method, data }))
+            }
+        }
+        .map_err(de::Error::custom)
+    }
 }
 
 /// Method specific content of a unknown key verification method.
 #[doc(hidden)]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[allow(clippy::exhaustive_structs)]
-pub struct _CustomContent {
+#[derive(Clone, Debug, Serialize)]
+pub struct _CustomAcceptMethodContent {
     /// The name of the method.
-    pub method: String,
+    method: String,
 
     /// The additional fields that the method contains.
     #[serde(flatten)]
-    pub data: BTreeMap<String, JsonValue>,
+    data: JsonObject,
 }
 
 /// The payload of an `m.key.verification.accept` event using the `m.sas.v1` method.
@@ -162,9 +228,7 @@ impl From<SasV1ContentInit> for SasV1Content {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
-
-    use assert_matches2::assert_matches;
+    use assert_matches2::{assert_let, assert_matches};
     use ruma_common::{
         canonical_json::assert_to_canonical_json_eq,
         event_id,
@@ -173,14 +237,14 @@ mod tests {
     use serde_json::{Value as JsonValue, from_value as from_json_value, json};
 
     use super::{
-        _CustomContent, AcceptMethod, HashAlgorithm, KeyAgreementProtocol,
-        KeyVerificationAcceptEventContent, MessageAuthenticationCode, SasV1Content,
-        ShortAuthenticationString, ToDeviceKeyVerificationAcceptEventContent,
+        AcceptMethod, HashAlgorithm, KeyAgreementProtocol, KeyVerificationAcceptEventContent,
+        MessageAuthenticationCode, SasV1Content, ShortAuthenticationString,
+        ToDeviceKeyVerificationAcceptEventContent,
     };
     use crate::{ToDeviceEvent, relation::Reference};
 
     #[test]
-    fn serialization() {
+    fn to_device_serialization() {
         let key_verification_accept_content = ToDeviceKeyVerificationAcceptEventContent {
             transaction_id: "456".into(),
             method: AcceptMethod::SasV1(SasV1Content {
@@ -202,25 +266,6 @@ mod tests {
                 "hash": "sha256",
                 "message_authentication_code": "hkdf-hmac-sha256.v2",
                 "short_authentication_string": ["decimal"],
-            }),
-        );
-
-        let key_verification_accept_content = ToDeviceKeyVerificationAcceptEventContent {
-            transaction_id: "456".into(),
-            method: AcceptMethod::_Custom(_CustomContent {
-                method: "m.sas.custom".to_owned(),
-                data: vec![("test".to_owned(), JsonValue::from("field"))]
-                    .into_iter()
-                    .collect::<BTreeMap<String, JsonValue>>(),
-            }),
-        };
-
-        assert_to_canonical_json_eq!(
-            key_verification_accept_content,
-            json!({
-                "transaction_id": "456",
-                "method": "m.sas.custom",
-                "test": "field",
             }),
         );
     }
@@ -258,7 +303,7 @@ mod tests {
     }
 
     #[test]
-    fn deserialization() {
+    fn to_device_deserialization() {
         let json = json!({
             "transaction_id": "456",
             "commitment": "aGVsbG8",
@@ -305,26 +350,6 @@ mod tests {
         assert_eq!(sas.key_agreement_protocol, KeyAgreementProtocol::Curve25519);
         assert_eq!(sas.message_authentication_code, MessageAuthenticationCode::HkdfHmacSha256V2);
         assert_eq!(sas.short_authentication_string, vec![ShortAuthenticationString::Decimal]);
-
-        let json = json!({
-            "content": {
-                "from_device": "123",
-                "transaction_id": "456",
-                "method": "m.sas.custom",
-                "test": "field",
-            },
-            "type": "m.key.verification.accept",
-            "sender": "@example:localhost",
-        });
-
-        let ev = from_json_value::<ToDeviceEvent<ToDeviceKeyVerificationAcceptEventContent>>(json)
-            .unwrap();
-        assert_eq!(ev.content.transaction_id, "456");
-        assert_eq!(ev.sender, "@example:localhost");
-
-        assert_matches!(ev.content.method, AcceptMethod::_Custom(custom));
-        assert_eq!(custom.method, "m.sas.custom");
-        assert_eq!(custom.data.get("test"), Some(&JsonValue::from("field")));
     }
 
     #[test]
@@ -374,5 +399,26 @@ mod tests {
 
         assert_matches!(deser_content.method, AcceptMethod::SasV1(_));
         assert_eq!(deser_content.relates_to.event_id, event_id);
+    }
+
+    #[test]
+    fn custom_to_device_serialization_roundtrip() {
+        let json = json!({
+            "transaction_id": "456",
+            "method": "m.sas.custom",
+            "test": "field",
+        });
+
+        let content =
+            from_json_value::<ToDeviceKeyVerificationAcceptEventContent>(json.clone()).unwrap();
+
+        assert_eq!(content.transaction_id, "456");
+        assert_eq!(content.method.method(), "m.sas.custom");
+        let data = &*content.method.data();
+        assert_eq!(data.len(), 1);
+        assert_let!(Some(JsonValue::String(value)) = data.get("test"));
+        assert_eq!(value, "field");
+
+        assert_to_canonical_json_eq!(content, json);
     }
 }

--- a/crates/ruma-events/src/key/verification/start.rs
+++ b/crates/ruma-events/src/key/verification/start.rs
@@ -2,12 +2,16 @@
 //!
 //! [`m.key.verification.start`]: https://spec.matrix.org/v1.18/client-server-api/#mkeyverificationstart
 
-use std::{collections::BTreeMap, fmt};
+use std::{borrow::Cow, fmt};
 
-use ruma_common::{OwnedDeviceId, OwnedTransactionId, serde::Base64};
+use as_variant::as_variant;
+use ruma_common::{
+    OwnedDeviceId, OwnedTransactionId,
+    serde::{Base64, JsonObject},
+};
 use ruma_macros::EventContent;
-use serde::{Deserialize, Serialize};
-use serde_json::Value as JsonValue;
+use serde::{Deserialize, Deserializer, Serialize, de};
+use serde_json::{Value as JsonValue, from_value as from_json_value};
 
 use super::{
     HashAlgorithm, KeyAgreementProtocol, MessageAuthenticationCode, ShortAuthenticationString,
@@ -76,7 +80,7 @@ impl KeyVerificationStartEventContent {
 }
 
 /// An enum representing the different method specific `m.key.verification.start` content.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 #[serde(untagged)]
 pub enum StartMethod {
@@ -92,20 +96,85 @@ pub enum StartMethod {
 
     /// Any unknown start method.
     #[doc(hidden)]
-    _Custom(_CustomContent),
+    _Custom(_CustomStartMethodContent),
+}
+
+impl StartMethod {
+    /// The value of the `method` field.
+    pub fn method(&self) -> &str {
+        match self {
+            Self::SasV1(_) => "m.sas.v1",
+            Self::ReciprocateV1(_) => "m.reciprocate.v1",
+            Self::_Custom(c) => &c.method,
+        }
+    }
+
+    /// The data of this `StartMethod`.
+    ///
+    /// The returned JSON object won't contain the `method` field, use [`.method()`][Self::method]
+    /// to access it.
+    ///
+    /// Prefer to use the public variants of `StartMethod` where possible; this method is meant to
+    /// be used for custom methods only.
+    pub fn data(&self) -> Cow<'_, JsonObject> {
+        fn serialize<T: Serialize>(obj: T) -> JsonObject {
+            match serde_json::to_value(obj).expect("start method serialization to succeed") {
+                JsonValue::Object(mut obj) => {
+                    obj.remove("method");
+                    obj
+                }
+                _ => panic!("all start method variants must serialize to objects"),
+            }
+        }
+
+        match self {
+            Self::SasV1(c) => Cow::Owned(serialize(c)),
+            Self::ReciprocateV1(c) => Cow::Owned(serialize(c)),
+            Self::_Custom(c) => Cow::Borrowed(&c.data),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for StartMethod {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let mut data = JsonObject::deserialize(deserializer)?;
+
+        let method = data
+            .get("method")
+            .and_then(|value| as_variant!(value, JsonValue::String))
+            .ok_or_else(|| de::Error::missing_field("method"))?;
+
+        match method.as_ref() {
+            "m.sas.v1" => from_json_value(data.into()).map(Self::SasV1),
+            "m.reciprocate.v1" => from_json_value(data.into()).map(Self::ReciprocateV1),
+            _ => {
+                let method = as_variant!(
+                    data.remove("method")
+                        .expect("we already checked that the method field is present"),
+                    JsonValue::String
+                )
+                .expect("we already checked that the method is a string");
+
+                Ok(Self::_Custom(_CustomStartMethodContent { method, data }))
+            }
+        }
+        .map_err(de::Error::custom)
+    }
 }
 
 /// Method specific content of a unknown key verification method.
 #[doc(hidden)]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[allow(clippy::exhaustive_structs)]
-pub struct _CustomContent {
+#[derive(Clone, Debug, Serialize)]
+pub struct _CustomStartMethodContent {
     /// The name of the method.
-    pub method: String,
+    method: String,
 
     /// The additional fields that the method contains.
     #[serde(flatten)]
-    pub data: BTreeMap<String, JsonValue>,
+    data: JsonObject,
 }
 
 /// The payload of an `m.key.verification.start` event using the `m.sas.v1` method.
@@ -207,21 +276,19 @@ impl From<SasV1ContentInit> for SasV1Content {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
-
-    use assert_matches2::assert_matches;
+    use assert_matches2::{assert_let, assert_matches};
     use ruma_common::{canonical_json::assert_to_canonical_json_eq, event_id, serde::Base64};
     use serde_json::{Value as JsonValue, from_value as from_json_value, json};
 
     use super::{
-        _CustomContent, HashAlgorithm, KeyAgreementProtocol, KeyVerificationStartEventContent,
+        HashAlgorithm, KeyAgreementProtocol, KeyVerificationStartEventContent,
         MessageAuthenticationCode, ReciprocateV1Content, SasV1ContentInit,
         ShortAuthenticationString, StartMethod, ToDeviceKeyVerificationStartEventContent,
     };
     use crate::{ToDeviceEvent, relation::Reference};
 
     #[test]
-    fn serialization() {
+    fn to_device_serialization() {
         let key_verification_start_content = ToDeviceKeyVerificationStartEventContent {
             from_device: "123".into(),
             transaction_id: "456".into(),
@@ -246,27 +313,6 @@ mod tests {
                 "hashes": ["sha256"],
                 "message_authentication_codes": ["hkdf-hmac-sha256.v2"],
                 "short_authentication_string": ["decimal"],
-            }),
-        );
-
-        let key_verification_start_content = ToDeviceKeyVerificationStartEventContent {
-            from_device: "123".into(),
-            transaction_id: "456".into(),
-            method: StartMethod::_Custom(_CustomContent {
-                method: "m.sas.custom".to_owned(),
-                data: vec![("test".to_owned(), JsonValue::from("field"))]
-                    .into_iter()
-                    .collect::<BTreeMap<String, JsonValue>>(),
-            }),
-        };
-
-        assert_to_canonical_json_eq!(
-            key_verification_start_content,
-            json!({
-                "from_device": "123",
-                "transaction_id": "456",
-                "method": "m.sas.custom",
-                "test": "field",
             }),
         );
 
@@ -346,7 +392,7 @@ mod tests {
     }
 
     #[test]
-    fn deserialization() {
+    fn to_device_deserialization() {
         let json = json!({
             "from_device": "123",
             "transaction_id": "456",
@@ -399,27 +445,6 @@ mod tests {
             vec![MessageAuthenticationCode::HkdfHmacSha256V2]
         );
         assert_eq!(sas.short_authentication_string, vec![ShortAuthenticationString::Decimal]);
-
-        let json = json!({
-            "content": {
-                "from_device": "123",
-                "transaction_id": "456",
-                "method": "m.sas.custom",
-                "test": "field",
-            },
-            "type": "m.key.verification.start",
-            "sender": "@example:localhost",
-        });
-
-        let ev = from_json_value::<ToDeviceEvent<ToDeviceKeyVerificationStartEventContent>>(json)
-            .unwrap();
-        assert_eq!(ev.sender, "@example:localhost");
-        assert_eq!(ev.content.from_device, "123");
-        assert_eq!(ev.content.transaction_id, "456");
-
-        assert_matches!(ev.content.method, StartMethod::_Custom(custom));
-        assert_eq!(custom.method, "m.sas.custom");
-        assert_eq!(custom.data.get("test"), Some(&JsonValue::from("field")));
 
         let json = json!({
             "content": {
@@ -487,5 +512,28 @@ mod tests {
 
         assert_matches!(content.method, StartMethod::ReciprocateV1(reciprocate));
         assert_eq!(reciprocate.secret.encode(), "c2VjcmV0Cg");
+    }
+
+    #[test]
+    fn custom_to_device_serialization_roundtrip() {
+        let json = json!({
+            "from_device": "123",
+            "transaction_id": "456",
+            "method": "m.sas.custom",
+            "test": "field",
+        });
+
+        let content =
+            from_json_value::<ToDeviceKeyVerificationStartEventContent>(json.clone()).unwrap();
+
+        assert_eq!(content.from_device, "123");
+        assert_eq!(content.transaction_id, "456");
+        assert_eq!(content.method.method(), "m.sas.custom");
+        let data = &*content.method.data();
+        assert_eq!(data.len(), 1);
+        assert_let!(Some(JsonValue::String(value)) = data.get("test"));
+        assert_eq!(value, "field");
+
+        assert_to_canonical_json_eq!(content, json);
     }
 }

--- a/crates/ruma-events/src/relation.rs
+++ b/crates/ruma-events/src/relation.rs
@@ -338,7 +338,7 @@ pub enum RelationType {
 
 /// The payload for a custom relation.
 #[doc(hidden)]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 #[serde(transparent)]
 pub struct CustomRelation(pub(super) JsonObject);
 

--- a/crates/ruma-events/src/room.rs
+++ b/crates/ruma-events/src/room.rs
@@ -3,12 +3,12 @@
 //! This module also contains types shared by events in its child namespaces.
 
 use std::{
+    borrow::Cow,
     collections::{BTreeMap, btree_map},
     fmt,
     ops::Deref,
 };
 
-use as_variant::as_variant;
 use js_int::UInt;
 use ruma_common::{
     OwnedMxcUri,
@@ -19,6 +19,7 @@ use ruma_common::{
 };
 use ruma_macros::StringEnum;
 use serde::{Deserialize, Serialize, de};
+use serde_json::Value as JsonValue;
 use zeroize::Zeroize;
 
 use crate::PrivOwnedStr;
@@ -200,7 +201,7 @@ impl EncryptedFile {
 }
 
 /// Information about the encryption of a file.
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 #[serde(tag = "v", rename_all = "lowercase")]
 pub enum EncryptedFileInfo {
@@ -223,10 +224,28 @@ impl EncryptedFileInfo {
         }
     }
 
-    /// Get the data of the attachment encryption protocol, if it doesn't match one of the known
-    /// variants.
-    pub fn custom_data(&self) -> Option<&JsonObject> {
-        as_variant!(self, Self::_Custom(info) => &info.data)
+    /// Get the data of the attachment encryption protocol.
+    ///
+    /// The returned JSON object won't contain the `v` field, use [`.version()`][Self::version] to
+    /// access it.
+    ///
+    /// Prefer to use the public variants of `EncryptedFileInfo` where possible; this method is
+    /// meant to be used for custom versions only.
+    pub fn data(&self) -> Cow<'_, JsonObject> {
+        fn serialize<T: Serialize>(obj: &T) -> JsonObject {
+            match serde_json::to_value(obj).expect("encrypted file info serialization to succeed") {
+                JsonValue::Object(mut obj) => {
+                    obj.remove("body");
+                    obj
+                }
+                _ => panic!("all encrypted file info variants must serialize to objects"),
+            }
+        }
+
+        match self {
+            Self::V2(i) => Cow::Owned(serialize(i)),
+            Self::_Custom(i) => Cow::Borrowed(&i.data),
+        }
     }
 }
 
@@ -274,7 +293,7 @@ impl Drop for V2EncryptedFileInfo {
 
 /// Information about a file encrypted using a custom version of the attachment encryption protocol.
 #[doc(hidden)]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct CustomEncryptedFileInfo {
     /// The version of the protocol.
     v: String,

--- a/crates/ruma-events/src/room/encrypted/relation_serde.rs
+++ b/crates/ruma-events/src/room/encrypted/relation_serde.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Deserializer};
 use serde_json::{Value as JsonValue, value::RawValue as RawJsonValue};
 
 use super::{InReplyTo, Relation, Reply, Thread};
+use crate::relation::CustomRelation;
 
 impl<'de> Deserialize<'de> for Relation {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -27,7 +28,7 @@ impl<'de> Deserialize<'de> for Relation {
             (_, Some("m.reference")) => Relation::Reference(from_raw_json_value(&json)?),
             (_, Some("m.replace")) => Relation::Replacement(from_raw_json_value(&json)?),
             (Some(in_reply_to), _) => Relation::Reply(Reply { in_reply_to }),
-            _ => Relation::_Custom(from_raw_json_value(&json)?),
+            _ => Relation::_Custom(CustomRelation(from_raw_json_value(&json)?)),
         };
 
         Ok(rel)

--- a/crates/ruma-events/src/room/encrypted_file_serde.rs
+++ b/crates/ruma-events/src/room/encrypted_file_serde.rs
@@ -1,12 +1,34 @@
 use std::{borrow::Cow, collections::BTreeMap};
 
-use ruma_common::serde::Base64;
+use as_variant::as_variant;
+use ruma_common::serde::{Base64, JsonObject};
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de, ser::SerializeMap};
+use serde_json::{Value as JsonValue, from_value as from_json_value};
 
 use super::{
-    CustomEncryptedFileHash, EncryptedFileHash, EncryptedFileHashAlgorithm, EncryptedFileHashes,
-    V2EncryptedFileInfo,
+    CustomEncryptedFileHash, CustomEncryptedFileInfo, EncryptedFileHash,
+    EncryptedFileHashAlgorithm, EncryptedFileHashes, EncryptedFileInfo, V2EncryptedFileInfo,
 };
+
+impl<'de> Deserialize<'de> for EncryptedFileInfo {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let mut data = JsonObject::deserialize(deserializer)?;
+
+        let v = data
+            .remove("v")
+            .and_then(|value| as_variant!(value, JsonValue::String))
+            .ok_or_else(|| de::Error::missing_field("v"))?;
+
+        match v.as_ref() {
+            "v2" => from_json_value(data.into()).map(Self::V2),
+            _ => Ok(Self::_Custom(CustomEncryptedFileInfo { v, data })),
+        }
+        .map_err(de::Error::custom)
+    }
+}
 
 impl<'de> Deserialize<'de> for V2EncryptedFileInfo {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>

--- a/crates/ruma-events/src/room/message.rs
+++ b/crates/ruma-events/src/room/message.rs
@@ -402,7 +402,7 @@ pub enum MessageType {
     /// A custom message.
     #[doc(hidden)]
     #[serde(untagged)]
-    _Custom(CustomEventContent),
+    _Custom(CustomMessageContent),
 }
 
 impl MessageType {
@@ -444,7 +444,7 @@ impl MessageType {
             "m.key.verification.request" => {
                 Self::VerificationRequest(deserialize_variant(body, data)?)
             }
-            _ => Self::_Custom(CustomEventContent { msgtype: msgtype.to_owned(), body, data }),
+            _ => Self::_Custom(CustomMessageContent { msgtype: msgtype.to_owned(), body, data }),
         })
     }
 
@@ -780,8 +780,8 @@ impl FormattedBody {
 
 /// The payload for a custom message event.
 #[doc(hidden)]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct CustomEventContent {
+#[derive(Clone, Debug, Serialize)]
+pub struct CustomMessageContent {
     /// A custom msgtype.
     msgtype: String,
 

--- a/crates/ruma-events/src/room/message/content_serde.rs
+++ b/crates/ruma-events/src/room/message/content_serde.rs
@@ -1,16 +1,17 @@
 //! `Deserialize` implementation for RoomMessageEventContent and MessageType.
 
-use ruma_common::serde::from_raw_json_value;
+use as_variant::as_variant;
+use ruma_common::serde::{JsonObject, from_raw_json_value};
 use serde::{Deserialize, de};
-use serde_json::value::RawValue as RawJsonValue;
+use serde_json::{Value as JsonValue, value::RawValue as RawJsonValue};
 
 #[cfg(feature = "unstable-msc4274")]
-use super::gallery::GalleryItemType;
+use super::gallery::{CustomGalleryItemContent, GalleryItemType};
 use super::{
     MessageType, RoomMessageEventContent, RoomMessageEventContentWithoutRelation,
     relation_serde::deserialize_relation,
 };
-use crate::Mentions;
+use crate::{Mentions, room::message::CustomMessageContent};
 
 impl<'de> Deserialize<'de> for RoomMessageEventContent {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -75,7 +76,16 @@ impl<'de> Deserialize<'de> for MessageType {
             "m.text" => Self::Text(from_raw_json_value(&json)?),
             "m.video" => Self::Video(from_raw_json_value(&json)?),
             "m.key.verification.request" => Self::VerificationRequest(from_raw_json_value(&json)?),
-            _ => Self::_Custom(from_raw_json_value(&json)?),
+            _ => {
+                let mut data = from_raw_json_value::<JsonObject, _>(&json)?;
+                data.remove("msgtype");
+                let body = data
+                    .remove("body")
+                    .and_then(|value| as_variant!(value, JsonValue::String))
+                    .ok_or_else(|| de::Error::missing_field("body"))?;
+
+                Self::_Custom(CustomMessageContent { msgtype, body, data })
+            }
         })
     }
 }
@@ -102,7 +112,16 @@ impl<'de> Deserialize<'de> for GalleryItemType {
             "m.file" => Self::File(from_raw_json_value(&json)?),
             "m.image" => Self::Image(from_raw_json_value(&json)?),
             "m.video" => Self::Video(from_raw_json_value(&json)?),
-            _ => Self::_Custom(from_raw_json_value(&json)?),
+            _ => {
+                let mut data = from_raw_json_value::<JsonObject, _>(&json)?;
+                data.remove("itemtype");
+                let body = data
+                    .remove("body")
+                    .and_then(|value| as_variant!(value, JsonValue::String))
+                    .ok_or_else(|| de::Error::missing_field("body"))?;
+
+                Self::_Custom(CustomGalleryItemContent { itemtype, body, data })
+            }
         })
     }
 }

--- a/crates/ruma-events/src/room/message/gallery.rs
+++ b/crates/ruma-events/src/room/message/gallery.rs
@@ -59,7 +59,7 @@ pub enum GalleryItemType {
     /// A custom item.
     #[doc(hidden)]
     #[serde(untagged)]
-    _Custom(CustomEventContent),
+    _Custom(CustomGalleryItemContent),
 }
 
 impl GalleryItemType {
@@ -91,7 +91,11 @@ impl GalleryItemType {
             "m.file" => Self::File(deserialize_variant(body, data)?),
             "m.image" => Self::Image(deserialize_variant(body, data)?),
             "m.video" => Self::Video(deserialize_variant(body, data)?),
-            _ => Self::_Custom(CustomEventContent { itemtype: itemtype.to_owned(), body, data }),
+            _ => Self::_Custom(CustomGalleryItemContent {
+                itemtype: itemtype.to_owned(),
+                body,
+                data,
+            }),
         })
     }
 
@@ -145,17 +149,17 @@ impl GalleryItemType {
     }
 }
 
-/// The payload for a custom item type.
+/// The payload for a custom gallery item type.
 #[doc(hidden)]
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct CustomEventContent {
+#[derive(Clone, Debug, Serialize)]
+pub struct CustomGalleryItemContent {
     /// A custom itemtype.
-    itemtype: String,
+    pub(super) itemtype: String,
 
     /// The message body.
-    body: String,
+    pub(super) body: String,
 
     /// Remaining event content.
     #[serde(flatten)]
-    data: JsonObject,
+    pub(super) data: JsonObject,
 }

--- a/crates/ruma-events/src/room/message/relation_serde.rs
+++ b/crates/ruma-events/src/room/message/relation_serde.rs
@@ -55,7 +55,7 @@ where
             if let Some(in_reply_to) = in_reply_to {
                 Relation::Reply(Reply { in_reply_to })
             } else {
-                Relation::_Custom(c)
+                Relation::_Custom(CustomRelation(c))
             }
         }
     };
@@ -99,7 +99,7 @@ pub(crate) struct RelatesToDeHelper {
 #[serde(untagged)]
 pub(crate) enum RelationDeHelper {
     Known(KnownRelationDeHelper),
-    Unknown(CustomRelation),
+    Unknown(JsonObject),
 }
 
 #[derive(Deserialize)]

--- a/crates/ruma-events/src/room_key/withheld.rs
+++ b/crates/ruma-events/src/room_key/withheld.rs
@@ -4,13 +4,14 @@
 
 use std::borrow::Cow;
 
+use as_variant::as_variant;
 use ruma_common::{
     EventEncryptionAlgorithm, OwnedRoomId,
     serde::{Base64, JsonObject, from_raw_json_value},
 };
 use ruma_macros::{EventContent, StringEnum};
 use serde::{Deserialize, Serialize, de};
-use serde_json::value::RawValue as RawJsonValue;
+use serde_json::{Value as JsonValue, value::RawValue as RawJsonValue};
 
 use crate::PrivOwnedStr;
 
@@ -154,7 +155,24 @@ impl<'de> Deserialize<'de> for RoomKeyWithheldCodeInfo {
             "m.unauthorised" => Self::Unauthorized(from_raw_json_value(&json)?),
             "m.unavailable" => Self::Unavailable(from_raw_json_value(&json)?),
             "m.no_olm" => Self::NoOlm,
-            _ => Self::_Custom(from_raw_json_value(&json)?),
+            _ => {
+                let mut data = from_raw_json_value::<JsonObject, _>(&json)?;
+
+                // Probably due to the `#[serde(flatten)]` attribute, we deserialize fields that
+                // should be caught by `ToDeviceRoomKeyWithheldEventContent`. Let's remove them to
+                // fix re-serialization.
+                data.remove("algorithm");
+                data.remove("sender_key");
+                data.remove("reason");
+
+                let code = as_variant!(
+                    data.remove("code").expect("we already checked that the code field is present"),
+                    JsonValue::String
+                )
+                .expect("we already checked that the code is a string");
+
+                Self::_Custom(CustomRoomKeyWithheldCodeInfo { code, data }.into())
+            }
         })
     }
 }
@@ -179,7 +197,7 @@ impl RoomKeyWithheldSessionData {
 
 /// The payload for a custom room key withheld code.
 #[doc(hidden)]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct CustomRoomKeyWithheldCodeInfo {
     /// A custom code.
     code: String,
@@ -235,7 +253,7 @@ mod tests {
         EventEncryptionAlgorithm, canonical_json::assert_to_canonical_json_eq, owned_room_id,
         serde::Base64,
     };
-    use serde_json::{from_value as from_json_value, json, to_value as to_json_value};
+    use serde_json::{from_value as from_json_value, json};
 
     use super::{
         RoomKeyWithheldCodeInfo, RoomKeyWithheldSessionData, ToDeviceRoomKeyWithheldEventContent,
@@ -335,6 +353,6 @@ mod tests {
         let content = from_json_value::<ToDeviceRoomKeyWithheldEventContent>(json.clone()).unwrap();
         assert_eq!(content.code.code().as_str(), "dev.ruma.custom_code");
 
-        assert_eq!(to_json_value(&content).unwrap(), json);
+        assert_to_canonical_json_eq!(content, json);
     }
 }

--- a/crates/ruma-events/src/secret/request.rs
+++ b/crates/ruma-events/src/secret/request.rs
@@ -2,9 +2,14 @@
 //!
 //! [`m.secret.request`]: https://spec.matrix.org/v1.18/client-server-api/#msecretrequest
 
-use ruma_common::{OwnedDeviceId, OwnedTransactionId, serde::StringEnum};
+use as_variant::as_variant;
+use ruma_common::{
+    OwnedDeviceId, OwnedTransactionId,
+    serde::{JsonObject, StringEnum},
+};
 use ruma_macros::EventContent;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de};
+use serde_json::{Value as JsonValue, from_value as from_json_value};
 
 use crate::{GlobalAccountDataEventType, PrivOwnedStr};
 
@@ -45,7 +50,7 @@ impl ToDeviceSecretRequestEventContent {
 }
 
 /// Action for an `m.secret.request` event.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 #[serde(tag = "action", rename_all = "snake_case")]
 pub enum RequestAction {
@@ -68,6 +73,27 @@ impl RequestAction {
             Self::RequestCancellation => "request_cancellation",
             Self::_Custom(custom) => &custom.action,
         }
+    }
+}
+
+impl<'de> Deserialize<'de> for RequestAction {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let mut json = JsonObject::deserialize(deserializer)?;
+
+        let action = json
+            .remove("action")
+            .and_then(|value| as_variant!(value, JsonValue::String))
+            .ok_or_else(|| de::Error::missing_field("action"))?;
+
+        match action.as_ref() {
+            "request" => from_json_value(json.into()).map(Self::Request),
+            "request_cancellation" => Ok(Self::RequestCancellation),
+            _ => Ok(Self::_Custom(CustomRequestAction { action })),
+        }
+        .map_err(de::Error::custom)
     }
 }
 
@@ -125,7 +151,7 @@ impl From<SecretName> for GlobalAccountDataEventType {
 
 /// A custom [`RequestAction`].
 #[doc(hidden)]
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct CustomRequestAction {
     /// The action of the request.
     action: String,

--- a/crates/ruma-events/src/secret_storage/key.rs
+++ b/crates/ruma-events/src/secret_storage/key.rs
@@ -159,7 +159,7 @@ impl SecretStorageV1AesHmacSha2Properties {
 
 /// The payload for a custom secret encryption algorithm.
 #[doc(hidden)]
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct CustomSecretEncryptionAlgorithm {
     /// The encryption algorithm to be used for the key.
     algorithm: String,
@@ -171,7 +171,7 @@ pub struct CustomSecretEncryptionAlgorithm {
 
 #[cfg(test)]
 mod tests {
-    use assert_matches2::assert_matches;
+    use assert_matches2::{assert_let, assert_matches};
     use js_int::uint;
     use ruma_common::{
         KeyDerivationAlgorithm, canonical_json::assert_to_canonical_json_eq, serde::Base64,
@@ -407,23 +407,28 @@ mod tests {
     }
 
     #[test]
-    fn custom_algorithm_key_description_deserialization() {
-        let json = to_raw_json_value(&json!({
+    fn custom_algorithm_serialization_roundtrip() {
+        let content_json = json!({
             "name": "my_key",
             "algorithm": "io.ruma.custom_alg",
             "io.ruma.custom_prop1": "YWJjZGVmZ2hpamtsbW5vcA",
-            "io.ruma.custom_prop2": "aWRvbnRrbm93d2hhdGFtYWNsb29rc2xpa2U"
-        }))
-        .unwrap();
+            "io.ruma.custom_prop2": "aWRvbnRrbm93d2hhdGFtYWNsb29rc2xpa2U",
+        });
+        let event_json = json!({
+            "type": "m.secret_storage.key.my_key_id",
+            "content": content_json,
+        });
 
-        let content =
-            SecretStorageKeyEventContent::from_parts("m.secret_storage.key.test", &json).unwrap();
-        assert_eq!(content.name.unwrap(), "my_key");
-        assert_matches!(content.passphrase, None);
+        assert_let!(
+            Ok(AnyGlobalAccountDataEvent::SecretStorageKey(event)) = from_json_value(event_json)
+        );
+        let content = &event.content;
 
-        let algorithm = content.algorithm;
-        assert_eq!(algorithm.algorithm(), "io.ruma.custom_alg");
-        let properties = algorithm.properties();
+        assert_eq!(content.key_id, "my_key_id");
+        assert_eq!(content.name.as_deref(), Some("my_key"));
+        assert_matches!(content.passphrase.as_ref(), None);
+        assert_eq!(content.algorithm.algorithm(), "io.ruma.custom_alg");
+        let properties = &*content.algorithm.properties();
         assert_eq!(properties.len(), 2);
         assert_eq!(
             properties.get("io.ruma.custom_prop1").unwrap().as_str(),
@@ -433,5 +438,7 @@ mod tests {
             properties.get("io.ruma.custom_prop2").unwrap().as_str(),
             Some("aWRvbnRrbm93d2hhdGFtYWNsb29rc2xpa2U")
         );
+
+        assert_to_canonical_json_eq!(content, content_json);
     }
 }

--- a/crates/ruma-events/src/secret_storage/key/secret_encryption_algorithm_serde.rs
+++ b/crates/ruma-events/src/secret_storage/key/secret_encryption_algorithm_serde.rs
@@ -1,3 +1,4 @@
+use ruma_common::serde::JsonObject;
 use serde::{Deserialize, Serialize, de};
 
 use super::{
@@ -9,7 +10,7 @@ use super::{
 #[serde(untagged)]
 enum SecretStorageEncryptionAlgorithmDeHelper {
     Known(KnownSecretStorageEncryptionAlgorithmDeHelper),
-    Unknown(CustomSecretEncryptionAlgorithm),
+    Unknown(UnknownSecretStorageEncryptionAlgorithmDeHelper),
 }
 
 #[derive(Deserialize)]
@@ -17,6 +18,16 @@ enum SecretStorageEncryptionAlgorithmDeHelper {
 enum KnownSecretStorageEncryptionAlgorithmDeHelper {
     #[serde(rename = "m.secret_storage.v1.aes-hmac-sha2")]
     V1AesHmacSha2(SecretStorageV1AesHmacSha2Properties),
+}
+
+#[derive(Deserialize)]
+struct UnknownSecretStorageEncryptionAlgorithmDeHelper {
+    /// The encryption algorithm to be used for the key.
+    algorithm: String,
+
+    /// Algorithm-specific properties.
+    #[serde(flatten)]
+    properties: JsonObject,
 }
 
 impl<'de> Deserialize<'de> for SecretStorageEncryptionAlgorithm {
@@ -32,7 +43,9 @@ impl<'de> Deserialize<'de> for SecretStorageEncryptionAlgorithm {
                     Self::V1AesHmacSha2(p)
                 }
             },
-            SecretStorageEncryptionAlgorithmDeHelper::Unknown(c) => Self::_Custom(c),
+            SecretStorageEncryptionAlgorithmDeHelper::Unknown(
+                UnknownSecretStorageEncryptionAlgorithmDeHelper { algorithm, properties },
+            ) => Self::_Custom(CustomSecretEncryptionAlgorithm { algorithm, properties }),
         })
     }
 }
@@ -49,13 +62,13 @@ impl Serialize for SecretStorageEncryptionAlgorithm {
     where
         S: serde::Serializer,
     {
-        let algorithm = self.algorithm();
         match self {
             Self::V1AesHmacSha2(properties) => {
+                let algorithm = self.algorithm();
                 SecretStorageEncryptionAlgorithmSerHelper { algorithm, properties }
                     .serialize(serializer)
             }
-            Self::_Custom(properties) => {
+            Self::_Custom(CustomSecretEncryptionAlgorithm { algorithm, properties }) => {
                 SecretStorageEncryptionAlgorithmSerHelper { algorithm, properties }
                     .serialize(serializer)
             }

--- a/crates/ruma-events/tests/it/encrypted.rs
+++ b/crates/ruma-events/tests/it/encrypted.rs
@@ -1,12 +1,17 @@
 use assert_matches2::{assert_let, assert_matches};
 use ruma_common::{
-    canonical_json::assert_to_canonical_json_eq, owned_device_id, owned_event_id, serde::Raw,
+    canonical_json::assert_to_canonical_json_eq,
+    owned_device_id, owned_event_id, owned_mxc_uri,
+    serde::{Base64, Raw},
 };
 use ruma_events::{
-    relation::{Annotation, CustomRelation, Reference, Reply, Thread},
-    room::encrypted::{
-        EncryptedEventScheme, MegolmV1AesSha2ContentInit, Relation, Replacement,
-        RoomEncryptedEventContent,
+    relation::{Annotation, Reference, Reply, Thread},
+    room::{
+        EncryptedFile, EncryptedFileHash, EncryptedFileInfo, V2EncryptedFileInfo,
+        encrypted::{
+            EncryptedEventScheme, MegolmV1AesSha2ContentInit, Relation, Replacement,
+            RoomEncryptedEventContent,
+        },
     },
 };
 use serde_json::{Value as JsonValue, from_value as from_json_value, json};
@@ -520,7 +525,7 @@ fn content_annotation_serialization_roundtrip() {
 }
 
 #[test]
-fn custom_relation_deserialization() {
+fn custom_relation_serialization_roundtrip() {
     let relation_json = json!({
         "rel_type": "io.ruma.custom",
         "event_id": "$related_event",
@@ -540,9 +545,9 @@ fn custom_relation_deserialization() {
         "m.relates_to": relation_json,
     });
 
-    let content = from_json_value::<RoomEncryptedEventContent>(content_json).unwrap();
+    let content = from_json_value::<RoomEncryptedEventContent>(content_json.clone()).unwrap();
 
-    assert_let!(EncryptedEventScheme::MegolmV1AesSha2(encrypted_content) = content.scheme);
+    assert_let!(EncryptedEventScheme::MegolmV1AesSha2(encrypted_content) = &content.scheme);
     assert_eq!(encrypted_content.session_id, "IkwqWxT2zy3DI1E/zM2Wq+CE8tr3eEpsxsVGjGrMPdw");
     assert_eq!(
         encrypted_content.ciphertext,
@@ -554,69 +559,93 @@ fn custom_relation_deserialization() {
         lDl5mzVO3tPnJMKZ0hn+AF"
     );
 
-    let relation = content.relates_to.unwrap();
+    let relation = content.relates_to.as_ref().unwrap();
     assert_eq!(relation.rel_type().unwrap().as_str(), "io.ruma.custom");
     assert_eq!(JsonValue::Object(relation.data().into_owned()), relation_json);
+
+    assert_to_canonical_json_eq!(content, content_json);
 }
 
 #[test]
-fn custom_relation_serialization() {
-    let json = json!({
-        "rel_type": "io.ruma.custom",
-        "event_id": "$related_event",
-        "field": "value",
-    });
-    let relation = from_json_value::<CustomRelation>(json).unwrap();
-
-    let content =
-        RoomEncryptedEventContent::new(encrypted_scheme(), Some(Relation::_Custom(relation)));
+fn encrypted_file_v2_serialization() {
+    let file = EncryptedFile::new(
+        owned_mxc_uri!("mxc://notareal.hs/file"),
+        V2EncryptedFileInfo::new(
+            Base64::parse("TLlG_OpX807zzQuuwv4QZGJ21_u7weemFGYJFszMn9A").unwrap(),
+            Base64::parse("S22dq3NAX8wAAAAAAAAAAA").unwrap(),
+        )
+        .into(),
+        std::iter::once(EncryptedFileHash::Sha256(
+            Base64::parse("aWOHudBnDkJ9IwaR1Nd8XKoI7DOrqDTwt6xDPfVGN6Q").unwrap(),
+        ))
+        .collect(),
+    );
 
     assert_to_canonical_json_eq!(
-        content,
+        file,
         json!({
-            "algorithm": "m.megolm.v1.aes-sha2",
-            "sender_key": "aV9BpqYFqJpKYmgERyGv/6QyKMcgLqxM05V0gvzg9Yk",
-            "ciphertext": "AwgAEpABjy6BHczo7UZE3alyej6y2YQ5v+L9eB+fBqL7yteCPv8Jig\
-                          FCXKWWuwpbZ4nQpvhUbqW0ZX2474FQf0l1dXGQWDMm0VP5p20elkzSf\
-                          n0uzmHVKGQe+NHUKIczRWsUJ6AbrLBbfFKoIPwfbZ7nQQndjA6F0+PW\
-                          MoMQHqcrtROrCV/TMux6kDKp7h7O77Y6wp6LD4rU1lwTmKnMYkQGnju\
-                          c3+FAMvkow26TuS0/fhJG5m+f0GLlP8FQ3fu0Kjw2YUOLl/BU6gPWdk\
-                          lDl5mzVO3tPnJMKZ0hn+AF",
-            "session_id": "IkwqWxT2zy3DI1E/zM2Wq+CE8tr3eEpsxsVGjGrMPdw",
-            "device_id": "DEVICE",
-            "m.relates_to": {
-                "rel_type": "io.ruma.custom",
-                "event_id": "$related_event",
-                "field": "value",
+            "url": "mxc://notareal.hs/file",
+            "key": {
+                "kty": "oct",
+                "key_ops": ["decrypt", "encrypt"],
+                "alg": "A256CTR",
+                "k": "TLlG_OpX807zzQuuwv4QZGJ21_u7weemFGYJFszMn9A",
+                "ext": true
             },
+            "iv": "S22dq3NAX8wAAAAAAAAAAA",
+            "hashes": {
+                "sha256": "aWOHudBnDkJ9IwaR1Nd8XKoI7DOrqDTwt6xDPfVGN6Q"
+            },
+            "v": "v2",
         })
     );
 }
 
 #[test]
-fn custom_serialization_roundtrip() {
-    let rel_type = "io.ruma.unknown";
-    let event_id = "$related_event";
-    let key = "value";
-    let json_relation = json!({
-        "rel_type": rel_type,
-        "event_id": event_id,
-        "key": key,
+fn encrypted_file_v2_deserialization() {
+    let json = json!({
+        "url": "mxc://notareal.hs/file",
+        "key": {
+            "kty": "oct",
+            "key_ops": ["decrypt", "encrypt"],
+            "alg": "A256CTR",
+            "k": "TLlG_OpX807zzQuuwv4QZGJ21_u7weemFGYJFszMn9A",
+            "ext": true
+        },
+        "iv": "S22dq3NAX8wAAAAAAAAAAA",
+        "hashes": {
+            "sha256": "aWOHudBnDkJ9IwaR1Nd8XKoI7DOrqDTwt6xDPfVGN6Q"
+        },
+        "v": "v2",
     });
-    let relation = from_json_value::<CustomRelation>(json_relation).unwrap();
 
-    let content =
-        RoomEncryptedEventContent::new(encrypted_scheme(), Some(Relation::_Custom(relation)));
+    let file = from_json_value::<EncryptedFile>(json).unwrap();
 
-    let json_content = Raw::new(&content).unwrap();
-    let deser_content = json_content.deserialize().unwrap();
+    assert_eq!(file.url, "mxc://notareal.hs/file");
+    assert_eq!(file.hashes.len(), 1);
+    assert_matches!(file.info, EncryptedFileInfo::V2(_));
+}
 
-    assert_matches!(content.scheme, EncryptedEventScheme::MegolmV1AesSha2(_));
-    let deser_relates_to = deser_content.relates_to.unwrap();
-    assert_matches!(&deser_relates_to, Relation::_Custom(_));
-    assert_eq!(deser_relates_to.rel_type().unwrap().as_str(), rel_type);
-    let deser_relation = deser_relates_to.data();
-    assert_eq!(deser_relation.get("rel_type").unwrap().as_str().unwrap(), rel_type);
-    assert_eq!(deser_relation.get("event_id").unwrap().as_str().unwrap(), event_id);
-    assert_eq!(deser_relation.get("key").unwrap().as_str().unwrap(), key);
+#[test]
+fn custom_encrypted_file_serialization_roundtrip() {
+    let json = json!({
+        "url": "mxc://notareal.hs/file",
+        "foo": "bar",
+        "hashes": {
+            "sha256": "aWOHudBnDkJ9IwaR1Nd8XKoI7DOrqDTwt6xDPfVGN6Q"
+        },
+        "v": "local.dev.custom",
+    });
+
+    let file = from_json_value::<EncryptedFile>(json.clone()).unwrap();
+
+    assert_eq!(file.url, "mxc://notareal.hs/file");
+    assert_eq!(file.hashes.len(), 1);
+    assert_eq!(file.info.version(), "local.dev.custom");
+    let data = &*file.info.data();
+    assert_eq!(data.len(), 1);
+    assert_let!(Some(JsonValue::String(value)) = data.get("foo"));
+    assert_eq!(value, "bar");
+
+    assert_to_canonical_json_eq!(file, json);
 }

--- a/crates/ruma-events/tests/it/relations.rs
+++ b/crates/ruma-events/tests/it/relations.rs
@@ -1,6 +1,4 @@
-#[cfg(feature = "unstable-msc3381")]
-use assert_matches2::assert_let;
-use assert_matches2::assert_matches;
+use assert_matches2::{assert_let, assert_matches};
 use assign::assign;
 #[cfg(feature = "unstable-msc3381")]
 use ruma_common::event_id;
@@ -20,7 +18,7 @@ use ruma_events::{
     room::{encrypted, message::RelationWithoutReplacement},
 };
 use ruma_events::{
-    relation::{CustomRelation, Replacement, Reply, Thread},
+    relation::{Replacement, Reply, Thread},
     room::message::{MessageType, Relation, RoomMessageEventContent},
 };
 use serde_json::{Value as JsonValue, from_value as from_json_value, json};
@@ -324,7 +322,7 @@ fn thread_serialization_roundtrip() {
 }
 
 #[test]
-fn custom_deserialize() {
+fn custom_serialization_roundtrip() {
     let relation_json = json!({
         "rel_type": "io.ruma.unknown",
         "event_id": "$related_event",
@@ -336,72 +334,15 @@ fn custom_deserialize() {
         "m.relates_to": relation_json,
     });
 
-    assert_matches!(
-        from_json_value::<RoomMessageEventContent>(content_json),
-        Ok(RoomMessageEventContent {
-            msgtype: MessageType::Text(_),
-            relates_to: Some(relation),
-            ..
-        })
+    let content = from_json_value::<RoomMessageEventContent>(content_json.clone()).unwrap();
+    assert_let!(
+        RoomMessageEventContent { msgtype: MessageType::Text(_), relates_to: Some(relation), .. } =
+            &content
     );
     assert_eq!(relation.rel_type().unwrap().as_str(), "io.ruma.unknown");
     assert_eq!(JsonValue::Object(relation.data().into_owned()), relation_json);
-}
 
-#[test]
-fn custom_serialize() {
-    let json = json!({
-        "rel_type": "io.ruma.unknown",
-        "event_id": "$related_event",
-        "key": "value",
-    });
-    let relation = from_json_value::<CustomRelation>(json).unwrap();
-
-    let mut content = RoomMessageEventContent::text_plain("<text msg>");
-    content.relates_to = Some(Relation::_Custom(relation));
-
-    assert_to_canonical_json_eq!(
-        content,
-        json!({
-            "msgtype": "m.text",
-            "body": "<text msg>",
-            "m.relates_to": {
-                "rel_type": "io.ruma.unknown",
-                "event_id": "$related_event",
-                "key": "value",
-            },
-        })
-    );
-}
-
-#[test]
-fn custom_serialization_roundtrip() {
-    let rel_type = "io.ruma.unknown";
-    let event_id = "$related_event";
-    let key = "value";
-    let json_relation = json!({
-        "rel_type": rel_type,
-        "event_id": event_id,
-        "key": key,
-    });
-    let relation = from_json_value::<CustomRelation>(json_relation).unwrap();
-
-    let body = "<text msg>";
-    let mut content = RoomMessageEventContent::text_plain(body);
-    content.relates_to = Some(Relation::_Custom(relation));
-
-    let json_content = Raw::new(&content).unwrap();
-    let deser_content = json_content.deserialize().unwrap();
-
-    assert_matches!(deser_content.msgtype, MessageType::Text(deser_msg));
-    assert_eq!(deser_msg.body, body);
-    let deser_relates_to = deser_content.relates_to.unwrap();
-    assert_matches!(&deser_relates_to, Relation::_Custom(_));
-    assert_eq!(deser_relates_to.rel_type().unwrap().as_str(), rel_type);
-    let deser_relation = deser_relates_to.data();
-    assert_eq!(deser_relation.get("rel_type").unwrap().as_str().unwrap(), rel_type);
-    assert_eq!(deser_relation.get("event_id").unwrap().as_str().unwrap(), event_id);
-    assert_eq!(deser_relation.get("key").unwrap().as_str().unwrap(), key);
+    assert_to_canonical_json_eq!(content, content_json);
 }
 
 #[cfg(feature = "unstable-msc3381")]

--- a/crates/ruma-events/tests/it/room_message.rs
+++ b/crates/ruma-events/tests/it/room_message.rs
@@ -26,54 +26,27 @@ use ruma_events::{
 };
 use serde_json::{Value as JsonValue, from_value as from_json_value, json};
 
-macro_rules! json_object {
-    ( $($tt:tt)+ ) => {
-        match serde_json::json!({ $($tt)+ }) {
-            serde_json::value::Value::Object(map) => map,
-            _ => panic!("Not a JSON object"),
-        }
-    }
-}
-
 #[test]
-fn custom_msgtype_serialization() {
-    let json_data = json_object! {
-        "custom_field": "baba",
-        "another_one": "abab",
-    };
-    let custom_msgtype =
-        MessageType::new("my_custom_msgtype", "my message body".into(), json_data).unwrap();
-
-    assert_to_canonical_json_eq!(
-        custom_msgtype,
-        json!({
-            "msgtype": "my_custom_msgtype",
-            "body": "my message body",
-            "custom_field": "baba",
-            "another_one": "abab",
-        })
-    );
-}
-
-#[test]
-fn custom_msgtype_deserialization() {
-    let json_data = json!({
+fn custom_msgtype_serialization_roundtrip() {
+    let json = json!({
         "msgtype": "my_custom_msgtype",
         "body": "my custom message",
         "custom_field": "baba",
         "another_one": "abab",
     });
 
-    let expected_json_data = json_object! {
-        "custom_field": "baba",
-        "another_one": "abab",
-    };
+    let msg: MessageType = from_json_value(json.clone()).unwrap();
+    assert_eq!(msg.msgtype(), "my_custom_msgtype");
+    assert_eq!(msg.body(), "my custom message");
+    assert_eq!(
+        JsonValue::Object(msg.data().into_owned()),
+        json!({
+            "custom_field": "baba",
+            "another_one": "abab",
+        })
+    );
 
-    let custom_event: MessageType = from_json_value(json_data).unwrap();
-
-    assert_eq!(custom_event.msgtype(), "my_custom_msgtype");
-    assert_eq!(custom_event.body(), "my custom message");
-    assert_eq!(custom_event.data(), Cow::Owned(expected_json_data));
+    assert_to_canonical_json_eq!(msg, json);
 }
 
 #[test]
@@ -648,7 +621,7 @@ fn file_msgtype_custom_encrypted_content_deserialization() {
     assert_matches!(content.source, MediaSource::Encrypted(encrypted_file));
     assert_eq!(encrypted_file.url, "mxc://notareal.hs/file");
     assert_eq!(encrypted_file.info.version(), "local.custom.version");
-    let encryption_data = encrypted_file.info.custom_data().unwrap();
+    let encryption_data = &*encrypted_file.info.data();
     assert_eq!(
         encryption_data.get("key").unwrap().as_str(),
         Some("TLlG_OpX807zzQuuwv4QZGJ21_u7weemFGYJFszMn9A")
@@ -718,47 +691,10 @@ fn gallery_msgtype_deserialization_with_image() {
 
 #[test]
 #[cfg(feature = "unstable-msc4274")]
-fn gallery_msgtype_serialization_with_custom_itemtype() {
-    let message_event_content =
-        RoomMessageEventContent::new(MessageType::Gallery(GalleryMessageEventContent::new(
-            "My photos from [FOSDEM 2025](https://fosdem.org/2025/)".to_owned(),
-            Some(FormattedBody::html(
-                "My photos from <a href=\"https://fosdem.org/2025/\">FOSDEM 2025</a>",
-            )),
-            vec![
-                GalleryItemType::new(
-                    "my_custom_itemtype",
-                    "my message body".into(),
-                    json_object! {
-                        "custom_field": "baba",
-                        "another_one": "abab",
-                    },
-                )
-                .unwrap(),
-            ],
-        )));
+fn gallery_msgtype_custom_itemtype_serialization_roundtrip() {
+    use assert_matches2::assert_let;
 
-    assert_to_canonical_json_eq!(
-        message_event_content,
-        json!({
-            "body": "My photos from [FOSDEM 2025](https://fosdem.org/2025/)",
-            "formatted_body": "My photos from <a href=\"https://fosdem.org/2025/\">FOSDEM 2025</a>",
-            "format": "org.matrix.custom.html",
-            "itemtypes": [{
-                "body": "my message body",
-                "custom_field": "baba",
-                "another_one": "abab",
-                "itemtype": "my_custom_itemtype",
-            }],
-            "msgtype": "dm.filament.gallery",
-        })
-    );
-}
-
-#[test]
-#[cfg(feature = "unstable-msc4274")]
-fn gallery_msgtype_deserialization_with_custom_itemtype() {
-    let json_data = json!({
+    let json = json!({
         "body": "My photos from [FOSDEM 2025](https://fosdem.org/2025/)",
         "formatted_body": "My photos from <a href=\"https://fosdem.org/2025/\">FOSDEM 2025</a>",
         "format": "org.matrix.custom.html",
@@ -771,23 +707,26 @@ fn gallery_msgtype_deserialization_with_custom_itemtype() {
         "msgtype": "dm.filament.gallery",
     });
 
-    let expected_json_data = json_object! {
-        "custom_field": "baba",
-        "another_one": "abab",
-    };
-
-    let event_content = from_json_value::<RoomMessageEventContent>(json_data).unwrap();
-    assert_matches!(event_content.msgtype, MessageType::Gallery(content));
+    let event_content = from_json_value::<RoomMessageEventContent>(json.clone()).unwrap();
+    assert_let!(MessageType::Gallery(content) = &event_content.msgtype);
     assert_eq!(content.body, "My photos from [FOSDEM 2025](https://fosdem.org/2025/)");
     assert_eq!(
-        content.formatted.unwrap().body,
+        content.formatted.as_ref().unwrap().body,
         "My photos from <a href=\"https://fosdem.org/2025/\">FOSDEM 2025</a>"
     );
-    assert_matches!(&content.itemtypes.len(), 1);
+    assert_eq!(content.itemtypes.len(), 1);
     let itemtype = content.itemtypes.first().unwrap();
     assert_eq!(itemtype.itemtype(), "my_custom_itemtype");
     assert_eq!(itemtype.body(), "my message body");
-    assert_eq!(itemtype.data(), Cow::Owned(expected_json_data));
+    assert_eq!(
+        JsonValue::Object(itemtype.data().into_owned()),
+        json!({
+            "custom_field": "baba",
+            "another_one": "abab",
+        })
+    );
+
+    assert_to_canonical_json_eq!(event_content, json);
 }
 
 #[test]

--- a/crates/ruma-federation-api/src/transactions/edu.rs
+++ b/crates/ruma-federation-api/src/transactions/edu.rs
@@ -12,7 +12,7 @@ use ruma_common::{
 };
 use ruma_events::{AnyToDeviceEventContent, ToDeviceEventType, receipt::Receipt};
 use serde::{Deserialize, Serialize, de};
-use serde_json::{Value as JsonValue, value::RawValue as RawJsonValue};
+use serde_json::value::RawValue as RawJsonValue;
 
 /// Type for passing ephemeral data to homeservers.
 #[derive(Clone, Debug, Serialize)]
@@ -49,14 +49,8 @@ pub enum Edu {
     SigningKeyUpdate(SigningKeyUpdateContent),
 
     #[doc(hidden)]
-    _Custom(JsonValue),
-}
-
-#[derive(Debug, Deserialize)]
-struct EduDeHelper {
-    /// The message type field
-    edu_type: String,
-    content: Box<RawJsonValue>,
+    #[serde(untagged)]
+    _Custom(CustomEdu),
 }
 
 impl<'de> Deserialize<'de> for Edu {
@@ -64,6 +58,12 @@ impl<'de> Deserialize<'de> for Edu {
     where
         D: de::Deserializer<'de>,
     {
+        #[derive(Debug, Deserialize)]
+        struct EduDeHelper {
+            edu_type: String,
+            content: Box<RawJsonValue>,
+        }
+
         let json = Box::<RawJsonValue>::deserialize(deserializer)?;
         let EduDeHelper { edu_type, content } = from_raw_json_value(&json)?;
 
@@ -74,7 +74,7 @@ impl<'de> Deserialize<'de> for Edu {
             "m.device_list_update" => Self::DeviceListUpdate(from_raw_json_value(&content)?),
             "m.direct_to_device" => Self::DirectToDevice(from_raw_json_value(&content)?),
             "m.signing_key_update" => Self::SigningKeyUpdate(from_raw_json_value(&content)?),
-            _ => Self::_Custom(from_raw_json_value(&content)?),
+            _ => Self::_Custom(CustomEdu { edu_type, content }),
         })
     }
 }
@@ -310,6 +310,17 @@ impl SigningKeyUpdateContent {
     pub fn new(user_id: OwnedUserId) -> Self {
         Self { user_id, master_key: None, self_signing_key: None }
     }
+}
+
+/// An unsupported EDU type.
+#[doc(hidden)]
+#[derive(Clone, Debug, Serialize)]
+pub struct CustomEdu {
+    /// The type of EDU.
+    edu_type: String,
+
+    /// The content of the EDU.
+    content: Box<RawJsonValue>,
 }
 
 #[cfg(test)]

--- a/crates/ruma-push-gateway-api/src/send_event_notification.rs
+++ b/crates/ruma-push-gateway-api/src/send_event_notification.rs
@@ -291,9 +291,7 @@ pub mod v1 {
                     Tweak::Sound(value) => map.serialize_entry("sound", value)?,
                     Tweak::_Custom(_) => map.serialize_entry(
                         &item.set_tweak(),
-                        &item
-                            .custom_value()
-                            .expect("Tweak::_Custom variant should return a custom value"),
+                        &item.value().expect("Tweak::_Custom variant should return a custom value"),
                     )?,
                     _ => unreachable!("variant added to Tweak not covered by _Custom"),
                 }


### PR DESCRIPTION
It turns out we had a lot those variants that could be constructed with deserialization. Sadly because of all the uses of `#[serde(flatten)]`, some of them require the enums to be deserialized to `JsonValue` in `Deserialize` rather than `Box<RawJsonValue>`.

I also used this occasion to fix some custom data accessors to work with all variants rather than only the `_Custom` variant, because if a new variant is added existing code might break otherwise.

Fixes #2336.\
Fixes #2467.