### PR TITLE
api: Add helper method on `Error` for unimplemented endpoint errors

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -77,6 +77,9 @@ Improvements:
 - Add unstable support for MSC4406.
 - Add `rule_type()` and `data()` methods to `AllowRule`.
 - Implement `PartialEq` and `Eq` on `CrossSigningKey` and `Signatures`.
+- Add `Error::is_endpoint_not_implemented()` helper method to check if it
+  matches the expected format for endpoints that are not implemented by the
+  homeserver.
 
 ## 0.17.1
 

--- a/crates/ruma-common/src/api/error.rs
+++ b/crates/ruma-common/src/api/error.rs
@@ -37,8 +37,7 @@ impl Error {
         Self { status_code, body }
     }
 
-    /// If `self` is a server error in the `errcode` + `error` format expected
-    /// for client-server API endpoints, returns the error kind (`errcode`).
+    /// If this is an error with a [`StandardErrorBody`], returns the [`ErrorKind`].
     pub fn error_kind(&self) -> Option<&ErrorKind> {
         as_variant!(&self.body, ErrorBody::Standard(StandardErrorBody { kind, .. }) => kind)
     }

--- a/crates/ruma-common/src/api/error.rs
+++ b/crates/ruma-common/src/api/error.rs
@@ -41,6 +41,20 @@ impl Error {
     pub fn error_kind(&self) -> Option<&ErrorKind> {
         as_variant!(&self.body, ErrorBody::Standard(StandardErrorBody { kind, .. }) => kind)
     }
+
+    /// Whether this error matches the expected format for an endpoint that is not implemented by
+    /// the homeserver.
+    ///
+    /// Return `true` if this contains an [`ErrorKind::Unrecognized`] with a
+    /// [`http::StatusCode::NOT_FOUND`].
+    ///
+    /// [unsupported endpoint]:
+    pub fn is_endpoint_not_implemented(&self) -> bool {
+        self.status_code == http::StatusCode::NOT_FOUND
+            && self
+                .error_kind()
+                .is_some_and(|error_kind| matches!(error_kind, ErrorKind::Unrecognized))
+    }
 }
 
 impl fmt::Display for Error {


### PR DESCRIPTION
The SDK checks for this sometimes to have better error variants, so let's upstream it as it can be generally helpful and comes from the spec (see the definition of `M_UNRECOGNIZED` in the [common error codes](https://spec.matrix.org/v1.18/client-server-api/#common-error-codes)).