### PR TITLE
Stabilize support for MSC2666

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -35,6 +35,7 @@ Improvements:
 - The `Profiles` sliding sync extension response data is wrapped in a `users` field instead of
   being decoded directly. The profile updates now use a `UserProfileUpdate` enum to signal if the
   profile changed or should be dropped.
+- Stabilize support for [MSC2666](https://github.com/matrix-org/matrix-spec-proposals/pull/2666) (Get rooms in common with another user).
 
 ## 0.24.0
 

--- a/crates/ruma-client-api/Cargo.toml
+++ b/crates/ruma-client-api/Cargo.toml
@@ -43,7 +43,6 @@ compat-upload-signatures = []
 # to be ignored if they have an invalid format and their deserialization fails.
 unstable-compat-lax-syncv5-deser = ["unstable-msc4186"]
 
-unstable-msc2666 = ["ruma-common/unstable-msc2666"]
 unstable-msc2448 = []
 unstable-msc2654 = []
 unstable-msc3488 = []

--- a/crates/ruma-client-api/src/membership.rs
+++ b/crates/ruma-client-api/src/membership.rs
@@ -10,7 +10,6 @@ pub mod joined_members;
 pub mod joined_rooms;
 pub mod kick_user;
 pub mod leave_room;
-#[cfg(feature = "unstable-msc2666")]
 pub mod mutual_rooms;
 pub mod unban_user;
 

--- a/crates/ruma-client-api/src/membership/mutual_rooms.rs
+++ b/crates/ruma-client-api/src/membership/mutual_rooms.rs
@@ -71,3 +71,78 @@ pub mod unstable {
         }
     }
 }
+
+pub mod v1 {
+    //! `/v1/` ([spec])
+    //!
+    //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv1mutual_rooms
+
+    use js_int::UInt;
+    use ruma_common::{
+        OwnedRoomId, OwnedUserId,
+        api::{auth_scheme::AccessToken, request, response},
+        metadata,
+    };
+
+    metadata! {
+        method: GET,
+        rate_limited: true,
+        authentication: AccessToken,
+        history: {
+            1.19 | stable("uk.half-shot.msc2666.query_mutual_rooms.stable") => "/_matrix/client/v1/mutual_rooms",
+        }
+    }
+
+    /// Request type for the `mutual_rooms` endpoint.
+    #[request]
+    pub struct Request {
+        /// The user to search mutual rooms for.
+        #[ruma_api(query)]
+        pub user_id: OwnedUserId,
+
+        /// The `next_batch` returned from a previous response, to get the next batch of
+        /// rooms.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        #[ruma_api(query)]
+        pub from: Option<String>,
+    }
+
+    /// Response type for the `mutual_rooms` endpoint.
+    #[response]
+    pub struct Response {
+        /// The total number of rooms the user is in together with the authenticated user.
+        /// This is unaffected by batching.
+        pub count: UInt,
+
+        /// A list of rooms the user is in together with the authenticated user.
+        pub joined: Vec<OwnedRoomId>,
+
+        /// An opaque string, returned when the server paginates this response.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub next_batch: Option<String>,
+    }
+
+    impl Request {
+        /// Creates a new `Request` with the given user id.
+        pub fn new(user_id: OwnedUserId) -> Self {
+            Self { user_id, from: None }
+        }
+
+        /// Creates a new `Request` with the given user id, together with a batch token.
+        pub fn with_token(user_id: OwnedUserId, token: String) -> Self {
+            Self { user_id, from: Some(token) }
+        }
+    }
+
+    impl Response {
+        /// Creates a `Response` with the given room ids.
+        pub fn new(count: UInt, joined: Vec<OwnedRoomId>) -> Self {
+            Self { count, joined, next_batch: None }
+        }
+
+        /// Creates a `Response` with the given room ids, together with a batch token.
+        pub fn with_token(count: UInt, joined: Vec<OwnedRoomId>, token: String) -> Self {
+            Self { count, joined, next_batch: Some(token) }
+        }
+    }
+}

--- a/crates/ruma-client-api/src/membership/mutual_rooms.rs
+++ b/crates/ruma-client-api/src/membership/mutual_rooms.rs
@@ -1,4 +1,4 @@
-//! `GET /_matrix/client/*/user/mutual_rooms/{user_id}`
+//! `GET /_matrix/client/*/mutual_rooms/{user_id}`
 //!
 //! Get mutual rooms with another user.
 
@@ -111,6 +111,7 @@ pub mod v1 {
     #[response]
     pub struct Response {
         /// The total number of rooms the user is in together with the authenticated user.
+        ///
         /// This is unaffected by batching.
         pub count: UInt,
 
@@ -129,19 +130,19 @@ pub mod v1 {
         }
 
         /// Creates a new `Request` with the given user id, together with a batch token.
-        pub fn with_token(user_id: OwnedUserId, token: String) -> Self {
+        pub fn with_batch_token(user_id: OwnedUserId, token: String) -> Self {
             Self { user_id, from: Some(token) }
         }
     }
 
     impl Response {
-        /// Creates a `Response` with the given room ids.
+        /// Creates a `Response` with the given count and room IDs.
         pub fn new(count: UInt, joined: Vec<OwnedRoomId>) -> Self {
             Self { count, joined, next_batch: None }
         }
 
-        /// Creates a `Response` with the given room ids, together with a batch token.
-        pub fn with_token(count: UInt, joined: Vec<OwnedRoomId>, token: String) -> Self {
+        /// Creates a `Response` with the given count and room IDs, together with a batch token.
+        pub fn with_batch_token(count: UInt, joined: Vec<OwnedRoomId>, token: String) -> Self {
             Self { count, joined, next_batch: Some(token) }
         }
     }

--- a/crates/ruma-client-api/src/membership/mutual_rooms.rs
+++ b/crates/ruma-client-api/src/membership/mutual_rooms.rs
@@ -1,4 +1,4 @@
-//! `GET /_matrix/client/*/mutual_rooms/{user_id}`
+//! `GET /_matrix/client/*/mutual_rooms`
 //!
 //! Get mutual rooms with another user.
 

--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -30,7 +30,6 @@ api = ["dep:date_header", "dep:http", "dep:konst"]
 js = ["getrandom?/wasm_js", "uuid?/js"]
 rand = ["dep:rand", "dep:getrandom", "dep:uuid"]
 
-unstable-msc2666 = []
 unstable-msc2870 = []
 unstable-msc3417 = []
 unstable-msc3768 = []

--- a/crates/ruma-common/src/api/metadata.rs
+++ b/crates/ruma-common/src/api/metadata.rs
@@ -715,9 +715,16 @@ pub enum FeatureFlag {
     /// Get rooms in common with another user.
     ///
     /// [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/2666
-    #[cfg(feature = "unstable-msc2666")]
     #[ruma_enum(rename = "uk.half-shot.msc2666.query_mutual_rooms")]
     Msc2666,
+
+    /// `uk.half-shot.msc2666.query_mutual_rooms.stable` ([MSC])
+    ///
+    /// Get rooms in common with another user. (stable version)
+    ///
+    /// [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/2666
+    #[ruma_enum(rename = "uk.half-shot.msc2666.query_mutual_rooms.stable")]
+    Msc2666Stable,
 
     /// `org.matrix.msc3030` ([MSC])
     ///

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -138,7 +138,6 @@ unstable-extensible-events = [
 unstable-msc1767 = ["ruma-events?/unstable-msc1767"]
 unstable-msc2448 = ["ruma-client-api?/unstable-msc2448", "ruma-events?/unstable-msc2448"]
 unstable-msc2654 = ["ruma-client-api?/unstable-msc2654"]
-unstable-msc2666 = ["ruma-common/unstable-msc2666", "ruma-client-api?/unstable-msc2666"]
 unstable-msc2747 = ["ruma-events?/unstable-msc2747"]
 unstable-msc2867 = ["ruma-events?/unstable-msc2867"]
 unstable-msc2870 = ["ruma-common/unstable-msc2870"]


### PR DESCRIPTION
This PR adds stable support for the mutual rooms endpoint (MSC2666). Closes #2483.

Note: Only the first commit of this PR contains functional changes. The remaining commits are housekeeping to make CI accept links to spec version 1.19.
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
