### PR TITLE
client-api: Add unstable support for MSC4437

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -8,6 +8,7 @@ Improvements:
   and variant names with the "transport" terminology of MSC4195. The
   LiveKit tag changes from `livekit_multi_sfu` to `livekit` on
   `/rtc/transports`.
+- Add support for replacing entire profiles, according to MSC4437.
 
 ## 0.23.1
 

--- a/crates/ruma-client-api/Cargo.toml
+++ b/crates/ruma-client-api/Cargo.toml
@@ -53,6 +53,7 @@ unstable-msc4293 = ["ruma-events/unstable-msc4293"]
 unstable-msc4306 = []
 unstable-msc4308 = []
 unstable-msc4388 = []
+unstable-msc4437 = []
 unstable-msc4439 = []
 
 [dependencies]

--- a/crates/ruma-client-api/src/profile.rs
+++ b/crates/ruma-client-api/src/profile.rs
@@ -18,6 +18,8 @@ pub mod get_profile_field;
 mod profile_field_serde;
 pub mod set_avatar_url;
 pub mod set_display_name;
+#[cfg(feature = "unstable-msc4437")]
+pub mod set_profile;
 pub mod set_profile_field;
 mod static_profile_field;
 

--- a/crates/ruma-client-api/src/profile.rs
+++ b/crates/ruma-client-api/src/profile.rs
@@ -16,10 +16,10 @@ pub mod get_profile;
 pub mod get_profile_field;
 #[cfg(feature = "client")]
 mod profile_field_serde;
+#[cfg(feature = "unstable-msc4437")]
+pub mod replace_profile;
 pub mod set_avatar_url;
 pub mod set_display_name;
-#[cfg(feature = "unstable-msc4437")]
-pub mod set_profile;
 pub mod set_profile_field;
 mod static_profile_field;
 

--- a/crates/ruma-client-api/src/profile/get_profile.rs
+++ b/crates/ruma-client-api/src/profile/get_profile.rs
@@ -7,7 +7,7 @@ pub mod v3 {
     //!
     //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3profileuserid
 
-    use std::collections::{BTreeMap, btree_map};
+    use std::collections::btree_map;
 
     use ruma_common::{
         OwnedUserId,
@@ -16,7 +16,7 @@ pub mod v3 {
         profile::{ProfileFieldName, ProfileFieldValue},
     };
     use serde_json::Value as JsonValue;
-
+    use ruma_common::profile::Profile;
     use crate::profile::StaticProfileField;
 
     metadata! {
@@ -39,11 +39,10 @@ pub mod v3 {
 
     /// Response type for the `get_profile` endpoint.
     #[response]
-    #[derive(Default)]
     pub struct Response {
         /// The profile data.
         #[ruma_api(body)]
-        data: BTreeMap<String, JsonValue>,
+        data: Profile,
     }
 
     impl Request {
@@ -56,7 +55,7 @@ pub mod v3 {
     impl Response {
         /// Creates a new empty `Response`.
         pub fn new() -> Self {
-            Self::default()
+            Self { data: Profile::new() }
         }
 
         /// Returns the value of the given profile field.

--- a/crates/ruma-client-api/src/profile/get_profile.rs
+++ b/crates/ruma-client-api/src/profile/get_profile.rs
@@ -13,10 +13,10 @@ pub mod v3 {
         OwnedUserId,
         api::{auth_scheme::NoAccessToken, request, response},
         metadata,
-        profile::{ProfileFieldName, ProfileFieldValue},
+        profile::{Profile, ProfileFieldName, ProfileFieldValue},
     };
     use serde_json::Value as JsonValue;
-    use ruma_common::profile::Profile;
+
     use crate::profile::StaticProfileField;
 
     metadata! {

--- a/crates/ruma-client-api/src/profile/replace_profile.rs
+++ b/crates/ruma-client-api/src/profile/replace_profile.rs
@@ -7,13 +7,14 @@ pub mod unstable {
     //!
     //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/4437
 
-    use ruma_common::profile::{ProfileFieldName, ProfileFieldValue};
+    use std::collections::BTreeMap;
+
     use ruma_common::{
         OwnedUserId,
         api::{auth_scheme::AccessToken, request, response},
         metadata,
+        profile::{ProfileFieldName, ProfileFieldValue},
     };
-    use std::collections::BTreeMap;
 
     metadata! {
         method: PUT,

--- a/crates/ruma-client-api/src/profile/replace_profile.rs
+++ b/crates/ruma-client-api/src/profile/replace_profile.rs
@@ -1,19 +1,19 @@
 //! `PUT /_matrix/client/*/profile/{userId}`
 //!
-//! Set the entire profile for a user
+//! Replace the entire profile for a user
 
 pub mod unstable {
     //! `/unstable/com.beeper.msc4437/` ([MSC])
     //!
     //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/4437
 
+    use ruma_common::profile::{ProfileFieldName, ProfileFieldValue};
     use ruma_common::{
         OwnedUserId,
         api::{auth_scheme::AccessToken, request, response},
         metadata,
     };
     use std::collections::BTreeMap;
-    use ruma_common::profile::{ProfileFieldName, ProfileFieldValue};
 
     metadata! {
         method: PUT,
@@ -24,26 +24,29 @@ pub mod unstable {
         }
     }
 
-    /// Request type for the `set_profile` endpoint.
+    /// Request type for the `replace_profile` endpoint.
     #[request]
     pub struct Request {
         /// The user whose profile will be set.
         #[ruma_api(path)]
         pub user_id: OwnedUserId,
 
-        /// The new profile for the user.
+        /// The new complete profile for the user.
         #[ruma_api(body)]
         pub data: BTreeMap<ProfileFieldName, ProfileFieldValue>,
     }
 
-    /// Response type for the `set_profile` endpoint.
+    /// Response type for the `replace_profile` endpoint.
     #[response]
     #[derive(Default)]
     pub struct Response {}
 
     impl Request {
         /// Creates a new `Request` with the given user ID and profile data.
-        pub fn new(user_id: OwnedUserId, data: BTreeMap<ProfileFieldName, ProfileFieldValue>) -> Self {
+        pub fn new(
+            user_id: OwnedUserId,
+            data: BTreeMap<ProfileFieldName, ProfileFieldValue>,
+        ) -> Self {
             Self { user_id, data }
         }
     }
@@ -55,4 +58,3 @@ pub mod unstable {
         }
     }
 }
-

--- a/crates/ruma-client-api/src/profile/replace_profile.rs
+++ b/crates/ruma-client-api/src/profile/replace_profile.rs
@@ -7,12 +7,11 @@ pub mod unstable {
     //!
     //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/4437
 
-
     use ruma_common::{
         OwnedUserId,
         api::{auth_scheme::AccessToken, request, response},
-        profile::Profile,
         metadata,
+        profile::Profile,
     };
 
     metadata! {
@@ -43,10 +42,7 @@ pub mod unstable {
 
     impl Request {
         /// Creates a new `Request` with the given user ID and profile data.
-        pub fn new(
-            user_id: OwnedUserId,
-            data: Profile,
-        ) -> Self {
+        pub fn new(user_id: OwnedUserId, data: Profile) -> Self {
             Self { user_id, data }
         }
     }

--- a/crates/ruma-client-api/src/profile/replace_profile.rs
+++ b/crates/ruma-client-api/src/profile/replace_profile.rs
@@ -7,13 +7,12 @@ pub mod unstable {
     //!
     //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/4437
 
-    use std::collections::BTreeMap;
 
     use ruma_common::{
         OwnedUserId,
         api::{auth_scheme::AccessToken, request, response},
+        profile::Profile,
         metadata,
-        profile::{ProfileFieldName, ProfileFieldValue},
     };
 
     metadata! {
@@ -34,7 +33,7 @@ pub mod unstable {
 
         /// The new complete profile for the user.
         #[ruma_api(body)]
-        pub data: BTreeMap<ProfileFieldName, ProfileFieldValue>,
+        pub data: Profile,
     }
 
     /// Response type for the `replace_profile` endpoint.
@@ -46,7 +45,7 @@ pub mod unstable {
         /// Creates a new `Request` with the given user ID and profile data.
         pub fn new(
             user_id: OwnedUserId,
-            data: BTreeMap<ProfileFieldName, ProfileFieldValue>,
+            data: Profile,
         ) -> Self {
             Self { user_id, data }
         }

--- a/crates/ruma-client-api/src/profile/set_profile.rs
+++ b/crates/ruma-client-api/src/profile/set_profile.rs
@@ -1,0 +1,58 @@
+//! `PUT /_matrix/client/*/profile/{userId}`
+//!
+//! Set the entire profile for a user
+
+pub mod unstable {
+    //! `/unstable/com.beeper.msc4437/` ([MSC])
+    //!
+    //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/4437
+
+    use ruma_common::{
+        OwnedUserId,
+        api::{auth_scheme::AccessToken, request, response},
+        metadata,
+    };
+    use serde_json::Value as JsonValue;
+    use std::collections::BTreeMap;
+
+    metadata! {
+        method: PUT,
+        rate_limited: true,
+        authentication: AccessToken,
+        history: {
+            unstable("com.beeper.msc4437") => "/_matrix/client/unstable/com.beeper.msc4437/profile/{user_id}",
+        }
+    }
+
+    /// Request type for the `set_profile` endpoint.
+    #[request]
+    pub struct Request {
+        /// The user whose profile will be set.
+        #[ruma_api(path)]
+        pub user_id: OwnedUserId,
+
+        /// The new profile for the user.
+        #[ruma_api(body)]
+        pub data: BTreeMap<String, JsonValue>,
+    }
+
+    /// Response type for the `set_profile` endpoint.
+    #[response]
+    #[derive(Default)]
+    pub struct Response {}
+
+    impl Request {
+        /// Creates a new `Request` with the given user ID and profile data.
+        pub fn new(user_id: OwnedUserId, data: BTreeMap<String, JsonValue>) -> Self {
+            Self { user_id, data }
+        }
+    }
+
+    impl Response {
+        /// Creates an empty `Response`.
+        pub fn new() -> Self {
+            Self {}
+        }
+    }
+}
+

--- a/crates/ruma-client-api/src/profile/set_profile.rs
+++ b/crates/ruma-client-api/src/profile/set_profile.rs
@@ -12,8 +12,8 @@ pub mod unstable {
         api::{auth_scheme::AccessToken, request, response},
         metadata,
     };
-    use serde_json::Value as JsonValue;
     use std::collections::BTreeMap;
+    use ruma_common::profile::{ProfileFieldName, ProfileFieldValue};
 
     metadata! {
         method: PUT,
@@ -33,7 +33,7 @@ pub mod unstable {
 
         /// The new profile for the user.
         #[ruma_api(body)]
-        pub data: BTreeMap<String, JsonValue>,
+        pub data: BTreeMap<ProfileFieldName, ProfileFieldValue>,
     }
 
     /// Response type for the `set_profile` endpoint.
@@ -43,7 +43,7 @@ pub mod unstable {
 
     impl Request {
         /// Creates a new `Request` with the given user ID and profile data.
-        pub fn new(user_id: OwnedUserId, data: BTreeMap<String, JsonValue>) -> Self {
+        pub fn new(user_id: OwnedUserId, data: BTreeMap<ProfileFieldName, ProfileFieldValue>) -> Self {
             Self { user_id, data }
         }
     }

--- a/crates/ruma-common/src/profile.rs
+++ b/crates/ruma-common/src/profile.rs
@@ -1,7 +1,7 @@
 //! Common types for user profile endpoints.
 
 use std::borrow::Cow;
-use std::collections::HashMap;
+use std::collections::{btree_map, BTreeMap};
 use ruma_macros::StringEnum;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value as JsonValue, from_value as from_json_value, to_value as to_json_value};
@@ -122,25 +122,22 @@ pub struct CustomProfileFieldValue {
 
 /// Represents a user's whole profile.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub struct Profile(HashMap<String, JsonValue>);
+pub struct Profile(BTreeMap<String, JsonValue>);
 
 impl Profile {
     /// Creates a new, empty profile.
     pub fn new() -> Self {
-        Profile(HashMap::new())
+        Profile(BTreeMap::new())
     }
 
     /// Inserts a field and its value into the profile.
-    pub fn insert(&mut self, field: ProfileFieldValue) {
-        self.0.insert(field.field_name().as_str().to_owned(), field.value().into_owned());
+    pub fn insert(&mut self, field: String, value: JsonValue) {
+        self.0.insert(field, value);
     }
 
-    /// Gets a single field, returning its value.
-    ///
-    /// If there is no field with the given key, None is returned.
-    /// If the field exists, but there is an error deserializing it, Some(Err(...)) is returned.
-    pub fn get(&self, field: &str) -> Option<serde_json::Result<ProfileFieldValue>> {
-        self.0.get(field).map(|value| ProfileFieldValue::new(field, value.to_owned()))
+    /// Gets a single field, returning its raw value.
+    pub fn get(&self, field: &str) -> Option<&JsonValue> {
+        self.0.get(field)
     }
 
     /// Removes a single field from the profile.
@@ -163,9 +160,56 @@ impl Profile {
         self.0.is_empty()
     }
 
-    /// Returns an iterator over the fields of the profile in no defined order.
-    pub fn iter(&self) -> impl Iterator<Item = (&String, &JsonValue)> {
+    /// Iterates over the values in the profile.
+    pub fn iter(&self) -> btree_map::Iter<'_, String, JsonValue> {
         self.0.iter()
+    }
+}
+
+impl FromIterator<(String, JsonValue)> for Profile {
+    fn from_iter<T: IntoIterator<Item = (String, JsonValue)>>(iter: T) -> Self {
+        Self(iter.into_iter().collect())
+    }
+}
+
+impl FromIterator<(ProfileFieldName, JsonValue)> for Profile {
+    fn from_iter<T: IntoIterator<Item = (ProfileFieldName, JsonValue)>>(iter: T) -> Self {
+        iter.into_iter().map(|(field, value)| (field.as_str().to_owned(), value)).collect()
+    }
+}
+
+impl FromIterator<ProfileFieldValue> for Profile {
+    fn from_iter<T: IntoIterator<Item = ProfileFieldValue>>(iter: T) -> Self {
+        iter.into_iter().map(|value| (value.field_name(), value.value().into_owned())).collect()
+    }
+}
+
+impl Extend<(String, JsonValue)> for Profile {
+    fn extend<T: IntoIterator<Item = (String, JsonValue)>>(&mut self, iter: T) {
+        self.0.extend(iter);
+    }
+}
+
+impl Extend<(ProfileFieldName, JsonValue)> for Profile {
+    fn extend<T: IntoIterator<Item = (ProfileFieldName, JsonValue)>>(&mut self, iter: T) {
+        self.extend(iter.into_iter().map(|(field, value)| (field.as_str().to_owned(), value)));
+    }
+}
+
+impl Extend<ProfileFieldValue> for Profile {
+    fn extend<T: IntoIterator<Item = ProfileFieldValue>>(&mut self, iter: T) {
+        self.extend(
+            iter.into_iter().map(|value| (value.field_name(), value.value().into_owned())),
+        );
+    }
+}
+
+impl IntoIterator for Profile {
+    type Item = (String, JsonValue);
+    type IntoIter = btree_map::IntoIter<String, JsonValue>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
     }
 }
 
@@ -224,24 +268,23 @@ mod tests {
         let profile = from_json_value::<Profile>(json).unwrap();
 
         assert_eq!(profile.len(), 3);
-        let avatar_url = profile.get("avatar_url").expect("avatar_url should not be None").unwrap();
-        assert_eq!(avatar_url.field_name().as_str(), "avatar_url");
-        assert_eq!(avatar_url.value().as_str(), Some("mxc://localhost/abcdef"));
-        let displayname = profile.get("display_name").expect("display_name should not be None").unwrap();
-        assert_eq!(displayname.field_name().as_str(), "display_name");
-        assert_eq!(displayname.value().as_str(), Some("Alice"));
-        let custom_field = profile.get("io.ruma.custom_field").expect("io.ruma.custom_field should not be None").unwrap();
-        assert_eq!(custom_field.field_name().as_str(), "io.ruma.custom_field");
-        assert_to_canonical_json_eq!(custom_field.value().into_owned(), json!({"key": "value"}));
+        let avatar_url = profile.get("avatar_url").unwrap();
+        assert_eq!(avatar_url.as_str(), Some("mxc://localhost/abcdef"));
+
+        let displayname = profile.get("display_name").unwrap();
+        assert_eq!(displayname.as_str(), Some("Alice"));
+
+        let custom_field = profile.get("io.ruma.custom_field").unwrap();
+        assert_to_canonical_json_eq!(custom_field, json!({"key": "value"}));
     }
 
     #[test]
     fn serialize_custom_profile() {
         let mut profile = Profile::new();
-        profile.insert(ProfileFieldValue::DisplayName("Alice".to_owned()));
-        profile.insert(ProfileFieldValue::TimeZone("Etc/UTC".to_owned()));
-        profile.insert(ProfileFieldValue::AvatarUrl(owned_mxc_uri!("mxc://localhost/abcdef")));
-        profile.insert(ProfileFieldValue::new("io.ruma.custom_field", json!({"key": "value"})).unwrap());
+        profile.insert("displayname".to_owned(), "Alice".into());
+        profile.insert("m.tz".to_owned(), "Etc/UTC".into());
+        profile.insert("avatar_url".to_owned(), "mxc://localhost/abcdef".into());
+        profile.insert("io.ruma.custom_field".to_owned(), json!({"key": "value"}));
 
         assert_to_canonical_json_eq!(profile, json!({
             "displayname": "Alice",

--- a/crates/ruma-common/src/profile.rs
+++ b/crates/ruma-common/src/profile.rs
@@ -1,7 +1,10 @@
 //! Common types for user profile endpoints.
 
-use std::borrow::Cow;
-use std::collections::{btree_map, BTreeMap};
+use std::{
+    borrow::Cow,
+    collections::{BTreeMap, btree_map},
+};
+
 use ruma_macros::StringEnum;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value as JsonValue, from_value as from_json_value, to_value as to_json_value};
@@ -198,9 +201,7 @@ impl Extend<(ProfileFieldName, JsonValue)> for Profile {
 
 impl Extend<ProfileFieldValue> for Profile {
     fn extend<T: IntoIterator<Item = ProfileFieldValue>>(&mut self, iter: T) {
-        self.extend(
-            iter.into_iter().map(|value| (value.field_name(), value.value().into_owned())),
-        );
+        self.extend(iter.into_iter().map(|value| (value.field_name(), value.value().into_owned())));
     }
 }
 
@@ -286,11 +287,14 @@ mod tests {
         profile.insert("avatar_url".to_owned(), "mxc://localhost/abcdef".into());
         profile.insert("io.ruma.custom_field".to_owned(), json!({"key": "value"}));
 
-        assert_to_canonical_json_eq!(profile, json!({
-            "displayname": "Alice",
-            "m.tz": "Etc/UTC",
-            "avatar_url": "mxc://localhost/abcdef",
-            "io.ruma.custom_field": {"key": "value"}
-        }));
+        assert_to_canonical_json_eq!(
+            profile,
+            json!({
+                "displayname": "Alice",
+                "m.tz": "Etc/UTC",
+                "avatar_url": "mxc://localhost/abcdef",
+                "io.ruma.custom_field": {"key": "value"}
+            })
+        );
     }
 }

--- a/crates/ruma-common/src/profile.rs
+++ b/crates/ruma-common/src/profile.rs
@@ -1,9 +1,9 @@
 //! Common types for user profile endpoints.
 
 use std::borrow::Cow;
-
+use std::collections::HashMap;
 use ruma_macros::StringEnum;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::{Value as JsonValue, from_value as from_json_value, to_value as to_json_value};
 
 use crate::{OwnedMxcUri, PrivOwnedStr};
@@ -120,12 +120,61 @@ pub struct CustomProfileFieldValue {
     value: JsonValue,
 }
 
+/// Represents a user's whole profile.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct Profile(HashMap<String, JsonValue>);
+
+impl Profile {
+    /// Creates a new, empty profile.
+    pub fn new() -> Self {
+        Profile(HashMap::new())
+    }
+
+    /// Inserts a field and its value into the profile.
+    pub fn insert(&mut self, field: ProfileFieldValue) {
+        self.0.insert(field.field_name().as_str().to_owned(), field.value().into_owned());
+    }
+
+    /// Gets a single field, returning its value.
+    ///
+    /// If there is no field with the given key, None is returned.
+    /// If the field exists, but there is an error deserializing it, Some(Err(...)) is returned.
+    pub fn get(&self, field: &str) -> Option<serde_json::Result<ProfileFieldValue>> {
+        self.0.get(field).map(|value| ProfileFieldValue::new(field, value.to_owned()))
+    }
+
+    /// Removes a single field from the profile.
+    pub fn remove(&mut self, field: &str) {
+        self.0.remove(field);
+    }
+
+    /// Clears the profile of all keys.
+    pub fn clear(&mut self) {
+        self.0.clear();
+    }
+
+    /// Returns the number of keys in the profile.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns `true` if the profile contains no keys.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Returns an iterator over the fields of the profile in no defined order.
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &JsonValue)> {
+        self.0.iter()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use ruma_common::{canonical_json::assert_to_canonical_json_eq, owned_mxc_uri};
     use serde_json::{from_value as from_json_value, json};
 
-    use super::ProfileFieldValue;
+    use super::{Profile, ProfileFieldValue};
 
     #[test]
     fn serialize_profile_field_value() {
@@ -167,5 +216,38 @@ mod tests {
         // Error if the object is empty.
         let json = json!({});
         from_json_value::<ProfileFieldValue>(json).unwrap_err();
+    }
+
+    #[test]
+    fn deserialize_profile() {
+        let json = json!({ "avatar_url": "mxc://localhost/abcdef", "display_name": "Alice", "io.ruma.custom_field": {"key": "value"} });
+        let profile = from_json_value::<Profile>(json).unwrap();
+
+        assert_eq!(profile.len(), 3);
+        let avatar_url = profile.get("avatar_url").expect("avatar_url should not be None").unwrap();
+        assert_eq!(avatar_url.field_name().as_str(), "avatar_url");
+        assert_eq!(avatar_url.value().as_str(), Some("mxc://localhost/abcdef"));
+        let displayname = profile.get("display_name").expect("display_name should not be None").unwrap();
+        assert_eq!(displayname.field_name().as_str(), "display_name");
+        assert_eq!(displayname.value().as_str(), Some("Alice"));
+        let custom_field = profile.get("io.ruma.custom_field").expect("io.ruma.custom_field should not be None").unwrap();
+        assert_eq!(custom_field.field_name().as_str(), "io.ruma.custom_field");
+        assert_to_canonical_json_eq!(custom_field.value().into_owned(), json!({"key": "value"}));
+    }
+
+    #[test]
+    fn serialize_custom_profile() {
+        let mut profile = Profile::new();
+        profile.insert(ProfileFieldValue::DisplayName("Alice".to_owned()));
+        profile.insert(ProfileFieldValue::TimeZone("Etc/UTC".to_owned()));
+        profile.insert(ProfileFieldValue::AvatarUrl(owned_mxc_uri!("mxc://localhost/abcdef")));
+        profile.insert(ProfileFieldValue::new("io.ruma.custom_field", json!({"key": "value"})).unwrap());
+
+        assert_to_canonical_json_eq!(profile, json!({
+            "displayname": "Alice",
+            "m.tz": "Etc/UTC",
+            "avatar_url": "mxc://localhost/abcdef",
+            "io.ruma.custom_field": {"key": "value"}
+        }));
     }
 }

--- a/crates/ruma-federation-api/src/query/get_profile_information.rs
+++ b/crates/ruma-federation-api/src/query/get_profile_information.rs
@@ -7,13 +7,13 @@ pub mod v1 {
     //!
     //! [spec]: https://spec.matrix.org/v1.18/server-server-api/#get_matrixfederationv1queryprofile
 
-    use std::collections::{BTreeMap, btree_map};
+    use std::collections::btree_map;
 
     use ruma_common::{
         OwnedUserId,
         api::{request, response},
         metadata,
-        profile::{ProfileFieldName, ProfileFieldValue},
+        profile::{Profile, ProfileFieldName, ProfileFieldValue},
     };
     use serde_json::Value as JsonValue;
 
@@ -48,17 +48,16 @@ pub mod v1 {
 
     /// Response type for the `get_profile_information` endpoint.
     #[response]
-    #[derive(Default)]
     pub struct Response {
         /// The profile data.
         #[ruma_api(body)]
-        data: BTreeMap<String, JsonValue>,
+        data: Profile,
     }
 
     impl Response {
         /// Creates a new empty `Response`.
         pub fn new() -> Self {
-            Self::default()
+            Self { data: Profile::new() }
         }
 
         /// Returns the value of the given profile field.

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -199,6 +199,7 @@ unstable-msc4380 = ["ruma-events?/unstable-msc4380"]
 unstable-msc4385 = ["ruma-events?/unstable-msc4385"]
 unstable-msc4388 = ["ruma-client-api?/unstable-msc4388"]
 unstable-msc4406 = ["ruma-common/unstable-msc4406"]
+unstable-msc4437 = ["ruma-client-api?/unstable-msc4437"]
 unstable-msc4439 = ["ruma-client-api?/unstable-msc4439"]
 unstable-uniffi = ["ruma-events?/unstable-uniffi"]
 


### PR DESCRIPTION
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->

Implements unstable support for the [MSC4437: Endpoint to replace entire profile](https://github.com/matrix-org/matrix-spec-proposals/pull/4437) endpoint
