### PR TITLE
common: Correctly check if a public room directory filter is empty

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+Bug fixes:
+- Properly check the room type filter in `ruma_common::directory::Filter`'s `is_empty` function.
+
 Breaking changes:
 
 - `RedactionError` was renamed to `CanonicalJsonFieldError` and its `MissingField` variant was

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 Bug fixes:
+
 - Properly check the room type filter in `ruma_common::directory::Filter`'s `is_empty` function.
 
 Breaking changes:

--- a/crates/ruma-common/src/directory.rs
+++ b/crates/ruma-common/src/directory.rs
@@ -201,7 +201,7 @@ impl Filter {
 
     /// Returns `true` if the filter is empty.
     pub fn is_empty(&self) -> bool {
-        self.generic_search_term.is_none()
+        self.generic_search_term.is_none() && self.room_types.is_empty()
     }
 }
 


### PR DESCRIPTION
Does what it says on the tin. This fixes a regression in Continuwuity introduced after switching off our fork of ruma.