### PR TITLE
canonical-json: Add `CanonicalJsonObjectExt` trait

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -2,10 +2,16 @@
 
 ## Unreleased
 
+Breaking changes:
+
+- `RedactionError` was renamed to `CanonicalJsonFieldError` and its `MissingField` variant was
+  renamed to `Missing`.
+
 Improvements:
 
 - The `IdDst` macro generates `Borrow<str>` implementations for the borrowed and
   owned identifier structs.
+- Add `CanonicalJsonObjectExt` as a helper trait to extract fields from a `CanonicalJsonObject`.
 
 ## 0.18.0
 

--- a/crates/ruma-common/src/canonical_json.rs
+++ b/crates/ruma-common/src/canonical_json.rs
@@ -12,8 +12,7 @@ mod value;
 
 pub use self::{
     redaction::{
-        RedactedBecause, RedactionError, RedactionEvent, redact, redact_content_in_place,
-        redact_in_place,
+        RedactedBecause, RedactionEvent, redact, redact_content_in_place, redact_in_place,
     },
     serializer::Serializer,
     value::{CanonicalJsonObject, CanonicalJsonType, CanonicalJsonValue},
@@ -118,6 +117,243 @@ pub enum JsonType {
     /// JSON Null.
     Null,
 }
+
+/// Helper trait to interact with a [`CanonicalJsonObject`].
+pub trait CanonicalJsonObjectExt {
+    /// Get the given field as an object.
+    ///
+    /// # Parameters
+    ///
+    /// * `field`: The name of the field to access.
+    /// * `path`: The full path of the field that will be used in errors. This can be different than
+    ///   the `field`, to clarify if this is a field nested under several objects.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the field is invalid.
+    fn get_as_object(
+        &self,
+        field: &str,
+        path: impl Into<String>,
+    ) -> Result<Option<&CanonicalJsonObject>, CanonicalJsonFieldError>;
+
+    /// Get the given required field as an object.
+    ///
+    /// # Parameters
+    ///
+    /// * `field`: The name of the field to access.
+    /// * `path`: The full path of the field that will be used in errors. This can be different than
+    ///   the `field`, to clarify if this is a field nested under several objects.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the field is missing or invalid.
+    fn get_as_required_object(
+        &self,
+        field: &str,
+        path: impl Into<String>,
+    ) -> Result<&CanonicalJsonObject, CanonicalJsonFieldError> {
+        let path = path.into();
+        self.get_as_object(field, &path)?.ok_or(CanonicalJsonFieldError::Missing { path })
+    }
+
+    /// Get the given field as a mutable object.
+    ///
+    /// # Parameters
+    ///
+    /// * `field`: The name of the field to access.
+    /// * `path`: The full path of the field that will be used in errors. This can be different than
+    ///   the `field`, to clarify if this is a field nested under several objects.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the field is invalid.
+    fn get_as_object_mut(
+        &mut self,
+        field: &str,
+        path: impl Into<String>,
+    ) -> Result<Option<&mut CanonicalJsonObject>, CanonicalJsonFieldError>;
+
+    /// Get the given required field as a mutable object.
+    ///
+    /// # Parameters
+    ///
+    /// * `field`: The name of the field to access.
+    /// * `path`: The full path of the field that will be used in errors. This can be different than
+    ///   the `field`, to clarify if this is a field nested under several objects.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the field is missing or invalid.
+    fn get_as_required_object_mut(
+        &mut self,
+        field: &str,
+        path: impl Into<String>,
+    ) -> Result<&mut CanonicalJsonObject, CanonicalJsonFieldError> {
+        let path = path.into();
+        self.get_as_object_mut(field, &path)?.ok_or(CanonicalJsonFieldError::Missing { path })
+    }
+
+    /// Get the given required field as a mutable object or insert it if it is missing.
+    ///
+    /// # Parameters
+    ///
+    /// * `field`: The name of the field to access.
+    /// * `path`: The full path of the field that will be used in errors. This can be different than
+    ///   the `field`, to clarify if this is a field nested under several objects.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the field is already be present but invalid.
+    fn get_as_object_or_insert_default(
+        &mut self,
+        field: impl Into<String>,
+        path: impl Into<String>,
+    ) -> Result<&mut CanonicalJsonObject, CanonicalJsonFieldError>;
+
+    /// Get the given field as a string.
+    ///
+    /// # Parameters
+    ///
+    /// * `field`: The name of the field to access.
+    /// * `path`: The full path of the field that will be used in errors. This can be different than
+    ///   the `field`, to clarify if this is a field nested under several objects.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the field is invalid.
+    fn get_as_string(
+        &self,
+        field: &str,
+        path: impl Into<String>,
+    ) -> Result<Option<&str>, CanonicalJsonFieldError>;
+
+    /// Get the given required field as a string.
+    ///
+    /// # Parameters
+    ///
+    /// * `field`: The name of the field to access.
+    /// * `path`: The full path of the field that will be used in errors. This can be different than
+    ///   the `field`, to clarify if this is a field nested under several objects.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the field is missing or invalid.
+    fn get_as_required_string(
+        &self,
+        field: &str,
+        path: impl Into<String>,
+    ) -> Result<&str, CanonicalJsonFieldError> {
+        let path = path.into();
+        self.get_as_string(field, &path)?.ok_or(CanonicalJsonFieldError::Missing { path })
+    }
+}
+
+impl CanonicalJsonObjectExt for CanonicalJsonObject {
+    fn get_as_object(
+        &self,
+        field: &str,
+        path: impl Into<String>,
+    ) -> Result<Option<&CanonicalJsonObject>, CanonicalJsonFieldError> {
+        match self.get(field) {
+            Some(CanonicalJsonValue::Object(object)) => Ok(Some(object)),
+            Some(value) => Err(CanonicalJsonFieldError::InvalidType {
+                path: path.into(),
+                expected: CanonicalJsonType::Object,
+                found: value.json_type(),
+            }),
+            None => Ok(None),
+        }
+    }
+
+    fn get_as_object_mut(
+        &mut self,
+        field: &str,
+        path: impl Into<String>,
+    ) -> Result<Option<&mut CanonicalJsonObject>, CanonicalJsonFieldError> {
+        match self.get_mut(field) {
+            Some(CanonicalJsonValue::Object(object)) => Ok(Some(object)),
+            Some(value) => Err(CanonicalJsonFieldError::InvalidType {
+                path: path.into(),
+                expected: CanonicalJsonType::Object,
+                found: value.json_type(),
+            }),
+            None => Ok(None),
+        }
+    }
+
+    fn get_as_object_or_insert_default(
+        &mut self,
+        field: impl Into<String>,
+        path: impl Into<String>,
+    ) -> Result<&mut CanonicalJsonObject, CanonicalJsonFieldError> {
+        let value = self
+            .entry(field.into())
+            .or_insert_with(|| CanonicalJsonValue::Object(Default::default()));
+        match value {
+            CanonicalJsonValue::Object(object) => Ok(object),
+            value => Err(CanonicalJsonFieldError::InvalidType {
+                path: path.into(),
+                expected: CanonicalJsonType::String,
+                found: value.json_type(),
+            }),
+        }
+    }
+
+    fn get_as_string(
+        &self,
+        field: &str,
+        path: impl Into<String>,
+    ) -> Result<Option<&str>, CanonicalJsonFieldError> {
+        match self.get(field) {
+            Some(CanonicalJsonValue::String(string)) => Ok(Some(string)),
+            Some(value) => Err(CanonicalJsonFieldError::InvalidType {
+                path: path.into(),
+                expected: CanonicalJsonType::String,
+                found: value.json_type(),
+            }),
+            None => Ok(None),
+        }
+    }
+}
+
+/// Errors that can happen when trying to access a field from a [`CanonicalJsonObject`].
+#[derive(Debug)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+pub enum CanonicalJsonFieldError {
+    /// The field at `path` was expected to be of type `expected`, but was received as `found`.
+    InvalidType {
+        /// The path of the invalid field.
+        path: String,
+
+        /// The type that was expected.
+        expected: CanonicalJsonType,
+
+        /// The type that was found.
+        found: CanonicalJsonType,
+    },
+
+    /// A required field is missing from a JSON object.
+    Missing {
+        /// The path of the missing field.
+        path: String,
+    },
+}
+
+impl fmt::Display for CanonicalJsonFieldError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidType { path, expected, found } => {
+                write!(f, "invalid type at `{path}`: expected {expected:?}, found {found:?}")
+            }
+            Self::Missing { path } => {
+                write!(f, "missing field: `{path}`")
+            }
+        }
+    }
+}
+
+impl std::error::Error for CanonicalJsonFieldError {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/ruma-common/src/canonical_json/redaction.rs
+++ b/crates/ruma-common/src/canonical_json/redaction.rs
@@ -1,6 +1,8 @@
-use std::{fmt, mem};
+use std::mem;
 
-use super::value::{CanonicalJsonObject, CanonicalJsonType, CanonicalJsonValue};
+use super::{
+    CanonicalJsonFieldError, CanonicalJsonObject, CanonicalJsonObjectExt, CanonicalJsonValue,
+};
 use crate::{room_version_rules::RedactionRules, serde::Raw};
 
 /// Redacts an event using the rules specified in the Matrix client-server specification.
@@ -31,7 +33,7 @@ pub fn redact(
     mut object: CanonicalJsonObject,
     rules: &RedactionRules,
     redacted_because: Option<RedactedBecause>,
-) -> Result<CanonicalJsonObject, RedactionError> {
+) -> Result<CanonicalJsonObject, CanonicalJsonFieldError> {
     redact_in_place(&mut object, rules, redacted_because)?;
     Ok(object)
 }
@@ -43,7 +45,7 @@ pub fn redact_in_place(
     event: &mut CanonicalJsonObject,
     rules: &RedactionRules,
     redacted_because: Option<RedactedBecause>,
-) -> Result<(), RedactionError> {
+) -> Result<(), CanonicalJsonFieldError> {
     retained_event_keys(event)?.apply(rules, event);
 
     if let Some(redacted_because) = redacted_because {
@@ -89,44 +91,6 @@ impl RedactedBecause {
 
 /// Marker trait for redaction events.
 pub trait RedactionEvent {}
-
-/// Errors that can happen in redaction.
-#[derive(Debug)]
-#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
-pub enum RedactionError {
-    /// The field at `path` was expected to be of type `expected`, but was received as `found`.
-    InvalidType {
-        /// The path of the invalid field.
-        path: String,
-
-        /// The type that was expected.
-        expected: CanonicalJsonType,
-
-        /// The type that was found.
-        found: CanonicalJsonType,
-    },
-
-    /// A required field is missing from a JSON object.
-    MissingField {
-        /// The path of the missing field.
-        path: String,
-    },
-}
-
-impl fmt::Display for RedactionError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            RedactionError::InvalidType { path, expected, found } => {
-                write!(f, "invalid type at `{path}`: expected {expected:?}, found {found:?}")
-            }
-            RedactionError::MissingField { path } => {
-                write!(f, "missing field: `{path}`")
-            }
-        }
-    }
-}
-
-impl std::error::Error for RedactionError {}
 
 /// A function that takes redaction rules and a key and returns whether the field should be
 /// retained.
@@ -198,18 +162,10 @@ impl RetainedKeys {
 }
 
 /// Get the given keys should be retained at the top level of an event.
-fn retained_event_keys(event: &CanonicalJsonObject) -> Result<RetainedKeys, RedactionError> {
-    let event_type = match event.get("type") {
-        Some(CanonicalJsonValue::String(event_type)) => event_type.clone(),
-        Some(value) => {
-            return Err(RedactionError::InvalidType {
-                path: "type".to_owned(),
-                expected: CanonicalJsonType::String,
-                found: value.json_type(),
-            });
-        }
-        None => return Err(RedactionError::MissingField { path: "type".to_owned() }),
-    };
+fn retained_event_keys(
+    event: &CanonicalJsonObject,
+) -> Result<RetainedKeys, CanonicalJsonFieldError> {
+    let event_type = event.get_as_required_string("type", "type")?.to_owned();
 
     Ok(RetainedKeys::some(move |rules, key| match key {
         "content" => RetainKey::Yes {

--- a/crates/ruma-signatures/CHANGELOG.md
+++ b/crates/ruma-signatures/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+Breaking changes:
+
+- Refactor the variants of `JsonError`: `InvalidType` and `JsonFieldMissingFromObject` were merged
+  into a single `Field` variant that uses the `CanonicalJsonFieldError` enum from `ruma-common`.
+
 ## 0.20.0
 
 Breaking changes:

--- a/crates/ruma-signatures/src/error.rs
+++ b/crates/ruma-signatures/src/error.rs
@@ -1,7 +1,5 @@
 use ruma_common::{
-    IdParseError,
-    canonical_json::{CanonicalJsonType, RedactionError},
-    serde::Base64DecodeError,
+    IdParseError, canonical_json::CanonicalJsonFieldError, serde::Base64DecodeError,
 };
 use thiserror::Error;
 
@@ -15,42 +13,13 @@ pub enum JsonError {
     #[error("PDU is larger than maximum of 65535 bytes")]
     PduTooLarge,
 
-    /// The field at `path` was expected to be of type `expected`, but was received as `found`.
-    #[error("invalid type at `{path}`: expected {expected:?}, found {found:?}")]
-    InvalidType {
-        /// The path of the invalid field.
-        path: String,
-
-        /// The type that was expected.
-        expected: CanonicalJsonType,
-
-        /// The type that was found.
-        found: CanonicalJsonType,
-    },
-
-    /// A required field is missing from a JSON object.
-    #[error("missing field: `{path}`")]
-    MissingField {
-        /// The path of the missing field.
-        path: String,
-    },
+    /// A field is missing or invalid.
+    #[error(transparent)]
+    Field(#[from] CanonicalJsonFieldError),
 
     /// A more generic JSON error from [`serde_json`].
     #[error(transparent)]
     Serde(#[from] serde_json::Error),
-}
-
-impl From<RedactionError> for JsonError {
-    fn from(err: RedactionError) -> Self {
-        match err {
-            RedactionError::InvalidType { path, expected, found } => {
-                JsonError::InvalidType { path, expected, found }
-            }
-            RedactionError::MissingField { path } => JsonError::MissingField { path },
-            #[allow(unreachable_patterns)]
-            _ => unreachable!(),
-        }
-    }
 }
 
 /// Errors relating to verification of signatures.
@@ -59,7 +28,7 @@ impl From<RedactionError> for JsonError {
 pub enum VerificationError {
     /// The JSON to check is invalid.
     #[error("Invalid JSON: {0}")]
-    Json(#[from] JsonError),
+    Json(JsonError),
 
     /// Parsing a base64-encoded signature failed.
     #[error("Could not parse base64-encoded signature at `path`: {source}")]
@@ -102,4 +71,13 @@ pub enum VerificationError {
     /// Error verifying an ed25519 signature.
     #[error(transparent)]
     Ed25519(#[from] Ed25519VerificationError),
+}
+
+impl<T> From<T> for VerificationError
+where
+    T: Into<JsonError>,
+{
+    fn from(value: T) -> Self {
+        Self::Json(value.into())
+    }
 }

--- a/crates/ruma-signatures/src/sign.rs
+++ b/crates/ruma-signatures/src/sign.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, collections::BTreeMap, mem};
 
 use ruma_common::{
     AnyKeyName, CanonicalJsonObject, CanonicalJsonValue, OwnedSigningKeyId, SigningKeyAlgorithm,
-    canonical_json::{CanonicalJsonType, redact},
+    canonical_json::{CanonicalJsonFieldError, CanonicalJsonObjectExt, CanonicalJsonType, redact},
     room_version_rules::RedactionRules,
     serde::{Base64, base64::Standard},
 };
@@ -124,24 +124,10 @@ where
 {
     let hash = content_hash(object)?;
 
-    let hashes_value = object
-        .entry("hashes".to_owned())
-        .or_insert_with(|| CanonicalJsonValue::Object(BTreeMap::new()));
+    let hashes = object.get_as_object_or_insert_default("hashes", "hashes")?;
+    hashes.insert("sha256".into(), CanonicalJsonValue::String(hash.encode()));
 
-    match hashes_value {
-        CanonicalJsonValue::Object(hashes) => {
-            hashes.insert("sha256".into(), CanonicalJsonValue::String(hash.encode()))
-        }
-        _ => {
-            return Err(JsonError::InvalidType {
-                path: "hashes".to_owned(),
-                expected: CanonicalJsonType::Object,
-                found: hashes_value.json_type(),
-            });
-        }
-    };
-
-    let mut redacted = redact(object.clone(), redaction_rules, None).map_err(JsonError::from)?;
+    let mut redacted = redact(object.clone(), redaction_rules, None)?;
 
     sign_json(entity_id, key_pair, &mut redacted)?;
 
@@ -217,11 +203,12 @@ where
     let (signatures_key, mut signature_map) = match object.remove_entry("signatures") {
         Some((key, CanonicalJsonValue::Object(signatures))) => (Cow::Owned(key), signatures),
         Some((_, value)) => {
-            return Err(JsonError::InvalidType {
+            return Err(CanonicalJsonFieldError::InvalidType {
                 path: "signatures".to_owned(),
                 expected: CanonicalJsonType::Object,
                 found: value.json_type(),
-            });
+            }
+            .into());
         }
         None => (Cow::Borrowed("signatures"), BTreeMap::new()),
     };
@@ -229,24 +216,14 @@ where
     let maybe_unsigned_entry = object.remove_entry("unsigned");
 
     // Get the canonical JSON string.
-    let json = to_json_string(object).map_err(JsonError::Serde)?;
+    let json = to_json_string(object)?;
 
     // Sign the canonical JSON string.
     let signature = key_pair.sign(json.as_bytes());
 
     // Insert the new signature in the map we pulled out (or created) previously.
     let signature_set = signature_map
-        .entry(entity_id.to_owned())
-        .or_insert_with(|| CanonicalJsonValue::Object(BTreeMap::new()));
-
-    let CanonicalJsonValue::Object(signature_set) = signature_set else {
-        return Err(JsonError::InvalidType {
-            path: format!("signatures.{entity_id}"),
-            expected: CanonicalJsonType::Object,
-            found: signature_set.json_type(),
-        });
-    };
-
+        .get_as_object_or_insert_default(entity_id.to_owned(), format!("signatures.{entity_id}"))?;
     signature_set.insert(signature.id(), CanonicalJsonValue::String(signature.base64()));
 
     // Put `signatures` and `unsigned` back in.

--- a/crates/ruma-signatures/src/verify.rs
+++ b/crates/ruma-signatures/src/verify.rs
@@ -5,7 +5,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use ruma_common::{
     AnyKeyName, CanonicalJsonObject, CanonicalJsonValue, IdParseError, OwnedEventId,
     OwnedServerName, SigningKeyAlgorithm, SigningKeyId, UserId,
-    canonical_json::{CanonicalJsonType, redact},
+    canonical_json::{CanonicalJsonFieldError, CanonicalJsonObjectExt, CanonicalJsonType, redact},
     room_version_rules::{RoomVersionRules, SignaturesRules},
     serde::{Base64, base64::Standard},
 };
@@ -95,46 +95,11 @@ pub fn verify_event(
     object: &CanonicalJsonObject,
     rules: &RoomVersionRules,
 ) -> Result<Verified, VerificationError> {
-    let redacted = redact(object.clone(), &rules.redaction, None).map_err(JsonError::from)?;
+    let redacted = redact(object.clone(), &rules.redaction, None)?;
 
-    let hashes = match object.get("hashes") {
-        Some(CanonicalJsonValue::Object(hashes)) => hashes,
-        Some(value) => {
-            return Err(JsonError::InvalidType {
-                path: "hashes".to_owned(),
-                expected: CanonicalJsonType::Object,
-                found: value.json_type(),
-            }
-            .into());
-        }
-        None => return Err(JsonError::MissingField { path: "hashes".to_owned() }.into()),
-    };
-
-    let hash = match hashes.get("sha256") {
-        Some(CanonicalJsonValue::String(hash)) => hash,
-        Some(value) => {
-            return Err(JsonError::InvalidType {
-                path: "hashes.sha256".to_owned(),
-                expected: CanonicalJsonType::String,
-                found: value.json_type(),
-            }
-            .into());
-        }
-        None => return Err(JsonError::MissingField { path: "hashes.sha256".to_owned() }.into()),
-    };
-
-    let signature_map = match object.get("signatures") {
-        Some(CanonicalJsonValue::Object(signatures)) => signatures,
-        Some(value) => {
-            return Err(JsonError::InvalidType {
-                path: "signatures".to_owned(),
-                expected: CanonicalJsonType::Object,
-                found: value.json_type(),
-            }
-            .into());
-        }
-        None => return Err(JsonError::MissingField { path: "signatures".to_owned() }.into()),
-    };
+    let hashes = object.get_as_required_object("hashes", "hashes")?;
+    let hash = hashes.get_as_required_string("sha256", "hashes.sha256")?;
+    let signature_map = object.get_as_required_object("signatures", "signatures")?;
 
     let servers_to_check = required_server_signatures_to_verify_event(object, &rules.signatures)?;
     let canonical_json = to_canonical_json_string_for_signing(&redacted)?;
@@ -213,19 +178,7 @@ pub fn verify_json(
     public_key_map: &PublicKeyMap,
     object: &CanonicalJsonObject,
 ) -> Result<(), VerificationError> {
-    let signature_map = match object.get("signatures") {
-        Some(CanonicalJsonValue::Object(signatures)) => signatures,
-        Some(value) => {
-            return Err(JsonError::InvalidType {
-                path: "signatures".to_owned(),
-                expected: CanonicalJsonType::Object,
-                found: value.json_type(),
-            }
-            .into());
-        }
-        None => return Err(JsonError::MissingField { path: "signatures".to_owned() }.into()),
-    };
-
+    let signature_map = object.get_as_required_object("signatures", "signatures")?;
     let canonical_json = to_canonical_json_string_for_signing(object)?;
 
     for entity_id in signature_map.keys() {
@@ -340,18 +293,9 @@ fn verify_canonical_json_for_entity(
     signature_map: &CanonicalJsonObject,
     canonical_json: &[u8],
 ) -> Result<(), VerificationError> {
-    let signature_set = match signature_map.get(entity_id) {
-        Some(CanonicalJsonValue::Object(set)) => set,
-        Some(value) => {
-            return Err(JsonError::InvalidType {
-                path: format!("signatures.{entity_id}"),
-                expected: CanonicalJsonType::Object,
-                found: value.json_type(),
-            }
-            .into());
-        }
-        None => return Err(VerificationError::NoSignaturesForEntity(entity_id.to_owned())),
-    };
+    let signature_set = signature_map
+        .get_as_object(entity_id, format!("signatures.{entity_id}"))?
+        .ok_or_else(|| VerificationError::NoSignaturesForEntity(entity_id.to_owned()))?;
 
     let public_keys = public_key_map
         .get(entity_id)
@@ -375,7 +319,7 @@ fn verify_canonical_json_for_entity(
         };
 
         let CanonicalJsonValue::String(signature) = signature else {
-            return Err(JsonError::InvalidType {
+            return Err(CanonicalJsonFieldError::InvalidType {
                 path: format!("signatures.{entity_id}.{key_id}"),
                 expected: CanonicalJsonType::String,
                 found: signature.json_type(),
@@ -449,68 +393,43 @@ pub fn required_server_signatures_to_verify_event(
     let mut servers_to_check = BTreeSet::new();
 
     if !is_invite_via_third_party_id(object)? {
-        match object.get("sender") {
-            Some(CanonicalJsonValue::String(raw_sender)) => {
-                let user_id = <&UserId>::try_from(raw_sender.as_str()).map_err(|source| {
-                    VerificationError::ParseIdentifier { identifier_type: "user ID", source }
-                })?;
+        let sender = object.get_as_required_string("sender", "sender")?;
+        let user_id = <&UserId>::try_from(sender).map_err(|source| {
+            VerificationError::ParseIdentifier { identifier_type: "user ID", source }
+        })?;
 
-                servers_to_check.insert(user_id.server_name().to_owned());
-            }
-            Some(value) => {
-                return Err(JsonError::InvalidType {
-                    path: "sender".to_owned(),
-                    expected: CanonicalJsonType::String,
-                    found: value.json_type(),
-                }
-                .into());
-            }
-            _ => return Err(JsonError::MissingField { path: "sender".to_owned() }.into()),
-        }
+        servers_to_check.insert(user_id.server_name().to_owned());
     }
 
     if rules.check_event_id_server {
-        match object.get("event_id") {
-            Some(CanonicalJsonValue::String(raw_event_id)) => {
-                let event_id: OwnedEventId = raw_event_id.parse().map_err(|source| {
-                    VerificationError::ParseIdentifier { identifier_type: "event ID", source }
-                })?;
+        let raw_event_id = object.get_as_required_string("event_id", "event_id")?;
+        let event_id: OwnedEventId = raw_event_id.parse().map_err(|source| {
+            VerificationError::ParseIdentifier { identifier_type: "event ID", source }
+        })?;
 
-                let server_name =
-                    event_id.server_name().map(ToOwned::to_owned).ok_or_else(|| {
-                        VerificationError::ParseIdentifier {
-                            identifier_type: "event ID",
-                            source: IdParseError::InvalidServerName,
-                        }
-                    })?;
+        let server_name = event_id.server_name().map(ToOwned::to_owned).ok_or_else(|| {
+            VerificationError::ParseIdentifier {
+                identifier_type: "event ID",
+                source: IdParseError::InvalidServerName,
+            }
+        })?;
 
-                servers_to_check.insert(server_name);
-            }
-            Some(value) => {
-                return Err(JsonError::InvalidType {
-                    path: "event_id".to_owned(),
-                    expected: CanonicalJsonType::String,
-                    found: value.json_type(),
-                }
-                .into());
-            }
-            _ => {
-                return Err(JsonError::MissingField { path: "event_id".to_owned() }.into());
-            }
-        }
+        servers_to_check.insert(server_name);
     }
 
     if rules.check_join_authorised_via_users_server
         && let Some(authorized_user) = object
             .get("content")
             .and_then(|c| c.as_object())
-            .and_then(|c| c.get("join_authorised_via_users_server"))
+            .map(|c| {
+                c.get_as_string(
+                    "join_authorised_via_users_server",
+                    "content.join_authorised_via_users_server",
+                )
+            })
+            .transpose()?
+            .flatten()
     {
-        let authorized_user = authorized_user.as_str().ok_or_else(|| JsonError::InvalidType {
-            path: "content.join_authorised_via_users_server".to_owned(),
-            expected: CanonicalJsonType::String,
-            found: authorized_user.json_type(),
-        })?;
         let authorized_user = <&UserId>::try_from(authorized_user).map_err(|source| {
             VerificationError::ParseIdentifier { identifier_type: "user ID", source }
         })?;
@@ -526,61 +445,20 @@ pub fn required_server_signatures_to_verify_event(
 ///
 /// Returns an error if the object has not the expected format of an `m.room.member` event.
 fn is_invite_via_third_party_id(object: &CanonicalJsonObject) -> Result<bool, JsonError> {
-    let raw_type = match object.get("type") {
-        Some(CanonicalJsonValue::String(raw_type)) => raw_type,
-        Some(value) => {
-            return Err(JsonError::InvalidType {
-                path: "type".to_owned(),
-                expected: CanonicalJsonType::String,
-                found: value.json_type(),
-            });
-        }
-        None => return Err(JsonError::MissingField { path: "type".to_owned() }),
-    };
+    let event_type = object.get_as_required_string("type", "type")?;
 
-    if raw_type != "m.room.member" {
+    if event_type != "m.room.member" {
         return Ok(false);
     }
 
-    let content = match object.get("content") {
-        Some(CanonicalJsonValue::Object(content)) => content,
-        Some(value) => {
-            return Err(JsonError::InvalidType {
-                path: "content".to_owned(),
-                expected: CanonicalJsonType::Object,
-                found: value.json_type(),
-            });
-        }
-        None => return Err(JsonError::MissingField { path: "content".to_owned() }),
-    };
-
-    let membership = match content.get("membership") {
-        Some(CanonicalJsonValue::String(membership)) => membership,
-        Some(value) => {
-            return Err(JsonError::InvalidType {
-                path: "content.membership".to_owned(),
-                expected: CanonicalJsonType::String,
-                found: value.json_type(),
-            });
-        }
-        None => {
-            return Err(JsonError::MissingField { path: "content.membership".to_owned() });
-        }
-    };
+    let content = object.get_as_required_object("content", "content")?;
+    let membership = content.get_as_required_string("membership", "content.membership")?;
 
     if membership != "invite" {
         return Ok(false);
     }
 
-    match content.get("third_party_invite") {
-        Some(CanonicalJsonValue::Object(_)) => Ok(true),
-        Some(value) => Err(JsonError::InvalidType {
-            path: "content.third_party_invite".to_owned(),
-            expected: CanonicalJsonType::Object,
-            found: value.json_type(),
-        }),
-        None => Ok(false),
-    }
+    Ok(content.get_as_object("third_party_invite", "content.third_party_invite")?.is_some())
 }
 
 /// A digital signature verifier.


### PR DESCRIPTION
It allows to access fields from a `CanonicalJsonObject` while handling common errors.

It requires its own error type that is identical to `RedactionError`, so we just rename that error type. And since we are at it, we stop proxying the variants of that field to `JsonError` and just use the enum.

Extracted from #2443.