### PR TITLE
time: Add conversion utilities

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -12,6 +12,8 @@ Improvements:
 - The `IdDst` macro generates `Borrow<str>` implementations for the borrowed and
   owned identifier structs.
 - Add `CanonicalJsonObjectExt` as a helper trait to extract fields from a `CanonicalJsonObject`.
+- Implement `TryFrom` trait and `checked_add` method for working with
+  `MilliSecondsSinceUnixEpoch` and rust time types.
 
 ## 0.18.0
 

--- a/crates/ruma-common/src/time.rs
+++ b/crates/ruma-common/src/time.rs
@@ -2,6 +2,7 @@ use std::fmt;
 
 use js_int::{UInt, uint};
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 use time::OffsetDateTime;
 use web_time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -28,6 +29,11 @@ impl MilliSecondsSinceUnixEpoch {
     /// Creates a new `SystemTime` from `self`, if it can be represented.
     pub fn to_system_time(self) -> Option<SystemTime> {
         UNIX_EPOCH.checked_add(Duration::from_millis(self.0.into()))
+    }
+
+    /// Adds the given Duration to the time, returning it if the new time can be represented.
+    pub fn checked_add(self, rhs: Duration) -> Option<Self> {
+        Some(Self(self.0.checked_add(rhs.as_millis().try_into().ok()?)?))
     }
 
     /// Get the time since the unix epoch in milliseconds.
@@ -68,6 +74,22 @@ impl fmt::Debug for MilliSecondsSinceUnixEpoch {
     }
 }
 
+impl TryFrom<SystemTime> for MilliSecondsSinceUnixEpoch {
+    type Error = TimeConversionError;
+
+    fn try_from(value: SystemTime) -> Result<Self, Self::Error> {
+        Self::from_system_time(value).ok_or(TimeConversionError::SystemTime(value))
+    }
+}
+
+impl TryFrom<MilliSecondsSinceUnixEpoch> for SystemTime {
+    type Error = TimeConversionError;
+
+    fn try_from(value: MilliSecondsSinceUnixEpoch) -> Result<Self, Self::Error> {
+        value.to_system_time().ok_or(TimeConversionError::MilliSecondsSinceUnixEpoch(value))
+    }
+}
+
 /// A timestamp represented as the number of seconds since the unix epoch.
 #[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
 #[allow(clippy::exhaustive_structs)]
@@ -91,6 +113,11 @@ impl SecondsSinceUnixEpoch {
     /// Creates a new `SystemTime` from `self`, if it can be represented.
     pub fn to_system_time(self) -> Option<SystemTime> {
         UNIX_EPOCH.checked_add(Duration::from_secs(self.0.into()))
+    }
+
+    /// Adds the given Duration to the time, returning it if the new time can be represented.
+    pub fn checked_add(self, rhs: Duration) -> Option<Self> {
+        Some(Self(self.0.checked_add(rhs.as_millis().try_into().ok()?)?))
     }
 
     /// Get time since the unix epoch in seconds.
@@ -122,6 +149,36 @@ impl fmt::Debug for SecondsSinceUnixEpoch {
             }
         }
     }
+}
+
+impl TryFrom<SystemTime> for SecondsSinceUnixEpoch {
+    type Error = TimeConversionError;
+
+    fn try_from(value: SystemTime) -> Result<Self, Self::Error> {
+        Self::from_system_time(value).ok_or(TimeConversionError::SystemTime(value))
+    }
+}
+
+impl TryFrom<SecondsSinceUnixEpoch> for SystemTime {
+    type Error = TimeConversionError;
+
+    fn try_from(value: SecondsSinceUnixEpoch) -> Result<Self, Self::Error> {
+        value.to_system_time().ok_or(TimeConversionError::SecondsSinceUnixEpoch(value))
+    }
+}
+
+/// The error type returned when failing to convert to or from SystemTime
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum TimeConversionError {
+    #[error("Cannot represent {0:?} as SystemTime")]
+    MilliSecondsSinceUnixEpoch(MilliSecondsSinceUnixEpoch),
+
+    #[error("Cannot represent {0:?} as SystemTime")]
+    SecondsSinceUnixEpoch(SecondsSinceUnixEpoch),
+
+    #[error("Cannot represent {0:?} as Ruma time type")]
+    SystemTime(SystemTime),
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Switching between `SystemTime` and `MillesecondsSinceUnixEpoch` values can be a bit cumbersome with the current functions. Implementing `TryFrom`, as well as a `checked_add` for adding a duration, makes for some more pleasant code.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
