### PR TITLE
common: Add new() constructors for MSC4426 profile field types

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -9,6 +9,7 @@ Improvements:
 - Add `M_CONCURRENT_WRITE` error code, used by [MSC4438].
 - Add `canonical_json::RedactingSerializer` to serialize a `CanonicalJsonObject`
   while redacting it on the fly.
+- Add `StatusProfileField::new()` and `CallProfileField::new()` constructors for MSC4426
 
 [MSC4438]: https://github.com/matrix-org/matrix-spec-proposals/pull/4438
 

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Bug fixes:
+
+- Add `StatusProfileField::new()` and `CallProfileField::new()` constructors for MSC4426
+
 Improvements:
 
 - Add `From` conversions between `MatrixToUri` and `MatrixUri`.
@@ -9,7 +13,6 @@ Improvements:
 - Add `M_CONCURRENT_WRITE` error code, used by [MSC4438].
 - Add `canonical_json::RedactingSerializer` to serialize a `CanonicalJsonObject`
   while redacting it on the fly.
-- Add `StatusProfileField::new()` and `CallProfileField::new()` constructors for MSC4426
 
 [MSC4438]: https://github.com/matrix-org/matrix-spec-proposals/pull/4438
 

--- a/crates/ruma-common/src/profile.rs
+++ b/crates/ruma-common/src/profile.rs
@@ -185,7 +185,7 @@ impl StatusProfileField {
 /// An indicator that the user is currently in a call, and optionally how long they’ve been in the
 /// call.
 #[cfg(feature = "unstable-msc4426")]
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct CallProfileField {
     /// The time that the user joined the call.
@@ -197,9 +197,9 @@ pub struct CallProfileField {
 
 #[cfg(feature = "unstable-msc4426")]
 impl CallProfileField {
-    /// Creates a new `CallProfileField` with the given optional join timestamp.
-    pub fn new(call_joined_ts: Option<SecondsSinceUnixEpoch>) -> Self {
-        Self { call_joined_ts }
+    /// Creates a new `CallProfileField` with default values.
+    pub fn new() -> Self {
+        Self::default()
     }
 }
 
@@ -279,9 +279,9 @@ mod tests {
         );
 
         // Call.
-        let value = ProfileFieldValue::Call(CallProfileField::new(Some(SecondsSinceUnixEpoch(
-            1_770_140_640.try_into().unwrap(),
-        ))));
+        let mut call = CallProfileField::new();
+        call.call_joined_ts = Some(SecondsSinceUnixEpoch(1_770_140_640.try_into().unwrap()));
+        let value = ProfileFieldValue::Call(call);
         assert_to_canonical_json_eq!(
             value,
             json!({ "org.matrix.msc4426.call": { "call_joined_ts": 1_770_140_640 } })
@@ -304,11 +304,12 @@ mod tests {
 
         // Call.
         let json = json!({ "org.matrix.msc4426.call": { "call_joined_ts": 1_168_380_060 } });
+        let mut expected_call = CallProfileField::new();
+        expected_call.call_joined_ts =
+            Some(SecondsSinceUnixEpoch(1_168_380_060.try_into().unwrap()));
         assert_eq!(
             from_json_value::<ProfileFieldValue>(json).unwrap(),
-            ProfileFieldValue::Call(CallProfileField::new(Some(SecondsSinceUnixEpoch(
-                1_168_380_060.try_into().unwrap(),
-            ))))
+            ProfileFieldValue::Call(expected_call)
         );
     }
 }

--- a/crates/ruma-common/src/profile.rs
+++ b/crates/ruma-common/src/profile.rs
@@ -174,6 +174,14 @@ pub struct StatusProfileField {
     pub emoji: String,
 }
 
+#[cfg(feature = "unstable-msc4426")]
+impl StatusProfileField {
+    /// Creates a new `StatusProfileField` with the given text and emoji.
+    pub fn new(text: String, emoji: String) -> Self {
+        Self { text, emoji }
+    }
+}
+
 /// An indicator that the user is currently in a call, and optionally how long they’ve been in the
 /// call.
 #[cfg(feature = "unstable-msc4426")]
@@ -185,6 +193,14 @@ pub struct CallProfileField {
     /// This allows users to see how long someone has been in a call.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub call_joined_ts: Option<SecondsSinceUnixEpoch>,
+}
+
+#[cfg(feature = "unstable-msc4426")]
+impl CallProfileField {
+    /// Creates a new `CallProfileField` with the given optional join timestamp.
+    pub fn new(call_joined_ts: Option<SecondsSinceUnixEpoch>) -> Self {
+        Self { call_joined_ts }
+    }
 }
 
 /// A custom value for a user's profile field.
@@ -255,19 +271,17 @@ mod tests {
     #[cfg(feature = "unstable-msc4426")]
     fn serialize_profile_status() {
         // Status.
-        let value = ProfileFieldValue::Status(StatusProfileField {
-            text: "Away".to_owned(),
-            emoji: "🌴".to_owned(),
-        });
+        let value =
+            ProfileFieldValue::Status(StatusProfileField::new("Away".to_owned(), "🌴".to_owned()));
         assert_to_canonical_json_eq!(
             value,
             json!({ "org.matrix.msc4426.status": { "text": "Away", "emoji": "🌴" } })
         );
 
         // Call.
-        let value = ProfileFieldValue::Call(CallProfileField {
-            call_joined_ts: Some(SecondsSinceUnixEpoch(1_770_140_640.try_into().unwrap())),
-        });
+        let value = ProfileFieldValue::Call(CallProfileField::new(Some(SecondsSinceUnixEpoch(
+            1_770_140_640.try_into().unwrap(),
+        ))));
         assert_to_canonical_json_eq!(
             value,
             json!({ "org.matrix.msc4426.call": { "call_joined_ts": 1_770_140_640 } })
@@ -282,19 +296,19 @@ mod tests {
             json!({ "org.matrix.msc4426.status": { "text": "Be right back", "emoji": "☕️" } });
         assert_eq!(
             from_json_value::<ProfileFieldValue>(json).unwrap(),
-            ProfileFieldValue::Status(StatusProfileField {
-                text: "Be right back".to_owned(),
-                emoji: "☕️".to_owned(),
-            })
+            ProfileFieldValue::Status(StatusProfileField::new(
+                "Be right back".to_owned(),
+                "☕️".to_owned(),
+            ))
         );
 
         // Call.
         let json = json!({ "org.matrix.msc4426.call": { "call_joined_ts": 1_168_380_060 } });
         assert_eq!(
             from_json_value::<ProfileFieldValue>(json).unwrap(),
-            ProfileFieldValue::Call(CallProfileField {
-                call_joined_ts: Some(SecondsSinceUnixEpoch(1_168_380_060.try_into().unwrap())),
-            })
+            ProfileFieldValue::Call(CallProfileField::new(Some(SecondsSinceUnixEpoch(
+                1_168_380_060.try_into().unwrap(),
+            ))))
         );
     }
 }


### PR DESCRIPTION
`StatusProfileField` and `CallProfileField` are `#[non_exhaustive]`, so external crates cannot build them with a struct literal. 
This PR adds `::new()` constructors on both structs and updates the existing tests to use them.
Related: [MSC4426](https://github.com/matrix-org/matrix-spec-proposals/pull/4426).