### PR TITLE
identifiers: Generate `Borrow<str>` implementations with `IdDst`

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+Improvements:
+
+- The `IdDst` macro generates `Borrow<str>` implementations for the borrowed and
+  owned identifier structs.
+
 ## 0.18.0
 
 Breaking changes:

--- a/crates/ruma-macros/src/identifiers/id_dst.rs
+++ b/crates/ruma-macros/src/identifiers/id_dst.rs
@@ -97,6 +97,13 @@ impl IdDst {
             }
 
             #[automatically_derived]
+            impl #impl_generics ::std::borrow::Borrow<#str> for #id {
+                fn borrow(&self) -> &#str {
+                    self.as_str()
+                }
+            }
+
+            #[automatically_derived]
             impl #impl_generics ::std::convert::AsRef<#id> for #id {
                 fn as_ref(&self) -> &#id {
                     self
@@ -359,6 +366,13 @@ impl IdDst {
             impl #impl_generics ::std::borrow::Borrow<#id> for #owned_id {
                 fn borrow(&self) -> &#id {
                     self.as_ref()
+                }
+            }
+
+            #[automatically_derived]
+            impl #impl_generics ::std::borrow::Borrow<#str> for #owned_id {
+                fn borrow(&self) -> &#str {
+                    self.as_inner_str()
                 }
             }
 


### PR DESCRIPTION
Because they are string types, it is safe to implement this trait for identifiers, and in maps that use an identifier type as key, it allows to use `.get()` with a `&str` to access a value.

This is extracted from #2443.