### PR TITLE
Add a common UserProfile type that can be shared across various APIs.

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+Improvements:
+
+- `profile::get_profile` is now using `ruma_common::profile::UserProfile` for its underlying data
+  storage.
+
 ## 0.24.0
 
 Breaking changes:

--- a/crates/ruma-client-api/src/profile.rs
+++ b/crates/ruma-client-api/src/profile.rs
@@ -25,6 +25,7 @@ pub mod set_avatar_url;
 pub mod set_display_name;
 pub mod set_profile_field;
 mod static_profile_field;
+pub mod user_profile;
 
 pub use self::static_profile_field::*;
 

--- a/crates/ruma-client-api/src/profile.rs
+++ b/crates/ruma-client-api/src/profile.rs
@@ -1,15 +1,12 @@
 //! Endpoints for user profiles.
 
+#[cfg(feature = "client")]
+use ruma_common::api::{
+    MatrixVersion,
+    path_builder::{StablePathSelector, VersionHistory},
+};
 #[cfg(feature = "unstable-msc4466")]
 use ruma_common::serde::StringEnum;
-#[cfg(feature = "client")]
-use ruma_common::{
-    api::{
-        MatrixVersion,
-        path_builder::{StablePathSelector, VersionHistory},
-    },
-    profile::ProfileFieldName,
-};
 
 #[cfg(feature = "unstable-msc4466")]
 use crate::PrivOwnedStr;
@@ -24,10 +21,8 @@ mod profile_field_serde;
 pub mod set_avatar_url;
 pub mod set_display_name;
 pub mod set_profile_field;
-mod static_profile_field;
-pub mod user_profile;
 
-pub use self::static_profile_field::*;
+pub use ruma_common::profile::*;
 
 /// Endpoint version history valid only for profile fields that didn't exist before Matrix 1.16.
 #[cfg(feature = "client")]

--- a/crates/ruma-client-api/src/profile/get_profile.rs
+++ b/crates/ruma-client-api/src/profile/get_profile.rs
@@ -7,7 +7,7 @@ pub mod v3 {
     //!
     //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3profileuserid
 
-    use std::collections::{BTreeMap, btree_map};
+    use std::collections::btree_map;
 
     use ruma_common::{
         OwnedUserId,
@@ -17,7 +17,7 @@ pub mod v3 {
     };
     use serde_json::Value as JsonValue;
 
-    use crate::profile::StaticProfileField;
+    use crate::profile::{StaticProfileField, user_profile::UserProfile};
 
     metadata! {
         method: GET,
@@ -43,7 +43,7 @@ pub mod v3 {
     pub struct Response {
         /// The profile data.
         #[ruma_api(body)]
-        data: BTreeMap<String, JsonValue>,
+        pub data: UserProfile,
     }
 
     impl Request {
@@ -72,7 +72,7 @@ pub mod v3 {
         pub fn get_static<F: StaticProfileField>(
             &self,
         ) -> Result<Option<F::Value>, serde_json::Error> {
-            self.data.get(F::NAME).map(|value| serde_json::from_value(value.clone())).transpose()
+            self.data.get_static::<F>()
         }
 
         /// Gets an iterator over the fields of the profile.
@@ -82,25 +82,31 @@ pub mod v3 {
 
         /// Sets a field to the given value.
         pub fn set(&mut self, field: String, value: JsonValue) {
-            self.data.insert(field, value);
+            self.data.set(field, value);
+        }
+    }
+
+    impl From<UserProfile> for Response {
+        fn from(value: UserProfile) -> Self {
+            Self { data: value }
         }
     }
 
     impl FromIterator<(String, JsonValue)> for Response {
         fn from_iter<T: IntoIterator<Item = (String, JsonValue)>>(iter: T) -> Self {
-            Self { data: iter.into_iter().collect() }
+            Self { data: UserProfile::from_iter(iter) }
         }
     }
 
     impl FromIterator<(ProfileFieldName, JsonValue)> for Response {
         fn from_iter<T: IntoIterator<Item = (ProfileFieldName, JsonValue)>>(iter: T) -> Self {
-            iter.into_iter().map(|(field, value)| (field.as_str().to_owned(), value)).collect()
+            Self { data: UserProfile::from_iter(iter) }
         }
     }
 
     impl FromIterator<ProfileFieldValue> for Response {
         fn from_iter<T: IntoIterator<Item = ProfileFieldValue>>(iter: T) -> Self {
-            iter.into_iter().map(|value| (value.field_name(), value.value().into_owned())).collect()
+            Self { data: UserProfile::from_iter(iter) }
         }
     }
 
@@ -112,15 +118,13 @@ pub mod v3 {
 
     impl Extend<(ProfileFieldName, JsonValue)> for Response {
         fn extend<T: IntoIterator<Item = (ProfileFieldName, JsonValue)>>(&mut self, iter: T) {
-            self.extend(iter.into_iter().map(|(field, value)| (field.as_str().to_owned(), value)));
+            self.data.extend(iter);
         }
     }
 
     impl Extend<ProfileFieldValue> for Response {
         fn extend<T: IntoIterator<Item = ProfileFieldValue>>(&mut self, iter: T) {
-            self.extend(
-                iter.into_iter().map(|value| (value.field_name(), value.value().into_owned())),
-            );
+            self.data.extend(iter);
         }
     }
 

--- a/crates/ruma-client-api/src/profile/get_profile.rs
+++ b/crates/ruma-client-api/src/profile/get_profile.rs
@@ -13,11 +13,9 @@ pub mod v3 {
         OwnedUserId,
         api::{auth_scheme::NoAccessToken, request, response},
         metadata,
-        profile::{ProfileFieldName, ProfileFieldValue},
+        profile::{ProfileFieldName, ProfileFieldValue, StaticProfileField, UserProfile},
     };
     use serde_json::Value as JsonValue;
-
-    use crate::profile::{StaticProfileField, user_profile::UserProfile};
 
     metadata! {
         method: GET,

--- a/crates/ruma-client-api/src/profile/get_profile_field.rs
+++ b/crates/ruma-client-api/src/profile/get_profile_field.rs
@@ -19,10 +19,8 @@ pub mod v3 {
         OwnedUserId,
         api::{Metadata, auth_scheme::NoAccessToken, error::Error, path_builder::VersionHistory},
         metadata,
-        profile::{ProfileFieldName, ProfileFieldValue},
+        profile::{ProfileFieldName, ProfileFieldValue, StaticProfileField},
     };
-
-    use crate::profile::StaticProfileField;
 
     metadata! {
         method: GET,

--- a/crates/ruma-client-api/src/profile/profile_field_serde.rs
+++ b/crates/ruma-client-api/src/profile/profile_field_serde.rs
@@ -1,13 +1,14 @@
 use std::fmt;
 
+use ruma_common::profile::StaticProfileField;
 use serde::de;
 
 /// Helper type to deserialize any type that implements [`StaticProfileField`].
-pub(super) struct StaticProfileFieldVisitor<F: super::StaticProfileField>(
+pub(super) struct StaticProfileFieldVisitor<F: StaticProfileField>(
     pub(super) std::marker::PhantomData<F>,
 );
 
-impl<'de, F: super::StaticProfileField> de::Visitor<'de> for StaticProfileFieldVisitor<F> {
+impl<'de, F: StaticProfileField> de::Visitor<'de> for StaticProfileFieldVisitor<F> {
     type Value = Option<F::Value>;
 
     fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/ruma-client-api/src/profile/user_profile.rs
+++ b/crates/ruma-client-api/src/profile/user_profile.rs
@@ -1,0 +1,90 @@
+//! All the profile information for a user.
+
+use std::collections::{BTreeMap, btree_map};
+
+use ruma_common::profile::{ProfileFieldName, ProfileFieldValue};
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+
+use crate::profile::static_profile_field::StaticProfileField;
+
+/// All the profile information for a user.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct UserProfile(BTreeMap<String, JsonValue>);
+
+impl UserProfile {
+    /// Creates a new empty `UserProfile`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns the value of the given profile field.
+    pub fn get(&self, field: &str) -> Option<&JsonValue> {
+        self.0.get(field)
+    }
+
+    /// Returns the value of the given [`StaticProfileField`].
+    ///
+    /// Returns `Ok(Some(_))` if the field is present and the value was deserialized
+    /// successfully, `Ok(None)` if the field is not set, or an error if deserialization of the
+    /// value failed.
+    pub fn get_static<F: StaticProfileField>(&self) -> Result<Option<F::Value>, serde_json::Error> {
+        self.0.get(F::NAME).map(|value| serde_json::from_value(value.clone())).transpose()
+    }
+
+    /// Gets an iterator over the fields of the profile.
+    pub fn iter(&self) -> btree_map::Iter<'_, String, JsonValue> {
+        self.0.iter()
+    }
+
+    /// Sets a field to the given value.
+    pub fn set(&mut self, field: String, value: JsonValue) {
+        self.0.insert(field, value);
+    }
+}
+
+impl FromIterator<(String, JsonValue)> for UserProfile {
+    fn from_iter<T: IntoIterator<Item = (String, JsonValue)>>(iter: T) -> Self {
+        Self(iter.into_iter().collect())
+    }
+}
+
+impl FromIterator<(ProfileFieldName, JsonValue)> for UserProfile {
+    fn from_iter<T: IntoIterator<Item = (ProfileFieldName, JsonValue)>>(iter: T) -> Self {
+        iter.into_iter().map(|(field, value)| (field.as_str().to_owned(), value)).collect()
+    }
+}
+
+impl FromIterator<ProfileFieldValue> for UserProfile {
+    fn from_iter<T: IntoIterator<Item = ProfileFieldValue>>(iter: T) -> Self {
+        iter.into_iter().map(|value| (value.field_name(), value.value().into_owned())).collect()
+    }
+}
+
+impl Extend<(String, JsonValue)> for UserProfile {
+    fn extend<T: IntoIterator<Item = (String, JsonValue)>>(&mut self, iter: T) {
+        self.0.extend(iter);
+    }
+}
+
+impl Extend<(ProfileFieldName, JsonValue)> for UserProfile {
+    fn extend<T: IntoIterator<Item = (ProfileFieldName, JsonValue)>>(&mut self, iter: T) {
+        self.extend(iter.into_iter().map(|(field, value)| (field.as_str().to_owned(), value)));
+    }
+}
+
+impl Extend<ProfileFieldValue> for UserProfile {
+    fn extend<T: IntoIterator<Item = ProfileFieldValue>>(&mut self, iter: T) {
+        self.extend(iter.into_iter().map(|value| (value.field_name(), value.value().into_owned())));
+    }
+}
+
+impl IntoIterator for UserProfile {
+    type Item = (String, JsonValue);
+    type IntoIter = btree_map::IntoIter<String, JsonValue>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -5,6 +5,7 @@
 Improvements:
 
 - Add `From` conversions between `MatrixToUri` and `MatrixUri`.
+- Extract a common `UserProfile` type out of `ruma_client_api::profile::get_profile`.
 
 ## 0.19.0
 

--- a/crates/ruma-common/src/profile.rs
+++ b/crates/ruma-common/src/profile.rs
@@ -13,9 +13,12 @@ use crate::SecondsSinceUnixEpoch;
 use crate::{OwnedMxcUri, PrivOwnedStr};
 
 mod profile_field_value_serde;
+mod static_profile_field;
+mod user_profile;
 
 #[doc(hidden)]
 pub use self::profile_field_value_serde::ProfileFieldValueVisitor;
+pub use self::{static_profile_field::*, user_profile::*};
 
 /// The possible fields of a user's [profile].
 ///

--- a/crates/ruma-common/src/profile/static_profile_field.rs
+++ b/crates/ruma-common/src/profile/static_profile_field.rs
@@ -1,3 +1,5 @@
+//! Types for common user profile fields.
+
 #![allow(clippy::exhaustive_structs)]
 
 use ruma_common::OwnedMxcUri;

--- a/crates/ruma-common/src/profile/user_profile.rs
+++ b/crates/ruma-common/src/profile/user_profile.rs
@@ -2,11 +2,10 @@
 
 use std::collections::{BTreeMap, btree_map};
 
-use ruma_common::profile::{ProfileFieldName, ProfileFieldValue};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
-use crate::profile::static_profile_field::StaticProfileField;
+use super::{ProfileFieldName, ProfileFieldValue, static_profile_field::StaticProfileField};
 
 /// All the profile information for a user.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]

--- a/crates/ruma-federation-api/CHANGELOG.md
+++ b/crates/ruma-federation-api/CHANGELOG.md
@@ -5,6 +5,8 @@
 Improvements:
 
 - Remove support for MSC4373, as the MSC is now closed.
+- `query::get_profile_information` is now using `ruma_common::profile::UserProfile` for its
+  underlying data storage.
 
 ## 0.15.0
 

--- a/crates/ruma-federation-api/src/query/get_profile_information.rs
+++ b/crates/ruma-federation-api/src/query/get_profile_information.rs
@@ -7,13 +7,13 @@ pub mod v1 {
     //!
     //! [spec]: https://spec.matrix.org/v1.18/server-server-api/#get_matrixfederationv1queryprofile
 
-    use std::collections::{BTreeMap, btree_map};
+    use std::collections::btree_map;
 
     use ruma_common::{
         OwnedUserId,
         api::{request, response},
         metadata,
-        profile::{ProfileFieldName, ProfileFieldValue},
+        profile::{ProfileFieldName, ProfileFieldValue, StaticProfileField, UserProfile},
     };
     use serde_json::Value as JsonValue;
 
@@ -52,7 +52,7 @@ pub mod v1 {
     pub struct Response {
         /// The profile data.
         #[ruma_api(body)]
-        data: BTreeMap<String, JsonValue>,
+        pub data: UserProfile,
     }
 
     impl Response {
@@ -66,6 +66,17 @@ pub mod v1 {
             self.data.get(field)
         }
 
+        /// Returns the value of the given [`StaticProfileField`].
+        ///
+        /// Returns `Ok(Some(_))` if the field is present and the value was deserialized
+        /// successfully, `Ok(None)` if the field is not set, or an error if deserialization of the
+        /// value failed.
+        pub fn get_static<F: StaticProfileField>(
+            &self,
+        ) -> Result<Option<F::Value>, serde_json::Error> {
+            self.data.get_static::<F>()
+        }
+
         /// Gets an iterator over the fields of the profile.
         pub fn iter(&self) -> btree_map::Iter<'_, String, JsonValue> {
             self.data.iter()
@@ -73,25 +84,31 @@ pub mod v1 {
 
         /// Sets a field to the given value.
         pub fn set(&mut self, field: String, value: JsonValue) {
-            self.data.insert(field, value);
+            self.data.set(field, value);
+        }
+    }
+
+    impl From<UserProfile> for Response {
+        fn from(value: UserProfile) -> Self {
+            Self { data: value }
         }
     }
 
     impl FromIterator<(String, JsonValue)> for Response {
         fn from_iter<T: IntoIterator<Item = (String, JsonValue)>>(iter: T) -> Self {
-            Self { data: iter.into_iter().collect() }
+            Self { data: UserProfile::from_iter(iter) }
         }
     }
 
     impl FromIterator<(ProfileFieldName, JsonValue)> for Response {
         fn from_iter<T: IntoIterator<Item = (ProfileFieldName, JsonValue)>>(iter: T) -> Self {
-            iter.into_iter().map(|(field, value)| (field.as_str().to_owned(), value)).collect()
+            Self { data: UserProfile::from_iter(iter) }
         }
     }
 
     impl FromIterator<ProfileFieldValue> for Response {
         fn from_iter<T: IntoIterator<Item = ProfileFieldValue>>(iter: T) -> Self {
-            iter.into_iter().map(|value| (value.field_name(), value.value().into_owned())).collect()
+            Self { data: UserProfile::from_iter(iter) }
         }
     }
 
@@ -103,15 +120,13 @@ pub mod v1 {
 
     impl Extend<(ProfileFieldName, JsonValue)> for Response {
         fn extend<T: IntoIterator<Item = (ProfileFieldName, JsonValue)>>(&mut self, iter: T) {
-            self.extend(iter.into_iter().map(|(field, value)| (field.as_str().to_owned(), value)));
+            self.data.extend(iter);
         }
     }
 
     impl Extend<ProfileFieldValue> for Response {
         fn extend<T: IntoIterator<Item = ProfileFieldValue>>(&mut self, iter: T) {
-            self.extend(
-                iter.into_iter().map(|value| (value.field_name(), value.value().into_owned())),
-            );
+            self.data.extend(iter);
         }
     }
 


### PR DESCRIPTION
Follow-up to #2498 and required for #2499, this PR extracts the underlying data type from `get_profile` into it's own `UserProfile` type that lives in ruma-common.

Let me know if it needs any changelog entries or not.

As before, none of the code in this PR was generated using an LLM, although I did ask one initially about possibility of extracting the BTreeMap into a dedicated struct before attempting it myself.