### PR TITLE
feat: Add a `zeroize` method on identifiers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4030,9 +4030,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ uniffi = { git = "https://github.com/mozilla/uniffi-rs.git", rev = "e5f4821410be
 url = { version = "2.5.0" }
 web-time = "1.1.0"
 wildmatch = "2.6.1"
-zeroize = "1.8.1"
+zeroize = "1.9.0"
 
 [workspace.lints.rust]
 rust_2018_idioms = { level = "warn", priority = -1 }

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -14,6 +14,8 @@ Improvements:
 - Add `canonical_json::RedactingSerializer` to serialize a `CanonicalJsonObject`
   while redacting it on the fly.
 - Add `MatrixVersion::V1_19`.
+- Add the `zeroize(mut self)` method on identifiers, which will call the
+  `zeroize` crate.
 
 [MSC4438]: https://github.com/matrix-org/matrix-spec-proposals/pull/4438
 

--- a/crates/ruma-common/src/identifiers/room_id.rs
+++ b/crates/ruma-common/src/identifiers/room_id.rs
@@ -344,4 +344,12 @@ mod tests {
         assert!(id_str.starts_with('!'));
         assert_eq!(&id_str[1..], reference_hash);
     }
+
+    #[test]
+    fn zeroize() {
+        let room_id = <&RoomId>::try_from("!room_id").expect("Failed to create RoomId.").to_owned();
+        assert_eq!(room_id.as_str(), "!room_id");
+
+        room_id.zeroize();
+    }
 }

--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -19,6 +19,7 @@ Improvements:
     part of the MSC.
   - The `unstable-msc2545` cargo feature was removed.
 - Add unstable support for [MSC4354](https://github.com/matrix-org/matrix-spec-proposals/pull/4354) Sticky Events behind the `unstable-msc4354` feature flag.
+- Add the `zeroize(mut self)` method on identifiers, which will call the `zeroize` crate.
 
 ## 0.34.0
 

--- a/crates/ruma-events/Cargo.toml
+++ b/crates/ruma-events/Cargo.toml
@@ -16,6 +16,7 @@ all-features = true
 [features]
 html = ["dep:ruma-html"]
 markdown = ["dep:pulldown-cmark"]
+
 unstable-msc1767 = []
 unstable-msc2448 = []
 unstable-msc2747 = []

--- a/crates/ruma-macros/src/identifiers/id_dst.rs
+++ b/crates/ruma-macros/src/identifiers/id_dst.rs
@@ -21,6 +21,7 @@ pub(crate) fn expand_id_dst(input: syn::ItemStruct) -> syn::Result<TokenStream> 
     let fallible_from_str_impls = id_dst.expand_fallible_from_str_impls();
     let infallible_from_str_impls = id_dst.expand_infallible_from_str_impls();
     let partial_eq_impls = id_dst.expand_partial_eq_impls();
+    let zeroize_impl = id_dst.expand_zeroize_impl();
 
     Ok(quote! {
         #as_str_and_bytes_impls
@@ -30,6 +31,7 @@ pub(crate) fn expand_id_dst(input: syn::ItemStruct) -> syn::Result<TokenStream> 
         #fallible_from_str_impls
         #infallible_from_str_impls
         #partial_eq_impls
+        #zeroize_impl
     })
 }
 
@@ -714,6 +716,58 @@ impl IdDst {
         ]
         .into_iter()
         .collect()
+    }
+
+    /// Generate the `zeroize` method for an owned type.
+    fn expand_zeroize_impl(&self) -> TokenStream {
+        let impl_generics = &self.impl_generics;
+
+        let owned_ident = &self.owned_ident;
+        let owned_id = &self.types.owned_id;
+        let parse_doc_header = format!(
+            "Securely zero memory (aka [zeroize](https://en.wikipedia.org/wiki/Zeroisation)) of `{owned_ident}`."
+        );
+
+        let box_str_cfg = &self.storage_cfg.box_str;
+        let arc_str_cfg = &self.storage_cfg.arc_str;
+
+        quote! {
+            #[automatically_derived]
+            impl #impl_generics #owned_id {
+                #[doc = #parse_doc_header]
+                ///
+                /// This method zeroizes this type by writing zeros in its
+                /// memory location before freeing it. It internally uses
+                /// [the `zeroize` crate][`zeroize`]. Note that this type
+                /// doesn't implement the `zeroize::Zeroize` trait because the
+                /// `Zeroize::zeroize` method takes a `&mut self`, which means
+                /// we could put this type into an inconsistent state if it is
+                /// used after calling that method. Instead, this method takes
+                /// ownership of the type, ensuring it's impossible to misuse
+                /// it.
+                ///
+                /// # Implementation details
+                ///
+                /// If the `ruma_identifiers_storage` configuration is
+                /// set to `Arc`, this type will be zeroized if and only if
+                /// [`Arc::get_mut`] returns `Some` reference, i.e. if there is no
+                /// other `Arc` or `Weak` pointers to this same location.
+                ///
+                /// [`zeroize`]: https://docs.rs/zeroize/
+                /// [`Arc::get_mut`]: https://doc.rust-lang.org/std/sync/struct.Arc.html#method.get_mut
+                pub fn zeroize(mut self) {
+                    #box_str_cfg
+                    { ::zeroize::Zeroize::zeroize(&mut self.inner); }
+
+                    #arc_str_cfg
+                    {
+                        if let Some(value) = ::std::sync::Arc::get_mut(&mut self.inner) {
+                            ::zeroize::Zeroize::zeroize(value);
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
This patch adds the `zeroize-identifiers` feature on `ruma`, `ruma-common` and `ruma-events`. It adds a `zeroize(mut self)` method on identifiers, calling the `zeroize` crate.

Note that identifiers **DO NOT** implement the `zeroize::Zeroize` trait because the `zeroize::Zeroize::zeroize` method takes `&mut self`, which means the identifiers would not be consumed, and then will contain invalid data. That's why we implement a custom `zeroize(mut self)` method consuming `self`.

Update: The `zeroize-identifiers` feature has been removed: the `zeroize(mut self)` method on identifiers is always present.

For reviewers:

- it's hard to test the `zeroize` method has really written zeros because it consumes `self`
- if the identifiers storage is `Arc`, it will do nothing except if `Arc::get_mut()` returns `Some`, again, difficult to test but the behaviour should be noted somewhere I suppose? What do you think?