### PR TITLE
api: Restructure OutgoingRequest

### DIFF
--- a/crates/ruma-appservice-api/src/event/push_events.rs
+++ b/crates/ruma-appservice-api/src/event/push_events.rs
@@ -341,7 +341,7 @@ pub mod v1 {
         #[cfg(feature = "client")]
         #[test]
         fn request_contains_events_field() {
-            use ruma_common::api::{OutgoingRequest, auth_scheme::SendAccessToken};
+            use ruma_common::api::{OutgoingRequestExt as _, auth_scheme::SendAccessToken};
 
             let dummy_event_json = json!({
                 "type": "m.room.message",

--- a/crates/ruma-client-api/src/delayed_events/delayed_message_event.rs
+++ b/crates/ruma-client-api/src/delayed_events/delayed_message_event.rs
@@ -127,7 +127,8 @@ pub mod unstable {
 
         use ruma_common::{
             api::{
-                MatrixVersion, OutgoingRequest, SupportedVersions, auth_scheme::SendAccessToken,
+                MatrixVersion, OutgoingRequestExt as _, SupportedVersions,
+                auth_scheme::SendAccessToken,
             },
             owned_room_id,
         };

--- a/crates/ruma-client-api/src/delayed_events/delayed_state_event.rs
+++ b/crates/ruma-client-api/src/delayed_events/delayed_state_event.rs
@@ -123,7 +123,8 @@ pub mod unstable {
 
         use ruma_common::{
             api::{
-                MatrixVersion, OutgoingRequest, SupportedVersions, auth_scheme::SendAccessToken,
+                MatrixVersion, OutgoingRequestExt as _, SupportedVersions,
+                auth_scheme::SendAccessToken,
             },
             owned_room_id,
             serde::Raw,

--- a/crates/ruma-client-api/src/delayed_events/send_delayed_event.rs
+++ b/crates/ruma-client-api/src/delayed_events/send_delayed_event.rs
@@ -122,7 +122,8 @@ pub mod unstable {
 
         use ruma_common::{
             api::{
-                MatrixVersion, OutgoingRequest, SupportedVersions, auth_scheme::SendAccessToken,
+                MatrixVersion, OutgoingRequestExt as _, SupportedVersions,
+                auth_scheme::SendAccessToken,
             },
             owned_room_id,
         };

--- a/crates/ruma-client-api/src/delayed_events/update_delayed_event.rs
+++ b/crates/ruma-client-api/src/delayed_events/update_delayed_event.rs
@@ -83,7 +83,7 @@ pub mod unstable_v2 {
         use std::borrow::Cow;
 
         use ruma_common::api::{
-            MatrixVersion, OutgoingRequest, SupportedVersions, auth_scheme::SendAccessToken,
+            MatrixVersion, OutgoingRequestExt as _, SupportedVersions, auth_scheme::SendAccessToken,
         };
         use serde_json::{Value as JsonValue, json};
 

--- a/crates/ruma-client-api/src/delayed_events/update_delayed_event/unstable_v1.rs
+++ b/crates/ruma-client-api/src/delayed_events/update_delayed_event/unstable_v1.rs
@@ -55,7 +55,7 @@ mod tests {
     use std::borrow::Cow;
 
     use ruma_common::api::{
-        MatrixVersion, OutgoingRequest, SupportedVersions, auth_scheme::SendAccessToken,
+        MatrixVersion, OutgoingRequestExt as _, SupportedVersions, auth_scheme::SendAccessToken,
     };
     use serde_json::{Value as JsonValue, json};
 

--- a/crates/ruma-client-api/src/directory/get_public_rooms.rs
+++ b/crates/ruma-client-api/src/directory/get_public_rooms.rs
@@ -91,7 +91,7 @@ pub mod v3 {
 
             use ruma_common::{
                 api::{
-                    MatrixVersion, OutgoingRequest as _, SupportedVersions,
+                    MatrixVersion, OutgoingRequestExt as _, SupportedVersions,
                     auth_scheme::SendAccessToken,
                 },
                 owned_server_name,

--- a/crates/ruma-client-api/src/filter/create_filter.rs
+++ b/crates/ruma-client-api/src/filter/create_filter.rs
@@ -90,7 +90,8 @@ pub mod v3 {
 
             use ruma_common::{
                 api::{
-                    MatrixVersion, OutgoingRequest, SupportedVersions, auth_scheme::SendAccessToken,
+                    MatrixVersion, OutgoingRequestExt as _, SupportedVersions,
+                    auth_scheme::SendAccessToken,
                 },
                 owned_user_id,
             };

--- a/crates/ruma-client-api/src/knock/knock_room.rs
+++ b/crates/ruma-client-api/src/knock/knock_room.rs
@@ -61,9 +61,10 @@ pub mod v3 {
     }
 
     /// Data in the request's body.
-    #[cfg_attr(feature = "client", derive(serde::Serialize))]
+    #[doc(hidden)]
+    #[cfg_attr(feature = "client", derive(serde::Serialize, ruma_common::api::OutgoingBodyJson))]
     #[cfg_attr(feature = "server", derive(serde::Deserialize))]
-    struct RequestBody {
+    pub struct RequestBody {
         /// The reason for joining a room.
         #[serde(skip_serializing_if = "Option::is_none")]
         reason: Option<String>,
@@ -71,16 +72,16 @@ pub mod v3 {
 
     #[cfg(feature = "client")]
     impl ruma_common::api::OutgoingRequest for Request {
+        type Body = RequestBody;
         type EndpointError = Error;
         type IncomingResponse = Response;
 
-        fn try_into_http_request<T: Default + bytes::BufMut + AsRef<[u8]>>(
+        fn try_into_http_request_inner(
             self,
             base_url: &str,
-            access_token: ruma_common::api::auth_scheme::SendAccessToken<'_>,
             considering: std::borrow::Cow<'_, ruma_common::api::SupportedVersions>,
-        ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
-            use ruma_common::api::{Metadata, auth_scheme::AuthScheme};
+        ) -> Result<http::Request<Self::Body>, ruma_common::api::error::IntoHttpError> {
+            use ruma_common::api::Metadata;
 
             // Only send `server_name` if the `via` parameter is not supported by the server.
             // `via` was introduced in Matrix 1.12.
@@ -98,7 +99,7 @@ pub mod v3 {
             let query_string =
                 serde_html_form::to_string(RequestQuery { server_name, via: self.via })?;
 
-            let mut http_request = http::Request::builder()
+            let http_request = http::Request::builder()
                 .method(Self::METHOD)
                 .uri(Self::make_endpoint_url(
                     considering,
@@ -107,10 +108,7 @@ pub mod v3 {
                     &query_string,
                 )?)
                 .header(http::header::CONTENT_TYPE, ruma_common::http_headers::APPLICATION_JSON)
-                .body(ruma_common::serde::json_to_buf(&RequestBody { reason: self.reason })?)?;
-
-            Self::Authentication::add_authentication(&mut http_request, access_token)
-                .map_err(ruma_common::api::error::IntoHttpError::authentication)?;
+                .body(RequestBody { reason: self.reason })?;
 
             Ok(http_request)
         }
@@ -180,7 +178,8 @@ pub mod v3 {
 
         use ruma_common::{
             api::{
-                MatrixVersion, OutgoingRequest, SupportedVersions, auth_scheme::SendAccessToken,
+                MatrixVersion, OutgoingRequestExt as _, SupportedVersions,
+                auth_scheme::SendAccessToken,
             },
             owned_room_id, owned_server_name,
         };

--- a/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
+++ b/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
@@ -67,9 +67,10 @@ pub mod v3 {
     }
 
     /// Data in the request's body.
-    #[cfg_attr(feature = "client", derive(serde::Serialize))]
+    #[doc(hidden)]
+    #[cfg_attr(feature = "client", derive(serde::Serialize, ruma_common::api::OutgoingBodyJson))]
     #[cfg_attr(feature = "server", derive(serde::Deserialize))]
-    struct RequestBody {
+    pub struct RequestBody {
         /// The signature of a `m.third_party_invite` token to prove that this user owns a third
         /// party identity which has been invited to the room.
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -82,16 +83,16 @@ pub mod v3 {
 
     #[cfg(feature = "client")]
     impl ruma_common::api::OutgoingRequest for Request {
+        type Body = RequestBody;
         type EndpointError = Error;
         type IncomingResponse = Response;
 
-        fn try_into_http_request<T: Default + bytes::BufMut + AsRef<[u8]>>(
+        fn try_into_http_request_inner(
             self,
             base_url: &str,
-            access_token: ruma_common::api::auth_scheme::SendAccessToken<'_>,
             considering: std::borrow::Cow<'_, ruma_common::api::SupportedVersions>,
-        ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
-            use ruma_common::api::{Metadata, auth_scheme::AuthScheme};
+        ) -> Result<http::Request<RequestBody>, ruma_common::api::error::IntoHttpError> {
+            use ruma_common::api::Metadata;
 
             // Only send `server_name` if the `via` parameter is not supported by the server.
             // `via` was introduced in Matrix 1.12.
@@ -109,7 +110,7 @@ pub mod v3 {
             let query_string =
                 serde_html_form::to_string(RequestQuery { server_name, via: self.via })?;
 
-            let mut http_request = http::Request::builder()
+            let http_request = http::Request::builder()
                 .method(Self::METHOD)
                 .uri(Self::make_endpoint_url(
                     considering,
@@ -118,13 +119,10 @@ pub mod v3 {
                     &query_string,
                 )?)
                 .header(http::header::CONTENT_TYPE, ruma_common::http_headers::APPLICATION_JSON)
-                .body(ruma_common::serde::json_to_buf(&RequestBody {
+                .body(RequestBody {
                     third_party_signed: self.third_party_signed,
                     reason: self.reason,
-                })?)?;
-
-            Self::Authentication::add_authentication(&mut http_request, access_token)
-                .map_err(ruma_common::api::error::IntoHttpError::authentication)?;
+                })?;
 
             Ok(http_request)
         }
@@ -199,7 +197,8 @@ pub mod v3 {
 
         use ruma_common::{
             api::{
-                MatrixVersion, OutgoingRequest, SupportedVersions, auth_scheme::SendAccessToken,
+                MatrixVersion, OutgoingRequestExt as _, SupportedVersions,
+                auth_scheme::SendAccessToken,
             },
             owned_room_id, owned_server_name,
         };

--- a/crates/ruma-client-api/src/message/get_message_events.rs
+++ b/crates/ruma-client-api/src/message/get_message_events.rs
@@ -178,7 +178,7 @@ pub mod v3 {
         use js_int::uint;
         use ruma_common::{
             api::{
-                Direction, MatrixVersion, OutgoingRequest, SupportedVersions,
+                Direction, MatrixVersion, OutgoingRequestExt as _, SupportedVersions,
                 auth_scheme::SendAccessToken,
             },
             owned_room_id,

--- a/crates/ruma-client-api/src/message/send_message_event.rs
+++ b/crates/ruma-client-api/src/message/send_message_event.rs
@@ -152,7 +152,9 @@ mod tests {
     use std::borrow::Cow;
 
     use ruma_common::{
-        api::{MatrixVersion, OutgoingRequest, SupportedVersions, auth_scheme::SendAccessToken},
+        api::{
+            MatrixVersion, OutgoingRequestExt as _, SupportedVersions, auth_scheme::SendAccessToken,
+        },
         owned_room_id,
         serde::Raw,
     };

--- a/crates/ruma-client-api/src/profile/get_profile_field.rs
+++ b/crates/ruma-client-api/src/profile/get_profile_field.rs
@@ -15,6 +15,8 @@ pub mod v3 {
 
     use std::marker::PhantomData;
 
+    #[cfg(feature = "client")]
+    use ruma_common::api::EmptyBody;
     use ruma_common::{
         OwnedUserId,
         api::{Metadata, auth_scheme::NoAccessToken, error::Error, path_builder::VersionHistory},
@@ -59,16 +61,16 @@ pub mod v3 {
 
     #[cfg(feature = "client")]
     impl ruma_common::api::OutgoingRequest for Request {
+        type Body = EmptyBody;
         type EndpointError = Error;
         type IncomingResponse = Response;
 
-        fn try_into_http_request<T: Default + bytes::BufMut + AsRef<[u8]>>(
+        fn try_into_http_request_inner(
             self,
             base_url: &str,
-            access_token: ruma_common::api::auth_scheme::SendAccessToken<'_>,
             considering: std::borrow::Cow<'_, ruma_common::api::SupportedVersions>,
-        ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
-            use ruma_common::api::{auth_scheme::AuthScheme, path_builder::PathBuilder};
+        ) -> Result<http::Request<EmptyBody>, ruma_common::api::error::IntoHttpError> {
+            use ruma_common::api::path_builder::PathBuilder;
 
             use crate::profile::field_existed_before_extended_profiles;
 
@@ -83,10 +85,8 @@ pub mod v3 {
                 )?
             };
 
-            let mut http_request =
-                http::Request::builder().method(Self::METHOD).uri(url).body(T::default())?;
-
-            Self::Authentication::add_authentication(&mut http_request, access_token)?;
+            let http_request =
+                http::Request::builder().method(Self::METHOD).uri(url).body(EmptyBody)?;
 
             Ok(http_request)
         }
@@ -153,20 +153,17 @@ pub mod v3 {
 
     #[cfg(feature = "client")]
     impl<F: StaticProfileField> ruma_common::api::OutgoingRequest for RequestStatic<F> {
+        type Body = EmptyBody;
         type EndpointError = Error;
         type IncomingResponse = ResponseStatic<F>;
 
-        fn try_into_http_request<T: Default + bytes::BufMut + AsRef<[u8]>>(
+        fn try_into_http_request_inner(
             self,
             base_url: &str,
-            access_token: ruma_common::api::auth_scheme::SendAccessToken<'_>,
             considering: std::borrow::Cow<'_, ruma_common::api::SupportedVersions>,
-        ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
-            Request::new(self.user_id, F::NAME.into()).try_into_http_request(
-                base_url,
-                access_token,
-                considering,
-            )
+        ) -> Result<http::Request<EmptyBody>, ruma_common::api::error::IntoHttpError> {
+            Request::new(self.user_id, F::NAME.into())
+                .try_into_http_request_inner(base_url, considering)
         }
     }
 
@@ -290,7 +287,9 @@ mod tests_client {
     fn serialize_request() {
         use std::borrow::Cow;
 
-        use ruma_common::api::{OutgoingRequest, SupportedVersions, auth_scheme::SendAccessToken};
+        use ruma_common::api::{
+            OutgoingRequestExt as _, SupportedVersions, auth_scheme::SendAccessToken,
+        };
 
         // Profile field that existed in Matrix 1.0.
         let avatar_url_request =

--- a/crates/ruma-client-api/src/profile/set_profile_field.rs
+++ b/crates/ruma-client-api/src/profile/set_profile_field.rs
@@ -63,18 +63,27 @@ pub mod v3 {
         }
     }
 
+    #[doc(hidden)]
+    #[derive(ruma_common::serde::_FakeDeriveSerde)]
+    #[cfg_attr(feature = "client", derive(serde::Serialize, ruma_common::api::OutgoingBodyJson))]
+    #[cfg_attr(feature = "server", derive(serde::Deserialize))]
+    #[serde(transparent)]
+    // attribute will go away when we update IncomingRequest to also use RequestBody
+    #[cfg_attr(not(feature = "client"), expect(dead_code))]
+    pub struct RequestBody(ProfileFieldValue);
+
     #[cfg(feature = "client")]
     impl ruma_common::api::OutgoingRequest for Request {
+        type Body = RequestBody;
         type EndpointError = Error;
         type IncomingResponse = Response;
 
-        fn try_into_http_request<T: Default + bytes::BufMut + AsRef<[u8]>>(
+        fn try_into_http_request_inner(
             self,
             base_url: &str,
-            access_token: ruma_common::api::auth_scheme::SendAccessToken<'_>,
             considering: std::borrow::Cow<'_, ruma_common::api::SupportedVersions>,
-        ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
-            use ruma_common::api::{Metadata, auth_scheme::AuthScheme, path_builder::PathBuilder};
+        ) -> Result<http::Request<RequestBody>, ruma_common::api::error::IntoHttpError> {
+            use ruma_common::api::{Metadata, path_builder::PathBuilder};
 
             use crate::profile::field_existed_before_extended_profiles;
 
@@ -101,14 +110,11 @@ pub mod v3 {
                 )?
             };
 
-            let mut http_request = http::Request::builder()
+            let http_request = http::Request::builder()
                 .method(Self::METHOD)
                 .uri(url)
                 .header(http::header::CONTENT_TYPE, ruma_common::http_headers::APPLICATION_JSON)
-                .body(ruma_common::serde::json_to_buf(&self.value)?)?;
-
-            Self::Authentication::add_authentication(&mut http_request, access_token)
-                .map_err(ruma_common::api::error::IntoHttpError::authentication)?;
+                .body(RequestBody(self.value))?;
 
             Ok(http_request)
         }
@@ -187,7 +193,7 @@ mod tests_client {
 
     use http::header;
     use ruma_common::{
-        api::{OutgoingRequest, SupportedVersions, auth_scheme::SendAccessToken},
+        api::{OutgoingRequestExt as _, SupportedVersions, auth_scheme::SendAccessToken},
         owned_mxc_uri, owned_user_id,
         profile::ProfileFieldValue,
     };

--- a/crates/ruma-client-api/src/push/set_pushrule.rs
+++ b/crates/ruma-client-api/src/push/set_pushrule.rs
@@ -58,46 +58,52 @@ pub mod v3 {
         }
     }
 
+    #[doc(hidden)]
+    // attribute will go away when we update IncomingRequest to also use RequestBody
+    #[cfg_attr(not(feature = "client"), expect(dead_code))]
+    pub struct RequestBody(NewPushRule);
+
+    #[cfg(feature = "client")]
+    impl ruma_common::api::OutgoingBody for RequestBody {
+        type Error = serde_json::Error;
+
+        fn try_into_buf<T: Default + bytes::BufMut + AsRef<[u8]>>(self) -> serde_json::Result<T> {
+            match self.0 {
+                NewPushRule::Override(r) | NewPushRule::Underride(r) => {
+                    let body =
+                        ConditionalRequestBody { actions: r.actions, conditions: r.conditions };
+                    ruma_common::serde::json_to_buf(&body)
+                }
+                NewPushRule::Content(r) => {
+                    let body = PatternedRequestBody { actions: r.actions, pattern: r.pattern };
+                    ruma_common::serde::json_to_buf(&body)
+                }
+                NewPushRule::Room(r) => {
+                    let body = SimpleRequestBody { actions: r.actions };
+                    ruma_common::serde::json_to_buf(&body)
+                }
+                NewPushRule::Sender(r) => {
+                    let body = SimpleRequestBody { actions: r.actions };
+                    ruma_common::serde::json_to_buf(&body)
+                }
+                #[cfg(not(ruma_unstable_exhaustive_types))]
+                _ => unreachable!("variant added to NewPushRule not serializable to request body"),
+            }
+        }
+    }
+
     #[cfg(feature = "client")]
     impl ruma_common::api::OutgoingRequest for Request {
+        type Body = RequestBody;
         type EndpointError = Error;
         type IncomingResponse = Response;
 
-        fn try_into_http_request<T: Default + bytes::BufMut + AsRef<[u8]>>(
+        fn try_into_http_request_inner(
             self,
             base_url: &str,
-            access_token: ruma_common::api::auth_scheme::SendAccessToken<'_>,
             considering: std::borrow::Cow<'_, ruma_common::api::SupportedVersions>,
-        ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
-            use ruma_common::api::{Metadata, auth_scheme::AuthScheme};
-
-            fn serialize_rule<T: Default + bytes::BufMut>(
-                rule: NewPushRule,
-            ) -> serde_json::Result<T> {
-                match rule {
-                    NewPushRule::Override(r) | NewPushRule::Underride(r) => {
-                        let body =
-                            ConditionalRequestBody { actions: r.actions, conditions: r.conditions };
-                        ruma_common::serde::json_to_buf(&body)
-                    }
-                    NewPushRule::Content(r) => {
-                        let body = PatternedRequestBody { actions: r.actions, pattern: r.pattern };
-                        ruma_common::serde::json_to_buf(&body)
-                    }
-                    NewPushRule::Room(r) => {
-                        let body = SimpleRequestBody { actions: r.actions };
-                        ruma_common::serde::json_to_buf(&body)
-                    }
-                    NewPushRule::Sender(r) => {
-                        let body = SimpleRequestBody { actions: r.actions };
-                        ruma_common::serde::json_to_buf(&body)
-                    }
-                    #[cfg(not(ruma_unstable_exhaustive_types))]
-                    _ => unreachable!(
-                        "variant added to NewPushRule not serializable to request body"
-                    ),
-                }
-            }
+        ) -> Result<http::Request<RequestBody>, ruma_common::api::error::IntoHttpError> {
+            use ruma_common::api::Metadata;
 
             let query_string = serde_html_form::to_string(RequestQuery {
                 before: self.before,
@@ -111,14 +117,11 @@ pub mod v3 {
                 &query_string,
             )?;
 
-            let mut http_request = http::Request::builder()
+            let http_request = http::Request::builder()
                 .method(Self::METHOD)
                 .uri(url)
                 .header(http::header::CONTENT_TYPE, ruma_common::http_headers::APPLICATION_JSON)
-                .body(serialize_rule(self.rule)?)?;
-
-            Self::Authentication::add_authentication(&mut http_request, access_token)
-                .map_err(ruma_common::api::error::IntoHttpError::authentication)?;
+                .body(RequestBody(self.rule))?;
 
             Ok(http_request)
         }

--- a/crates/ruma-client-api/src/rendezvous/create_rendezvous_session.rs
+++ b/crates/ruma-client-api/src/rendezvous/create_rendezvous_session.rs
@@ -10,7 +10,7 @@ pub mod unstable_msc4108 {
 
     use http::header::{CONTENT_TYPE, ETAG, EXPIRES, LAST_MODIFIED};
     #[cfg(feature = "client")]
-    use ruma_common::api::error::FromHttpResponseError;
+    use ruma_common::api::{BytesBody, error::FromHttpResponseError};
     use ruma_common::{
         api::{
             auth_scheme::NoAccessToken,
@@ -41,28 +41,27 @@ pub mod unstable_msc4108 {
 
     #[cfg(feature = "client")]
     impl ruma_common::api::OutgoingRequest for Request {
+        type Body = BytesBody;
         type EndpointError = Error;
         type IncomingResponse = Response;
 
-        fn try_into_http_request<T: Default + bytes::BufMut>(
+        fn try_into_http_request_inner(
             self,
             base_url: &str,
-            _: ruma_common::api::auth_scheme::SendAccessToken<'_>,
             considering: std::borrow::Cow<'_, ruma_common::api::SupportedVersions>,
-        ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
+        ) -> Result<http::Request<BytesBody>, ruma_common::api::error::IntoHttpError> {
             use http::header::CONTENT_LENGTH;
             use ruma_common::api::Metadata;
 
             let url = Self::make_endpoint_url(considering, base_url, &[], "")?;
-            let body = self.content.as_bytes();
-            let content_length = body.len();
+            let content_length = self.content.len();
 
             Ok(http::Request::builder()
                 .method(Self::METHOD)
                 .uri(url)
                 .header(CONTENT_TYPE, "text/plain")
                 .header(CONTENT_LENGTH, content_length)
-                .body(ruma_common::serde::slice_to_buf(body))?)
+                .body(BytesBody(self.content.into()))?)
         }
     }
 

--- a/crates/ruma-client-api/src/search/search_events.rs
+++ b/crates/ruma-client-api/src/search/search_events.rs
@@ -605,7 +605,7 @@ mod tests {
     use js_int::uint;
     use ruma_common::{
         api::{
-            IncomingRequest, IncomingResponse, OutgoingRequest, OutgoingResponse,
+            IncomingRequest, IncomingResponse, OutgoingRequestExt as _, OutgoingResponse,
             SupportedVersions, auth_scheme::SendAccessToken,
         },
         event_id, room_id,

--- a/crates/ruma-client-api/src/session/login.rs
+++ b/crates/ruma-client-api/src/session/login.rs
@@ -495,7 +495,8 @@ pub mod v3 {
             use std::borrow::Cow;
 
             use ruma_common::api::{
-                MatrixVersion, OutgoingRequest, SupportedVersions, auth_scheme::SendAccessToken,
+                MatrixVersion, OutgoingRequestExt as _, SupportedVersions,
+                auth_scheme::SendAccessToken,
             };
             use serde_json::Value as JsonValue;
 

--- a/crates/ruma-client-api/src/session/logout.rs
+++ b/crates/ruma-client-api/src/session/logout.rs
@@ -7,6 +7,8 @@ pub mod v3 {
     //!
     //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3logout
 
+    #[cfg(feature = "client")]
+    use ruma_common::api::EmptyBody;
     use ruma_common::{
         api::{auth_scheme::AccessToken, error::Error, response},
         metadata,
@@ -36,24 +38,21 @@ pub mod v3 {
 
     #[cfg(feature = "client")]
     impl ruma_common::api::OutgoingRequest for Request {
+        type Body = EmptyBody;
         type EndpointError = Error;
         type IncomingResponse = Response;
 
-        fn try_into_http_request<T: Default + bytes::BufMut + AsRef<[u8]>>(
+        fn try_into_http_request_inner(
             self,
             base_url: &str,
-            access_token: ruma_common::api::auth_scheme::SendAccessToken<'_>,
             considering: std::borrow::Cow<'_, ruma_common::api::SupportedVersions>,
-        ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
-            use ruma_common::api::{Metadata, auth_scheme::AuthScheme};
+        ) -> Result<http::Request<EmptyBody>, ruma_common::api::error::IntoHttpError> {
+            use ruma_common::api::Metadata;
 
             let url = Self::make_endpoint_url(considering, base_url, &[], "")?;
 
-            let mut http_request =
-                http::Request::builder().method(Self::METHOD).uri(url).body(T::default())?;
-
-            Self::Authentication::add_authentication(&mut http_request, access_token)
-                .map_err(ruma_common::api::error::IntoHttpError::authentication)?;
+            let http_request =
+                http::Request::builder().method(Self::METHOD).uri(url).body(EmptyBody)?;
 
             Ok(http_request)
         }

--- a/crates/ruma-client-api/src/session/logout_all.rs
+++ b/crates/ruma-client-api/src/session/logout_all.rs
@@ -7,6 +7,8 @@ pub mod v3 {
     //!
     //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3logoutall
 
+    #[cfg(feature = "client")]
+    use ruma_common::api::EmptyBody;
     use ruma_common::{
         api::{auth_scheme::AccessToken, error::Error, response},
         metadata,
@@ -36,24 +38,21 @@ pub mod v3 {
 
     #[cfg(feature = "client")]
     impl ruma_common::api::OutgoingRequest for Request {
+        type Body = EmptyBody;
         type EndpointError = Error;
         type IncomingResponse = Response;
 
-        fn try_into_http_request<T: Default + bytes::BufMut + AsRef<[u8]>>(
+        fn try_into_http_request_inner(
             self,
             base_url: &str,
-            access_token: ruma_common::api::auth_scheme::SendAccessToken<'_>,
             considering: std::borrow::Cow<'_, ruma_common::api::SupportedVersions>,
-        ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
-            use ruma_common::api::{Metadata, auth_scheme::AuthScheme};
+        ) -> Result<http::Request<EmptyBody>, ruma_common::api::error::IntoHttpError> {
+            use ruma_common::api::Metadata;
 
             let url = Self::make_endpoint_url(considering, base_url, &[], "")?;
 
-            let mut http_request =
-                http::Request::builder().method(Self::METHOD).uri(url).body(T::default())?;
-
-            Self::Authentication::add_authentication(&mut http_request, access_token)
-                .map_err(ruma_common::api::error::IntoHttpError::authentication)?;
+            let http_request =
+                http::Request::builder().method(Self::METHOD).uri(url).body(EmptyBody)?;
 
             Ok(http_request)
         }

--- a/crates/ruma-client-api/src/session/sso_login.rs
+++ b/crates/ruma-client-api/src/session/sso_login.rs
@@ -69,7 +69,7 @@ pub mod v3 {
         use std::borrow::Cow;
 
         use ruma_common::api::{
-            MatrixVersion, OutgoingRequest, SupportedVersions, auth_scheme::SendAccessToken,
+            MatrixVersion, OutgoingRequestExt as _, SupportedVersions, auth_scheme::SendAccessToken,
         };
 
         use super::Request;

--- a/crates/ruma-client-api/src/session/sso_login_with_provider.rs
+++ b/crates/ruma-client-api/src/session/sso_login_with_provider.rs
@@ -75,7 +75,7 @@ pub mod v3 {
         use std::borrow::Cow;
 
         use ruma_common::api::{
-            MatrixVersion, OutgoingRequest as _, SupportedVersions, auth_scheme::SendAccessToken,
+            MatrixVersion, OutgoingRequestExt as _, SupportedVersions, auth_scheme::SendAccessToken,
         };
 
         use super::Request;

--- a/crates/ruma-client-api/src/state/get_state_event_for_key.rs
+++ b/crates/ruma-client-api/src/state/get_state_event_for_key.rs
@@ -7,6 +7,8 @@ pub mod v3 {
     //!
     //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#get_matrixclientv3roomsroomidstateeventtypestatekey
 
+    #[cfg(feature = "client")]
+    use ruma_common::api::EmptyBody;
     use ruma_common::{
         OwnedRoomId,
         api::{auth_scheme::AccessToken, error::Error, response},
@@ -125,20 +127,20 @@ pub mod v3 {
 
     #[cfg(feature = "client")]
     impl ruma_common::api::OutgoingRequest for Request {
+        type Body = EmptyBody;
         type EndpointError = Error;
         type IncomingResponse = Response;
 
-        fn try_into_http_request<T: Default + bytes::BufMut + AsRef<[u8]>>(
+        fn try_into_http_request_inner(
             self,
             base_url: &str,
-            access_token: ruma_common::api::auth_scheme::SendAccessToken<'_>,
             considering: std::borrow::Cow<'_, ruma_common::api::SupportedVersions>,
-        ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
-            use ruma_common::api::{Metadata, auth_scheme::AuthScheme};
+        ) -> Result<http::Request<EmptyBody>, ruma_common::api::error::IntoHttpError> {
+            use ruma_common::api::Metadata;
 
             let query_string = serde_html_form::to_string(RequestQuery { format: self.format })?;
 
-            let mut http_request = http::Request::builder()
+            let http_request = http::Request::builder()
                 .method(Self::METHOD)
                 .uri(Self::make_endpoint_url(
                     considering,
@@ -146,10 +148,7 @@ pub mod v3 {
                     &[&self.room_id, &self.event_type, &self.state_key],
                     &query_string,
                 )?)
-                .body(T::default())?;
-
-            Self::Authentication::add_authentication(&mut http_request, access_token)
-                .map_err(ruma_common::api::error::IntoHttpError::authentication)?;
+                .body(EmptyBody)?;
 
             Ok(http_request)
         }

--- a/crates/ruma-client-api/src/state/send_state_event.rs
+++ b/crates/ruma-client-api/src/state/send_state_event.rs
@@ -128,18 +128,27 @@ pub mod v3 {
         }
     }
 
+    #[doc(hidden)]
+    #[derive(ruma_common::serde::_FakeDeriveSerde)]
+    #[cfg_attr(feature = "client", derive(serde::Serialize, ruma_common::api::OutgoingBodyJson))]
+    #[cfg_attr(feature = "server", derive(serde::Deserialize))]
+    #[serde(transparent)]
+    // attribute will go away when we update IncomingRequest to also use RequestBody
+    #[cfg_attr(not(feature = "client"), expect(dead_code))]
+    pub struct RequestBody(Raw<AnyStateEventContent>);
+
     #[cfg(feature = "client")]
     impl ruma_common::api::OutgoingRequest for Request {
+        type Body = RequestBody;
         type EndpointError = Error;
         type IncomingResponse = Response;
 
-        fn try_into_http_request<T: Default + bytes::BufMut + AsRef<[u8]>>(
+        fn try_into_http_request_inner(
             self,
             base_url: &str,
-            access_token: ruma_common::api::auth_scheme::SendAccessToken<'_>,
             considering: std::borrow::Cow<'_, ruma_common::api::SupportedVersions>,
-        ) -> Result<http::Request<T>, ruma_common::api::error::IntoHttpError> {
-            use ruma_common::api::{Metadata, auth_scheme::AuthScheme};
+        ) -> Result<http::Request<RequestBody>, ruma_common::api::error::IntoHttpError> {
+            use ruma_common::api::Metadata;
 
             let query_string = serde_html_form::to_string(RequestQuery {
                 timestamp: self.timestamp,
@@ -147,7 +156,7 @@ pub mod v3 {
                 sticky_duration_ms: self.sticky_duration_ms,
             })?;
 
-            let mut http_request = http::Request::builder()
+            let http_request = http::Request::builder()
                 .method(Self::METHOD)
                 .uri(Self::make_endpoint_url(
                     considering,
@@ -156,10 +165,7 @@ pub mod v3 {
                     &query_string,
                 )?)
                 .header(http::header::CONTENT_TYPE, ruma_common::http_headers::APPLICATION_JSON)
-                .body(ruma_common::serde::json_to_buf(&self.body)?)?;
-
-            Self::Authentication::add_authentication(&mut http_request, access_token)
-                .map_err(ruma_common::api::error::IntoHttpError::authentication)?;
+                .body(RequestBody(self.body))?;
 
             Ok(http_request)
         }
@@ -244,7 +250,9 @@ mod tests {
     use std::borrow::Cow;
 
     use ruma_common::{
-        api::{MatrixVersion, OutgoingRequest, SupportedVersions, auth_scheme::SendAccessToken},
+        api::{
+            MatrixVersion, OutgoingRequestExt as _, SupportedVersions, auth_scheme::SendAccessToken,
+        },
         owned_room_id,
     };
     use ruma_events::{EmptyStateKey, room::name::RoomNameEventContent};

--- a/crates/ruma-client-api/src/sync/sync_events/v3.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v3.rs
@@ -833,7 +833,7 @@ mod client_tests {
     use ruma_common::{
         RoomVersionId,
         api::{
-            IncomingResponse as _, MatrixVersion, OutgoingRequest as _, SupportedVersions,
+            IncomingResponse as _, MatrixVersion, OutgoingRequestExt as _, SupportedVersions,
             auth_scheme::SendAccessToken,
         },
         event_id, room_id, user_id,

--- a/crates/ruma-client-api/tests/it/headers.rs
+++ b/crates/ruma-client-api/tests/it/headers.rs
@@ -2,7 +2,7 @@
 
 use http::HeaderMap;
 use ruma_client_api::discovery::discover_homeserver;
-use ruma_common::api::{OutgoingRequest as _, auth_scheme::SendAccessToken};
+use ruma_common::api::{OutgoingRequestExt as _, auth_scheme::SendAccessToken};
 
 #[test]
 fn get_request_headers() {

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+Breaking changes:
+
+- `OutgoingRequest::try_into_http_request` has been moved to a new `OutgoingRequestExt` trait
+  that is automatically implemented for any `T: OutgoingRequest`
+  - Implementors of `OutgoingRequest` now instead have to provide the new `type Body`
+    and `fn try_into_http_request_inner`
+
 Bug fixes:
 
 - Add `StatusProfileField::new()` and `CallProfileField::new()` constructors for MSC4426

--- a/crates/ruma-common/src/api.rs
+++ b/crates/ruma-common/src/api.rs
@@ -15,6 +15,7 @@
 use std::{convert::TryInto as _, error::Error as StdError};
 
 use bytes::BufMut;
+pub use ruma_macros::OutgoingBodyJson;
 /// Generates [`OutgoingRequest`] and [`IncomingRequest`] implementations.
 ///
 /// The `OutgoingRequest` impl is feature-gated behind `cfg(feature = "client")`.
@@ -253,20 +254,55 @@ pub use crate::metadata;
 use crate::{DeviceId, UserId};
 
 pub mod auth_scheme;
+mod body;
 pub mod error;
 mod metadata;
 pub mod path_builder;
 
-pub use self::metadata::{FeatureFlag, MatrixVersion, Metadata, SupportedVersions};
+pub use self::{
+    body::{BytesBody, EmptyBody, OutgoingBody},
+    metadata::{FeatureFlag, MatrixVersion, Metadata, SupportedVersions},
+};
 
 /// A request type for a Matrix API endpoint, used for sending requests.
 pub trait OutgoingRequest: Metadata + Clone {
+    /// HTTP body type pre-serialization.
+    type Body: OutgoingBody;
+
     /// A type capturing the expected error conditions the server can return.
     type EndpointError: EndpointError;
 
     /// Response type returned when the request is successful.
     type IncomingResponse: IncomingResponse<EndpointError = Self::EndpointError>;
 
+    /// Tries to convert this request into an `http::Request`.
+    ///
+    /// The endpoints path will be appended to the given `base_url`, for example
+    /// `https://matrix.org`. Since all paths begin with a slash, it is not necessary for the
+    /// `base_url` to have a trailing slash. If it has one however, it will be ignored.
+    ///
+    /// ## Errors
+    ///
+    /// This method can return an error in the following cases:
+    ///
+    /// * On endpoints that have several versions for the path, when there are no supported versions
+    ///   for the endpoint, i.e. when [`PathBuilder::make_endpoint_url()`] returns an error.
+    /// * If the request serialization fails, which should only happen in case of bugs in Ruma.
+    ///
+    /// [`AuthScheme::add_authentication()`]: auth_scheme::AuthScheme::add_authentication
+    /// [`PathBuilder::make_endpoint_url()`]: path_builder::PathBuilder::make_endpoint_url
+    fn try_into_http_request_inner(
+        self,
+        base_url: &str,
+        path_builder_input: <Self::PathBuilder as path_builder::PathBuilder>::Input<'_>,
+    ) -> Result<http::Request<Self::Body>, IntoHttpError>;
+}
+
+/// Convenience functionality on top of [`OutgoingRequest`].
+pub trait OutgoingRequestExt: OutgoingRequest
+where
+    IntoHttpError: From<<Self::Body as OutgoingBody>::Error>,
+{
     /// Tries to convert this request into an `http::Request`.
     ///
     /// The endpoints path will be appended to the given `base_url`, for example
@@ -290,7 +326,24 @@ pub trait OutgoingRequest: Metadata + Clone {
         base_url: &str,
         authentication_input: <Self::Authentication as auth_scheme::AuthScheme>::Input<'_>,
         path_builder_input: <Self::PathBuilder as path_builder::PathBuilder>::Input<'_>,
-    ) -> Result<http::Request<T>, IntoHttpError>;
+    ) -> Result<http::Request<T>, IntoHttpError> {
+        let (parts, body) =
+            self.try_into_http_request_inner(base_url, path_builder_input)?.into_parts();
+        let mut request = http::Request::from_parts(parts, body.try_into_buf()?);
+
+        <Self::Authentication as auth_scheme::AuthScheme>::add_authentication(
+            &mut request,
+            authentication_input,
+        )
+        .map_err(IntoHttpError::authentication)?;
+
+        Ok(request)
+    }
+}
+
+impl<T: OutgoingRequest> OutgoingRequestExt for T where
+    IntoHttpError: From<<Self::Body as OutgoingBody>::Error>
+{
 }
 
 /// A response type for a Matrix API endpoint, used for receiving responses.
@@ -311,6 +364,7 @@ pub trait IncomingResponse: Sized {
 /// these methods with the Client-Server API.
 pub trait OutgoingRequestAppserviceExt: OutgoingRequest
 where
+    IntoHttpError: From<<Self::Body as OutgoingBody>::Error>,
     for<'a> Self::Authentication:
         auth_scheme::AuthScheme<Input<'a> = auth_scheme::SendAccessToken<'a>>,
 {
@@ -332,9 +386,11 @@ where
     }
 }
 
-impl<T: OutgoingRequest> OutgoingRequestAppserviceExt for T where
+impl<T: OutgoingRequest> OutgoingRequestAppserviceExt for T
+where
+    IntoHttpError: From<<Self::Body as OutgoingBody>::Error>,
     for<'a> Self::Authentication:
-        auth_scheme::AuthScheme<Input<'a> = auth_scheme::SendAccessToken<'a>>
+        auth_scheme::AuthScheme<Input<'a> = auth_scheme::SendAccessToken<'a>>,
 {
 }
 

--- a/crates/ruma-common/src/api/auth_scheme.rs
+++ b/crates/ruma-common/src/api/auth_scheme.rs
@@ -110,7 +110,7 @@ impl AuthScheme for AccessToken {
     type Output = String;
     type ExtractAuthenticationError = ExtractTokenError;
 
-    fn add_authentication<T: AsRef<[u8]>>(
+    fn add_authentication<T>(
         request: &mut http::Request<T>,
         access_token: SendAccessToken<'_>,
     ) -> Result<(), Self::AddAuthenticationError> {

--- a/crates/ruma-common/src/api/body.rs
+++ b/crates/ruma-common/src/api/body.rs
@@ -1,0 +1,42 @@
+use std::convert::Infallible;
+
+use bytes::BufMut;
+
+use crate::serde::slice_to_buf;
+
+/// HTTP message body pre-serialization.
+pub trait OutgoingBody {
+    /// The type of error that can happen in `try_info_buf`.
+    type Error;
+
+    /// Turn `self` into a byte buffer (copying a raw body or serializing a JSON one).
+    fn try_into_buf<T: Default + BufMut + AsRef<[u8]>>(self) -> Result<T, Self::Error>;
+}
+
+/// "Empty" body type, used mostly for GET requests.
+///
+/// If `TRULY_EMPTY` is `true`, serializes to an empty buffer.
+/// If `TRULY_EMPTY` is `false`, serializes to an empty JSON object.
+/// (that case is not encoded as a separate type due to macro requirements)
+#[expect(clippy::exhaustive_structs)]
+pub struct EmptyBody<const TRULY_EMPTY: bool = true>;
+
+impl<const TRULY_EMPTY: bool> OutgoingBody for EmptyBody<TRULY_EMPTY> {
+    type Error = Infallible;
+
+    fn try_into_buf<T: Default + BufMut + AsRef<[u8]>>(self) -> Result<T, Infallible> {
+        if TRULY_EMPTY { Ok(Default::default()) } else { Ok(slice_to_buf(b"{}")) }
+    }
+}
+
+/// Raw-bytes body type, used for some media endpoints.
+#[expect(clippy::exhaustive_structs)]
+pub struct BytesBody(pub Vec<u8>);
+
+impl OutgoingBody for BytesBody {
+    type Error = Infallible;
+
+    fn try_into_buf<T: Default + BufMut + AsRef<[u8]>>(self) -> Result<T, Infallible> {
+        Ok(slice_to_buf(&self.0))
+    }
+}

--- a/crates/ruma-common/src/api/error.rs
+++ b/crates/ruma-common/src/api/error.rs
@@ -244,6 +244,12 @@ impl IntoHttpError {
     }
 }
 
+impl From<std::convert::Infallible> for IntoHttpError {
+    fn from(value: std::convert::Infallible) -> Self {
+        match value {}
+    }
+}
+
 impl From<http::header::InvalidHeaderValue> for IntoHttpError {
     fn from(value: http::header::InvalidHeaderValue) -> Self {
         Self::Header(value.into())

--- a/crates/ruma-common/src/api/metadata.rs
+++ b/crates/ruma-common/src/api/metadata.rs
@@ -276,7 +276,7 @@ pub trait Metadata: Sized {
 ///
 /// Ruma keeps track of when endpoints are added, deprecated, and removed. It'll automatically
 /// select the right endpoint stability variation to use depending on which Matrix versions you
-/// pass to [`try_into_http_request`](super::OutgoingRequest::try_into_http_request), see its
+/// pass to [`try_into_http_request`](super::OutgoingRequestExt::try_into_http_request), see its
 /// respective documentation for more information.
 ///
 /// The `PartialOrd` and `Ord` implementations of this type sort the variants by release date. A

--- a/crates/ruma-common/tests/it/api/conversions.rs
+++ b/crates/ruma-common/tests/it/api/conversions.rs
@@ -6,8 +6,8 @@ use http::header::CONTENT_TYPE;
 use ruma_common::{
     OwnedUserId,
     api::{
-        AppserviceUserIdentity, IncomingRequest as _, MatrixVersion, OutgoingRequest as _,
-        OutgoingRequestAppserviceExt, SupportedVersions,
+        AppserviceUserIdentity, IncomingRequest as _, MatrixVersion, OutgoingRequestAppserviceExt,
+        OutgoingRequestExt as _, SupportedVersions,
         auth_scheme::{NoAccessToken, SendAccessToken},
         request, response,
     },

--- a/crates/ruma-common/tests/it/api/header_override.rs
+++ b/crates/ruma-common/tests/it/api/header_override.rs
@@ -5,7 +5,7 @@ use std::borrow::Cow;
 use http::header::{CONTENT_TYPE, Entry, LOCATION};
 use ruma_common::{
     api::{
-        MatrixVersion, OutgoingRequest as _, OutgoingResponse as _, SupportedVersions,
+        MatrixVersion, OutgoingRequestExt as _, OutgoingResponse as _, SupportedVersions,
         auth_scheme::NoAuthentication, request, response,
     },
     metadata,

--- a/crates/ruma-common/tests/it/api/manual_endpoint_impl.rs
+++ b/crates/ruma-common/tests/it/api/manual_endpoint_impl.rs
@@ -10,12 +10,13 @@ use http::{header::CONTENT_TYPE, method::Method};
 use ruma_common::{
     OwnedRoomAliasId, OwnedRoomId,
     api::{
-        EndpointError, IncomingRequest, IncomingResponse, MatrixVersion, Metadata, OutgoingRequest,
-        OutgoingResponse, SupportedVersions,
+        EndpointError, IncomingRequest, IncomingResponse, MatrixVersion, Metadata, OutgoingBody,
+        OutgoingRequest, OutgoingResponse, SupportedVersions,
         auth_scheme::NoAuthentication,
         error::{Error, FromHttpRequestError, FromHttpResponseError, IntoHttpError},
         path_builder::{StablePathSelector, VersionHistory},
     },
+    serde::json_to_buf,
 };
 use serde::{Deserialize, Serialize};
 
@@ -58,15 +59,15 @@ impl Metadata for Request {
 }
 
 impl OutgoingRequest for Request {
+    type Body = RequestBody;
     type EndpointError = Error;
     type IncomingResponse = Response;
 
-    fn try_into_http_request<T: Default + BufMut>(
+    fn try_into_http_request_inner(
         self,
         base_url: &str,
-        _input: (),
         considering: Cow<'_, SupportedVersions>,
-    ) -> Result<http::Request<T>, IntoHttpError> {
+    ) -> Result<http::Request<RequestBody>, IntoHttpError> {
         let url = Self::make_endpoint_url(considering, base_url, &[&self.room_alias], "")?;
 
         let request_body = RequestBody { room_id: self.room_id };
@@ -74,7 +75,7 @@ impl OutgoingRequest for Request {
         let http_request = http::Request::builder()
             .method(Self::METHOD)
             .uri(url)
-            .body(ruma_common::serde::json_to_buf(&request_body)?)
+            .body(request_body)
             // this cannot fail because we don't give user-supplied data to any of the
             // builder methods
             .unwrap();
@@ -111,8 +112,16 @@ impl IncomingRequest for Request {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-struct RequestBody {
+pub struct RequestBody {
     room_id: OwnedRoomId,
+}
+
+impl OutgoingBody for RequestBody {
+    type Error = serde_json::Error;
+
+    fn try_into_buf<T: Default + BufMut + AsRef<[u8]>>(self) -> serde_json::Result<T> {
+        json_to_buf(&self)
+    }
 }
 
 /// The response to a request to create a new room alias.

--- a/crates/ruma-common/tests/it/api/no_fields.rs
+++ b/crates/ruma-common/tests/it/api/no_fields.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use ruma_common::api::{
-    MatrixVersion, OutgoingRequest as _, OutgoingResponse as _, SupportedVersions,
+    MatrixVersion, OutgoingRequestExt as _, OutgoingResponse as _, SupportedVersions,
 };
 
 mod get {

--- a/crates/ruma-common/tests/it/api/optional_headers.rs
+++ b/crates/ruma-common/tests/it/api/optional_headers.rs
@@ -4,8 +4,8 @@ use assert_matches2::assert_matches;
 use http::header::{CONTENT_DISPOSITION, LOCATION};
 use ruma_common::{
     api::{
-        IncomingRequest, IncomingResponse, MatrixVersion, OutgoingRequest, OutgoingResponse,
-        SupportedVersions, auth_scheme::NoAuthentication, request, response,
+        IncomingRequest, IncomingResponse, MatrixVersion, OutgoingRequestExt as _,
+        OutgoingResponse, SupportedVersions, auth_scheme::NoAuthentication, request, response,
     },
     http_headers::{ContentDisposition, ContentDispositionType},
     metadata,

--- a/crates/ruma-common/tests/it/api/required_headers.rs
+++ b/crates/ruma-common/tests/it/api/required_headers.rs
@@ -4,8 +4,8 @@ use assert_matches2::assert_matches;
 use http::header::{CONTENT_DISPOSITION, LOCATION};
 use ruma_common::{
     api::{
-        IncomingRequest, IncomingResponse, MatrixVersion, OutgoingRequest, OutgoingResponse,
-        SupportedVersions,
+        IncomingRequest, IncomingResponse, MatrixVersion, OutgoingRequestExt as _,
+        OutgoingResponse, SupportedVersions,
         auth_scheme::NoAuthentication,
         error::{
             DeserializationError, FromHttpRequestError, FromHttpResponseError,

--- a/crates/ruma-federation-api/tests/it/authentication.rs
+++ b/crates/ruma-federation-api/tests/it/authentication.rs
@@ -3,7 +3,7 @@
 use js_int::uint;
 use ruma_common::{
     MilliSecondsSinceUnixEpoch,
-    api::{OutgoingRequest, auth_scheme::AuthScheme},
+    api::{OutgoingRequestExt as _, auth_scheme::AuthScheme},
     owned_server_name,
     serde::Base64,
     server_name,

--- a/crates/ruma-macros/src/api.rs
+++ b/crates/ruma-macros/src/api.rs
@@ -5,6 +5,7 @@ use std::{env, fs, path::Path, sync::OnceLock};
 use proc_macro2::Span;
 use serde::{Deserialize, de::IgnoredAny};
 
+pub mod body;
 mod common;
 pub mod request;
 pub mod response;

--- a/crates/ruma-macros/src/api/body.rs
+++ b/crates/ruma-macros/src/api/body.rs
@@ -1,0 +1,28 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::DeriveInput;
+
+use crate::util::{RumaCommon, RumaCommonReexport};
+
+pub(crate) fn expand_derive_outgoing_body_json(input: DeriveInput) -> TokenStream {
+    let ruma_common = RumaCommon::new();
+    let bytes = ruma_common.reexported(RumaCommonReexport::Bytes);
+    let serde_json = ruma_common.reexported(RumaCommonReexport::SerdeJson);
+    let ident = input.ident;
+
+    quote! {
+        #[automatically_derived]
+        impl #ruma_common::api::OutgoingBody for #ident {
+            type Error = #serde_json::Error;
+
+            fn try_into_buf<T>(self) -> #serde_json::Result<T>
+            where
+                T: ::std::default::Default
+                    + #bytes::BufMut
+                    + ::std::convert::AsRef<[::std::primitive::u8]>,
+            {
+                #ruma_common::serde::json_to_buf(&self)
+            }
+        }
+    }
+}

--- a/crates/ruma-macros/src/api/common.rs
+++ b/crates/ruma-macros/src/api/common.rs
@@ -3,7 +3,7 @@
 use std::collections::BTreeMap;
 
 use proc_macro2::{Span, TokenStream};
-use quote::{format_ident, quote};
+use quote::{ToTokens, format_ident, quote};
 use syn::parse_quote;
 
 use crate::util::{
@@ -245,6 +245,36 @@ impl Body {
         Ok(())
     }
 
+    pub(super) fn type_name(
+        &self,
+        kind: MacroKind,
+        ruma_common: &RumaCommon,
+        meta_ident: &syn::Ident,
+    ) -> TokenStream {
+        match &self.fields {
+            BodyFields::Empty => {
+                let http = ruma_common.reexported(RumaCommonReexport::Http);
+                quote! {
+                    #ruma_common::api::EmptyBody<{
+                        // Need this static to work around
+                        // 'destructor of http::Method cannot be evaluated at compile-time'.
+                        static M: #http::Method = <#meta_ident as #ruma_common::api::Metadata>::METHOD;
+                        // Need to use match instead of == since the latter goes through the
+                        // PartialEq trait and that can't be used in const contexts yet.
+                        match M {
+                            #http::Method::GET => true,
+                            _ => false
+                        }
+                    }>
+                }
+            }
+            BodyFields::JsonFields(_) | BodyFields::JsonAll(_) => {
+                kind.as_struct_ident(StructSuffix::Body).into_token_stream()
+            }
+            BodyFields::Raw(_) => quote! { #ruma_common::api::BytesBody },
+        }
+    }
+
     /// The content type of the body, if it can be determined.
     ///
     /// Returns a `const` from `ruma_common::http_headers`.
@@ -309,12 +339,19 @@ impl Body {
             extra_attrs.extend(quote! { #[serde(transparent)] });
         }
 
+        let outgoing_body_feature = match kind {
+            MacroKind::Request => "client",
+            MacroKind::Response => "server",
+        };
+
         Some(quote! {
             /// Data in the request body.
+            #[doc(hidden)]
             #[cfg(any(feature = "client", feature = "server"))]
             #[derive(Debug, #ruma_macros::_FakeDeriveRumaApi, #ruma_macros::_FakeDeriveSerde)]
+            #[cfg_attr(feature = #outgoing_body_feature, derive(#ruma_macros::OutgoingBodyJson))]
             #extra_attrs
-            struct #ident { #( #fields ),* }
+            pub struct #ident { #( #fields ),* }
         })
     }
 
@@ -377,6 +414,25 @@ impl Body {
             let #body_ident {
                 #body_fields
             } = body;
+        }
+    }
+
+    pub(super) fn body_expr(&self, kind: MacroKind, ruma_common: &RumaCommon) -> TokenStream {
+        match &self.fields {
+            BodyFields::Empty => quote! { #ruma_common::api::EmptyBody },
+            BodyFields::JsonFields(_) | BodyFields::JsonAll(_) => {
+                let serde_struct = kind.as_struct_ident(StructSuffix::Body);
+                let fields = self.expand_fields();
+                quote! {
+                    #serde_struct { #fields }
+                }
+            }
+            BodyFields::Raw(field) => {
+                let field_ident = field.ident.to_token_stream();
+                quote! {
+                    #ruma_common::api::BytesBody(#field_ident)
+                }
+            }
         }
     }
 

--- a/crates/ruma-macros/src/api/request/outgoing.rs
+++ b/crates/ruma-macros/src/api/request/outgoing.rs
@@ -10,8 +10,12 @@ use crate::{
 impl Request {
     /// Generate the `ruma_common::api::OutgoingRequest` implementation for this request struct.
     pub fn expand_outgoing(&self, ruma_common: &RumaCommon) -> TokenStream {
-        let bytes = ruma_common.reexported(RumaCommonReexport::Bytes);
         let http = ruma_common.reexported(RumaCommonReexport::Http);
+
+        let (impl_generics, ty_generics, where_clause) = self.generics.split_for_impl();
+        let ident = &self.ident;
+        let error_ty = &self.error_ty;
+        let request = KIND.as_variable_ident();
 
         let path_fields = self.path.expand_fields();
         let path_idents = self.path.0.iter().map(|field| field.ident());
@@ -22,27 +26,23 @@ impl Request {
         let headers_serialize = self.headers.expand_serialize(KIND, &self.body, ruma_common, &http);
         let headers_fields = self.headers.expand_fields();
 
-        let body_serialize = self.body.expand_serialize(KIND, ruma_common);
+        let body_type = self.body.type_name(KIND, ruma_common, ident);
+        let body_expr = self.body.body_expr(KIND, ruma_common);
         let body_fields = self.body.expand_fields();
-
-        let (impl_generics, ty_generics, where_clause) = self.generics.split_for_impl();
-        let ident = &self.ident;
-        let error_ty = &self.error_ty;
-        let request = KIND.as_variable_ident();
 
         quote! {
             #[automatically_derived]
             #[cfg(feature = "client")]
             impl #impl_generics #ruma_common::api::OutgoingRequest for #ident #ty_generics #where_clause {
+                type Body = #body_type;
                 type EndpointError = #error_ty;
                 type IncomingResponse = Response;
 
-                fn try_into_http_request<T: ::std::default::Default + #bytes::BufMut + ::std::convert::AsRef<[::std::primitive::u8]>>(
+                fn try_into_http_request_inner(
                     self,
                     base_url: &::std::primitive::str,
-                    authentication_input: <<Self as #ruma_common::api::Metadata>::Authentication as #ruma_common::api::auth_scheme::AuthScheme>::Input<'_>,
                     path_builder_input: <<Self as #ruma_common::api::Metadata>::PathBuilder as #ruma_common::api::path_builder::PathBuilder>::Input<'_>,
-                ) -> ::std::result::Result<#http::Request<T>, #ruma_common::api::error::IntoHttpError> {
+                ) -> ::std::result::Result<#http::Request<Self::Body>, #ruma_common::api::error::IntoHttpError> {
                     let Self {
                         #path_fields
                         #query_fields
@@ -60,15 +60,9 @@ impl Request {
                             &[ #( &#path_idents ),* ],
                             &request_query_string,
                         )?)
-                        .body(#body_serialize)?;
+                        .body(#body_expr)?;
 
                     #headers_serialize
-
-                    <<Self as #ruma_common::api::Metadata>::Authentication as #ruma_common::api::auth_scheme::AuthScheme>::add_authentication(
-                        &mut #request,
-                        authentication_input
-                    )
-                        .map_err(#ruma_common::api::error::IntoHttpError::authentication)?;
 
                     Ok(#request)
                 }

--- a/crates/ruma-macros/src/lib.rs
+++ b/crates/ruma-macros/src/lib.rs
@@ -26,6 +26,7 @@ mod util;
 
 use self::{
     api::{
+        body::expand_derive_outgoing_body_json,
         request::{expand_derive_request, expand_request},
         response::{expand_derive_response, expand_response},
     },
@@ -798,6 +799,13 @@ pub fn derive_request(input: TokenStream) -> TokenStream {
 pub fn derive_response(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input);
     expand_derive_response(input).unwrap_or_else(syn::Error::into_compile_error).into()
+}
+
+/// Implement `OutgoingBody` in terms of `ruma_common::serde::json_to_buf`.
+#[proc_macro_derive(OutgoingBodyJson)]
+pub fn derive_outgoing_body_json(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input);
+    expand_derive_outgoing_body_json(input).into()
 }
 
 /// A derive macro that generates no code, but registers the ruma_api attribute so both


### PR DESCRIPTION
The following changes are made:

- Rename the main trait method from `try_into_http_request` to `try_into_http_request_inner`
- Make the main trait method non-generic, by introducing a new associated type `Body`, and changing the Ok return value from `http::Request<T: Default + BufMut + AsRef<[u8]>>` to `http::Request<Self::Body>`, where `Body` implements a new `OutgoingBody` trait that's responsible for serializing it
- Remove authentication from the main trait method, because it relies on being able to read the body bytes (for server-to-server signatures)
- Add trait `OutgoingRequestExt` that provides `try_into_http_request` with the same functionality / semantics as the previous `OutgoingRequest::try_into_http_request`.

This is useful for a number of reasons:

- Trait implementations can now be fully codegen'ed, which might be useful for downstream crates because their (own) compile times should be lowered since they no longer have to monomorphize these implementations (at the same time, the compile time of Ruma itself will likely increase, just like the on-disk size of the compiled API crates)
- We can likely reuse these trait impls as-is for CBOR serialization, should we ever implement that
- We can definitely reuse these trait impls for error-path-tracking serialization (though that is really much more interesting for *de*serialization)

If this gets approved, I will work on making the same sort of change to the other API traits.
