### PR TITLE
signatures: Expose the two separate steps of `hash_and_sign_event()`

### DIFF
--- a/crates/ruma-signatures/CHANGELOG.md
+++ b/crates/ruma-signatures/CHANGELOG.md
@@ -7,6 +7,12 @@ Breaking changes:
 - Refactor the variants of `JsonError`: `InvalidType` and `JsonFieldMissingFromObject` were merged
   into a single `Field` variant that uses the `CanonicalJsonFieldError` enum from `ruma-common`.
 
+Improvements:
+
+- The two steps of `hash_and_sign_event()` are now available as separate functions:
+  `add_content_hash_to_event()` and `sign_event()`. This is to help servers that need to add extra
+  signatures on an already hashed and signed event, like policy servers.
+
 ## 0.20.0
 
 Breaking changes:

--- a/crates/ruma-signatures/src/hash.rs
+++ b/crates/ruma-signatures/src/hash.rs
@@ -1,7 +1,7 @@
 use base64::{Engine, alphabet};
 use ruma_common::{
-    CanonicalJsonObject,
-    canonical_json::redact,
+    CanonicalJsonObject, CanonicalJsonValue,
+    canonical_json::{CanonicalJsonObjectExt, redact},
     room_version_rules::{EventIdFormatVersion, RoomVersionRules},
     serde::{Base64, base64::Standard},
 };
@@ -19,6 +19,77 @@ static CONTENT_HASH_FIELDS_TO_REMOVE: &[&str] = &["hashes", "signatures", "unsig
 
 /// The fields to remove from a JSON object when creating a reference hash of an event.
 static REFERENCE_HASH_FIELDS_TO_REMOVE: &[&str] = &["signatures", "unsigned"];
+
+/// Compute and add the [content hash] to the given event.
+///
+/// This adds or overwrites the `sha256` key in the `hashes` object of the event.
+///
+/// This should only be called when creating a new event.
+///
+/// # Parameters
+///
+/// * `object`: A JSON object to be hashed according to the Matrix specification.
+///
+/// # Errors
+///
+/// Returns an error if the `hashes` key is present and is not an object.
+///
+/// # Examples
+///
+/// ```
+/// use ruma_common::CanonicalJsonObject;
+/// use ruma_signatures::add_content_hash_to_event;
+///
+/// // Deserialize an event from JSON.
+/// let mut event = serde_json::from_str(
+///     r#"{
+///         "room_id": "!x:domain",
+///         "sender": "@a:domain",
+///         "origin": "domain",
+///         "origin_server_ts": 1000000,
+///         "type": "X",
+///         "content": {},
+///         "prev_events": [],
+///         "auth_events": [],
+///         "depth": 3
+///     }"#,
+/// )?;
+///
+/// // Hash the JSON.
+/// add_content_hash_to_event(&mut event)?;
+///
+/// // The hash was added.
+/// assert_eq!(
+///     event,
+///     serde_json::from_str::<CanonicalJsonObject>(
+///         r#"{
+///             "room_id": "!x:domain",
+///             "sender": "@a:domain",
+///             "origin": "domain",
+///             "origin_server_ts": 1000000,
+///             "type": "X",
+///             "content": {},
+///             "prev_events": [],
+///             "auth_events": [],
+///             "depth": 3,
+///             "hashes": {
+///                 "sha256": "5jM4wQpv6lnBo7CLIghJuHdW+s2CMBJPUOGOC89ncos"
+///             }
+///         }"#,
+///     )?
+/// );
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+///
+/// [content hash]: https://spec.matrix.org/v1.18/server-server-api/#calculating-the-content-hash-for-an-event
+pub fn add_content_hash_to_event(object: &mut CanonicalJsonObject) -> Result<(), JsonError> {
+    let hash = content_hash(object)?;
+
+    let hashes = object.get_as_object_or_insert_default("hashes", "hashes")?;
+    hashes.insert("sha256".into(), CanonicalJsonValue::String(hash.encode()));
+
+    Ok(())
+}
 
 /// Computes the [content hash] of the given event.
 ///
@@ -51,6 +122,9 @@ pub fn content_hash(object: &CanonicalJsonObject) -> Result<Base64<Standard, [u8
 ///
 /// The reference hash of an event covers the essential fields of an event, including content
 /// hashes.
+///
+/// When creating a new event, [`add_content_hash_to_event()`] must be called before this function
+/// to add the content hash.
 ///
 /// Returns the hash as a base64-encoded string, without padding. The correct character set is used
 /// depending on the room version:

--- a/crates/ruma-signatures/src/lib.rs
+++ b/crates/ruma-signatures/src/lib.rs
@@ -42,8 +42,10 @@
 //! Homeservers are required to generate hashes of event contents as well as signing events before
 //! exchanging them with other homeservers. Although the algorithm for hashing and signing an event
 //! is more complicated than for signing arbitrary JSON, the interface to a user of ruma-signatures
-//! is the same. To hash and sign an event, use the [`hash_and_sign_event()`] function. See the
-//! documentation of this function for more details and a full example of use.
+//! is the same. To add the content hash to an event use [`add_content_hash_to_event()`], and to
+//! sign an event use [`sign_event()`]. Both steps can be done at once by calling
+//! [`hash_and_sign_event()`] instead. See the documentation of theses functions for more details
+//! and examples of use.
 //!
 //! # Verifying signatures and hashes
 //!
@@ -64,8 +66,8 @@ pub use ruma_common::{IdParseError, SigningKeyAlgorithm};
 pub use self::{
     ed25519::{Ed25519KeyPair, Ed25519KeyPairParseError, Ed25519VerificationError},
     error::{JsonError, VerificationError},
-    hash::{content_hash, reference_hash},
-    sign::{KeyPair, Signature, hash_and_sign_event, sign_json},
+    hash::{add_content_hash_to_event, content_hash, reference_hash},
+    sign::{KeyPair, Signature, hash_and_sign_event, sign_event, sign_json},
     verify::{
         PublicKeyMap, PublicKeySet, Verified, required_server_signatures_to_verify_event,
         to_canonical_json_string_for_signing, verify_canonical_json_bytes, verify_event,

--- a/crates/ruma-signatures/src/sign.rs
+++ b/crates/ruma-signatures/src/sign.rs
@@ -8,7 +8,7 @@ use ruma_common::{
 };
 use serde_json::to_string as to_json_string;
 
-use crate::{JsonError, content_hash};
+use crate::{JsonError, add_content_hash_to_event};
 
 /// The fields to remove from a JSON object when serializing it for signing.
 pub(crate) static FIELDS_TO_REMOVE_FOR_SIGNING: &[&str] = &["signatures", "unsigned"];
@@ -18,6 +18,8 @@ pub(crate) static FIELDS_TO_REMOVE_FOR_SIGNING: &[&str] = &["signatures", "unsig
 ///
 /// If `hashes` and/or `signatures` are already present, the new data will be appended to the
 /// existing data.
+///
+/// This is a convenience function that calls [`add_content_hash_to_event()`] then [`sign_event()`].
 ///
 /// # Parameters
 ///
@@ -122,11 +124,114 @@ pub fn hash_and_sign_event<K>(
 where
     K: KeyPair,
 {
-    let hash = content_hash(object)?;
+    add_content_hash_to_event(object)?;
+    sign_event(entity_id, key_pair, object, redaction_rules)
+}
 
-    let hashes = object.get_as_object_or_insert_default("hashes", "hashes")?;
-    hashes.insert("sha256".into(), CanonicalJsonValue::String(hash.encode()));
-
+/// Compute and add the [signature] of the given event.
+///
+/// This adds or overwrites the signature for the given entity and key in the `signatures` object of
+/// the event.
+///
+/// When creating a new event, [`add_content_hash_to_event()`](crate::add_content_hash_to_event)
+/// should be called first.
+///
+/// # Parameters
+///
+/// * `entity_id`: The identifier of the entity creating the signature. Generally this means a
+///   homeserver, e.g. "example.com".
+/// * `key_pair`: The cryptographic key pair used to sign the event.
+/// * `object`: The event to be signed according to the Matrix specification.
+/// * `redaction_rules`: The redaction rules for the version of the event's room.
+///
+/// # Errors
+///
+/// Returns an error if:
+///
+/// * `object` contains a field called `content` that is not a JSON object.
+/// * `object` contains a field called `signatures` that is not a JSON object.
+/// * `object` is missing the `type` field or the field is not a JSON string.
+///
+/// # Examples
+///
+/// ```rust
+/// use ruma_common::CanonicalJsonObject;
+/// use ruma_signatures::sign_event;
+/// # use ruma_common::serde::Base64;
+/// #
+/// # const PKCS8: &str = "\
+/// #     MFECAQEwBQYDK2VwBCIEINjozvdfbsGEt6DD+7Uf4PiJ/YvTNXV2mIPc/\
+/// #     tA0T+6tgSEA3TPraTczVkDPTRaX4K+AfUuyx7Mzq1UafTXypnl0t2k\
+/// # ";
+/// # let der: Base64 = Base64::parse(PKCS8)?;
+/// # let key_pair = ruma_signatures::Ed25519KeyPair::from_der(
+/// #    der.as_bytes(),
+/// #    "1".into(), // The "version" of the key.
+/// # )?;
+/// # let room_version_rules = || { ruma_common::room_version_rules::RoomVersionRules::V6 };
+///
+/// // Deserialize an event from JSON.
+/// let mut event = serde_json::from_str(
+///     r#"{
+///         "room_id": "!x:domain",
+///         "sender": "@a:domain",
+///         "origin": "domain",
+///         "origin_server_ts": 1000000,
+///         "type": "X",
+///         "content": {},
+///         "prev_events": [],
+///         "auth_events": [],
+///         "depth": 3,
+///         "hashes": {
+///             "sha256": "5jM4wQpv6lnBo7CLIghJuHdW+s2CMBJPUOGOC89ncos"
+///         }
+///     }"#,
+/// )?;
+///
+/// // Get the rules for the version of the current room.
+/// let rules = room_version_rules();
+///
+/// // Sign the event with the key pair.
+/// sign_event("domain", &key_pair, &mut event, &rules.redaction)?;
+///
+/// // The signature was added.
+/// assert_eq!(
+///     event,
+///     serde_json::from_str::<CanonicalJsonObject>(
+///         r#"{
+///             "room_id": "!x:domain",
+///             "sender": "@a:domain",
+///             "origin": "domain",
+///             "origin_server_ts": 1000000,
+///             "type": "X",
+///             "content": {},
+///             "prev_events": [],
+///             "auth_events": [],
+///             "depth": 3,
+///             "hashes": {
+///                 "sha256": "5jM4wQpv6lnBo7CLIghJuHdW+s2CMBJPUOGOC89ncos"
+///             },
+///             "signatures": {
+///                 "domain": {
+///                     "ed25519:1": "PxOFMn6ORll8PFSQp0IRF6037MEZt3Mfzu/ROiT/gb/ccs1G+f6Ddoswez4KntLPBI3GKCGIkhctiK37JOy2Aw"
+///                 }
+///             }
+///         }"#,
+///     )?
+/// );
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+///
+/// [signature]: https://spec.matrix.org/v1.18/server-server-api/#signing-events
+pub fn sign_event<K>(
+    entity_id: &str,
+    key_pair: &K,
+    object: &mut CanonicalJsonObject,
+    redaction_rules: &RedactionRules,
+) -> Result<(), JsonError>
+where
+    K: KeyPair,
+{
     let mut redacted = redact(object.clone(), redaction_rules, None)?;
 
     sign_json(entity_id, key_pair, &mut redacted)?;


### PR DESCRIPTION
Policy servers only need to add a signature to the event, not add a content hash.

Split out of #2443.

