### PR TITLE
client-api: Route MSC4133 extended profile field endpoints to stable path when uk.tcpip.msc4133.stable is advertised

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -9,6 +9,10 @@ Improvements:
 - Add support for MSC4262 (Profile Updates Sliding Sync Extension).
 - Added new `unstable-compat-lax-syncv5-deser` feature, which allows the `name` and `avatar` fields
   for rooms and hero users to be ignored during deserialization if they have an invalid format.
+- Route the MSC4133 extended profile field endpoints (`set_profile_field`, `get_profile_field`,
+  `delete_profile_field`) to the stable `/v3/profile/{user}/{field}` path when a homeserver
+  advertises the `uk.tcpip.msc4133.stable` unstable feature, even if it has not yet advertised
+  Matrix v1.16 in its `/versions` response.
 
 ## 0.24.0
 

--- a/crates/ruma-client-api/src/profile.rs
+++ b/crates/ruma-client-api/src/profile.rs
@@ -32,7 +32,10 @@ const EXTENDED_PROFILE_FIELD_HISTORY: VersionHistory = VersionHistory::new(
         "/_matrix/client/unstable/uk.tcpip.msc4133/profile/{user_id}/{field}",
     )],
     &[(
-        StablePathSelector::Version(MatrixVersion::V1_16),
+        StablePathSelector::FeatureAndVersion {
+            feature: "uk.tcpip.msc4133.stable",
+            version: MatrixVersion::V1_16,
+        },
         "/_matrix/client/v3/profile/{user_id}/{field}",
     )],
     None,

--- a/crates/ruma-client-api/src/profile/delete_profile_field.rs
+++ b/crates/ruma-client-api/src/profile/delete_profile_field.rs
@@ -23,7 +23,7 @@ pub mod v3 {
         authentication: AccessToken,
         history: {
             unstable("uk.tcpip.msc4133") => "/_matrix/client/unstable/uk.tcpip.msc4133/profile/{user_id}/{field}",
-            1.16 => "/_matrix/client/v3/profile/{user_id}/{field}",
+            1.16 | stable("uk.tcpip.msc4133.stable") => "/_matrix/client/v3/profile/{user_id}/{field}",
         }
     }
 


### PR DESCRIPTION
Ensure we can use the proper endpoint for MSC4133 when uk.tcpip.msc4133.stable is advertised in the features. 