### PR TITLE
state-res: Fix knock authorization in room versions 7-9

### DIFF
--- a/crates/ruma-state-res/CHANGELOG.md
+++ b/crates/ruma-state-res/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+Bug fixes:
+
+- Fix `m.room.member` authorization for events with `knock` membership in
+  room versions 7-9. The check that the join rule supports knocking was
+  unreachable, so any non-knock join rule was accepted.
+
 ## 0.16.0
 
 Breaking:

--- a/crates/ruma-state-res/src/event_auth/room_member.rs
+++ b/crates/ruma-state-res/src/event_auth/room_member.rs
@@ -465,9 +465,10 @@ fn check_room_member_knock<E: Event>(
     // v7-v9, if the join_rule is anything other than knock, reject.
     // Since v10, if the join_rule is anything other than knock or knock_restricted,
     // reject.
-    if join_rule != JoinRuleKind::Knock
-        && (rules.knock_restricted_join_rule && !matches!(join_rule, JoinRuleKind::KnockRestricted))
-    {
+    let supports_knock = matches!(join_rule, JoinRuleKind::Knock)
+        || (rules.knock_restricted_join_rule && matches!(join_rule, JoinRuleKind::KnockRestricted));
+
+    if !supports_knock {
         return Err(
             "join rule is not set to knock or knock_restricted, knocking is not allowed".to_owned()
         );

--- a/crates/ruma-state-res/src/event_auth/room_member/tests.rs
+++ b/crates/ruma-state-res/src/event_auth/room_member/tests.rs
@@ -1856,3 +1856,84 @@ fn knock_after_join() {
         "cannot knock if user is banned, invited or joined"
     );
 }
+
+#[test]
+fn knock_public_join_rule_v7() {
+    let mut factory = RoomTimelineFactory::with_public_chat_preset(RoomVersionId::V7);
+
+    let pdu = factory.create_room_member(
+        owned_event_id!("$room-member-zara-knock"),
+        UserFactory::Zara.user_id(),
+        RoomMemberPduContent::Knock,
+    );
+
+    // v7-v9: only `knock` is accepted; `public` must reject.
+    assert_eq!(
+        check_room_member(
+            RoomMemberEvent::new(pdu),
+            &AuthorizationRules::V7,
+            factory.room_create_pdu(),
+            factory.state_event_fn(),
+        )
+        .unwrap_err(),
+        "join rule is not set to knock or knock_restricted, knocking is not allowed"
+    );
+}
+
+#[test]
+fn knock_invite_join_rule_v8() {
+    let mut factory = RoomTimelineFactory::with_public_chat_preset(RoomVersionId::V8);
+
+    factory.add_room_join_rules(
+        owned_event_id!("$room-join-rules-invite"),
+        UserFactory::Alice.user_id(),
+        JoinRule::Invite,
+    );
+
+    let pdu = factory.create_room_member(
+        owned_event_id!("$room-member-zara-knock"),
+        UserFactory::Zara.user_id(),
+        RoomMemberPduContent::Knock,
+    );
+
+    // v7-v9: `invite` is not a knock-supporting join rule.
+    assert_eq!(
+        check_room_member(
+            RoomMemberEvent::new(pdu),
+            &AuthorizationRules::V8,
+            factory.room_create_pdu(),
+            factory.state_event_fn(),
+        )
+        .unwrap_err(),
+        "join rule is not set to knock or knock_restricted, knocking is not allowed"
+    );
+}
+
+#[test]
+fn knock_knock_restricted_join_rule_v8() {
+    let mut factory = RoomTimelineFactory::with_public_chat_preset(RoomVersionId::V8);
+
+    factory.add_room_join_rules(
+        owned_event_id!("$room-join-rules-knock-restricted"),
+        UserFactory::Alice.user_id(),
+        JoinRule::KnockRestricted(Restricted::new(vec![])),
+    );
+
+    let pdu = factory.create_room_member(
+        owned_event_id!("$room-member-zara-knock"),
+        UserFactory::Zara.user_id(),
+        RoomMemberPduContent::Knock,
+    );
+
+    // knock_restricted does not exist before v10.
+    assert_eq!(
+        check_room_member(
+            RoomMemberEvent::new(pdu),
+            &AuthorizationRules::V8,
+            factory.room_create_pdu(),
+            factory.state_event_fn(),
+        )
+        .unwrap_err(),
+        "join rule is not set to knock or knock_restricted, knocking is not allowed"
+    );
+}


### PR DESCRIPTION
The check that the join rule supports knocking was unreachable for
events with `knock` membership in room versions 7-9. The rejection
condition required `knock_restricted_join_rule`, which is false there,
so any non-knock join rule was accepted.

Tests cover v7 with `public`, v8 with `invite`, and v8 with
`knock_restricted` (which does not exist before v10).