### PR TITLE
events: Add support for `m.room.member` in `unsigned.redacted_because`

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -42,6 +42,9 @@ Breaking changes:
 - Remove support for the `m.room.aliases` event type. It was removed from the
   specification in Matrix Client-Server API r0.6.1. `m.room.canonical_alias`
   should be used instead.
+- The `redacted_because` field of `RedactedUnsigned` is now a `Raw<AnyRedactionEvent>`. It is an
+  enum that allows to deserialize other event types than `m.room.redaction`.
+  - Add unstable support for `m.room.member` in `redacted_because`, according to MSC4293.
 
 Bug fixes:
 

--- a/crates/ruma-events/src/room/member.rs
+++ b/crates/ruma-events/src/room/member.rs
@@ -3,6 +3,8 @@
 //! [`m.room.member`]: https://spec.matrix.org/v1.18/client-server-api/#mroommember
 
 use js_int::Int;
+#[cfg(feature = "unstable-msc4293")]
+use ruma_common::canonical_json::RedactionEvent;
 use ruma_common::{
     OwnedMxcUri, OwnedTransactionId, OwnedUserId, ServerSignatures, UserId,
     room_version_rules::RedactionRules,
@@ -915,6 +917,18 @@ impl CanBeEmpty for RoomMemberUnsigned {
             && self.relations.is_empty()
     }
 }
+
+#[cfg(feature = "unstable-msc4293")]
+impl RedactionEvent for OriginalRoomMemberEvent {}
+
+#[cfg(feature = "unstable-msc4293")]
+impl RedactionEvent for OriginalSyncRoomMemberEvent {}
+
+#[cfg(feature = "unstable-msc4293")]
+impl RedactionEvent for RoomMemberEvent {}
+
+#[cfg(feature = "unstable-msc4293")]
+impl RedactionEvent for SyncRoomMemberEvent {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/ruma-events/src/unsigned.rs
+++ b/crates/ruma-events/src/unsigned.rs
@@ -1,6 +1,6 @@
 use js_int::Int;
 use ruma_common::{
-    MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, OwnedUserId,
+    EventId, MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedTransactionId, OwnedUserId, UserId,
     serde::{CanBeEmpty, Raw},
 };
 use serde::{Deserialize, de::DeserializeOwned};
@@ -10,6 +10,9 @@ use super::{
     relation::{BundledMessageLikeRelations, BundledStateRelations},
     room::redaction::RoomRedactionEventContent,
 };
+use crate::TimelineEventType;
+
+mod redacted_because_serde;
 
 /// Extra information about a message event that is not incorporated into the event's hash.
 #[derive(Clone, Debug, Deserialize)]
@@ -115,17 +118,76 @@ impl<C: PossiblyRedactedStateEventContent> Default for StateUnsigned<C> {
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct RedactedUnsigned {
     /// The event that redacted this event, if any.
-    pub redacted_because: Raw<UnsignedRoomRedactionEvent>,
+    pub redacted_because: Raw<AnyRedactionEvent>,
 }
 
 impl RedactedUnsigned {
     /// Create a new `RedactedUnsigned` with the given redaction event.
-    pub fn new(redacted_because: Raw<UnsignedRoomRedactionEvent>) -> Self {
+    pub fn new(redacted_because: Raw<AnyRedactionEvent>) -> Self {
         Self { redacted_because }
     }
 }
 
-/// A redaction event as found in `unsigned.redacted_because`.
+/// Any event that can redact another event, i.e. an event that can be found in
+/// `unsigned.redacted_because`.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+#[allow(clippy::large_enum_variant)]
+pub enum AnyRedactionEvent {
+    /// m.room.redaction
+    RoomRedaction(UnsignedRoomRedactionEvent),
+
+    /// m.room.member
+    #[cfg(feature = "unstable-msc4293")]
+    RoomMember(super::room::member::SyncRoomMemberEvent),
+
+    #[doc(hidden)]
+    _Custom(CustomRedactionEvent),
+}
+
+impl AnyRedactionEvent {
+    /// Returns the `type` of this event.
+    pub fn event_type(&self) -> TimelineEventType {
+        match self {
+            Self::RoomRedaction(_) => TimelineEventType::RoomRedaction,
+            #[cfg(feature = "unstable-msc4293")]
+            Self::RoomMember(_) => TimelineEventType::RoomMember,
+            Self::_Custom(e) => TimelineEventType::from(&*e.event_type),
+        }
+    }
+
+    /// Returns the `origin_server_ts` of this event.
+    pub fn origin_server_ts(&self) -> MilliSecondsSinceUnixEpoch {
+        match self {
+            Self::RoomRedaction(e) => e.origin_server_ts,
+            #[cfg(feature = "unstable-msc4293")]
+            Self::RoomMember(e) => e.origin_server_ts(),
+            Self::_Custom(e) => e.origin_server_ts,
+        }
+    }
+
+    /// Returns the `event_id` of this event.
+    pub fn event_id(&self) -> &EventId {
+        match self {
+            Self::RoomRedaction(e) => &e.event_id,
+            #[cfg(feature = "unstable-msc4293")]
+            Self::RoomMember(e) => e.event_id(),
+            Self::_Custom(e) => &e.event_id,
+        }
+    }
+
+    /// Returns the `sender` of this event.
+    pub fn sender(&self) -> &UserId {
+        match self {
+            Self::RoomRedaction(e) => &e.sender,
+            #[cfg(feature = "unstable-msc4293")]
+            Self::RoomMember(e) => e.sender(),
+            Self::_Custom(e) => &e.sender,
+        }
+    }
+}
+
+/// An `m.room.redaction` event as found in `unsigned.redacted_because`.
 ///
 /// While servers usually send this with the `redacts` field (unless nested), the ID of the event
 /// being redacted is known from context wherever this type is used, so it's not reflected as a
@@ -151,4 +213,68 @@ pub struct UnsignedRoomRedactionEvent {
     /// Additional key-value pairs not signed by the homeserver.
     #[serde(default)]
     pub unsigned: MessageLikeUnsigned<RoomRedactionEventContent>,
+}
+
+/// A custom redaction event.
+#[doc(hidden)]
+#[derive(Clone, Debug)]
+pub struct CustomRedactionEvent {
+    /// The type of the event
+    event_type: Box<str>,
+
+    /// The globally unique event identifier for the user who sent the event.
+    event_id: OwnedEventId,
+
+    /// The fully-qualified ID of the user who sent this event.
+    sender: OwnedUserId,
+
+    /// Timestamp in milliseconds on originating homeserver when this event was sent.
+    origin_server_ts: MilliSecondsSinceUnixEpoch,
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_matches2::assert_matches;
+    use js_int::uint;
+    use serde_json::{from_value as from_json_value, json};
+
+    use super::AnyRedactionEvent;
+    use crate::TimelineEventType;
+
+    #[test]
+    fn deserialize_any_redaction_event_room_redaction() {
+        let json = json!({
+            "type": "m.room.redaction",
+            "content": {
+                "redacts": "$redactedevent",
+            },
+            "event_id": "$redactionevent",
+            "origin_server_ts": 1,
+            "sender": "@carl:example.com",
+        });
+
+        let event = from_json_value::<AnyRedactionEvent>(json).unwrap();
+        assert_eq!(event.event_id(), "$redactionevent");
+        assert_eq!(event.origin_server_ts().0, uint!(1));
+        assert_eq!(event.sender(), "@carl:example.com");
+        assert_eq!(event.event_type(), TimelineEventType::RoomRedaction);
+        assert_matches!(event, AnyRedactionEvent::RoomRedaction(_));
+    }
+
+    #[test]
+    fn deserialize_any_redaction_event_custom() {
+        let json = json!({
+            "type": "local.dev.custom_type",
+            "content": {},
+            "event_id": "$redactionevent",
+            "origin_server_ts": 1,
+            "sender": "@carl:example.com",
+        });
+
+        let event = from_json_value::<AnyRedactionEvent>(json).unwrap();
+        assert_eq!(event.event_id(), "$redactionevent");
+        assert_eq!(event.origin_server_ts().0, uint!(1));
+        assert_eq!(event.sender(), "@carl:example.com");
+        assert_eq!(event.event_type().to_string(), "local.dev.custom_type");
+    }
 }

--- a/crates/ruma-events/src/unsigned/redacted_because_serde.rs
+++ b/crates/ruma-events/src/unsigned/redacted_because_serde.rs
@@ -1,0 +1,50 @@
+use ruma_common::{
+    MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedUserId, serde::from_raw_json_value,
+};
+use serde::{Deserialize, de};
+use serde_json::value::RawValue as RawJsonValue;
+
+use super::{AnyRedactionEvent, CustomRedactionEvent};
+use crate::EventTypeDeHelper;
+
+impl<'de> Deserialize<'de> for AnyRedactionEvent {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        let json = Box::<RawJsonValue>::deserialize(deserializer)?;
+        let EventTypeDeHelper { ev_type, .. } = from_raw_json_value(&json)?;
+
+        match &*ev_type {
+            "m.room.redaction" => from_raw_json_value(&json).map(Self::RoomRedaction),
+            #[cfg(feature = "unstable-msc4293")]
+            "m.room.member" => from_raw_json_value(&json).map(Self::RoomMember),
+            _ => {
+                let CustomRedactionEventDeHelper { event_type, event_id, sender, origin_server_ts } =
+                    from_raw_json_value(&json)?;
+                Ok(Self::_Custom(CustomRedactionEvent {
+                    event_type,
+                    event_id,
+                    sender,
+                    origin_server_ts,
+                }))
+            }
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct CustomRedactionEventDeHelper {
+    /// The type of the event
+    #[serde(rename = "type")]
+    event_type: Box<str>,
+
+    /// The globally unique event identifier for the user who sent the event.
+    event_id: OwnedEventId,
+
+    /// The fully-qualified ID of the user who sent this event.
+    sender: OwnedUserId,
+
+    /// Timestamp in milliseconds on originating homeserver when this event was sent.
+    origin_server_ts: MilliSecondsSinceUnixEpoch,
+}


### PR DESCRIPTION
Follow up to #2453.

This requires a breaking change, so it would be nice to merge this before the next release.

