### PR TITLE
Move `POLICY_SERVER_ED25519_SIGNING_KEY_ID` constant to ruma-events

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -14,6 +14,7 @@ Bug fixes:
 Improvements:
 
 - Add unstable support for event streams, according to MSC4471.
+- Expose the signing key ID that must be used by a Policy Server for its ed25519 signature.
 
 ## 0.33.0
 

--- a/crates/ruma-events/src/room/policy.rs
+++ b/crates/ruma-events/src/room/policy.rs
@@ -10,6 +10,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::EmptyStateKey;
 
+/// The signing key ID that must be used by a Policy Server for its ed25519 signature.
+pub const POLICY_SERVER_ED25519_SIGNING_KEY_ID: &str = "ed25519:policy_server";
+
 /// The content of an [`m.room.policy`] event.
 ///
 /// A [Policy Server] configuration.

--- a/crates/ruma-federation-api/CHANGELOG.md
+++ b/crates/ruma-federation-api/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+Breaking changes:
+
+- The `policy::sign_event::v1::Response::POLICY_SERVER_ED25519_SIGNING_KEY_ID` associated constant
+  was moved as `ruma_events::room::policy::POLICY_SERVER_ED25519_SIGNING_KEY_ID`.
+
 ## 0.14.0
 
 Breaking changes:

--- a/crates/ruma-federation-api/src/policy/sign_event.rs
+++ b/crates/ruma-federation-api/src/policy/sign_event.rs
@@ -23,6 +23,7 @@ pub mod v1 {
         api::{request, response},
         metadata,
     };
+    use ruma_events::room::policy::POLICY_SERVER_ED25519_SIGNING_KEY_ID;
     use serde_json::value::RawValue as RawJsonValue;
 
     use crate::authentication::ServerSignatures as ServerSignaturesAuth;
@@ -63,15 +64,12 @@ pub mod v1 {
     }
 
     impl Response {
-        /// The signing key ID that must be used by the Policy Server for the ed25519 signature.
-        pub const POLICY_SERVER_ED25519_SIGNING_KEY_ID: &str = "ed25519:policy_server";
-
         /// Creates a new `Response` with the given Policy Server name and event signature.
         pub fn new(server_name: OwnedServerName, ed25519_signature: String) -> Self {
             Self {
                 signatures: ServerSignaturesMap::from_iter(std::iter::once((
                     server_name,
-                    SigningKeyId::parse(Self::POLICY_SERVER_ED25519_SIGNING_KEY_ID)
+                    SigningKeyId::parse(POLICY_SERVER_ED25519_SIGNING_KEY_ID)
                         .expect("Policy Server default ed25519 signing key ID should be valid"),
                     ed25519_signature,
                 ))),
@@ -84,7 +82,7 @@ pub mod v1 {
                 .get(server_name)?
                 .get(
                     <&SigningKeyId<ServerSigningKeyVersion>>::try_from(
-                        Self::POLICY_SERVER_ED25519_SIGNING_KEY_ID,
+                        POLICY_SERVER_ED25519_SIGNING_KEY_ID,
                     )
                     .expect("Policy Server default ed25519 signing key ID should be valid"),
                 )


### PR DESCRIPTION
We will need to be able to use it in ruma-signatures to check policy server signatures, so we need to move its definition to another crate.

This should be the last breaking change needed that was split out of #2443.
