### PR TITLE
feat(sync): add support for sticky event in sync v3 and v5

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -20,10 +20,10 @@ Improvements:
   `delete_profile_field`) to the stable `/v3/profile/{user}/{field}` path when a homeserver
   advertises the `uk.tcpip.msc4133.stable` unstable feature, even if it has not yet advertised
   Matrix v1.16 in its `/versions` response.
-- Add unstable support for [MSC4354](https://github.com/matrix-org/matrix-spec-proposals/pull/4354) Sticky Events behind the `unstable-msc4354` feature flag.
-  Adds a `sticky_duration_ms` query parameter to `send_message_event` / `send_state_event`.
-- Add sticky event sync extension, for v3 and v5 [MSC4480](https://github.com/matrix-org/matrix-spec-proposals/pull/4480)
-  Sliding Sync Sticky Events extension behind the `unstable-msc4480` feature flag.
+- Add unstable support for [MSC4354](https://github.com/matrix-org/matrix-spec-proposals/pull/4354) Sticky Events behind
+  the `unstable-msc4354` feature flag. Adds a `sticky_duration_ms` query parameter to `send_message_event`
+  and `send_state_event` as well as sync v3 support. Add sync extension v5 behind the `unstable-msc4480`
+  feature flag as per [MSC4480](https://github.com/matrix-org/matrix-spec-proposals/pull/4480).
 
 ## 0.24.0
 

--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -22,6 +22,8 @@ Improvements:
   Matrix v1.16 in its `/versions` response.
 - Add unstable support for [MSC4354](https://github.com/matrix-org/matrix-spec-proposals/pull/4354) Sticky Events behind the `unstable-msc4354` feature flag.
   Adds a `sticky_duration_ms` query parameter to `send_message_event` / `send_state_event`.
+- Add sticky event sync extension, for v3 and v5 [MSC4480](https://github.com/matrix-org/matrix-spec-proposals/pull/4480)
+  Sliding Sync Sticky Events extension behind the `unstable-msc4480` feature flag.
 
 ## 0.24.0
 

--- a/crates/ruma-client-api/Cargo.toml
+++ b/crates/ruma-client-api/Cargo.toml
@@ -66,6 +66,7 @@ unstable-msc4383 = []
 unstable-msc4388 = ["ruma-common/unstable-msc4388"]
 unstable-msc4439 = []
 unstable-msc4466 = []
+unstable-msc4480 = ["unstable-msc4354"]
 
 [dependencies]
 as_variant = { workspace = true }

--- a/crates/ruma-client-api/src/sync/sync_events/v3.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v3.rs
@@ -294,6 +294,13 @@ pub struct JoinedRoom {
     #[serde(skip_serializing_if = "Ephemeral::is_empty")]
     pub ephemeral: Ephemeral,
 
+    /// The sticky events in the room that aren't recorded in the timeline of the room.
+    ///
+    /// See [MSC4354](https://github.com/matrix-org/matrix-spec-proposals/pull/4354).
+    #[cfg(feature = "unstable-msc4354")]
+    #[serde(rename = "msc4354_sticky", skip_serializing_if = "Sticky::is_empty")]
+    pub sticky: Sticky,
+
     /// The number of unread events since the latest read receipt.
     ///
     /// This uses the unstable prefix in [MSC2654].
@@ -320,6 +327,8 @@ impl JoinedRoom {
             state,
             account_data,
             ephemeral,
+            #[cfg(feature = "unstable-msc4354")]
+            sticky,
             #[cfg(feature = "unstable-msc2654")]
             unread_count,
         } = self;
@@ -329,14 +338,19 @@ impl JoinedRoom {
         #[cfg(feature = "unstable-msc2654")]
         let unread_count_is_none = unread_count.is_none();
 
-        summary.is_empty()
+        let is_empty = summary.is_empty()
             && unread_notifications.is_empty()
             && unread_thread_notifications.is_empty()
             && timeline.is_empty()
             && state.is_empty()
             && account_data.is_empty()
             && ephemeral.is_empty()
-            && unread_count_is_none
+            && unread_count_is_none;
+
+        #[cfg(feature = "unstable-msc4354")]
+        let is_empty = is_empty && sticky.is_empty();
+
+        is_empty
     }
 }
 
@@ -569,6 +583,32 @@ impl Ephemeral {
     }
 }
 
+/// Sticky events in the room that aren't recorded in the timeline of the room.
+///
+/// See [MSC4354](https://github.com/matrix-org/matrix-spec-proposals/pull/4354).
+#[cfg(feature = "unstable-msc4354")]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+pub struct Sticky {
+    /// A list of sticky events.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub events: Vec<Raw<AnySyncTimelineEvent>>,
+}
+
+#[cfg(feature = "unstable-msc4354")]
+impl Sticky {
+    /// Creates an empty `Sticky`.
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Returns true if there are no sticky events.
+    pub fn is_empty(&self) -> bool {
+        let Self { events } = self;
+        events.is_empty()
+    }
+}
+
 /// Information about room for rendering to clients.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
@@ -707,8 +747,10 @@ impl ToDevice {
 
 #[cfg(test)]
 mod tests {
+    use assert_matches2::assert_let;
     use assign::assign;
     use ruma_common::canonical_json::assert_to_canonical_json_eq;
+    use ruma_events::{AnySyncMessageLikeEvent, AnySyncTimelineEvent, SyncMessageLikeEvent};
     use serde_json::{from_value as from_json_value, json};
 
     use super::Timeline;
@@ -728,6 +770,59 @@ mod tests {
         let timeline_default_deserialized =
             from_json_value::<Timeline>(json!({ "events": [] })).unwrap();
         assert!(!timeline_default_deserialized.limited);
+    }
+
+    #[cfg(feature = "unstable-msc4354")]
+    #[test]
+    fn joined_room_sticky_section_serde() {
+        use serde_json::to_value as to_json_value;
+
+        use super::JoinedRoom;
+
+        fn sticky_event() -> serde_json::Value {
+            json!({
+                "content": { "body": "sticky", "msgtype": "m.text" },
+                "event_id": "$1:example.com",
+                "origin_server_ts": 1,
+                "sender": "@alice:example.com",
+                "type": "m.room.message",
+                "msc4354_sticky": {
+                    "duration_ms": 300_000
+                },
+                "unsigned": { "sticky_duration_ttl_ms": 258_113 }
+            })
+        }
+
+        // The unstable `msc4354_sticky` section is deserialized into `sticky`.
+        let joined_room = from_json_value::<JoinedRoom>(json!({
+            "msc4354_sticky": { "events": [sticky_event()] }
+        }))
+        .unwrap();
+        assert_eq!(joined_room.sticky.events.len(), 1);
+
+        // A server sending both the stable and unstable keys must not error (no serde
+        // `alias` is used); the unstable key wins.
+        let joined_room = from_json_value::<JoinedRoom>(json!({
+            "sticky": { "events": [] },
+            "msc4354_sticky": { "events": [sticky_event()] },
+        }))
+        .unwrap();
+        assert_eq!(joined_room.sticky.events.len(), 1);
+        let event_raw = joined_room.sticky.events.first().unwrap();
+
+        assert_let!(
+            AnySyncTimelineEvent::MessageLike(AnySyncMessageLikeEvent::RoomMessage(
+                SyncMessageLikeEvent::Original(ev)
+            )) = event_raw.deserialize().unwrap()
+        );
+
+        let duration = ev.sticky.map(|s| s.duration_ms.get());
+        assert_eq!(duration, Some(300_000));
+
+        // Serialization uses the unstable key.
+        let serialized = to_json_value(&joined_room).unwrap();
+        assert!(serialized.get("msc4354_sticky").is_some());
+        assert!(serialized.get("sticky").is_none());
     }
 }
 

--- a/crates/ruma-client-api/src/sync/sync_events/v3.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v3.rs
@@ -747,10 +747,8 @@ impl ToDevice {
 
 #[cfg(test)]
 mod tests {
-    use assert_matches2::assert_let;
     use assign::assign;
     use ruma_common::canonical_json::assert_to_canonical_json_eq;
-    use ruma_events::{AnySyncMessageLikeEvent, AnySyncTimelineEvent, SyncMessageLikeEvent};
     use serde_json::{from_value as from_json_value, json};
 
     use super::Timeline;
@@ -775,6 +773,8 @@ mod tests {
     #[cfg(feature = "unstable-msc4354")]
     #[test]
     fn joined_room_sticky_section_serde() {
+        use assert_matches2::assert_let;
+        use ruma_events::{AnySyncMessageLikeEvent, AnySyncTimelineEvent, SyncMessageLikeEvent};
         use serde_json::to_value as to_json_value;
 
         use super::JoinedRoom;

--- a/crates/ruma-client-api/src/sync/sync_events/v3.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v3.rs
@@ -338,19 +338,20 @@ impl JoinedRoom {
         #[cfg(feature = "unstable-msc2654")]
         let unread_count_is_none = unread_count.is_none();
 
-        let is_empty = summary.is_empty()
+        #[cfg(not(feature = "unstable-msc4354"))]
+        let sticky_is_empty = true;
+        #[cfg(feature = "unstable-msc4354")]
+        let sticky_is_empty = sticky.is_empty();
+
+        summary.is_empty()
             && unread_notifications.is_empty()
             && unread_thread_notifications.is_empty()
             && timeline.is_empty()
             && state.is_empty()
             && account_data.is_empty()
             && ephemeral.is_empty()
-            && unread_count_is_none;
-
-        #[cfg(feature = "unstable-msc4354")]
-        let is_empty = is_empty && sticky.is_empty();
-
-        is_empty
+            && unread_count_is_none
+            && sticky_is_empty
     }
 }
 
@@ -779,23 +780,21 @@ mod tests {
 
         use super::JoinedRoom;
 
-        fn sticky_event() -> serde_json::Value {
-            json!({
-                "content": { "body": "sticky", "msgtype": "m.text" },
-                "event_id": "$1:example.com",
-                "origin_server_ts": 1,
-                "sender": "@alice:example.com",
-                "type": "m.room.message",
-                "msc4354_sticky": {
-                    "duration_ms": 300_000
-                },
-                "unsigned": { "sticky_duration_ttl_ms": 258_113 }
-            })
-        }
+        let sticky_event = json!({
+            "content": { "body": "sticky", "msgtype": "m.text" },
+            "event_id": "$1:example.com",
+            "origin_server_ts": 1,
+            "sender": "@alice:example.com",
+            "type": "m.room.message",
+            "msc4354_sticky": {
+                "duration_ms": 300_000
+            },
+            "unsigned": { "sticky_duration_ttl_ms": 258_113 }
+        });
 
         // The unstable `msc4354_sticky` section is deserialized into `sticky`.
         let joined_room = from_json_value::<JoinedRoom>(json!({
-            "msc4354_sticky": { "events": [sticky_event()] }
+            "msc4354_sticky": { "events": [sticky_event] }
         }))
         .unwrap();
         assert_eq!(joined_room.sticky.events.len(), 1);
@@ -804,7 +803,7 @@ mod tests {
         // `alias` is used); the unstable key wins.
         let joined_room = from_json_value::<JoinedRoom>(json!({
             "sticky": { "events": [] },
-            "msc4354_sticky": { "events": [sticky_event()] },
+            "msc4354_sticky": { "events": [sticky_event] },
         }))
         .unwrap();
         assert_eq!(joined_room.sticky.events.len(), 1);

--- a/crates/ruma-client-api/src/sync/sync_events/v3/response_serde.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v3/response_serde.rs
@@ -6,6 +6,8 @@ use ruma_common::{OwnedEventId, serde::from_raw_json_value};
 use serde::{Deserialize, Deserializer};
 use serde_json::value::RawValue as RawJsonValue;
 
+#[cfg(feature = "unstable-msc4354")]
+use super::Sticky;
 use super::{
     Ephemeral, JoinedRoom, LeftRoom, RoomAccountData, RoomSummary, State, StateEvents, Timeline,
     UnreadNotificationsCount,
@@ -71,6 +73,9 @@ struct JoinedRoomDeHelper {
     account_data: RoomAccountData,
     #[serde(default)]
     ephemeral: Ephemeral,
+    #[cfg(feature = "unstable-msc4354")]
+    #[serde(rename = "msc4354_sticky", default)]
+    sticky: Sticky,
     #[cfg(feature = "unstable-msc2654")]
     #[serde(rename = "org.matrix.msc2654.unread_count")]
     unread_count: Option<UInt>,
@@ -91,6 +96,8 @@ impl<'de> Deserialize<'de> for JoinedRoom {
             timeline,
             account_data,
             ephemeral,
+            #[cfg(feature = "unstable-msc4354")]
+            sticky,
             #[cfg(feature = "unstable-msc2654")]
             unread_count,
         } = from_raw_json_value(&json)?;
@@ -103,6 +110,8 @@ impl<'de> Deserialize<'de> for JoinedRoom {
             state,
             account_data,
             ephemeral,
+            #[cfg(feature = "unstable-msc4354")]
+            sticky,
             #[cfg(feature = "unstable-msc2654")]
             unread_count,
         })

--- a/crates/ruma-client-api/src/sync/sync_events/v5.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v5.rs
@@ -223,6 +223,15 @@ pub mod request {
         #[serde(default, skip_serializing_if = "Profiles::is_empty")]
         pub profiles: Profiles,
 
+        /// Configure the sticky events extension.
+        #[cfg(feature = "unstable-msc4480")]
+        #[serde(
+            default,
+            skip_serializing_if = "StickyEvents::is_empty",
+            rename = "org.matrix.msc4354.sticky_events"
+        )]
+        pub sticky_events: StickyEvents,
+
         /// Extensions may add further fields to the list.
         #[serde(flatten)]
         other: BTreeMap<String, serde_json::Value>,
@@ -246,6 +255,11 @@ pub mod request {
             #[cfg(feature = "unstable-msc4262")]
             {
                 empty = empty && self.profiles.is_empty();
+            }
+
+            #[cfg(feature = "unstable-msc4480")]
+            {
+                empty = empty && self.sticky_events.is_empty();
             }
 
             empty
@@ -307,6 +321,36 @@ pub mod request {
     }
 
     impl ToDevice {
+        /// Whether all fields are empty or `None`.
+        pub fn is_empty(&self) -> bool {
+            self.enabled.is_none() && self.limit.is_none() && self.since.is_none()
+        }
+    }
+
+    /// Sticky events extension configuration.
+    ///
+    /// According to [MSC4480](https://github.com/matrix-org/matrix-spec-proposals/pull/4480).
+    #[cfg(feature = "unstable-msc4480")]
+    #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+    #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+    pub struct StickyEvents {
+        /// Activate or deactivate this extension.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub enabled: Option<bool>,
+
+        /// Maximum number of sticky events to return per response.
+        ///
+        /// Defaults to 100 (server-side) and the server may override it to a lower value.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub limit: Option<UInt>,
+
+        /// Return sticky events since this token only.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub since: Option<String>,
+    }
+
+    #[cfg(feature = "unstable-msc4480")]
+    impl StickyEvents {
         /// Whether all fields are empty or `None`.
         pub fn is_empty(&self) -> bool {
             self.enabled.is_none() && self.limit.is_none() && self.since.is_none()
@@ -750,6 +794,15 @@ pub mod response {
         #[cfg(feature = "unstable-msc4262")]
         #[serde(default, skip_serializing_if = "BTreeMap::is_empty", rename = "users")]
         pub profiles: BTreeMap<OwnedUserId, UserProfileUpdate>,
+
+        /// Sticky events extension response.
+        #[cfg(feature = "unstable-msc4480")]
+        #[serde(
+            default,
+            skip_serializing_if = "StickyEvents::is_empty",
+            rename = "org.matrix.msc4354.sticky_events"
+        )]
+        pub sticky_events: StickyEvents,
     }
 
     impl Extensions {
@@ -773,6 +826,11 @@ pub mod response {
                 empty = empty && self.profiles.is_empty();
             }
 
+            #[cfg(feature = "unstable-msc4480")]
+            {
+                empty = empty && self.sticky_events.is_empty();
+            }
+
             empty
         }
     }
@@ -789,6 +847,42 @@ pub mod response {
         /// The to-device events.
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         pub events: Vec<Raw<AnyToDeviceEvent>>,
+    }
+
+    /// Sticky events extension response.
+    ///
+    /// According to [MSC4480](https://github.com/matrix-org/matrix-spec-proposals/pull/4480).
+    #[cfg(feature = "unstable-msc4480")]
+    #[derive(Clone, Debug, Default, Serialize, Deserialize)]
+    #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+    pub struct StickyEvents {
+        /// The token to supply in the `since` param of the next request.
+        ///
+        /// Set when there are changes.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub next_batch: Option<String>,
+
+        /// The sticky events, grouped by room.
+        #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+        pub rooms: BTreeMap<OwnedRoomId, StickyEventsRoom>,
+    }
+
+    #[cfg(feature = "unstable-msc4480")]
+    impl StickyEvents {
+        /// Whether the extension data is empty.
+        pub fn is_empty(&self) -> bool {
+            self.next_batch.is_none() && self.rooms.is_empty()
+        }
+    }
+
+    /// Sticky events for a single room in the sticky events extension response.
+    #[cfg(feature = "unstable-msc4480")]
+    #[derive(Clone, Debug, Default, Serialize, Deserialize)]
+    #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+    pub struct StickyEventsRoom {
+        /// The sticky events for this room.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        pub events: Vec<Raw<AnySyncTimelineEvent>>,
     }
 
     /// E2EE extension response.
@@ -942,6 +1036,48 @@ mod tests {
             serde_json::from_str::<ExtensionRoomConfig>(r#""!foo:bar.baz""#).unwrap(),
             ExtensionRoomConfig::Room(owned_room_id!("!foo:bar.baz"))
         );
+    }
+
+    #[cfg(feature = "unstable-msc4480")]
+    #[test]
+    fn sticky_events_extension_serde() {
+        use super::{request, response};
+
+        // The request extension serializes under the unstable extension key.
+        let mut extensions = request::Extensions::default();
+        extensions.sticky_events =
+            request::StickyEvents { enabled: Some(true), ..Default::default() };
+        assert_eq!(
+            serde_json::to_value(&extensions).unwrap(),
+            serde_json::json!({ "org.matrix.msc4354.sticky_events": { "enabled": true } })
+        );
+
+        // The response extension and its per-room sticky events deserialize.
+        let response: response::Extensions = serde_json::from_value(serde_json::json!({
+            "org.matrix.msc4354.sticky_events": {
+                "next_batch": "s123",
+                "rooms": {
+                    "!room:example.com": {
+                        "events": [{
+                            "content": { "body": "sticky", "msgtype": "m.text" },
+                            "event_id": "$1:example.com",
+                            "origin_server_ts": 1,
+                            "sender": "@alice:example.com",
+                            "type": "m.room.message",
+                            "msc4354_sticky": {
+                                "duration_ms": 300_000
+                            },
+                        }]
+                    }
+                }
+            }
+        }))
+        .unwrap();
+
+        assert_eq!(response.sticky_events.next_batch.as_deref(), Some("s123"));
+        assert_eq!(response.sticky_events.rooms.len(), 1);
+        let room = response.sticky_events.rooms.values().next().unwrap();
+        assert_eq!(room.events.len(), 1);
     }
 
     #[test]

--- a/crates/ruma-client-api/src/sync/sync_events/v5.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v5.rs
@@ -1041,14 +1041,16 @@ mod tests {
     #[cfg(feature = "unstable-msc4480")]
     #[test]
     fn sticky_events_extension_serde() {
+        use ruma_common::assert_to_canonical_json_eq;
+
         use super::{request, response};
 
         // The request extension serializes under the unstable extension key.
         let mut extensions = request::Extensions::default();
         extensions.sticky_events =
             request::StickyEvents { enabled: Some(true), ..Default::default() };
-        assert_eq!(
-            serde_json::to_value(&extensions).unwrap(),
+        assert_to_canonical_json_eq!(
+            extensions,
             serde_json::json!({ "org.matrix.msc4354.sticky_events": { "enabled": true } })
         );
 

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -208,6 +208,7 @@ unstable-msc4426 = ["ruma-common/unstable-msc4426"]
 unstable-msc4439 = ["ruma-client-api?/unstable-msc4439"]
 unstable-msc4466 = ["ruma-client-api?/unstable-msc4466"]
 unstable-msc4471 = ["ruma-events?/unstable-msc4471"]
+unstable-msc4480 = ["unstable-msc4354", "ruma-client-api?/unstable-msc4480"]
 unstable-uniffi = ["ruma-events?/unstable-uniffi"]
 
 [dependencies]


### PR DESCRIPTION
The sync API changes for sticky event got split in two MSCs:
For legacy sync it is in [MSC4354](https://github.com/matrix-org/matrix-spec-proposals/pull/4354)
and for sliding sync it is in [MSC4480](https://github.com/matrix-org/matrix-spec-proposals/pull/4480)

This PR adds support for that.
Without it, the sticky event map can only be created incrementally by getting events from the timeline sync response.
This change allows to get from the server the list of currently active sticky in the sync.

Follow up of https://github.com/ruma/ruma/pull/2230
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
