### PR TITLE
events: Add `replaces_state` field to `StateUnsigned`

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Improvements:
+
+- Add `replaces_state` field to `StateUnsigned`, due to a clarification in the Matrix spec.
+
 ## 0.34.0
 
 Breaking changes:

--- a/crates/ruma-events/src/unsigned.rs
+++ b/crates/ruma-events/src/unsigned.rs
@@ -76,6 +76,9 @@ pub struct StateUnsigned<C: PossiblyRedactedStateEventContent> {
     /// which sent it.
     pub transaction_id: Option<OwnedTransactionId>,
 
+    /// The event ID of the state event replaced by this event.
+    pub replaces_state: Option<OwnedEventId>,
+
     /// Optional previous content of the event.
     pub prev_content: Option<C>,
 
@@ -89,7 +92,13 @@ pub struct StateUnsigned<C: PossiblyRedactedStateEventContent> {
 impl<C: PossiblyRedactedStateEventContent> StateUnsigned<C> {
     /// Create a new `Unsigned` with fields set to `None`.
     pub fn new() -> Self {
-        Self { age: None, transaction_id: None, prev_content: None, relations: Default::default() }
+        Self {
+            age: None,
+            transaction_id: None,
+            replaces_state: None,
+            prev_content: None,
+            relations: Default::default(),
+        }
     }
 }
 


### PR DESCRIPTION
Due to [a clarification in the Matrix spec](https://github.com/matrix-org/matrix-spec/pull/2345).

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
