### PR TITLE
Handle non-compliant/corrupt fields in simplified sliding sync responses

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -7,6 +7,8 @@ Improvements:
 - `profile::get_profile` is now using `ruma_common::profile::UserProfile` for its underlying data
   storage.
 - Add support for MSC4262 (Profile Updates Sliding Sync Extension).
+- Added new `unstable-compat-lax-syncv5-deser` feature, which allows the `name` and `avatar` fields
+  for rooms and hero users to be ignored during deserialization if they have an invalid format.
 
 ## 0.24.0
 

--- a/crates/ruma-client-api/Cargo.toml
+++ b/crates/ruma-client-api/Cargo.toml
@@ -36,6 +36,13 @@ compat-get-3pids = []
 # since that's what Synapse sends.
 compat-upload-signatures = []
 
+# unstable: by using any of the below features, you opt out of all semver guarantees
+#           that Ruma otherwise provides!
+
+# Allow name and avatar fields for rooms and hero users (in a sync v5 response)
+# to be ignored if they have an invalid format and their deserialization fails.
+unstable-compat-lax-syncv5-deser = ["unstable-msc4186"]
+
 unstable-msc2666 = ["ruma-common/unstable-msc2666"]
 unstable-msc2448 = []
 unstable-msc2654 = []

--- a/crates/ruma-client-api/src/sync/sync_events/v5.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v5.rs
@@ -585,11 +585,25 @@ pub mod response {
     #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
     pub struct Room {
         /// The name as calculated by the server.
+        ///
+        /// If the `unstable-compat-lax-syncv5-deser` feature is enabled,
+        /// this field is ignored if its deserialization fails.
         #[serde(skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(
+            feature = "unstable-compat-lax-syncv5-deser",
+            serde(default, deserialize_with = "ruma_common::serde::default_on_error")
+        )]
         pub name: Option<String>,
 
         /// The avatar.
+        ///
+        /// If the `unstable-compat-lax-syncv5-deser` feature is enabled,
+        /// this field is ignored if its deserialization fails.
         #[serde(default, skip_serializing_if = "JsOption::is_undefined")]
+        #[cfg_attr(
+            feature = "unstable-compat-lax-syncv5-deser",
+            serde(deserialize_with = "ruma_common::serde::default_on_error")
+        )]
         pub avatar: JsOption<OwnedMxcUri>,
 
         /// Whether it is an initial response.
@@ -670,11 +684,25 @@ pub mod response {
         pub user_id: OwnedUserId,
 
         /// The name.
+        ///
+        /// If the `unstable-compat-lax-syncv5-deser` feature is enabled,
+        /// this field is ignored if its deserialization fails.
         #[serde(rename = "displayname", skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(
+            feature = "unstable-compat-lax-syncv5-deser",
+            serde(default, deserialize_with = "ruma_common::serde::default_on_error")
+        )]
         pub name: Option<String>,
 
         /// The avatar.
+        ///
+        /// If the `unstable-compat-lax-syncv5-deser` feature is enabled,
+        /// this field is ignored if its deserialization fails.
         #[serde(rename = "avatar_url", skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(
+            feature = "unstable-compat-lax-syncv5-deser",
+            serde(default, deserialize_with = "ruma_common::serde::default_on_error")
+        )]
         pub avatar: Option<OwnedMxcUri>,
     }
 
@@ -914,5 +942,38 @@ mod tests {
             serde_json::from_str::<ExtensionRoomConfig>(r#""!foo:bar.baz""#).unwrap(),
             ExtensionRoomConfig::Room(owned_room_id!("!foo:bar.baz"))
         );
+    }
+
+    #[test]
+    #[cfg(feature = "unstable-compat-lax-syncv5-deser")]
+    fn deserialize_room_ignores_invalid_string_fields() {
+        use super::response::Room;
+
+        let room: Room = serde_json::from_str(
+            r#"{
+                "name": {},
+                "avatar": {},
+                "heroes": [{ "user_id": "@alice:localhost", "displayname": {}, "avatar_url": {} }]
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(room.name, None);
+        assert!(room.avatar.is_undefined());
+        let hero = &room.heroes.unwrap()[0];
+        assert_eq!(hero.name, None);
+        assert_eq!(hero.avatar, None);
+
+        // Valid values are still kept.
+        let room: Room = serde_json::from_str(
+            r#"{ "name": "Room", "avatar": "mxc://localhost/a", "heroes": [{ "user_id": "@alice:localhost", "displayname": "Alice", "avatar_url": "mxc://localhost/b" }] }"#,
+        )
+        .unwrap();
+
+        assert_eq!(room.name.as_deref(), Some("Room"));
+        assert_eq!(room.avatar.into_option().unwrap().as_str(), "mxc://localhost/a");
+        let hero = &room.heroes.unwrap()[0];
+        assert_eq!(hero.name.as_deref(), Some("Alice"));
+        assert_eq!(hero.avatar.as_ref().unwrap().as_str(), "mxc://localhost/b");
     }
 }

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -122,8 +122,12 @@ compat-lax-room-topic-deser = ["ruma-events?/compat-lax-room-topic-deser"]
 # Specific compatibility for past ring public/private key documents.
 ring-compat = ["dep:ruma-signatures", "ruma-signatures?/ring-compat"]
 
-# unstable: by using any of these, you opt out of all semver guarantees Ruma
-#           otherwise provides!
+# unstable: by using any of the below features, you opt out of all semver guarantees
+#           that Ruma otherwise provides!
+
+# Allow name and avatar fields for rooms and hero users (in a sync v5 response)
+# to be ignored if they have an invalid format and their deserialization fails.
+unstable-compat-lax-syncv5-deser = ["unstable-msc4186", "ruma-client-api?/unstable-compat-lax-syncv5-deser"]
 unstable-extensible-events = [
     "unstable-msc3246",
     "unstable-msc3488",


### PR DESCRIPTION
## Problem
Sometimes a malformed or corrupted value that's *supposed* to be a string (e.g., a room name, avatar, or room hero display name or avatr MxcUri) may be sent in a homeserver's SSS payload, which might be a homeserver problem or a buggy client-side update.

This makes the *entire* sync payload invalid because ruma is strict about deserializing it, which then causes the matrix-rust-sdk to fail to handle it (e.g., the rooms list service fails and can't get udpated, and then it flip-flops between Online/Running and Offline, which is a pretty bad user experience.)

## Background/references
This was first brought to my attention here https://github.com/project-robius/robrix/issues/886, and it also occurs in other clients that use the matrix-rust-sdk, as expected. That user [confirmed](https://github.com/project-robius/robrix/issues/886#issuecomment-4698312946) that this fix addressed their sync failures.
Edit: better, more specific links [here](https://github.com/project-robius/robrix/issues/886#issuecomment-4595060196) and [here](https://github.com/project-robius/robrix/issues/886#issuecomment-4605998100)

Note: ideally a user's change to something like an avatar or room name wouldn't ever cause problems, as their client should prevent malformed/invalid changes like that. But realistically we can't actually rely on that, so this change seems reasonable. Another way of looking at it (which is what convinced me) is that if someone joins a room that is corrupted (or their homeserver just messes things up in some other way), then they can't _ever_ get a sync response processed at all, rendering their new client (one that uses matrix-rust-sdk/ruma) practially useless. imho, one bad room update shouldn't be able to block client-side syncing of all other rooms/spaces. 

## Solution
This PR ignores those invalid fields (mostly strings) so deserialization can continue. If we encounter an invalid field, we just treat it as if it wasn't provided in the first place, which prevents a single invalid/corrupt room from breaking sync for the user's entire account. AFAICT this is spec-compliant, and it also follows ruma's existing conventions for other fields that might be absent/corrupted.

## PR checklist
- [x] Run `cargo xtask ci` locally before posting the PR
   * ~~I did get errors, and they seem to be mostly due to test cases that are intended to fail but now succeed due to more flexiblity. I can look into those if needed.~~
   * Edit: nvm, that's cuz i was locked to specific nightly compiler version on my local machine. The CI passes here, which is what matters.
- [x] Documented public API changes in CHANGELOG.md files
   * no API changes, just internal behavior

