### PR TITLE
client-api: Add MSC4472 room version stability type

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -9,6 +9,7 @@ Improvements:
   LiveKit tag changes from `livekit_multi_sfu` to `livekit` on
   `/rtc/transports`.
 - Add unstable support for MSC4466 "Altering profile change propagation".
+- Add unstable support for MSC4472 deprecated room version stability type.
 
 ## 0.23.1
 

--- a/crates/ruma-client-api/Cargo.toml
+++ b/crates/ruma-client-api/Cargo.toml
@@ -55,6 +55,7 @@ unstable-msc4308 = []
 unstable-msc4388 = []
 unstable-msc4439 = []
 unstable-msc4466 = []
+unstable-msc4472 = []
 
 [dependencies]
 as_variant = { workspace = true }

--- a/crates/ruma-client-api/src/discovery/get_capabilities.rs
+++ b/crates/ruma-client-api/src/discovery/get_capabilities.rs
@@ -301,6 +301,11 @@ pub mod v3 {
         /// Support for the given version is unstable.
         Unstable,
 
+        /// Support for the given version is deprecated.
+        #[cfg(feature = "unstable-msc4472")]
+        #[ruma_enum(rename = "uk.timedout.msc4472.deprecated")]
+        Deprecated,
+
         #[doc(hidden)]
         _Custom(PrivOwnedStr),
     }

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -201,6 +201,7 @@ unstable-msc4388 = ["ruma-client-api?/unstable-msc4388"]
 unstable-msc4406 = ["ruma-common/unstable-msc4406"]
 unstable-msc4439 = ["ruma-client-api?/unstable-msc4439"]
 unstable-msc4466 = ["ruma-client-api?/unstable-msc4466"]
+unstable-msc4472 = ["ruma-client-api?/unstable-msc4472"]
 unstable-uniffi = ["ruma-events?/unstable-uniffi"]
 
 [dependencies]


### PR DESCRIPTION
Implements the unstable `deprecated` room version stability type, specified in [MSC4472: Deprecated room version kind](https://github.com/matrix-org/matrix-spec-proposals/pull/4472). I doubt this needs anything but the additional enum definition.

Required for [continuwuity #1768](https://forgejo.ellis.link/continuwuation/continuwuity/pulls/1768). Marked as draft until the proposal gets some feedback.