### PR TITLE
Update spec links to point to the latest version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -202,7 +202,7 @@ Then, in the subsequent version module, embed the version and specification link
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3sync
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3sync
 }
 ```
 

--- a/crates/ruma-appservice-api/src/event/push_events.rs
+++ b/crates/ruma-appservice-api/src/event/push_events.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/application-service-api/#put_matrixappv1transactionstxnid
+    //! [spec]: https://spec.matrix.org/v1.19/application-service-api/#put_matrixappv1transactionstxnid
 
     use std::borrow::Cow;
     #[cfg(feature = "unstable-msc3202")]

--- a/crates/ruma-appservice-api/src/lib.rs
+++ b/crates/ruma-appservice-api/src/lib.rs
@@ -3,7 +3,7 @@
 //! (De)serializable types for the [Matrix Application Service API][appservice-api].
 //! These types can be shared by application service and server code.
 //!
-//! [appservice-api]: https://spec.matrix.org/v1.18/application-service-api/
+//! [appservice-api]: https://spec.matrix.org/v1.19/application-service-api/
 
 #![warn(missing_docs)]
 
@@ -16,7 +16,7 @@ pub mod thirdparty;
 
 /// A namespace defined by an application service.
 ///
-/// Used for [appservice registration](https://spec.matrix.org/v1.18/application-service-api/#registration).
+/// Used for [appservice registration](https://spec.matrix.org/v1.19/application-service-api/#registration).
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct Namespace {
@@ -36,7 +36,7 @@ impl Namespace {
 
 /// Namespaces defined by an application service.
 ///
-/// Used for [appservice registration](https://spec.matrix.org/v1.18/application-service-api/#registration).
+/// Used for [appservice registration](https://spec.matrix.org/v1.19/application-service-api/#registration).
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct Namespaces {
@@ -66,7 +66,7 @@ impl Namespaces {
 /// To create an instance of this type, first create a `RegistrationInit` and convert it via
 /// `Registration::from` / `.into()`.
 ///
-/// Used for [appservice registration](https://spec.matrix.org/v1.18/application-service-api/#registration).
+/// Used for [appservice registration](https://spec.matrix.org/v1.19/application-service-api/#registration).
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct Registration {
@@ -113,7 +113,7 @@ pub struct Registration {
 /// This struct will not be updated even if additional fields are added to `Registration` in a new
 /// (non-breaking) release of the Matrix specification.
 ///
-/// Used for [appservice registration](https://spec.matrix.org/v1.18/application-service-api/#registration).
+/// Used for [appservice registration](https://spec.matrix.org/v1.19/application-service-api/#registration).
 #[derive(Debug)]
 #[allow(clippy::exhaustive_structs)]
 pub struct RegistrationInit {

--- a/crates/ruma-appservice-api/src/ping/send_ping.rs
+++ b/crates/ruma-appservice-api/src/ping/send_ping.rs
@@ -53,7 +53,7 @@ pub mod unstable {
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/application-service-api/#post_matrixappv1ping
+    //! [spec]: https://spec.matrix.org/v1.19/application-service-api/#post_matrixappv1ping
 
     use ruma_common::{
         OwnedTransactionId,

--- a/crates/ruma-appservice-api/src/query/query_room_alias.rs
+++ b/crates/ruma-appservice-api/src/query/query_room_alias.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/application-service-api/#get_matrixappv1roomsroomalias
+    //! [spec]: https://spec.matrix.org/v1.19/application-service-api/#get_matrixappv1roomsroomalias
 
     use ruma_common::{
         OwnedRoomAliasId,

--- a/crates/ruma-appservice-api/src/query/query_user_id.rs
+++ b/crates/ruma-appservice-api/src/query/query_user_id.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/application-service-api/#get_matrixappv1usersuserid
+    //! [spec]: https://spec.matrix.org/v1.19/application-service-api/#get_matrixappv1usersuserid
 
     use ruma_common::{
         OwnedUserId,

--- a/crates/ruma-appservice-api/src/thirdparty/get_location_for_protocol.rs
+++ b/crates/ruma-appservice-api/src/thirdparty/get_location_for_protocol.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/application-service-api/#get_matrixappv1thirdpartylocationprotocol
+    //! [spec]: https://spec.matrix.org/v1.19/application-service-api/#get_matrixappv1thirdpartylocationprotocol
 
     use std::collections::BTreeMap;
 

--- a/crates/ruma-appservice-api/src/thirdparty/get_location_for_room_alias.rs
+++ b/crates/ruma-appservice-api/src/thirdparty/get_location_for_room_alias.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/application-service-api/#get_matrixappv1thirdpartylocation
+    //! [spec]: https://spec.matrix.org/v1.19/application-service-api/#get_matrixappv1thirdpartylocation
 
     use ruma_common::{
         OwnedRoomAliasId,

--- a/crates/ruma-appservice-api/src/thirdparty/get_protocol.rs
+++ b/crates/ruma-appservice-api/src/thirdparty/get_protocol.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/application-service-api/#get_matrixappv1thirdpartyprotocolprotocol
+    //! [spec]: https://spec.matrix.org/v1.19/application-service-api/#get_matrixappv1thirdpartyprotocolprotocol
 
     use std::collections::BTreeMap;
 

--- a/crates/ruma-appservice-api/src/thirdparty/get_user_for_protocol.rs
+++ b/crates/ruma-appservice-api/src/thirdparty/get_user_for_protocol.rs
@@ -6,7 +6,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/application-service-api/#get_matrixappv1thirdpartyuserprotocol
+    //! [spec]: https://spec.matrix.org/v1.19/application-service-api/#get_matrixappv1thirdpartyuserprotocol
 
     use std::collections::BTreeMap;
 

--- a/crates/ruma-appservice-api/src/thirdparty/get_user_for_user_id.rs
+++ b/crates/ruma-appservice-api/src/thirdparty/get_user_for_user_id.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/application-service-api/#get_matrixappv1thirdpartyuser
+    //! [spec]: https://spec.matrix.org/v1.19/application-service-api/#get_matrixappv1thirdpartyuser
 
     use ruma_common::{
         OwnedUserId,

--- a/crates/ruma-client-api/src/account/add_3pid.rs
+++ b/crates/ruma-client-api/src/account/add_3pid.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3account3pidadd
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3account3pidadd
 
     use ruma_common::{
         OwnedClientSecret, OwnedSessionId,

--- a/crates/ruma-client-api/src/account/bind_3pid.rs
+++ b/crates/ruma-client-api/src/account/bind_3pid.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3account3pidbind
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3account3pidbind
 
     use ruma_common::{
         OwnedClientSecret, OwnedSessionId,

--- a/crates/ruma-client-api/src/account/change_password.rs
+++ b/crates/ruma-client-api/src/account/change_password.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3accountpassword
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3accountpassword
 
     use ruma_common::{
         api::{auth_scheme::AccessTokenOptional, request, response},

--- a/crates/ruma-client-api/src/account/check_registration_token_validity.rs
+++ b/crates/ruma-client-api/src/account/check_registration_token_validity.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv1registermloginregistration_tokenvalidity
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv1registermloginregistration_tokenvalidity
 
     use ruma_common::{
         api::{auth_scheme::NoAccessToken, request, response},

--- a/crates/ruma-client-api/src/account/deactivate.rs
+++ b/crates/ruma-client-api/src/account/deactivate.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3accountdeactivate
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3accountdeactivate
 
     use ruma_common::{
         api::{auth_scheme::AccessTokenOptional, request, response},

--- a/crates/ruma-client-api/src/account/delete_3pid.rs
+++ b/crates/ruma-client-api/src/account/delete_3pid.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3account3piddelete
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3account3piddelete
 
     use ruma_common::{
         api::{auth_scheme::AccessToken, request, response},

--- a/crates/ruma-client-api/src/account/get_3pids.rs
+++ b/crates/ruma-client-api/src/account/get_3pids.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3account3pid
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3account3pid
 
     use ruma_common::{
         api::{auth_scheme::AccessToken, request, response},

--- a/crates/ruma-client-api/src/account/get_username_availability.rs
+++ b/crates/ruma-client-api/src/account/get_username_availability.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3registeravailable
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3registeravailable
 
     use ruma_common::{
         api::{auth_scheme::NoAccessToken, request, response},

--- a/crates/ruma-client-api/src/account/register.rs
+++ b/crates/ruma-client-api/src/account/register.rs
@@ -9,7 +9,7 @@ use crate::PrivOwnedStr;
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3register
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3register
 
     use std::time::Duration;
 
@@ -88,13 +88,13 @@ pub mod v3 {
         /// Appservices can [bypass the registration flows][admin] entirely by providing their
         /// token in the header and setting this login `type` to `m.login.application_service`.
         ///
-        /// [admin]: https://spec.matrix.org/v1.18/application-service-api/#server-admin-style-permissions
+        /// [admin]: https://spec.matrix.org/v1.19/application-service-api/#server-admin-style-permissions
         #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
         pub login_type: Option<LoginType>,
 
         /// If set to `true`, the client supports [refresh tokens].
         ///
-        /// [refresh tokens]: https://spec.matrix.org/v1.18/client-server-api/#refreshing-access-tokens
+        /// [refresh tokens]: https://spec.matrix.org/v1.19/client-server-api/#refreshing-access-tokens
         #[serde(default, skip_serializing_if = "ruma_common::serde::is_default")]
         pub refresh_token: bool,
 
@@ -102,7 +102,7 @@ pub mod v3 {
         ///
         /// If this is set, the `username` field is also required.
         ///
-        /// [guest user]: https://spec.matrix.org/v1.18/client-server-api/#guest-access
+        /// [guest user]: https://spec.matrix.org/v1.19/client-server-api/#guest-access
         #[serde(skip_serializing_if = "Option::is_none")]
         pub guest_access_token: Option<String>,
     }
@@ -135,7 +135,7 @@ pub mod v3 {
         ///
         /// Omitted if the request's `inhibit_login` was set to `true`.
         ///
-        /// [refresh token]: https://spec.matrix.org/v1.18/client-server-api/#refreshing-access-tokens
+        /// [refresh token]: https://spec.matrix.org/v1.19/client-server-api/#refreshing-access-tokens
         /// [`refresh_token`]: crate::session::refresh_token
         #[serde(skip_serializing_if = "Option::is_none")]
         pub refresh_token: Option<String>,

--- a/crates/ruma-client-api/src/account/request_3pid_management_token_via_email.rs
+++ b/crates/ruma-client-api/src/account/request_3pid_management_token_via_email.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3account3pidemailrequesttoken
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3account3pidemailrequesttoken
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-client-api/src/account/request_3pid_management_token_via_msisdn.rs
+++ b/crates/ruma-client-api/src/account/request_3pid_management_token_via_msisdn.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3account3pidmsisdnrequesttoken
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3account3pidmsisdnrequesttoken
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-client-api/src/account/request_openid_token.rs
+++ b/crates/ruma-client-api/src/account/request_openid_token.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3useruseridopenidrequest_token
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3useruseridopenidrequest_token
 
     use std::time::Duration;
 

--- a/crates/ruma-client-api/src/account/request_password_change_token_via_email.rs
+++ b/crates/ruma-client-api/src/account/request_password_change_token_via_email.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3accountpasswordemailrequesttoken
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3accountpasswordemailrequesttoken
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-client-api/src/account/request_password_change_token_via_msisdn.rs
+++ b/crates/ruma-client-api/src/account/request_password_change_token_via_msisdn.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3accountpasswordmsisdnrequesttoken
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3accountpasswordmsisdnrequesttoken
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-client-api/src/account/request_registration_token_via_email.rs
+++ b/crates/ruma-client-api/src/account/request_registration_token_via_email.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3registeremailrequesttoken
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3registeremailrequesttoken
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-client-api/src/account/request_registration_token_via_msisdn.rs
+++ b/crates/ruma-client-api/src/account/request_registration_token_via_msisdn.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3registermsisdnrequesttoken
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3registermsisdnrequesttoken
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-client-api/src/account/unbind_3pid.rs
+++ b/crates/ruma-client-api/src/account/unbind_3pid.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3account3pidunbind
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3account3pidunbind
 
     use ruma_common::{
         api::{auth_scheme::AccessToken, request, response},

--- a/crates/ruma-client-api/src/account/whoami.rs
+++ b/crates/ruma-client-api/src/account/whoami.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3accountwhoami
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3accountwhoami
 
     use ruma_common::{
         OwnedDeviceId, OwnedUserId,

--- a/crates/ruma-client-api/src/admin/get_user_info.rs
+++ b/crates/ruma-client-api/src/admin/get_user_info.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3adminwhoisuserid
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3adminwhoisuserid
 
     use std::collections::BTreeMap;
 

--- a/crates/ruma-client-api/src/admin/is_user_locked.rs
+++ b/crates/ruma-client-api/src/admin/is_user_locked.rs
@@ -10,7 +10,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv1adminlockuserid
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv1adminlockuserid
 
     use ruma_common::{
         OwnedUserId,

--- a/crates/ruma-client-api/src/admin/is_user_suspended.rs
+++ b/crates/ruma-client-api/src/admin/is_user_suspended.rs
@@ -10,7 +10,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv1adminsuspenduserid
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv1adminsuspenduserid
 
     use ruma_common::{
         OwnedUserId,

--- a/crates/ruma-client-api/src/admin/lock_user.rs
+++ b/crates/ruma-client-api/src/admin/lock_user.rs
@@ -11,7 +11,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#put_matrixclientv1adminlockuserid
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#put_matrixclientv1adminlockuserid
 
     use ruma_common::{
         OwnedUserId,

--- a/crates/ruma-client-api/src/admin/suspend_user.rs
+++ b/crates/ruma-client-api/src/admin/suspend_user.rs
@@ -11,7 +11,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#put_matrixclientv1adminsuspenduserid
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#put_matrixclientv1adminsuspenduserid
 
     use ruma_common::{
         OwnedUserId,

--- a/crates/ruma-client-api/src/alias/create_alias.rs
+++ b/crates/ruma-client-api/src/alias/create_alias.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#put_matrixclientv3directoryroomroomalias
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#put_matrixclientv3directoryroomroomalias
 
     use ruma_common::{
         OwnedRoomAliasId, OwnedRoomId,

--- a/crates/ruma-client-api/src/alias/delete_alias.rs
+++ b/crates/ruma-client-api/src/alias/delete_alias.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#delete_matrixclientv3directoryroomroomalias
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#delete_matrixclientv3directoryroomroomalias
 
     use ruma_common::{
         OwnedRoomAliasId,

--- a/crates/ruma-client-api/src/alias/get_alias.rs
+++ b/crates/ruma-client-api/src/alias/get_alias.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3directoryroomroomalias
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3directoryroomroomalias
 
     use ruma_common::{
         OwnedRoomAliasId, OwnedRoomId, OwnedServerName,

--- a/crates/ruma-client-api/src/appservice/request_ping.rs
+++ b/crates/ruma-client-api/src/appservice/request_ping.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/application-service-api/#post_matrixclientv1appserviceappserviceidping
+    //! [spec]: https://spec.matrix.org/v1.19/application-service-api/#post_matrixclientv1appserviceappserviceidping
 
     use std::time::Duration;
 

--- a/crates/ruma-client-api/src/appservice/set_room_visibility.rs
+++ b/crates/ruma-client-api/src/appservice/set_room_visibility.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/application-service-api/#put_matrixclientv3directorylistappservicenetworkidroomid
+    //! [spec]: https://spec.matrix.org/v1.19/application-service-api/#put_matrixclientv3directorylistappservicenetworkidroomid
 
     use ruma_common::{
         OwnedRoomId,

--- a/crates/ruma-client-api/src/authenticated_media.rs
+++ b/crates/ruma-client-api/src/authenticated_media.rs
@@ -1,6 +1,6 @@
 //! Authenticated endpoints for the [content repository].
 //!
-//! [content repository]: https://spec.matrix.org/v1.18/client-server-api/#content-repository
+//! [content repository]: https://spec.matrix.org/v1.19/client-server-api/#content-repository
 
 pub mod get_content;
 pub mod get_content_as_filename;

--- a/crates/ruma-client-api/src/authenticated_media/get_content.rs
+++ b/crates/ruma-client-api/src/authenticated_media/get_content.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv1mediadownloadservernamemediaid
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv1mediadownloadservernamemediaid
 
     use std::time::Duration;
 

--- a/crates/ruma-client-api/src/authenticated_media/get_content_as_filename.rs
+++ b/crates/ruma-client-api/src/authenticated_media/get_content_as_filename.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv1mediadownloadservernamemediaidfilename
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv1mediadownloadservernamemediaidfilename
 
     use std::time::Duration;
 

--- a/crates/ruma-client-api/src/authenticated_media/get_content_thumbnail.rs
+++ b/crates/ruma-client-api/src/authenticated_media/get_content_thumbnail.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv1mediathumbnailservernamemediaid
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv1mediathumbnailservernamemediaid
 
     use std::time::Duration;
 

--- a/crates/ruma-client-api/src/authenticated_media/get_media_config.rs
+++ b/crates/ruma-client-api/src/authenticated_media/get_media_config.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv1mediaconfig
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv1mediaconfig
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-client-api/src/authenticated_media/get_media_preview.rs
+++ b/crates/ruma-client-api/src/authenticated_media/get_media_preview.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv1mediapreview_url
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv1mediapreview_url
 
     use ruma_common::{
         MilliSecondsSinceUnixEpoch,

--- a/crates/ruma-client-api/src/backup/add_backup_keys.rs
+++ b/crates/ruma-client-api/src/backup/add_backup_keys.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#put_matrixclientv3room_keyskeys
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#put_matrixclientv3room_keyskeys
 
     use std::collections::BTreeMap;
 

--- a/crates/ruma-client-api/src/backup/add_backup_keys_for_room.rs
+++ b/crates/ruma-client-api/src/backup/add_backup_keys_for_room.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#put_matrixclientv3room_keyskeysroomid
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#put_matrixclientv3room_keyskeysroomid
 
     use std::collections::BTreeMap;
 

--- a/crates/ruma-client-api/src/backup/add_backup_keys_for_session.rs
+++ b/crates/ruma-client-api/src/backup/add_backup_keys_for_session.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#put_matrixclientv3room_keyskeysroomidsessionid
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#put_matrixclientv3room_keyskeysroomidsessionid
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-client-api/src/backup/create_backup_version.rs
+++ b/crates/ruma-client-api/src/backup/create_backup_version.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3room_keysversion
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3room_keysversion
 
     use ruma_common::{
         api::{auth_scheme::AccessToken, request, response},

--- a/crates/ruma-client-api/src/backup/delete_backup_keys.rs
+++ b/crates/ruma-client-api/src/backup/delete_backup_keys.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#delete_matrixclientv3room_keyskeys
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#delete_matrixclientv3room_keyskeys
     //!
     //! This deletes keys from a backup version, but not the version itself.
 

--- a/crates/ruma-client-api/src/backup/delete_backup_keys_for_room.rs
+++ b/crates/ruma-client-api/src/backup/delete_backup_keys_for_room.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#delete_matrixclientv3room_keyskeysroomid
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#delete_matrixclientv3room_keyskeysroomid
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-client-api/src/backup/delete_backup_keys_for_session.rs
+++ b/crates/ruma-client-api/src/backup/delete_backup_keys_for_session.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#delete_matrixclientv3room_keyskeysroomidsessionid
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#delete_matrixclientv3room_keyskeysroomidsessionid
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-client-api/src/backup/delete_backup_version.rs
+++ b/crates/ruma-client-api/src/backup/delete_backup_version.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#delete_matrixclientv3room_keysversionversion
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#delete_matrixclientv3room_keysversionversion
     //!
     //! This deletes a backup version and its room keys.
 

--- a/crates/ruma-client-api/src/backup/get_backup_info.rs
+++ b/crates/ruma-client-api/src/backup/get_backup_info.rs
@@ -6,7 +6,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3room_keysversionversion
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3room_keysversionversion
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-client-api/src/backup/get_backup_keys.rs
+++ b/crates/ruma-client-api/src/backup/get_backup_keys.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3room_keyskeys
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3room_keyskeys
 
     use std::collections::BTreeMap;
 

--- a/crates/ruma-client-api/src/backup/get_backup_keys_for_room.rs
+++ b/crates/ruma-client-api/src/backup/get_backup_keys_for_room.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3room_keyskeysroomid
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3room_keyskeysroomid
 
     use std::collections::BTreeMap;
 

--- a/crates/ruma-client-api/src/backup/get_backup_keys_for_session.rs
+++ b/crates/ruma-client-api/src/backup/get_backup_keys_for_session.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3room_keyskeysroomidsessionid
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3room_keyskeysroomidsessionid
 
     use ruma_common::{
         OwnedRoomId,

--- a/crates/ruma-client-api/src/backup/get_latest_backup_info.rs
+++ b/crates/ruma-client-api/src/backup/get_latest_backup_info.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3room_keysversion
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3room_keysversion
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-client-api/src/backup/update_backup_version.rs
+++ b/crates/ruma-client-api/src/backup/update_backup_version.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#put_matrixclientv3room_keysversionversion
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#put_matrixclientv3room_keysversionversion
 
     use ruma_common::{
         api::{auth_scheme::AccessToken, request, response},

--- a/crates/ruma-client-api/src/config/get_global_account_data.rs
+++ b/crates/ruma-client-api/src/config/get_global_account_data.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3useruseridaccount_datatype
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3useruseridaccount_datatype
 
     use ruma_common::{
         OwnedUserId,

--- a/crates/ruma-client-api/src/config/get_room_account_data.rs
+++ b/crates/ruma-client-api/src/config/get_room_account_data.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3useruseridroomsroomidaccount_datatype
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3useruseridroomsroomidaccount_datatype
 
     use ruma_common::{
         OwnedRoomId, OwnedUserId,

--- a/crates/ruma-client-api/src/config/set_global_account_data.rs
+++ b/crates/ruma-client-api/src/config/set_global_account_data.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#put_matrixclientv3useruseridaccount_datatype
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#put_matrixclientv3useruseridaccount_datatype
 
     use ruma_common::{
         OwnedUserId,

--- a/crates/ruma-client-api/src/config/set_room_account_data.rs
+++ b/crates/ruma-client-api/src/config/set_room_account_data.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#put_matrixclientv3useruseridroomsroomidaccount_datatype
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#put_matrixclientv3useruseridroomsroomidaccount_datatype
 
     use ruma_common::{
         OwnedRoomId, OwnedUserId,

--- a/crates/ruma-client-api/src/context/get_context.rs
+++ b/crates/ruma-client-api/src/context/get_context.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3roomsroomidcontexteventid
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3roomsroomidcontexteventid
 
     use js_int::{UInt, uint};
     use ruma_common::{

--- a/crates/ruma-client-api/src/delayed_events/delayed_message_event.rs
+++ b/crates/ruma-client-api/src/delayed_events/delayed_message_event.rs
@@ -53,7 +53,7 @@ pub mod unstable {
         ///
         /// It will be used by the server to ensure idempotency of requests.
         ///
-        /// [access token is refreshed]: https://spec.matrix.org/v1.18/client-server-api/#refreshing-access-tokens
+        /// [access token is refreshed]: https://spec.matrix.org/v1.19/client-server-api/#refreshing-access-tokens
         #[ruma_api(path)]
         pub txn_id: OwnedTransactionId,
 

--- a/crates/ruma-client-api/src/delayed_events/send_delayed_event.rs
+++ b/crates/ruma-client-api/src/delayed_events/send_delayed_event.rs
@@ -45,7 +45,7 @@ pub mod unstable {
         ///
         /// It will be used by the server to ensure idempotency of requests.
         ///
-        /// [access token is refreshed]: https://spec.matrix.org/v1.18/client-server-api/#refreshing-access-tokens
+        /// [access token is refreshed]: https://spec.matrix.org/v1.19/client-server-api/#refreshing-access-tokens
         #[ruma_api(path)]
         pub txn_id: OwnedTransactionId,
 

--- a/crates/ruma-client-api/src/device/delete_device.rs
+++ b/crates/ruma-client-api/src/device/delete_device.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#delete_matrixclientv3devicesdeviceid
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#delete_matrixclientv3devicesdeviceid
 
     use ruma_common::{
         OwnedDeviceId,

--- a/crates/ruma-client-api/src/device/delete_devices.rs
+++ b/crates/ruma-client-api/src/device/delete_devices.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3delete_devices
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3delete_devices
 
     use ruma_common::{
         OwnedDeviceId,

--- a/crates/ruma-client-api/src/device/get_device.rs
+++ b/crates/ruma-client-api/src/device/get_device.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3devicesdeviceid
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3devicesdeviceid
 
     use ruma_common::{
         OwnedDeviceId,

--- a/crates/ruma-client-api/src/device/get_devices.rs
+++ b/crates/ruma-client-api/src/device/get_devices.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3devices
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3devices
 
     use ruma_common::{
         api::{auth_scheme::AccessToken, request, response},

--- a/crates/ruma-client-api/src/device/update_device.rs
+++ b/crates/ruma-client-api/src/device/update_device.rs
@@ -7,7 +7,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#put_matrixclientv3devicesdeviceid
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#put_matrixclientv3devicesdeviceid
 
     use ruma_common::{
         OwnedDeviceId,

--- a/crates/ruma-client-api/src/directory/get_public_rooms.rs
+++ b/crates/ruma-client-api/src/directory/get_public_rooms.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3publicrooms
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3publicrooms
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-client-api/src/directory/get_public_rooms_filtered.rs
+++ b/crates/ruma-client-api/src/directory/get_public_rooms_filtered.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3publicrooms
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3publicrooms
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-client-api/src/directory/get_room_visibility.rs
+++ b/crates/ruma-client-api/src/directory/get_room_visibility.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3directorylistroomroomid
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3directorylistroomroomid
 
     use ruma_common::{
         OwnedRoomId,

--- a/crates/ruma-client-api/src/directory/set_room_visibility.rs
+++ b/crates/ruma-client-api/src/directory/set_room_visibility.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#put_matrixclientv3directorylistroomroomid
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#put_matrixclientv3directorylistroomroomid
 
     use ruma_common::{
         OwnedRoomId,

--- a/crates/ruma-client-api/src/discovery/discover_homeserver.rs
+++ b/crates/ruma-client-api/src/discovery/discover_homeserver.rs
@@ -1,6 +1,6 @@
 //! `GET /.well-known/matrix/client` ([spec])
 //!
-//! [spec]: https://spec.matrix.org/v1.18/client-server-api/#getwell-knownmatrixclient
+//! [spec]: https://spec.matrix.org/v1.19/client-server-api/#getwell-knownmatrixclient
 //!
 //! Get discovery information about the domain.
 

--- a/crates/ruma-client-api/src/discovery/discover_policy_server.rs
+++ b/crates/ruma-client-api/src/discovery/discover_policy_server.rs
@@ -5,8 +5,8 @@
 //! Note that this endpoint is not necessarily handled by the homeserver or Policy Server. It may be
 //! served by another webserver.
 //!
-//! [spec]: https://spec.matrix.org/v1.18/client-server-api/#getwell-knownmatrixpolicy_server
-//! [Policy Server]: https://spec.matrix.org/v1.18/client-server-api/#policy-servers
+//! [spec]: https://spec.matrix.org/v1.19/client-server-api/#getwell-knownmatrixpolicy_server
+//! [Policy Server]: https://spec.matrix.org/v1.19/client-server-api/#policy-servers
 
 use std::collections::BTreeMap;
 

--- a/crates/ruma-client-api/src/discovery/discover_support.rs
+++ b/crates/ruma-client-api/src/discovery/discover_support.rs
@@ -1,6 +1,6 @@
 //! `GET /.well-known/matrix/support` ([spec])
 //!
-//! [spec]: https://spec.matrix.org/v1.18/client-server-api/#getwell-knownmatrixsupport
+//! [spec]: https://spec.matrix.org/v1.19/client-server-api/#getwell-knownmatrixsupport
 //!
 //! Get server admin contact and support page of a homeserver's domain.
 

--- a/crates/ruma-client-api/src/discovery/get_authorization_server_metadata.rs
+++ b/crates/ruma-client-api/src/discovery/get_authorization_server_metadata.rs
@@ -7,7 +7,7 @@ mod serde;
 pub mod v1 {
     //! `v1` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv1auth_metadata
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv1auth_metadata
 
     use std::collections::BTreeSet;
 
@@ -147,13 +147,13 @@ pub mod v1 {
         /// URL where the user is able to access the account management capabilities of the
         /// authorization server ([spec]).
         ///
-        /// [spec]: https://spec.matrix.org/v1.18/client-server-api/#account-management-url-discovery
+        /// [spec]: https://spec.matrix.org/v1.19/client-server-api/#account-management-url-discovery
         #[serde(skip_serializing_if = "Option::is_none")]
         pub account_management_uri: Option<Url>,
 
         /// List of actions that the account management URL supports ([spec]).
         ///
-        /// [spec]: https://spec.matrix.org/v1.18/client-server-api/#account-management-url-discovery
+        /// [spec]: https://spec.matrix.org/v1.19/client-server-api/#account-management-url-discovery
         #[serde(skip_serializing_if = "BTreeSet::is_empty")]
         pub account_management_actions_supported: BTreeSet<AccountManagementAction>,
 
@@ -458,7 +458,7 @@ pub mod v1 {
     #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
     ///
     /// [MSC4191]: https://github.com/matrix-org/matrix-spec-proposals/pull/4191
-    /// [action]: https://spec.matrix.org/v1.18/client-server-api/#account-management-url-actions
+    /// [action]: https://spec.matrix.org/v1.19/client-server-api/#account-management-url-actions
     #[derive(Clone, StringEnum)]
     #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
     pub enum AccountManagementAction {
@@ -513,7 +513,7 @@ pub mod v1 {
         ///
         /// Servers should use this action in the URL of the [`m.oauth`] UIA type.
         ///
-        /// [`m.oauth`]: https://spec.matrix.org/v1.18/client-server-api/#oauth-authentication
+        /// [`m.oauth`]: https://spec.matrix.org/v1.19/client-server-api/#oauth-authentication
         #[ruma_enum(rename = "org.matrix.cross_signing_reset")]
         CrossSigningReset,
 
@@ -524,7 +524,7 @@ pub mod v1 {
     /// The [action] that the user wishes to do at the account management URL with its associated
     /// data.
     ///
-    /// [action]: https://spec.matrix.org/v1.18/client-server-api/#account-management-url-actions
+    /// [action]: https://spec.matrix.org/v1.19/client-server-api/#account-management-url-actions
     #[derive(Debug, Clone)]
     #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
     pub enum AccountManagementActionData<'a> {

--- a/crates/ruma-client-api/src/discovery/get_capabilities.rs
+++ b/crates/ruma-client-api/src/discovery/get_capabilities.rs
@@ -3,12 +3,12 @@
 //! Get information about the server's supported feature set and other relevant capabilities
 //! ([spec]).
 //!
-//! [spec]: https://spec.matrix.org/v1.18/client-server-api/#capabilities-negotiation
+//! [spec]: https://spec.matrix.org/v1.19/client-server-api/#capabilities-negotiation
 
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3capabilities
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3capabilities
 
     use std::{borrow::Cow, collections::BTreeMap};
 
@@ -145,7 +145,7 @@ pub mod v3 {
         /// Capability to indicate if the user can perform account moderation actions via [server
         /// administration] endpoints.
         ///
-        /// [server administration]: https://spec.matrix.org/v1.18/client-server-api/#server-administration
+        /// [server administration]: https://spec.matrix.org/v1.19/client-server-api/#server-administration
         #[serde(
             rename = "m.account_moderation",
             default,
@@ -453,7 +453,7 @@ pub mod v3 {
 
     /// Information about the [`m.forget_forced_upon_leave`] capability.
     ///
-    /// [`m.forget_forced_upon_leave`]: https://spec.matrix.org/v1.18/client-server-api/#mforget_forced_upon_leave-capability
+    /// [`m.forget_forced_upon_leave`]: https://spec.matrix.org/v1.19/client-server-api/#mforget_forced_upon_leave-capability
     #[derive(Clone, Debug, Default, Serialize, Deserialize)]
     #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
     pub struct ForgetForcedUponLeaveCapability {

--- a/crates/ruma-client-api/src/discovery/get_supported_versions.rs
+++ b/crates/ruma-client-api/src/discovery/get_supported_versions.rs
@@ -2,7 +2,7 @@
 //!
 //! Get the versions of the client-server API supported by this homeserver.
 //!
-//! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientversions
+//! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientversions
 
 use std::collections::BTreeMap;
 

--- a/crates/ruma-client-api/src/filter.rs
+++ b/crates/ruma-client-api/src/filter.rs
@@ -97,7 +97,7 @@ pub struct RoomEventFilter {
     ///
     /// Only applies to the [`sync_events`] endpoint.
     ///
-    /// [per-thread notification counts]: https://spec.matrix.org/v1.18/client-server-api/#receiving-notifications
+    /// [per-thread notification counts]: https://spec.matrix.org/v1.19/client-server-api/#receiving-notifications
     /// [`sync_events`]: crate::sync::sync_events
     #[serde(default, skip_serializing_if = "ruma_common::serde::is_default")]
     pub unread_thread_notifications: bool,
@@ -120,7 +120,7 @@ impl RoomEventFilter {
     ///
     /// Redundant membership events are disabled.
     ///
-    /// [room member lazy-loading]: https://spec.matrix.org/v1.18/client-server-api/#lazy-loading-room-members
+    /// [room member lazy-loading]: https://spec.matrix.org/v1.19/client-server-api/#lazy-loading-room-members
     pub fn with_lazy_loading() -> Self {
         Self {
             lazy_load_options: LazyLoadOptions::Enabled { include_redundant_members: false },
@@ -215,7 +215,7 @@ impl RoomFilter {
     ///
     /// Redundant membership events are disabled.
     ///
-    /// [room member lazy-loading]: https://spec.matrix.org/v1.18/client-server-api/#lazy-loading-room-members
+    /// [room member lazy-loading]: https://spec.matrix.org/v1.19/client-server-api/#lazy-loading-room-members
     pub fn with_lazy_loading() -> Self {
         Self { state: RoomEventFilter::with_lazy_loading(), ..Default::default() }
     }
@@ -350,7 +350,7 @@ impl FilterDefinition {
     ///
     /// Redundant membership events are disabled.
     ///
-    /// [room member lazy-loading]: https://spec.matrix.org/v1.18/client-server-api/#lazy-loading-room-members
+    /// [room member lazy-loading]: https://spec.matrix.org/v1.19/client-server-api/#lazy-loading-room-members
     pub fn with_lazy_loading() -> Self {
         Self { room: RoomFilter::with_lazy_loading(), ..Default::default() }
     }

--- a/crates/ruma-client-api/src/filter/create_filter.rs
+++ b/crates/ruma-client-api/src/filter/create_filter.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3useruseridfilter
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3useruseridfilter
 
     use ruma_common::{
         OwnedUserId,

--- a/crates/ruma-client-api/src/filter/get_filter.rs
+++ b/crates/ruma-client-api/src/filter/get_filter.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3useruseridfilterfilterid
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3useruseridfilterfilterid
 
     use ruma_common::{
         OwnedUserId,

--- a/crates/ruma-client-api/src/filter/lazy_load.rs
+++ b/crates/ruma-client-api/src/filter/lazy_load.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize, Serializer, ser::SerializeStruct as _};
 /// Specifies options for [lazy-loading membership events][lazy-loading] on
 /// supported endpoints
 ///
-/// [lazy-loading]: https://spec.matrix.org/v1.18/client-server-api/#lazy-loading-room-members
+/// [lazy-loading]: https://spec.matrix.org/v1.19/client-server-api/#lazy-loading-room-members
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Deserialize)]
 #[serde(from = "LazyLoadJsonRepr")]
 #[allow(clippy::exhaustive_enums)]

--- a/crates/ruma-client-api/src/keys/claim_keys/v3.rs
+++ b/crates/ruma-client-api/src/keys/claim_keys/v3.rs
@@ -1,6 +1,6 @@
 //! `/v3/` ([spec])
 //!
-//! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3keysclaim
+//! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3keysclaim
 
 use std::{collections::BTreeMap, time::Duration};
 

--- a/crates/ruma-client-api/src/keys/get_key_changes.rs
+++ b/crates/ruma-client-api/src/keys/get_key_changes.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3keyschanges
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3keyschanges
 
     use ruma_common::{
         OwnedUserId,

--- a/crates/ruma-client-api/src/keys/get_keys.rs
+++ b/crates/ruma-client-api/src/keys/get_keys.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3keysquery
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3keysquery
 
     use std::{collections::BTreeMap, time::Duration};
 

--- a/crates/ruma-client-api/src/keys/upload_keys.rs
+++ b/crates/ruma-client-api/src/keys/upload_keys.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3keysupload
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3keysupload
 
     use std::collections::BTreeMap;
 

--- a/crates/ruma-client-api/src/keys/upload_signatures.rs
+++ b/crates/ruma-client-api/src/keys/upload_signatures.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3keyssignaturesupload
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3keyssignaturesupload
 
     use std::collections::BTreeMap;
 

--- a/crates/ruma-client-api/src/keys/upload_signing_keys.rs
+++ b/crates/ruma-client-api/src/keys/upload_signing_keys.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3keysdevice_signingupload
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3keysdevice_signingupload
 
     use ruma_common::{
         api::{auth_scheme::AccessToken, request, response},

--- a/crates/ruma-client-api/src/knock/knock_room.rs
+++ b/crates/ruma-client-api/src/knock/knock_room.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3knockroomidoralias
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3knockroomidoralias
 
     use ruma_common::{
         OwnedRoomId, OwnedRoomOrAliasId, OwnedServerName,

--- a/crates/ruma-client-api/src/lib.rs
+++ b/crates/ruma-client-api/src/lib.rs
@@ -3,7 +3,7 @@
 //! (De)serializable types for the [Matrix Client-Server API][client-api].
 //! These types can be shared by client and server code.
 //!
-//! [client-api]: https://spec.matrix.org/v1.18/client-server-api/
+//! [client-api]: https://spec.matrix.org/v1.19/client-server-api/
 
 #![cfg(any(feature = "client", feature = "server"))]
 #![cfg_attr(docsrs, feature(doc_cfg))]

--- a/crates/ruma-client-api/src/media.rs
+++ b/crates/ruma-client-api/src/media.rs
@@ -12,7 +12,7 @@ pub mod get_media_preview;
 /// Checks whether a given `Content-Type` is considered "safe" for having a `Content-Disposition` of
 /// `inline` returned on `/download`, as recommended by the [spec].
 ///
-/// [spec]: https://spec.matrix.org/v1.18/client-server-api/#serving-inline-content
+/// [spec]: https://spec.matrix.org/v1.19/client-server-api/#serving-inline-content
 pub fn is_safe_inline_content_type(content_type: &str) -> bool {
     const SAFE_CONTENT_TYPES: [&str; 26] = [
         "text/css",

--- a/crates/ruma-client-api/src/media/create_content.rs
+++ b/crates/ruma-client-api/src/media/create_content.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixmediav3upload
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixmediav3upload
 
     use http::header::CONTENT_TYPE;
     use ruma_common::{

--- a/crates/ruma-client-api/src/media/create_content_async.rs
+++ b/crates/ruma-client-api/src/media/create_content_async.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#put_matrixmediav3uploadservernamemediaid
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#put_matrixmediav3uploadservernamemediaid
 
     use http::header::CONTENT_TYPE;
     use ruma_common::{

--- a/crates/ruma-client-api/src/media/create_mxc_uri.rs
+++ b/crates/ruma-client-api/src/media/create_mxc_uri.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixmediav1create
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixmediav1create
 
     use ruma_common::{
         MilliSecondsSinceUnixEpoch, OwnedMxcUri,

--- a/crates/ruma-client-api/src/media/get_content.rs
+++ b/crates/ruma-client-api/src/media/get_content.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixmediav3downloadservernamemediaid
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixmediav3downloadservernamemediaid
 
     use std::time::Duration;
 

--- a/crates/ruma-client-api/src/media/get_content_as_filename.rs
+++ b/crates/ruma-client-api/src/media/get_content_as_filename.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixmediav3downloadservernamemediaidfilename
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixmediav3downloadservernamemediaidfilename
 
     use std::time::Duration;
 

--- a/crates/ruma-client-api/src/media/get_content_thumbnail.rs
+++ b/crates/ruma-client-api/src/media/get_content_thumbnail.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixmediav3thumbnailservernamemediaid
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixmediav3thumbnailservernamemediaid
 
     use std::time::Duration;
 

--- a/crates/ruma-client-api/src/media/get_media_config.rs
+++ b/crates/ruma-client-api/src/media/get_media_config.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixmediav3config
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixmediav3config
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-client-api/src/media/get_media_preview.rs
+++ b/crates/ruma-client-api/src/media/get_media_preview.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixmediav3preview_url
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixmediav3preview_url
 
     use ruma_common::{
         MilliSecondsSinceUnixEpoch,

--- a/crates/ruma-client-api/src/membership/ban_user.rs
+++ b/crates/ruma-client-api/src/membership/ban_user.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3roomsroomidban
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3roomsroomidban
 
     use ruma_common::{
         OwnedRoomId, OwnedUserId,

--- a/crates/ruma-client-api/src/membership/forget_room.rs
+++ b/crates/ruma-client-api/src/membership/forget_room.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3roomsroomidforget
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3roomsroomidforget
 
     use ruma_common::{
         OwnedRoomId,

--- a/crates/ruma-client-api/src/membership/get_member_events.rs
+++ b/crates/ruma-client-api/src/membership/get_member_events.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3roomsroomidmembers
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3roomsroomidmembers
 
     use ruma_common::{
         OwnedRoomId,

--- a/crates/ruma-client-api/src/membership/invite_user.rs
+++ b/crates/ruma-client-api/src/membership/invite_user.rs
@@ -9,8 +9,8 @@ pub mod v3 {
     //! [by their Matrix identifier][spec-mxid], and one to invite a user
     //! [by their third party identifier][spec-3pid].
     //!
-    //! [spec-mxid]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3roomsroomidinvite
-    //! [spec-3pid]: https://spec.matrix.org/v1.18/client-server-api/#thirdparty_post_matrixclientv3roomsroomidinvite
+    //! [spec-mxid]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3roomsroomidinvite
+    //! [spec-3pid]: https://spec.matrix.org/v1.19/client-server-api/#thirdparty_post_matrixclientv3roomsroomidinvite
 
     use ruma_common::{
         OwnedRoomId, OwnedUserId,

--- a/crates/ruma-client-api/src/membership/join_room_by_id.rs
+++ b/crates/ruma-client-api/src/membership/join_room_by_id.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3roomsroomidjoin
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3roomsroomidjoin
 
     use ruma_common::{
         OwnedRoomId,

--- a/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
+++ b/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3joinroomidoralias
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3joinroomidoralias
 
     use ruma_common::{
         OwnedRoomId, OwnedRoomOrAliasId, OwnedServerName,

--- a/crates/ruma-client-api/src/membership/joined_members.rs
+++ b/crates/ruma-client-api/src/membership/joined_members.rs
@@ -6,7 +6,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3roomsroomidjoined_members
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3roomsroomidjoined_members
 
     use std::collections::BTreeMap;
 

--- a/crates/ruma-client-api/src/membership/joined_rooms.rs
+++ b/crates/ruma-client-api/src/membership/joined_rooms.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3joined_rooms
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3joined_rooms
 
     use ruma_common::{
         OwnedRoomId,

--- a/crates/ruma-client-api/src/membership/kick_user.rs
+++ b/crates/ruma-client-api/src/membership/kick_user.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3roomsroomidkick
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3roomsroomidkick
 
     use ruma_common::{
         OwnedRoomId, OwnedUserId,

--- a/crates/ruma-client-api/src/membership/leave_room.rs
+++ b/crates/ruma-client-api/src/membership/leave_room.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3roomsroomidleave
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3roomsroomidleave
 
     use ruma_common::{
         OwnedRoomId,

--- a/crates/ruma-client-api/src/membership/unban_user.rs
+++ b/crates/ruma-client-api/src/membership/unban_user.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3roomsroomidunban
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3roomsroomidunban
 
     use ruma_common::{
         OwnedRoomId, OwnedUserId,

--- a/crates/ruma-client-api/src/message/get_message_events.rs
+++ b/crates/ruma-client-api/src/message/get_message_events.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3roomsroomidmessages
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3roomsroomidmessages
 
     use js_int::{UInt, uint};
     use ruma_common::{

--- a/crates/ruma-client-api/src/message/send_message_event.rs
+++ b/crates/ruma-client-api/src/message/send_message_event.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#put_matrixclientv3roomsroomidsendeventtypetxnid
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#put_matrixclientv3roomsroomidsendeventtypetxnid
 
     use ruma_common::{
         MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedTransactionId,
@@ -47,7 +47,7 @@ pub mod v3 {
         ///
         /// It will be used by the server to ensure idempotency of requests.
         ///
-        /// [access token is refreshed]: https://spec.matrix.org/v1.18/client-server-api/#refreshing-access-tokens
+        /// [access token is refreshed]: https://spec.matrix.org/v1.19/client-server-api/#refreshing-access-tokens
         #[ruma_api(path)]
         pub txn_id: OwnedTransactionId,
 
@@ -62,7 +62,7 @@ pub mod v3 {
         ///
         /// Note that this does not change the position of the event in the timeline.
         ///
-        /// [timestamp massaging]: https://spec.matrix.org/v1.18/application-service-api/#timestamp-massaging
+        /// [timestamp massaging]: https://spec.matrix.org/v1.19/application-service-api/#timestamp-massaging
         #[ruma_api(query)]
         #[serde(skip_serializing_if = "Option::is_none", rename = "ts")]
         pub timestamp: Option<MilliSecondsSinceUnixEpoch>,

--- a/crates/ruma-client-api/src/peeking.rs
+++ b/crates/ruma-client-api/src/peeking.rs
@@ -1,6 +1,6 @@
 //! Endpoints for [previewing a room] without joining it, aka peeking.
 //!
-//! [previewing a room]: https://spec.matrix.org/v1.18/client-server-api/#room-previews
+//! [previewing a room]: https://spec.matrix.org/v1.19/client-server-api/#room-previews
 
 pub mod get_current_state;
 pub mod listen_to_new_events;

--- a/crates/ruma-client-api/src/peeking/get_current_state.rs
+++ b/crates/ruma-client-api/src/peeking/get_current_state.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3roomsroomidinitialsync
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3roomsroomidinitialsync
 
     use ruma_common::{
         OwnedRoomId,

--- a/crates/ruma-client-api/src/peeking/listen_to_new_events.rs
+++ b/crates/ruma-client-api/src/peeking/listen_to_new_events.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#peeking_get_matrixclientv3events
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#peeking_get_matrixclientv3events
 
     use std::time::Duration;
 

--- a/crates/ruma-client-api/src/presence/get_presence.rs
+++ b/crates/ruma-client-api/src/presence/get_presence.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3presenceuseridstatus
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3presenceuseridstatus
 
     use std::time::Duration;
 

--- a/crates/ruma-client-api/src/presence/set_presence.rs
+++ b/crates/ruma-client-api/src/presence/set_presence.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#put_matrixclientv3presenceuseridstatus
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#put_matrixclientv3presenceuseridstatus
 
     use ruma_common::{
         OwnedUserId,

--- a/crates/ruma-client-api/src/profile/delete_profile_field.rs
+++ b/crates/ruma-client-api/src/profile/delete_profile_field.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#delete_matrixclientv3profileuseridkeyname
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#delete_matrixclientv3profileuseridkeyname
 
     use ruma_common::{
         OwnedUserId,

--- a/crates/ruma-client-api/src/profile/get_profile.rs
+++ b/crates/ruma-client-api/src/profile/get_profile.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3profileuserid
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3profileuserid
 
     use std::collections::btree_map;
 

--- a/crates/ruma-client-api/src/profile/get_profile_field.rs
+++ b/crates/ruma-client-api/src/profile/get_profile_field.rs
@@ -9,7 +9,7 @@ pub mod v3 {
     //! it will only work with homeservers advertising support for the proper unstable feature or
     //! a version compatible with Matrix 1.16.
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3profileuseridkeyname
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3profileuseridkeyname
     //! [`get_avatar_url`]: crate::profile::get_avatar_url
     //! [`get_display_name`]: crate::profile::get_display_name
 

--- a/crates/ruma-client-api/src/profile/set_profile_field.rs
+++ b/crates/ruma-client-api/src/profile/set_profile_field.rs
@@ -9,7 +9,7 @@ pub mod v3 {
     //! it will only work with homeservers advertising support for the proper unstable feature or
     //! a version compatible with Matrix 1.16.
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#put_matrixclientv3profileuseridkeyname
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#put_matrixclientv3profileuseridkeyname
     //! [`set_avatar_url`]: crate::profile::set_avatar_url
     //! [`set_display_name`]: crate::profile::set_display_name
 

--- a/crates/ruma-client-api/src/push/delete_pushrule.rs
+++ b/crates/ruma-client-api/src/push/delete_pushrule.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#delete_matrixclientv3pushrulesglobalkindruleid
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#delete_matrixclientv3pushrulesglobalkindruleid
 
     use ruma_common::{
         api::{auth_scheme::AccessToken, request, response},

--- a/crates/ruma-client-api/src/push/get_notifications.rs
+++ b/crates/ruma-client-api/src/push/get_notifications.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3notifications
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3notifications
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-client-api/src/push/get_pushers.rs
+++ b/crates/ruma-client-api/src/push/get_pushers.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3pushers
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3pushers
 
     use ruma_common::{
         api::{auth_scheme::AccessToken, request, response},

--- a/crates/ruma-client-api/src/push/get_pushrule.rs
+++ b/crates/ruma-client-api/src/push/get_pushrule.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3pushrulesglobalkindruleid
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3pushrulesglobalkindruleid
 
     use ruma_common::{
         api::{auth_scheme::AccessToken, request, response},

--- a/crates/ruma-client-api/src/push/get_pushrule_actions.rs
+++ b/crates/ruma-client-api/src/push/get_pushrule_actions.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3pushrulesglobalkindruleidactions
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3pushrulesglobalkindruleidactions
 
     use ruma_common::{
         api::{auth_scheme::AccessToken, request, response},

--- a/crates/ruma-client-api/src/push/get_pushrule_enabled.rs
+++ b/crates/ruma-client-api/src/push/get_pushrule_enabled.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3pushrulesglobalkindruleidenabled
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3pushrulesglobalkindruleidenabled
 
     use ruma_common::{
         api::{auth_scheme::AccessToken, request, response},

--- a/crates/ruma-client-api/src/push/get_pushrules_all.rs
+++ b/crates/ruma-client-api/src/push/get_pushrules_all.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3pushrules
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3pushrules
 
     use ruma_common::{
         api::{auth_scheme::AccessToken, request, response},

--- a/crates/ruma-client-api/src/push/get_pushrules_global_scope.rs
+++ b/crates/ruma-client-api/src/push/get_pushrules_global_scope.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3pushrulesglobal
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3pushrulesglobal
 
     use ruma_common::{
         api::{auth_scheme::AccessToken, request, response},

--- a/crates/ruma-client-api/src/push/set_pusher.rs
+++ b/crates/ruma-client-api/src/push/set_pusher.rs
@@ -7,7 +7,7 @@ mod set_pusher_serde;
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3pushersset
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3pushersset
 
     use ruma_common::{
         api::{auth_scheme::AccessToken, request, response},

--- a/crates/ruma-client-api/src/push/set_pushrule.rs
+++ b/crates/ruma-client-api/src/push/set_pushrule.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#put_matrixclientv3pushrulesglobalkindruleid
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#put_matrixclientv3pushrulesglobalkindruleid
 
     use ruma_common::{
         api::{auth_scheme::AccessToken, error::Error, response},

--- a/crates/ruma-client-api/src/push/set_pushrule_actions.rs
+++ b/crates/ruma-client-api/src/push/set_pushrule_actions.rs
@@ -6,7 +6,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#put_matrixclientv3pushrulesglobalkindruleidactions
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#put_matrixclientv3pushrulesglobalkindruleidactions
 
     use ruma_common::{
         api::{auth_scheme::AccessToken, request, response},

--- a/crates/ruma-client-api/src/push/set_pushrule_enabled.rs
+++ b/crates/ruma-client-api/src/push/set_pushrule_enabled.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#put_matrixclientv3pushrulesglobalkindruleidenabled
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#put_matrixclientv3pushrulesglobalkindruleidenabled
 
     use ruma_common::{
         api::{auth_scheme::AccessToken, request, response},

--- a/crates/ruma-client-api/src/read_marker/set_read_marker.rs
+++ b/crates/ruma-client-api/src/read_marker/set_read_marker.rs
@@ -9,7 +9,7 @@ pub mod v3 {
     //! This endpoint is equivalent to calling the [`create_receipt`] endpoint,
     //! but is provided as a way to update several read markers with a single call.
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3roomsroomidread_markers
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3roomsroomidread_markers
     //! [`create_receipt`]: crate::receipt::create_receipt
 
     use ruma_common::{

--- a/crates/ruma-client-api/src/receipt/create_receipt.rs
+++ b/crates/ruma-client-api/src/receipt/create_receipt.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3roomsroomidreceiptreceipttypeeventid
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3roomsroomidreceiptreceipttypeeventid
 
     use ruma_common::{
         OwnedEventId, OwnedRoomId,
@@ -90,7 +90,7 @@ pub mod v3 {
         ///
         /// This receipt is federated to other users.
         ///
-        /// [public read receipt]: https://spec.matrix.org/v1.18/client-server-api/#receipts
+        /// [public read receipt]: https://spec.matrix.org/v1.19/client-server-api/#receipts
         #[ruma_enum(rename = "m.read")]
         Read,
 
@@ -101,7 +101,7 @@ pub mod v3 {
         /// This read receipt is not federated so only the user and their homeserver
         /// are aware of it.
         ///
-        /// [private read receipt]: https://spec.matrix.org/v1.18/client-server-api/#private-read-receipts
+        /// [private read receipt]: https://spec.matrix.org/v1.19/client-server-api/#private-read-receipts
         #[ruma_enum(rename = "m.read.private")]
         ReadPrivate,
 
@@ -112,7 +112,7 @@ pub mod v3 {
         /// This is actually not a receipt, but a piece of room account data. It is
         /// provided here for convenience.
         ///
-        /// [fully read marker]: https://spec.matrix.org/v1.18/client-server-api/#fully-read-markers
+        /// [fully read marker]: https://spec.matrix.org/v1.19/client-server-api/#fully-read-markers
         #[ruma_enum(rename = "m.fully_read")]
         FullyRead,
 

--- a/crates/ruma-client-api/src/redact/redact_event.rs
+++ b/crates/ruma-client-api/src/redact/redact_event.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#put_matrixclientv3roomsroomidredacteventidtxnid
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#put_matrixclientv3roomsroomidredacteventidtxnid
 
     use ruma_common::{
         OwnedEventId, OwnedRoomId, OwnedTransactionId,
@@ -42,7 +42,7 @@ pub mod v3 {
         ///
         /// It will be used by the server to ensure idempotency of requests.
         ///
-        /// [access token is refreshed]: https://spec.matrix.org/v1.18/client-server-api/#refreshing-access-tokens
+        /// [access token is refreshed]: https://spec.matrix.org/v1.19/client-server-api/#refreshing-access-tokens
         #[ruma_api(path)]
         pub txn_id: OwnedTransactionId,
 

--- a/crates/ruma-client-api/src/relations/get_relating_events.rs
+++ b/crates/ruma-client-api/src/relations/get_relating_events.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv1roomsroomidrelationseventid
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv1roomsroomidrelationseventid
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-client-api/src/relations/get_relating_events_with_rel_type.rs
+++ b/crates/ruma-client-api/src/relations/get_relating_events_with_rel_type.rs
@@ -6,7 +6,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv1roomsroomidrelationseventidreltype
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv1roomsroomidrelationseventidreltype
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-client-api/src/relations/get_relating_events_with_rel_type_and_event_type.rs
+++ b/crates/ruma-client-api/src/relations/get_relating_events_with_rel_type_and_event_type.rs
@@ -6,7 +6,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv1roomsroomidrelationseventidreltypeeventtype
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv1roomsroomidrelationseventidreltypeeventtype
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-client-api/src/reporting/report_user.rs
+++ b/crates/ruma-client-api/src/reporting/report_user.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3usersuseridreport
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3usersuseridreport
 
     use ruma_common::{
         OwnedUserId,

--- a/crates/ruma-client-api/src/room/aliases.rs
+++ b/crates/ruma-client-api/src/room/aliases.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3roomsroomidaliases
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3roomsroomidaliases
 
     use ruma_common::{
         OwnedRoomAliasId, OwnedRoomId,

--- a/crates/ruma-client-api/src/room/create_room.rs
+++ b/crates/ruma-client-api/src/room/create_room.rs
@@ -16,7 +16,7 @@ use serde::Serialize;
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3createroom
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3createroom
 
     use assign::assign;
     use ruma_common::{

--- a/crates/ruma-client-api/src/room/get_event_by_timestamp.rs
+++ b/crates/ruma-client-api/src/room/get_event_by_timestamp.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv1roomsroomidtimestamp_to_event
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv1roomsroomidtimestamp_to_event
 
     use ruma_common::{
         MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId,

--- a/crates/ruma-client-api/src/room/get_room_event.rs
+++ b/crates/ruma-client-api/src/room/get_room_event.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3roomsroomideventeventid
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3roomsroomideventeventid
 
     use ruma_common::{
         OwnedEventId, OwnedRoomId,

--- a/crates/ruma-client-api/src/room/get_summary.rs
+++ b/crates/ruma-client-api/src/room/get_summary.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `v1` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv1room_summaryroomidoralias
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv1room_summaryroomidoralias
 
     use ruma_common::{
         OwnedRoomOrAliasId, OwnedServerName,

--- a/crates/ruma-client-api/src/room/report_content.rs
+++ b/crates/ruma-client-api/src/room/report_content.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3roomsroomidreporteventid
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3roomsroomidreporteventid
 
     use ruma_common::{
         OwnedEventId, OwnedRoomId,

--- a/crates/ruma-client-api/src/room/report_room.rs
+++ b/crates/ruma-client-api/src/room/report_room.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3roomsroomidreport
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3roomsroomidreport
 
     use ruma_common::{
         OwnedRoomId,

--- a/crates/ruma-client-api/src/room/upgrade_room.rs
+++ b/crates/ruma-client-api/src/room/upgrade_room.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3roomsroomidupgrade
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3roomsroomidupgrade
 
     use ruma_common::{
         OwnedRoomId, OwnedUserId, RoomVersionId,

--- a/crates/ruma-client-api/src/search/search_events.rs
+++ b/crates/ruma-client-api/src/search/search_events.rs
@@ -7,7 +7,7 @@ mod result_group_map_serde;
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3search
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3search
 
     use std::{
         collections::{BTreeMap, btree_map},

--- a/crates/ruma-client-api/src/session/get_login_token.rs
+++ b/crates/ruma-client-api/src/session/get_login_token.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv1loginget_token
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv1loginget_token
 
     use std::time::Duration;
 

--- a/crates/ruma-client-api/src/session/get_login_types.rs
+++ b/crates/ruma-client-api/src/session/get_login_types.rs
@@ -6,7 +6,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3login
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3login
 
     use std::borrow::Cow;
 
@@ -178,7 +178,7 @@ pub mod v3 {
         ///
         /// If this is `true`, [OAuth 2.0 aware clients] must only offer this flow to the user.
         ///
-        /// [OAuth 2.0 aware clients]: https://spec.matrix.org/v1.18/client-server-api/#oauth-20-aware-clients
+        /// [OAuth 2.0 aware clients]: https://spec.matrix.org/v1.19/client-server-api/#oauth-20-aware-clients
         #[serde(default, skip_serializing_if = "ruma_common::serde::is_default")]
         pub oauth_aware_preferred: bool,
     }

--- a/crates/ruma-client-api/src/session/login.rs
+++ b/crates/ruma-client-api/src/session/login.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3login
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3login
 
     use std::{borrow::Cow, fmt, time::Duration};
 
@@ -53,7 +53,7 @@ pub mod v3 {
 
         /// If set to `true`, the client supports [refresh tokens].
         ///
-        /// [refresh tokens]: https://spec.matrix.org/v1.18/client-server-api/#refreshing-access-tokens
+        /// [refresh tokens]: https://spec.matrix.org/v1.19/client-server-api/#refreshing-access-tokens
         #[serde(default, skip_serializing_if = "ruma_common::serde::is_default")]
         pub refresh_token: bool,
     }
@@ -92,7 +92,7 @@ pub mod v3 {
         /// This token can be used to obtain a new access token when it expires by calling the
         /// [`refresh_token`] endpoint.
         ///
-        /// [refresh token]: https://spec.matrix.org/v1.18/client-server-api/#refreshing-access-tokens
+        /// [refresh token]: https://spec.matrix.org/v1.19/client-server-api/#refreshing-access-tokens
         /// [`refresh_token`]: crate::session::refresh_token
         #[serde(skip_serializing_if = "Option::is_none")]
         pub refresh_token: Option<String>,

--- a/crates/ruma-client-api/src/session/login_fallback.rs
+++ b/crates/ruma-client-api/src/session/login_fallback.rs
@@ -2,7 +2,7 @@
 //!
 //! Get login fallback web page.
 //!
-//! [spec]: https://spec.matrix.org/v1.18/client-server-api/#login-fallback
+//! [spec]: https://spec.matrix.org/v1.19/client-server-api/#login-fallback
 
 use ruma_common::{
     OwnedDeviceId,

--- a/crates/ruma-client-api/src/session/logout.rs
+++ b/crates/ruma-client-api/src/session/logout.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3logout
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3logout
 
     use ruma_common::{
         api::{auth_scheme::AccessToken, error::Error, response},

--- a/crates/ruma-client-api/src/session/logout_all.rs
+++ b/crates/ruma-client-api/src/session/logout_all.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3logoutall
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3logoutall
 
     use ruma_common::{
         api::{auth_scheme::AccessToken, error::Error, response},

--- a/crates/ruma-client-api/src/session/refresh_token.rs
+++ b/crates/ruma-client-api/src/session/refresh_token.rs
@@ -23,7 +23,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3refresh
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3refresh
 
     use std::time::Duration;
 

--- a/crates/ruma-client-api/src/session/sso_login.rs
+++ b/crates/ruma-client-api/src/session/sso_login.rs
@@ -3,7 +3,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3loginssoredirect
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3loginssoredirect
 
     use http::header::{LOCATION, SET_COOKIE};
     use ruma_common::{

--- a/crates/ruma-client-api/src/session/sso_login_with_provider.rs
+++ b/crates/ruma-client-api/src/session/sso_login_with_provider.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3loginssoredirectidpid
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3loginssoredirectidpid
 
     use http::header::{LOCATION, SET_COOKIE};
     use ruma_common::{

--- a/crates/ruma-client-api/src/space.rs
+++ b/crates/ruma-client-api/src/space.rs
@@ -2,7 +2,7 @@
 //!
 //! See the [Matrix specification][spec] for more details about spaces.
 //!
-//! [spec]: https://spec.matrix.org/v1.18/client-server-api/#spaces
+//! [spec]: https://spec.matrix.org/v1.19/client-server-api/#spaces
 
 use ruma_common::{
     room::RoomSummary,

--- a/crates/ruma-client-api/src/space/get_hierarchy.rs
+++ b/crates/ruma-client-api/src/space/get_hierarchy.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv1roomsroomidhierarchy
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv1roomsroomidhierarchy
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-client-api/src/state/get_state_event_for_key.rs
+++ b/crates/ruma-client-api/src/state/get_state_event_for_key.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3roomsroomidstateeventtypestatekey
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3roomsroomidstateeventtypestatekey
 
     use ruma_common::{
         OwnedRoomId,

--- a/crates/ruma-client-api/src/state/get_state_events.rs
+++ b/crates/ruma-client-api/src/state/get_state_events.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3roomsroomidstate
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3roomsroomidstate
 
     use ruma_common::{
         OwnedRoomId,

--- a/crates/ruma-client-api/src/state/send_state_event.rs
+++ b/crates/ruma-client-api/src/state/send_state_event.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#put_matrixclientv3roomsroomidstateeventtypestatekey
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#put_matrixclientv3roomsroomidstateeventtypestatekey
 
     use std::borrow::Borrow;
 
@@ -52,7 +52,7 @@ pub mod v3 {
         ///
         /// Note that this does not change the position of the event in the timeline.
         ///
-        /// [timestamp massaging]: https://spec.matrix.org/v1.18/application-service-api/#timestamp-massaging
+        /// [timestamp massaging]: https://spec.matrix.org/v1.19/application-service-api/#timestamp-massaging
         pub timestamp: Option<MilliSecondsSinceUnixEpoch>,
 
         /// The duration to stick the event for.

--- a/crates/ruma-client-api/src/sync/sync_events/v3.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v3.rs
@@ -1,6 +1,6 @@
 //! `/v3/` ([spec])
 //!
-//! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3sync
+//! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3sync
 
 use std::{collections::BTreeMap, time::Duration};
 
@@ -259,7 +259,7 @@ pub struct JoinedRoom {
     /// If `unread_thread_notifications` was set to `true` in the [`RoomEventFilter`], these
     /// include only the unread notifications for the main timeline.
     ///
-    /// [unread notifications]: https://spec.matrix.org/v1.18/client-server-api/#receiving-notifications
+    /// [unread notifications]: https://spec.matrix.org/v1.19/client-server-api/#receiving-notifications
     /// [`RoomEventFilter`]: crate::filter::RoomEventFilter
     #[serde(skip_serializing_if = "UnreadNotificationsCount::is_empty")]
     pub unread_notifications: UnreadNotificationsCount,
@@ -270,7 +270,7 @@ pub struct JoinedRoom {
     ///
     /// Only set if `unread_thread_notifications` was set to `true` in the [`RoomEventFilter`].
     ///
-    /// [unread notifications]: https://spec.matrix.org/v1.18/client-server-api/#receiving-notifications
+    /// [unread notifications]: https://spec.matrix.org/v1.19/client-server-api/#receiving-notifications
     /// [`RoomEventFilter`]: crate::filter::RoomEventFilter
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
     pub unread_thread_notifications: BTreeMap<OwnedEventId, UnreadNotificationsCount>,

--- a/crates/ruma-client-api/src/tag/create_tag.rs
+++ b/crates/ruma-client-api/src/tag/create_tag.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#put_matrixclientv3useruseridroomsroomidtagstag
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#put_matrixclientv3useruseridroomsroomidtagstag
 
     use ruma_common::{
         OwnedRoomId, OwnedUserId,

--- a/crates/ruma-client-api/src/tag/delete_tag.rs
+++ b/crates/ruma-client-api/src/tag/delete_tag.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#put_matrixclientv3useruseridroomsroomidtagstag
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#put_matrixclientv3useruseridroomsroomidtagstag
 
     use ruma_common::{
         OwnedRoomId, OwnedUserId,

--- a/crates/ruma-client-api/src/tag/get_tags.rs
+++ b/crates/ruma-client-api/src/tag/get_tags.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3useruseridroomsroomidtags
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3useruseridroomsroomidtags
 
     use ruma_common::{
         OwnedRoomId, OwnedUserId,

--- a/crates/ruma-client-api/src/thirdparty/get_location_for_protocol.rs
+++ b/crates/ruma-client-api/src/thirdparty/get_location_for_protocol.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3thirdpartylocationprotocol
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3thirdpartylocationprotocol
 
     use std::collections::BTreeMap;
 

--- a/crates/ruma-client-api/src/thirdparty/get_location_for_room_alias.rs
+++ b/crates/ruma-client-api/src/thirdparty/get_location_for_room_alias.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3thirdpartylocation
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3thirdpartylocation
 
     use ruma_common::{
         OwnedRoomAliasId,

--- a/crates/ruma-client-api/src/thirdparty/get_protocol.rs
+++ b/crates/ruma-client-api/src/thirdparty/get_protocol.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3thirdpartyprotocolprotocol
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3thirdpartyprotocolprotocol
 
     use ruma_common::{
         api::{auth_scheme::AccessToken, request, response},

--- a/crates/ruma-client-api/src/thirdparty/get_protocols.rs
+++ b/crates/ruma-client-api/src/thirdparty/get_protocols.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3thirdpartyprotocols
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3thirdpartyprotocols
 
     use std::collections::BTreeMap;
 

--- a/crates/ruma-client-api/src/thirdparty/get_user_for_protocol.rs
+++ b/crates/ruma-client-api/src/thirdparty/get_user_for_protocol.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3thirdpartyuserprotocol
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3thirdpartyuserprotocol
 
     use std::collections::BTreeMap;
 

--- a/crates/ruma-client-api/src/thirdparty/get_user_for_user_id.rs
+++ b/crates/ruma-client-api/src/thirdparty/get_user_for_user_id.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3thirdpartyuser
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3thirdpartyuser
 
     use ruma_common::{
         OwnedUserId,

--- a/crates/ruma-client-api/src/threads/get_threads.rs
+++ b/crates/ruma-client-api/src/threads/get_threads.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv1roomsroomidthreads
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv1roomsroomidthreads
 
     use js_int::UInt;
     use ruma_common::{
@@ -104,7 +104,7 @@ pub mod v1 {
         ///
         /// Only include thread roots for threads where [`current_user_participated`] is `true`.
         ///
-        /// [`current_user_participated`]: https://spec.matrix.org/v1.18/client-server-api/#server-side-aggregation-of-mthread-relationships
+        /// [`current_user_participated`]: https://spec.matrix.org/v1.19/client-server-api/#server-side-aggregation-of-mthread-relationships
         Participated,
 
         #[doc(hidden)]

--- a/crates/ruma-client-api/src/to_device/send_event_to_device.rs
+++ b/crates/ruma-client-api/src/to_device/send_event_to_device.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#put_matrixclientv3sendtodeviceeventtypetxnid
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#put_matrixclientv3sendtodeviceeventtypetxnid
 
     use std::collections::BTreeMap;
 
@@ -43,7 +43,7 @@ pub mod v3 {
         ///
         /// It will be used by the server to ensure idempotency of requests.
         ///
-        /// [access token is refreshed]: https://spec.matrix.org/v1.18/client-server-api/#refreshing-access-tokens
+        /// [access token is refreshed]: https://spec.matrix.org/v1.19/client-server-api/#refreshing-access-tokens
         #[ruma_api(path)]
         pub txn_id: OwnedTransactionId,
 

--- a/crates/ruma-client-api/src/typing/create_typing_event.rs
+++ b/crates/ruma-client-api/src/typing/create_typing_event.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#put_matrixclientv3roomsroomidtypinguserid
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#put_matrixclientv3roomsroomidtypinguserid
 
     use std::time::Duration;
 

--- a/crates/ruma-client-api/src/uiaa.rs
+++ b/crates/ruma-client-api/src/uiaa.rs
@@ -1,6 +1,6 @@
 //! Module for [User-Interactive Authentication API][uiaa] types.
 //!
-//! [uiaa]: https://spec.matrix.org/v1.18/client-server-api/#user-interactive-authentication-api
+//! [uiaa]: https://spec.matrix.org/v1.19/client-server-api/#user-interactive-authentication-api
 
 use std::{borrow::Cow, fmt, marker::PhantomData};
 

--- a/crates/ruma-client-api/src/uiaa/auth_data.rs
+++ b/crates/ruma-client-api/src/uiaa/auth_data.rs
@@ -199,7 +199,7 @@ impl fmt::Debug for AuthData {
 ///
 /// See [the spec] for how to use this.
 ///
-/// [the spec]: https://spec.matrix.org/v1.18/client-server-api/#password-based
+/// [the spec]: https://spec.matrix.org/v1.19/client-server-api/#password-based
 #[derive(Clone, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 #[serde(tag = "type", rename = "m.login.password")]
@@ -235,7 +235,7 @@ impl fmt::Debug for Password {
 ///
 /// See [the spec] for how to use this.
 ///
-/// [the spec]: https://spec.matrix.org/v1.18/client-server-api/#google-recaptcha
+/// [the spec]: https://spec.matrix.org/v1.19/client-server-api/#google-recaptcha
 #[derive(Clone, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 #[serde(tag = "type", rename = "m.login.recaptcha")]
@@ -265,7 +265,7 @@ impl fmt::Debug for ReCaptcha {
 ///
 /// See [the spec] for how to use this.
 ///
-/// [the spec]: https://spec.matrix.org/v1.18/client-server-api/#email-based-identity--homeserver
+/// [the spec]: https://spec.matrix.org/v1.19/client-server-api/#email-based-identity--homeserver
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 #[serde(tag = "type", rename = "m.login.email.identity")]
@@ -282,7 +282,7 @@ pub struct EmailIdentity {
 ///
 /// See [the spec] for how to use this.
 ///
-/// [the spec]: https://spec.matrix.org/v1.18/client-server-api/#phone-numbermsisdn-based-identity--homeserver
+/// [the spec]: https://spec.matrix.org/v1.19/client-server-api/#phone-numbermsisdn-based-identity--homeserver
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 #[serde(tag = "type", rename = "m.login.msisdn")]
@@ -299,7 +299,7 @@ pub struct Msisdn {
 ///
 /// See [the spec] for how to use this.
 ///
-/// [the spec]: https://spec.matrix.org/v1.18/client-server-api/#dummy-auth
+/// [the spec]: https://spec.matrix.org/v1.19/client-server-api/#dummy-auth
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 #[serde(tag = "type", rename = "m.login.dummy")]
@@ -319,7 +319,7 @@ impl Dummy {
 ///
 /// See [the spec] for how to use this.
 ///
-/// [the spec]: https://spec.matrix.org/v1.18/client-server-api/#token-authenticated-registration
+/// [the spec]: https://spec.matrix.org/v1.19/client-server-api/#token-authenticated-registration
 #[derive(Clone, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 #[serde(tag = "type", rename = "m.login.registration_token")]
@@ -349,7 +349,7 @@ impl fmt::Debug for RegistrationToken {
 ///
 /// See [the spec] for how to use this.
 ///
-/// [the spec]: https://spec.matrix.org/v1.18/client-server-api/#fallback
+/// [the spec]: https://spec.matrix.org/v1.19/client-server-api/#fallback
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct FallbackAcknowledgement {
@@ -370,7 +370,7 @@ impl FallbackAcknowledgement {
 ///
 /// See [the spec] for how to use this.
 ///
-/// [the spec]: https://spec.matrix.org/v1.18/client-server-api/#terms-of-service-at-registration
+/// [the spec]: https://spec.matrix.org/v1.19/client-server-api/#terms-of-service-at-registration
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 #[serde(tag = "type", rename = "m.login.terms")]
@@ -388,7 +388,7 @@ impl Terms {
 
 /// Data for an [OAuth 2.0-based] UIAA flow.
 ///
-/// [OAuth 2.0-based]: https://spec.matrix.org/v1.18/client-server-api/#oauth-authentication
+/// [OAuth 2.0-based]: https://spec.matrix.org/v1.19/client-server-api/#oauth-authentication
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 #[serde(tag = "type", rename = "m.oauth")]

--- a/crates/ruma-client-api/src/uiaa/auth_params.rs
+++ b/crates/ruma-client-api/src/uiaa/auth_params.rs
@@ -12,7 +12,7 @@ mod params_serde;
 ///
 /// See [the spec] for how to use this.
 ///
-/// [the spec]: https://spec.matrix.org/v1.18/client-server-api/#terms-of-service-at-registration
+/// [the spec]: https://spec.matrix.org/v1.19/client-server-api/#terms-of-service-at-registration
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct LoginTermsParams {
@@ -72,7 +72,7 @@ impl PolicyTranslation {
 
 /// Parameters for an [OAuth 2.0-based] UIAA flow.
 ///
-/// [OAuth 2.0-based]: https://spec.matrix.org/v1.18/client-server-api/#oauth-authentication
+/// [OAuth 2.0-based]: https://spec.matrix.org/v1.19/client-server-api/#oauth-authentication
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct OAuthParams {

--- a/crates/ruma-client-api/src/uiaa/get_uiaa_fallback_page.rs
+++ b/crates/ruma-client-api/src/uiaa/get_uiaa_fallback_page.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#fallback
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#fallback
 
     use ruma_common::{
         api::{auth_scheme::NoAccessToken, request},

--- a/crates/ruma-client-api/src/user_directory/search_users.rs
+++ b/crates/ruma-client-api/src/user_directory/search_users.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3user_directorysearch
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3user_directorysearch
 
     use http::header::ACCEPT_LANGUAGE;
     use js_int::{UInt, uint};

--- a/crates/ruma-client-api/src/voip/get_turn_server_info.rs
+++ b/crates/ruma-client-api/src/voip/get_turn_server_info.rs
@@ -5,7 +5,7 @@
 pub mod v3 {
     //! `/v3/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3voipturnserver
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3voipturnserver
 
     use std::time::Duration;
 

--- a/crates/ruma-common/src/api.rs
+++ b/crates/ruma-common/src/api.rs
@@ -10,7 +10,7 @@
 //! successful response. Such types can then be used by client code to make requests, and by server
 //! code to fulfill those requests.
 //!
-//! [apis]: https://spec.matrix.org/v1.18/#matrix-apis
+//! [apis]: https://spec.matrix.org/v1.19/#matrix-apis
 
 use std::{convert::TryInto as _, error::Error as StdError};
 
@@ -417,7 +417,7 @@ impl Direction {
 
 /// Data to [assert the identity] of an appservice virtual user.
 ///
-/// [assert the identity]: https://spec.matrix.org/v1.18/application-service-api/#identity-assertion
+/// [assert the identity]: https://spec.matrix.org/v1.19/application-service-api/#identity-assertion
 #[derive(Debug, Clone, Copy, Default, Serialize)]
 #[non_exhaustive]
 pub struct AppserviceUserIdentity<'a> {

--- a/crates/ruma-common/src/api/error/kind.rs
+++ b/crates/ruma-common/src/api/error/kind.rs
@@ -26,9 +26,9 @@ pub enum ErrorKind {
     /// [legacy authentication API] in a way that is not supported by the homeserver, because the
     /// server only supports the [OAuth 2.0 API].
     ///
-    /// [`m.login.application_service`]: https://spec.matrix.org/v1.18/application-service-api/#server-admin-style-permissions
-    /// [legacy authentication API]: https://spec.matrix.org/v1.18/client-server-api/#legacy-api
-    /// [OAuth 2.0 API]: https://spec.matrix.org/v1.18/client-server-api/#oauth-20-api
+    /// [`m.login.application_service`]: https://spec.matrix.org/v1.19/application-service-api/#server-admin-style-permissions
+    /// [legacy authentication API]: https://spec.matrix.org/v1.19/client-server-api/#legacy-api
+    /// [OAuth 2.0 API]: https://spec.matrix.org/v1.19/client-server-api/#oauth-20-api
     AppserviceLoginUnsupported,
 
     /// `M_BAD_ALIAS`
@@ -36,7 +36,7 @@ pub enum ErrorKind {
     /// One or more [room aliases] within the `m.room.canonical_alias` event do not point to the
     /// room ID for which the state event is to be sent to.
     ///
-    /// [room aliases]: https://spec.matrix.org/v1.18/client-server-api/#room-aliases
+    /// [room aliases]: https://spec.matrix.org/v1.19/client-server-api/#room-aliases
     BadAlias,
 
     /// `M_BAD_JSON`
@@ -60,7 +60,7 @@ pub enum ErrorKind {
     ///
     /// The user is unable to reject an invite to join the [server notices] room.
     ///
-    /// [server notices]: https://spec.matrix.org/v1.18/client-server-api/#server-notices
+    /// [server notices]: https://spec.matrix.org/v1.19/client-server-api/#server-notices
     CannotLeaveServerNoticeRoom,
 
     /// `M_CANNOT_OVERWRITE_MEDIA`
@@ -109,7 +109,7 @@ pub enum ErrorKind {
     ///
     /// The request is an attempt to send a [duplicate annotation].
     ///
-    /// [duplicate annotation]: https://spec.matrix.org/v1.18/client-server-api/#avoiding-duplicate-annotations
+    /// [duplicate annotation]: https://spec.matrix.org/v1.19/client-server-api/#avoiding-duplicate-annotations
     DuplicateAnnotation,
 
     /// `M_EXCLUSIVE`
@@ -127,7 +127,7 @@ pub enum ErrorKind {
     ///
     /// The room or resource does not permit [guests] to access it.
     ///
-    /// [guests]: https://spec.matrix.org/v1.18/client-server-api/#guest-access
+    /// [guests]: https://spec.matrix.org/v1.19/client-server-api/#guest-access
     GuestAccessForbidden,
 
     /// `M_INCOMPATIBLE_ROOM_VERSION`
@@ -164,7 +164,7 @@ pub enum ErrorKind {
     /// The request has been refused due to [rate limiting]: too many requests have been sent in a
     /// short period of time.
     ///
-    /// [rate limiting]: https://spec.matrix.org/v1.18/client-server-api/#rate-limiting
+    /// [rate limiting]: https://spec.matrix.org/v1.19/client-server-api/#rate-limiting
     LimitExceeded(LimitExceededErrorData),
 
     /// `M_MISSING_PARAM`
@@ -176,7 +176,7 @@ pub enum ErrorKind {
     ///
     /// No [access token] was specified for the request, but one is required.
     ///
-    /// [access token]: https://spec.matrix.org/v1.18/client-server-api/#client-authentication
+    /// [access token]: https://spec.matrix.org/v1.19/client-server-api/#client-authentication
     MissingToken,
 
     /// `M_NOT_FOUND`
@@ -216,7 +216,7 @@ pub enum ErrorKind {
     /// The [room alias] specified in the `POST /_matrix/client/*/createRoom` request is already
     /// taken.
     ///
-    /// [room alias]: https://spec.matrix.org/v1.18/client-server-api/#room-aliases
+    /// [room alias]: https://spec.matrix.org/v1.19/client-server-api/#room-aliases
     RoomInUse,
 
     /// `M_SENDER_IGNORED`
@@ -237,7 +237,7 @@ pub enum ErrorKind {
     ///
     /// Authentication could not be performed on the [third-party identifier].
     ///
-    /// [third-party identifier]: https://spec.matrix.org/v1.18/client-server-api/#adding-account-administrative-contact-information
+    /// [third-party identifier]: https://spec.matrix.org/v1.19/client-server-api/#adding-account-administrative-contact-information
     ThreepidAuthFailed,
 
     /// `M_THREEPID_DENIED`
@@ -245,28 +245,28 @@ pub enum ErrorKind {
     /// The server does not permit this [third-party identifier]. This may happen if the server
     /// only permits, for example, email addresses from a particular domain.
     ///
-    /// [third-party identifier]: https://spec.matrix.org/v1.18/client-server-api/#adding-account-administrative-contact-information
+    /// [third-party identifier]: https://spec.matrix.org/v1.19/client-server-api/#adding-account-administrative-contact-information
     ThreepidDenied,
 
     /// `M_THREEPID_IN_USE`
     ///
     /// The [third-party identifier] is already in use by another user.
     ///
-    /// [third-party identifier]: https://spec.matrix.org/v1.18/client-server-api/#adding-account-administrative-contact-information
+    /// [third-party identifier]: https://spec.matrix.org/v1.19/client-server-api/#adding-account-administrative-contact-information
     ThreepidInUse,
 
     /// `M_THREEPID_MEDIUM_NOT_SUPPORTED`
     ///
     /// The homeserver does not support adding a [third-party identifier] of the given medium.
     ///
-    /// [third-party identifier]: https://spec.matrix.org/v1.18/client-server-api/#adding-account-administrative-contact-information
+    /// [third-party identifier]: https://spec.matrix.org/v1.19/client-server-api/#adding-account-administrative-contact-information
     ThreepidMediumNotSupported,
 
     /// `M_THREEPID_NOT_FOUND`
     ///
     /// No account matching the given [third-party identifier] could be found.
     ///
-    /// [third-party identifier]: https://spec.matrix.org/v1.18/client-server-api/#adding-account-administrative-contact-information
+    /// [third-party identifier]: https://spec.matrix.org/v1.19/client-server-api/#adding-account-administrative-contact-information
     ThreepidNotFound,
 
     /// `M_TOKEN_INCORRECT`
@@ -285,7 +285,7 @@ pub enum ErrorKind {
     /// This can happen if the homeserver does not know about any of the rooms listed as
     /// conditions, for example.
     ///
-    /// [restricted]: https://spec.matrix.org/v1.18/client-server-api/#restricted-rooms
+    /// [restricted]: https://spec.matrix.org/v1.19/client-server-api/#restricted-rooms
     UnableToAuthorizeJoin,
 
     /// `M_UNABLE_TO_GRANT_JOIN`
@@ -295,7 +295,7 @@ pub enum ErrorKind {
     /// of [restricted rooms], but the resident server would be unable to meet the authorization
     /// rules.
     ///
-    /// [restricted rooms]: https://spec.matrix.org/v1.18/client-server-api/#restricted-rooms
+    /// [restricted rooms]: https://spec.matrix.org/v1.19/client-server-api/#restricted-rooms
     UnableToGrantJoin,
 
     /// `M_UNACTIONABLE`
@@ -328,7 +328,7 @@ pub enum ErrorKind {
     ///
     /// The [access or refresh token] specified was not recognized.
     ///
-    /// [access or refresh token]: https://spec.matrix.org/v1.18/client-server-api/#client-authentication
+    /// [access or refresh token]: https://spec.matrix.org/v1.19/client-server-api/#client-authentication
     UnknownToken(UnknownTokenErrorData),
 
     /// `M_UNRECOGNIZED`
@@ -373,21 +373,21 @@ pub enum ErrorKind {
     ///
     /// The account has been [locked] and cannot be used at this time.
     ///
-    /// [locked]: https://spec.matrix.org/v1.18/client-server-api/#account-locking
+    /// [locked]: https://spec.matrix.org/v1.19/client-server-api/#account-locking
     UserLocked,
 
     /// `M_USER_SUSPENDED`
     ///
     /// The account has been [suspended] and can only be used for limited actions at this time.
     ///
-    /// [suspended]: https://spec.matrix.org/v1.18/client-server-api/#account-suspension
+    /// [suspended]: https://spec.matrix.org/v1.19/client-server-api/#account-suspension
     UserSuspended,
 
     /// `M_WEAK_PASSWORD`
     ///
     /// The password was [rejected] by the server for being too weak.
     ///
-    /// [rejected]: https://spec.matrix.org/v1.18/client-server-api/#password-management
+    /// [rejected]: https://spec.matrix.org/v1.19/client-server-api/#password-management
     WeakPassword,
 
     /// `M_WRONG_ROOM_KEYS_VERSION`
@@ -395,7 +395,7 @@ pub enum ErrorKind {
     /// The version of the [room keys backup] provided in the request does not match the current
     /// backup version.
     ///
-    /// [room keys backup]: https://spec.matrix.org/v1.18/client-server-api/#server-side-key-backups
+    /// [room keys backup]: https://spec.matrix.org/v1.19/client-server-api/#server-side-key-backups
     WrongRoomKeysVersion(WrongRoomKeysVersionErrorData),
 
     #[doc(hidden)]
@@ -610,7 +610,7 @@ pub struct UnknownTokenErrorData {
     /// re-authentication but the session is not invalidated. The client can acquire a new
     /// access token by specifying the device ID it is already using to the login API.
     ///
-    /// [soft logout]: https://spec.matrix.org/v1.18/client-server-api/#soft-logout
+    /// [soft logout]: https://spec.matrix.org/v1.19/client-server-api/#soft-logout
     pub soft_logout: bool,
 }
 
@@ -677,7 +677,7 @@ pub struct CustomErrorKind {
 
 /// The possible [error codes] defined in the Matrix spec.
 ///
-/// [error codes]: https://spec.matrix.org/v1.18/client-server-api/#standard-error-response
+/// [error codes]: https://spec.matrix.org/v1.19/client-server-api/#standard-error-response
 #[derive(Clone, StringEnum)]
 #[non_exhaustive]
 #[ruma_enum(rename_all(prefix = "M_", rule = "SCREAMING_SNAKE_CASE"))]
@@ -689,9 +689,9 @@ pub enum ErrorCode {
     /// [legacy authentication API] in a way that is not supported by the homeserver, because the
     /// server only supports the [OAuth 2.0 API].
     ///
-    /// [`m.login.application_service`]: https://spec.matrix.org/v1.18/application-service-api/#server-admin-style-permissions
-    /// [legacy authentication API]: https://spec.matrix.org/v1.18/client-server-api/#legacy-api
-    /// [OAuth 2.0 API]: https://spec.matrix.org/v1.18/client-server-api/#oauth-20-api
+    /// [`m.login.application_service`]: https://spec.matrix.org/v1.19/application-service-api/#server-admin-style-permissions
+    /// [legacy authentication API]: https://spec.matrix.org/v1.19/client-server-api/#legacy-api
+    /// [OAuth 2.0 API]: https://spec.matrix.org/v1.19/client-server-api/#oauth-20-api
     AppserviceLoginUnsupported,
 
     /// `M_BAD_ALIAS`
@@ -699,7 +699,7 @@ pub enum ErrorCode {
     /// One or more [room aliases] within the `m.room.canonical_alias` event do not point to the
     /// room ID for which the state event is to be sent to.
     ///
-    /// [room aliases]: https://spec.matrix.org/v1.18/client-server-api/#room-aliases
+    /// [room aliases]: https://spec.matrix.org/v1.19/client-server-api/#room-aliases
     BadAlias,
 
     /// `M_BAD_JSON`
@@ -723,7 +723,7 @@ pub enum ErrorCode {
     ///
     /// The user is unable to reject an invite to join the [server notices] room.
     ///
-    /// [server notices]: https://spec.matrix.org/v1.18/client-server-api/#server-notices
+    /// [server notices]: https://spec.matrix.org/v1.19/client-server-api/#server-notices
     CannotLeaveServerNoticeRoom,
 
     /// `M_CANNOT_OVERWRITE_MEDIA`
@@ -778,7 +778,7 @@ pub enum ErrorCode {
     ///
     /// The request is an attempt to send a [duplicate annotation].
     ///
-    /// [duplicate annotation]: https://spec.matrix.org/v1.18/client-server-api/#avoiding-duplicate-annotations
+    /// [duplicate annotation]: https://spec.matrix.org/v1.19/client-server-api/#avoiding-duplicate-annotations
     DuplicateAnnotation,
 
     /// `M_EXCLUSIVE`
@@ -796,7 +796,7 @@ pub enum ErrorCode {
     ///
     /// The room or resource does not permit [guests] to access it.
     ///
-    /// [guests]: https://spec.matrix.org/v1.18/client-server-api/#guest-access
+    /// [guests]: https://spec.matrix.org/v1.19/client-server-api/#guest-access
     GuestAccessForbidden,
 
     /// `M_INCOMPATIBLE_ROOM_VERSION`
@@ -836,7 +836,7 @@ pub enum ErrorCode {
     /// The request has been refused due to [rate limiting]: too many requests have been sent in a
     /// short period of time.
     ///
-    /// [rate limiting]: https://spec.matrix.org/v1.18/client-server-api/#rate-limiting
+    /// [rate limiting]: https://spec.matrix.org/v1.19/client-server-api/#rate-limiting
     LimitExceeded,
 
     /// `M_MISSING_PARAM`
@@ -848,7 +848,7 @@ pub enum ErrorCode {
     ///
     /// No [access token] was specified for the request, but one is required.
     ///
-    /// [access token]: https://spec.matrix.org/v1.18/client-server-api/#client-authentication
+    /// [access token]: https://spec.matrix.org/v1.19/client-server-api/#client-authentication
     MissingToken,
 
     /// `M_NOT_FOUND`
@@ -889,7 +889,7 @@ pub enum ErrorCode {
     /// The [room alias] specified in the `POST /_matrix/client/*/createRoom` request is already
     /// taken.
     ///
-    /// [room alias]: https://spec.matrix.org/v1.18/client-server-api/#room-aliases
+    /// [room alias]: https://spec.matrix.org/v1.19/client-server-api/#room-aliases
     RoomInUse,
 
     /// `M_SENDER_IGNORED`
@@ -911,7 +911,7 @@ pub enum ErrorCode {
     ///
     /// Authentication could not be performed on the [third-party identifier].
     ///
-    /// [third-party identifier]: https://spec.matrix.org/v1.18/client-server-api/#adding-account-administrative-contact-information
+    /// [third-party identifier]: https://spec.matrix.org/v1.19/client-server-api/#adding-account-administrative-contact-information
     ThreepidAuthFailed,
 
     /// `M_THREEPID_DENIED`
@@ -919,28 +919,28 @@ pub enum ErrorCode {
     /// The server does not permit this [third-party identifier]. This may happen if the server
     /// only permits, for example, email addresses from a particular domain.
     ///
-    /// [third-party identifier]: https://spec.matrix.org/v1.18/client-server-api/#adding-account-administrative-contact-information
+    /// [third-party identifier]: https://spec.matrix.org/v1.19/client-server-api/#adding-account-administrative-contact-information
     ThreepidDenied,
 
     /// `M_THREEPID_IN_USE`
     ///
     /// The [third-party identifier] is already in use by another user.
     ///
-    /// [third-party identifier]: https://spec.matrix.org/v1.18/client-server-api/#adding-account-administrative-contact-information
+    /// [third-party identifier]: https://spec.matrix.org/v1.19/client-server-api/#adding-account-administrative-contact-information
     ThreepidInUse,
 
     /// `M_THREEPID_MEDIUM_NOT_SUPPORTED`
     ///
     /// The homeserver does not support adding a [third-party identifier] of the given medium.
     ///
-    /// [third-party identifier]: https://spec.matrix.org/v1.18/client-server-api/#adding-account-administrative-contact-information
+    /// [third-party identifier]: https://spec.matrix.org/v1.19/client-server-api/#adding-account-administrative-contact-information
     ThreepidMediumNotSupported,
 
     /// `M_THREEPID_NOT_FOUND`
     ///
     /// No account matching the given [third-party identifier] could be found.
     ///
-    /// [third-party identifier]: https://spec.matrix.org/v1.18/client-server-api/#adding-account-administrative-contact-information
+    /// [third-party identifier]: https://spec.matrix.org/v1.19/client-server-api/#adding-account-administrative-contact-information
     ThreepidNotFound,
 
     /// `M_TOKEN_INCORRECT`
@@ -959,7 +959,7 @@ pub enum ErrorCode {
     /// This can happen if the homeserver does not know about any of the rooms listed as
     /// conditions, for example.
     ///
-    /// [restricted]: https://spec.matrix.org/v1.18/client-server-api/#restricted-rooms
+    /// [restricted]: https://spec.matrix.org/v1.19/client-server-api/#restricted-rooms
     #[ruma_enum(rename = "M_UNABLE_TO_AUTHORISE_JOIN")]
     UnableToAuthorizeJoin,
 
@@ -970,7 +970,7 @@ pub enum ErrorCode {
     /// of [restricted rooms], but the resident server would be unable to meet the authorization
     /// rules.
     ///
-    /// [restricted rooms]: https://spec.matrix.org/v1.18/client-server-api/#restricted-rooms
+    /// [restricted rooms]: https://spec.matrix.org/v1.19/client-server-api/#restricted-rooms
     UnableToGrantJoin,
 
     /// `M_UNACTIONABLE`
@@ -1003,7 +1003,7 @@ pub enum ErrorCode {
     ///
     /// The [access or refresh token] specified was not recognized.
     ///
-    /// [access or refresh token]: https://spec.matrix.org/v1.18/client-server-api/#client-authentication
+    /// [access or refresh token]: https://spec.matrix.org/v1.19/client-server-api/#client-authentication
     UnknownToken,
 
     /// `M_UNRECOGNIZED`
@@ -1045,21 +1045,21 @@ pub enum ErrorCode {
     ///
     /// The account has been [locked] and cannot be used at this time.
     ///
-    /// [locked]: https://spec.matrix.org/v1.18/client-server-api/#account-locking
+    /// [locked]: https://spec.matrix.org/v1.19/client-server-api/#account-locking
     UserLocked,
 
     /// `M_USER_SUSPENDED`
     ///
     /// The account has been [suspended] and can only be used for limited actions at this time.
     ///
-    /// [suspended]: https://spec.matrix.org/v1.18/client-server-api/#account-suspension
+    /// [suspended]: https://spec.matrix.org/v1.19/client-server-api/#account-suspension
     UserSuspended,
 
     /// `M_WEAK_PASSWORD`
     ///
     /// The password was [rejected] by the server for being too weak.
     ///
-    /// [rejected]: https://spec.matrix.org/v1.18/client-server-api/#password-management
+    /// [rejected]: https://spec.matrix.org/v1.19/client-server-api/#password-management
     WeakPassword,
 
     /// `M_WRONG_ROOM_KEYS_VERSION`
@@ -1067,7 +1067,7 @@ pub enum ErrorCode {
     /// The version of the [room keys backup] provided in the request does not match the current
     /// backup version.
     ///
-    /// [room keys backup]: https://spec.matrix.org/v1.18/client-server-api/#server-side-key-backups
+    /// [room keys backup]: https://spec.matrix.org/v1.19/client-server-api/#server-side-key-backups
     WrongRoomKeysVersion,
 
     #[doc(hidden)]

--- a/crates/ruma-common/src/api/metadata.rs
+++ b/crates/ruma-common/src/api/metadata.rs
@@ -272,7 +272,7 @@ pub trait Metadata: Sized {
 /// Every new version denotes stable support for endpoints in a *relatively* backwards-compatible
 /// manner.
 ///
-/// Matrix has a deprecation policy, read more about it here: <https://spec.matrix.org/v1.18/#deprecation-policy>.
+/// Matrix has a deprecation policy, read more about it here: <https://spec.matrix.org/v1.19/#deprecation-policy>.
 ///
 /// Ruma keeps track of when endpoints are added, deprecated, and removed. It'll automatically
 /// select the right endpoint stability variation to use depending on which Matrix versions you
@@ -296,7 +296,7 @@ pub enum MatrixVersion {
     ///
     /// The other APIs are not supported because they do not have a `GET /versions` endpoint.
     ///
-    /// See <https://spec.matrix.org/v1.18/#legacy-versioning>.
+    /// See <https://spec.matrix.org/v1.19/#legacy-versioning>.
     V1_0,
 
     /// Version 1.1 of the Matrix specification, released in Q4 2021.

--- a/crates/ruma-common/src/encryption.rs
+++ b/crates/ruma-common/src/encryption.rs
@@ -1,6 +1,6 @@
 //! Common types for [encryption] related tasks.
 //!
-//! [encryption]: https://spec.matrix.org/v1.18/client-server-api/#end-to-end-encryption
+//! [encryption]: https://spec.matrix.org/v1.19/client-server-api/#end-to-end-encryption
 
 use std::collections::BTreeMap;
 
@@ -117,7 +117,7 @@ pub enum OneTimeKey {
 
 /// A [cross-signing] key.
 ///
-/// [cross-signing]: https://spec.matrix.org/v1.18/client-server-api/#cross-signing
+/// [cross-signing]: https://spec.matrix.org/v1.19/client-server-api/#cross-signing
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct CrossSigningKey {

--- a/crates/ruma-common/src/identifiers/base64_public_key.rs
+++ b/crates/ruma-common/src/identifiers/base64_public_key.rs
@@ -8,7 +8,7 @@ use crate::serde::{Base64, Base64DecodeError, base64::Standard};
 /// This string is validated using the set `[a-zA-Z0-9+/=]`, but it is not validated to be decodable
 /// as base64. This type is provided simply for its semantic value.
 ///
-/// [cross-signing]: https://spec.matrix.org/v1.18/client-server-api/#cross-signing
+/// [cross-signing]: https://spec.matrix.org/v1.19/client-server-api/#cross-signing
 #[repr(transparent)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
 #[ruma_id(validate = ruma_identifiers_validation::base64_public_key::validate)]

--- a/crates/ruma-common/src/identifiers/crypto_algorithms.rs
+++ b/crates/ruma-common/src/identifiers/crypto_algorithms.rs
@@ -6,7 +6,7 @@ use crate::PrivOwnedStr;
 
 /// The algorithms for the [device keys] defined in the Matrix spec.
 ///
-/// [device keys]: https://spec.matrix.org/v1.18/client-server-api/#device-keys
+/// [device keys]: https://spec.matrix.org/v1.19/client-server-api/#device-keys
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
 #[derive(Clone, StringEnum)]
 #[non_exhaustive]
@@ -67,7 +67,7 @@ pub enum KeyDerivationAlgorithm {
 
 /// The algorithms for [one-time and fallback keys] defined in the Matrix spec.
 ///
-/// [one-time and fallback keys]: https://spec.matrix.org/v1.18/client-server-api/#one-time-and-fallback-keys
+/// [one-time and fallback keys]: https://spec.matrix.org/v1.19/client-server-api/#one-time-and-fallback-keys
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
 #[derive(Clone, StringEnum)]
 #[non_exhaustive]

--- a/crates/ruma-common/src/identifiers/event_id.rs
+++ b/crates/ruma-common/src/identifiers/event_id.rs
@@ -51,8 +51,8 @@ use super::{IdParseError, ServerName};
 /// );
 /// ```
 ///
-/// [event ID]: https://spec.matrix.org/v1.18/appendices/#event-ids
-/// [room versions]: https://spec.matrix.org/v1.18/rooms/
+/// [event ID]: https://spec.matrix.org/v1.19/appendices/#event-ids
+/// [room versions]: https://spec.matrix.org/v1.19/rooms/
 #[repr(transparent)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
 #[ruma_id(validate = ruma_identifiers_validation::event_id::validate)]

--- a/crates/ruma-common/src/identifiers/key_id.rs
+++ b/crates/ruma-common/src/identifiers/key_id.rs
@@ -15,12 +15,12 @@ use super::{
 /// A key algorithm and key name delimited by a colon.
 ///
 /// Examples of the use of this struct are [`DeviceKeyId`], which identifies a Ed25519 or Curve25519
-/// [device key](https://spec.matrix.org/v1.18/client-server-api/#device-keys), and
+/// [device key](https://spec.matrix.org/v1.19/client-server-api/#device-keys), and
 /// [`CrossSigningKeyId`], which identifies a user's
-/// [cross signing key](https://spec.matrix.org/v1.18/client-server-api/#cross-signing).
+/// [cross signing key](https://spec.matrix.org/v1.19/client-server-api/#cross-signing).
 ///
 /// This format of identifier is often used in the `signatures` field of
-/// [signed JSON](https://spec.matrix.org/v1.18/appendices/#signing-details)
+/// [signed JSON](https://spec.matrix.org/v1.19/appendices/#signing-details)
 /// where it is referred to as a "signing key identifier".
 ///
 /// This struct is rarely used directly - instead you should expect to use one of the type aliases
@@ -118,54 +118,54 @@ pub type OwnedServerSigningKeyId = OwnedSigningKeyId<ServerSigningKeyVersion>;
 
 /// Algorithm + key name for [device signing keys].
 ///
-/// [device signing keys]: https://spec.matrix.org/v1.18/client-server-api/#device-keys
+/// [device signing keys]: https://spec.matrix.org/v1.19/client-server-api/#device-keys
 pub type DeviceSigningKeyId = SigningKeyId<DeviceId>;
 
 /// Algorithm + key name for [device signing] keys.
 ///
-/// [device signing keys]: https://spec.matrix.org/v1.18/client-server-api/#device-keys
+/// [device signing keys]: https://spec.matrix.org/v1.19/client-server-api/#device-keys
 pub type OwnedDeviceSigningKeyId = OwnedSigningKeyId<DeviceId>;
 
 /// Algorithm + key name for [cross-signing] keys.
 ///
-/// [cross-signing]: https://spec.matrix.org/v1.18/client-server-api/#cross-signing
+/// [cross-signing]: https://spec.matrix.org/v1.19/client-server-api/#cross-signing
 pub type CrossSigningKeyId = SigningKeyId<Base64PublicKey>;
 
 /// Algorithm + key name for [cross-signing] keys.
 ///
-/// [cross-signing]: https://spec.matrix.org/v1.18/client-server-api/#cross-signing
+/// [cross-signing]: https://spec.matrix.org/v1.19/client-server-api/#cross-signing
 pub type OwnedCrossSigningKeyId = OwnedSigningKeyId<Base64PublicKey>;
 
 /// Algorithm + key name for [cross-signing] or [device signing] keys.
 ///
-/// [cross-signing]: https://spec.matrix.org/v1.18/client-server-api/#cross-signing
-/// [device signing]: https://spec.matrix.org/v1.18/client-server-api/#device-keys
+/// [cross-signing]: https://spec.matrix.org/v1.19/client-server-api/#cross-signing
+/// [device signing]: https://spec.matrix.org/v1.19/client-server-api/#device-keys
 pub type CrossSigningOrDeviceSigningKeyId = SigningKeyId<Base64PublicKeyOrDeviceId>;
 
 /// Algorithm + key name for [cross-signing] or [device signing] keys.
 ///
-/// [cross-signing]: https://spec.matrix.org/v1.18/client-server-api/#cross-signing
-/// [device signing]: https://spec.matrix.org/v1.18/client-server-api/#device-keys
+/// [cross-signing]: https://spec.matrix.org/v1.19/client-server-api/#cross-signing
+/// [device signing]: https://spec.matrix.org/v1.19/client-server-api/#device-keys
 pub type OwnedCrossSigningOrDeviceSigningKeyId = OwnedSigningKeyId<Base64PublicKeyOrDeviceId>;
 
 /// Algorithm + key name for [device keys].
 ///
-/// [device keys]: https://spec.matrix.org/v1.18/client-server-api/#device-keys
+/// [device keys]: https://spec.matrix.org/v1.19/client-server-api/#device-keys
 pub type DeviceKeyId = KeyId<DeviceKeyAlgorithm, DeviceId>;
 
 /// Algorithm + key name for [device keys].
 ///
-/// [device keys]: https://spec.matrix.org/v1.18/client-server-api/#device-keys
+/// [device keys]: https://spec.matrix.org/v1.19/client-server-api/#device-keys
 pub type OwnedDeviceKeyId = OwnedKeyId<DeviceKeyAlgorithm, DeviceId>;
 
 /// Algorithm + key name for [one-time and fallback keys].
 ///
-/// [one-time and fallback keys]: https://spec.matrix.org/v1.18/client-server-api/#one-time-and-fallback-keys
+/// [one-time and fallback keys]: https://spec.matrix.org/v1.19/client-server-api/#one-time-and-fallback-keys
 pub type OneTimeKeyId = KeyId<OneTimeKeyAlgorithm, OneTimeKeyName>;
 
 /// Algorithm + key name for [one-time and fallback keys].
 ///
-/// [one-time and fallback keys]: https://spec.matrix.org/v1.18/client-server-api/#one-time-and-fallback-keys
+/// [one-time and fallback keys]: https://spec.matrix.org/v1.19/client-server-api/#one-time-and-fallback-keys
 pub type OwnedOneTimeKeyId = OwnedKeyId<OneTimeKeyAlgorithm, OneTimeKeyName>;
 
 // The following impls are usually derived using the std macros.

--- a/crates/ruma-common/src/identifiers/matrix_uri.rs
+++ b/crates/ruma-common/src/identifiers/matrix_uri.rs
@@ -257,7 +257,7 @@ impl From<(&RoomAliasId, &EventId)> for MatrixId {
 /// Get the URI through its `Display` implementation (i.e. by interpolating it
 /// in a formatting macro or via `.to_string()`).
 ///
-/// [`matrix.to` URI]: https://spec.matrix.org/v1.18/appendices/#matrixto-navigation
+/// [`matrix.to` URI]: https://spec.matrix.org/v1.19/appendices/#matrixto-navigation
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MatrixToUri {
     id: MatrixId,
@@ -442,7 +442,7 @@ impl From<Box<str>> for UriAction {
 /// Get the URI through its `Display` implementation (i.e. by interpolating it
 /// in a formatting macro or via `.to_string()`).
 ///
-/// [`matrix:` URI]: https://spec.matrix.org/v1.18/appendices/#matrix-uri-scheme
+/// [`matrix:` URI]: https://spec.matrix.org/v1.19/appendices/#matrix-uri-scheme
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MatrixUri {
     id: MatrixId,

--- a/crates/ruma-common/src/identifiers/mxc_uri.rs
+++ b/crates/ruma-common/src/identifiers/mxc_uri.rs
@@ -1,6 +1,6 @@
 //! A URI that should be a Matrix-spec compliant [MXC URI].
 //!
-//! [MXC URI]: https://spec.matrix.org/v1.18/client-server-api/#matrix-content-mxc-uris
+//! [MXC URI]: https://spec.matrix.org/v1.19/client-server-api/#matrix-content-mxc-uris
 
 use std::num::NonZeroU8;
 
@@ -13,7 +13,7 @@ type Result<T, E = MxcUriError> = std::result::Result<T, E>;
 
 /// A URI that should be a Matrix-spec compliant [MXC URI].
 ///
-/// [MXC URI]: https://spec.matrix.org/v1.18/client-server-api/#matrix-content-mxc-uris
+/// [MXC URI]: https://spec.matrix.org/v1.19/client-server-api/#matrix-content-mxc-uris
 #[repr(transparent)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
 pub struct MxcUri(str);

--- a/crates/ruma-common/src/identifiers/one_time_key_name.rs
+++ b/crates/ruma-common/src/identifiers/one_time_key_name.rs
@@ -7,7 +7,7 @@ use super::{IdParseError, KeyName};
 /// One-time and fallback key names in Matrix are completely opaque character sequences. This
 /// type is provided simply for its semantic value.
 ///
-/// [one-time or fallback key]: https://spec.matrix.org/v1.18/client-server-api/#one-time-and-fallback-keys
+/// [one-time or fallback key]: https://spec.matrix.org/v1.19/client-server-api/#one-time-and-fallback-keys
 #[repr(transparent)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
 pub struct OneTimeKeyName(str);

--- a/crates/ruma-common/src/identifiers/room_alias_id.rs
+++ b/crates/ruma-common/src/identifiers/room_alias_id.rs
@@ -14,7 +14,7 @@ use super::{MatrixToUri, MatrixUri, OwnedEventId, matrix_uri::UriAction, server_
 /// assert_eq!(<&RoomAliasId>::try_from("#ruma:example.com").unwrap(), "#ruma:example.com");
 /// ```
 ///
-/// [room alias ID]: https://spec.matrix.org/v1.18/appendices/#room-aliases
+/// [room alias ID]: https://spec.matrix.org/v1.19/appendices/#room-aliases
 #[repr(transparent)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
 #[ruma_id(validate = ruma_identifiers_validation::room_alias_id::validate)]

--- a/crates/ruma-common/src/identifiers/room_id.rs
+++ b/crates/ruma-common/src/identifiers/room_id.rs
@@ -18,7 +18,7 @@ use crate::RoomOrAliasId;
 /// assert_eq!(<&RoomId>::try_from("!n8f893n9:example.com").unwrap(), "!n8f893n9:example.com");
 /// ```
 ///
-/// [room ID]: https://spec.matrix.org/v1.18/appendices/#room-ids
+/// [room ID]: https://spec.matrix.org/v1.19/appendices/#room-ids
 #[repr(transparent)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
 #[ruma_id(validate = ruma_identifiers_validation::room_id::validate)]
@@ -116,7 +116,7 @@ impl RoomId {
     /// );
     /// ```
     ///
-    /// [routing algorithm]: https://spec.matrix.org/v1.18/appendices/#routing
+    /// [routing algorithm]: https://spec.matrix.org/v1.19/appendices/#routing
     pub fn matrix_to_uri_via<T>(&self, via: T) -> MatrixToUri
     where
         T: IntoIterator,
@@ -140,7 +140,7 @@ impl RoomId {
     ///
     /// If you don't have a list of servers, you can use [`RoomId::matrix_to_event_uri()`] instead.
     ///
-    /// [routing algorithm]: https://spec.matrix.org/v1.18/appendices/#routing
+    /// [routing algorithm]: https://spec.matrix.org/v1.19/appendices/#routing
     pub fn matrix_to_event_uri_via<T>(&self, ev_id: impl Into<OwnedEventId>, via: T) -> MatrixToUri
     where
         T: IntoIterator,
@@ -197,7 +197,7 @@ impl RoomId {
     /// );
     /// ```
     ///
-    /// [routing algorithm]: https://spec.matrix.org/v1.18/appendices/#routing
+    /// [routing algorithm]: https://spec.matrix.org/v1.19/appendices/#routing
     pub fn matrix_uri_via<T>(&self, via: T, join: bool) -> MatrixUri
     where
         T: IntoIterator,
@@ -225,7 +225,7 @@ impl RoomId {
     ///
     /// If you don't have a list of servers, you can use [`RoomId::matrix_event_uri()`] instead.
     ///
-    /// [routing algorithm]: https://spec.matrix.org/v1.18/appendices/#routing
+    /// [routing algorithm]: https://spec.matrix.org/v1.19/appendices/#routing
     pub fn matrix_event_uri_via<T>(&self, ev_id: impl Into<OwnedEventId>, via: T) -> MatrixUri
     where
         T: IntoIterator,

--- a/crates/ruma-common/src/identifiers/room_or_alias_id.rs
+++ b/crates/ruma-common/src/identifiers/room_or_alias_id.rs
@@ -27,8 +27,8 @@ use super::{OwnedRoomAliasId, OwnedRoomId, RoomAliasId, RoomId, server_name::Ser
 /// For example, `<&RoomId>::try_from(room_or_alias_id)` returns either `Ok(room_id)` or
 /// `Err(room_alias_id)`.
 ///
-/// [room ID]: https://spec.matrix.org/v1.18/appendices/#room-ids
-/// [room alias ID]: https://spec.matrix.org/v1.18/appendices/#room-aliases
+/// [room ID]: https://spec.matrix.org/v1.19/appendices/#room-ids
+/// [room alias ID]: https://spec.matrix.org/v1.19/appendices/#room-aliases
 #[repr(transparent)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
 #[ruma_id(validate = ruma_identifiers_validation::room_id_or_alias_id::validate)]

--- a/crates/ruma-common/src/identifiers/room_version_id.rs
+++ b/crates/ruma-common/src/identifiers/room_version_id.rs
@@ -27,7 +27,7 @@ use crate::room_version_rules::RoomVersionRules;
 /// string representations, which have no special meaning. To check the compatibility between
 /// room versions, one should use the [`RoomVersionRules`] instead.
 ///
-/// [room version]: https://spec.matrix.org/v1.18/rooms/
+/// [room version]: https://spec.matrix.org/v1.19/rooms/
 #[derive(Clone, Debug, PartialEq, Eq, Hash, DisplayAsRefStr)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub enum RoomVersionId {

--- a/crates/ruma-common/src/identifiers/server_name.rs
+++ b/crates/ruma-common/src/identifiers/server_name.rs
@@ -8,7 +8,7 @@ use ruma_macros::IdDst;
 ///
 /// It consists of a host and an optional port (separated by a colon if present).
 ///
-/// [server name]: https://spec.matrix.org/v1.18/appendices/#server-name
+/// [server name]: https://spec.matrix.org/v1.19/appendices/#server-name
 #[repr(transparent)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
 #[ruma_id(validate = ruma_identifiers_validation::server_name::validate)]

--- a/crates/ruma-common/src/identifiers/server_signing_key_version.rs
+++ b/crates/ruma-common/src/identifiers/server_signing_key_version.rs
@@ -10,7 +10,7 @@ use super::{IdParseError, KeyName};
 /// With the `compat-server-signing-key-version` cargo feature, the validation of this type is
 /// relaxed to accept any string.
 ///
-/// [homeserver signing key]: https://spec.matrix.org/v1.18/server-server-api/#retrieving-server-keys
+/// [homeserver signing key]: https://spec.matrix.org/v1.19/server-server-api/#retrieving-server-keys
 #[repr(transparent)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
 #[ruma_id(

--- a/crates/ruma-common/src/identifiers/space_child_order.rs
+++ b/crates/ruma-common/src/identifiers/space_child_order.rs
@@ -8,7 +8,7 @@ use ruma_macros::IdDst;
 /// within the range `\x20` (space) and `\x7E` (~), inclusive. Their length must must not exceed 50
 /// characters.
 ///
-/// [`m.space.child`]: https://spec.matrix.org/v1.18/client-server-api/#mspacechild
+/// [`m.space.child`]: https://spec.matrix.org/v1.19/client-server-api/#mspacechild
 #[repr(transparent)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
 #[ruma_id(validate = ruma_identifiers_validation::space_child_order::validate)]

--- a/crates/ruma-common/src/identifiers/user_id.rs
+++ b/crates/ruma-common/src/identifiers/user_id.rs
@@ -16,7 +16,7 @@ use super::{IdParseError, MatrixToUri, MatrixUri, ServerName, matrix_uri::UriAct
 /// assert_eq!(<&UserId>::try_from("@carl:example.com").unwrap(), "@carl:example.com");
 /// ```
 ///
-/// [user ID]: https://spec.matrix.org/v1.18/appendices/#user-identifiers
+/// [user ID]: https://spec.matrix.org/v1.19/appendices/#user-identifiers
 #[repr(transparent)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
 #[ruma_id(validate = ruma_identifiers_validation::user_id::validate)]
@@ -87,7 +87,7 @@ impl UserId {
     /// This should be used to validate newly created user IDs as historical user IDs are
     /// deprecated.
     ///
-    /// [strict grammar]: https://spec.matrix.org/v1.18/appendices/#user-identifiers
+    /// [strict grammar]: https://spec.matrix.org/v1.19/appendices/#user-identifiers
     pub fn validate_strict(&self) -> Result<(), IdParseError> {
         let is_fully_conforming = self.validate_fully_conforming()?;
 
@@ -102,7 +102,7 @@ impl UserId {
     /// Contrary to [`UserId::is_historical()`] this method also includes user IDs that conform to
     /// the latest grammar.
     ///
-    /// [historical grammar]: https://spec.matrix.org/v1.18/appendices/#historical-user-ids
+    /// [historical grammar]: https://spec.matrix.org/v1.19/appendices/#historical-user-ids
     pub fn validate_historical(&self) -> Result<(), IdParseError> {
         self.validate_fully_conforming()?;
         Ok(())
@@ -113,7 +113,7 @@ impl UserId {
     /// A [historical user ID] is one that doesn't conform to the latest specification of the user
     /// ID grammar but is still accepted because it was previously allowed.
     ///
-    /// [historical user ID]: https://spec.matrix.org/v1.18/appendices/#historical-user-ids
+    /// [historical user ID]: https://spec.matrix.org/v1.19/appendices/#historical-user-ids
     pub fn is_historical(&self) -> bool {
         self.validate_fully_conforming().is_ok_and(|is_fully_conforming| !is_fully_conforming)
     }

--- a/crates/ruma-common/src/media.rs
+++ b/crates/ruma-common/src/media.rs
@@ -1,6 +1,6 @@
 //! Common types and functions for the [content repository].
 //!
-//! [content repository]: https://spec.matrix.org/v1.18/client-server-api/#content-repository
+//! [content repository]: https://spec.matrix.org/v1.19/client-server-api/#content-repository
 
 use std::time::Duration;
 

--- a/crates/ruma-common/src/power_levels.rs
+++ b/crates/ruma-common/src/power_levels.rs
@@ -1,6 +1,6 @@
 //! Common types for the [`m.room.power_levels` event][power_levels].
 //!
-//! [power_levels]: https://spec.matrix.org/v1.18/client-server-api/#mroompower_levels
+//! [power_levels]: https://spec.matrix.org/v1.19/client-server-api/#mroompower_levels
 
 use js_int::{Int, int};
 use ruma_macros::StringEnum;

--- a/crates/ruma-common/src/presence.rs
+++ b/crates/ruma-common/src/presence.rs
@@ -1,6 +1,6 @@
 //! Common types for the [presence module][presence].
 //!
-//! [presence]: https://spec.matrix.org/v1.18/client-server-api/#presence
+//! [presence]: https://spec.matrix.org/v1.19/client-server-api/#presence
 
 use crate::{PrivOwnedStr, serde::StringEnum};
 

--- a/crates/ruma-common/src/profile.rs
+++ b/crates/ruma-common/src/profile.rs
@@ -26,7 +26,7 @@ pub use self::{static_profile_field::*, user_profile::*};
 
 /// The possible fields of a user's [profile].
 ///
-/// [profile]: https://spec.matrix.org/v1.18/client-server-api/#profiles
+/// [profile]: https://spec.matrix.org/v1.19/client-server-api/#profiles
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
 #[derive(Clone, StringEnum)]
 #[ruma_enum(rename_all = "snake_case")]
@@ -63,7 +63,7 @@ pub enum ProfileFieldName {
 
 /// The possible values of a field of a user's [profile].
 ///
-/// [profile]: https://spec.matrix.org/v1.18/client-server-api/#profiles
+/// [profile]: https://spec.matrix.org/v1.19/client-server-api/#profiles
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]

--- a/crates/ruma-common/src/profile/static_profile_field.rs
+++ b/crates/ruma-common/src/profile/static_profile_field.rs
@@ -10,7 +10,7 @@ use serde::{Serialize, de::DeserializeOwned};
 /// Trait implemented by types representing a field in a user's [profile] having a statically-known
 /// name.
 ///
-/// [profile]: https://spec.matrix.org/v1.18/client-server-api/#profiles
+/// [profile]: https://spec.matrix.org/v1.19/client-server-api/#profiles
 pub trait StaticProfileField {
     /// The type for the value of the field.
     type Value: Sized + Serialize + DeserializeOwned;

--- a/crates/ruma-common/src/push.rs
+++ b/crates/ruma-common/src/push.rs
@@ -1,6 +1,6 @@
 //! Common types for the [push notifications module][push].
 //!
-//! [push]: https://spec.matrix.org/v1.18/client-server-api/#push-notifications
+//! [push]: https://spec.matrix.org/v1.19/client-server-api/#push-notifications
 //!
 //! ## Understanding the types of this module
 //!
@@ -765,7 +765,7 @@ impl HttpPusherData {
 /// A special format that the homeserver should use when sending notifications to a Push Gateway.
 /// Currently, only `event_id_only` is supported, see the [Push Gateway API][spec].
 ///
-/// [spec]: https://spec.matrix.org/v1.18/push-gateway-api/#homeserver-behaviour
+/// [spec]: https://spec.matrix.org/v1.19/push-gateway-api/#homeserver-behaviour
 #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/doc/string_enum.md"))]
 #[derive(Clone, StringEnum)]
 #[ruma_enum(rename_all = "snake_case")]

--- a/crates/ruma-common/src/push/action.rs
+++ b/crates/ruma-common/src/push/action.rs
@@ -15,7 +15,7 @@ use crate::{
 /// This represents the different actions that should be taken when a rule is matched, and
 /// controls how notifications are delivered to the client.
 ///
-/// See [the spec](https://spec.matrix.org/v1.18/client-server-api/#actions) for details.
+/// See [the spec](https://spec.matrix.org/v1.19/client-server-api/#actions) for details.
 #[derive(Clone, Debug)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub enum Action {

--- a/crates/ruma-common/src/push/condition.rs
+++ b/crates/ruma-common/src/push/condition.rs
@@ -207,7 +207,7 @@ impl From<ThreadSubscriptionConditionData> for PushCondition {
 pub struct EventMatchConditionData {
     /// The [dot-separated path] of the property of the event to match.
     ///
-    /// [dot-separated path]: https://spec.matrix.org/v1.18/appendices/#dot-separated-property-paths
+    /// [dot-separated path]: https://spec.matrix.org/v1.19/appendices/#dot-separated-property-paths
     pub key: String,
 
     /// The glob-style pattern to match against.
@@ -375,7 +375,7 @@ impl RoomVersionFeature {
 pub struct EventPropertyIsConditionData {
     /// The [dot-separated path] of the property of the event to match.
     ///
-    /// [dot-separated path]: https://spec.matrix.org/v1.18/appendices/#dot-separated-property-paths
+    /// [dot-separated path]: https://spec.matrix.org/v1.19/appendices/#dot-separated-property-paths
     pub key: String,
 
     /// The value to match against.
@@ -404,7 +404,7 @@ impl EventPropertyIsConditionData {
 pub struct EventPropertyContainsConditionData {
     /// The [dot-separated path] of the property of the event to match.
     ///
-    /// [dot-separated path]: https://spec.matrix.org/v1.18/appendices/#dot-separated-property-paths
+    /// [dot-separated path]: https://spec.matrix.org/v1.19/appendices/#dot-separated-property-paths
     pub key: String,
 
     /// The value to match against.
@@ -1029,7 +1029,7 @@ mod tests {
         assert!(!"m".matches_word("[[:alpha:]]?"));
         assert!("[[:alpha:]]!".matches_word("[[:alpha:]]?"));
 
-        // From the spec: <https://spec.matrix.org/v1.18/client-server-api/#conditions-1>
+        // From the spec: <https://spec.matrix.org/v1.19/client-server-api/#conditions-1>
         assert!("An example event.".matches_word("ex*ple"));
         assert!("exple".matches_word("ex*ple"));
         assert!("An exciting triple-whammy".matches_word("ex*ple"));
@@ -1078,7 +1078,7 @@ mod tests {
         assert!("".matches_pattern("*", false));
         assert!(!"foo".matches_pattern("", false));
 
-        // From the spec: <https://spec.matrix.org/v1.18/client-server-api/#conditions-1>
+        // From the spec: <https://spec.matrix.org/v1.19/client-server-api/#conditions-1>
         assert!("Lunch plans".matches_pattern("lunc?*", false));
         assert!("LUNCH".matches_pattern("lunc?*", false));
         assert!(!" lunch".matches_pattern("lunc?*", false));

--- a/crates/ruma-common/src/push/predefined.rs
+++ b/crates/ruma-common/src/push/predefined.rs
@@ -1,6 +1,6 @@
 //! Constructors for [predefined push rules].
 //!
-//! [predefined push rules]: https://spec.matrix.org/v1.18/client-server-api/#predefined-rules
+//! [predefined push rules]: https://spec.matrix.org/v1.19/client-server-api/#predefined-rules
 
 use ruma_macros::StringEnum;
 
@@ -20,7 +20,7 @@ impl Ruleset {
     /// - `user_id`: the user for which to generate the default rules. Some rules depend on the
     ///   user's ID (for instance those to send notifications when they are mentioned).
     ///
-    /// [predefined push rules]: https://spec.matrix.org/v1.18/client-server-api/#predefined-rules
+    /// [predefined push rules]: https://spec.matrix.org/v1.19/client-server-api/#predefined-rules
     pub fn server_default(user_id: &UserId) -> Self {
         Self {
             override_: [
@@ -248,7 +248,7 @@ impl ConditionalPushRule {
 
     /// Matches [reactions] to a message.
     ///
-    /// [reactions]: https://spec.matrix.org/v1.18/client-server-api/#event-annotations-and-reactions
+    /// [reactions]: https://spec.matrix.org/v1.19/client-server-api/#event-annotations-and-reactions
     pub fn reaction() -> Self {
         Self {
             actions: vec![],
@@ -264,7 +264,7 @@ impl ConditionalPushRule {
 
     /// Matches [room server ACLs].
     ///
-    /// [room server ACLs]: https://spec.matrix.org/v1.18/client-server-api/#server-access-control-lists-acls-for-rooms
+    /// [room server ACLs]: https://spec.matrix.org/v1.19/client-server-api/#server-access-control-lists-acls-for-rooms
     pub fn server_acl() -> Self {
         Self {
             actions: vec![],
@@ -280,7 +280,7 @@ impl ConditionalPushRule {
 
     /// Matches [event replacements].
     ///
-    /// [event replacements]: https://spec.matrix.org/v1.18/client-server-api/#event-replacements
+    /// [event replacements]: https://spec.matrix.org/v1.19/client-server-api/#event-replacements
     pub fn suppress_edits() -> Self {
         Self {
             actions: vec![],

--- a/crates/ruma-common/src/room_version_rules.rs
+++ b/crates/ruma-common/src/room_version_rules.rs
@@ -1,6 +1,6 @@
 //! Types for the rules applied to the different [room versions].
 //!
-//! [room versions]: https://spec.matrix.org/v1.18/rooms/
+//! [room versions]: https://spec.matrix.org/v1.19/rooms/
 
 #[allow(clippy::disallowed_types)]
 use std::collections::HashSet;
@@ -14,7 +14,7 @@ use crate::OwnedUserId;
 /// This type can be constructed from one of its constants (like [`RoomVersionRules::V1`]), or from
 /// [`RoomVersionId::rules()`].
 ///
-/// [room version]: https://spec.matrix.org/v1.18/rooms/
+/// [room version]: https://spec.matrix.org/v1.19/rooms/
 /// [`RoomVersionId::rules()`]: crate::RoomVersionId::rules
 #[derive(Debug, Clone)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
@@ -37,7 +37,7 @@ pub struct RoomVersionRules {
     /// Whether to enforce the key validity period when verifying signatures ([spec]), introduced
     /// in room version 5.
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/rooms/v5/#signing-key-validity-period
+    /// [spec]: https://spec.matrix.org/v1.19/rooms/v5/#signing-key-validity-period
     pub enforce_key_validity: bool,
 
     /// The tweaks in the authorization rules.
@@ -56,7 +56,7 @@ pub struct RoomVersionRules {
 impl RoomVersionRules {
     /// Rules for [room version 1].
     ///
-    /// [room version 1]: https://spec.matrix.org/v1.18/rooms/v1/
+    /// [room version 1]: https://spec.matrix.org/v1.19/rooms/v1/
     pub const V1: Self = Self {
         disposition: RoomVersionDisposition::Stable,
         event_id_format: EventIdFormatVersion::V1,
@@ -72,13 +72,13 @@ impl RoomVersionRules {
 
     /// Rules for [room version 2].
     ///
-    /// [room version 2]: https://spec.matrix.org/v1.18/rooms/v2/
+    /// [room version 2]: https://spec.matrix.org/v1.19/rooms/v2/
     pub const V2: Self =
         Self { state_res: StateResolutionVersion::V2(StateResolutionV2Rules::V2_0), ..Self::V1 };
 
     /// Rules for [room version 3].
     ///
-    /// [room version 3]: https://spec.matrix.org/v1.18/rooms/v3/
+    /// [room version 3]: https://spec.matrix.org/v1.19/rooms/v3/
     pub const V3: Self = Self {
         event_id_format: EventIdFormatVersion::V2,
         events_reference_format: EventsReferenceFormatVersion::V2,
@@ -90,28 +90,28 @@ impl RoomVersionRules {
 
     /// Rules for [room version 4].
     ///
-    /// [room version 4]: https://spec.matrix.org/v1.18/rooms/v4/
+    /// [room version 4]: https://spec.matrix.org/v1.19/rooms/v4/
     pub const V4: Self = Self { event_id_format: EventIdFormatVersion::V3, ..Self::V3 };
 
     /// Rules for [room version 5].
     ///
-    /// [room version 5]: https://spec.matrix.org/v1.18/rooms/v5/
+    /// [room version 5]: https://spec.matrix.org/v1.19/rooms/v5/
     pub const V5: Self = Self { enforce_key_validity: true, ..Self::V4 };
 
     /// Rules for [room version 6].
     ///
-    /// [room version 6]: https://spec.matrix.org/v1.18/rooms/v6/
+    /// [room version 6]: https://spec.matrix.org/v1.19/rooms/v6/
     pub const V6: Self =
         Self { authorization: AuthorizationRules::V6, redaction: RedactionRules::V6, ..Self::V5 };
 
     /// Rules for [room version 7].
     ///
-    /// [room version 7]: https://spec.matrix.org/v1.18/rooms/v7/
+    /// [room version 7]: https://spec.matrix.org/v1.19/rooms/v7/
     pub const V7: Self = Self { authorization: AuthorizationRules::V7, ..Self::V6 };
 
     /// Rules for [room version 8].
     ///
-    /// [room version 8]: https://spec.matrix.org/v1.18/rooms/v8/
+    /// [room version 8]: https://spec.matrix.org/v1.19/rooms/v8/
     pub const V8: Self = Self {
         authorization: AuthorizationRules::V8,
         redaction: RedactionRules::V8,
@@ -121,17 +121,17 @@ impl RoomVersionRules {
 
     /// Rules for [room version 9].
     ///
-    /// [room version 9]: https://spec.matrix.org/v1.18/rooms/v9/
+    /// [room version 9]: https://spec.matrix.org/v1.19/rooms/v9/
     pub const V9: Self = Self { redaction: RedactionRules::V9, ..Self::V8 };
 
     /// Rules for [room version 10].
     ///
-    /// [room version 10]: https://spec.matrix.org/v1.18/rooms/v10/
+    /// [room version 10]: https://spec.matrix.org/v1.19/rooms/v10/
     pub const V10: Self = Self { authorization: AuthorizationRules::V10, ..Self::V9 };
 
     /// Rules for [room version 11].
     ///
-    /// [room version 11]: https://spec.matrix.org/v1.18/rooms/v11/
+    /// [room version 11]: https://spec.matrix.org/v1.19/rooms/v11/
     pub const V11: Self = Self {
         authorization: AuthorizationRules::V11,
         redaction: RedactionRules::V11,
@@ -171,29 +171,29 @@ pub enum RoomVersionDisposition {
 
 /// The format of [event IDs] for a room version.
 ///
-/// [event IDs]: https://spec.matrix.org/v1.18/appendices/#event-ids
+/// [event IDs]: https://spec.matrix.org/v1.19/appendices/#event-ids
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub enum EventIdFormatVersion {
     /// `$id:server` format ([spec]), introduced in room version 1.
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/rooms/v1/#event-ids
+    /// [spec]: https://spec.matrix.org/v1.19/rooms/v1/#event-ids
     V1,
 
     /// `$hash` format using standard unpadded base64 ([spec]), introduced in room version 3.
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/rooms/v3/#event-ids
+    /// [spec]: https://spec.matrix.org/v1.19/rooms/v3/#event-ids
     V2,
 
     /// `$hash` format using URL-safe unpadded base64 ([spec]), introduced in room version 4.
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/rooms/v4/#event-ids
+    /// [spec]: https://spec.matrix.org/v1.19/rooms/v4/#event-ids
     V3,
 }
 
 /// The format of [room IDs] for a room version.
 ///
-/// [room IDs]: https://spec.matrix.org/v1.18/appendices/#room-ids
+/// [room IDs]: https://spec.matrix.org/v1.19/appendices/#room-ids
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub enum RoomIdFormatVersion {
@@ -207,35 +207,35 @@ pub enum RoomIdFormatVersion {
 
 /// The format of [PDU] `auth_events` and `prev_events` for a room version.
 ///
-/// [PDU]: https://spec.matrix.org/v1.18/server-server-api/#pdus
+/// [PDU]: https://spec.matrix.org/v1.19/server-server-api/#pdus
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub enum EventsReferenceFormatVersion {
     /// `[["$id:server", {"sha256": "hash"}]]` format ([spec]), introduced in room version 1.
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/rooms/v1/#event-format
+    /// [spec]: https://spec.matrix.org/v1.19/rooms/v1/#event-format
     V1,
 
     /// `["$hash"]` format ([spec]), introduced in room version 3.
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/rooms/v3/#event-format
+    /// [spec]: https://spec.matrix.org/v1.19/rooms/v3/#event-format
     V2,
 }
 
 /// The version of [state resolution] for a room version.
 ///
-/// [state resolution]: https://spec.matrix.org/v1.18/server-server-api/#room-state-resolution
+/// [state resolution]: https://spec.matrix.org/v1.19/server-server-api/#room-state-resolution
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub enum StateResolutionVersion {
     /// First version of the state resolution algorithm ([spec]), introduced in room version 1.
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/rooms/v1/#state-resolution
+    /// [spec]: https://spec.matrix.org/v1.19/rooms/v1/#state-resolution
     V1,
 
     /// Second version of the state resolution algorithm ([spec]), introduced in room version 2.
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/rooms/v2/#state-resolution
+    /// [spec]: https://spec.matrix.org/v1.19/rooms/v2/#state-resolution
     V2(StateResolutionV2Rules),
 }
 
@@ -253,7 +253,7 @@ impl StateResolutionVersion {
 /// or by constructing a [`RoomVersionRules`] first and using the `state_res` field (if the room
 /// version uses version 2 of the state resolution algorithm).
 ///
-/// [state resolution v2 algorithm]: https://spec.matrix.org/v1.18/rooms/v2/#state-resolution
+/// [state resolution v2 algorithm]: https://spec.matrix.org/v1.19/rooms/v2/#state-resolution
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct StateResolutionV2Rules {
@@ -288,20 +288,20 @@ impl StateResolutionV2Rules {
 /// This type can be constructed from one of its constants (like [`AuthorizationRules::V1`]), or by
 /// constructing a [`RoomVersionRules`] first and using the `authorization` field.
 ///
-/// [authorization rules]: https://spec.matrix.org/v1.18/server-server-api/#authorization-rules
+/// [authorization rules]: https://spec.matrix.org/v1.19/server-server-api/#authorisation-rules
 #[derive(Debug, Clone)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct AuthorizationRules {
     /// Whether to apply special authorization rules for `m.room.redaction` events ([spec]),
     /// disabled since room version 3.
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/rooms/v3/#handling-redactions
+    /// [spec]: https://spec.matrix.org/v1.19/rooms/v3/#handling-redactions
     pub special_case_room_redaction: bool,
 
     /// Whether to apply special authorization rules for `m.room.aliases` events ([spec]), disabled
     /// since room version 6.
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/rooms/v6/#authorization-rules
+    /// [spec]: https://spec.matrix.org/v1.19/rooms/v6/#authorisation-rules
     pub special_case_room_aliases: bool,
 
     /// Whether to strictly enforce [canonical JSON] ([spec]), introduced in room version 6.
@@ -310,44 +310,44 @@ pub struct AuthorizationRules {
     /// 2<sup>53</sup> - 1], represented without exponents or decimal places, and negative zero
     /// (`-0`) MUST NOT appear.
     ///
-    /// [canonical JSON]: https://spec.matrix.org/v1.18/appendices/#canonical-json
-    /// [spec]: https://spec.matrix.org/v1.18/rooms/v6/#canonical-json
+    /// [canonical JSON]: https://spec.matrix.org/v1.19/appendices/#canonical-json
+    /// [spec]: https://spec.matrix.org/v1.19/rooms/v6/#canonical-json
     pub strict_canonical_json: bool,
 
     /// Whether to check the `notifications` field when checking `m.room.power_levels` events
     /// ([spec]), introduced in room version 6.
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/rooms/v6/#authorization-rules
+    /// [spec]: https://spec.matrix.org/v1.19/rooms/v6/#authorisation-rules
     pub limit_notifications_power_levels: bool,
 
     /// Whether to allow the `knock` membership for `m.room.member` events and the `knock` join
     /// rule for `m.room.join_rules` events ([spec]), introduced in room version 7.
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/rooms/v7/#authorization-rules
+    /// [spec]: https://spec.matrix.org/v1.19/rooms/v7/#authorisation-rules
     pub knocking: bool,
 
     /// Whether to allow the `restricted` join rule for `m.room.join_rules` events ([spec]),
     /// introduced in room version 8.
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/rooms/v8/#authorization-rules
+    /// [spec]: https://spec.matrix.org/v1.19/rooms/v8/#authorisation-rules
     pub restricted_join_rule: bool,
 
     /// Whether to allow the `knock_restricted` join rule for `m.room.join_rules` events ([spec]),
     /// introduced in room version 10.
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/rooms/v10/#authorization-rules
+    /// [spec]: https://spec.matrix.org/v1.19/rooms/v10/#authorisation-rules
     pub knock_restricted_join_rule: bool,
 
     /// Whether to enforce that power levels values in `m.room.power_levels` events be integers
     /// ([spec]), introduced in room version 10.
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/rooms/v10/#values-in-mroompower_levels-events-must-be-integers
+    /// [spec]: https://spec.matrix.org/v1.19/rooms/v10/#values-in-mroompower_levels-events-must-be-integers
     pub integer_power_levels: bool,
 
     /// Whether the room creator should be determined using the `m.room.create` event's `sender`,
     /// instead of the event content's `creator` field ([spec]), introduced in room version 11.
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/rooms/v11/#event-format
+    /// [spec]: https://spec.matrix.org/v1.19/rooms/v11/#event-format
     pub use_room_create_sender: bool,
 
     /// Whether room creators should always be considered to have "infinite" power level,
@@ -366,7 +366,7 @@ pub struct AuthorizationRules {
 impl AuthorizationRules {
     /// Authorization rules as introduced in room version 1 ([spec]).
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/rooms/v1/#authorization-rules
+    /// [spec]: https://spec.matrix.org/v1.19/rooms/v1/#authorisation-rules
     pub const V1: Self = Self {
         special_case_room_redaction: true,
         special_case_room_aliases: true,
@@ -384,12 +384,12 @@ impl AuthorizationRules {
 
     /// Authorization rules with tweaks introduced in room version 3 ([spec]).
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/rooms/v3/#authorization-rules
+    /// [spec]: https://spec.matrix.org/v1.19/rooms/v3/#authorisation-rules
     pub const V3: Self = Self { special_case_room_redaction: false, ..Self::V1 };
 
     /// Authorization rules with tweaks introduced in room version 6 ([spec]).
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/rooms/v6/#authorization-rules
+    /// [spec]: https://spec.matrix.org/v1.19/rooms/v6/#authorisation-rules
     pub const V6: Self = Self {
         special_case_room_aliases: false,
         strict_canonical_json: true,
@@ -399,23 +399,23 @@ impl AuthorizationRules {
 
     /// Authorization rules with tweaks introduced in room version 7 ([spec]).
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/rooms/v7/#authorization-rules
+    /// [spec]: https://spec.matrix.org/v1.19/rooms/v7/#authorisation-rules
     pub const V7: Self = Self { knocking: true, ..Self::V6 };
 
     /// Authorization rules with tweaks introduced in room version 8 ([spec]).
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/rooms/v8/#authorization-rules
+    /// [spec]: https://spec.matrix.org/v1.19/rooms/v8/#authorisation-rules
     pub const V8: Self = Self { restricted_join_rule: true, ..Self::V7 };
 
     /// Authorization rules with tweaks introduced in room version 10 ([spec]).
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/rooms/v10/#authorization-rules
+    /// [spec]: https://spec.matrix.org/v1.19/rooms/v10/#authorisation-rules
     pub const V10: Self =
         Self { knock_restricted_join_rule: true, integer_power_levels: true, ..Self::V8 };
 
     /// Authorization rules with tweaks introduced in room version 11 ([spec]).
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/rooms/v11/#authorization-rules
+    /// [spec]: https://spec.matrix.org/v1.19/rooms/v11/#authorisation-rules
     pub const V11: Self = Self { use_room_create_sender: true, ..Self::V10 };
 
     /// Authorization rules with tweaks introduced in room version 12.
@@ -432,63 +432,63 @@ impl AuthorizationRules {
 /// This type can be constructed from one of its constants (like [`RedactionRules::V1`]), or by
 /// constructing a [`RoomVersionRules`] first and using the `redaction` field.
 ///
-/// [redaction]: https://spec.matrix.org/v1.18/client-server-api/#redactions
+/// [redaction]: https://spec.matrix.org/v1.19/client-server-api/#redactions
 #[derive(Debug, Clone)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct RedactionRules {
     /// Whether to keep the `aliases` field in the `content` of `m.room.aliases` events ([spec]),
     /// disabled since room version 6.
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/rooms/v6/#redactions
+    /// [spec]: https://spec.matrix.org/v1.19/rooms/v6/#redactions
     pub keep_room_aliases_aliases: bool,
 
     /// Whether to keep the `allow` field in the `content` of `m.room.join_rules` events ([spec]),
     /// introduced in room version 8.
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/rooms/v8/#redactions
+    /// [spec]: https://spec.matrix.org/v1.19/rooms/v8/#redactions
     pub keep_room_join_rules_allow: bool,
 
     /// Whether to keep the `join_authorised_via_users_server` field in the `content` of
     /// `m.room.member` events ([spec]), introduced in room version 9.
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/rooms/v9/#redactions
+    /// [spec]: https://spec.matrix.org/v1.19/rooms/v9/#redactions
     pub keep_room_member_join_authorised_via_users_server: bool,
 
     /// Whether to keep the `origin`, `membership` and `prev_state` fields a the top-level of all
     /// events ([spec]), disabled since room version 11.
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/rooms/v11/#redactions
+    /// [spec]: https://spec.matrix.org/v1.19/rooms/v11/#redactions
     pub keep_origin_membership_prev_state: bool,
 
     /// Whether to keep the entire `content` of `m.room.create` events ([spec]), introduced in room
     /// version 11.
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/rooms/v11/#redactions
+    /// [spec]: https://spec.matrix.org/v1.19/rooms/v11/#redactions
     pub keep_room_create_content: bool,
 
     /// Whether to keep the `redacts` field in the `content` of `m.room.redaction` events ([spec]),
     /// introduced in room version 11.
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/rooms/v11/#redactions
+    /// [spec]: https://spec.matrix.org/v1.19/rooms/v11/#redactions
     pub keep_room_redaction_redacts: bool,
 
     /// Whether to keep the `invite` field in the `content` of `m.room.power_levels` events
     /// ([spec]), introduced in room version 11.
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/rooms/v11/#redactions
+    /// [spec]: https://spec.matrix.org/v1.19/rooms/v11/#redactions
     pub keep_room_power_levels_invite: bool,
 
     /// Whether to keep the `signed` field in `third_party_invite` of the `content` of
     /// `m.room.member` events ([spec]), introduced in room version 11.
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/rooms/v11/#redactions
+    /// [spec]: https://spec.matrix.org/v1.19/rooms/v11/#redactions
     pub keep_room_member_third_party_invite_signed: bool,
 
     /// Whether the `content.redacts` field should be used to determine the event an event
     /// redacts, as opposed to the top-level `redacts` field ([spec]), introduced in room version
     /// 11.
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/rooms/v11/#redactions
+    /// [spec]: https://spec.matrix.org/v1.19/rooms/v11/#redactions
     pub content_field_redacts: bool,
 
     /// Whether to keep the `allow`, `deny` and `allow_ip_literals` in the `content` of
@@ -502,7 +502,7 @@ pub struct RedactionRules {
 impl RedactionRules {
     /// Redaction rules as introduced in room version 1 ([spec]).
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/rooms/v1/#redactions
+    /// [spec]: https://spec.matrix.org/v1.19/rooms/v1/#redactions
     pub const V1: Self = Self {
         keep_room_aliases_aliases: true,
         keep_room_join_rules_allow: false,
@@ -519,23 +519,23 @@ impl RedactionRules {
 
     /// Redaction rules with tweaks introduced in room version 6 ([spec]).
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/rooms/v6/#redactions
+    /// [spec]: https://spec.matrix.org/v1.19/rooms/v6/#redactions
     pub const V6: Self = Self { keep_room_aliases_aliases: false, ..Self::V1 };
 
     /// Redaction rules with tweaks introduced in room version 8 ([spec]).
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/rooms/v8/#redactions
+    /// [spec]: https://spec.matrix.org/v1.19/rooms/v8/#redactions
     pub const V8: Self = Self { keep_room_join_rules_allow: true, ..Self::V6 };
 
     /// Redaction rules with tweaks introduced in room version 9 ([spec]).
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/rooms/v9/#redactions
+    /// [spec]: https://spec.matrix.org/v1.19/rooms/v9/#redactions
     pub const V9: Self =
         Self { keep_room_member_join_authorised_via_users_server: true, ..Self::V8 };
 
     /// Redaction rules with tweaks introduced in room version 11 ([spec]).
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/rooms/v11/#redactions
+    /// [spec]: https://spec.matrix.org/v1.19/rooms/v11/#redactions
     pub const V11: Self = Self {
         keep_origin_membership_prev_state: false,
         keep_room_create_content: true,
@@ -559,7 +559,7 @@ impl RedactionRules {
 /// This type can be constructed from one of its constants (like [`SignaturesRules::V1`]), or by
 /// constructing a [`RoomVersionRules`] first and using the `signatures` field.
 ///
-/// [verifying the signatures]: https://spec.matrix.org/v1.18/server-server-api/#validating-hashes-and-signatures-on-received-events
+/// [verifying the signatures]: https://spec.matrix.org/v1.19/server-server-api/#validating-hashes-and-signatures-on-received-events
 #[derive(Debug, Clone)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct SignaturesRules {
@@ -569,7 +569,7 @@ pub struct SignaturesRules {
     /// Whether to check the server of the `join_authorised_via_users_server` field in the
     /// `content` of `m.room.member` events ([spec]), introduced in room version 8.
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/rooms/v8/#authorization-rules
+    /// [spec]: https://spec.matrix.org/v1.19/rooms/v8/#authorisation-rules
     pub check_join_authorised_via_users_server: bool,
 }
 

--- a/crates/ruma-common/src/third_party_invite.rs
+++ b/crates/ruma-common/src/third_party_invite.rs
@@ -1,6 +1,6 @@
 //! Common types for [third-party invites].
 //!
-//! [third-party invites]: https://spec.matrix.org/v1.18/client-server-api/#third-party-invites
+//! [third-party invites]: https://spec.matrix.org/v1.19/client-server-api/#third-party-invites
 
 use std::ops::Deref;
 
@@ -20,7 +20,7 @@ use crate::serde::{
 ///
 /// The key can be decoded by calling [`IdentityServerBase64PublicKey::decode()`].
 ///
-/// [identity server]: https://spec.matrix.org/v1.18/identity-service-api/
+/// [identity server]: https://spec.matrix.org/v1.19/identity-service-api/
 /// [compatibility with Sydent]: https://github.com/matrix-org/sydent/issues/593
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[allow(clippy::exhaustive_structs)]

--- a/crates/ruma-common/src/thirdparty.rs
+++ b/crates/ruma-common/src/thirdparty.rs
@@ -1,6 +1,6 @@
 //! Common types for the [third party networks module][thirdparty].
 //!
-//! [thirdparty]: https://spec.matrix.org/v1.18/client-server-api/#third-party-networks
+//! [thirdparty]: https://spec.matrix.org/v1.19/client-server-api/#third-party-networks
 
 use std::{
     collections::BTreeMap,

--- a/crates/ruma-common/src/to_device.rs
+++ b/crates/ruma-common/src/to_device.rs
@@ -1,6 +1,6 @@
 //! Common types for the Send-To-Device Messaging
 //!
-//! [send-to-device]: https://spec.matrix.org/v1.18/client-server-api/#send-to-device-messaging
+//! [send-to-device]: https://spec.matrix.org/v1.19/client-server-api/#send-to-device-messaging
 
 use std::fmt::{Display, Formatter, Result as FmtResult};
 

--- a/crates/ruma-events/src/call/answer.rs
+++ b/crates/ruma-events/src/call/answer.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.call.answer`] event.
 //!
-//! [`m.call.answer`]: https://spec.matrix.org/v1.18/client-server-api/#mcallanswer
+//! [`m.call.answer`]: https://spec.matrix.org/v1.19/client-server-api/#mcallanswer
 
 use std::collections::BTreeMap;
 

--- a/crates/ruma-events/src/call/candidates.rs
+++ b/crates/ruma-events/src/call/candidates.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.call.candidates`] event.
 //!
-//! [`m.call.candidates`]: https://spec.matrix.org/v1.18/client-server-api/#mcallcandidates
+//! [`m.call.candidates`]: https://spec.matrix.org/v1.19/client-server-api/#mcallcandidates
 
 use js_int::UInt;
 use ruma_common::{OwnedVoipId, VoipVersionId};

--- a/crates/ruma-events/src/call/hangup.rs
+++ b/crates/ruma-events/src/call/hangup.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.call.hangup`] event.
 //!
-//! [`m.call.hangup`]: https://spec.matrix.org/v1.18/client-server-api/#mcallhangup
+//! [`m.call.hangup`]: https://spec.matrix.org/v1.19/client-server-api/#mcallhangup
 
 use ruma_common::{OwnedVoipId, VoipVersionId, serde::StringEnum};
 use ruma_macros::EventContent;

--- a/crates/ruma-events/src/call/invite.rs
+++ b/crates/ruma-events/src/call/invite.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.call.invite`] event.
 //!
-//! [`m.call.invite`]: https://spec.matrix.org/v1.18/client-server-api/#mcallinvite
+//! [`m.call.invite`]: https://spec.matrix.org/v1.19/client-server-api/#mcallinvite
 
 use std::collections::BTreeMap;
 

--- a/crates/ruma-events/src/call/negotiate.rs
+++ b/crates/ruma-events/src/call/negotiate.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.call.negotiate`] event.
 //!
-//! [`m.call.negotiate`]: https://spec.matrix.org/v1.18/client-server-api/#mcallnegotiate
+//! [`m.call.negotiate`]: https://spec.matrix.org/v1.19/client-server-api/#mcallnegotiate
 
 use std::collections::BTreeMap;
 

--- a/crates/ruma-events/src/call/reject.rs
+++ b/crates/ruma-events/src/call/reject.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.call.reject`] event.
 //!
-//! [`m.call.reject`]: https://spec.matrix.org/v1.18/client-server-api/#mcallreject
+//! [`m.call.reject`]: https://spec.matrix.org/v1.19/client-server-api/#mcallreject
 
 use ruma_common::{OwnedVoipId, VoipVersionId};
 use ruma_macros::EventContent;

--- a/crates/ruma-events/src/call/sdp_stream_metadata_changed.rs
+++ b/crates/ruma-events/src/call/sdp_stream_metadata_changed.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.call.sdp_stream_metadata_changed`] event.
 //!
-//! [`m.call.sdp_stream_metadata_changed`]: https://spec.matrix.org/v1.18/client-server-api/#mcallsdp_stream_metadata_changed
+//! [`m.call.sdp_stream_metadata_changed`]: https://spec.matrix.org/v1.19/client-server-api/#mcallsdp_stream_metadata_changed
 
 use std::collections::BTreeMap;
 

--- a/crates/ruma-events/src/call/select_answer.rs
+++ b/crates/ruma-events/src/call/select_answer.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.call.select_answer`] event.
 //!
-//! [`m.call.select_answer`]: https://spec.matrix.org/v1.18/client-server-api/#mcallselect_answer
+//! [`m.call.select_answer`]: https://spec.matrix.org/v1.19/client-server-api/#mcallselect_answer
 
 use ruma_common::{OwnedVoipId, VoipVersionId};
 use ruma_macros::EventContent;

--- a/crates/ruma-events/src/direct.rs
+++ b/crates/ruma-events/src/direct.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.direct`] event.
 //!
-//! [`m.direct`]: https://spec.matrix.org/v1.18/client-server-api/#mdirect
+//! [`m.direct`]: https://spec.matrix.org/v1.19/client-server-api/#mdirect
 
 use std::{
     collections::{BTreeMap, btree_map},

--- a/crates/ruma-events/src/dummy.rs
+++ b/crates/ruma-events/src/dummy.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.dummy`] event.
 //!
-//! [`m.dummy`]: https://spec.matrix.org/v1.18/client-server-api/#mdummy
+//! [`m.dummy`]: https://spec.matrix.org/v1.19/client-server-api/#mdummy
 
 use std::fmt;
 

--- a/crates/ruma-events/src/enums.rs
+++ b/crates/ruma-events/src/enums.rs
@@ -16,7 +16,7 @@ use super::room::encrypted;
 /// Event types that servers should send as [stripped state] to help clients identify a room when
 /// they can't access the full room state.
 ///
-/// [stripped state]: https://spec.matrix.org/v1.18/client-server-api/#stripped-state
+/// [stripped state]: https://spec.matrix.org/v1.19/client-server-api/#stripped-state
 pub const RECOMMENDED_STRIPPED_STATE_EVENT_TYPES: &[StateEventType] = &[
     StateEventType::RoomCreate,
     StateEventType::RoomName,
@@ -30,7 +30,7 @@ pub const RECOMMENDED_STRIPPED_STATE_EVENT_TYPES: &[StateEventType] = &[
 /// Event types that servers should transfer upon [room upgrade]. The exact details for what is
 /// transferred is left as an implementation detail.
 ///
-/// [room upgrade]: https://spec.matrix.org/v1.18/client-server-api/#server-behaviour-21
+/// [room upgrade]: https://spec.matrix.org/v1.19/client-server-api/#server-behaviour-21
 pub const RECOMMENDED_TRANSFERABLE_STATE_EVENT_TYPES: &[StateEventType] = &[
     StateEventType::RoomServerAcl,
     StateEventType::RoomEncryption,

--- a/crates/ruma-events/src/forwarded_room_key.rs
+++ b/crates/ruma-events/src/forwarded_room_key.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.forwarded_room_key`] event.
 //!
-//! [`m.forwarded_room_key`]: https://spec.matrix.org/v1.18/client-server-api/#mforwarded_room_key
+//! [`m.forwarded_room_key`]: https://spec.matrix.org/v1.19/client-server-api/#mforwarded_room_key
 
 use ruma_common::{EventEncryptionAlgorithm, OwnedRoomId};
 use ruma_macros::EventContent;

--- a/crates/ruma-events/src/fully_read.rs
+++ b/crates/ruma-events/src/fully_read.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.fully_read`] event.
 //!
-//! [`m.fully_read`]: https://spec.matrix.org/v1.18/client-server-api/#mfully_read
+//! [`m.fully_read`]: https://spec.matrix.org/v1.19/client-server-api/#mfully_read
 
 use ruma_common::OwnedEventId;
 use ruma_macros::EventContent;

--- a/crates/ruma-events/src/identity_server.rs
+++ b/crates/ruma-events/src/identity_server.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.identity_server`] event.
 //!
-//! [`m.identity_server`]: https://spec.matrix.org/v1.18/client-server-api/#midentity_server
+//! [`m.identity_server`]: https://spec.matrix.org/v1.19/client-server-api/#midentity_server
 
 use js_option::JsOption;
 use ruma_macros::EventContent;

--- a/crates/ruma-events/src/ignored_user_list.rs
+++ b/crates/ruma-events/src/ignored_user_list.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.ignored_user_list`] event.
 //!
-//! [`m.ignored_user_list`]: https://spec.matrix.org/v1.18/client-server-api/#mignored_user_list
+//! [`m.ignored_user_list`]: https://spec.matrix.org/v1.19/client-server-api/#mignored_user_list
 
 use std::collections::BTreeMap;
 

--- a/crates/ruma-events/src/invite_permission_config.rs
+++ b/crates/ruma-events/src/invite_permission_config.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.invite_permission_config`] account data.
 //!
-//! [`m.invite_permission_config`]: https://spec.matrix.org/v1.18/client-server-api/#minvite_permission_config
+//! [`m.invite_permission_config`]: https://spec.matrix.org/v1.19/client-server-api/#minvite_permission_config
 
 use ruma_macros::{EventContent, StringEnum};
 use serde::{Deserialize, Serialize};
@@ -11,7 +11,7 @@ use crate::PrivOwnedStr;
 ///
 /// Controls whether invites to this account are permitted.
 ///
-/// [`m.invite_permission_config`]: https://spec.matrix.org/v1.18/client-server-api/#minvite_permission_config
+/// [`m.invite_permission_config`]: https://spec.matrix.org/v1.19/client-server-api/#minvite_permission_config
 #[derive(Clone, Debug, Default, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 #[ruma_event(
@@ -26,7 +26,7 @@ pub struct InvitePermissionConfigEventContent {
     /// normal. Other parts of the specification might still have effects on invites, like
     /// [ignoring users].
     ///
-    /// [ignoring users]: https://spec.matrix.org/v1.18/client-server-api/#ignoring-users
+    /// [ignoring users]: https://spec.matrix.org/v1.19/client-server-api/#ignoring-users
     #[serde(
         default,
         deserialize_with = "ruma_common::serde::default_on_error",

--- a/crates/ruma-events/src/key/verification.rs
+++ b/crates/ruma-events/src/key/verification.rs
@@ -22,7 +22,7 @@ pub mod ready;
 pub mod request;
 pub mod start;
 
-// For these two constants, see <https://spec.matrix.org/v1.18/client-server-api/#key-verification-framework>
+// For these two constants, see <https://spec.matrix.org/v1.19/client-server-api/#key-verification-framework>
 /// The amount of time after which a verification request should be ignored, relative to its
 /// `origin_server_ts` (for in-room events) or its `timestamp` (for to-device events).
 ///

--- a/crates/ruma-events/src/key/verification/accept.rs
+++ b/crates/ruma-events/src/key/verification/accept.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.key.verification.accept`] event.
 //!
-//! [`m.key.verification.accept`]: https://spec.matrix.org/v1.18/client-server-api/#mkeyverificationaccept
+//! [`m.key.verification.accept`]: https://spec.matrix.org/v1.19/client-server-api/#mkeyverificationaccept
 
 use std::borrow::Cow;
 

--- a/crates/ruma-events/src/key/verification/cancel.rs
+++ b/crates/ruma-events/src/key/verification/cancel.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.key.verification.cancel`] event.
 //!
-//! [`m.key.verification.cancel`]: https://spec.matrix.org/v1.18/client-server-api/#mkeyverificationcancel
+//! [`m.key.verification.cancel`]: https://spec.matrix.org/v1.19/client-server-api/#mkeyverificationcancel
 
 use ruma_common::{OwnedTransactionId, serde::StringEnum};
 use ruma_macros::EventContent;

--- a/crates/ruma-events/src/key/verification/done.rs
+++ b/crates/ruma-events/src/key/verification/done.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.key.verification.done`] event.
 //!
-//! [`m.key.verification.done`]: https://spec.matrix.org/v1.18/client-server-api/#mkeyverificationdone
+//! [`m.key.verification.done`]: https://spec.matrix.org/v1.19/client-server-api/#mkeyverificationdone
 
 use ruma_common::OwnedTransactionId;
 use ruma_macros::EventContent;

--- a/crates/ruma-events/src/key/verification/key.rs
+++ b/crates/ruma-events/src/key/verification/key.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.key.verification.key`] event.
 //!
-//! [`m.key.verification.key`]: https://spec.matrix.org/v1.18/client-server-api/#mkeyverificationkey
+//! [`m.key.verification.key`]: https://spec.matrix.org/v1.19/client-server-api/#mkeyverificationkey
 
 use ruma_common::{OwnedTransactionId, serde::Base64};
 use ruma_macros::EventContent;

--- a/crates/ruma-events/src/key/verification/mac.rs
+++ b/crates/ruma-events/src/key/verification/mac.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.key.verification.mac`] event.
 //!
-//! [`m.key.verification.mac`]: https://spec.matrix.org/v1.18/client-server-api/#mkeyverificationmac
+//! [`m.key.verification.mac`]: https://spec.matrix.org/v1.19/client-server-api/#mkeyverificationmac
 
 use std::collections::BTreeMap;
 

--- a/crates/ruma-events/src/key/verification/ready.rs
+++ b/crates/ruma-events/src/key/verification/ready.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.key.verification.ready`] event.
 //!
-//! [`m.key.verification.ready`]: https://spec.matrix.org/v1.18/client-server-api/#mkeyverificationready
+//! [`m.key.verification.ready`]: https://spec.matrix.org/v1.19/client-server-api/#mkeyverificationready
 
 use ruma_common::{OwnedDeviceId, OwnedTransactionId};
 use ruma_macros::EventContent;

--- a/crates/ruma-events/src/key/verification/request.rs
+++ b/crates/ruma-events/src/key/verification/request.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.key.verification.request`] event.
 //!
-//! [`m.key.verification.request`]: https://spec.matrix.org/v1.18/client-server-api/#mkeyverificationrequest
+//! [`m.key.verification.request`]: https://spec.matrix.org/v1.19/client-server-api/#mkeyverificationrequest
 
 use ruma_common::{MilliSecondsSinceUnixEpoch, OwnedDeviceId, OwnedTransactionId};
 use ruma_macros::EventContent;

--- a/crates/ruma-events/src/key/verification/start.rs
+++ b/crates/ruma-events/src/key/verification/start.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.key.verification.start`] event.
 //!
-//! [`m.key.verification.start`]: https://spec.matrix.org/v1.18/client-server-api/#mkeyverificationstart
+//! [`m.key.verification.start`]: https://spec.matrix.org/v1.19/client-server-api/#mkeyverificationstart
 
 use std::{borrow::Cow, fmt};
 
@@ -91,7 +91,7 @@ pub enum StartMethod {
     ///
     /// The spec entry for this method can be found [here].
     ///
-    /// [here]: https://spec.matrix.org/v1.18/client-server-api/#mkeyverificationstartmreciprocatev1
+    /// [here]: https://spec.matrix.org/v1.19/client-server-api/#mkeyverificationstartmreciprocatev1
     ReciprocateV1(ReciprocateV1Content),
 
     /// Any unknown start method.

--- a/crates/ruma-events/src/marked_unread.rs
+++ b/crates/ruma-events/src/marked_unread.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.marked_unread`] event.
 //!
-//! [`m.marked_unread`]: https://spec.matrix.org/v1.18/client-server-api/#unread-markers
+//! [`m.marked_unread`]: https://spec.matrix.org/v1.19/client-server-api/#unread-markers
 
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-events/src/policy/rule/room.rs
+++ b/crates/ruma-events/src/policy/rule/room.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.policy.rule.room`] event.
 //!
-//! [`m.policy.rule.room`]: https://spec.matrix.org/v1.18/client-server-api/#mpolicyruleroom
+//! [`m.policy.rule.room`]: https://spec.matrix.org/v1.19/client-server-api/#mpolicyruleroom
 
 use ruma_common::room_version_rules::RedactionRules;
 use ruma_macros::EventContent;

--- a/crates/ruma-events/src/policy/rule/server.rs
+++ b/crates/ruma-events/src/policy/rule/server.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.policy.rule.server`] event.
 //!
-//! [`m.policy.rule.server`]: https://spec.matrix.org/v1.18/client-server-api/#mpolicyruleserver
+//! [`m.policy.rule.server`]: https://spec.matrix.org/v1.19/client-server-api/#mpolicyruleserver
 
 use ruma_common::room_version_rules::RedactionRules;
 use ruma_macros::EventContent;

--- a/crates/ruma-events/src/policy/rule/user.rs
+++ b/crates/ruma-events/src/policy/rule/user.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.policy.rule.user`] event.
 //!
-//! [`m.policy.rule.user`]: https://spec.matrix.org/v1.18/client-server-api/#mpolicyruleuser
+//! [`m.policy.rule.user`]: https://spec.matrix.org/v1.19/client-server-api/#mpolicyruleuser
 
 use ruma_common::room_version_rules::RedactionRules;
 use ruma_macros::EventContent;

--- a/crates/ruma-events/src/push_rules.rs
+++ b/crates/ruma-events/src/push_rules.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.push_rules`] event.
 //!
-//! [`m.push_rules`]: https://spec.matrix.org/v1.18/client-server-api/#mpush_rules
+//! [`m.push_rules`]: https://spec.matrix.org/v1.19/client-server-api/#mpush_rules
 
 use ruma_common::push::Ruleset;
 use ruma_macros::EventContent;

--- a/crates/ruma-events/src/reaction.rs
+++ b/crates/ruma-events/src/reaction.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.reaction`] event.
 //!
-//! [`m.reaction`]: https://spec.matrix.org/v1.18/client-server-api/#mreaction
+//! [`m.reaction`]: https://spec.matrix.org/v1.19/client-server-api/#mreaction
 
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-events/src/receipt.rs
+++ b/crates/ruma-events/src/receipt.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.receipt`] event.
 //!
-//! [`m.receipt`]: https://spec.matrix.org/v1.18/client-server-api/#mreceipt
+//! [`m.receipt`]: https://spec.matrix.org/v1.19/client-server-api/#mreceipt
 
 mod receipt_thread_serde;
 
@@ -90,7 +90,7 @@ pub enum ReceiptType {
     /// If both `Read` and `ReadPrivate` are present, the one that references
     /// the most recent event is used to get the latest read receipt.
     ///
-    /// [public read receipt]: https://spec.matrix.org/v1.18/client-server-api/#receipts
+    /// [public read receipt]: https://spec.matrix.org/v1.19/client-server-api/#receipts
     #[ruma_enum(rename = "m.read")]
     Read,
 
@@ -105,7 +105,7 @@ pub enum ReceiptType {
     /// If both `Read` and `ReadPrivate` are present, the one that references
     /// the most recent event is used to get the latest read receipt.
     ///
-    /// [private read receipt]: https://spec.matrix.org/v1.18/client-server-api/#private-read-receipts
+    /// [private read receipt]: https://spec.matrix.org/v1.19/client-server-api/#private-read-receipts
     #[ruma_enum(rename = "m.read.private")]
     ReadPrivate,
 
@@ -149,7 +149,7 @@ impl Receipt {
 /// To check for values that are not available as a documented variant here, use its string
 /// representation, obtained through [`.as_str()`](Self::as_str()).
 ///
-/// [thread a receipt applies to]: https://spec.matrix.org/v1.18/client-server-api/#threaded-read-receipts
+/// [thread a receipt applies to]: https://spec.matrix.org/v1.19/client-server-api/#threaded-read-receipts
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum ReceiptThread {

--- a/crates/ruma-events/src/recent_emoji.rs
+++ b/crates/ruma-events/src/recent_emoji.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.recent_emoji`] account data event.
 //!
-//! [`m.recent_emoji`]: https://spec.matrix.org/v1.18/client-server-api/#mrecent_emoji
+//! [`m.recent_emoji`]: https://spec.matrix.org/v1.19/client-server-api/#mrecent_emoji
 
 use js_int::{UInt, uint};
 use ruma_macros::EventContent;
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 /// The content of an [`m.recent_emoji`] event.
 ///
-/// [`m.recent_emoji`]: https://spec.matrix.org/v1.18/client-server-api/#mrecent_emoji
+/// [`m.recent_emoji`]: https://spec.matrix.org/v1.19/client-server-api/#mrecent_emoji
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 #[ruma_event(type = "m.recent_emoji", kind = GlobalAccountData)]

--- a/crates/ruma-events/src/relation.rs
+++ b/crates/ruma-events/src/relation.rs
@@ -1,6 +1,6 @@
 //! Types describing [relationships between events].
 //!
-//! [relationships between events]: https://spec.matrix.org/v1.18/client-server-api/#forming-relationships-between-events
+//! [relationships between events]: https://spec.matrix.org/v1.19/client-server-api/#forming-relationships-between-events
 
 use std::fmt::Debug;
 
@@ -17,7 +17,7 @@ mod rel_serde;
 
 /// A [rich reply] to an event.
 ///
-/// [rich reply]: https://spec.matrix.org/v1.18/client-server-api/#rich-replies
+/// [rich reply]: https://spec.matrix.org/v1.19/client-server-api/#rich-replies
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct Reply {
@@ -40,7 +40,7 @@ impl Reply {
 
 /// Information about the event a [rich reply] is replying to.
 ///
-/// [rich reply]: https://spec.matrix.org/v1.18/client-server-api/#rich-replies
+/// [rich reply]: https://spec.matrix.org/v1.19/client-server-api/#rich-replies
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct InReplyTo {
@@ -57,7 +57,7 @@ impl InReplyTo {
 
 /// An [annotation] for an event.
 ///
-/// [annotation]: https://spec.matrix.org/v1.18/client-server-api/#event-annotations-and-reactions
+/// [annotation]: https://spec.matrix.org/v1.19/client-server-api/#event-annotations-and-reactions
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 #[serde(tag = "rel_type", rename = "m.annotation")]
@@ -83,7 +83,7 @@ impl Annotation {
 
 /// The content of a [replacement] relation.
 ///
-/// [replacement]: https://spec.matrix.org/v1.18/client-server-api/#event-replacements
+/// [replacement]: https://spec.matrix.org/v1.19/client-server-api/#event-replacements
 #[derive(Clone, Debug)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct Replacement<C> {
@@ -103,7 +103,7 @@ impl<C> Replacement<C> {
 
 /// The content of a [thread] relation.
 ///
-/// [thread]: https://spec.matrix.org/v1.18/client-server-api/#threading
+/// [thread]: https://spec.matrix.org/v1.19/client-server-api/#threading
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 #[serde(tag = "rel_type", rename = "m.thread")]
@@ -179,7 +179,7 @@ impl BundledThread {
 
 /// A [reference] to another event.
 ///
-/// [reference]: https://spec.matrix.org/v1.18/client-server-api/#reference-relations
+/// [reference]: https://spec.matrix.org/v1.19/client-server-api/#reference-relations
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 #[serde(tag = "rel_type", rename = "m.reference")]
@@ -227,7 +227,7 @@ impl ReferenceChunk {
 
 /// [Bundled aggregations] of related child events of a message-like event.
 ///
-/// [Bundled aggregations]: https://spec.matrix.org/v1.18/client-server-api/#aggregations-of-child-events
+/// [Bundled aggregations]: https://spec.matrix.org/v1.19/client-server-api/#aggregations-of-child-events
 #[derive(Clone, Debug, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct BundledMessageLikeRelations<E> {
@@ -288,7 +288,7 @@ impl<E> Default for BundledMessageLikeRelations<E> {
 
 /// [Bundled aggregations] of related child events of a state event.
 ///
-/// [Bundled aggregations]: https://spec.matrix.org/v1.18/client-server-api/#aggregations-of-child-events
+/// [Bundled aggregations]: https://spec.matrix.org/v1.19/client-server-api/#aggregations-of-child-events
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct BundledStateRelations {

--- a/crates/ruma-events/src/room/avatar.rs
+++ b/crates/ruma-events/src/room/avatar.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.room.avatar`] event.
 //!
-//! [`m.room.avatar`]: https://spec.matrix.org/v1.18/client-server-api/#mroomavatar
+//! [`m.room.avatar`]: https://spec.matrix.org/v1.19/client-server-api/#mroomavatar
 
 use js_int::UInt;
 use ruma_common::OwnedMxcUri;

--- a/crates/ruma-events/src/room/canonical_alias.rs
+++ b/crates/ruma-events/src/room/canonical_alias.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.room.canonical_alias`] event.
 //!
-//! [`m.room.canonical_alias`]: https://spec.matrix.org/v1.18/client-server-api/#mroomcanonical_alias
+//! [`m.room.canonical_alias`]: https://spec.matrix.org/v1.19/client-server-api/#mroomcanonical_alias
 
 use ruma_common::OwnedRoomAliasId;
 use ruma_macros::EventContent;

--- a/crates/ruma-events/src/room/create.rs
+++ b/crates/ruma-events/src/room/create.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.room.create`] event.
 //!
-//! [`m.room.create`]: https://spec.matrix.org/v1.18/client-server-api/#mroomcreate
+//! [`m.room.create`]: https://spec.matrix.org/v1.19/client-server-api/#mroomcreate
 
 use ruma_common::{
     OwnedEventId, OwnedRoomId, OwnedUserId, RoomVersionId, room::RoomType,

--- a/crates/ruma-events/src/room/encrypted.rs
+++ b/crates/ruma-events/src/room/encrypted.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.room.encrypted`] event.
 //!
-//! [`m.room.encrypted`]: https://spec.matrix.org/v1.18/client-server-api/#mroomencrypted
+//! [`m.room.encrypted`]: https://spec.matrix.org/v1.19/client-server-api/#mroomencrypted
 
 use std::{borrow::Cow, collections::BTreeMap};
 
@@ -175,7 +175,7 @@ impl From<RelationWithoutReplacement> for Relation {
 /// struct doesn't store the new content, since that is part of the encrypted content of an
 /// `m.room.encrypted` events.
 ///
-/// [replaces another event]: https://spec.matrix.org/v1.18/client-server-api/#event-replacements
+/// [replaces another event]: https://spec.matrix.org/v1.19/client-server-api/#event-replacements
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 #[serde(tag = "rel_type", rename = "m.replace")]

--- a/crates/ruma-events/src/room/encryption.rs
+++ b/crates/ruma-events/src/room/encryption.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.room.encryption`] event.
 //!
-//! [`m.room.encryption`]: https://spec.matrix.org/v1.18/client-server-api/#mroomencryption
+//! [`m.room.encryption`]: https://spec.matrix.org/v1.19/client-server-api/#mroomencryption
 
 use js_int::{UInt, uint};
 use ruma_macros::EventContent;
@@ -57,7 +57,7 @@ impl RoomEncryptionEventContent {
     /// Note that changing the values of the fields is not a breaking change and you shouldn't rely
     /// on those specific values.
     pub fn with_recommended_defaults() -> Self {
-        // Defaults defined at <https://spec.matrix.org/v1.18/client-server-api/#mroomencryption>
+        // Defaults defined at <https://spec.matrix.org/v1.19/client-server-api/#mroomencryption>
         Self {
             algorithm: EventEncryptionAlgorithm::MegolmV1AesSha2,
             #[cfg(feature = "unstable-msc4362")]

--- a/crates/ruma-events/src/room/guest_access.rs
+++ b/crates/ruma-events/src/room/guest_access.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.room.guest_access`] event.
 //!
-//! [`m.room.guest_access`]: https://spec.matrix.org/v1.18/client-server-api/#mroomguest_access
+//! [`m.room.guest_access`]: https://spec.matrix.org/v1.19/client-server-api/#mroomguest_access
 
 use ruma_common::serde::StringEnum;
 use ruma_macros::EventContent;

--- a/crates/ruma-events/src/room/history_visibility.rs
+++ b/crates/ruma-events/src/room/history_visibility.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.room.history_visibility`] event.
 //!
-//! [`m.room.history_visibility`]: https://spec.matrix.org/v1.18/client-server-api/#mroomhistory_visibility
+//! [`m.room.history_visibility`]: https://spec.matrix.org/v1.19/client-server-api/#mroomhistory_visibility
 
 use ruma_common::serde::StringEnum;
 use ruma_macros::EventContent;

--- a/crates/ruma-events/src/room/join_rules.rs
+++ b/crates/ruma-events/src/room/join_rules.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.room.join_rules`] event.
 //!
-//! [`m.room.join_rules`]: https://spec.matrix.org/v1.18/client-server-api/#mroomjoin_rules
+//! [`m.room.join_rules`]: https://spec.matrix.org/v1.19/client-server-api/#mroomjoin_rules
 
 pub use ruma_common::room::{AllowRule, JoinRule, Restricted};
 use ruma_common::{

--- a/crates/ruma-events/src/room/member.rs
+++ b/crates/ruma-events/src/room/member.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.room.member`] event.
 //!
-//! [`m.room.member`]: https://spec.matrix.org/v1.18/client-server-api/#mroommember
+//! [`m.room.member`]: https://spec.matrix.org/v1.19/client-server-api/#mroommember
 
 use js_int::Int;
 #[cfg(feature = "unstable-msc4293")]
@@ -160,7 +160,7 @@ impl RoomMemberEventContent {
     ///
     /// Check [the specification][spec] for details.
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/client-server-api/#mroommember
+    /// [spec]: https://spec.matrix.org/v1.19/client-server-api/#mroommember
     pub fn membership_change<'a>(
         &'a self,
         prev_details: Option<MembershipDetails<'a>>,
@@ -301,7 +301,7 @@ impl PossiblyRedactedRoomMemberEventContent {
     ///
     /// Check [the specification][spec] for details.
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/client-server-api/#mroommember
+    /// [spec]: https://spec.matrix.org/v1.19/client-server-api/#mroommember
     pub fn membership_change<'a>(
         &'a self,
         prev_details: Option<MembershipDetails<'a>>,
@@ -450,7 +450,7 @@ impl RedactedRoomMemberEventContent {
     ///
     /// Check [the specification][spec] for details.
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/client-server-api/#mroommember
+    /// [spec]: https://spec.matrix.org/v1.19/client-server-api/#mroommember
     pub fn membership_change<'a>(
         &'a self,
         prev_details: Option<MembershipDetails<'a>>,
@@ -680,7 +680,7 @@ impl OriginalRoomMemberEvent {
     ///
     /// Check [the specification][spec] for details.
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/client-server-api/#mroommember
+    /// [spec]: https://spec.matrix.org/v1.19/client-server-api/#mroommember
     pub fn membership_change(&self) -> MembershipChange<'_> {
         membership_change(self.details(), self.prev_details(), &self.sender, &self.state_key)
     }
@@ -717,7 +717,7 @@ impl RedactedRoomMemberEvent {
     ///
     /// Check [the specification][spec] for details.
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/client-server-api/#mroommember
+    /// [spec]: https://spec.matrix.org/v1.19/client-server-api/#mroommember
     pub fn membership_change<'a>(
         &'a self,
         prev_details: Option<MembershipDetails<'a>>,
@@ -763,7 +763,7 @@ impl OriginalSyncRoomMemberEvent {
     ///
     /// Check [the specification][spec] for details.
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/client-server-api/#mroommember
+    /// [spec]: https://spec.matrix.org/v1.19/client-server-api/#mroommember
     pub fn membership_change(&self) -> MembershipChange<'_> {
         membership_change(self.details(), self.prev_details(), &self.sender, &self.state_key)
     }
@@ -800,7 +800,7 @@ impl RedactedSyncRoomMemberEvent {
     ///
     /// Check [the specification][spec] for details.
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/client-server-api/#mroommember
+    /// [spec]: https://spec.matrix.org/v1.19/client-server-api/#mroommember
     pub fn membership_change<'a>(
         &'a self,
         prev_details: Option<MembershipDetails<'a>>,
@@ -839,7 +839,7 @@ impl StrippedRoomMemberEvent {
     ///
     /// Check [the specification][spec] for details.
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/client-server-api/#mroommember
+    /// [spec]: https://spec.matrix.org/v1.19/client-server-api/#mroommember
     pub fn membership_change<'a>(
         &'a self,
         prev_details: Option<MembershipDetails<'a>>,
@@ -891,7 +891,7 @@ pub struct RoomMemberUnsigned {
 
     /// [Bundled aggregations] of related child events.
     ///
-    /// [Bundled aggregations]: https://spec.matrix.org/v1.18/client-server-api/#aggregations-of-child-events
+    /// [Bundled aggregations]: https://spec.matrix.org/v1.19/client-server-api/#aggregations-of-child-events
     #[serde(rename = "m.relations", default)]
     pub relations: BundledStateRelations,
 }

--- a/crates/ruma-events/src/room/member/change.rs
+++ b/crates/ruma-events/src/room/member/change.rs
@@ -97,7 +97,7 @@ impl<T: PartialEq> Change<T> {
 ///
 /// This must match the table for [`m.room.member`] in the spec.
 ///
-/// [`m.room.member`]: https://spec.matrix.org/v1.18/client-server-api/#mroommember
+/// [`m.room.member`]: https://spec.matrix.org/v1.19/client-server-api/#mroommember
 pub(super) fn membership_change<'a>(
     details: MembershipDetails<'a>,
     prev_details: Option<MembershipDetails<'a>>,

--- a/crates/ruma-events/src/room/message.rs
+++ b/crates/ruma-events/src/room/message.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.room.message`] event.
 //!
-//! [`m.room.message`]: https://spec.matrix.org/v1.18/client-server-api/#mroommessage
+//! [`m.room.message`]: https://spec.matrix.org/v1.19/client-server-api/#mroommessage
 
 use std::borrow::Cow;
 
@@ -84,7 +84,7 @@ pub struct RoomMessageEventContent {
 
     /// Information about [related messages].
     ///
-    /// [related messages]: https://spec.matrix.org/v1.18/client-server-api/#forming-relationships-between-events
+    /// [related messages]: https://spec.matrix.org/v1.19/client-server-api/#forming-relationships-between-events
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
     pub relates_to: Option<Relation<RoomMessageEventContentWithoutRelation>>,
 
@@ -96,7 +96,7 @@ pub struct RoomMessageEventContent {
     /// beforehand to avoid re-triggering notifications for users that were already mentioned in
     /// the original event.
     ///
-    /// [mentions]: https://spec.matrix.org/v1.18/client-server-api/#user-and-room-mentions
+    /// [mentions]: https://spec.matrix.org/v1.19/client-server-api/#user-and-room-mentions
     #[serde(rename = "m.mentions", skip_serializing_if = "Option::is_none")]
     pub mentions: Option<Mentions>,
 
@@ -177,7 +177,7 @@ impl RoomMessageEventContent {
     ///
     /// If `AddMentions::Yes` is used, the `sender` in the metadata is added as a user mention.
     ///
-    /// [rich reply]: https://spec.matrix.org/v1.18/client-server-api/#rich-replies
+    /// [rich reply]: https://spec.matrix.org/v1.19/client-server-api/#rich-replies
     #[track_caller]
     pub fn make_reply_to<'a>(
         self,
@@ -201,7 +201,7 @@ impl RoomMessageEventContent {
     ///
     /// If `AddMentions::Yes` is used, the `sender` in the metadata is added as a user mention.
     ///
-    /// [thread]: https://spec.matrix.org/v1.18/client-server-api/#threading
+    /// [thread]: https://spec.matrix.org/v1.19/client-server-api/#threading
     pub fn make_for_thread<'a>(
         self,
         metadata: impl Into<ReplyMetadata<'a>>,
@@ -228,7 +228,7 @@ impl RoomMessageEventContent {
     ///
     /// Panics if `self` has a `formatted_body` with a format other than HTML.
     ///
-    /// [replacement]: https://spec.matrix.org/v1.18/client-server-api/#event-replacements
+    /// [replacement]: https://spec.matrix.org/v1.19/client-server-api/#event-replacements
     #[track_caller]
     pub fn make_replacement(self, metadata: impl Into<ReplacementMetadata>) -> Self {
         self.without_relation().make_replacement(metadata)
@@ -243,7 +243,7 @@ impl RoomMessageEventContent {
     /// This should be called before methods that add a relation, like [`Self::make_reply_to()`] and
     /// [`Self::make_replacement()`], for the mentions to be correctly set.
     ///
-    /// [mentions]: https://spec.matrix.org/v1.18/client-server-api/#user-and-room-mentions
+    /// [mentions]: https://spec.matrix.org/v1.19/client-server-api/#user-and-room-mentions
     pub fn add_mentions(mut self, mentions: Mentions) -> Self {
         self.mentions.get_or_insert_with(Mentions::new).add(mentions);
         self
@@ -290,8 +290,8 @@ impl RoomMessageEventContent {
     ///
     /// This method is only effective on text, notice and emote messages.
     ///
-    /// [tags and attributes]: https://spec.matrix.org/v1.18/client-server-api/#mroommessage-msgtypes
-    /// [rich reply]: https://spec.matrix.org/v1.18/client-server-api/#rich-replies
+    /// [tags and attributes]: https://spec.matrix.org/v1.19/client-server-api/#mroommessage-msgtypes
+    /// [rich reply]: https://spec.matrix.org/v1.19/client-server-api/#rich-replies
     #[cfg(feature = "html")]
     pub fn sanitize(
         &mut self,
@@ -330,7 +330,7 @@ pub enum ForwardThread {
     /// This should be set if your client doesn't render threads (see the [info
     /// box for clients which are acutely aware of threads]).
     ///
-    /// [info box for clients which are acutely aware of threads]: https://spec.matrix.org/v1.18/client-server-api/#fallback-for-unthreaded-clients
+    /// [info box for clients which are acutely aware of threads]: https://spec.matrix.org/v1.19/client-server-api/#fallback-for-unthreaded-clients
     Yes,
 
     /// Create a reply in the main conversation even if the original message is in a thread.
@@ -364,14 +364,14 @@ pub enum ReplyWithinThread {
     ///
     /// Create a [reply within the thread].
     ///
-    /// [reply within the thread]: https://spec.matrix.org/v1.18/client-server-api/#replies-within-threads
+    /// [reply within the thread]: https://spec.matrix.org/v1.19/client-server-api/#replies-within-threads
     Yes,
 
     /// This is not a reply.
     ///
     /// Create a regular message in the thread, with a [fallback for unthreaded clients].
     ///
-    /// [fallback for unthreaded clients]: https://spec.matrix.org/v1.18/client-server-api/#fallback-for-unthreaded-clients
+    /// [fallback for unthreaded clients]: https://spec.matrix.org/v1.19/client-server-api/#fallback-for-unthreaded-clients
     No,
 }
 
@@ -434,7 +434,7 @@ pub enum MessageType {
 impl MessageType {
     /// Creates a new `MessageType`.
     ///
-    /// The `msgtype` and `body` are required fields as defined by [the `m.room.message` spec](https://spec.matrix.org/v1.18/client-server-api/#mroommessage).
+    /// The `msgtype` and `body` are required fields as defined by [the `m.room.message` spec](https://spec.matrix.org/v1.19/client-server-api/#mroommessage).
     /// Additionally it's possible to add arbitrary key/value pairs to the event content for custom
     /// events through the `data` map.
     ///
@@ -606,8 +606,8 @@ impl MessageType {
     ///
     /// This method is only effective on text, notice and emote messages.
     ///
-    /// [tags and attributes]: https://spec.matrix.org/v1.18/client-server-api/#mroommessage-msgtypes
-    /// [rich reply]: https://spec.matrix.org/v1.18/client-server-api/#rich-replies
+    /// [tags and attributes]: https://spec.matrix.org/v1.19/client-server-api/#mroommessage-msgtypes
+    /// [rich reply]: https://spec.matrix.org/v1.19/client-server-api/#rich-replies
     #[cfg(feature = "html")]
     pub fn sanitize(
         &mut self,
@@ -790,8 +790,8 @@ impl FormattedBody {
     ///
     /// Returns the sanitized HTML if the format is `MessageFormat::Html`.
     ///
-    /// [tags and attributes]: https://spec.matrix.org/v1.18/client-server-api/#mroommessage-msgtypes
-    /// [rich reply]: https://spec.matrix.org/v1.18/client-server-api/#rich-replies
+    /// [tags and attributes]: https://spec.matrix.org/v1.19/client-server-api/#mroommessage-msgtypes
+    /// [rich reply]: https://spec.matrix.org/v1.19/client-server-api/#rich-replies
     #[cfg(feature = "html")]
     pub fn sanitize_html(
         &mut self,

--- a/crates/ruma-events/src/room/message/audio.rs
+++ b/crates/ruma-events/src/room/message/audio.rs
@@ -94,7 +94,7 @@ impl AudioMessageEventContent {
         Self { info: info.into(), ..self }
     }
 
-    /// Computes the filename for the audio file as defined by the [spec](https://spec.matrix.org/v1.18/client-server-api/#media-captions).
+    /// Computes the filename for the audio file as defined by the [spec](https://spec.matrix.org/v1.19/client-server-api/#media-captions).
     ///
     /// This differs from the `filename` field as this method falls back to the `body` field when
     /// the `filename` field is not set.
@@ -102,7 +102,7 @@ impl AudioMessageEventContent {
         self.filename.as_deref().unwrap_or(&self.body)
     }
 
-    /// Returns the caption for the audio as defined by the [spec](https://spec.matrix.org/v1.18/client-server-api/#media-captions).
+    /// Returns the caption for the audio as defined by the [spec](https://spec.matrix.org/v1.19/client-server-api/#media-captions).
     ///
     /// In short, this is the `body` field if the `filename` field exists and has a different value,
     /// otherwise the media file does not have a caption.
@@ -110,7 +110,7 @@ impl AudioMessageEventContent {
         caption(&self.body, self.filename.as_deref())
     }
 
-    /// Returns the formatted caption for the audio as defined by the [spec](https://spec.matrix.org/v1.18/client-server-api/#media-captions).
+    /// Returns the formatted caption for the audio as defined by the [spec](https://spec.matrix.org/v1.19/client-server-api/#media-captions).
     ///
     /// This is the same as `caption`, but returns the formatted body instead of the plain body.
     pub fn formatted_caption(&self) -> Option<&FormattedBody> {

--- a/crates/ruma-events/src/room/message/file.rs
+++ b/crates/ruma-events/src/room/message/file.rs
@@ -66,7 +66,7 @@ impl FileMessageEventContent {
         Self { info: info.into(), ..self }
     }
 
-    /// Computes the filename for the file as defined by the [spec](https://spec.matrix.org/v1.18/client-server-api/#media-captions).
+    /// Computes the filename for the file as defined by the [spec](https://spec.matrix.org/v1.19/client-server-api/#media-captions).
     ///
     /// This differs from the `filename` field as this method falls back to the `body` field when
     /// the `filename` field is not set.
@@ -74,7 +74,7 @@ impl FileMessageEventContent {
         self.filename.as_deref().unwrap_or(&self.body)
     }
 
-    /// Returns the caption of the media file as defined by the [spec](https://spec.matrix.org/v1.18/client-server-api/#media-captions).
+    /// Returns the caption of the media file as defined by the [spec](https://spec.matrix.org/v1.19/client-server-api/#media-captions).
     ///
     /// In short, this is the `body` field if the `filename` field exists and has a different value,
     /// otherwise the media file does not have a caption.
@@ -82,7 +82,7 @@ impl FileMessageEventContent {
         caption(&self.body, self.filename.as_deref())
     }
 
-    /// Returns the formatted caption of the media file as defined by the [spec](https://spec.matrix.org/v1.18/client-server-api/#media-captions).
+    /// Returns the formatted caption of the media file as defined by the [spec](https://spec.matrix.org/v1.19/client-server-api/#media-captions).
     ///
     /// This is the same as `caption`, but returns the formatted body instead of the plain body.
     pub fn formatted_caption(&self) -> Option<&FormattedBody> {

--- a/crates/ruma-events/src/room/message/image.rs
+++ b/crates/ruma-events/src/room/message/image.rs
@@ -65,7 +65,7 @@ impl ImageMessageEventContent {
         Self { info: info.into(), ..self }
     }
 
-    /// Computes the filename of the image as defined by the [spec](https://spec.matrix.org/v1.18/client-server-api/#media-captions).
+    /// Computes the filename of the image as defined by the [spec](https://spec.matrix.org/v1.19/client-server-api/#media-captions).
     ///
     /// This differs from the `filename` field as this method falls back to the `body` field when
     /// the `filename` field is not set.
@@ -73,7 +73,7 @@ impl ImageMessageEventContent {
         self.filename.as_deref().unwrap_or(&self.body)
     }
 
-    /// Returns the caption for the image as defined by the [spec](https://spec.matrix.org/v1.18/client-server-api/#media-captions).
+    /// Returns the caption for the image as defined by the [spec](https://spec.matrix.org/v1.19/client-server-api/#media-captions).
     ///
     /// In short, this is the `body` field if the `filename` field exists and has a different value,
     /// otherwise the media file does not have a caption.
@@ -81,7 +81,7 @@ impl ImageMessageEventContent {
         caption(&self.body, self.filename.as_deref())
     }
 
-    /// Returns the formatted caption for the image as defined by the [spec](https://spec.matrix.org/v1.18/client-server-api/#media-captions).
+    /// Returns the formatted caption for the image as defined by the [spec](https://spec.matrix.org/v1.19/client-server-api/#media-captions).
     ///
     /// This is the same as `caption`, but returns the formatted body instead of the plain body.
     pub fn formatted_caption(&self) -> Option<&FormattedBody> {

--- a/crates/ruma-events/src/room/message/media_caption.rs
+++ b/crates/ruma-events/src/room/message/media_caption.rs
@@ -2,7 +2,7 @@
 
 use crate::room::message::FormattedBody;
 
-/// Computes the caption of a media file as defined by the [spec](https://spec.matrix.org/v1.18/client-server-api/#media-captions).
+/// Computes the caption of a media file as defined by the [spec](https://spec.matrix.org/v1.19/client-server-api/#media-captions).
 ///
 /// In short, this is the `body` field if the `filename` field exists and has a different value,
 /// otherwise the media file does not have a caption.
@@ -10,7 +10,7 @@ pub(crate) fn caption<'a>(body: &'a str, filename: Option<&str>) -> Option<&'a s
     filename.is_some_and(|filename| body != filename).then_some(body)
 }
 
-/// Computes the formatted caption of a media file as defined by the [spec](https://spec.matrix.org/v1.18/client-server-api/#media-captions).
+/// Computes the formatted caption of a media file as defined by the [spec](https://spec.matrix.org/v1.19/client-server-api/#media-captions).
 ///
 /// This is the same as `caption`, but returns the formatted body instead of the plain body.
 pub(crate) fn formatted_caption<'a>(

--- a/crates/ruma-events/src/room/message/sanitize.rs
+++ b/crates/ruma-events/src/room/message/sanitize.rs
@@ -2,7 +2,7 @@
 
 /// Remove the [rich reply] fallback of the given plain text string.
 ///
-/// [rich reply]: https://spec.matrix.org/v1.18/client-server-api/#rich-replies
+/// [rich reply]: https://spec.matrix.org/v1.19/client-server-api/#rich-replies
 pub fn remove_plain_reply_fallback(mut s: &str) -> &str {
     // A reply fallback must begin with a mention of the original sender between `<` and `>`, and
     // emotes add `*` as a prefix. If there is no newline, removing the detected fallback would

--- a/crates/ruma-events/src/room/message/video.rs
+++ b/crates/ruma-events/src/room/message/video.rs
@@ -70,7 +70,7 @@ impl VideoMessageEventContent {
         Self { info: info.into(), ..self }
     }
 
-    /// Computes the filename of the video as defined by the [spec](https://spec.matrix.org/v1.18/client-server-api/#media-captions).
+    /// Computes the filename of the video as defined by the [spec](https://spec.matrix.org/v1.19/client-server-api/#media-captions).
     ///
     /// This differs from the `filename` field as this method falls back to the `body` field when
     /// the `filename` field is not set.
@@ -78,7 +78,7 @@ impl VideoMessageEventContent {
         self.filename.as_deref().unwrap_or(&self.body)
     }
 
-    /// Returns the caption of the video as defined by the [spec](https://spec.matrix.org/v1.18/client-server-api/#media-captions).
+    /// Returns the caption of the video as defined by the [spec](https://spec.matrix.org/v1.19/client-server-api/#media-captions).
     ///
     /// In short, this is the `body` field if the `filename` field exists and has a different value,
     /// otherwise the media file does not have a caption.
@@ -86,7 +86,7 @@ impl VideoMessageEventContent {
         caption(&self.body, self.filename.as_deref())
     }
 
-    /// Returns the formatted caption of the video as defined by the [spec](https://spec.matrix.org/v1.18/client-server-api/#media-captions).
+    /// Returns the formatted caption of the video as defined by the [spec](https://spec.matrix.org/v1.19/client-server-api/#media-captions).
     ///
     /// This is the same as `caption`, but returns the formatted body instead of the plain body.
     pub fn formatted_caption(&self) -> Option<&FormattedBody> {

--- a/crates/ruma-events/src/room/message/without_relation.rs
+++ b/crates/ruma-events/src/room/message/without_relation.rs
@@ -23,7 +23,7 @@ pub struct RoomMessageEventContentWithoutRelation {
 
     /// The [mentions] of this event.
     ///
-    /// [mentions]: https://spec.matrix.org/v1.18/client-server-api/#user-and-room-mentions
+    /// [mentions]: https://spec.matrix.org/v1.19/client-server-api/#user-and-room-mentions
     #[serde(rename = "m.mentions", skip_serializing_if = "Option::is_none")]
     pub mentions: Option<Mentions>,
 
@@ -121,7 +121,7 @@ impl RoomMessageEventContentWithoutRelation {
     ///
     /// If `AddMentions::Yes` is used, the `sender` in the metadata is added as a user mention.
     ///
-    /// [rich reply]: https://spec.matrix.org/v1.18/client-server-api/#rich-replies
+    /// [rich reply]: https://spec.matrix.org/v1.19/client-server-api/#rich-replies
     #[track_caller]
     pub fn make_reply_to<'a>(
         mut self,
@@ -165,7 +165,7 @@ impl RoomMessageEventContentWithoutRelation {
     ///
     /// If `AddMentions::Yes` is used, the `sender` in the metadata is added as a user mention.
     ///
-    /// [thread]: https://spec.matrix.org/v1.18/client-server-api/#threading
+    /// [thread]: https://spec.matrix.org/v1.19/client-server-api/#threading
     pub fn make_for_thread<'a>(
         self,
         metadata: impl Into<ReplyMetadata<'a>>,
@@ -212,7 +212,7 @@ impl RoomMessageEventContentWithoutRelation {
     ///
     /// Panics if `self` has a `formatted_body` with a format other than HTML.
     ///
-    /// [replacement]: https://spec.matrix.org/v1.18/client-server-api/#event-replacements
+    /// [replacement]: https://spec.matrix.org/v1.19/client-server-api/#event-replacements
     #[track_caller]
     pub fn make_replacement(
         mut self,
@@ -270,7 +270,7 @@ impl RoomMessageEventContentWithoutRelation {
     /// mentions by extending the previous `user_ids` with the new ones, and applies a logical OR to
     /// the values of `room`.
     ///
-    /// [mentions]: https://spec.matrix.org/v1.18/client-server-api/#user-and-room-mentions
+    /// [mentions]: https://spec.matrix.org/v1.19/client-server-api/#user-and-room-mentions
     pub fn add_mentions(mut self, mentions: Mentions) -> Self {
         self.mentions.get_or_insert_with(Mentions::new).add(mentions);
         self

--- a/crates/ruma-events/src/room/name.rs
+++ b/crates/ruma-events/src/room/name.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.room.name`] event.
 //!
-//! [`m.room.name`]: https://spec.matrix.org/v1.18/client-server-api/#mroomname
+//! [`m.room.name`]: https://spec.matrix.org/v1.19/client-server-api/#mroomname
 
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-events/src/room/pinned_events.rs
+++ b/crates/ruma-events/src/room/pinned_events.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.room.pinned_events`] event.
 //!
-//! [`m.room.pinned_events`]: https://spec.matrix.org/v1.18/client-server-api/#mroompinned_events
+//! [`m.room.pinned_events`]: https://spec.matrix.org/v1.19/client-server-api/#mroompinned_events
 
 use ruma_common::OwnedEventId;
 use ruma_macros::EventContent;

--- a/crates/ruma-events/src/room/policy.rs
+++ b/crates/ruma-events/src/room/policy.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.room.policy`] event.
 //!
-//! [`m.room.policy`]: https://spec.matrix.org/v1.18/client-server-api/#mroompolicy
+//! [`m.room.policy`]: https://spec.matrix.org/v1.19/client-server-api/#mroompolicy
 
 use std::collections::BTreeMap;
 
@@ -19,8 +19,8 @@ pub const POLICY_SERVER_ED25519_SIGNING_KEY_ID: &str = "ed25519:policy_server";
 ///
 /// If invalid or not set, the room does not use a Policy Server.
 ///
-/// [`m.room.policy`]: https://spec.matrix.org/v1.18/client-server-api/#mroompolicy
-/// [Policy Server]: https://spec.matrix.org/v1.18/client-server-api/#policy-servers
+/// [`m.room.policy`]: https://spec.matrix.org/v1.19/client-server-api/#mroompolicy
+/// [Policy Server]: https://spec.matrix.org/v1.19/client-server-api/#policy-servers
 #[derive(Clone, Debug, Deserialize, Serialize, EventContent)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 #[ruma_event(type = "m.room.policy", kind = State, state_key_type = EmptyStateKey)]

--- a/crates/ruma-events/src/room/power_levels.rs
+++ b/crates/ruma-events/src/room/power_levels.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.room.power_levels`] event.
 //!
-//! [`m.room.power_levels`]: https://spec.matrix.org/v1.18/client-server-api/#mroompower_levels
+//! [`m.room.power_levels`]: https://spec.matrix.org/v1.19/client-server-api/#mroompower_levels
 
 use std::{
     cmp::{Ordering, max},

--- a/crates/ruma-events/src/room/redaction.rs
+++ b/crates/ruma-events/src/room/redaction.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.room.redaction`] event.
 //!
-//! [`m.room.redaction`]: https://spec.matrix.org/v1.18/client-server-api/#mroomredaction
+//! [`m.room.redaction`]: https://spec.matrix.org/v1.19/client-server-api/#mroomredaction
 
 use as_variant::as_variant;
 use js_int::Int;
@@ -459,7 +459,7 @@ pub struct RoomRedactionUnsigned {
 
     /// [Bundled aggregations] of related child events.
     ///
-    /// [Bundled aggregations]: https://spec.matrix.org/v1.18/client-server-api/#aggregations-of-child-events
+    /// [Bundled aggregations]: https://spec.matrix.org/v1.19/client-server-api/#aggregations-of-child-events
     #[serde(rename = "m.relations", default)]
     pub relations: BundledMessageLikeRelations<OriginalSyncRoomRedactionEvent>,
 }

--- a/crates/ruma-events/src/room/server_acl.rs
+++ b/crates/ruma-events/src/room/server_acl.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.room.server_acl`] event.
 //!
-//! [`m.room.server_acl`]: https://spec.matrix.org/v1.18/client-server-api/#mroomserver_acl
+//! [`m.room.server_acl`]: https://spec.matrix.org/v1.19/client-server-api/#mroomserver_acl
 
 use ruma_common::ServerName;
 use ruma_macros::EventContent;

--- a/crates/ruma-events/src/room/third_party_invite.rs
+++ b/crates/ruma-events/src/room/third_party_invite.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.room.third_party_invite`] event.
 //!
-//! [`m.room.third_party_invite`]: https://spec.matrix.org/v1.18/client-server-api/#mroomthird_party_invite
+//! [`m.room.third_party_invite`]: https://spec.matrix.org/v1.19/client-server-api/#mroomthird_party_invite
 
 use ruma_common::third_party_invite::IdentityServerBase64PublicKey;
 use ruma_macros::EventContent;

--- a/crates/ruma-events/src/room/tombstone.rs
+++ b/crates/ruma-events/src/room/tombstone.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.room.tombstone`] event.
 //!
-//! [`m.room.tombstone`]: https://spec.matrix.org/v1.18/client-server-api/#mroomtombstone
+//! [`m.room.tombstone`]: https://spec.matrix.org/v1.19/client-server-api/#mroomtombstone
 
 use ruma_common::OwnedRoomId;
 use ruma_macros::EventContent;

--- a/crates/ruma-events/src/room/topic.rs
+++ b/crates/ruma-events/src/room/topic.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.room.topic`] event.
 //!
-//! [`m.room.topic`]: https://spec.matrix.org/v1.18/client-server-api/#mroomtopic
+//! [`m.room.topic`]: https://spec.matrix.org/v1.19/client-server-api/#mroomtopic
 
 use ruma_macros::EventContent;
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-events/src/room_key.rs
+++ b/crates/ruma-events/src/room_key.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.room_key`] event.
 //!
-//! [`m.room_key`]: https://spec.matrix.org/v1.18/client-server-api/#mroom_key
+//! [`m.room_key`]: https://spec.matrix.org/v1.19/client-server-api/#mroom_key
 
 use ruma_common::{EventEncryptionAlgorithm, OwnedRoomId};
 use ruma_macros::EventContent;

--- a/crates/ruma-events/src/room_key/withheld.rs
+++ b/crates/ruma-events/src/room_key/withheld.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.room_key.withheld`] event.
 //!
-//! [`m.room_key.withheld`]: https://spec.matrix.org/v1.18/client-server-api/#mroom_keywithheld
+//! [`m.room_key.withheld`]: https://spec.matrix.org/v1.19/client-server-api/#mroom_keywithheld
 
 use std::borrow::Cow;
 
@@ -19,7 +19,7 @@ use crate::PrivOwnedStr;
 ///
 /// Typically encrypted as an `m.room.encrypted` event, then sent as a to-device event.
 ///
-/// [`m.room_key.withheld`]: https://spec.matrix.org/v1.18/client-server-api/#mroom_keywithheld
+/// [`m.room_key.withheld`]: https://spec.matrix.org/v1.19/client-server-api/#mroom_keywithheld
 #[derive(Clone, Debug, Serialize, EventContent)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 #[ruma_event(type = "m.room_key.withheld", kind = ToDevice)]

--- a/crates/ruma-events/src/room_key_request.rs
+++ b/crates/ruma-events/src/room_key_request.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.room_key_request`] event.
 //!
-//! [`m.room_key_request`]: https://spec.matrix.org/v1.18/client-server-api/#mroom_key_request
+//! [`m.room_key_request`]: https://spec.matrix.org/v1.19/client-server-api/#mroom_key_request
 
 use ruma_common::{
     EventEncryptionAlgorithm, OwnedDeviceId, OwnedRoomId, OwnedTransactionId, serde::StringEnum,

--- a/crates/ruma-events/src/secret/request.rs
+++ b/crates/ruma-events/src/secret/request.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.secret.request`] event.
 //!
-//! [`m.secret.request`]: https://spec.matrix.org/v1.18/client-server-api/#msecretrequest
+//! [`m.secret.request`]: https://spec.matrix.org/v1.19/client-server-api/#msecretrequest
 
 use as_variant::as_variant;
 use ruma_common::{

--- a/crates/ruma-events/src/secret/send.rs
+++ b/crates/ruma-events/src/secret/send.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.secret.send`] event.
 //!
-//! [`m.secret.send`]: https://spec.matrix.org/v1.18/client-server-api/#msecretsend
+//! [`m.secret.send`]: https://spec.matrix.org/v1.19/client-server-api/#msecretsend
 
 use std::fmt;
 

--- a/crates/ruma-events/src/secret_storage/default_key.rs
+++ b/crates/ruma-events/src/secret_storage/default_key.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.secret_storage.default_key`] event.
 //!
-//! [`m.secret_storage.default_key`]: https://spec.matrix.org/v1.18/client-server-api/#key-storage
+//! [`m.secret_storage.default_key`]: https://spec.matrix.org/v1.19/client-server-api/#key-storage
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/ruma-events/src/secret_storage/key.rs
+++ b/crates/ruma-events/src/secret_storage/key.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.secret_storage.key.*`] event.
 //!
-//! [`m.secret_storage.key.*`]: https://spec.matrix.org/v1.18/client-server-api/#key-storage
+//! [`m.secret_storage.key.*`]: https://spec.matrix.org/v1.19/client-server-api/#key-storage
 
 use std::borrow::Cow;
 
@@ -57,7 +57,7 @@ fn is_default_bits(val: &UInt) -> bool {
 ///
 /// The only algorithm currently specified is `m.secret_storage.v1.aes-hmac-sha2`, so this
 /// essentially represents `AesHmacSha2KeyDescription` in the
-/// [spec](https://spec.matrix.org/v1.18/client-server-api/#msecret_storagev1aes-hmac-sha2).
+/// [spec](https://spec.matrix.org/v1.19/client-server-api/#msecret_storagev1aes-hmac-sha2).
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 #[derive(Clone, Debug, Serialize, EventContent)]
 #[ruma_event(type = "m.secret_storage.key.*", kind = GlobalAccountData)]
@@ -138,7 +138,7 @@ impl SecretStorageEncryptionAlgorithm {
 /// The key properties for the `m.secret_storage.v1.aes-hmac-sha2` algorithm.
 ///
 /// Corresponds to the AES-specific properties of `AesHmacSha2KeyDescription` in the
-/// [spec](https://spec.matrix.org/v1.18/client-server-api/#msecret_storagev1aes-hmac-sha2).
+/// [spec](https://spec.matrix.org/v1.19/client-server-api/#msecret_storagev1aes-hmac-sha2).
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct SecretStorageV1AesHmacSha2Properties {

--- a/crates/ruma-events/src/space.rs
+++ b/crates/ruma-events/src/space.rs
@@ -1,6 +1,6 @@
 //! Types for the `m.space` events.
 //!
-//! See [the specification](https://spec.matrix.org/v1.18/client-server-api/#spaces).
+//! See [the specification](https://spec.matrix.org/v1.19/client-server-api/#spaces).
 
 pub mod child;
 pub mod parent;

--- a/crates/ruma-events/src/space/child.rs
+++ b/crates/ruma-events/src/space/child.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.space.child`] event.
 //!
-//! [`m.space.child`]: https://spec.matrix.org/v1.18/client-server-api/#mspacechild
+//! [`m.space.child`]: https://spec.matrix.org/v1.19/client-server-api/#mspacechild
 
 use std::{cmp::Ordering, ops::Deref};
 
@@ -132,7 +132,7 @@ impl JsonCastable<JsonObject> for HierarchySpaceChildEvent {}
 /// This trait can be used to sort a slice using `.sort_by(SpaceChildOrd::cmp_space_child)`. It is
 /// also possible to use [`SpaceChildOrdHelper`] to sort the events in a `BTreeMap` or a `BTreeSet`.
 ///
-/// [ordering children within a space]: https://spec.matrix.org/v1.18/client-server-api/#ordering-of-children-within-a-space
+/// [ordering children within a space]: https://spec.matrix.org/v1.19/client-server-api/#ordering-of-children-within-a-space
 pub trait SpaceChildOrd {
     #[doc(hidden)]
     fn space_child_ord_fields(&self) -> SpaceChildOrdFields<'_>;
@@ -140,7 +140,7 @@ pub trait SpaceChildOrd {
     /// Return an [`Ordering`] between `self` and `other`, using the algorithm for [ordering
     /// children within a space].
     ///
-    /// [ordering children within a space]: https://spec.matrix.org/v1.18/client-server-api/#ordering-of-children-within-a-space
+    /// [ordering children within a space]: https://spec.matrix.org/v1.19/client-server-api/#ordering-of-children-within-a-space
     fn cmp_space_child(&self, other: &impl SpaceChildOrd) -> Ordering {
         self.space_child_ord_fields().cmp(&other.space_child_ord_fields())
     }
@@ -149,7 +149,7 @@ pub trait SpaceChildOrd {
 /// Fields necessary to implement `Ord` for space child events using the algorithm for [ordering
 /// children within a space].
 ///
-/// [ordering children within a space]: https://spec.matrix.org/v1.18/client-server-api/#ordering-of-children-within-a-space
+/// [ordering children within a space]: https://spec.matrix.org/v1.19/client-server-api/#ordering-of-children-within-a-space
 #[doc(hidden)]
 #[derive(PartialEq, Eq)]
 pub struct SpaceChildOrdFields<'a> {
@@ -265,7 +265,7 @@ impl SpaceChildOrd for HierarchySpaceChildEvent {
 ///
 /// This type can be use with `BTreeMap` or `BTreeSet` to order space child events.
 ///
-/// [ordering children within a space]: https://spec.matrix.org/v1.18/client-server-api/#ordering-of-children-within-a-space
+/// [ordering children within a space]: https://spec.matrix.org/v1.19/client-server-api/#ordering-of-children-within-a-space
 #[derive(Debug, Clone)]
 #[allow(clippy::exhaustive_structs)]
 pub struct SpaceChildOrdHelper<T: SpaceChildOrd>(pub T);

--- a/crates/ruma-events/src/space/parent.rs
+++ b/crates/ruma-events/src/space/parent.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.space.parent`] event.
 //!
-//! [`m.space.parent`]: https://spec.matrix.org/v1.18/client-server-api/#mspaceparent
+//! [`m.space.parent`]: https://spec.matrix.org/v1.19/client-server-api/#mspaceparent
 
 use ruma_common::{OwnedRoomId, OwnedServerName};
 use ruma_macros::EventContent;

--- a/crates/ruma-events/src/sticker.rs
+++ b/crates/ruma-events/src/sticker.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.sticker`] event.
 //!
-//! [`m.sticker`]: https://spec.matrix.org/v1.18/client-server-api/#msticker
+//! [`m.sticker`]: https://spec.matrix.org/v1.19/client-server-api/#msticker
 
 use ruma_common::OwnedMxcUri;
 use ruma_macros::EventContent;

--- a/crates/ruma-events/src/tag.rs
+++ b/crates/ruma-events/src/tag.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.tag`] event.
 //!
-//! [`m.tag`]: https://spec.matrix.org/v1.18/client-server-api/#mtag
+//! [`m.tag`]: https://spec.matrix.org/v1.19/client-server-api/#mtag
 
 use std::{collections::BTreeMap, error::Error, fmt, str::FromStr};
 
@@ -86,7 +86,7 @@ pub enum TagName {
     LowPriority,
 
     /// `m.server_notice`: Used to identify
-    /// [Server Notice Rooms](https://spec.matrix.org/v1.18/client-server-api/#server-notices).
+    /// [Server Notice Rooms](https://spec.matrix.org/v1.19/client-server-api/#server-notices).
     ServerNotice,
 
     /// `u.*`: User-defined tag

--- a/crates/ruma-events/src/typing.rs
+++ b/crates/ruma-events/src/typing.rs
@@ -1,6 +1,6 @@
 //! Types for the [`m.typing`] event.
 //!
-//! [`m.typing`]: https://spec.matrix.org/v1.18/client-server-api/#mtyping
+//! [`m.typing`]: https://spec.matrix.org/v1.19/client-server-api/#mtyping
 
 use ruma_common::OwnedUserId;
 use ruma_macros::EventContent;

--- a/crates/ruma-events/src/unsigned.rs
+++ b/crates/ruma-events/src/unsigned.rs
@@ -35,7 +35,7 @@ pub struct MessageLikeUnsigned<C: MessageLikeEventContent> {
 
     /// [Bundled aggregations] of related child events.
     ///
-    /// [Bundled aggregations]: https://spec.matrix.org/v1.18/client-server-api/#aggregations-of-child-events
+    /// [Bundled aggregations]: https://spec.matrix.org/v1.19/client-server-api/#aggregations-of-child-events
     #[serde(rename = "m.relations", default)]
     pub relations: BundledMessageLikeRelations<OriginalSyncMessageLikeEvent<C>>,
 
@@ -107,7 +107,7 @@ pub struct StateUnsigned<C: PossiblyRedactedStateEventContent> {
 
     /// [Bundled aggregations] of related child events.
     ///
-    /// [Bundled aggregations]: https://spec.matrix.org/v1.18/client-server-api/#aggregations-of-child-events
+    /// [Bundled aggregations]: https://spec.matrix.org/v1.19/client-server-api/#aggregations-of-child-events
     #[serde(rename = "m.relations", default)]
     pub relations: BundledStateRelations,
 

--- a/crates/ruma-federation-api/src/authenticated_media/get_content/v1.rs
+++ b/crates/ruma-federation-api/src/authenticated_media/get_content/v1.rs
@@ -1,6 +1,6 @@
 //! `/v1/` ([spec])
 //!
-//! [spec]: https://spec.matrix.org/v1.18/server-server-api/#get_matrixfederationv1mediadownloadmediaid
+//! [spec]: https://spec.matrix.org/v1.19/server-server-api/#get_matrixfederationv1mediadownloadmediaid
 
 use std::time::Duration;
 

--- a/crates/ruma-federation-api/src/authenticated_media/get_content_thumbnail/v1.rs
+++ b/crates/ruma-federation-api/src/authenticated_media/get_content_thumbnail/v1.rs
@@ -1,6 +1,6 @@
 //! `/v1/` ([spec])
 //!
-//! [spec]: https://spec.matrix.org/v1.18/server-server-api/#get_matrixfederationv1mediathumbnailmediaid
+//! [spec]: https://spec.matrix.org/v1.19/server-server-api/#get_matrixfederationv1mediathumbnailmediaid
 
 use std::time::Duration;
 

--- a/crates/ruma-federation-api/src/authentication.rs
+++ b/crates/ruma-federation-api/src/authentication.rs
@@ -18,7 +18,7 @@ use tracing::debug;
 /// Authentication is performed by adding an `X-Matrix` header including a signature in the request
 /// headers, as defined in the [Matrix Server-Server API][spec].
 ///
-/// [spec]: https://spec.matrix.org/v1.18/server-server-api/#request-authentication
+/// [spec]: https://spec.matrix.org/v1.19/server-server-api/#request-authentication
 #[derive(Debug, Clone, Copy, Default)]
 #[allow(clippy::exhaustive_structs)]
 pub struct ServerSignatures;
@@ -78,7 +78,7 @@ impl<'a> ServerSignaturesInput<'a> {
 /// Typed representation of an `Authorization` header of scheme `X-Matrix`, as defined in the
 /// [Matrix Server-Server API][spec].
 ///
-/// [spec]: https://spec.matrix.org/v1.18/server-server-api/#request-authentication
+/// [spec]: https://spec.matrix.org/v1.19/server-server-api/#request-authentication
 #[derive(Clone)]
 #[non_exhaustive]
 pub struct XMatrix {

--- a/crates/ruma-federation-api/src/authorization/get_event_authorization.rs
+++ b/crates/ruma-federation-api/src/authorization/get_event_authorization.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/server-server-api/#get_matrixfederationv1event_authroomideventid
+    //! [spec]: https://spec.matrix.org/v1.19/server-server-api/#get_matrixfederationv1event_authroomideventid
 
     use ruma_common::{
         OwnedEventId, OwnedRoomId,

--- a/crates/ruma-federation-api/src/backfill/get_backfill.rs
+++ b/crates/ruma-federation-api/src/backfill/get_backfill.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/server-server-api/#get_matrixfederationv1backfillroomid
+    //! [spec]: https://spec.matrix.org/v1.19/server-server-api/#get_matrixfederationv1backfillroomid
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-federation-api/src/device/get_devices.rs
+++ b/crates/ruma-federation-api/src/device/get_devices.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/server-server-api/#get_matrixfederationv1userdevicesuserid
+    //! [spec]: https://spec.matrix.org/v1.19/server-server-api/#get_matrixfederationv1userdevicesuserid
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-federation-api/src/directory/get_public_rooms.rs
+++ b/crates/ruma-federation-api/src/directory/get_public_rooms.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/server-server-api/#post_matrixfederationv1publicrooms
+    //! [spec]: https://spec.matrix.org/v1.19/server-server-api/#post_matrixfederationv1publicrooms
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-federation-api/src/directory/get_public_rooms_filtered.rs
+++ b/crates/ruma-federation-api/src/directory/get_public_rooms_filtered.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/server-server-api/#post_matrixfederationv1publicrooms
+    //! [spec]: https://spec.matrix.org/v1.19/server-server-api/#post_matrixfederationv1publicrooms
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-federation-api/src/discovery/discover_homeserver.rs
+++ b/crates/ruma-federation-api/src/discovery/discover_homeserver.rs
@@ -2,7 +2,7 @@
 //!
 //! Get discovery information about the domain.
 //!
-//! [spec]: https://spec.matrix.org/v1.18/server-server-api/#getwell-knownmatrixserver
+//! [spec]: https://spec.matrix.org/v1.19/server-server-api/#getwell-knownmatrixserver
 
 use ruma_common::{
     OwnedServerName,

--- a/crates/ruma-federation-api/src/discovery/get_remote_server_keys.rs
+++ b/crates/ruma-federation-api/src/discovery/get_remote_server_keys.rs
@@ -6,7 +6,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/server-server-api/#get_matrixkeyv2queryservername
+    //! [spec]: https://spec.matrix.org/v1.19/server-server-api/#get_matrixkeyv2queryservername
 
     use ruma_common::{
         MilliSecondsSinceUnixEpoch, OwnedServerName,

--- a/crates/ruma-federation-api/src/discovery/get_remote_server_keys_batch.rs
+++ b/crates/ruma-federation-api/src/discovery/get_remote_server_keys_batch.rs
@@ -6,7 +6,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/server-server-api/#post_matrixkeyv2query
+    //! [spec]: https://spec.matrix.org/v1.19/server-server-api/#post_matrixkeyv2query
 
     use std::collections::BTreeMap;
 

--- a/crates/ruma-federation-api/src/discovery/get_server_keys.rs
+++ b/crates/ruma-federation-api/src/discovery/get_server_keys.rs
@@ -5,7 +5,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/server-server-api/#get_matrixkeyv2server
+    //! [spec]: https://spec.matrix.org/v1.19/server-server-api/#get_matrixkeyv2server
 
     use ruma_common::{
         api::{auth_scheme::NoAuthentication, request, response},

--- a/crates/ruma-federation-api/src/discovery/get_server_version.rs
+++ b/crates/ruma-federation-api/src/discovery/get_server_version.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/server-server-api/#get_matrixfederationv1version
+    //! [spec]: https://spec.matrix.org/v1.19/server-server-api/#get_matrixfederationv1version
 
     use ruma_common::{
         api::{auth_scheme::NoAuthentication, request, response},

--- a/crates/ruma-federation-api/src/event/get_event.rs
+++ b/crates/ruma-federation-api/src/event/get_event.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/server-server-api/#get_matrixfederationv1eventeventid
+    //! [spec]: https://spec.matrix.org/v1.19/server-server-api/#get_matrixfederationv1eventeventid
 
     use ruma_common::{
         MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedServerName,

--- a/crates/ruma-federation-api/src/event/get_event_by_timestamp/v1.rs
+++ b/crates/ruma-federation-api/src/event/get_event_by_timestamp/v1.rs
@@ -1,6 +1,6 @@
 //! `/v1/` ([spec])
 //!
-//! [spec]: https://spec.matrix.org/v1.18/server-server-api/#get_matrixfederationv1timestamp_to_eventroomid
+//! [spec]: https://spec.matrix.org/v1.19/server-server-api/#get_matrixfederationv1timestamp_to_eventroomid
 
 use ruma_common::{
     MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId,

--- a/crates/ruma-federation-api/src/event/get_missing_events.rs
+++ b/crates/ruma-federation-api/src/event/get_missing_events.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/server-server-api/#post_matrixfederationv1get_missing_eventsroomid
+    //! [spec]: https://spec.matrix.org/v1.19/server-server-api/#post_matrixfederationv1get_missing_eventsroomid
 
     use js_int::{UInt, uint};
     use ruma_common::{

--- a/crates/ruma-federation-api/src/event/get_room_state.rs
+++ b/crates/ruma-federation-api/src/event/get_room_state.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/server-server-api/#get_matrixfederationv1stateroomid
+    //! [spec]: https://spec.matrix.org/v1.19/server-server-api/#get_matrixfederationv1stateroomid
 
     use ruma_common::{
         OwnedEventId, OwnedRoomId,

--- a/crates/ruma-federation-api/src/event/get_room_state_ids.rs
+++ b/crates/ruma-federation-api/src/event/get_room_state_ids.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/server-server-api/#get_matrixfederationv1state_idsroomid
+    //! [spec]: https://spec.matrix.org/v1.19/server-server-api/#get_matrixfederationv1state_idsroomid
 
     use ruma_common::{
         OwnedEventId, OwnedRoomId,

--- a/crates/ruma-federation-api/src/keys/claim_keys.rs
+++ b/crates/ruma-federation-api/src/keys/claim_keys.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/server-server-api/#post_matrixfederationv1userkeysclaim
+    //! [spec]: https://spec.matrix.org/v1.19/server-server-api/#post_matrixfederationv1userkeysclaim
 
     use std::collections::BTreeMap;
 

--- a/crates/ruma-federation-api/src/keys/get_keys.rs
+++ b/crates/ruma-federation-api/src/keys/get_keys.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/server-server-api/#post_matrixfederationv1userkeysquery
+    //! [spec]: https://spec.matrix.org/v1.19/server-server-api/#post_matrixfederationv1userkeysquery
 
     use std::collections::BTreeMap;
 

--- a/crates/ruma-federation-api/src/lib.rs
+++ b/crates/ruma-federation-api/src/lib.rs
@@ -3,7 +3,7 @@
 //! (De)serializable types for the [Matrix Server-Server API][federation-api].
 //! These types are used by server code.
 //!
-//! [federation-api]: https://spec.matrix.org/v1.18/server-server-api/
+//! [federation-api]: https://spec.matrix.org/v1.19/server-server-api/
 
 #![warn(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg))]

--- a/crates/ruma-federation-api/src/membership/create_invite/v1.rs
+++ b/crates/ruma-federation-api/src/membership/create_invite/v1.rs
@@ -1,6 +1,6 @@
 //! `/v1/` ([spec])
 //!
-//! [spec]: https://spec.matrix.org/v1.18/server-server-api/#put_matrixfederationv1inviteroomideventid
+//! [spec]: https://spec.matrix.org/v1.19/server-server-api/#put_matrixfederationv1inviteroomideventid
 
 use ruma_common::{
     MilliSecondsSinceUnixEpoch, OwnedEventId, OwnedRoomId, OwnedServerName, OwnedUserId,

--- a/crates/ruma-federation-api/src/membership/create_invite/v2.rs
+++ b/crates/ruma-federation-api/src/membership/create_invite/v2.rs
@@ -1,6 +1,6 @@
 //! `/v2/` ([spec])
 //!
-//! [spec]: https://spec.matrix.org/v1.18/server-server-api/#put_matrixfederationv2inviteroomideventid
+//! [spec]: https://spec.matrix.org/v1.19/server-server-api/#put_matrixfederationv2inviteroomideventid
 
 #[cfg(feature = "unstable-msc4125")]
 use ruma_common::OwnedServerName;

--- a/crates/ruma-federation-api/src/membership/create_join_event/v2.rs
+++ b/crates/ruma-federation-api/src/membership/create_join_event/v2.rs
@@ -1,6 +1,6 @@
 //! `/v2/` ([spec])
 //!
-//! [spec]: https://spec.matrix.org/v1.18/server-server-api/#put_matrixfederationv2send_joinroomideventid
+//! [spec]: https://spec.matrix.org/v1.19/server-server-api/#put_matrixfederationv2send_joinroomideventid
 
 use ruma_common::{
     OwnedEventId, OwnedRoomId,
@@ -48,7 +48,7 @@ pub struct Request {
     /// the response `state` field, and include the auth chains for these membership events in
     /// the response `auth_chain` field.
     ///
-    /// [Client-Server `/sync` response]: https://spec.matrix.org/v1.18/client-server-api/#get_matrixclientv3sync
+    /// [Client-Server `/sync` response]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3sync
     #[ruma_api(query)]
     #[serde(default, skip_serializing_if = "ruma_common::serde::is_default")]
     pub omit_members: bool,

--- a/crates/ruma-federation-api/src/membership/create_knock_event/v1.rs
+++ b/crates/ruma-federation-api/src/membership/create_knock_event/v1.rs
@@ -1,6 +1,6 @@
 //! `/v1/` ([spec])
 //!
-//! [spec]: https://spec.matrix.org/v1.18/server-server-api/#put_matrixfederationv1send_knockroomideventid
+//! [spec]: https://spec.matrix.org/v1.19/server-server-api/#put_matrixfederationv1send_knockroomideventid
 
 use ruma_common::{
     OwnedEventId, OwnedRoomId,

--- a/crates/ruma-federation-api/src/membership/create_leave_event/v2.rs
+++ b/crates/ruma-federation-api/src/membership/create_leave_event/v2.rs
@@ -1,6 +1,6 @@
 //! `/v2/` ([spec])
 //!
-//! [spec]: https://spec.matrix.org/v1.18/server-server-api/#put_matrixfederationv2send_leaveroomideventid
+//! [spec]: https://spec.matrix.org/v1.19/server-server-api/#put_matrixfederationv2send_leaveroomideventid
 
 use ruma_common::{
     OwnedEventId, OwnedRoomId,

--- a/crates/ruma-federation-api/src/membership/prepare_join_event.rs
+++ b/crates/ruma-federation-api/src/membership/prepare_join_event.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/server-server-api/#get_matrixfederationv1make_joinroomiduserid
+    //! [spec]: https://spec.matrix.org/v1.19/server-server-api/#get_matrixfederationv1make_joinroomiduserid
 
     use ruma_common::{
         OwnedRoomId, OwnedUserId, RoomVersionId,

--- a/crates/ruma-federation-api/src/membership/prepare_knock_event/v1.rs
+++ b/crates/ruma-federation-api/src/membership/prepare_knock_event/v1.rs
@@ -1,6 +1,6 @@
 //! `/v1/` ([spec])
 //!
-//! [spec]: https://spec.matrix.org/v1.18/server-server-api/#get_matrixfederationv1make_knockroomiduserid
+//! [spec]: https://spec.matrix.org/v1.19/server-server-api/#get_matrixfederationv1make_knockroomiduserid
 
 use ruma_common::{
     OwnedRoomId, OwnedUserId, RoomVersionId,

--- a/crates/ruma-federation-api/src/membership/prepare_leave_event.rs
+++ b/crates/ruma-federation-api/src/membership/prepare_leave_event.rs
@@ -6,7 +6,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/server-server-api/#get_matrixfederationv1make_leaveroomiduserid
+    //! [spec]: https://spec.matrix.org/v1.19/server-server-api/#get_matrixfederationv1make_leaveroomiduserid
 
     use ruma_common::{
         OwnedRoomId, OwnedUserId, RoomVersionId,

--- a/crates/ruma-federation-api/src/openid/get_openid_userinfo.rs
+++ b/crates/ruma-federation-api/src/openid/get_openid_userinfo.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/server-server-api/#get_matrixfederationv1openiduserinfo
+    //! [spec]: https://spec.matrix.org/v1.19/server-server-api/#get_matrixfederationv1openiduserinfo
 
     use ruma_common::{
         OwnedUserId,

--- a/crates/ruma-federation-api/src/policy.rs
+++ b/crates/ruma-federation-api/src/policy.rs
@@ -1,5 +1,5 @@
 //! [Policy Servers] endpoints.
 //!
-//! [Policy Servers]: https://spec.matrix.org/v1.18/server-server-api/#policy-servers
+//! [Policy Servers]: https://spec.matrix.org/v1.19/server-server-api/#policy-servers
 
 pub mod sign_event;

--- a/crates/ruma-federation-api/src/policy/sign_event.rs
+++ b/crates/ruma-federation-api/src/policy/sign_event.rs
@@ -10,12 +10,12 @@
 //! Whether a signature is required by a Policy Server further depends on whether the room has
 //! enabled a Policy Server.
 //!
-//! [Policy Server]: https://spec.matrix.org/v1.18/server-server-api/#policy-servers
+//! [Policy Server]: https://spec.matrix.org/v1.19/server-server-api/#policy-servers
 
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/server-server-api/#post_matrixpolicyv1sign
+    //! [spec]: https://spec.matrix.org/v1.19/server-server-api/#post_matrixpolicyv1sign
 
     use ruma_common::{
         OwnedServerName, ServerName, ServerSignatures as ServerSignaturesMap,

--- a/crates/ruma-federation-api/src/query/get_custom_information.rs
+++ b/crates/ruma-federation-api/src/query/get_custom_information.rs
@@ -6,7 +6,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/server-server-api/#get_matrixfederationv1queryquerytype
+    //! [spec]: https://spec.matrix.org/v1.19/server-server-api/#get_matrixfederationv1queryquerytype
 
     use std::collections::BTreeMap;
 

--- a/crates/ruma-federation-api/src/query/get_profile_information.rs
+++ b/crates/ruma-federation-api/src/query/get_profile_information.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/server-server-api/#get_matrixfederationv1queryprofile
+    //! [spec]: https://spec.matrix.org/v1.19/server-server-api/#get_matrixfederationv1queryprofile
 
     use std::collections::btree_map;
 

--- a/crates/ruma-federation-api/src/query/get_room_information.rs
+++ b/crates/ruma-federation-api/src/query/get_room_information.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/server-server-api/#get_matrixfederationv1querydirectory
+    //! [spec]: https://spec.matrix.org/v1.19/server-server-api/#get_matrixfederationv1querydirectory
 
     use ruma_common::{
         OwnedRoomAliasId, OwnedRoomId, OwnedServerName,

--- a/crates/ruma-federation-api/src/serde/v1_pdu.rs
+++ b/crates/ruma-federation-api/src/serde/v1_pdu.rs
@@ -1,7 +1,7 @@
 //! A module to deserialize a response from incorrectly specified endpoint:
 //!
 //! - [PUT /_matrix/federation/v1/send_join/{roomId}/{eventId}](https://spec.matrix.org/v1.17/server-server-api/#put_matrixfederationv1send_joinroomideventid)
-//! - [PUT /_matrix/federation/v1/invite/{roomId}/{eventId}](https://spec.matrix.org/v1.18/server-server-api/#put_matrixfederationv1inviteroomideventid)
+//! - [PUT /_matrix/federation/v1/invite/{roomId}/{eventId}](https://spec.matrix.org/v1.19/server-server-api/#put_matrixfederationv1inviteroomideventid)
 //! - [PUT /_matrix/federation/v1/send_leave/{roomId}/{eventId}](https://spec.matrix.org/v1.17/server-server-api/#put_matrixfederationv1send_leaveroomideventid)
 //!
 //! For more information, see this [GitHub issue][issue].

--- a/crates/ruma-federation-api/src/space/get_hierarchy/v1.rs
+++ b/crates/ruma-federation-api/src/space/get_hierarchy/v1.rs
@@ -1,6 +1,6 @@
 //! `/v1/` ([spec])
 //!
-//! [spec]: https://spec.matrix.org/v1.18/server-server-api/#get_matrixfederationv1hierarchyroomid
+//! [spec]: https://spec.matrix.org/v1.19/server-server-api/#get_matrixfederationv1hierarchyroomid
 
 use ruma_common::{
     OwnedRoomId,

--- a/crates/ruma-federation-api/src/thirdparty/bind_callback.rs
+++ b/crates/ruma-federation-api/src/thirdparty/bind_callback.rs
@@ -7,7 +7,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/server-server-api/#put_matrixfederationv13pidonbind
+    //! [spec]: https://spec.matrix.org/v1.19/server-server-api/#put_matrixfederationv13pidonbind
 
     use ruma_common::{
         OwnedRoomId, OwnedUserId,

--- a/crates/ruma-federation-api/src/thirdparty/exchange_invite.rs
+++ b/crates/ruma-federation-api/src/thirdparty/exchange_invite.rs
@@ -4,12 +4,12 @@
 //! If valid, the receiving server will issue an invite as per the [Inviting to a room] section
 //! before returning a response to this request.
 //!
-//! [Inviting to a room]: https://spec.matrix.org/v1.18/server-server-api/#inviting-to-a-room
+//! [Inviting to a room]: https://spec.matrix.org/v1.19/server-server-api/#inviting-to-a-room
 
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/server-server-api/#put_matrixfederationv1exchange_third_party_inviteroomid
+    //! [spec]: https://spec.matrix.org/v1.19/server-server-api/#put_matrixfederationv1exchange_third_party_inviteroomid
 
     use ruma_common::{
         OwnedRoomId, OwnedUserId,

--- a/crates/ruma-federation-api/src/transactions/send_transaction_message.rs
+++ b/crates/ruma-federation-api/src/transactions/send_transaction_message.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/server-server-api/#put_matrixfederationv1sendtxnid
+    //! [spec]: https://spec.matrix.org/v1.19/server-server-api/#put_matrixfederationv1sendtxnid
 
     use std::collections::BTreeMap;
 

--- a/crates/ruma-html/src/helpers.rs
+++ b/crates/ruma-html/src/helpers.rs
@@ -8,8 +8,8 @@ use crate::{Html, HtmlSanitizerMode, SanitizerConfig};
 ///
 /// It can also optionally remove the [rich reply] fallback.
 ///
-/// [tags and attributes]: https://spec.matrix.org/v1.18/client-server-api/#mroommessage-msgtypes
-/// [rich reply]: https://spec.matrix.org/v1.18/client-server-api/#rich-replies
+/// [tags and attributes]: https://spec.matrix.org/v1.19/client-server-api/#mroommessage-msgtypes
+/// [rich reply]: https://spec.matrix.org/v1.19/client-server-api/#rich-replies
 pub fn sanitize_html(
     s: &str,
     mode: HtmlSanitizerMode,
@@ -29,7 +29,7 @@ pub fn sanitize_html(
 
 /// Whether to remove the [rich reply] fallback while sanitizing.
 ///
-/// [rich reply]: https://spec.matrix.org/v1.18/client-server-api/#rich-replies
+/// [rich reply]: https://spec.matrix.org/v1.19/client-server-api/#rich-replies
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[allow(clippy::exhaustive_enums)]
 pub enum RemoveReplyFallback {
@@ -45,7 +45,7 @@ pub enum RemoveReplyFallback {
 /// Due to the fact that the HTML is parsed, note that malformed HTML and comments will be stripped
 /// from the output.
 ///
-/// [rich reply]: https://spec.matrix.org/v1.18/client-server-api/#rich-replies
+/// [rich reply]: https://spec.matrix.org/v1.19/client-server-api/#rich-replies
 pub fn remove_html_reply_fallback(s: &str) -> String {
     let config = SanitizerConfig::new().remove_reply_fallback();
     sanitize_inner(s, &config)

--- a/crates/ruma-html/src/html.rs
+++ b/crates/ruma-html/src/html.rs
@@ -322,7 +322,7 @@ pub struct ElementData {
 impl ElementData {
     /// Convert this element data to typed data as [suggested by the Matrix Specification][spec].
     ///
-    /// [spec]: https://spec.matrix.org/v1.18/client-server-api/#mroommessage-msgtypes
+    /// [spec]: https://spec.matrix.org/v1.19/client-server-api/#mroommessage-msgtypes
     #[cfg(feature = "matrix")]
     pub fn to_matrix(&self) -> matrix::MatrixElementData {
         matrix::MatrixElementData::parse(&self.name, &self.attrs.borrow())

--- a/crates/ruma-html/src/html/matrix.rs
+++ b/crates/ruma-html/src/html/matrix.rs
@@ -1,6 +1,6 @@
 //! Types to work with HTML elements and attributes [suggested by the Matrix Specification][spec].
 //!
-//! [spec]: https://spec.matrix.org/v1.18/client-server-api/#mroommessage-msgtypes
+//! [spec]: https://spec.matrix.org/v1.19/client-server-api/#mroommessage-msgtypes
 
 use std::collections::BTreeSet;
 
@@ -21,7 +21,7 @@ const CLASS_LANGUAGE_PREFIX: &str = "language-";
 /// by [`MatrixElement::Other`] and unsupported attributes are listed in the `attrs` field.
 ///
 /// [`ElementData`]: crate::ElementData
-/// [spec]: https://spec.matrix.org/v1.18/client-server-api/#mroommessage-msgtypes
+/// [spec]: https://spec.matrix.org/v1.19/client-server-api/#mroommessage-msgtypes
 #[derive(Debug, Clone)]
 #[allow(clippy::exhaustive_structs)]
 pub struct MatrixElementData {
@@ -48,7 +48,7 @@ impl MatrixElementData {
 ///
 /// Suggested attributes are represented as optional fields on the variants structs.
 ///
-/// [spec]: https://spec.matrix.org/v1.18/client-server-api/#mroommessage-msgtypes
+/// [spec]: https://spec.matrix.org/v1.19/client-server-api/#mroommessage-msgtypes
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum MatrixElement {
@@ -214,7 +214,7 @@ pub enum MatrixElement {
 
     /// [`mx-reply`], a Matrix rich reply fallback element.
     ///
-    /// [`mx-reply`]: https://spec.matrix.org/v1.18/client-server-api/#rich-replies
+    /// [`mx-reply`]: https://spec.matrix.org/v1.19/client-server-api/#rich-replies
     MatrixReply,
 
     /// An HTML element that is not in the suggested list.
@@ -594,7 +594,7 @@ pub struct SpanData {
     /// The value is the reason of the spoiler. If the string is empty, this is a spoiler
     /// without a reason.
     ///
-    /// [spoiler message]: https://spec.matrix.org/v1.18/client-server-api/#spoiler-messages
+    /// [spoiler message]: https://spec.matrix.org/v1.19/client-server-api/#spoiler-messages
     pub spoiler: Option<StrTendril>,
 
     /// `data-mx-maths`, an inline Matrix [mathematical message].
@@ -604,7 +604,7 @@ pub struct SpanData {
     /// If this attribute is present, the content of the span is the fallback representation of the
     /// mathematical notation.
     ///
-    /// [mathematical message]: https://spec.matrix.org/v1.18/client-server-api/#mathematical-messages
+    /// [mathematical message]: https://spec.matrix.org/v1.19/client-server-api/#mathematical-messages
     /// [LaTeX]: https://www.latex-project.org/
     pub maths: Option<StrTendril>,
 
@@ -764,7 +764,7 @@ pub struct DivData {
     /// If this attribute is present, the content of the div is the fallback representation of the
     /// mathematical notation.
     ///
-    /// [mathematical message]: https://spec.matrix.org/v1.18/client-server-api/#mathematical-messages
+    /// [mathematical message]: https://spec.matrix.org/v1.19/client-server-api/#mathematical-messages
     /// [LaTeX]: https://www.latex-project.org/
     pub maths: Option<StrTendril>,
 }

--- a/crates/ruma-html/src/lib.rs
+++ b/crates/ruma-html/src/lib.rs
@@ -12,7 +12,7 @@
 //! * `matrix` - Allow to convert HTML elements data into enums with variants for elements and
 //!   attributes [suggested by the Matrix Specification][spec].
 //!
-//! [spec]: https://spec.matrix.org/v1.18/client-server-api/#mroommessage-msgtypes
+//! [spec]: https://spec.matrix.org/v1.19/client-server-api/#mroommessage-msgtypes
 
 #![warn(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
@@ -27,7 +27,7 @@ pub use self::{helpers::*, html::*, sanitizer_config::*};
 
 /// What [HTML elements and attributes] should be kept by the sanitizer.
 ///
-/// [HTML elements and attributes]: https://spec.matrix.org/v1.18/client-server-api/#mroommessage-msgtypes
+/// [HTML elements and attributes]: https://spec.matrix.org/v1.19/client-server-api/#mroommessage-msgtypes
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[allow(clippy::exhaustive_enums)]
 pub enum HtmlSanitizerMode {

--- a/crates/ruma-html/src/sanitizer_config.rs
+++ b/crates/ruma-html/src/sanitizer_config.rs
@@ -113,7 +113,7 @@ impl SanitizerConfig {
     ///
     /// This is the same as calling `SanitizerConfig::with_mode(HtmlSanitizerMode::Strict)`.
     ///
-    /// [suggested in the Matrix specification]: https://spec.matrix.org/v1.18/client-server-api/#mroommessage-msgtypes
+    /// [suggested in the Matrix specification]: https://spec.matrix.org/v1.19/client-server-api/#mroommessage-msgtypes
     pub fn strict() -> Self {
         Self::with_mode(HtmlSanitizerMode::Strict)
     }
@@ -133,7 +133,7 @@ impl SanitizerConfig {
     ///
     /// This is the same as calling `SanitizerConfig::with_mode(HtmlSanitizerMode::Compat)`.
     ///
-    /// [listed in the Matrix specification]: https://spec.matrix.org/v1.18/client-server-api/#mroommessage-msgtypes
+    /// [listed in the Matrix specification]: https://spec.matrix.org/v1.19/client-server-api/#mroommessage-msgtypes
     pub fn compat() -> Self {
         Self::with_mode(HtmlSanitizerMode::Compat)
     }
@@ -184,7 +184,7 @@ impl SanitizerConfig {
     /// Removing elements has a higher priority than ignoring or allowing. So if this settings is
     /// set, `mx-reply` will always be removed.
     ///
-    /// [rich reply]: https://spec.matrix.org/v1.18/client-server-api/#rich-replies
+    /// [rich reply]: https://spec.matrix.org/v1.19/client-server-api/#rich-replies
     pub fn remove_reply_fallback(mut self) -> Self {
         self.remove_reply_fallback = true;
         self

--- a/crates/ruma-identifiers-validation/src/error.rs
+++ b/crates/ruma-identifiers-validation/src/error.rs
@@ -77,7 +77,7 @@ pub enum MxcUriError {
     /// Media identifier malformed due to invalid characters detected.
     ///
     /// Valid characters are (in regex notation) `[A-Za-z0-9_-]+`.
-    /// See [here](https://spec.matrix.org/v1.18/client-server-api/#security-considerations-5) for more details.
+    /// See [here](https://spec.matrix.org/v1.19/client-server-api/#matrix-content-mxc-uris) for more details.
     #[error("Media Identifier malformed, invalid characters")]
     MediaIdMalformed,
 

--- a/crates/ruma-identifiers-validation/src/lib.rs
+++ b/crates/ruma-identifiers-validation/src/lib.rs
@@ -61,7 +61,7 @@ pub trait KeyName: AsRef<str> {
 /// According to the spec, localparts can consist of any legal non-surrogate Unicode code points
 /// except for `:` and `NUL` (`U+0000`).
 ///
-/// [allowed over federation]: https://spec.matrix.org/v1.18/appendices/#historical-user-ids
+/// [allowed over federation]: https://spec.matrix.org/v1.19/appendices/#historical-user-ids
 pub fn localpart_is_backwards_compatible(localpart: &str) -> Result<(), Error> {
     let is_invalid = localpart.contains([':', '\0']);
     if is_invalid { Err(Error::InvalidCharacters) } else { Ok(()) }

--- a/crates/ruma-identifiers-validation/src/mxc_uri.rs
+++ b/crates/ruma-identifiers-validation/src/mxc_uri.rs
@@ -15,7 +15,7 @@ pub fn validate(uri: &str) -> Result<NonZeroU8, MxcUriError> {
 
     let server_name = &uri[..index];
     let media_id = &uri[index + 1..];
-    // See: https://spec.matrix.org/v1.18/client-server-api/#security-considerations-5
+    // See: https://spec.matrix.org/v1.19/client-server-api/#matrix-content-mxc-uris
     let media_id_is_valid = media_id
         .bytes()
         .all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'z' | b'A'..=b'Z' | b'-' | b'_' ));

--- a/crates/ruma-identifiers-validation/src/room_alias_id.rs
+++ b/crates/ruma-identifiers-validation/src/room_alias_id.rs
@@ -2,7 +2,7 @@ use crate::{Error, localpart_is_backwards_compatible, parse_id};
 
 /// Validate a [room alias] as used by clients and servers.
 ///
-/// [room alias]: https://spec.matrix.org/v1.18/appendices/#room-aliases
+/// [room alias]: https://spec.matrix.org/v1.19/appendices/#room-aliases
 pub fn validate(s: &str) -> Result<(), Error> {
     let colon_idx = parse_id(s, b'#')?;
     let localpart = &s[1..colon_idx];

--- a/crates/ruma-identifiers-validation/src/room_id.rs
+++ b/crates/ruma-identifiers-validation/src/room_id.rs
@@ -2,7 +2,7 @@ use crate::{Error, validate_id};
 
 /// Validate a [room ID] as used by clients.
 ///
-/// [room ID]: https://spec.matrix.org/v1.18/appendices/#room-ids
+/// [room ID]: https://spec.matrix.org/v1.19/appendices/#room-ids
 pub fn validate(s: &str) -> Result<(), Error> {
     validate_id(s, b'!')?;
 

--- a/crates/ruma-identifiers-validation/src/space_child_order.rs
+++ b/crates/ruma-identifiers-validation/src/space_child_order.rs
@@ -10,7 +10,7 @@ use crate::Error;
 /// Returns `Ok(())` if the order passes validation, or an error if the order doesn't respect
 /// the rules from the spec, as it cannot be used for ordering.
 ///
-/// [`m.space.child`]: https://spec.matrix.org/v1.18/client-server-api/#mspacechild
+/// [`m.space.child`]: https://spec.matrix.org/v1.19/client-server-api/#mspacechild
 pub fn validate(s: &str) -> Result<(), Error> {
     if s.len() > 50 {
         return Err(Error::MaximumLengthExceeded);

--- a/crates/ruma-identifiers-validation/src/user_id.rs
+++ b/crates/ruma-identifiers-validation/src/user_id.rs
@@ -2,7 +2,7 @@ use crate::{Error, ID_MAX_BYTES, localpart_is_backwards_compatible, parse_id};
 
 /// Validate a [user ID] as used by clients.
 ///
-/// [user ID]: https://spec.matrix.org/v1.18/appendices/#user-identifiers
+/// [user ID]: https://spec.matrix.org/v1.19/appendices/#user-identifiers
 pub fn validate(s: &str) -> Result<(), Error> {
     let colon_idx = parse_id(s, b'@')?;
     let localpart = &s[1..colon_idx];
@@ -14,7 +14,7 @@ pub fn validate(s: &str) -> Result<(), Error> {
 
 /// Validate a [user ID] to follow the spec recommendations when generating them.
 ///
-/// [user ID]: https://spec.matrix.org/v1.18/appendices/#user-identifiers
+/// [user ID]: https://spec.matrix.org/v1.19/appendices/#user-identifiers
 pub fn validate_strict(s: &str) -> Result<(), Error> {
     // Since the length check can be disabled with `compat-arbitrary-length-ids`, check it again
     // here.
@@ -37,13 +37,13 @@ pub fn validate_strict(s: &str) -> Result<(), Error> {
 /// Returns an `Err` for invalid user ID localparts, `Ok(false)` for historical user ID localparts
 /// and `Ok(true)` for fully conforming user ID localparts.
 ///
-/// [user ID]: https://spec.matrix.org/v1.18/appendices/#user-identifiers
+/// [user ID]: https://spec.matrix.org/v1.19/appendices/#user-identifiers
 pub fn localpart_is_fully_conforming(localpart: &str) -> Result<bool, Error> {
     if localpart.is_empty() {
         return Err(Error::Empty);
     }
 
-    // See https://spec.matrix.org/v1.18/appendices/#user-identifiers
+    // See https://spec.matrix.org/v1.19/appendices/#user-identifiers
     let is_fully_conforming = localpart
         .bytes()
         .all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'z' | b'-' | b'.' | b'=' | b'_' | b'/' | b'+'));
@@ -51,7 +51,7 @@ pub fn localpart_is_fully_conforming(localpart: &str) -> Result<bool, Error> {
     if !is_fully_conforming {
         // If it's not fully conforming, check if it contains characters that are also disallowed
         // for historical user IDs, or is empty. If that's the case, return an error.
-        // See https://spec.matrix.org/v1.18/appendices/#historical-user-ids
+        // See https://spec.matrix.org/v1.19/appendices/#historical-user-ids
         let is_invalid_historical = localpart.bytes().any(|b| b < 0x21 || b == b':' || b > 0x7E);
 
         if is_invalid_historical {

--- a/crates/ruma-identity-service-api/src/association/bind_3pid.rs
+++ b/crates/ruma-identity-service-api/src/association/bind_3pid.rs
@@ -5,7 +5,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/identity-service-api/#post_matrixidentityv23pidbind
+    //! [spec]: https://spec.matrix.org/v1.19/identity-service-api/#post_matrixidentityv23pidbind
 
     use ruma_common::{
         MilliSecondsSinceUnixEpoch, OwnedClientSecret, OwnedSessionId, OwnedUserId,

--- a/crates/ruma-identity-service-api/src/association/check_3pid_validity.rs
+++ b/crates/ruma-identity-service-api/src/association/check_3pid_validity.rs
@@ -5,7 +5,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/identity-service-api/#get_matrixidentityv23pidgetvalidated3pid
+    //! [spec]: https://spec.matrix.org/v1.19/identity-service-api/#get_matrixidentityv23pidgetvalidated3pid
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-identity-service-api/src/association/email/create_email_validation_session.rs
+++ b/crates/ruma-identity-service-api/src/association/email/create_email_validation_session.rs
@@ -5,7 +5,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/identity-service-api/#post_matrixidentityv2validateemailrequesttoken
+    //! [spec]: https://spec.matrix.org/v1.19/identity-service-api/#post_matrixidentityv2validateemailrequesttoken
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-identity-service-api/src/association/email/validate_email.rs
+++ b/crates/ruma-identity-service-api/src/association/email/validate_email.rs
@@ -5,7 +5,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/identity-service-api/#post_matrixidentityv2validateemailsubmittoken
+    //! [spec]: https://spec.matrix.org/v1.19/identity-service-api/#post_matrixidentityv2validateemailsubmittoken
 
     use ruma_common::{
         OwnedClientSecret, OwnedSessionId,

--- a/crates/ruma-identity-service-api/src/association/email/validate_email_by_end_user.rs
+++ b/crates/ruma-identity-service-api/src/association/email/validate_email_by_end_user.rs
@@ -5,7 +5,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/identity-service-api/#get_matrixidentityv2validateemailsubmittoken
+    //! [spec]: https://spec.matrix.org/v1.19/identity-service-api/#get_matrixidentityv2validateemailsubmittoken
 
     use ruma_common::{
         OwnedClientSecret, OwnedSessionId,

--- a/crates/ruma-identity-service-api/src/association/msisdn/create_msisdn_validation_session.rs
+++ b/crates/ruma-identity-service-api/src/association/msisdn/create_msisdn_validation_session.rs
@@ -5,7 +5,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/identity-service-api/#post_matrixidentityv2validatemsisdnrequesttoken
+    //! [spec]: https://spec.matrix.org/v1.19/identity-service-api/#post_matrixidentityv2validatemsisdnrequesttoken
 
     use js_int::UInt;
     use ruma_common::{

--- a/crates/ruma-identity-service-api/src/association/msisdn/validate_msisdn.rs
+++ b/crates/ruma-identity-service-api/src/association/msisdn/validate_msisdn.rs
@@ -5,7 +5,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/identity-service-api/#post_matrixidentityv2validatemsisdnsubmittoken
+    //! [spec]: https://spec.matrix.org/v1.19/identity-service-api/#post_matrixidentityv2validatemsisdnsubmittoken
 
     use ruma_common::{
         OwnedClientSecret, OwnedSessionId,

--- a/crates/ruma-identity-service-api/src/association/msisdn/validate_msisdn_by_phone_number.rs
+++ b/crates/ruma-identity-service-api/src/association/msisdn/validate_msisdn_by_phone_number.rs
@@ -5,7 +5,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/identity-service-api/#get_matrixidentityv2validatemsisdnsubmittoken
+    //! [spec]: https://spec.matrix.org/v1.19/identity-service-api/#get_matrixidentityv2validatemsisdnsubmittoken
 
     use ruma_common::{
         OwnedClientSecret, OwnedSessionId,

--- a/crates/ruma-identity-service-api/src/association/unbind_3pid.rs
+++ b/crates/ruma-identity-service-api/src/association/unbind_3pid.rs
@@ -5,7 +5,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/identity-service-api/#post_matrixidentityv23pidunbind
+    //! [spec]: https://spec.matrix.org/v1.19/identity-service-api/#post_matrixidentityv23pidunbind
 
     use ruma_common::{
         OwnedClientSecret, OwnedSessionId, OwnedUserId,

--- a/crates/ruma-identity-service-api/src/authentication/get_account_information.rs
+++ b/crates/ruma-identity-service-api/src/authentication/get_account_information.rs
@@ -5,7 +5,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/identity-service-api/#get_matrixidentityv2account
+    //! [spec]: https://spec.matrix.org/v1.19/identity-service-api/#get_matrixidentityv2account
 
     use ruma_common::{
         OwnedUserId,

--- a/crates/ruma-identity-service-api/src/authentication/logout.rs
+++ b/crates/ruma-identity-service-api/src/authentication/logout.rs
@@ -6,7 +6,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/identity-service-api/#post_matrixidentityv2accountlogout
+    //! [spec]: https://spec.matrix.org/v1.19/identity-service-api/#post_matrixidentityv2accountlogout
 
     use ruma_common::{
         api::{auth_scheme::AccessToken, request, response},

--- a/crates/ruma-identity-service-api/src/authentication/register.rs
+++ b/crates/ruma-identity-service-api/src/authentication/register.rs
@@ -5,7 +5,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/identity-service-api/#post_matrixidentityv2accountregister
+    //! [spec]: https://spec.matrix.org/v1.19/identity-service-api/#post_matrixidentityv2accountregister
 
     use std::time::Duration;
 

--- a/crates/ruma-identity-service-api/src/discovery/get_server_status.rs
+++ b/crates/ruma-identity-service-api/src/discovery/get_server_status.rs
@@ -5,7 +5,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/identity-service-api/#get_matrixidentityv2
+    //! [spec]: https://spec.matrix.org/v1.19/identity-service-api/#get_matrixidentityv2
 
     use ruma_common::{
         api::{auth_scheme::NoAccessToken, request, response},

--- a/crates/ruma-identity-service-api/src/discovery/get_supported_versions.rs
+++ b/crates/ruma-identity-service-api/src/discovery/get_supported_versions.rs
@@ -8,7 +8,7 @@
 //!
 //! Note: This endpoint does not contain an unstable variant for 1.0.
 //!
-//! [spec]: https://spec.matrix.org/v1.18/identity-service-api/#get_matrixidentityversions
+//! [spec]: https://spec.matrix.org/v1.19/identity-service-api/#get_matrixidentityversions
 
 use std::collections::BTreeMap;
 

--- a/crates/ruma-identity-service-api/src/invitation/sign_invitation_ed25519.rs
+++ b/crates/ruma-identity-service-api/src/invitation/sign_invitation_ed25519.rs
@@ -5,7 +5,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/identity-service-api/#post_matrixidentityv2sign-ed25519
+    //! [spec]: https://spec.matrix.org/v1.19/identity-service-api/#post_matrixidentityv2sign-ed25519
 
     use ruma_common::{
         OwnedUserId, ServerSignatures,

--- a/crates/ruma-identity-service-api/src/invitation/store_invitation.rs
+++ b/crates/ruma-identity-service-api/src/invitation/store_invitation.rs
@@ -5,7 +5,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/identity-service-api/#post_matrixidentityv2store-invite
+    //! [spec]: https://spec.matrix.org/v1.19/identity-service-api/#post_matrixidentityv2store-invite
 
     use ruma_common::{
         OwnedMxcUri, OwnedRoomAliasId, OwnedRoomId, OwnedUserId,

--- a/crates/ruma-identity-service-api/src/keys/check_public_key_validity.rs
+++ b/crates/ruma-identity-service-api/src/keys/check_public_key_validity.rs
@@ -6,7 +6,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/identity-service-api/#get_matrixidentityv2pubkeyisvalid
+    //! [spec]: https://spec.matrix.org/v1.19/identity-service-api/#get_matrixidentityv2pubkeyisvalid
 
     use ruma_common::{
         api::{auth_scheme::NoAccessToken, request, response},

--- a/crates/ruma-identity-service-api/src/keys/get_public_key.rs
+++ b/crates/ruma-identity-service-api/src/keys/get_public_key.rs
@@ -5,7 +5,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/identity-service-api/#get_matrixidentityv2pubkeykeyid
+    //! [spec]: https://spec.matrix.org/v1.19/identity-service-api/#get_matrixidentityv2pubkeykeyid
 
     use ruma_common::{
         OwnedServerSigningKeyId,

--- a/crates/ruma-identity-service-api/src/keys/validate_ephemeral_key.rs
+++ b/crates/ruma-identity-service-api/src/keys/validate_ephemeral_key.rs
@@ -5,7 +5,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/identity-service-api/#get_matrixidentityv2pubkeyephemeralisvalid
+    //! [spec]: https://spec.matrix.org/v1.19/identity-service-api/#get_matrixidentityv2pubkeyephemeralisvalid
 
     use ruma_common::{
         api::{auth_scheme::NoAccessToken, request, response},

--- a/crates/ruma-identity-service-api/src/lib.rs
+++ b/crates/ruma-identity-service-api/src/lib.rs
@@ -3,7 +3,7 @@
 //! (De)serializable types for the [Matrix Identity Service API][identity-api].
 //! These types can be shared by client and identity service code.
 //!
-//! [identity-api]: https://spec.matrix.org/v1.18/identity-service-api/
+//! [identity-api]: https://spec.matrix.org/v1.19/identity-service-api/
 
 #![warn(missing_docs)]
 

--- a/crates/ruma-identity-service-api/src/lookup/get_hash_parameters.rs
+++ b/crates/ruma-identity-service-api/src/lookup/get_hash_parameters.rs
@@ -6,7 +6,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/identity-service-api/#get_matrixidentityv2hash_details
+    //! [spec]: https://spec.matrix.org/v1.19/identity-service-api/#get_matrixidentityv2hash_details
 
     use ruma_common::{
         api::{auth_scheme::AccessToken, request, response},

--- a/crates/ruma-identity-service-api/src/lookup/lookup_3pid.rs
+++ b/crates/ruma-identity-service-api/src/lookup/lookup_3pid.rs
@@ -5,7 +5,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/identity-service-api/#post_matrixidentityv2lookup
+    //! [spec]: https://spec.matrix.org/v1.19/identity-service-api/#post_matrixidentityv2lookup
 
     use std::collections::BTreeMap;
 

--- a/crates/ruma-identity-service-api/src/tos/accept_terms_of_service.rs
+++ b/crates/ruma-identity-service-api/src/tos/accept_terms_of_service.rs
@@ -5,7 +5,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/identity-service-api/#post_matrixidentityv2terms
+    //! [spec]: https://spec.matrix.org/v1.19/identity-service-api/#post_matrixidentityv2terms
 
     use ruma_common::{
         api::{auth_scheme::AccessToken, request, response},

--- a/crates/ruma-identity-service-api/src/tos/get_terms_of_service.rs
+++ b/crates/ruma-identity-service-api/src/tos/get_terms_of_service.rs
@@ -5,7 +5,7 @@
 pub mod v2 {
     //! `/v2/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/identity-service-api/#get_matrixidentityv2terms
+    //! [spec]: https://spec.matrix.org/v1.19/identity-service-api/#get_matrixidentityv2terms
 
     use std::collections::BTreeMap;
 

--- a/crates/ruma-push-gateway-api/src/lib.rs
+++ b/crates/ruma-push-gateway-api/src/lib.rs
@@ -3,7 +3,7 @@
 //! (De)serializable types for the [Matrix Push Gateway API][push-api].
 //! These types can be shared by push gateway and server code.
 //!
-//! [push-api]: https://spec.matrix.org/v1.18/push-gateway-api/
+//! [push-api]: https://spec.matrix.org/v1.19/push-gateway-api/
 
 #![warn(missing_docs)]
 

--- a/crates/ruma-push-gateway-api/src/send_event_notification.rs
+++ b/crates/ruma-push-gateway-api/src/send_event_notification.rs
@@ -5,7 +5,7 @@
 pub mod v1 {
     //! `/v1/` ([spec])
     //!
-    //! [spec]: https://spec.matrix.org/v1.18/push-gateway-api/#post_matrixpushv1notify
+    //! [spec]: https://spec.matrix.org/v1.19/push-gateway-api/#post_matrixpushv1notify
 
     use js_int::{UInt, uint};
     use ruma_common::{

--- a/crates/ruma-signatures/src/hash.rs
+++ b/crates/ruma-signatures/src/hash.rs
@@ -11,7 +11,7 @@ use crate::JsonError;
 
 /// The [maximum size allowed] for a PDU.
 ///
-/// [maximum size allowed]: https://spec.matrix.org/v1.18/client-server-api/#size-limits
+/// [maximum size allowed]: https://spec.matrix.org/v1.19/client-server-api/#size-limits
 const MAX_PDU_BYTES: usize = 65_535;
 
 /// The fields to remove from a JSON object when creating a content hash of an event.
@@ -81,7 +81,7 @@ static REFERENCE_HASH_FIELDS_TO_REMOVE: &[&str] = &["signatures", "unsigned"];
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 ///
-/// [content hash]: https://spec.matrix.org/v1.18/server-server-api/#calculating-the-content-hash-for-an-event
+/// [content hash]: https://spec.matrix.org/v1.19/server-server-api/#calculating-the-content-hash-for-an-event
 pub fn add_content_hash_to_event(object: &mut CanonicalJsonObject) -> Result<(), JsonError> {
     let hash = content_hash(object)?;
 
@@ -104,7 +104,7 @@ pub fn add_content_hash_to_event(object: &mut CanonicalJsonObject) -> Result<(),
 ///
 /// Returns an error if the event is too large.
 ///
-/// [content hash]: https://spec.matrix.org/v1.18/server-server-api/#calculating-the-content-hash-for-an-event
+/// [content hash]: https://spec.matrix.org/v1.19/server-server-api/#calculating-the-content-hash-for-an-event
 pub fn content_hash(object: &CanonicalJsonObject) -> Result<Base64<Standard, [u8; 32]>, JsonError> {
     let json = RedactingSerializer::new()
         .custom_redacted_root_fields(CONTENT_HASH_FIELDS_TO_REMOVE)
@@ -146,7 +146,7 @@ pub fn content_hash(object: &CanonicalJsonObject) -> Result<Base64<Standard, [u8
 ///
 /// Returns an error if the event is too large or redaction fails.
 ///
-/// [reference hash]: https://spec.matrix.org/v1.18/server-server-api#calculating-the-reference-hash-for-an-event
+/// [reference hash]: https://spec.matrix.org/v1.19/server-server-api#calculating-the-reference-hash-for-an-event
 pub fn reference_hash(
     object: &CanonicalJsonObject,
     rules: &RoomVersionRules,

--- a/crates/ruma-signatures/src/lib.rs
+++ b/crates/ruma-signatures/src/lib.rs
@@ -56,8 +56,8 @@
 //! signatures and hashes on an event, use the [`verify_event()`] function. See the documentation
 //! for these respective functions for more details and full examples of use.
 //!
-//! [canonical JSON]: https://spec.matrix.org/v1.18/appendices/#canonical-json
-//! [room version 6]: https://spec.matrix.org/v1.18/rooms/v6/
+//! [canonical JSON]: https://spec.matrix.org/v1.19/appendices/#canonical-json
+//! [room version 6]: https://spec.matrix.org/v1.19/rooms/v6/
 
 #![warn(missing_docs)]
 

--- a/crates/ruma-signatures/src/sign.rs
+++ b/crates/ruma-signatures/src/sign.rs
@@ -219,7 +219,7 @@ where
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 ///
-/// [signature]: https://spec.matrix.org/v1.18/server-server-api/#signing-events
+/// [signature]: https://spec.matrix.org/v1.19/server-server-api/#signing-events
 pub fn sign_event<K>(
     entity_id: &str,
     key_pair: &K,

--- a/crates/ruma-signatures/src/verify.rs
+++ b/crates/ruma-signatures/src/verify.rs
@@ -299,8 +299,8 @@ pub fn verify_canonical_json_bytes(
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 ///
-/// [signing]: https://spec.matrix.org/v1.18/appendices/#signing-details
-/// [canonical JSON]: https://spec.matrix.org/v1.18/appendices/#canonical-json
+/// [signing]: https://spec.matrix.org/v1.19/appendices/#signing-details
+/// [canonical JSON]: https://spec.matrix.org/v1.19/appendices/#canonical-json
 pub fn to_canonical_json_string_for_signing(
     object: &CanonicalJsonObject,
 ) -> Result<String, JsonError> {
@@ -325,7 +325,7 @@ pub fn to_canonical_json_string_for_signing(
 ///
 /// Returns an error if verification fails.
 ///
-/// [checking signatures]: https://spec.matrix.org/v1.18/appendices/#checking-for-a-signature
+/// [checking signatures]: https://spec.matrix.org/v1.19/appendices/#checking-for-a-signature
 fn verify_canonical_json_for_entity(
     entity_id: &str,
     fetch_public_keys: &impl FetchEntityPublicSigningKey,
@@ -415,7 +415,7 @@ where
 /// - For room versions that support restricted join rules, if it's a join event with a
 ///   `join_authorised_via_users_server`, add the server of that user.
 ///
-/// [validating signatures on received events]: https://spec.matrix.org/v1.18/server-server-api/#validating-hashes-and-signatures-on-received-events
+/// [validating signatures on received events]: https://spec.matrix.org/v1.19/server-server-api/#validating-hashes-and-signatures-on-received-events
 pub fn required_server_signatures_to_verify_event(
     object: &CanonicalJsonObject,
     rules: &SignaturesRules,

--- a/crates/ruma-state-res/src/event_auth.rs
+++ b/crates/ruma-state-res/src/event_auth.rs
@@ -39,7 +39,7 @@ use crate::{
 /// Returns an `Err(_)` if a field could not be deserialized because `content` does not respect the
 /// expected format for the `event_type`.
 ///
-/// [relevant auth events]: https://spec.matrix.org/v1.18/server-server-api/#auth-events-selection
+/// [relevant auth events]: https://spec.matrix.org/v1.19/server-server-api/#auth-events-selection
 pub fn auth_types_for_event(
     event_type: &TimelineEventType,
     sender: &UserId,
@@ -139,7 +139,7 @@ pub fn auth_types_for_event(
 ///
 /// If the check fails, this returns an `Err(_)` with a description of the check that failed.
 ///
-/// [authorization rules]: https://spec.matrix.org/v1.18/server-server-api/#authorization-rules
+/// [authorization rules]: https://spec.matrix.org/v1.19/server-server-api/#authorisation-rules
 #[instrument(skip_all, fields(event_id = incoming_event.event_id().borrow().as_str()))]
 pub fn check_state_independent_auth_rules<E: Event>(
     rules: &AuthorizationRules,
@@ -262,8 +262,8 @@ pub fn check_state_independent_auth_rules<E: Event>(
 ///
 /// If the check fails, this returns an `Err(_)` with a description of the check that failed.
 ///
-/// [authorization rules]: https://spec.matrix.org/v1.18/server-server-api/#authorization-rules
-/// [checks on receipt of a PDU]: https://spec.matrix.org/v1.18/server-server-api/#checks-performed-on-receipt-of-a-pdu
+/// [authorization rules]: https://spec.matrix.org/v1.19/server-server-api/#authorisation-rules
+/// [checks on receipt of a PDU]: https://spec.matrix.org/v1.19/server-server-api/#checks-performed-on-receipt-of-a-pdu
 #[instrument(skip_all, fields(event_id = incoming_event.event_id().borrow().as_str()))]
 pub fn check_state_dependent_auth_rules<E: Event>(
     rules: &AuthorizationRules,

--- a/crates/ruma-state-res/src/event_format.rs
+++ b/crates/ruma-state-res/src/event_format.rs
@@ -7,17 +7,17 @@ use serde_json::to_string as to_json_string;
 
 /// The [maximum size allowed] for a PDU.
 ///
-/// [maximum size allowed]: https://spec.matrix.org/v1.18/client-server-api/#size-limits
+/// [maximum size allowed]: https://spec.matrix.org/v1.19/client-server-api/#size-limits
 const MAX_PDU_BYTES: usize = 65_535;
 
 /// The [maximum length allowed] for the `prev_events` array of a PDU.
 ///
-/// [maximum length allowed]: https://spec.matrix.org/v1.18/rooms/v1/#event-format
+/// [maximum length allowed]: https://spec.matrix.org/v1.19/rooms/v1/#event-format
 const MAX_PREV_EVENTS_LENGTH: usize = 20;
 
 /// The [maximum length allowed] for the `auth_events` array of a PDU.
 ///
-/// [maximum length allowed]: https://spec.matrix.org/v1.18/rooms/v1/#event-format
+/// [maximum length allowed]: https://spec.matrix.org/v1.19/rooms/v1/#event-format
 const MAX_AUTH_EVENTS_LENGTH: usize = 10;
 
 /// Check that the given canonicalized PDU respects the event format of the room version and the
@@ -39,8 +39,8 @@ const MAX_AUTH_EVENTS_LENGTH: usize = 10;
 ///
 /// Returns an `Err(_)` if the JSON is malformed or if the PDU doesn't pass the checks.
 ///
-/// [size limits]: https://spec.matrix.org/v1.18/client-server-api/#size-limits
-/// [checks performed on receipt of a PDU]: https://spec.matrix.org/v1.18/server-server-api/#checks-performed-on-receipt-of-a-pdu
+/// [size limits]: https://spec.matrix.org/v1.19/client-server-api/#size-limits
+/// [checks performed on receipt of a PDU]: https://spec.matrix.org/v1.19/server-server-api/#checks-performed-on-receipt-of-a-pdu
 pub fn check_pdu_format(pdu: &CanonicalJsonObject, rules: &EventFormatRules) -> Result<(), String> {
     // Check the PDU size, it must occur on the full PDU with signatures.
     let json =

--- a/crates/ruma-state-res/src/lib.rs
+++ b/crates/ruma-state-res/src/lib.rs
@@ -57,11 +57,11 @@
 //! The types from ruma-events are still appropriate to be used to create a new event, or to
 //! validate an event received from a client.
 //!
-//! [canonical JSON]: https://spec.matrix.org/v1.18/appendices/#canonical-json
-//! [room version 6]: https://spec.matrix.org/v1.18/rooms/v6/
-//! [state-res-v1]: https://spec.matrix.org/v1.18/rooms/v1/#state-resolution
+//! [canonical JSON]: https://spec.matrix.org/v1.19/appendices/#canonical-json
+//! [room version 6]: https://spec.matrix.org/v1.19/rooms/v6/
+//! [state-res-v1]: https://spec.matrix.org/v1.19/rooms/v1/#state-resolution
 //! [ruma-signatures]: https://crates.io/crates/ruma-signatures
-//! [necessary checks on receipt of a PDU]: https://spec.matrix.org/v1.18/server-server-api/#checks-performed-on-receipt-of-a-pdu
+//! [necessary checks on receipt of a PDU]: https://spec.matrix.org/v1.19/server-server-api/#checks-performed-on-receipt-of-a-pdu
 //! [ruma-events]: https://crates.io/crates/ruma-events
 
 #![warn(missing_docs)]

--- a/crates/ruma-state-res/src/state_res.rs
+++ b/crates/ruma-state-res/src/state_res.rs
@@ -34,7 +34,7 @@ use crate::{
 /// This is the representation of what the Matrix specification calls a "room state" or a "state
 /// map" during [state resolution].
 ///
-/// [state resolution]: https://spec.matrix.org/v1.18/rooms/v2/#state-resolution
+/// [state resolution]: https://spec.matrix.org/v1.19/rooms/v2/#state-resolution
 pub type StateMap<T> = HashMap<(StateEventType, String), T>;
 
 /// Apply the [state resolution] algorithm introduced in room version 2 to resolve the state of a
@@ -66,7 +66,7 @@ pub type StateMap<T> = HashMap<(StateEventType, String), T>;
 ///
 /// The resolved room state.
 ///
-/// [state resolution]: https://spec.matrix.org/v1.18/rooms/v2/#state-resolution
+/// [state resolution]: https://spec.matrix.org/v1.19/rooms/v2/#state-resolution
 #[instrument(skip_all)]
 pub fn resolve<'a, E, MapsIter>(
     auth_rules: &AuthorizationRules,

--- a/crates/ruma/src/lib.rs
+++ b/crates/ruma/src/lib.rs
@@ -166,7 +166,7 @@ pub use ruma_state_res as state_res;
 /// (De)serializable types for various [Matrix APIs][apis] requests and responses and abstractions
 /// for them.
 ///
-/// [apis]: https://spec.matrix.org/v1.18/#matrix-apis
+/// [apis]: https://spec.matrix.org/v1.19/#matrix-apis
 #[cfg(feature = "api")]
 pub mod api {
     #[cfg(any(feature = "appservice-api-c", feature = "appservice-api-s"))]

--- a/xtask/src/spec_links.rs
+++ b/xtask/src/spec_links.rs
@@ -81,7 +81,7 @@ impl SpecLink {
     const URL_PREFIX: &str = "https://spec.matrix.org/";
 
     /// The version that spec links should use.
-    const PREFERRED_VERSION: &str = "v1.18";
+    const PREFERRED_VERSION: &str = "v1.19";
 
     /// URLs that are allowed to use a different spec version than
     /// [`PREFERRED_VERSION`](Self::PREFERRED_VERSION).


### PR DESCRIPTION
By changing the preferred version to `v1.19` and running `xtask spec-links update`.

This required a few manual changes:

- A spec PR renamed `authorization` to `authorisation`, so a few URL fragments needed to be updated.
- The "Security considerations" for MXC URIs got a unique URL fragment, and the validation rule now appears on the main section of MXC URIs so we redirect there directly. 

This will also allow to add links to newly stabilized features in following PRs.