### PR TITLE
state-res: Reserve mainline-position 0 for events with no PL ancestor

### DIFF
--- a/crates/ruma-state-res/CHANGELOG.md
+++ b/crates/ruma-state-res/CHANGELOG.md
@@ -9,8 +9,9 @@ Bug fixes:
   unreachable, so any non-knock join rule was accepted.
 - Fix `mainline_sort` collision between events with no power-levels ancestor in
   their auth chain and events whose deepest power-levels ancestor is the oldest
-  in the mainline. Real positions are now 1-based; 0 is reserved as the
-  no-mainline-ancestor sentinel and sorts before all chain-rooted events.
+  in the mainline. Mainline positions are now `Option<NonZero<usize>>`, with
+  `None` representing the no-mainline-ancestor case and sorting before all
+  chain-rooted events.
 
 ## 0.16.0
 

--- a/crates/ruma-state-res/CHANGELOG.md
+++ b/crates/ruma-state-res/CHANGELOG.md
@@ -7,6 +7,10 @@ Bug fixes:
 - Fix `m.room.member` authorization for events with `knock` membership in
   room versions 7-9. The check that the join rule supports knocking was
   unreachable, so any non-knock join rule was accepted.
+- Fix `mainline_sort` collision between events with no power-levels ancestor in
+  their auth chain and events whose deepest power-levels ancestor is the oldest
+  in the mainline. Real positions are now 1-based; 0 is reserved as the
+  no-mainline-ancestor sentinel and sorts before all chain-rooted events.
 
 ## 0.16.0
 

--- a/crates/ruma-state-res/src/state_res.rs
+++ b/crates/ruma-state-res/src/state_res.rs
@@ -3,6 +3,7 @@ use std::{
     cmp::{Ordering, Reverse},
     collections::{BinaryHeap, HashMap, HashSet},
     hash::Hash,
+    num::NonZero,
     sync::OnceLock,
 };
 
@@ -764,11 +765,18 @@ fn mainline_sort<E: Event>(
         // tasks can make progress
     }
 
+    // Real positions are 1..=N. `mainline_position` returns `None` for events
+    // without a mainline ancestor, and `Option<NonZero<_>>` orders `None`
+    // before any `Some(_)`, so no-PL events sort before all chain-rooted ones
+    // under the ascending sort below.
     let mainline_map = mainline
         .iter()
         .rev()
         .enumerate()
-        .map(|(idx, event_id)| ((*event_id).clone(), idx))
+        .map(|(idx, event_id)| {
+            let position = NonZero::new(idx + 1).expect("idx + 1 is non-zero");
+            ((*event_id).clone(), position)
+        })
         .collect::<EventIdMap<_, _>>();
 
     let mut order_map = HashMap::new();
@@ -829,13 +837,14 @@ fn mainline_sort<E: Event>(
 ///
 /// ## Returns
 ///
-/// Returns the mainline position of the event, or an `Err(_)` if one of the events in the auth
+/// Returns the mainline position of the event (`Some` for events whose auth chain reaches the
+/// mainline, `None` for the spec's `i = ∞` case), or an `Err(_)` if one of the events in the auth
 /// chain of the event was not found.
 fn mainline_position<E: Event>(
     event: E,
-    mainline_map: &EventIdMap<E::Id, usize>,
+    mainline_map: &EventIdMap<E::Id, NonZero<usize>>,
     fetch_event: impl Fn(&EventId) -> Option<E>,
-) -> Result<usize> {
+) -> Result<Option<NonZero<usize>>> {
     let mut current_event = Some(event);
 
     while let Some(event) = current_event {
@@ -844,7 +853,7 @@ fn mainline_position<E: Event>(
 
         // If the current event is in the mainline map, return its position.
         if let Some(position) = mainline_map.get(event_id.borrow()) {
-            return Ok(*position);
+            return Ok(Some(*position));
         }
 
         current_event = None;
@@ -861,8 +870,8 @@ fn mainline_position<E: Event>(
         }
     }
 
-    // Did not find a power level event so we default to zero.
-    Ok(0)
+    // No power-levels ancestor in the auth chain.
+    Ok(None)
 }
 
 /// Add the event with the given event ID and all the events in its auth chain that are in the full

--- a/crates/ruma-state-res/src/state_res.rs
+++ b/crates/ruma-state-res/src/state_res.rs
@@ -765,10 +765,12 @@ fn mainline_sort<E: Event>(
         // tasks can make progress
     }
 
-    // Real positions are 1..=N. `mainline_position` returns `None` for events
-    // without a mainline ancestor, and `Option<NonZero<_>>` orders `None`
-    // before any `Some(_)`, so no-PL events sort before all chain-rooted ones
-    // under the ascending sort below.
+    // The reverse iterator inverts the spec convention: position 1 is the
+    // deepest mainline event and N is the current power-levels event, where
+    // the spec uses 0 for the most recent and ∞ for no ancestor. With
+    // `Option<NonZero<usize>>`, ascending sort by `(position,
+    // origin_server_ts, event_id)` matches the spec mainline ordering, with
+    // no-ancestor events (`None`) first.
     let mainline_map = mainline
         .iter()
         .rev()
@@ -837,9 +839,13 @@ fn mainline_sort<E: Event>(
 ///
 /// ## Returns
 ///
-/// Returns the mainline position of the event (`Some` for events whose auth chain reaches the
-/// mainline, `None` for the spec's `i = ∞` case), or an `Err(_)` if one of the events in the auth
+/// Returns the mainline position of the event, or an `Err(_)` if one of the events in the auth
 /// chain of the event was not found.
+///
+/// `None` is returned for the spec's `i = ∞` case (no power-levels ancestor in the auth chain).
+/// The position is the reverse of the spec encoding: `1` is the deepest mainline event and `N`
+/// the current power-levels event. Ascending sort by `(position, origin_server_ts, event_id)`
+/// then matches the spec mainline ordering.
 fn mainline_position<E: Event>(
     event: E,
     mainline_map: &EventIdMap<E::Id, NonZero<usize>>,

--- a/crates/ruma-state-res/src/state_res/tests.rs
+++ b/crates/ruma-state-res/src/state_res/tests.rs
@@ -8,7 +8,7 @@ use test_log::test;
 
 use super::{StateMap, is_power_event};
 use crate::{
-    test_utils::RoomTimelineFactory,
+    test_utils::{RoomPowerLevelsPduContent, RoomTimelineFactory, UserFactory},
     utils::{event_id_map::EventIdMap, event_id_set::EventIdSet},
 };
 
@@ -67,6 +67,61 @@ fn test_mainline_sort() {
             ]
         );
     }
+}
+
+#[test]
+fn test_mainline_sort_no_pl_ancestor_sorts_first() {
+    let mut factory = RoomTimelineFactory::with_public_chat_preset(RoomVersionId::V10);
+    let alice = UserFactory::Alice.user_id();
+
+    // Send a message rooted at the initial m.room.power_levels.
+    let msg_old = factory.create_text_message(
+        owned_event_id!("$msg-old"),
+        alice.clone(),
+        "rooted at oldest mainline PL",
+    );
+
+    // Extend the mainline with two more PL events.
+    factory.add_room_power_levels(
+        owned_event_id!("$pl-2"),
+        alice.clone(),
+        RoomPowerLevelsPduContent::Default,
+    );
+    factory.add_room_power_levels(
+        owned_event_id!("$pl-3"),
+        alice.clone(),
+        RoomPowerLevelsPduContent::Default,
+    );
+
+    // Send a message rooted at the current PL.
+    let msg_new = factory.create_text_message(
+        owned_event_id!("$msg-new"),
+        alice.clone(),
+        "rooted at current mainline PL",
+    );
+
+    // Send a message with no PL in its auth chain. The factory auto-populates
+    // auth_events with the resolved PL; drop it so the chain has no PL ancestor.
+    let mut msg_no_pl =
+        factory.create_text_message(owned_event_id!("$msg-no-pl"), alice.clone(), "no PL ancestor");
+    msg_no_pl.auth_events.remove(&owned_event_id!("$pl-3"));
+
+    factory.add_pdu(msg_old);
+    factory.add_pdu(msg_new);
+    factory.add_pdu(msg_no_pl);
+
+    let events = vec![
+        owned_event_id!("$msg-old"),
+        owned_event_id!("$msg-new"),
+        owned_event_id!("$msg-no-pl"),
+    ];
+    let power_level = factory.state_event_id(&StateEventType::RoomPowerLevels, "").unwrap().clone();
+
+    let sorted_events = super::mainline_sort(&events, Some(power_level), factory.get_fn()).unwrap();
+
+    // Per spec, an event with i = ∞ (no mainline ancestor) sorts before all
+    // chain-rooted events under "x < y if x.position is greater than y's".
+    assert_eq!(sorted_events, ["$msg-no-pl", "$msg-old", "$msg-new"]);
 }
 
 #[test]


### PR DESCRIPTION
Position 0 was used both for events with no mainline ancestor and for
events whose deepest mainline ancestor is the oldest in the chain. The
spec sorts the former before the latter, so real positions are now
1-based and 0 is reserved as the no-mainline-ancestor sentinel.

Tests construct three messages whose auth chains reach the oldest, the
current, and no mainline power-levels event; the no-mainline one must
sort first.