### PR TITLE
Don't serialize empty "name" of Secret Storage key

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -46,6 +46,7 @@ Breaking changes:
 Bug fixes:
 
 - Fix a double `msgtype` in a `m.location` event.
+- Do not serialize `name` in `SecretStorageKeyEventContent` when its value is `None`.
 
 Improvements:
 

--- a/crates/ruma-events/src/secret_storage/key.rs
+++ b/crates/ruma-events/src/secret_storage/key.rs
@@ -68,6 +68,7 @@ pub struct SecretStorageKeyEventContent {
     pub key_id: String,
 
     /// The name of the key.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 
     /// The encryption algorithm used for this key.


### PR DESCRIPTION
The CS-API describes the "name" field as an optional string, but seralizing it from None will cause it to have a JSON value of null. Instead, skip seralizing it when None, as is done for "passphrase".
