### PR TITLE
Add experimental support for MSC4495: Selective Presence

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -13,6 +13,8 @@ Improvements:
   `delete_profile_field`) to the stable `/v3/profile/{user}/{field}` path when a homeserver
   advertises the `uk.tcpip.msc4133.stable` unstable feature, even if it has not yet advertised
   Matrix v1.16 in its `/versions` response.
+- Add support for [MSC4495: Selective Presence](https://github.com/matrix-org/matrix-spec-proposals/pull/4495)'s
+  `m.selective_presence` capability.
 
 ## 0.24.0
 

--- a/crates/ruma-client-api/Cargo.toml
+++ b/crates/ruma-client-api/Cargo.toml
@@ -65,6 +65,7 @@ unstable-msc4383 = []
 unstable-msc4388 = ["ruma-common/unstable-msc4388"]
 unstable-msc4439 = []
 unstable-msc4466 = []
+unstable-msc4495 = ["ruma-events/unstable-msc4495"]
 
 [dependencies]
 as_variant = { workspace = true }

--- a/crates/ruma-client-api/src/discovery/get_capabilities.rs
+++ b/crates/ruma-client-api/src/discovery/get_capabilities.rs
@@ -153,6 +153,17 @@ pub mod v3 {
         )]
         pub account_moderation: AccountModerationCapability,
 
+        /// Capability to indicate if the server utilizes [MSC4495 Selective Presence][MSC4495].
+        ///
+        /// [MSC4495]: https://github.com/matrix-org/matrix-spec-proposals/pull/4495
+        #[cfg(feature = "unstable-msc4495")]
+        #[serde(
+            rename = "org.continuwuity.presence_v2.msc4495.selective_presence",
+            default,
+            skip_serializing_if = "SelectivePresenceCapability::is_default"
+        )]
+        pub selective_presence: SelectivePresenceCapability,
+
         /// Any other custom capabilities that the server supports outside of the specification,
         /// labeled using the Java package naming convention and stored as arbitrary JSON values.
         #[serde(flatten)]
@@ -499,6 +510,28 @@ pub mod v3 {
         /// Returns whether all fields have their default value.
         pub fn is_default(&self) -> bool {
             !self.suspend && !self.lock
+        }
+    }
+
+    /// Information about the `org.continuwuity.presence_v2.msc4495.selective_presence` capability.
+    #[cfg(feature = "unstable-msc4495")]
+    #[derive(Clone, Debug, Default, Serialize, Deserialize)]
+    #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+    pub struct SelectivePresenceCapability {
+        /// Whether the server supports selective presence.
+        pub enabled: bool,
+    }
+
+    #[cfg(feature = "unstable-msc4495")]
+    impl SelectivePresenceCapability {
+        /// Creates a new `SelectivePresenceCapability` with the given enabled flag.
+        pub fn new(enabled: bool) -> Self {
+            Self { enabled }
+        }
+
+        /// Returns whether all fields have their default value.
+        pub fn is_default(&self) -> bool {
+            !self.enabled
         }
     }
 }

--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -5,6 +5,8 @@
 Improvements:
 
 - Add `replaces_state` field to `StateUnsigned`, due to a clarification in the Matrix spec.
+- Add support for [MSC4495: Selective Presence](https://github.com/matrix-org/matrix-spec-proposals/pull/4495)
+  and its events (`m.room.presence_sharing`, `m.presence.sharing`, and `m.presence.prompted`)
 
 ## 0.34.0
 

--- a/crates/ruma-events/Cargo.toml
+++ b/crates/ruma-events/Cargo.toml
@@ -57,6 +57,7 @@ unstable-msc4362 = []
 unstable-msc4380 = []
 unstable-msc4385 = []
 unstable-msc4471 = []
+unstable-msc4495 = []
 unstable-uniffi = ["dep:uniffi"]
 
 # Allow some mandatory fields to be missing, defaulting them to an empty string

--- a/crates/ruma-events/src/enums.rs
+++ b/crates/ruma-events/src/enums.rs
@@ -41,6 +41,8 @@ pub const RECOMMENDED_TRANSFERABLE_STATE_EVENT_TYPES: &[StateEventType] = &[
     StateEventType::RoomHistoryVisibility,
     StateEventType::RoomJoinRules,
     StateEventType::RoomPowerLevels,
+    #[cfg(feature = "unstable-msc4495")]
+    StateEventType::RoomPresenceSharing,
 ];
 
 event_enum! {
@@ -72,6 +74,12 @@ event_enum! {
         "im.ponies.emote_rooms" => super::image_pack,
         "m.recent_emoji" => super::recent_emoji,
         "m.key_backup" => super::key_backup,
+        #[cfg(feature = "unstable-msc4495")]
+        #[ruma_enum(ident = PresenceSharing)]
+        "org.continuwuity.presence_v2.msc4495.presence.sharing" => super::presence::sharing,
+        #[cfg(feature = "unstable-msc4495")]
+        #[ruma_enum(ident = PresencePrompted)]
+        "org.continuwuity.presence_v2.msc4495.presence.prompted" => super::presence::prompted,
     }
 
     /// Any room account data event.
@@ -203,6 +211,9 @@ event_enum! {
         "m.room.third_party_invite" => super::room::third_party_invite,
         "m.room.tombstone" => super::room::tombstone,
         "m.room.topic" => super::room::topic,
+        #[cfg(feature = "unstable-msc4495")]
+        #[ruma_enum(alias = "m.room.presence_sharing")]
+        "org.continuwuity.presence_v2.msc4495.room.presence_sharing" => super::room::presence_sharing,
         "m.space.child" => super::space::child,
         "m.space.parent" => super::space::parent,
         #[cfg(feature = "unstable-msc2545")]

--- a/crates/ruma-events/src/presence.rs
+++ b/crates/ruma-events/src/presence.rs
@@ -2,6 +2,11 @@
 //!
 //! The only content valid for this event is `PresenceEventContent`.
 
+#[cfg(feature = "unstable-msc4495")]
+pub mod prompted;
+#[cfg(feature = "unstable-msc4495")]
+pub mod sharing;
+
 use js_int::UInt;
 use ruma_common::{OwnedMxcUri, OwnedUserId, presence::PresenceState};
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-events/src/presence/prompted.rs
+++ b/crates/ruma-events/src/presence/prompted.rs
@@ -1,0 +1,83 @@
+//! Types for the `m.presence.prompted` account data key.
+//!
+//! This uses the unstable prefix defined in [MSC4495].
+//!
+//! [MSC4495]: https://github.com/matrix-org/matrix-spec-proposals/pull/4495
+
+use ruma_common::{OwnedRoomId, OwnedUserId};
+use ruma_macros::EventContent;
+use serde::{Deserialize, Serialize};
+
+/// The content of the `m.presence.prompted` account data key.
+///
+/// This uses the unstable prefix defined in [MSC4495].
+///
+/// [MSC4495]: https://github.com/matrix-org/matrix-spec-proposals/pull/4495
+#[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+#[ruma_event(type = "org.continuwuity.presence_v2.msc4495.presence.prompted", kind = GlobalAccountData)]
+pub struct PresencePromptedEventContent {
+    /// The list of users that have previously had the presence sharing prompt displayed.
+    pub users: Vec<OwnedUserId>,
+
+    /// The list of rooms that have previously had the presence sharing prompt displayed.
+    pub rooms: Vec<OwnedRoomId>,
+}
+
+impl PresencePromptedEventContent {
+    /// Creates a new `PresencePromptedEventContent` with the given users and rooms.
+    pub fn new(users: Vec<OwnedUserId>, rooms: Vec<OwnedRoomId>) -> Self {
+        Self { users, rooms }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ruma_common::{canonical_json::assert_to_canonical_json_eq, owned_room_id, owned_user_id};
+    use serde_json::{from_value as from_json_value, json};
+
+    use super::PresencePromptedEventContent;
+
+    #[test]
+    fn serialization() {
+        let content = PresencePromptedEventContent {
+            users: vec![
+                owned_user_id!("@alice:example.com"),
+                owned_user_id!("@mallory:example.com"),
+            ],
+            rooms: vec![owned_room_id!("!family-group-chat")],
+        };
+
+        assert_to_canonical_json_eq!(
+            content,
+            json!({
+                "users": [
+                    "@alice:example.com",
+                    "@mallory:example.com",
+                ],
+                "rooms": [
+                    "!family-group-chat",
+                ],
+            }),
+        );
+    }
+
+    #[test]
+    fn deserialization() {
+        let json_data = json!({
+            "users": [
+                "@alice:example.com",
+                "@mallory:example.com",
+            ],
+            "rooms": [
+                "!family-group-chat",
+            ],
+        });
+
+        let content = from_json_value::<PresencePromptedEventContent>(json_data).unwrap();
+
+        assert_eq!(content.users[0], "@alice:example.com");
+        assert_eq!(content.users[1], "@mallory:example.com");
+        assert_eq!(content.rooms[0], "!family-group-chat");
+    }
+}

--- a/crates/ruma-events/src/presence/sharing.rs
+++ b/crates/ruma-events/src/presence/sharing.rs
@@ -1,0 +1,170 @@
+//! Types for the `m.presence.sharing` account data key.
+//!
+//! This uses the unstable prefix defined in [MSC4495].
+//!
+//! [MSC4495]: https://github.com/matrix-org/matrix-spec-proposals/pull/4495
+
+use std::collections::BTreeMap;
+
+use ruma_common::{OwnedRoomId, OwnedServerName, OwnedUserId};
+use ruma_macros::{EventContent, StringEnum};
+use serde::{Deserialize, Serialize};
+
+use crate::PrivOwnedStr;
+
+/// A possible state for a user in the `m.presence.sharing` configuration.
+#[derive(Clone, StringEnum)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+#[ruma_enum(rename_all = "snake_case")]
+pub enum UserPresenceSharingState {
+    /// The user may receive presence updates.
+    Allow,
+
+    /// The user must not receive presence updates.
+    Deny,
+
+    #[doc(hidden)]
+    _Custom(PrivOwnedStr),
+}
+
+/// A possible state for a room in the `m.presence.sharing` configuration.
+#[derive(Clone, StringEnum)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+#[ruma_enum(rename_all = "snake_case")]
+pub enum RoomPresenceSharingState {
+    /// The room may receive presence updates.
+    Allow,
+
+    #[doc(hidden)]
+    _Custom(PrivOwnedStr),
+}
+
+/// A possible state for a server in the `m.presence.sharing` configuration.
+#[derive(Clone, StringEnum)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+#[ruma_enum(rename_all = "snake_case")]
+pub enum ServerPresenceSharingState {
+    /// The server must not receive presence updates.
+    Deny,
+
+    #[doc(hidden)]
+    _Custom(PrivOwnedStr),
+}
+
+/// The content of the `m.presence.sharing` account data key.
+///
+/// This uses the unstable prefix defined in [MSC4495].
+///
+/// [MSC4495]: https://github.com/matrix-org/matrix-spec-proposals/pull/4495
+#[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+#[ruma_event(type = "org.continuwuity.presence_v2.msc4495.presence.sharing", kind = GlobalAccountData)]
+pub struct PresenceSharingEventContent {
+    /// Whether presence should be shared with all users on the local homeserver.
+    pub share_locally: bool,
+
+    /// Configuration for sharing presence with users.
+    pub users: BTreeMap<OwnedUserId, UserPresenceSharingState>,
+
+    /// Configuration for sharing presence with rooms.
+    ///
+    /// Sharing presence with rooms also depends on the room's presence sharing hint.
+    pub rooms: BTreeMap<OwnedRoomId, RoomPresenceSharingState>,
+
+    /// Configuration for sharing presence with servers.
+    pub servers: BTreeMap<OwnedServerName, ServerPresenceSharingState>,
+}
+
+impl PresenceSharingEventContent {
+    /// Creates a new `PresenceSharingEventContent` with the given parameters.
+    pub fn new(
+        share_locally: bool,
+        users: BTreeMap<OwnedUserId, UserPresenceSharingState>,
+        rooms: BTreeMap<OwnedRoomId, RoomPresenceSharingState>,
+        servers: BTreeMap<OwnedServerName, ServerPresenceSharingState>,
+    ) -> Self {
+        Self { share_locally, users, rooms, servers }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ruma_common::{
+        canonical_json::assert_to_canonical_json_eq, owned_room_id, owned_server_name,
+        owned_user_id,
+    };
+    use serde_json::{from_value as from_json_value, json};
+
+    use crate::presence::sharing::{
+        PresenceSharingEventContent, RoomPresenceSharingState, ServerPresenceSharingState,
+        UserPresenceSharingState,
+    };
+
+    #[test]
+    fn serialization() {
+        let content = PresenceSharingEventContent {
+            share_locally: true,
+            users: [
+                (owned_user_id!("@alice:example.com"), UserPresenceSharingState::Allow),
+                (owned_user_id!("@mallory:example.com"), UserPresenceSharingState::Deny),
+            ]
+            .into(),
+            rooms: [(owned_room_id!("!family-group-chat"), RoomPresenceSharingState::Allow)].into(),
+            servers: [(owned_server_name!("matrix.org"), ServerPresenceSharingState::Deny)].into(),
+        };
+
+        assert_to_canonical_json_eq!(
+            content,
+            json!({
+                "share_locally": true,
+                "users": {
+                    "@alice:example.com": "allow",
+                    "@mallory:example.com": "deny",
+                },
+                "rooms": {
+                    "!family-group-chat": "allow",
+                },
+                "servers": {
+                    "matrix.org": "deny",
+                },
+            }),
+        );
+    }
+
+    #[test]
+    fn deserialization() {
+        let json_data = json!({
+            "share_locally": true,
+            "users": {
+                "@alice:example.com": "allow",
+                "@mallory:example.com": "deny",
+            },
+            "rooms": {
+                "!family-group-chat": "allow",
+            },
+            "servers": {
+                "matrix.org": "deny",
+            }
+        });
+
+        let content = from_json_value::<PresenceSharingEventContent>(json_data).unwrap();
+
+        assert!(content.share_locally);
+        assert_eq!(content.users.len(), 2);
+        assert_eq!(
+            content.users.get("@alice:example.com").unwrap(),
+            &UserPresenceSharingState::Allow
+        );
+        assert_eq!(
+            content.users.get("@mallory:example.com").unwrap(),
+            &UserPresenceSharingState::Deny
+        );
+        assert_eq!(content.rooms.len(), 1);
+        assert_eq!(
+            content.rooms.get("!family-group-chat").unwrap(),
+            &RoomPresenceSharingState::Allow
+        );
+        assert_eq!(content.servers.len(), 1);
+        assert_eq!(content.servers.get("matrix.org").unwrap(), &ServerPresenceSharingState::Deny);
+    }
+}

--- a/crates/ruma-events/src/room.rs
+++ b/crates/ruma-events/src/room.rs
@@ -41,6 +41,8 @@ pub mod name;
 pub mod pinned_events;
 pub mod policy;
 pub mod power_levels;
+#[cfg(feature = "unstable-msc4495")]
+pub mod presence_sharing;
 pub mod redaction;
 pub mod server_acl;
 pub mod third_party_invite;

--- a/crates/ruma-events/src/room/presence_sharing.rs
+++ b/crates/ruma-events/src/room/presence_sharing.rs
@@ -1,0 +1,102 @@
+//! Types for the `m.room.presence_sharing` state event.
+//!
+//! This event uses the unstable prefix defined in [MSC4495].
+//!
+//! [MSC4495]: https://github.com/matrix-org/matrix-spec-proposals/pull/4495
+
+use ruma_macros::{EventContent, StringEnum};
+use serde::{Deserialize, Serialize};
+
+use crate::{EmptyStateKey, PrivOwnedStr};
+
+/// A room's presence sharing hint.
+///
+/// The room's presence sharing hint indicates either:
+/// 1. Sharing presence within the room is prohibited ([Self::Forbid]), or
+/// 2. Sharing presence within the room should be recommended by clients ([Self::Suggest])
+///
+/// This type is defined in [MSC4495].
+///
+/// [MSC4495]: https://github.com/matrix-org/matrix-spec-proposals/pull/4495
+#[derive(Clone, StringEnum)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+#[ruma_enum(rename_all = "snake_case")]
+pub enum PresenceSharingHint {
+    /// Sharing presence within the room is prohibited.
+    Forbid,
+
+    /// Sharing presence within the room should be recommended by clients.
+    Suggest,
+
+    #[doc(hidden)]
+    _Custom(PrivOwnedStr),
+}
+
+/// The content of an `m.room.presence_sharing` event.
+///
+/// The room's presence sharing hint indicates either:
+/// 1. Sharing presence within the room is prohibited (`forbid`), or
+/// 2. Sharing presence within the room should be recommended by clients (`suggest`)
+///
+/// This event uses the unstable prefix defined in [MSC4495].
+///
+/// [MSC4495]: https://github.com/matrix-org/matrix-spec-proposals/pull/4495
+#[derive(Clone, Debug, Serialize, Deserialize, EventContent)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+#[ruma_event(type = "org.continuwuity.presence_v2.msc4495.room.presence_sharing", kind = State, state_key_type = EmptyStateKey)]
+pub struct RoomPresenceSharingEventContent {
+    /// The room's presence sharing hint.
+    pub presence_sharing: PresenceSharingHint,
+}
+
+impl RoomPresenceSharingEventContent {
+    /// Creates a new `RoomPresenceSharingEventContent` with the given hint.
+    pub fn new(hint: PresenceSharingHint) -> Self {
+        Self { presence_sharing: hint }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ruma_common::canonical_json::assert_to_canonical_json_eq;
+    use serde_json::{from_value as from_json_value, json};
+
+    use super::{PresenceSharingHint, RoomPresenceSharingEventContent};
+    use crate::OriginalStateEvent;
+
+    #[test]
+    fn serialization() {
+        let content =
+            RoomPresenceSharingEventContent { presence_sharing: PresenceSharingHint::Forbid };
+
+        assert_to_canonical_json_eq!(
+            content,
+            json!({
+                "presence_sharing": "forbid",
+            }),
+        );
+    }
+
+    #[test]
+    fn deserialization() {
+        let json_data = json!({
+            "content": {
+                "presence_sharing": "suggest"
+            },
+            "event_id": "$h29iv0s8:example.com",
+            "origin_server_ts": 1,
+            "room_id": "!n8f893n9:example.com",
+            "sender": "@carl:example.com",
+            "state_key": "",
+            "type": "org.continuwuity.presence_v2.msc4495.room.presence_sharing"
+        });
+
+        assert_eq!(
+            from_json_value::<OriginalStateEvent<RoomPresenceSharingEventContent>>(json_data)
+                .unwrap()
+                .content
+                .presence_sharing,
+            PresenceSharingHint::Suggest
+        );
+    }
+}

--- a/crates/ruma-federation-api/CHANGELOG.md
+++ b/crates/ruma-federation-api/CHANGELOG.md
@@ -7,6 +7,8 @@ Improvements:
 - Remove support for MSC4373, as the MSC is now closed.
 - `query::get_profile_information` is now using `ruma_common::profile::UserProfile` for its
   underlying data storage.
+- Add experimental support for [MSC4495: Selective Presence](https://github.com/matrix-org/matrix-spec-proposals/pull/4495)'s
+  `get_presence_recipients` endpoint, alongside its updates to the `m.presence` EDU.
 
 ## 0.15.0
 

--- a/crates/ruma-federation-api/Cargo.toml
+++ b/crates/ruma-federation-api/Cargo.toml
@@ -25,6 +25,7 @@ unstable-msc3618 = []
 unstable-msc3723 = []
 unstable-msc3843 = ["ruma-common/unstable-msc3843"]
 unstable-msc4125 = []
+unstable-msc4495 = ["ruma-events/unstable-msc4495"]
 
 [dependencies]
 bytes = { workspace = true, optional = true }

--- a/crates/ruma-federation-api/src/query.rs
+++ b/crates/ruma-federation-api/src/query.rs
@@ -1,5 +1,7 @@
 //! Endpoints to retrieve information from a homeserver about a resource.
 
 pub mod get_custom_information;
+#[cfg(feature = "unstable-msc4495")]
+pub mod get_presence_recipients;
 pub mod get_profile_information;
 pub mod get_room_information;

--- a/crates/ruma-federation-api/src/query/get_presence_recipients.rs
+++ b/crates/ruma-federation-api/src/query/get_presence_recipients.rs
@@ -1,0 +1,54 @@
+//! `GET /_matrix/federation/*/query/presence_recipients`
+pub mod msc4495 {
+    //! [`/unstable/org.continuwuity.presence_v2.msc4495/`][MSC4495]
+    //!
+    //! [MSC4495]: https://github.com/matrix-org/matrix-spec-proposals/pull/4495
+
+    use js_int::UInt;
+    use ruma_common::{
+        OwnedUserId,
+        api::{request, response},
+        metadata,
+    };
+
+    use crate::authentication::ServerSignatures;
+
+    metadata! {
+        method: GET,
+        rate_limited: false,
+        authentication: ServerSignatures,
+        path: "/_matrix/federation/unstable/org.continuwuity.presence_v2.msc4495/query/presence_recipients",
+    }
+
+    /// Request type for the `get_presence_recipients` endpoint.
+    #[request]
+    pub struct Request {
+        /// The user ID to query. Must be local to the queried server.
+        #[ruma_api(query)]
+        pub user_id: OwnedUserId,
+    }
+
+    impl Request {
+        /// Creates a new `Request` with the given user ID.
+        pub fn new(user_id: OwnedUserId) -> Self {
+            Self { user_id }
+        }
+    }
+
+    /// Response type for the `get_presence_recipients` endpoint.
+    #[response]
+    pub struct Response {
+        /// A unique identifier for the user's current recipient user set.
+        pub stream_id: UInt,
+
+        /// An array of local recipients the user intends to push presence to.
+        pub recipients: Vec<OwnedUserId>,
+    }
+
+    impl Response {
+        /// Creates a new `Response` with the given stream ID and recipients.
+        pub fn new(stream_id: UInt, recipients: Vec<OwnedUserId>) -> Self {
+            Self { stream_id, recipients }
+        }
+    }
+}

--- a/crates/ruma-federation-api/src/transactions/edu.rs
+++ b/crates/ruma-federation-api/src/transactions/edu.rs
@@ -2,6 +2,8 @@
 
 use std::collections::BTreeMap;
 
+#[cfg(feature = "unstable-msc4495")]
+use js_int::Int;
 use js_int::UInt;
 use ruma_common::{
     OwnedDeviceId, OwnedEventId, OwnedRoomId, OwnedTransactionId, OwnedUserId,
@@ -94,6 +96,26 @@ impl PresenceContent {
     }
 }
 
+/// A list of added or removed users in a user's presence recipient list.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+#[cfg(feature = "unstable-msc4495")]
+pub struct PresenceRecipientListUpdates {
+    /// A list of users that have been added to the recipient list.
+    pub add: Vec<OwnedUserId>,
+
+    /// A list of users that have been removed from the recipient list.
+    pub delete: Vec<OwnedUserId>,
+}
+
+#[cfg(feature = "unstable-msc4495")]
+impl PresenceRecipientListUpdates {
+    /// Creates a new `PresenceRecipientListUpdates` with the given added and removed users.
+    pub fn new(add: Vec<OwnedUserId>, delete: Vec<OwnedUserId>) -> Self {
+        Self { add, delete }
+    }
+}
+
 /// An update to the presence of a user.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
@@ -116,6 +138,38 @@ pub struct PresenceUpdate {
     /// Defaults to false.
     #[serde(default)]
     pub currently_active: bool,
+
+    /// Changes to the user's presence recipient list since the last EDU was sent, if any.
+    ///
+    /// This field will only be present if `prev_id` is also present.
+    ///
+    /// This field uses the unstable prefix defined in [MSC4495].
+    ///
+    /// [MSC4495]: https://github.com/matrix-org/matrix-spec-proposals/pull/4495
+    #[cfg(feature = "unstable-msc4495")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recipients: Option<PresenceRecipientListUpdates>,
+
+    /// The stream ID of the user's current presence recipient list.
+    ///
+    /// This field uses the unstable prefix defined in [MSC4495].
+    ///
+    /// [MSC4495]: https://github.com/matrix-org/matrix-spec-proposals/pull/4495
+    #[cfg(feature = "unstable-msc4495")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stream_id: Option<Int>,
+
+    /// The prior stream ID in the user's presence delta stream, if any.
+    ///
+    /// If this field does not match the most recently seen `stream_id`, the presence list should
+    /// be re-fetched.
+    ///
+    /// This field uses the unstable prefix defined in [MSC4495].
+    ///
+    /// [MSC4495]: https://github.com/matrix-org/matrix-spec-proposals/pull/4495
+    #[cfg(feature = "unstable-msc4495")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prev_id: Option<Int>,
 }
 
 impl PresenceUpdate {
@@ -127,6 +181,12 @@ impl PresenceUpdate {
             last_active_ago: last_activity,
             status_msg: None,
             currently_active: false,
+            #[cfg(feature = "unstable-msc4495")]
+            recipients: None,
+            #[cfg(feature = "unstable-msc4495")]
+            stream_id: None,
+            #[cfg(feature = "unstable-msc4495")]
+            prev_id: None,
         }
     }
 }
@@ -327,7 +387,9 @@ pub struct CustomEdu {
 mod tests {
     use assert_matches2::assert_matches;
     use js_int::uint;
-    use ruma_common::{room_id, user_id};
+    use ruma_common::{
+        canonical_json::assert_to_canonical_json_eq, presence::PresenceState, room_id, user_id,
+    };
     use ruma_events::ToDeviceEventType;
     use serde_json::json;
 
@@ -549,5 +611,90 @@ mod tests {
         assert!(content.self_signing_key.is_some());
 
         assert_eq!(serde_json::to_value(&edu).unwrap(), json);
+    }
+
+    #[test]
+    fn presence_edu() {
+        let json = json!({
+            "content": {
+                "push": [
+                    {
+                        "user_id": "@alice:example.com",
+                        "presence": "online",
+                        "currently_active": true,
+                        "last_active_ago": 1000,
+                        "status_msg": "Making cupcakes"
+                    }
+                ]
+            },
+            "edu_type": "m.presence"
+        });
+
+        let edu = serde_json::from_value::<Edu>(json.clone()).unwrap();
+        assert_matches!(&edu, Edu::Presence(content));
+        assert_eq!(content.push.len(), 1);
+        let presence_update = &content.push[0];
+        assert_eq!(presence_update.user_id, "@alice:example.com");
+        assert_eq!(presence_update.presence, PresenceState::Online);
+        assert!(presence_update.currently_active);
+        assert_eq!(presence_update.last_active_ago, uint!(1000));
+        assert_eq!(presence_update.status_msg.as_deref(), Some("Making cupcakes"));
+        #[cfg(feature = "unstable-msc4495")]
+        {
+            assert!(presence_update.recipients.is_none());
+            assert!(presence_update.stream_id.is_none());
+            assert!(presence_update.prev_id.is_none());
+        }
+
+        assert_to_canonical_json_eq!(edu, json);
+    }
+
+    #[cfg(feature = "unstable-msc4495")]
+    #[test]
+    fn msc4495_presence_edu() {
+        use js_int::int;
+
+        use crate::transactions::edu::PresenceRecipientListUpdates;
+
+        let json = json!({
+            "content": {
+                "push": [
+                    {
+                        "user_id": "@alice:example.com",
+                        "presence": "online",
+                        "currently_active": true,
+                        "last_active_ago": 1000,
+                        "status_msg": "Making cupcakes",
+                        "stream_id": 321,
+                        "prev_id": 123,
+                        "recipients": {
+                            "add": ["@bob:example.com"],
+                            "delete": ["@charlie:example.com"]
+                        }
+                    }
+                ]
+            },
+            "edu_type": "m.presence"
+        });
+
+        let edu = serde_json::from_value::<Edu>(json.clone()).unwrap();
+        assert_matches!(&edu, Edu::Presence(content));
+        assert_eq!(content.push.len(), 1);
+        let presence_update = &content.push[0];
+        assert_eq!(presence_update.user_id, "@alice:example.com");
+        assert_eq!(presence_update.presence, PresenceState::Online);
+        assert!(presence_update.currently_active);
+        assert_eq!(presence_update.last_active_ago, uint!(1000));
+        assert_eq!(presence_update.status_msg.as_deref(), Some("Making cupcakes"));
+        assert_eq!(presence_update.stream_id, Some(int!(321)));
+        assert_eq!(presence_update.prev_id, Some(int!(123)));
+        assert_matches!(
+            &presence_update.recipients,
+            Some(PresenceRecipientListUpdates { add, delete })
+        );
+        assert_eq!(add.len(), 1);
+        assert_eq!(delete.len(), 1);
+
+        assert_to_canonical_json_eq!(edu, json);
     }
 }

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -208,6 +208,11 @@ unstable-msc4426 = ["ruma-common/unstable-msc4426"]
 unstable-msc4439 = ["ruma-client-api?/unstable-msc4439"]
 unstable-msc4466 = ["ruma-client-api?/unstable-msc4466"]
 unstable-msc4471 = ["ruma-events?/unstable-msc4471"]
+unstable-msc4495 = [
+    "ruma-events?/unstable-msc4495",
+    "ruma-federation-api?/unstable-msc4495",
+    "ruma-client-api?/unstable-msc4495",
+]
 unstable-uniffi = ["ruma-events?/unstable-uniffi"]
 
 [dependencies]


### PR DESCRIPTION
This PR adds experimental support for the types defined in [MSC4495: Selective Presence](https://github.com/matrix-org/matrix-spec-proposals/pull/4495) ([rendered](https://github.com/thetayloredman/matrix-spec-proposals/blob/presence-v2/selective/proposals/4495-selective-presence.md)).

This includes the following definitions:
- `/_matrix/federation/unstable/org.continuwuity.presence_v2.msc4495/query/presence_recipients`
- `org.continuwuity.presence_v2.msc4495.room.presence_sharing` state event
- `org.continuwuity.presence_v2.msc4495.presence.sharing` global account data
- `org.continuwuity.presence_v2.msc4495.presence.prompted` global account data
- `recipients` (`add` and `remove`), `prev_id`, and `stream_id` on the `m.presence` EDU content
