### PR TITLE
client-api: Reject non-object event content on /send and /state

### DIFF
--- a/crates/ruma-client-api/src/message/send_message_event.rs
+++ b/crates/ruma-client-api/src/message/send_message_event.rs
@@ -51,6 +51,7 @@ pub mod v3 {
 
         /// The event content to send.
         #[ruma_api(body)]
+        #[serde(deserialize_with = "ruma_common::serde::deserialize_raw_object")]
         pub body: Raw<AnyMessageLikeEventContent>,
 
         /// Timestamp to use for the `origin_server_ts` of the event.

--- a/crates/ruma-client-api/src/state/send_state_event.rs
+++ b/crates/ruma-client-api/src/state/send_state_event.rs
@@ -181,16 +181,9 @@ pub mod v3 {
             let request_query: RequestQuery =
                 serde_html_form::from_str(request.uri().query().unwrap_or(""))?;
 
-            let body: Raw<AnyStateEventContent> = serde_json::from_slice(request.body().as_ref())?;
-            if !body.json().get().trim_start().starts_with('{') {
-                return Err(ruma_common::api::error::DeserializationError::Json(
-                    serde::de::Error::invalid_type(
-                        serde::de::Unexpected::Other("non-object value"),
-                        &"a JSON object",
-                    ),
-                )
-                .into());
-            }
+            let body: Raw<AnyStateEventContent> = ruma_common::serde::deserialize_raw_object(
+                &mut serde_json::Deserializer::from_slice(request.body().as_ref()),
+            )?;
 
             Ok(Self { room_id, event_type, state_key, body, timestamp: request_query.timestamp })
         }

--- a/crates/ruma-client-api/src/state/send_state_event.rs
+++ b/crates/ruma-client-api/src/state/send_state_event.rs
@@ -181,7 +181,16 @@ pub mod v3 {
             let request_query: RequestQuery =
                 serde_html_form::from_str(request.uri().query().unwrap_or(""))?;
 
-            let body = serde_json::from_slice(request.body().as_ref())?;
+            let body: Raw<AnyStateEventContent> = serde_json::from_slice(request.body().as_ref())?;
+            if !body.json().get().trim_start().starts_with('{') {
+                return Err(ruma_common::api::error::DeserializationError::Json(
+                    serde::de::Error::invalid_type(
+                        serde::de::Unexpected::Other("non-object value"),
+                        &"a JSON object",
+                    ),
+                )
+                .into());
+            }
 
             Ok(Self { room_id, event_type, state_key, body, timestamp: request_query.timestamp })
         }

--- a/crates/ruma-client-api/tests/it/event_content.rs
+++ b/crates/ruma-client-api/tests/it/event_content.rs
@@ -1,0 +1,65 @@
+#![cfg(feature = "server")]
+
+use assert_matches2::assert_matches;
+use ruma_client_api::{message::send_message_event, state::send_state_event};
+use ruma_common::api::{
+    IncomingRequest as _,
+    error::{DeserializationError, FromHttpRequestError},
+};
+
+const ROOM_ID: &str = "!room:server.tld";
+
+fn http_put(uri: &str, body: &[u8]) -> http::Request<Vec<u8>> {
+    http::Request::builder().method(http::Method::PUT).uri(uri).body(body.to_vec()).unwrap()
+}
+
+fn assert_non_object_rejected(err: FromHttpRequestError) {
+    assert_matches!(err, FromHttpRequestError::Deserialization(DeserializationError::Json(_)));
+}
+
+#[test]
+fn send_message_event_rejects_non_object_body() {
+    let path_args = [ROOM_ID, "m.room.message", "txn1"];
+    let bodies: &[&[u8]] = &[br#""string""#, br#"["array"]"#, b"42", b"null", b"true"];
+
+    for body in bodies {
+        let req =
+            http_put("/_matrix/client/v3/rooms/!room:server.tld/send/m.room.message/txn1", body);
+        let err = send_message_event::v3::Request::try_from_http_request(req, &path_args)
+            .expect_err(&format!("body {body:?} should be rejected"));
+        assert_non_object_rejected(err);
+    }
+}
+
+#[test]
+fn send_message_event_accepts_object_body() {
+    let path_args = [ROOM_ID, "m.room.message", "txn1"];
+    let req = http_put(
+        "/_matrix/client/v3/rooms/!room:server.tld/send/m.room.message/txn1",
+        br#"{"msgtype":"m.text","body":"hi"}"#,
+    );
+    send_message_event::v3::Request::try_from_http_request(req, &path_args).unwrap();
+}
+
+#[test]
+fn send_state_event_rejects_non_object_body() {
+    let path_args = [ROOM_ID, "m.room.topic", ""];
+    let bodies: &[&[u8]] = &[br#""string""#, br#"["array"]"#, b"42", b"null", b"true"];
+
+    for body in bodies {
+        let req = http_put("/_matrix/client/v3/rooms/!room:server.tld/state/m.room.topic/", body);
+        let err = send_state_event::v3::Request::try_from_http_request(req, &path_args)
+            .expect_err(&format!("body {body:?} should be rejected"));
+        assert_non_object_rejected(err);
+    }
+}
+
+#[test]
+fn send_state_event_accepts_object_body() {
+    let path_args = [ROOM_ID, "m.room.topic", ""];
+    let req = http_put(
+        "/_matrix/client/v3/rooms/!room:server.tld/state/m.room.topic/",
+        br#"{"topic":"hi"}"#,
+    );
+    send_state_event::v3::Request::try_from_http_request(req, &path_args).unwrap();
+}

--- a/crates/ruma-client-api/tests/it/main.rs
+++ b/crates/ruma-client-api/tests/it/main.rs
@@ -1,2 +1,3 @@
+mod event_content;
 mod headers;
 mod uiaa;

--- a/crates/ruma-common/src/serde.rs
+++ b/crates/ruma-common/src/serde.rs
@@ -143,6 +143,27 @@ where
     deserializer.deserialize_seq(SkipInvalid(PhantomData))
 }
 
+/// Deserialize a `Raw<T>` and reject any value whose top-level JSON shape is
+/// not an object. Use as `#[serde(deserialize_with =
+/// "ruma_common::serde::deserialize_raw_object")]` on request body fields where the Matrix spec
+/// mandates an object (e.g., `Raw<EventContent>` for `/_matrix/client/.../send` endpoints).
+pub fn deserialize_raw_object<'de, T, D>(deserializer: D) -> Result<Raw<T>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    use serde::de::Error;
+
+    let raw = <Raw<T> as Deserialize>::deserialize(deserializer)?;
+    if !raw.json().get().trim_start().starts_with('{') {
+        return Err(D::Error::invalid_type(
+            de::Unexpected::Other("non-object value"),
+            &"a JSON object",
+        ));
+    }
+
+    Ok(raw)
+}
+
 pub use ruma_macros::{
     _FakeDeriveSerde, AsRefStr, AsStrAsRefStr, DebugAsRefStr, DeserializeFromCowStr,
     DisplayAsRefStr, EqAsRefStr, FromString, OrdAsRefStr, SerializeAsRefStr, StringEnum,

--- a/crates/ruma-common/src/serde.rs
+++ b/crates/ruma-common/src/serde.rs
@@ -143,10 +143,11 @@ where
     deserializer.deserialize_seq(SkipInvalid(PhantomData))
 }
 
-/// Deserialize a `Raw<T>` and reject any value whose top-level JSON shape is
-/// not an object. Use as `#[serde(deserialize_with =
-/// "ruma_common::serde::deserialize_raw_object")]` on request body fields where the Matrix spec
-/// mandates an object (e.g., `Raw<EventContent>` for `/_matrix/client/.../send` endpoints).
+/// Deserialize a `Raw<T>` and reject any value whose top-level JSON shape is not an object.
+///
+/// Use as `#[serde(deserialize_with = "ruma_common::serde::deserialize_raw_object")]` wherever
+/// the Matrix spec mandates an object (e.g., `Raw<EventContent>` on the body of
+/// `/_matrix/client/.../send` endpoints, or on inner fields, response fields, etc.).
 pub fn deserialize_raw_object<'de, T, D>(deserializer: D) -> Result<Raw<T>, D::Error>
 where
     D: Deserializer<'de>,


### PR DESCRIPTION
The Matrix CS-API requires event `content` to be a JSON object, but
`Raw<T>` accepts any JSON value, so the PUT routes for
`/rooms/{roomId}/send/{eventType}/{txnId}` and
`/state/{eventType}/{stateKey}` will land a bare string or number in
the room as event content. We hit this when Complement
matrix-org/complement#850 ("Stop testing unspecced POST /send", merged
2026-03-18) switched `TestJson` from POST `/send/{eventType}` to the
spec'd PUT, routing through ruma for the first time. The Go test
constructs its bodies as `[]byte`, and `json.Marshal([]byte(...))`
base64-encodes those bytes into a JSON string, so the request payload
was literally a quoted string. Our server accepted it; the test
expects 400, so it failed.