### PR TITLE
client-api: Fix regressions in `rtc::transports`

### DIFF
--- a/crates/ruma-client-api/src/rtc/transports.rs
+++ b/crates/ruma-client-api/src/rtc/transports.rs
@@ -142,7 +142,7 @@ pub mod v1 {
             let json = Box::<RawJsonValue>::deserialize(deserializer)?;
             let RtcTransportDeHelper { transport_type } = from_raw_json_value(&json)?;
 
-            Ok(match transport_type.as_ref() {
+            Ok(match transport_type.as_str() {
                 #[cfg(feature = "unstable-msc4195")]
                 "livekit_multi_sfu" => Self::LivekitMultiSfu(from_raw_json_value(&json)?),
                 _ => {

--- a/crates/ruma-client-api/src/rtc/transports.rs
+++ b/crates/ruma-client-api/src/rtc/transports.rs
@@ -9,12 +9,10 @@ pub mod v1 {
 
     use std::borrow::Cow;
 
-    #[cfg(feature = "unstable-msc4195")]
-    use ruma_common::serde::from_raw_json_value;
     use ruma_common::{
         api::{auth_scheme::AccessToken, request, response},
         metadata,
-        serde::JsonObject,
+        serde::{JsonObject, from_raw_json_value},
     };
     use serde::{Deserialize, Deserializer, Serialize, de::DeserializeOwned};
     use serde_json::{Value as JsonValue, value::RawValue as RawJsonValue};


### PR DESCRIPTION
These are regressions from #2468.

They weren't noticed because the whole module is under an unstable cargo feature, and some of the code in the module is behind another unstable cargo feature and we don't check unstable features separately in CI. I found this out by trying to upgrade Ruma in the SDK, because they only enable the module-level unstable feature.

