### PR TITLE
Optimize stack size of two types commonly used inside `Result::Err`

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+Breaking changes:
+
+- `UiaaInfo`s field `auth_error` from `Option<StandardErrorBody>` to `Option<Box<StandardErrorBody>>`
+  (this saves a couple bytes when the field is not set, and gets rid of a default-warn clippy
+  lint that was showing up in ruma-client and matrix-sdk)
+
 Bug fixes:
 
 - In the `sync_events::v3` module, fix the serialization of `Response` when only the `knock`

--- a/crates/ruma-client-api/src/uiaa.rs
+++ b/crates/ruma-client-api/src/uiaa.rs
@@ -97,7 +97,7 @@ pub struct UiaaInfo {
 
     /// Authentication-related errors for previous request returned by homeserver.
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
-    pub auth_error: Option<StandardErrorBody>,
+    pub auth_error: Option<Box<StandardErrorBody>>,
 }
 
 impl UiaaInfo {

--- a/crates/ruma-common/src/api/error/kind.rs
+++ b/crates/ruma-common/src/api/error/kind.rs
@@ -399,7 +399,7 @@ pub enum ErrorKind {
     WrongRoomKeysVersion(WrongRoomKeysVersionErrorData),
 
     #[doc(hidden)]
-    _Custom(CustomErrorKind),
+    _Custom(Box<CustomErrorKind>),
 }
 
 impl ErrorKind {
@@ -469,7 +469,7 @@ impl ErrorKind {
             ErrorKind::UserSuspended => ErrorCode::UserSuspended,
             ErrorKind::WeakPassword => ErrorCode::WeakPassword,
             ErrorKind::WrongRoomKeysVersion(_) => ErrorCode::WrongRoomKeysVersion,
-            ErrorKind::_Custom(CustomErrorKind { errcode, .. }) => errcode.as_str().into(),
+            ErrorKind::_Custom(kind) => kind.errcode.as_str().into(),
         }
     }
 
@@ -1072,4 +1072,18 @@ pub enum ErrorCode {
 
     #[doc(hidden)]
     _Custom(PrivOwnedStr),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ErrorKind;
+
+    #[test]
+    fn test_error_kind_type_size() {
+        // There is no strict requirement for this type to be 40 bytes or smaller,
+        // but it's been optimized by hand (Boxing the `_Custom` variant)
+        // and it would be nice to keep track of any regressions.
+        let size = size_of::<ErrorKind>();
+        assert!(size <= 40, "size_of::<ErrorKind>() has regressed, is now {size}");
+    }
 }

--- a/crates/ruma-common/src/api/error/kind_serde.rs
+++ b/crates/ruma-common/src/api/error/kind_serde.rs
@@ -311,7 +311,7 @@ impl<'de> Visitor<'de> for ErrorKindVisitor {
                 })
             }
             ErrorCode::_Custom(errcode) => {
-                ErrorKind::_Custom(CustomErrorKind { errcode: errcode.0.into(), data })
+                ErrorKind::_Custom(Box::new(CustomErrorKind { errcode: errcode.0.into(), data }))
             }
         })
     }
@@ -375,8 +375,8 @@ impl Serialize for ErrorKind {
                     st.serialize_entry("sender", sender)?;
                 }
             }
-            Self::_Custom(CustomErrorKind { data, .. }) => {
-                for (k, v) in data {
+            Self::_Custom(kind) => {
+                for (k, v) in &kind.data {
                     st.serialize_entry(k, v)?;
                 }
             }


### PR DESCRIPTION
Looks like this is enough to get `ruma_client::Error<_, UiaaResponse>` down below Clippy's default treshold.