### PR TITLE
Update unstable support for MSC4140

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -25,8 +25,10 @@ Improvements:
   field on `discovery::get_supported_versions::Response` carries the
   homeserver implementation name and version, mirroring the federation
   `/version` payload.
+- Update unstable support for [MSC4140] "Cancellable delayed events".
 
 [MSC4383]: https://github.com/matrix-org/matrix-spec-proposals/pull/4383
+[MSC4140]: https://github.com/matrix-org/matrix-spec-proposals/pull/4140
 
 ## 0.23.1
 

--- a/crates/ruma-client-api/src/delayed_events.rs
+++ b/crates/ruma-client-api/src/delayed_events.rs
@@ -1,27 +1,142 @@
 //! Endpoints for sending and interacting with delayed events.
+//!
+//! Delayed events are an unstable feature added by [MSC4140](https://github.com/matrix-org/matrix-spec-proposals/pull/4140)
 
-pub mod delayed_message_event;
-pub mod delayed_state_event;
+pub mod get_all_delayed_events;
+pub mod get_delayed_event;
+pub mod send_delayed_event;
 pub mod update_delayed_event;
 
+// deprecated endpoints
+pub mod delayed_message_event;
+pub mod delayed_state_event;
+
+use std::time::Duration;
+
+use ruma_common::{
+    MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId,
+    api::error::StandardErrorBody,
+    serde::{Raw, StringEnum},
+};
+use ruma_events::{AnyTimelineEventContent, TimelineEventType};
 use serde::{Deserialize, Serialize};
-use web_time::Duration;
+
+use crate::PrivOwnedStr;
+
+/// The structure of the data for returning a delayed event from a GET endpoint
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+pub struct DelayedEventData {
+    /// The ID of the delayed event.
+    pub delay_id: String,
+
+    /// The ID of the room that the delayed event was scheduled to be sent in.
+    pub room_id: OwnedRoomId,
+
+    /// The event type of the delayed event.
+    #[serde(rename = "type")]
+    pub event_type: TimelineEventType,
+
+    /// The State Key if the event is a state event, nothing otherwise
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state_key: Option<String>,
+
+    /// The event content to send.
+    ///
+    /// This is the content that was submitted to the send endpoint, not the content of the final
+    /// event
+    pub content: Raw<AnyTimelineEventContent>,
+
+    /// The duration that the server should wait before sending this event
+    #[serde(with = "ruma_common::serde::duration::ms")]
+    pub delay: Duration,
+
+    /// The timestamp when the delayed event was scheduled or last restarted.
+    pub running_since: MilliSecondsSinceUnixEpoch,
+
+    /// The error that prevented the delayed event from being sent.
+    /// Present only for finalized events that were cancelled due to an error.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<StandardErrorBody>,
+
+    /// The event_id this event got when it was sent.
+    /// Present only for events that were sent successfully.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub event_id: Option<OwnedEventId>,
+
+    /// The timestamp when the event was finalized.
+    /// Present only for events that were finalized (sent, failed to send, or cancelled).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "finalised_ts")]
+    pub finalized_ts: Option<MilliSecondsSinceUnixEpoch>,
+}
+
+impl DelayedEventData {
+    /// Create a new delayed event data object with the given parameters
+    pub fn new(
+        delay_id: String,
+        room_id: OwnedRoomId,
+        event_type: TimelineEventType,
+        state_key: Option<String>,
+        content: Raw<AnyTimelineEventContent>,
+        delay: Duration,
+        running_since: MilliSecondsSinceUnixEpoch,
+    ) -> Self {
+        Self {
+            delay_id,
+            room_id,
+            event_type,
+            state_key,
+            delay,
+            running_since,
+            content,
+            error: None,
+            event_id: None,
+            finalized_ts: None,
+        }
+    }
+
+    /// Returns the status indicated by this delayed event data.
+    pub fn status(&self) -> DelayedEventStatus {
+        if self.finalized_ts.is_none() {
+            DelayedEventStatus::Scheduled
+        } else if self.event_id.is_some() {
+            DelayedEventStatus::Send
+        } else if self.error.is_some() {
+            DelayedEventStatus::Error
+        } else {
+            DelayedEventStatus::Cancel
+        }
+    }
+}
+
+/// The status that a delayed event stored on the server can have.
+#[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
+#[derive(Clone, StringEnum)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+#[ruma_enum(rename_all = "snake_case")]
+pub enum DelayedEventStatus {
+    /// The event is currently scheduled to be submitted at a later date.
+    /// It may be restarted, sent or cancelled via the management endpoint.
+    Scheduled,
+
+    /// The event has been sent successfully.
+    Send,
+
+    /// The event has been cancelled.
+    Cancel,
+
+    /// The event has encountered an error when trying to send.
+    Error,
+
+    #[doc(hidden)]
+    _Custom(PrivOwnedStr),
+}
 
 /// The query parameters for a delayed event request.
 /// It contains the `timeout` configuration for a delayed event.
 ///
-/// ### Note:
-///
-/// This is an Enum since the following properties might be added:
-///
-/// The **Timeout** case might get an additional optional `delay_parent_id` property.
-/// The optional parent id is used to create a secondary timeout.  
-/// In a delay group with two timeouts only one of them will ever be sent.
-///
-/// The **Action** case might be added:
-/// Adds an additional action to a delay event without a timeout but requires a `delay_id` (of the
-/// parent delay event). A possible matrix event that can be send as an alternative to the parent
-/// delay.
+/// This enum is no longer used except by deprecated endpoints.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 #[serde(untagged)]

--- a/crates/ruma-client-api/src/delayed_events/delayed_state_event.rs
+++ b/crates/ruma-client-api/src/delayed_events/delayed_state_event.rs
@@ -1,6 +1,12 @@
 //! `PUT /_matrix/client/*/rooms/{roomId}/state/{eventType}/{txnId}`
 //!
-//! Send a delayed state event (a scheduled state event) to a room. [MSC](https://github.com/matrix-org/matrix-spec-proposals/pull/4140)
+//! Send a delayed state event (a scheduled state event) to a room.
+//!
+//! This endpoint implements a previous iteration of MSC4140 at commit [`3ee73ab`].
+//! At the time of writing, this matches the current implementation of Synapse but the latest
+//! iteration of the MSC uses the `send_delayed_event` endpoint instead.
+//!
+//! [`3ee73ab`]: https://github.com/matrix-org/matrix-spec-proposals/blob/3ee73abe5f81252b00877cfb5db941ee9aa6c18d/proposals/4140-delayed-events-futures.md
 
 pub mod unstable {
     //! `msc4140` ([MSC])
@@ -105,7 +111,7 @@ pub mod unstable {
 
     impl Response {
         /// Creates a new `Response` with the tokens required to control the delayed event using the
-        /// [`crate::delayed_events::update_delayed_event::unstable::Request`] request.
+        /// [`crate::delayed_events::update_delayed_event::unstable_v1::Request`] request.
         pub fn new(delay_id: String) -> Self {
             Self { delay_id }
         }

--- a/crates/ruma-client-api/src/delayed_events/get_all_delayed_events.rs
+++ b/crates/ruma-client-api/src/delayed_events/get_all_delayed_events.rs
@@ -1,0 +1,119 @@
+//! `GET /_matrix/client/*/rooms/{roomId}/delayed_events`
+//!
+//! Get all of the user's delayed events.
+
+pub mod unstable {
+    //! `msc4140` ([MSC])
+    //!
+    //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/4140
+
+    use ruma_common::{
+        api::{auth_scheme::AccessToken, request, response},
+        metadata,
+    };
+
+    use crate::delayed_events::DelayedEventData;
+
+    metadata! {
+        method: GET,
+        rate_limited: true,
+        authentication: AccessToken,
+        history: {
+            unstable("org.matrix.msc4140") => "/_matrix/client/unstable/org.matrix.msc4140/delayed_events",
+        }
+    }
+
+    /// Request type for the
+    /// [`get_all_delayed_events`](crate::delayed_events::get_all_delayed_events) endpoint
+    #[request]
+    pub struct Request {}
+
+    /// Response type for the
+    /// [`get_all_delayed_events`](crate::delayed_events::get_all_delayed_events) endpoint
+    #[response]
+    pub struct Response {
+        /// An array of objects describing scheduled delayed events owned by the requesting user
+        pub delayed_events: Vec<DelayedEventData>,
+    }
+
+    impl Request {
+        /// Create a new Request
+        pub fn new() -> Self {
+            Self {}
+        }
+    }
+
+    impl Default for Request {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    impl Response {
+        /// Create a new Response.
+        pub fn new(delayed_events: Vec<DelayedEventData>) -> Self {
+            Self { delayed_events }
+        }
+    }
+
+    #[cfg(all(test, feature = "server"))]
+    mod server_tests {
+
+        use std::time::Duration;
+
+        use js_int::UInt;
+        use ruma_common::{
+            MilliSecondsSinceUnixEpoch, api::OutgoingResponse, owned_event_id, owned_room_id,
+            serde::Raw,
+        };
+        use ruma_events::TimelineEventType;
+        use serde_json::{Value as JsonValue, json};
+
+        use super::Response;
+        use crate::delayed_events::DelayedEventData;
+
+        #[test]
+        fn serialize_get_all_delayed_events_response() {
+            let content = json!({
+                "topic": "test topic"
+            })
+            .to_string();
+
+            let mut event0 = DelayedEventData::new(
+                "a_delay_id".to_owned(),
+                owned_room_id!("!roomid:example.org"),
+                TimelineEventType::RoomTopic,
+                Some("a_state_key".to_owned()),
+                Raw::from_json_string(content).unwrap(),
+                Duration::from_millis(103),
+                MilliSecondsSinceUnixEpoch(UInt::new(70000).unwrap()),
+            );
+
+            event0.event_id = Some(owned_event_id!("$event:imaginary.hs"));
+            event0.finalized_ts = Some(MilliSecondsSinceUnixEpoch(UInt::new(70103).unwrap()));
+
+            let response = Response::new(vec![event0]);
+
+            let response: http::Response<Vec<u8>> = response.try_into_http_response().unwrap();
+
+            assert_eq!(
+                json!({
+                    "delayed_events" : [{
+                        "content": {
+                            "topic": "test topic"
+                        },
+                        "delay": 103,
+                        "delay_id": "a_delay_id",
+                        "event_id": "$event:imaginary.hs",
+                        "finalised_ts": 70103,
+                        "room_id": "!roomid:example.org",
+                        "running_since": 70000,
+                        "state_key": "a_state_key",
+                        "type": "m.room.topic"
+                        }]
+                }),
+                serde_json::from_slice::<JsonValue>(response.body()).unwrap()
+            );
+        }
+    }
+}

--- a/crates/ruma-client-api/src/delayed_events/get_delayed_event.rs
+++ b/crates/ruma-client-api/src/delayed_events/get_delayed_event.rs
@@ -1,0 +1,177 @@
+//! `GET /_matrix/client/*/rooms/{roomId}/delayed_events/{delay_id}`
+//!
+//! Get the information about a delayed event.
+
+pub mod unstable {
+    //! `msc4140` ([MSC])
+    //!
+    //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/4140
+
+    use ruma_common::{
+        api::{auth_scheme::AccessToken, request, response},
+        metadata,
+    };
+
+    use crate::delayed_events::DelayedEventData;
+
+    metadata! {
+        method: GET,
+        rate_limited: true,
+        authentication: AccessToken,
+        history: {
+            unstable("org.matrix.msc4140") => "/_matrix/client/unstable/org.matrix.msc4140/delayed_events/{delay_id}",
+        }
+    }
+
+    /// Request type for the [`get_delayed_event`](crate::delayed_events::get_delayed_event)
+    /// endpoint
+    #[request]
+    pub struct Request {
+        /// The ID of the requested delayed event.
+        #[ruma_api(path)]
+        pub delay_id: String,
+    }
+
+    /// Response type for the [`get_delayed_event`](crate::delayed_events::get_delayed_event)
+    /// endpoint
+    #[response]
+    pub struct Response {
+        /// The returned delayed event information
+        #[ruma_api(body)]
+        pub delayed_event: DelayedEventData,
+    }
+
+    impl Request {
+        /// Create a new Request object
+        pub fn new(delay_id: String) -> Self {
+            Self { delay_id }
+        }
+    }
+
+    impl Response {
+        /// Create a new Response object
+        pub fn new(delayed_event: DelayedEventData) -> Self {
+            Self { delayed_event }
+        }
+    }
+
+    impl From<DelayedEventData> for Response {
+        fn from(delayed_event: DelayedEventData) -> Self {
+            Self { delayed_event }
+        }
+    }
+
+    #[cfg(all(test, feature = "server"))]
+    mod server_tests {
+        use std::time::Duration;
+
+        use js_int::UInt;
+        use ruma_common::{
+            MilliSecondsSinceUnixEpoch, api::OutgoingResponse, owned_event_id, owned_room_id,
+            serde::Raw,
+        };
+        use ruma_events::TimelineEventType;
+        use serde_json::{Value as JsonValue, json};
+
+        use super::Response;
+        use crate::delayed_events::DelayedEventData;
+
+        #[test]
+        fn serialize_get_delayed_event_response() {
+            let content = json!({
+                "topic": "test topic"
+            })
+            .to_string();
+
+            let mut event_data = DelayedEventData::new(
+                "a_delay_id".to_owned(),
+                owned_room_id!("!roomid:example.org"),
+                TimelineEventType::RoomTopic,
+                Some("a_state_key".to_owned()),
+                Raw::from_json_string(content).unwrap(),
+                Duration::from_millis(103),
+                MilliSecondsSinceUnixEpoch(UInt::new(70000).unwrap()),
+            );
+            event_data.event_id = Some(owned_event_id!("$event:imaginary.hs"));
+            event_data.finalized_ts = Some(MilliSecondsSinceUnixEpoch(UInt::new(70103).unwrap()));
+
+            let response: http::Response<Vec<u8>> =
+                Response::new(event_data).try_into_http_response().unwrap();
+
+            assert_eq!(
+                json!({
+                    "content": {
+                        "topic": "test topic"
+                    },
+                    "delay": 103,
+                    "delay_id": "a_delay_id",
+                    "event_id": "$event:imaginary.hs",
+                    "finalised_ts": 70103,
+                    "room_id": "!roomid:example.org",
+                    "running_since": 70000,
+                    "state_key": "a_state_key",
+                    "type": "m.room.topic"
+                }),
+                serde_json::from_slice::<JsonValue>(response.body()).unwrap()
+            );
+        }
+    }
+
+    #[cfg(all(test, feature = "client"))]
+    mod client_tests {
+        use std::time::Duration;
+
+        use js_int::UInt;
+        use ruma_common::{
+            MilliSecondsSinceUnixEpoch, api::IncomingResponse, owned_event_id, owned_room_id,
+        };
+        use ruma_events::TimelineEventType;
+        use serde_json::{Value as JsonValue, json};
+
+        use super::Response;
+
+        #[test]
+        fn deserialize_get_delayed_event_request() {
+            let body = json!({
+                "content": {
+                    "topic": "test topic"
+                },
+                "delay": 103,
+                "delay_id": "a_delay_id",
+                "event_id": "$event:imaginary.hs",
+                "finalised_ts": 70103,
+                "room_id": "!roomid:example.org",
+                "running_since": 70000,
+                "state_key": "a_state_key",
+                "type": "m.room.topic"
+            })
+            .to_string();
+
+            let res =
+                Response::try_from_http_response(http::Response::builder().body(body).unwrap())
+                    .unwrap()
+                    .delayed_event;
+
+            let content = json!({
+                "topic": "test topic"
+            });
+
+            assert_eq!(res.delay_id, "a_delay_id".to_owned());
+            assert_eq!(res.room_id, owned_room_id!("!roomid:example.org"));
+            assert_eq!(res.event_type, TimelineEventType::RoomTopic);
+            assert_eq!(res.state_key, Some("a_state_key".to_owned()));
+            assert_eq!(res.delay, Duration::from_millis(103));
+            assert_eq!(res.running_since, MilliSecondsSinceUnixEpoch(UInt::new(70000).unwrap()));
+            assert_eq!(
+                serde_json::from_str::<JsonValue>(res.content.json().get()).unwrap(),
+                content
+            );
+            assert!(res.error.is_none());
+            assert_eq!(res.event_id, Some(owned_event_id!("$event:imaginary.hs")));
+            assert_eq!(
+                res.finalized_ts,
+                Some(MilliSecondsSinceUnixEpoch(UInt::new(70103).unwrap()))
+            );
+        }
+    }
+}

--- a/crates/ruma-client-api/src/delayed_events/send_delayed_event.rs
+++ b/crates/ruma-client-api/src/delayed_events/send_delayed_event.rs
@@ -1,17 +1,13 @@
-//! `PUT /_matrix/client/*/rooms/{roomId}/send/{eventType}/{txnId}`
+//! `PUT /_matrix/client/*/rooms/{roomId}/delayed_event/{eventType}/{txnId}`
 //!
 //! Send a delayed event (a scheduled message) to a room.
-//!
-//! This endpoint implements a previous iteration of MSC4140 at commit [`3ee73ab`].
-//! At the time of writing, this matches the current implementation of Synapse but the latest
-//! iteration of the MSC uses the `send_delayed_event` endpoint instead.
-//!
-//! [`3ee73ab`]: https://github.com/matrix-org/matrix-spec-proposals/blob/3ee73abe5f81252b00877cfb5db941ee9aa6c18d/proposals/4140-delayed-events-futures.md
 
 pub mod unstable {
     //! `msc4140` ([MSC])
     //!
     //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/4140
+
+    use std::time::Duration;
 
     use ruma_common::{
         OwnedRoomId, OwnedTransactionId,
@@ -19,21 +15,17 @@ pub mod unstable {
         metadata,
         serde::Raw,
     };
-    use ruma_events::{AnyMessageLikeEventContent, MessageLikeEventContent, MessageLikeEventType};
-    use serde_json::value::to_raw_value as to_raw_json_value;
-
-    use crate::delayed_events::DelayParameters;
+    use ruma_events::{AnyTimelineEventContent, TimelineEventType};
 
     metadata! {
         method: PUT,
-        rate_limited: false,
+        rate_limited: true,
         authentication: AccessToken,
         history: {
-            // We use the unstable prefix for the delay query parameter but the stable v3 endpoint.
-            unstable => "/_matrix/client/v3/rooms/{room_id}/send/{event_type}/{txn_id}",
+            unstable("org.matrix.msc4140") => "/_matrix/client/unstable/org.matrix.msc4140/rooms/{room_id}/delayed_event/{event_type}/{txn_id}",
         }
     }
-    /// Request type for the [`delayed_message_event`](crate::delayed_events::delayed_message_event)
+    /// Request type for the [`send_delayed_event`](crate::delayed_events::send_delayed_event)
     /// endpoint.
     #[request]
     pub struct Request {
@@ -43,7 +35,7 @@ pub mod unstable {
 
         /// The type of event to send.
         #[ruma_api(path)]
-        pub event_type: MessageLikeEventType,
+        pub event_type: TimelineEventType,
 
         /// The transaction ID for this event.
         ///
@@ -57,17 +49,20 @@ pub mod unstable {
         #[ruma_api(path)]
         pub txn_id: OwnedTransactionId,
 
-        /// The timeout duration for this delayed event.
-        #[ruma_api(query_all)]
-        pub delay_parameters: DelayParameters,
+        /// The duration that the server should wait before sending this event
+        #[serde(with = "ruma_common::serde::duration::ms")]
+        pub delay: Duration,
+
+        /// The State Key if the event is a state event, nothing otherwise
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub state_key: Option<String>,
 
         /// The event content to send.
-        #[ruma_api(body)]
-        pub body: Raw<AnyMessageLikeEventContent>,
+        pub content: Raw<AnyTimelineEventContent>,
     }
 
     /// Response type for the
-    /// [`delayed_message_event`](crate::delayed_events::delayed_message_event) endpoint.
+    /// [`send_delayed_event`](crate::delayed_events::send_delayed_event) endpoint.
     #[response]
     pub struct Response {
         /// The `delay_id` generated for this delayed event. Used to interact with delayed events.
@@ -82,47 +77,47 @@ pub mod unstable {
         ///
         /// Since `Request` stores the request body in serialized form, this function can fail if
         /// `T`s [`::serde::Serialize`] implementation can fail.
-        pub fn new<T>(
+        pub fn new(
             room_id: OwnedRoomId,
             txn_id: OwnedTransactionId,
-            delay_parameters: DelayParameters,
-            content: &T,
-        ) -> serde_json::Result<Self>
-        where
-            T: MessageLikeEventContent,
-        {
+            delay: Duration,
+            state_key: Option<String>,
+            content: &AnyTimelineEventContent,
+        ) -> serde_json::Result<Self> {
             Ok(Self {
                 room_id,
                 txn_id,
                 event_type: content.event_type(),
-                delay_parameters,
-                body: Raw::from_json(to_raw_json_value(content)?),
+                state_key,
+                delay,
+                content: Raw::new(content)?,
             })
         }
 
         /// Creates a new `Request` with the given room id, transaction id, event type,
         /// `delay_parameters` and raw event content.
         pub fn new_raw(
+            event_type: TimelineEventType,
             room_id: OwnedRoomId,
             txn_id: OwnedTransactionId,
-            event_type: MessageLikeEventType,
-            delay_parameters: DelayParameters,
-            body: Raw<AnyMessageLikeEventContent>,
-        ) -> Self {
-            Self { room_id, event_type, txn_id, delay_parameters, body }
+            delay: Duration,
+            state_key: Option<String>,
+            content: Raw<AnyTimelineEventContent>,
+        ) -> serde_json::Result<Self> {
+            Ok(Self { room_id, txn_id, event_type, state_key, delay, content })
         }
     }
 
     impl Response {
         /// Creates a new `Response` with the tokens required to control the delayed event using the
-        /// [`crate::delayed_events::update_delayed_event::unstable_v1::Request`] request.
+        /// [`crate::delayed_events::update_delayed_event::unstable_v2::Request`] request.
         pub fn new(delay_id: String) -> Self {
             Self { delay_id }
         }
     }
 
     #[cfg(all(test, feature = "client"))]
-    mod tests {
+    mod client_tests {
         use std::borrow::Cow;
 
         use ruma_common::{
@@ -131,15 +126,14 @@ pub mod unstable {
             },
             owned_room_id,
         };
-        use ruma_events::room::message::RoomMessageEventContent;
+        use ruma_events::{AnyMessageLikeEventContent, room::message::RoomMessageEventContent};
         use serde_json::{Value as JsonValue, json};
         use web_time::Duration;
 
         use super::Request;
-        use crate::delayed_events::delayed_message_event::unstable::DelayParameters;
 
         #[test]
-        fn serialize_delayed_message_request() {
+        fn serialize_send_delayed_event_request() {
             let room_id = owned_room_id!("!roomid:example.org");
             let supported = SupportedVersions {
                 versions: [MatrixVersion::V1_1].into(),
@@ -149,8 +143,10 @@ pub mod unstable {
             let req = Request::new(
                 room_id,
                 "1234".into(),
-                DelayParameters::Timeout { timeout: Duration::from_millis(103) },
-                &RoomMessageEventContent::text_plain("test"),
+                Duration::from_millis(103),
+                None,
+                &AnyMessageLikeEventContent::from(RoomMessageEventContent::text_plain("test"))
+                    .into(),
             )
             .unwrap();
             let request: http::Request<Vec<u8>> = req
@@ -162,13 +158,54 @@ pub mod unstable {
                 .unwrap();
             let (parts, body) = request.into_parts();
             assert_eq!(
-                "https://homeserver.tld/_matrix/client/v3/rooms/!roomid:example.org/send/m.room.message/1234?org.matrix.msc4140.delay=103",
+                "https://homeserver.tld/_matrix/client/unstable/org.matrix.msc4140/rooms/!roomid:example.org/delayed_event/m.room.message/1234",
                 parts.uri.to_string()
             );
             assert_eq!("PUT", parts.method.to_string());
             assert_eq!(
-                json!({"msgtype":"m.text","body":"test"}),
+                json!({"content":{"msgtype":"m.text","body":"test"}, "delay": 103}),
                 serde_json::from_str::<JsonValue>(std::str::from_utf8(&body).unwrap()).unwrap()
+            );
+        }
+    }
+
+    #[cfg(all(test, feature = "server"))]
+    mod server_tests {
+
+        use std::time::Duration;
+
+        use ruma_common::{OwnedTransactionId, api::IncomingRequest, owned_room_id};
+        use serde_json::json;
+
+        use super::Request;
+
+        #[test]
+        fn deserialize_send_delayed_events_request() {
+            let uri = http::Uri::builder()
+                .scheme("https")
+                .authority("matrix.org")
+                .path_and_query(
+                    "/_matrix/client/unstable/org.matrix.msc4140/rooms/!roomid:example.org/delayed_event/m.room.message/5678",
+                )
+                .build()
+                .unwrap();
+
+            let body = json!({"content":{"msgtype":"m.text","body":"test"}, "delay": 103});
+
+            let req = Request::try_from_http_request(
+                http::Request::builder().method("PUT").uri(uri).body(body.to_string()).unwrap(),
+                &["!roomid:example.org", "m.room.message", "5678"],
+            )
+            .unwrap();
+
+            assert_eq!(req.room_id, owned_room_id!("!roomid:example.org"));
+            assert_eq!(req.event_type, "m.room.message".into());
+            assert_eq!(req.txn_id, OwnedTransactionId::from("5678"));
+            assert_eq!(req.delay, Duration::from_millis(103));
+            assert_eq!(req.state_key, None);
+            assert_eq!(
+                serde_json::from_str::<serde_json::Value>(req.content.json().get()).unwrap(),
+                json!({"msgtype":"m.text","body":"test"}),
             );
         }
     }

--- a/crates/ruma-client-api/src/delayed_events/update_delayed_event.rs
+++ b/crates/ruma-client-api/src/delayed_events/update_delayed_event.rs
@@ -3,44 +3,50 @@
 //! Send a delayed event update. This can be a updateing/canceling/sending the associated delayed
 //! event.
 
-pub mod unstable {
+use ruma_common::serde::StringEnum;
+
+use crate::PrivOwnedStr;
+
+/// The possible update actions we can do for updating a delayed event.
+#[derive(Clone, StringEnum)]
+#[ruma_enum(rename_all = "lowercase")]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+pub enum UpdateAction {
+    /// Restart the delayed event timeout. (heartbeat ping)
+    Restart,
+    /// Send the delayed event immediately independent of the timeout state. (deletes all
+    /// timers)
+    Send,
+    /// Delete the delayed event and never send it. (deletes all timers)
+    Cancel,
+
+    #[doc(hidden)]
+    _Custom(PrivOwnedStr),
+}
+
+pub mod unstable_v1;
+
+pub mod unstable_v2 {
     //! `msc3814` ([MSC])
     //!
     //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/4140
 
     use ruma_common::{
-        api::{auth_scheme::AccessToken, request, response},
+        api::{auth_scheme::NoAccessToken, request, response},
         metadata,
-        serde::StringEnum,
     };
 
-    use crate::PrivOwnedStr;
+    use super::UpdateAction;
 
     metadata! {
         method: POST,
         rate_limited: true,
-        authentication: AccessToken,
+        authentication: NoAccessToken,
         history: {
-            unstable("org.matrix.msc4140") => "/_matrix/client/unstable/org.matrix.msc4140/delayed_events/{delay_id}",
+            unstable("org.matrix.msc4140") => "/_matrix/client/unstable/org.matrix.msc4140/delayed_events/{delay_id}/{action}",
         }
     }
 
-    /// The possible update actions we can do for updating a delayed event.
-    #[derive(Clone, StringEnum)]
-    #[ruma_enum(rename_all = "lowercase")]
-    #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
-    pub enum UpdateAction {
-        /// Restart the delayed event timeout. (heartbeat ping)
-        Restart,
-        /// Send the delayed event immediately independent of the timeout state. (deletes all
-        /// timers)
-        Send,
-        /// Delete the delayed event and never send it. (deletes all timers)
-        Cancel,
-
-        #[doc(hidden)]
-        _Custom(PrivOwnedStr),
-    }
     /// Request type for the [`update_delayed_event`](crate::delayed_events::update_delayed_event)
     /// endpoint.
     #[request]
@@ -49,6 +55,7 @@ pub mod unstable {
         #[ruma_api(path)]
         pub delay_id: String,
         /// Which kind of update we want to request for the delayed event.
+        #[ruma_api(path)]
         pub action: UpdateAction,
     }
 
@@ -72,7 +79,7 @@ pub mod unstable {
     }
 
     #[cfg(all(test, feature = "client"))]
-    mod tests {
+    mod client_tests {
         use std::borrow::Cow;
 
         use ruma_common::api::{
@@ -81,6 +88,7 @@ pub mod unstable {
         use serde_json::{Value as JsonValue, json};
 
         use super::{Request, UpdateAction};
+
         #[test]
         fn serialize_update_delayed_event_request() {
             let supported = SupportedVersions {
@@ -91,7 +99,7 @@ pub mod unstable {
                 Request::new("1234".to_owned(), UpdateAction::Cancel)
                     .try_into_http_request(
                         "https://homeserver.tld",
-                        SendAccessToken::IfRequired("auth_tok"),
+                        SendAccessToken::None,
                         Cow::Owned(supported),
                     )
                     .unwrap();
@@ -99,14 +107,43 @@ pub mod unstable {
             let (parts, body) = request.into_parts();
 
             assert_eq!(
-                "https://homeserver.tld/_matrix/client/unstable/org.matrix.msc4140/delayed_events/1234",
+                "https://homeserver.tld/_matrix/client/unstable/org.matrix.msc4140/delayed_events/1234/cancel",
                 parts.uri.to_string()
             );
             assert_eq!("POST", parts.method.to_string());
             assert_eq!(
-                json!({"action": "cancel"}),
+                json!({}),
                 serde_json::from_str::<JsonValue>(std::str::from_utf8(&body).unwrap()).unwrap()
             );
+        }
+    }
+
+    #[cfg(all(test, feature = "server"))]
+    mod server_tests {
+
+        use ruma_common::api::IncomingRequest;
+
+        use super::{Request, UpdateAction};
+
+        #[test]
+        fn deserialize_update_delayed_events_request() {
+            let uri = http::Uri::builder()
+                .scheme("https")
+                .authority("matrix.org")
+                .path_and_query(
+                    "/_matrix/client/unstable/org.matrix.msc4140/delayed_events/a_delay_id/send",
+                )
+                .build()
+                .unwrap();
+
+            let req = Request::try_from_http_request(
+                http::Request::builder().method("POST").uri(uri).body("").unwrap(),
+                &["a_delay_id", "send"],
+            )
+            .unwrap();
+
+            assert_eq!(req.delay_id, "a_delay_id".to_owned());
+            assert_eq!(req.action, UpdateAction::Send);
         }
     }
 }

--- a/crates/ruma-client-api/src/delayed_events/update_delayed_event/unstable_v1.rs
+++ b/crates/ruma-client-api/src/delayed_events/update_delayed_event/unstable_v1.rs
@@ -1,0 +1,89 @@
+//! `msc4140` ([MSC])
+//!
+//! Old endpoint definition from MSC 4140. Does not correspond to the current state of the MSC.
+//!
+//! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/blob/3ee73abe5f81252b00877cfb5db941ee9aa6c18d/proposals/4140-delayed-events-futures.md
+
+use ruma_common::{
+    api::{auth_scheme::AccessToken, request, response},
+    metadata,
+};
+
+use super::UpdateAction;
+
+metadata! {
+    method: POST,
+    rate_limited: true,
+    authentication: AccessToken,
+    history: {
+        unstable("org.matrix.msc4140") => "/_matrix/client/unstable/org.matrix.msc4140/delayed_events/{delay_id}",
+    }
+}
+
+/// Request type for the [`update_delayed_event`](crate::delayed_events::update_delayed_event)
+/// endpoint.
+#[request]
+pub struct Request {
+    /// The delay id that we want to update.
+    #[ruma_api(path)]
+    pub delay_id: String,
+    /// Which kind of update we want to request for the delayed event.
+    pub action: UpdateAction,
+}
+
+impl Request {
+    /// Creates a new `Request` to update a delayed event.
+    pub fn new(delay_id: String, action: UpdateAction) -> Self {
+        Self { delay_id, action }
+    }
+}
+
+/// Response type for the [`update_delayed_event`](crate::delayed_events::update_delayed_event)
+/// endpoint.
+#[response]
+pub struct Response {}
+impl Response {
+    /// Creates a new empty response for the
+    /// [`update_delayed_event`](crate::delayed_events::update_delayed_event) endpoint.
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+#[cfg(all(test, feature = "client"))]
+mod tests {
+    use std::borrow::Cow;
+
+    use ruma_common::api::{
+        MatrixVersion, OutgoingRequest, SupportedVersions, auth_scheme::SendAccessToken,
+    };
+    use serde_json::{Value as JsonValue, json};
+
+    use super::{Request, UpdateAction};
+    #[test]
+    fn serialize_update_delayed_event_request() {
+        let supported = SupportedVersions {
+            versions: [MatrixVersion::V1_1].into(),
+            features: Default::default(),
+        };
+        let request: http::Request<Vec<u8>> = Request::new("1234".to_owned(), UpdateAction::Cancel)
+            .try_into_http_request(
+                "https://homeserver.tld",
+                SendAccessToken::IfRequired("auth_tok"),
+                Cow::Owned(supported),
+            )
+            .unwrap();
+
+        let (parts, body) = request.into_parts();
+
+        assert_eq!(
+            "https://homeserver.tld/_matrix/client/unstable/org.matrix.msc4140/delayed_events/1234",
+            parts.uri.to_string()
+        );
+        assert_eq!("POST", parts.method.to_string());
+        assert_eq!(
+            json!({"action": "cancel"}),
+            serde_json::from_str::<JsonValue>(std::str::from_utf8(&body).unwrap()).unwrap()
+        );
+    }
+}

--- a/crates/ruma-common/src/api.rs
+++ b/crates/ruma-common/src/api.rs
@@ -408,6 +408,13 @@ pub enum Direction {
     Forward,
 }
 
+impl Direction {
+    /// method for providing forward as the default direction to serde instead
+    pub fn forward() -> Self {
+        Self::Forward
+    }
+}
+
 /// Data to [assert the identity] of an appservice virtual user.
 ///
 /// [assert the identity]: https://spec.matrix.org/v1.18/application-service-api/#identity-assertion

--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -12,6 +12,8 @@ Breaking changes:
 Bug fixes:
 
 - Export `AnyRedactionEvent`.
+- Added a `AnyTimelineEventContent` enum which may contain either
+  a `StateEventContent` or a `MessageLIkeEventContent`
 
 Improvements:
 

--- a/crates/ruma-events/src/enums.rs
+++ b/crates/ruma-events/src/enums.rs
@@ -1,6 +1,6 @@
 use ruma_common::{
     EventId, MilliSecondsSinceUnixEpoch, OwnedRoomId, RoomId, TransactionId, UserId,
-    serde::from_raw_json_value,
+    serde::{JsonCastable, from_raw_json_value},
 };
 #[cfg(feature = "unstable-msc3381")]
 use ruma_events::{
@@ -8,7 +8,7 @@ use ruma_events::{
     room::encrypted::Replacement,
 };
 use ruma_macros::{EventEnumFromEvent, event_enum};
-use serde::{Deserialize, de};
+use serde::{Deserialize, Serialize, de};
 use serde_json::value::RawValue as RawJsonValue;
 
 use super::room::encrypted;
@@ -371,6 +371,36 @@ impl From<AnyTimelineEvent> for AnySyncTimelineEvent {
         }
     }
 }
+
+/// Any room event content.
+#[allow(clippy::large_enum_variant, clippy::exhaustive_enums)]
+#[derive(Clone, Debug, EventEnumFromEvent, Serialize)]
+#[serde(untagged)]
+pub enum AnyTimelineEventContent {
+    /// Any message-like event content.
+    MessageLike(AnyMessageLikeEventContent),
+
+    /// Any state event content.
+    State(AnyStateEventContent),
+}
+
+impl AnyTimelineEventContent {
+    /// Get the event's type
+    pub fn event_type(&self) -> TimelineEventType {
+        match self {
+            Self::MessageLike(content) => {
+                <AnyMessageLikeEventContent as crate::MessageLikeEventContent>::event_type(content)
+                    .into()
+            }
+            Self::State(content) => {
+                <AnyStateEventContent as crate::StateEventContent>::event_type(content).into()
+            }
+        }
+    }
+}
+
+impl JsonCastable<AnyTimelineEventContent> for AnyMessageLikeEventContent {}
+impl JsonCastable<AnyTimelineEventContent> for AnyStateEventContent {}
 
 #[derive(Deserialize)]
 #[allow(clippy::exhaustive_structs)]


### PR DESCRIPTION
[MSC4140](https://github.com/matrix-org/matrix-spec-proposals/pull/4140) "Cancellable delayed events"

Update the `delayed_events` module to match the current state of the MSC.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
