### PR TITLE
fix: avoid adding formatted_body to edit events

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -22,6 +22,10 @@ Improvements:
 - Add the `zeroize(mut self)` method on identifiers, which will call the `zeroize` crate.
 - Add `RoomMessageEventContent::thread` accessor.
 
+Bug fixes:
+
+- Avoid creating empty formatted body fields when editing plain text message events.
+
 ## 0.34.0
 
 Breaking changes:

--- a/crates/ruma-events/src/room/message.rs
+++ b/crates/ruma-events/src/room/message.rs
@@ -628,19 +628,11 @@ impl MessageType {
     }
 
     fn make_replacement_body(&mut self) {
-        let empty_formatted_body = || FormattedBody::html(String::new());
-
         let (body, formatted) = {
             match self {
-                MessageType::Emote(m) => {
-                    (&mut m.body, Some(m.formatted.get_or_insert_with(empty_formatted_body)))
-                }
-                MessageType::Notice(m) => {
-                    (&mut m.body, Some(m.formatted.get_or_insert_with(empty_formatted_body)))
-                }
-                MessageType::Text(m) => {
-                    (&mut m.body, Some(m.formatted.get_or_insert_with(empty_formatted_body)))
-                }
+                MessageType::Emote(m) => (&mut m.body, m.formatted.as_mut()),
+                MessageType::Notice(m) => (&mut m.body, m.formatted.as_mut()),
+                MessageType::Text(m) => (&mut m.body, m.formatted.as_mut()),
                 MessageType::Audio(m) => (&mut m.body, None),
                 MessageType::File(m) => (&mut m.body, None),
                 #[cfg(feature = "unstable-msc4274")]

--- a/crates/ruma-events/tests/it/room_message.rs
+++ b/crates/ruma-events/tests/it/room_message.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use assert_matches2::assert_matches;
+use assert_matches2::{assert_let, assert_matches};
 use ruma_common::{
     OwnedDeviceId,
     canonical_json::assert_to_canonical_json_eq,
@@ -456,6 +456,35 @@ fn make_replacement() {
     let formatted = formatted.unwrap();
     assert_eq!(formatted.body, "* This is <em>an edited</em> message.");
     assert_matches!(content.mentions, None);
+}
+
+#[test]
+fn make_replacement_plain_text_no_reply() {
+    let content = RoomMessageEventContent::text_plain("This is an edited message.");
+
+    let original_message_json = json!({
+        "content": {
+            "body": "Hello, World!",
+            "msgtype": "m.text",
+        },
+        "event_id": "$143273582443PhrSn",
+        "origin_server_ts": 134_829_848,
+        "room_id": "!roomid:notareal.hs",
+        "sender": "@user:notareal.hs",
+        "type": "m.room.message",
+    });
+    let original_message: OriginalSyncRoomMessageEvent =
+        from_json_value(original_message_json).unwrap();
+
+    let content = content.make_replacement(&original_message);
+
+    assert_let!(
+        MessageType::Text(TextMessageEventContent { body, formatted, .. }) = &content.msgtype
+    );
+    assert_eq!(body, "* This is an edited message.");
+    // A plain-text message should not gain a formatted_body from the edit
+    // fallback.
+    assert_matches!(formatted, None);
 }
 
 #[test]


### PR DESCRIPTION
When an edit event is plain text it should not have a `formatted_body` field. Fix the helper function to avoid adding an empty string as a `formatted_body`.

Fixes: #2536

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
