### PR TITLE
events: Clarify docs of `SasV1Content`'s `commitment` field

### DIFF
--- a/crates/ruma-events/src/key/verification/accept.rs
+++ b/crates/ruma-events/src/key/verification/accept.rs
@@ -148,9 +148,9 @@ pub struct SasV1Content {
     /// message.
     pub short_authentication_string: Vec<ShortAuthenticationString>,
 
-    /// The hash (encoded as unpadded base64) of the concatenation of the
-    /// device's ephemeral public key (encoded as unpadded base64) and the
-    /// canonical JSON representation of the `m.key.verification.start` message.
+    /// The hash (encoded as unpadded base64) of the concatenation of the device's ephemeral public
+    /// key (encoded as unpadded base64) and the canonical JSON representation of the `content` of
+    /// the `m.key.verification.start` message.
     pub commitment: Base64,
 }
 


### PR DESCRIPTION
Due to [a clarification in the Matrix spec](https://github.com/matrix-org/matrix-spec/issues/2344).

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
