### PR TITLE
Make RoomMessageEventContent::thread public

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -20,6 +20,7 @@ Improvements:
   - The `unstable-msc2545` cargo feature was removed.
 - Add unstable support for [MSC4354](https://github.com/matrix-org/matrix-spec-proposals/pull/4354) Sticky Events behind the `unstable-msc4354` feature flag.
 - Add the `zeroize(mut self)` method on identifiers, which will call the `zeroize` crate.
+- Add `RoomMessageEventContent::thread` accessor.
 
 ## 0.34.0
 

--- a/crates/ruma-events/src/room/message.rs
+++ b/crates/ruma-events/src/room/message.rs
@@ -262,6 +262,11 @@ impl RoomMessageEventContent {
         self.msgtype.body()
     }
 
+    /// Get the thread relation from this content, if any.
+    pub fn thread(&self) -> Option<&Thread> {
+        self.relates_to.as_ref().and_then(as_variant!(Relation::Thread))
+    }
+
     /// Apply the given new content from a [`Replacement`] to this message.
     ///
     /// [`Replacement`]: crate::relation::Replacement
@@ -313,11 +318,6 @@ impl RoomMessageEventContent {
         }
 
         self.into()
-    }
-
-    /// Get the thread relation from this content, if any.
-    fn thread(&self) -> Option<&Thread> {
-        self.relates_to.as_ref().and_then(|relates_to| as_variant!(relates_to, Relation::Thread))
     }
 }
 


### PR DESCRIPTION
This was brought up on the Ruma matrix channel and I don't see why not to have this as a public method.