### PR TITLE
fix: do not invent empty formatted_body on plain-text edits

### DIFF
--- a/crates/ruma-events/src/room/message.rs
+++ b/crates/ruma-events/src/room/message.rs
@@ -628,19 +628,13 @@ impl MessageType {
     }
 
     fn make_replacement_body(&mut self) {
-        let empty_formatted_body = || FormattedBody::html(String::new());
-
+        // Only prefix an existing formatted_body. Inserting an empty one for plain-text
+        // edits made clients that prefer formatted_body show just "*" (#2536).
         let (body, formatted) = {
             match self {
-                MessageType::Emote(m) => {
-                    (&mut m.body, Some(m.formatted.get_or_insert_with(empty_formatted_body)))
-                }
-                MessageType::Notice(m) => {
-                    (&mut m.body, Some(m.formatted.get_or_insert_with(empty_formatted_body)))
-                }
-                MessageType::Text(m) => {
-                    (&mut m.body, Some(m.formatted.get_or_insert_with(empty_formatted_body)))
-                }
+                MessageType::Emote(m) => (&mut m.body, m.formatted.as_mut()),
+                MessageType::Notice(m) => (&mut m.body, m.formatted.as_mut()),
+                MessageType::Text(m) => (&mut m.body, m.formatted.as_mut()),
                 MessageType::Audio(m) => (&mut m.body, None),
                 MessageType::File(m) => (&mut m.body, None),
                 #[cfg(feature = "unstable-msc4274")]

--- a/crates/ruma-events/tests/it/room_message.rs
+++ b/crates/ruma-events/tests/it/room_message.rs
@@ -459,6 +459,35 @@ fn make_replacement() {
 }
 
 #[test]
+fn make_replacement_plain_text_keeps_formatted_none() {
+    let content = RoomMessageEventContent::text_plain("This is an edited message.");
+
+    let original_message_json = json!({
+        "content": {
+            "body": "Hello, World!",
+            "msgtype": "m.text",
+        },
+        "event_id": "$143273582443PhrSn",
+        "origin_server_ts": 134_829_848,
+        "room_id": "!roomid:notareal.hs",
+        "sender": "@user:notareal.hs",
+        "type": "m.room.message",
+    });
+    let original_message: OriginalSyncRoomMessageEvent =
+        from_json_value(original_message_json).unwrap();
+
+    let content = content.make_replacement(&original_message);
+
+    assert_matches!(
+        content.msgtype,
+        MessageType::Text(TextMessageEventContent { body, formatted, .. })
+    );
+    assert_eq!(body, "* This is an edited message.");
+    // A plain-text message should not gain a formatted_body from the edit fallback.
+    assert!(formatted.is_none());
+}
+
+#[test]
 fn audio_msgtype_serialization() {
     let message_event_content =
         RoomMessageEventContent::new(MessageType::Audio(AudioMessageEventContent::plain(


### PR DESCRIPTION
## Summary
- `MessageType::make_replacement_body` no longer inserts an empty HTML `formatted_body` when editing plain-text Emote/Notice/Text messages.
- Only messages that already have `formatted` get the `* …` HTML fallback prefix.
- Adds a regression test that plain-text replacements keep `formatted: None`.
- Fixes #2536

## Test plan
- [ ] `cargo test -p ruma-events --test it make_replacement`
- [ ] Confirm `make_replacement_plain_text_keeps_formatted_none` passes
- [ ] Confirm existing `make_replacement` (HTML) test still passes