### PR TITLE
events: implement conversions between MatrixToUri and MatrixUri

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Improvements:
+
+- Add `From` conversions between `MatrixToUri` and `MatrixUri`.
+
 ## 0.19.0
 
 Bug fixes:

--- a/crates/ruma-common/src/identifiers/matrix_uri.rs
+++ b/crates/ruma-common/src/identifiers/matrix_uri.rs
@@ -538,6 +538,18 @@ impl FromStr for MatrixUri {
     }
 }
 
+impl From<MatrixUri> for MatrixToUri {
+    fn from(value: MatrixUri) -> Self {
+        Self { id: value.id, via: value.via }
+    }
+}
+
+impl From<MatrixToUri> for MatrixUri {
+    fn from(value: MatrixToUri) -> Self {
+        Self { id: value.id, via: value.via, action: None }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use assert_matches2::assert_matches;

--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add `From` conversions between `MatrixToUri` and `MatrixUri`
+
 ## 0.34.0
 
 Breaking changes:

--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-Improvements:
-
-- Add `From` conversions between `MatrixToUri` and `MatrixUri`.
-
 ## 0.34.0
 
 Breaking changes:

--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-- Add `From` conversions between `MatrixToUri` and `MatrixUri`
+Improvements:
+
+- Add `From` conversions between `MatrixToUri` and `MatrixUri`.
 
 ## 0.34.0
 


### PR DESCRIPTION
Since those Uri constructors aren't public, being able to convert them without reparsing them is useful.

The public API hasn't been changed (only the From trait has been implemented on both structs).

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
