### PR TITLE
MSC4262: Update Profiles types for latest revision.

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -24,6 +24,11 @@ Improvements:
   the `unstable-msc4354` feature flag. Adds a `sticky_duration_ms` query parameter to `send_message_event`
   and `send_state_event` as well as sync v3 support. Add sync extension v5 behind the `unstable-msc4480`
   feature flag as per [MSC4480](https://github.com/matrix-org/matrix-spec-proposals/pull/4480).
+- The `Profiles` sliding sync extension request no longer contains an `include_history` field as
+  this was removed from the MSC.
+- The `Profiles` sliding sync extension response data is wrapped in a `users` field instead of
+  being decoded directly. The profile updates now use a `UserProfileUpdate` enum to signal if the
+  profile changed or should be dropped.
 
 ## 0.24.0
 

--- a/crates/ruma-client-api/src/sync/sync_events/v5.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v5.rs
@@ -1017,11 +1017,8 @@ pub mod response {
     #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
     pub struct Profiles {
         /// Profile updates keyed by user ID.
-        ///
-        /// A value of `None` for a particular user is a signal to the client that they may stop
-        /// tracking this user, as they have left all shared rooms.
         #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-        pub users: BTreeMap<OwnedUserId, Option<UserProfileUpdate>>,
+        pub users: BTreeMap<OwnedUserId, UserProfileUpdate>,
     }
 
     #[cfg(feature = "unstable-msc4262")]

--- a/crates/ruma-client-api/src/sync/sync_events/v5.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v5.rs
@@ -220,7 +220,11 @@ pub mod request {
 
         /// Configure the profiles extension.
         #[cfg(feature = "unstable-msc4262")]
-        #[serde(default, skip_serializing_if = "Profiles::is_empty")]
+        #[serde(
+            default,
+            skip_serializing_if = "Profiles::is_empty",
+            rename = "org.matrix.msc4262.profiles"
+        )]
         pub profiles: Profiles,
 
         /// Configure the sticky events extension.
@@ -537,14 +541,6 @@ pub mod request {
         /// profile field updates are included.
         #[serde(skip_serializing_if = "Option::is_none")]
         pub fields: Option<Vec<ruma_common::profile::ProfileFieldName>>,
-
-        /// Optional flag to control whether the initial sync includes recent historical profile
-        /// changes:
-        ///
-        /// If false (default), only current profile states are sent on initial sync.
-        /// If true, the server may include recent profile changes that occurred before the sync.
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub include_history: Option<bool>,
     }
 
     #[cfg(feature = "unstable-msc4262")]
@@ -792,8 +788,12 @@ pub mod response {
 
         /// Profiles extension response.
         #[cfg(feature = "unstable-msc4262")]
-        #[serde(default, skip_serializing_if = "BTreeMap::is_empty", rename = "users")]
-        pub profiles: BTreeMap<OwnedUserId, UserProfileUpdate>,
+        #[serde(
+            default,
+            skip_serializing_if = "Profiles::is_empty",
+            rename = "org.matrix.msc4262.profiles"
+        )]
+        pub profiles: Profiles,
 
         /// Sticky events extension response.
         #[cfg(feature = "unstable-msc4480")]
@@ -1006,6 +1006,29 @@ pub mod response {
         /// Whether all fields are empty or `None`.
         pub fn is_empty(&self) -> bool {
             self.subscribed.is_empty() && self.unsubscribed.is_empty() && self.prev_batch.is_none()
+        }
+    }
+
+    /// Profiles extension response.
+    ///
+    /// Specified as part of [MSC4262](https://github.com/matrix-org/matrix-spec-proposals/pull/4262).
+    #[cfg(feature = "unstable-msc4262")]
+    #[derive(Clone, Debug, Default, Serialize, Deserialize)]
+    #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+    pub struct Profiles {
+        /// Profile updates keyed by user ID.
+        ///
+        /// A value of `None` for a particular user is a signal to the client that they may stop
+        /// tracking this user, as they have left all shared rooms.
+        #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+        pub users: BTreeMap<OwnedUserId, Option<UserProfileUpdate>>,
+    }
+
+    #[cfg(feature = "unstable-msc4262")]
+    impl Profiles {
+        /// Whether all fields are empty or `None`.
+        pub fn is_empty(&self) -> bool {
+            self.users.is_empty()
         }
     }
 }

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -16,6 +16,10 @@ Improvements:
 - Add `MatrixVersion::V1_19`.
 - Add the `zeroize(mut self)` method on identifiers, which will call the
   `zeroize` crate.
+- `UserProfileUpdate` has been replaced with `UserProfileChanges` and a new `UserProfileUpdate`
+  enum has been introduced to either wrap the changes or signal that the stored profile should be
+  dropped.
+- `UserProfile::merge` has been renamed to `UserProfile::apply`.
 
 [MSC4438]: https://github.com/matrix-org/matrix-spec-proposals/pull/4438
 

--- a/crates/ruma-common/src/profile/user_profile.rs
+++ b/crates/ruma-common/src/profile/user_profile.rs
@@ -44,17 +44,16 @@ impl UserProfile {
         self.0.insert(field, value);
     }
 
-    /// Merges a profile that contains updates (such as from a sync response) with this
-    /// profile.
-    ///
-    /// This operation preserves omitted values and removes null values.
+    /// Applies the changes from a [`UserProfileUpdate`] to this profile.
     #[cfg(feature = "unstable-msc4262")]
-    pub fn merge(&mut self, profile_update: UserProfileUpdate) {
-        for (field, value) in profile_update {
-            if value.is_null() {
-                self.0.remove(&field);
-            } else {
-                self.0.insert(field, value);
+    pub fn apply(&mut self, profile_update: UserProfileUpdate) {
+        for (field, value) in profile_update.updated {
+            self.0.insert(field.to_string(), value);
+        }
+
+        if let Some(removed) = profile_update.removed {
+            for field in removed {
+                self.0.remove(field.as_str());
             }
         }
     }
@@ -108,18 +107,18 @@ impl IntoIterator for UserProfile {
 #[cfg(test)]
 #[cfg(all(feature = "unstable-msc4262", feature = "unstable-msc4426"))]
 mod tests {
-    use serde_json::{Value as JsonValue, json};
+    use serde_json::json;
 
     use crate::{
         owned_mxc_uri,
         profile::{
-            AvatarUrl, Call, CallProfileField, DisplayName, ProfileFieldValue, Status,
-            StatusProfileField, UserProfile, UserProfileUpdate,
+            AvatarUrl, Call, CallProfileField, DisplayName, ProfileFieldName, ProfileFieldValue,
+            Status, StatusProfileField, UserProfile, UserProfileUpdate,
         },
     };
 
     #[test]
-    fn merge_profile() {
+    fn apply_profile_update() {
         let mut profile = UserProfile::from_iter([
             ProfileFieldValue::DisplayName("Alice".to_owned()),
             ProfileFieldValue::AvatarUrl(owned_mxc_uri!("mxc://localhost/abcdef")),
@@ -129,13 +128,14 @@ mod tests {
             }),
         ]);
 
-        let profile_update = UserProfileUpdate::from_iter([
-            ("avatar_url".to_owned(), JsonValue::Null),
-            ("org.matrix.msc4426.status".to_owned(), json!({ "text": "Holiday", "emoji": "🏖️"})),
-            ("org.matrix.msc4426.call".to_owned(), json!({})),
-        ]);
+        let mut profile_update = UserProfileUpdate::new();
+        profile_update.removed = Some(vec![ProfileFieldName::AvatarUrl]);
+        profile_update
+            .updated
+            .insert(ProfileFieldName::Status, json!({ "text": "Holiday", "emoji": "🏖️"}));
+        profile_update.updated.insert(ProfileFieldName::Call, json!({}));
 
-        profile.merge(profile_update);
+        profile.apply(profile_update);
 
         assert_eq!(
             profile.get_static::<DisplayName>().unwrap().unwrap(),

--- a/crates/ruma-common/src/profile/user_profile.rs
+++ b/crates/ruma-common/src/profile/user_profile.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
 #[cfg(feature = "unstable-msc4262")]
-use super::UserProfileUpdate;
+use super::UserProfileChanges;
 use super::{ProfileFieldName, ProfileFieldValue, static_profile_field::StaticProfileField};
 
 /// All the profile information for a user.
@@ -44,14 +44,14 @@ impl UserProfile {
         self.0.insert(field, value);
     }
 
-    /// Applies the changes from a [`UserProfileUpdate`] to this profile.
+    /// Applies the changes from a [`UserProfileChanges`] to this profile.
     #[cfg(feature = "unstable-msc4262")]
-    pub fn apply(&mut self, profile_update: UserProfileUpdate) {
-        for (field, value) in profile_update.updated {
+    pub fn apply(&mut self, changes: UserProfileChanges) {
+        for (field, value) in changes.updated {
             self.0.insert(field.to_string(), value);
         }
 
-        if let Some(removed) = profile_update.removed {
+        if let Some(removed) = changes.removed {
             for field in removed {
                 self.0.remove(field.as_str());
             }
@@ -113,7 +113,7 @@ mod tests {
         owned_mxc_uri,
         profile::{
             AvatarUrl, Call, CallProfileField, DisplayName, ProfileFieldName, ProfileFieldValue,
-            Status, StatusProfileField, UserProfile, UserProfileUpdate,
+            Status, StatusProfileField, UserProfile, UserProfileChanges,
         },
     };
 
@@ -128,7 +128,7 @@ mod tests {
             }),
         ]);
 
-        let mut profile_update = UserProfileUpdate::new();
+        let mut profile_update = UserProfileChanges::new();
         profile_update.removed = Some(vec![ProfileFieldName::AvatarUrl]);
         profile_update
             .updated

--- a/crates/ruma-common/src/profile/user_profile.rs
+++ b/crates/ruma-common/src/profile/user_profile.rs
@@ -51,10 +51,8 @@ impl UserProfile {
             self.0.insert(field.to_string(), value);
         }
 
-        if let Some(removed) = changes.removed {
-            for field in removed {
-                self.0.remove(field.as_str());
-            }
+        for field in changes.removed {
+            self.0.remove(field.as_str());
         }
     }
 }
@@ -107,6 +105,8 @@ impl IntoIterator for UserProfile {
 #[cfg(test)]
 #[cfg(all(feature = "unstable-msc4262", feature = "unstable-msc4426"))]
 mod tests {
+    use std::collections::BTreeMap;
+
     use serde_json::json;
 
     use crate::{
@@ -129,11 +129,11 @@ mod tests {
         ]);
 
         let mut profile_update = UserProfileChanges::new();
-        profile_update.removed = Some(vec![ProfileFieldName::AvatarUrl]);
-        profile_update
-            .updated
-            .insert(ProfileFieldName::Status, json!({ "text": "Holiday", "emoji": "🏖️"}));
-        profile_update.updated.insert(ProfileFieldName::Call, json!({}));
+        profile_update.removed = vec![ProfileFieldName::AvatarUrl];
+        profile_update.updated = BTreeMap::from([
+            (ProfileFieldName::Status, json!({ "text": "Holiday", "emoji": "🏖️"})),
+            (ProfileFieldName::Call, json!({})),
+        ]);
 
         profile.apply(profile_update);
 

--- a/crates/ruma-common/src/profile/user_profile_update.rs
+++ b/crates/ruma-common/src/profile/user_profile_update.rs
@@ -55,8 +55,8 @@ pub struct UserProfileChanges {
     pub updated: BTreeMap<ProfileFieldName, JsonValue>,
 
     /// Fields that have been removed from the profile.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub removed: Option<Vec<ProfileFieldName>>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub removed: Vec<ProfileFieldName>,
 }
 
 impl UserProfileChanges {

--- a/crates/ruma-common/src/profile/user_profile_update.rs
+++ b/crates/ruma-common/src/profile/user_profile_update.rs
@@ -2,18 +2,54 @@
 
 use std::collections::BTreeMap;
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value as JsonValue;
 
 use super::{ProfileFieldName, ProfileFieldValue, StaticProfileField};
 
-/// An update to the profile information for a user.
+/// An update to a user's profile.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub enum UserProfileUpdate {
+    /// The user's profile has been updated with the included changes.
+    Updated(UserProfileChanges),
+
+    /// This user no longer needs to be tracked as they have left all shared rooms.
+    Dropped,
+}
+
+impl<'d> Deserialize<'d> for UserProfileUpdate {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'d>,
+    {
+        Option::<UserProfileChanges>::deserialize(deserializer).map(|value| match value {
+            Some(changes) => Self::Updated(changes),
+            None => Self::Dropped,
+        })
+    }
+}
+
+impl Serialize for UserProfileUpdate {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::Updated(changes) => serializer.serialize_some(changes),
+            Self::Dropped => serializer.serialize_none(),
+        }
+    }
+}
+
+/// A collection of changes to be applied to a user's profile.
 ///
-/// This type is not supposed to be used directly, but merged into a
-/// [`UserProfile`](super::UserProfile).
+/// This type is not supposed to be used directly, but applied to an existing
+/// [`UserProfile`](super::UserProfile). If a profile doesn't exist, the changes should be applied
+/// to an empty one.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[non_exhaustive]
-pub struct UserProfileUpdate {
+pub struct UserProfileChanges {
     /// Fields that have been newly set, or updated.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub updated: BTreeMap<ProfileFieldName, JsonValue>,
@@ -23,7 +59,7 @@ pub struct UserProfileUpdate {
     pub removed: Option<Vec<ProfileFieldName>>,
 }
 
-impl UserProfileUpdate {
+impl UserProfileChanges {
     /// Creates a new empty `UserProfileUpdate`.
     pub fn new() -> Self {
         Self::default()

--- a/crates/ruma-common/src/profile/user_profile_update.rs
+++ b/crates/ruma-common/src/profile/user_profile_update.rs
@@ -1,19 +1,27 @@
 //! An update to the profile information for a user.
 
-use std::collections::{BTreeMap, btree_map};
+use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
-use super::{ProfileFieldName, ProfileFieldValue, static_profile_field::StaticProfileField};
+use super::{ProfileFieldName, ProfileFieldValue, StaticProfileField};
 
 /// An update to the profile information for a user.
 ///
 /// This type is not supposed to be used directly, but merged into a
 /// [`UserProfile`](super::UserProfile).
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
-#[serde(transparent)]
-pub struct UserProfileUpdate(BTreeMap<String, JsonValue>);
+#[non_exhaustive]
+pub struct UserProfileUpdate {
+    /// Fields that have been newly set, or updated.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub updated: BTreeMap<ProfileFieldName, JsonValue>,
+
+    /// Fields that have been removed from the profile.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub removed: Option<Vec<ProfileFieldName>>,
+}
 
 impl UserProfileUpdate {
     /// Creates a new empty `UserProfileUpdate`.
@@ -21,72 +29,22 @@ impl UserProfileUpdate {
         Self::default()
     }
 
-    /// Returns the value of the given profile field.
-    pub fn get(&self, field: &str) -> Option<&JsonValue> {
-        self.0.get(field)
-    }
-
-    /// Returns the value of the given [`StaticProfileField`].
+    /// Returns the updated value of the given [`StaticProfileField`].
     ///
-    /// Returns `Ok(Some(_))` if the field is present and the value was deserialized
-    /// successfully, `Ok(None)` if the field is not set, or an error if deserialization of the
-    /// value failed.
-    pub fn get_static<F: StaticProfileField>(&self) -> Result<Option<F::Value>, serde_json::Error> {
-        self.0.get(F::NAME).map(|value| serde_json::from_value(value.clone())).transpose()
+    /// Returns `Ok(Some(_))` if an update to the field is included and the value was deserialized
+    /// successfully, `Ok(None)` if the field update is not included, or an error if deserialization
+    /// of the value failed.
+    pub fn get_updated_static<F: StaticProfileField>(
+        &self,
+    ) -> Result<Option<F::Value>, serde_json::Error> {
+        self.updated
+            .get(&ProfileFieldName::from(F::NAME))
+            .map(|value| serde_json::from_value(value.clone()))
+            .transpose()
     }
 
-    /// Gets an iterator over the fields of the profile.
-    pub fn iter(&self) -> btree_map::Iter<'_, String, JsonValue> {
-        self.0.iter()
-    }
-
-    /// Sets a field to the given value.
-    pub fn set(&mut self, field: String, value: JsonValue) {
-        self.0.insert(field, value);
-    }
-}
-
-impl FromIterator<(String, JsonValue)> for UserProfileUpdate {
-    fn from_iter<T: IntoIterator<Item = (String, JsonValue)>>(iter: T) -> Self {
-        Self(iter.into_iter().collect())
-    }
-}
-
-impl FromIterator<(ProfileFieldName, JsonValue)> for UserProfileUpdate {
-    fn from_iter<T: IntoIterator<Item = (ProfileFieldName, JsonValue)>>(iter: T) -> Self {
-        iter.into_iter().map(|(field, value)| (field.as_str().to_owned(), value)).collect()
-    }
-}
-
-impl FromIterator<ProfileFieldValue> for UserProfileUpdate {
-    fn from_iter<T: IntoIterator<Item = ProfileFieldValue>>(iter: T) -> Self {
-        iter.into_iter().map(|value| (value.field_name(), value.value().into_owned())).collect()
-    }
-}
-
-impl Extend<(String, JsonValue)> for UserProfileUpdate {
-    fn extend<T: IntoIterator<Item = (String, JsonValue)>>(&mut self, iter: T) {
-        self.0.extend(iter);
-    }
-}
-
-impl Extend<(ProfileFieldName, JsonValue)> for UserProfileUpdate {
-    fn extend<T: IntoIterator<Item = (ProfileFieldName, JsonValue)>>(&mut self, iter: T) {
-        self.extend(iter.into_iter().map(|(field, value)| (field.as_str().to_owned(), value)));
-    }
-}
-
-impl Extend<ProfileFieldValue> for UserProfileUpdate {
-    fn extend<T: IntoIterator<Item = ProfileFieldValue>>(&mut self, iter: T) {
-        self.extend(iter.into_iter().map(|value| (value.field_name(), value.value().into_owned())));
-    }
-}
-
-impl IntoIterator for UserProfileUpdate {
-    type Item = (String, JsonValue);
-    type IntoIter = btree_map::IntoIter<String, JsonValue>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
+    /// Inserts an update for the supplied profile field value.
+    pub fn insert_updated_value(&mut self, value: ProfileFieldValue) {
+        self.updated.insert(value.field_name(), value.value().into_owned());
     }
 }


### PR DESCRIPTION
This PR updates the types used by MSC4262 so that Ruma is compliant with [the latest revision](https://github.com/matrix-org/matrix-spec-proposals/pull/4262/commits/45ca5e0f89c5dbe62ea7e779f0829c5aa76a9eb5). It also simplifies the `UserProfileUpdate` type as I don't think much of the copy & paste from `UserProfile` is useful any more.

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- [x] Documented public API changes in CHANGELOG.md files (will do this once happy with the changes)
