### PR TITLE
api: Remove generics from IncomingResponse and EndpointError

### DIFF
--- a/crates/ruma-client-api/src/delayed_events/get_delayed_event.rs
+++ b/crates/ruma-client-api/src/delayed_events/get_delayed_event.rs
@@ -147,10 +147,11 @@ pub mod unstable {
             })
             .to_string();
 
-            let res =
-                Response::try_from_http_response(http::Response::builder().body(body).unwrap())
-                    .unwrap()
-                    .delayed_event;
+            let res = Response::try_from_http_response(
+                http::Response::builder().body(body.as_bytes()).unwrap(),
+            )
+            .unwrap()
+            .delayed_event;
 
             let content = json!({
                 "topic": "test topic"

--- a/crates/ruma-client-api/src/delayed_events/get_delayed_event.rs
+++ b/crates/ruma-client-api/src/delayed_events/get_delayed_event.rs
@@ -123,7 +123,8 @@ pub mod unstable {
 
         use js_int::UInt;
         use ruma_common::{
-            MilliSecondsSinceUnixEpoch, api::IncomingResponse, owned_event_id, owned_room_id,
+            MilliSecondsSinceUnixEpoch, api::IncomingResponseExt as _, owned_event_id,
+            owned_room_id,
         };
         use ruma_events::TimelineEventType;
         use serde_json::{Value as JsonValue, json};

--- a/crates/ruma-client-api/src/filter/get_filter.rs
+++ b/crates/ruma-client-api/src/filter/get_filter.rs
@@ -64,7 +64,7 @@ pub mod v3 {
         #[cfg(feature = "client")]
         #[test]
         fn deserialize_response() {
-            use ruma_common::api::IncomingResponse;
+            use ruma_common::api::IncomingResponseExt as _;
 
             let res = super::Response::try_from_http_response(
                 http::Response::builder().body(b"{}" as &[u8]).unwrap(),

--- a/crates/ruma-client-api/src/profile/get_profile.rs
+++ b/crates/ruma-client-api/src/profile/get_profile.rs
@@ -172,30 +172,31 @@ mod tests {
     #[cfg(feature = "client")]
     fn deserialize_response() {
         use ruma_common::api::IncomingResponse;
-        use serde_json::to_vec as to_json_vec;
 
         use crate::profile::{AvatarUrl, DisplayName};
 
         // Values are set.
-        let body = to_json_vec(&json!({
+        let body = json!({
             "avatar_url": "mxc://localhost/abcdef",
             "displayname": "Alice",
             "custom_field": "value",
-        }))
-        .unwrap();
+        })
+        .to_string();
 
-        let response = Response::try_from_http_response(http::Response::new(body)).unwrap();
+        let response =
+            Response::try_from_http_response(http::Response::new(body.as_bytes())).unwrap();
         assert_eq!(response.get_static::<AvatarUrl>().unwrap().unwrap(), "mxc://localhost/abcdef");
         assert_eq!(response.get_static::<DisplayName>().unwrap().unwrap(), "Alice");
         assert_eq!(response.get("custom_field").unwrap().as_str().unwrap(), "value");
 
         // Values are missing or null.
-        let body = to_json_vec(&json!({
+        let body = json!({
             "custom_field": null,
-        }))
-        .unwrap();
+        })
+        .to_string();
 
-        let response = Response::try_from_http_response(http::Response::new(body)).unwrap();
+        let response =
+            Response::try_from_http_response(http::Response::new(body.as_bytes())).unwrap();
         assert_eq!(response.get_static::<AvatarUrl>().unwrap(), None);
         assert_eq!(response.get_static::<DisplayName>().unwrap(), None);
         assert!(response.get("custom_field").unwrap().is_null());

--- a/crates/ruma-client-api/src/profile/get_profile.rs
+++ b/crates/ruma-client-api/src/profile/get_profile.rs
@@ -171,7 +171,7 @@ mod tests {
     #[test]
     #[cfg(feature = "client")]
     fn deserialize_response() {
-        use ruma_common::api::IncomingResponse;
+        use ruma_common::api::IncomingResponseExt as _;
 
         use crate::profile::{AvatarUrl, DisplayName};
 

--- a/crates/ruma-client-api/src/profile/get_profile_field.rs
+++ b/crates/ruma-client-api/src/profile/get_profile_field.rs
@@ -186,8 +186,8 @@ pub mod v3 {
     impl ruma_common::api::IncomingResponse for Response {
         type EndpointError = Error;
 
-        fn try_from_http_response<T: AsRef<[u8]>>(
-            response: http::Response<T>,
+        fn try_from_http_response(
+            response: http::Response<&[u8]>,
         ) -> Result<Self, ruma_common::api::error::FromHttpResponseError<Self::EndpointError>>
         {
             use ruma_common::{api::EndpointError, profile::ProfileFieldValueVisitor};
@@ -199,7 +199,7 @@ pub mod v3 {
                 ));
             }
 
-            let mut de = serde_json::Deserializer::from_slice(response.body().as_ref());
+            let mut de = serde_json::Deserializer::from_slice(response.body());
             let value = de.deserialize_map(ProfileFieldValueVisitor::new(None))?;
             de.end()?;
 
@@ -250,8 +250,8 @@ pub mod v3 {
     impl<F: StaticProfileField> ruma_common::api::IncomingResponse for ResponseStatic<F> {
         type EndpointError = Error;
 
-        fn try_from_http_response<T: AsRef<[u8]>>(
-            response: http::Response<T>,
+        fn try_from_http_response(
+            response: http::Response<&[u8]>,
         ) -> Result<Self, ruma_common::api::error::FromHttpResponseError<Self::EndpointError>>
         {
             use ruma_common::api::EndpointError;
@@ -265,7 +265,7 @@ pub mod v3 {
                 ));
             }
 
-            let value = serde_json::Deserializer::from_slice(response.into_body().as_ref())
+            let value = serde_json::Deserializer::from_slice(response.into_body())
                 .deserialize_map(StaticProfileFieldVisitor(PhantomData::<F>))?;
 
             Ok(Self { value })
@@ -370,19 +370,19 @@ mod tests_client {
     fn deserialize_response() {
         use ruma_common::api::IncomingResponse;
 
-        let body = to_json_vec(&json!({
+        let body = json!({
             "custom_field": "value",
-        }))
-        .unwrap();
+        })
+        .to_string();
 
-        let response = Response::try_from_http_response(http::Response::new(body)).unwrap();
+        let response =
+            Response::try_from_http_response(http::Response::new(body.as_bytes())).unwrap();
         let value = response.value.unwrap();
         assert_eq!(value.field_name().as_str(), "custom_field");
         assert_eq!(value.value().as_str().unwrap(), "value");
 
-        let empty_body = to_json_vec(&json!({})).unwrap();
-
-        let response = Response::try_from_http_response(http::Response::new(empty_body)).unwrap();
+        let response =
+            Response::try_from_http_response(http::Response::new(b"{}".as_slice())).unwrap();
         assert!(response.value.is_none());
     }
 
@@ -396,7 +396,7 @@ mod tests_client {
 
         let body =
             value.map(|value| to_json_vec(&value).unwrap()).unwrap_or_else(|| b"{}".to_vec());
-        R::IncomingResponse::try_from_http_response(http::Response::new(body))
+        R::IncomingResponse::try_from_http_response(http::Response::new(body.as_slice()))
     }
 
     #[test]

--- a/crates/ruma-client-api/src/profile/get_profile_field.rs
+++ b/crates/ruma-client-api/src/profile/get_profile_field.rs
@@ -186,18 +186,11 @@ pub mod v3 {
     impl ruma_common::api::IncomingResponse for Response {
         type EndpointError = Error;
 
-        fn try_from_http_response(
+        fn try_from_http_response_inner(
             response: http::Response<&[u8]>,
-        ) -> Result<Self, ruma_common::api::error::FromHttpResponseError<Self::EndpointError>>
-        {
-            use ruma_common::{api::EndpointError, profile::ProfileFieldValueVisitor};
+        ) -> Result<Self, ruma_common::api::error::DeserializationError> {
+            use ruma_common::profile::ProfileFieldValueVisitor;
             use serde::Deserializer;
-
-            if response.status().as_u16() >= 400 {
-                return Err(ruma_common::api::error::FromHttpResponseError::Server(
-                    Self::EndpointError::from_http_response(response),
-                ));
-            }
 
             let mut de = serde_json::Deserializer::from_slice(response.body());
             let value = de.deserialize_map(ProfileFieldValueVisitor::new(None))?;
@@ -250,20 +243,12 @@ pub mod v3 {
     impl<F: StaticProfileField> ruma_common::api::IncomingResponse for ResponseStatic<F> {
         type EndpointError = Error;
 
-        fn try_from_http_response(
+        fn try_from_http_response_inner(
             response: http::Response<&[u8]>,
-        ) -> Result<Self, ruma_common::api::error::FromHttpResponseError<Self::EndpointError>>
-        {
-            use ruma_common::api::EndpointError;
+        ) -> Result<Self, ruma_common::api::error::DeserializationError> {
             use serde::de::Deserializer;
 
             use crate::profile::profile_field_serde::StaticProfileFieldVisitor;
-
-            if response.status().as_u16() >= 400 {
-                return Err(ruma_common::api::error::FromHttpResponseError::Server(
-                    Self::EndpointError::from_http_response(response),
-                ));
-            }
 
             let value = serde_json::Deserializer::from_slice(response.into_body())
                 .deserialize_map(StaticProfileFieldVisitor(PhantomData::<F>))?;
@@ -368,7 +353,7 @@ mod tests_client {
 
     #[test]
     fn deserialize_response() {
-        use ruma_common::api::IncomingResponse;
+        use ruma_common::api::IncomingResponseExt as _;
 
         let body = json!({
             "custom_field": "value",
@@ -392,7 +377,7 @@ mod tests_client {
         value: Option<ProfileFieldValue>,
     ) -> Result<R::IncomingResponse, ruma_common::api::error::FromHttpResponseError<R::EndpointError>>
     {
-        use ruma_common::api::IncomingResponse;
+        use ruma_common::api::IncomingResponseExt as _;
 
         let body =
             value.map(|value| to_json_vec(&value).unwrap()).unwrap_or_else(|| b"{}".to_vec());

--- a/crates/ruma-client-api/src/rendezvous/create_rendezvous_session.rs
+++ b/crates/ruma-client-api/src/rendezvous/create_rendezvous_session.rs
@@ -10,7 +10,7 @@ pub mod unstable_msc4108 {
 
     use http::header::{CONTENT_TYPE, ETAG, EXPIRES, LAST_MODIFIED};
     #[cfg(feature = "client")]
-    use ruma_common::api::{BytesBody, error::FromHttpResponseError};
+    use ruma_common::api::{BytesBody, error::DeserializationError};
     use ruma_common::{
         api::{
             auth_scheme::NoAccessToken,
@@ -144,18 +144,10 @@ pub mod unstable_msc4108 {
     impl ruma_common::api::IncomingResponse for Response {
         type EndpointError = Error;
 
-        fn try_from_http_response(
+        fn try_from_http_response_inner(
             response: http::Response<&[u8]>,
-        ) -> Result<Self, FromHttpResponseError<Self::EndpointError>> {
-            use ruma_common::api::EndpointError;
-
-            if response.status().as_u16() >= 400 {
-                return Err(FromHttpResponseError::Server(
-                    Self::EndpointError::from_http_response(response),
-                ));
-            }
-
-            let get_date = |header: http::HeaderName| -> Result<SystemTime, FromHttpResponseError<Self::EndpointError>> {
+        ) -> Result<Self, DeserializationError> {
+            let get_date = |header: http::HeaderName| -> Result<SystemTime, DeserializationError> {
                 let date = response
                     .headers()
                     .get(&header)

--- a/crates/ruma-client-api/src/rendezvous/create_rendezvous_session.rs
+++ b/crates/ruma-client-api/src/rendezvous/create_rendezvous_session.rs
@@ -144,8 +144,8 @@ pub mod unstable_msc4108 {
     impl ruma_common::api::IncomingResponse for Response {
         type EndpointError = Error;
 
-        fn try_from_http_response<T: AsRef<[u8]>>(
-            response: http::Response<T>,
+        fn try_from_http_response(
+            response: http::Response<&[u8]>,
         ) -> Result<Self, FromHttpResponseError<Self::EndpointError>> {
             use ruma_common::api::EndpointError;
 
@@ -175,7 +175,7 @@ pub mod unstable_msc4108 {
             let expires = get_date(EXPIRES)?;
             let last_modified = get_date(LAST_MODIFIED)?;
 
-            let body: ResponseBody = serde_json::from_slice(response.body().as_ref())?;
+            let body: ResponseBody = serde_json::from_slice(response.body())?;
 
             Ok(Self { url: body.url, etag, expires, last_modified })
         }

--- a/crates/ruma-client-api/src/room/get_summary.rs
+++ b/crates/ruma-client-api/src/room/get_summary.rs
@@ -101,21 +101,14 @@ pub mod v1 {
     impl ruma_common::api::IncomingResponse for Response {
         type EndpointError = ruma_common::api::error::Error;
 
-        fn try_from_http_response(
+        fn try_from_http_response_inner(
             response: http::Response<&[u8]>,
-        ) -> Result<Self, ruma_common::api::error::FromHttpResponseError<Self::EndpointError>>
-        {
-            use ruma_common::{api::EndpointError, serde::from_raw_json_value};
+        ) -> Result<Self, ruma_common::api::error::DeserializationError> {
+            use ruma_common::serde::from_raw_json_value;
 
             #[derive(serde::Deserialize)]
             struct ResponseDeHelper {
                 membership: Option<MembershipState>,
-            }
-
-            if response.status().as_u16() >= 400 {
-                return Err(ruma_common::api::error::FromHttpResponseError::Server(
-                    Self::EndpointError::from_http_response(response),
-                ));
             }
 
             let raw_json =
@@ -131,7 +124,7 @@ pub mod v1 {
 
 #[cfg(all(test, feature = "client"))]
 mod tests {
-    use ruma_common::api::IncomingResponse;
+    use ruma_common::api::IncomingResponseExt as _;
     use ruma_events::room::member::MembershipState;
     use serde_json::json;
 

--- a/crates/ruma-client-api/src/room/get_summary.rs
+++ b/crates/ruma-client-api/src/room/get_summary.rs
@@ -101,8 +101,8 @@ pub mod v1 {
     impl ruma_common::api::IncomingResponse for Response {
         type EndpointError = ruma_common::api::error::Error;
 
-        fn try_from_http_response<T: AsRef<[u8]>>(
-            response: http::Response<T>,
+        fn try_from_http_response(
+            response: http::Response<&[u8]>,
         ) -> Result<Self, ruma_common::api::error::FromHttpResponseError<Self::EndpointError>>
         {
             use ruma_common::{api::EndpointError, serde::from_raw_json_value};
@@ -118,9 +118,8 @@ pub mod v1 {
                 ));
             }
 
-            let raw_json = serde_json::from_slice::<Box<serde_json::value::RawValue>>(
-                response.body().as_ref(),
-            )?;
+            let raw_json =
+                serde_json::from_slice::<Box<serde_json::value::RawValue>>(response.body())?;
             let summary = from_raw_json_value::<RoomSummary, serde_json::Error>(&raw_json)?;
             let membership =
                 from_raw_json_value::<ResponseDeHelper, serde_json::Error>(&raw_json)?.membership;
@@ -134,7 +133,7 @@ pub mod v1 {
 mod tests {
     use ruma_common::api::IncomingResponse;
     use ruma_events::room::member::MembershipState;
-    use serde_json::{json, to_vec as to_json_vec};
+    use serde_json::json;
 
     use super::v1::Response;
 
@@ -148,10 +147,11 @@ mod tests {
             "join_rule": "restricted",
             "allowed_room_ids": ["!otherroom:localhost"],
             "membership": "invite",
-        });
-        let response = http::Response::new(to_json_vec(&body).unwrap());
-
+        })
+        .to_string();
+        let response = http::Response::new(body.as_bytes());
         let response = Response::try_from_http_response(response).unwrap();
+
         assert_eq!(response.summary.room_id, "!room:localhost");
         assert_eq!(response.membership, Some(MembershipState::Invite));
     }

--- a/crates/ruma-client-api/src/search/search_events.rs
+++ b/crates/ruma-client-api/src/search/search_events.rs
@@ -605,7 +605,7 @@ mod tests {
     use js_int::uint;
     use ruma_common::{
         api::{
-            IncomingRequest, IncomingResponse, OutgoingRequestExt as _, OutgoingResponse,
+            IncomingRequest, IncomingResponseExt as _, OutgoingRequestExt as _, OutgoingResponse,
             SupportedVersions, auth_scheme::SendAccessToken,
         },
         event_id, room_id,

--- a/crates/ruma-client-api/src/search/search_events.rs
+++ b/crates/ruma-client-api/src/search/search_events.rs
@@ -704,7 +704,8 @@ mod tests {
         });
         let result_event_id = event_id!("$144429830826TWwbB:localhost");
 
-        let http_request = http::Response::new(to_json_vec(&body).unwrap());
+        let body_bytes = body.to_string().into_bytes();
+        let http_request = http::Response::new(body_bytes.as_slice());
         let response = Response::try_from_http_response(http_request).unwrap();
 
         let results = &response.search_categories.room_events;

--- a/crates/ruma-client-api/src/session/login_fallback.rs
+++ b/crates/ruma-client-api/src/session/login_fallback.rs
@@ -75,8 +75,8 @@ impl ruma_common::api::OutgoingResponse for Response {
 impl ruma_common::api::IncomingResponse for Response {
     type EndpointError = ruma_common::api::error::Error;
 
-    fn try_from_http_response<T: AsRef<[u8]>>(
-        response: http::Response<T>,
+    fn try_from_http_response(
+        response: http::Response<&[u8]>,
     ) -> Result<Self, ruma_common::api::error::FromHttpResponseError<Self::EndpointError>> {
         use ruma_common::api::{EndpointError, error::FromHttpResponseError};
 
@@ -86,7 +86,7 @@ impl ruma_common::api::IncomingResponse for Response {
             )));
         }
 
-        let body = response.into_body().as_ref().to_owned();
+        let body = response.into_body().to_owned();
         Ok(Self { body })
     }
 }

--- a/crates/ruma-client-api/src/session/login_fallback.rs
+++ b/crates/ruma-client-api/src/session/login_fallback.rs
@@ -75,17 +75,9 @@ impl ruma_common::api::OutgoingResponse for Response {
 impl ruma_common::api::IncomingResponse for Response {
     type EndpointError = ruma_common::api::error::Error;
 
-    fn try_from_http_response(
+    fn try_from_http_response_inner(
         response: http::Response<&[u8]>,
-    ) -> Result<Self, ruma_common::api::error::FromHttpResponseError<Self::EndpointError>> {
-        use ruma_common::api::{EndpointError, error::FromHttpResponseError};
-
-        if response.status().as_u16() >= 400 {
-            return Err(FromHttpResponseError::Server(Self::EndpointError::from_http_response(
-                response,
-            )));
-        }
-
+    ) -> Result<Self, ruma_common::api::error::DeserializationError> {
         let body = response.into_body().to_owned();
         Ok(Self { body })
     }

--- a/crates/ruma-client-api/src/space/get_hierarchy.rs
+++ b/crates/ruma-client-api/src/space/get_hierarchy.rs
@@ -91,7 +91,7 @@ pub mod v1 {
 
 #[cfg(all(test, feature = "client"))]
 mod tests {
-    use ruma_common::api::IncomingResponse;
+    use ruma_common::api::IncomingResponseExt as _;
     use serde_json::json;
 
     use super::v1::Response;

--- a/crates/ruma-client-api/src/space/get_hierarchy.rs
+++ b/crates/ruma-client-api/src/space/get_hierarchy.rs
@@ -92,7 +92,7 @@ pub mod v1 {
 #[cfg(all(test, feature = "client"))]
 mod tests {
     use ruma_common::api::IncomingResponse;
-    use serde_json::{json, to_vec as to_json_vec};
+    use serde_json::json;
 
     use super::v1::Response;
 
@@ -122,10 +122,12 @@ mod tests {
                     ],
                 },
             ],
-        });
-        let response = http::Response::new(to_json_vec(&body).unwrap());
+        })
+        .to_string();
 
+        let response = http::Response::new(body.as_bytes());
         let response = Response::try_from_http_response(response).unwrap();
+
         let room = &response.rooms[0];
         assert_eq!(room.summary.room_id, "!room:localhost");
         let space_child = room.children_state[0].deserialize().unwrap();

--- a/crates/ruma-client-api/src/state/get_state_event_for_key.rs
+++ b/crates/ruma-client-api/src/state/get_state_event_for_key.rs
@@ -211,7 +211,7 @@ pub mod v3 {
 
 #[cfg(all(test, feature = "client"))]
 mod tests {
-    use ruma_common::api::IncomingResponse;
+    use ruma_common::api::IncomingResponseExt as _;
     use ruma_events::room::name::RoomNameEventContent;
     use serde_json::json;
 

--- a/crates/ruma-client-api/src/state/get_state_event_for_key.rs
+++ b/crates/ruma-client-api/src/state/get_state_event_for_key.rs
@@ -213,7 +213,7 @@ pub mod v3 {
 mod tests {
     use ruma_common::api::IncomingResponse;
     use ruma_events::room::name::RoomNameEventContent;
-    use serde_json::{json, to_vec as to_json_vec};
+    use serde_json::json;
 
     use super::v3::Response;
 
@@ -221,8 +221,9 @@ mod tests {
     fn deserialize_response() {
         let body = json!({
             "name": "Nice room 🙂"
-        });
-        let response = http::Response::new(to_json_vec(&body).unwrap());
+        })
+        .to_string();
+        let response = http::Response::new(body.as_bytes());
 
         let response = Response::try_from_http_response(response).unwrap();
         let content =

--- a/crates/ruma-client-api/src/sync/sync_events/v3.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v3.rs
@@ -839,7 +839,7 @@ mod client_tests {
         event_id, room_id, user_id,
     };
     use ruma_events::AnyStrippedStateEvent;
-    use serde_json::{Value as JsonValue, json, to_vec as to_json_vec};
+    use serde_json::{Value as JsonValue, json};
 
     use super::{Filter, PresenceState, Request, Response, State};
 
@@ -932,8 +932,9 @@ mod client_tests {
                     },
                 },
             },
-        });
-        let http_response = http::Response::new(to_json_vec(&body).unwrap());
+        })
+        .to_string();
+        let http_response = http::Response::new(body.as_bytes());
 
         let response = Response::try_from_http_response(http_response).unwrap();
         assert_eq!(response.next_batch, "a00");
@@ -973,9 +974,10 @@ mod client_tests {
                     },
                 },
             },
-        });
+        })
+        .to_string();
 
-        let http_response = http::Response::new(to_json_vec(&body).unwrap());
+        let http_response = http::Response::new(body.as_bytes());
 
         let response = Response::try_from_http_response(http_response).unwrap();
         assert_eq!(response.next_batch, "aaa");
@@ -1017,9 +1019,10 @@ mod client_tests {
                     },
                 },
             },
-        });
+        })
+        .to_string();
 
-        let http_response = http::Response::new(to_json_vec(&body).unwrap());
+        let http_response = http::Response::new(body.as_bytes());
 
         let response = Response::try_from_http_response(http_response).unwrap();
         assert_eq!(response.next_batch, "aaa");
@@ -1054,9 +1057,10 @@ mod client_tests {
                     },
                 },
             },
-        });
+        })
+        .to_string();
 
-        let http_response = http::Response::new(to_json_vec(&body).unwrap());
+        let http_response = http::Response::new(body.as_bytes());
 
         let response = Response::try_from_http_response(http_response).unwrap();
         assert_eq!(response.next_batch, "aaa");
@@ -1100,9 +1104,10 @@ mod client_tests {
                     },
                 },
             },
-        });
+        })
+        .to_string();
 
-        let http_response = http::Response::new(to_json_vec(&body).unwrap());
+        let http_response = http::Response::new(body.as_bytes());
 
         let response = Response::try_from_http_response(http_response).unwrap();
         assert_eq!(response.next_batch, "aaa");

--- a/crates/ruma-client-api/src/sync/sync_events/v3.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v3.rs
@@ -833,7 +833,7 @@ mod client_tests {
     use ruma_common::{
         RoomVersionId,
         api::{
-            IncomingResponse as _, MatrixVersion, OutgoingRequestExt as _, SupportedVersions,
+            IncomingResponseExt as _, MatrixVersion, OutgoingRequestExt as _, SupportedVersions,
             auth_scheme::SendAccessToken,
         },
         event_id, room_id, user_id,

--- a/crates/ruma-client-api/src/uiaa.rs
+++ b/crates/ruma-client-api/src/uiaa.rs
@@ -214,9 +214,9 @@ impl From<MatrixError> for UiaaResponse {
 }
 
 impl EndpointError for UiaaResponse {
-    fn from_http_response<T: AsRef<[u8]>>(response: http::Response<T>) -> Self {
+    fn from_http_response(response: http::Response<&[u8]>) -> Self {
         if response.status() == http::StatusCode::UNAUTHORIZED
-            && let Ok(uiaa_info) = from_json_slice(response.body().as_ref())
+            && let Ok(uiaa_info) = from_json_slice(response.body())
         {
             return Self::AuthResponse(uiaa_info);
         }

--- a/crates/ruma-client-api/src/uiaa/get_uiaa_fallback_page.rs
+++ b/crates/ruma-client-api/src/uiaa/get_uiaa_fallback_page.rs
@@ -104,8 +104,8 @@ pub mod v3 {
     impl ruma_common::api::IncomingResponse for Response {
         type EndpointError = ruma_common::api::error::Error;
 
-        fn try_from_http_response<T: AsRef<[u8]>>(
-            response: http::Response<T>,
+        fn try_from_http_response(
+            response: http::Response<&[u8]>,
         ) -> Result<Self, ruma_common::api::error::FromHttpResponseError<Self::EndpointError>>
         {
             use ruma_common::api::{
@@ -133,7 +133,7 @@ pub mod v3 {
                 return Ok(Self::Redirect(Redirect { url: url.to_owned() }));
             }
 
-            let body = response.into_body().as_ref().to_owned();
+            let body = response.into_body().to_owned();
             Ok(Self::Html(HtmlPage { body }))
         }
     }
@@ -153,7 +153,7 @@ pub mod v3 {
             let http_response = http::Response::builder()
                 .status(http::StatusCode::FOUND)
                 .header(LOCATION, "http://localhost/redirect")
-                .body(Vec::<u8>::new())
+                .body(b"".as_slice())
                 .unwrap();
 
             let response = Response::try_from_http_response(http_response).unwrap();
@@ -168,7 +168,7 @@ pub mod v3 {
             let http_response = http::Response::builder()
                 .status(http::StatusCode::OK)
                 .header(CONTENT_TYPE, "text/html; charset=utf-8")
-                .body(b"<h1>My Page</h1>")
+                .body(b"<h1>My Page</h1>".as_slice())
                 .unwrap();
 
             let response = Response::try_from_http_response(http_response).unwrap();

--- a/crates/ruma-client-api/src/uiaa/get_uiaa_fallback_page.rs
+++ b/crates/ruma-client-api/src/uiaa/get_uiaa_fallback_page.rs
@@ -104,27 +104,15 @@ pub mod v3 {
     impl ruma_common::api::IncomingResponse for Response {
         type EndpointError = ruma_common::api::error::Error;
 
-        fn try_from_http_response(
+        fn try_from_http_response_inner(
             response: http::Response<&[u8]>,
-        ) -> Result<Self, ruma_common::api::error::FromHttpResponseError<Self::EndpointError>>
-        {
-            use ruma_common::api::{
-                EndpointError,
-                error::{DeserializationError, FromHttpResponseError, HeaderDeserializationError},
-            };
-
-            if response.status().as_u16() >= 400 {
-                return Err(FromHttpResponseError::Server(
-                    Self::EndpointError::from_http_response(response),
-                ));
-            }
+        ) -> Result<Self, ruma_common::api::error::DeserializationError> {
+            use ruma_common::api::error::HeaderDeserializationError;
 
             if response.status() == http::StatusCode::FOUND {
                 let Some(location) = response.headers().get(http::header::LOCATION) else {
-                    return Err(DeserializationError::Header(
-                        HeaderDeserializationError::MissingHeader(
-                            http::header::LOCATION.to_string(),
-                        ),
+                    return Err(HeaderDeserializationError::MissingHeader(
+                        http::header::LOCATION.to_string(),
                     )
                     .into());
                 };
@@ -142,7 +130,7 @@ pub mod v3 {
     mod tests_client {
         use assert_matches2::assert_let;
         use http::header::{CONTENT_TYPE, LOCATION};
-        use ruma_common::api::IncomingResponse;
+        use ruma_common::api::IncomingResponseExt as _;
 
         use super::Response;
 

--- a/crates/ruma-common/src/api.rs
+++ b/crates/ruma-common/src/api.rs
@@ -347,8 +347,8 @@ pub trait IncomingResponse: Sized {
     type EndpointError: EndpointError;
 
     /// Tries to convert the given `http::Response` into this response type.
-    fn try_from_http_response<T: AsRef<[u8]>>(
-        response: http::Response<T>,
+    fn try_from_http_response(
+        response: http::Response<&[u8]>,
     ) -> Result<Self, FromHttpResponseError<Self::EndpointError>>;
 }
 

--- a/crates/ruma-common/src/api.rs
+++ b/crates/ruma-common/src/api.rs
@@ -439,7 +439,7 @@ pub trait EndpointError: OutgoingResponse + StdError + Sized + Send + 'static {
     ///
     /// This will always return `Err` variant when no `error` field is defined in
     /// the `ruma_api` macro.
-    fn from_http_response<T: AsRef<[u8]>>(response: http::Response<T>) -> Self;
+    fn from_http_response(response: http::Response<&[u8]>) -> Self;
 }
 
 /// The direction to return events from.

--- a/crates/ruma-common/src/api.rs
+++ b/crates/ruma-common/src/api.rs
@@ -259,6 +259,7 @@ pub mod error;
 mod metadata;
 pub mod path_builder;
 
+use self::error::DeserializationError;
 pub use self::{
     body::{BytesBody, EmptyBody, OutgoingBody},
     metadata::{FeatureFlag, MatrixVersion, Metadata, SupportedVersions},
@@ -347,10 +348,30 @@ pub trait IncomingResponse: Sized {
     type EndpointError: EndpointError;
 
     /// Tries to convert the given `http::Response` into this response type.
+    ///
+    /// Only called for successful responses (HTTP status code < 400).
+    fn try_from_http_response_inner(
+        response: http::Response<&[u8]>,
+    ) -> Result<Self, DeserializationError>;
+}
+
+/// Convenience functionality on top of [`IncomingResponse`].
+pub trait IncomingResponseExt: IncomingResponse {
+    /// Tries to convert the given `http::Response` into this response type.
     fn try_from_http_response(
         response: http::Response<&[u8]>,
-    ) -> Result<Self, FromHttpResponseError<Self::EndpointError>>;
+    ) -> Result<Self, FromHttpResponseError<Self::EndpointError>> {
+        if response.status().as_u16() >= 400 {
+            return Err(FromHttpResponseError::Server(Self::EndpointError::from_http_response(
+                response,
+            )));
+        }
+
+        Self::try_from_http_response_inner(response).map_err(Into::into)
+    }
 }
+
+impl<T: IncomingResponse> IncomingResponseExt for T {}
 
 /// An extension to [`OutgoingRequest`] which provides Appservice specific methods.
 ///

--- a/crates/ruma-common/src/api/error.rs
+++ b/crates/ruma-common/src/api/error.rs
@@ -107,10 +107,10 @@ impl OutgoingResponse for Error {
 }
 
 impl EndpointError for Error {
-    fn from_http_response<T: AsRef<[u8]>>(response: http::Response<T>) -> Self {
+    fn from_http_response(response: http::Response<&[u8]>) -> Self {
         let status = response.status();
 
-        let body_bytes = &response.body().as_ref();
+        let body_bytes = response.body();
         let error_body: ErrorBody = match from_json_slice::<StandardErrorBody>(body_bytes) {
             Ok(mut standard_body) => {
                 let headers = response.headers();

--- a/crates/ruma-common/src/api/error/tests.rs
+++ b/crates/ruma-common/src/api/error/tests.rs
@@ -41,15 +41,14 @@ fn deserialize_wrong_room_key_version() {
 
 #[test]
 fn deserialize_limit_exceeded_no_retry_after() {
+    let body = json!({
+        "errcode": "M_LIMIT_EXCEEDED",
+        "error": "Too many requests",
+    })
+    .to_string();
     let response = http::Response::builder()
         .status(http::StatusCode::TOO_MANY_REQUESTS)
-        .body(
-            serde_json::to_string(&json!({
-                "errcode": "M_LIMIT_EXCEEDED",
-                "error": "Too many requests",
-            }))
-            .unwrap(),
-        )
+        .body(body.as_bytes())
         .unwrap();
     let error = Error::from_http_response(response);
 
@@ -65,16 +64,15 @@ fn deserialize_limit_exceeded_no_retry_after() {
 
 #[test]
 fn deserialize_limit_exceeded_retry_after_body() {
+    let body = json!({
+        "errcode": "M_LIMIT_EXCEEDED",
+        "error": "Too many requests",
+        "retry_after_ms": 2000,
+    })
+    .to_string();
     let response = http::Response::builder()
         .status(http::StatusCode::TOO_MANY_REQUESTS)
-        .body(
-            serde_json::to_string(&json!({
-                "errcode": "M_LIMIT_EXCEEDED",
-                "error": "Too many requests",
-                "retry_after_ms": 2000,
-            }))
-            .unwrap(),
-        )
+        .body(body.as_bytes())
         .unwrap();
     let error = Error::from_http_response(response);
 
@@ -94,16 +92,15 @@ fn deserialize_limit_exceeded_retry_after_body() {
 
 #[test]
 fn deserialize_limit_exceeded_retry_after_header_delay() {
+    let body = json!({
+        "errcode": "M_LIMIT_EXCEEDED",
+        "error": "Too many requests",
+    })
+    .to_string();
     let response = http::Response::builder()
         .status(http::StatusCode::TOO_MANY_REQUESTS)
         .header(http::header::RETRY_AFTER, "2")
-        .body(
-            serde_json::to_string(&json!({
-                "errcode": "M_LIMIT_EXCEEDED",
-                "error": "Too many requests",
-            }))
-            .unwrap(),
-        )
+        .body(body.as_bytes())
         .unwrap();
     let error = Error::from_http_response(response);
 
@@ -123,16 +120,15 @@ fn deserialize_limit_exceeded_retry_after_header_delay() {
 
 #[test]
 fn deserialize_limit_exceeded_retry_after_header_datetime() {
+    let body = json!({
+        "errcode": "M_LIMIT_EXCEEDED",
+        "error": "Too many requests",
+    })
+    .to_string();
     let response = http::Response::builder()
         .status(http::StatusCode::TOO_MANY_REQUESTS)
         .header(http::header::RETRY_AFTER, "Fri, 15 May 2015 15:34:21 GMT")
-        .body(
-            serde_json::to_string(&json!({
-                "errcode": "M_LIMIT_EXCEEDED",
-                "error": "Too many requests",
-            }))
-            .unwrap(),
-        )
+        .body(body.as_bytes())
         .unwrap();
     let error = Error::from_http_response(response);
 
@@ -152,17 +148,16 @@ fn deserialize_limit_exceeded_retry_after_header_datetime() {
 
 #[test]
 fn deserialize_limit_exceeded_retry_after_header_over_body() {
+    let body = json!({
+        "errcode": "M_LIMIT_EXCEEDED",
+        "error": "Too many requests",
+        "retry_after_ms": 3000,
+    })
+    .to_string();
     let response = http::Response::builder()
         .status(http::StatusCode::TOO_MANY_REQUESTS)
         .header(http::header::RETRY_AFTER, "2")
-        .body(
-            serde_json::to_string(&json!({
-                "errcode": "M_LIMIT_EXCEEDED",
-                "error": "Too many requests",
-                "retry_after_ms": 3000,
-            }))
-            .unwrap(),
-        )
+        .body(body.as_bytes())
         .unwrap();
     let error = Error::from_http_response(response);
 

--- a/crates/ruma-common/tests/it/api/manual_endpoint_impl.rs
+++ b/crates/ruma-common/tests/it/api/manual_endpoint_impl.rs
@@ -131,8 +131,8 @@ pub struct Response;
 impl IncomingResponse for Response {
     type EndpointError = Error;
 
-    fn try_from_http_response<T: AsRef<[u8]>>(
-        http_response: http::Response<T>,
+    fn try_from_http_response(
+        http_response: http::Response<&[u8]>,
     ) -> Result<Self, FromHttpResponseError<Error>> {
         if http_response.status().as_u16() < 400 {
             Ok(Response)

--- a/crates/ruma-common/tests/it/api/manual_endpoint_impl.rs
+++ b/crates/ruma-common/tests/it/api/manual_endpoint_impl.rs
@@ -10,10 +10,10 @@ use http::{header::CONTENT_TYPE, method::Method};
 use ruma_common::{
     OwnedRoomAliasId, OwnedRoomId,
     api::{
-        EndpointError, IncomingRequest, IncomingResponse, MatrixVersion, Metadata, OutgoingBody,
-        OutgoingRequest, OutgoingResponse, SupportedVersions,
+        IncomingRequest, IncomingResponse, MatrixVersion, Metadata, OutgoingBody, OutgoingRequest,
+        OutgoingResponse, SupportedVersions,
         auth_scheme::NoAuthentication,
-        error::{Error, FromHttpRequestError, FromHttpResponseError, IntoHttpError},
+        error::{DeserializationError, Error, FromHttpRequestError, IntoHttpError},
         path_builder::{StablePathSelector, VersionHistory},
     },
     serde::json_to_buf,
@@ -131,14 +131,10 @@ pub struct Response;
 impl IncomingResponse for Response {
     type EndpointError = Error;
 
-    fn try_from_http_response(
-        http_response: http::Response<&[u8]>,
-    ) -> Result<Self, FromHttpResponseError<Error>> {
-        if http_response.status().as_u16() < 400 {
-            Ok(Response)
-        } else {
-            Err(FromHttpResponseError::Server(Error::from_http_response(http_response)))
-        }
+    fn try_from_http_response_inner(
+        _http_response: http::Response<&[u8]>,
+    ) -> Result<Self, DeserializationError> {
+        Ok(Response)
     }
 }
 

--- a/crates/ruma-common/tests/it/api/optional_headers.rs
+++ b/crates/ruma-common/tests/it/api/optional_headers.rs
@@ -4,7 +4,7 @@ use assert_matches2::assert_matches;
 use http::header::{CONTENT_DISPOSITION, LOCATION};
 use ruma_common::{
     api::{
-        IncomingRequest, IncomingResponse, MatrixVersion, OutgoingRequestExt as _,
+        IncomingRequest, IncomingResponseExt as _, MatrixVersion, OutgoingRequestExt as _,
         OutgoingResponse, SupportedVersions, auth_scheme::NoAuthentication, request, response,
     },
     http_headers::{ContentDisposition, ContentDispositionType},

--- a/crates/ruma-common/tests/it/api/optional_headers.rs
+++ b/crates/ruma-common/tests/it/api/optional_headers.rs
@@ -99,7 +99,8 @@ fn request_serde_with_header() {
 fn response_serde_no_header() {
     let res = Response { stuff: None, content_disposition: None };
 
-    let http_res = res.clone().try_into_http_response::<Vec<u8>>().unwrap();
+    let (parts, body) = res.clone().try_into_http_response::<Vec<u8>>().unwrap().into_parts();
+    let http_res = http::Response::from_parts(parts, body.as_slice());
     assert_matches!(http_res.headers().get(LOCATION), None);
     assert_matches!(http_res.headers().get(CONTENT_DISPOSITION), None);
 
@@ -118,7 +119,8 @@ fn response_serde_with_header() {
         content_disposition: Some(content_disposition.clone()),
     };
 
-    let mut http_res = res.clone().try_into_http_response::<Vec<u8>>().unwrap();
+    let (parts, body) = res.clone().try_into_http_response::<Vec<u8>>().unwrap().into_parts();
+    let mut http_res = http::Response::from_parts(parts, body.as_slice());
     assert_matches!(http_res.headers().get(LOCATION), Some(_));
     assert_matches!(http_res.headers().get(CONTENT_DISPOSITION), Some(_));
 

--- a/crates/ruma-common/tests/it/api/required_headers.rs
+++ b/crates/ruma-common/tests/it/api/required_headers.rs
@@ -98,7 +98,9 @@ fn response_serde() {
     let res =
         Response { stuff: location.to_owned(), content_disposition: content_disposition.clone() };
 
-    let mut http_res = res.clone().try_into_http_response::<Vec<u8>>().unwrap();
+    let (parts, body) = res.clone().try_into_http_response::<Vec<u8>>().unwrap().into_parts();
+    let mut http_res = http::Response::from_parts(parts, body.as_slice());
+
     assert_matches!(http_res.headers().get(LOCATION), Some(_));
     assert_matches!(http_res.headers().get(CONTENT_DISPOSITION), Some(_));
 

--- a/crates/ruma-common/tests/it/api/required_headers.rs
+++ b/crates/ruma-common/tests/it/api/required_headers.rs
@@ -4,7 +4,7 @@ use assert_matches2::assert_matches;
 use http::header::{CONTENT_DISPOSITION, LOCATION};
 use ruma_common::{
     api::{
-        IncomingRequest, IncomingResponse, MatrixVersion, OutgoingRequestExt as _,
+        IncomingRequest, IncomingResponseExt as _, MatrixVersion, OutgoingRequestExt as _,
         OutgoingResponse, SupportedVersions,
         auth_scheme::NoAuthentication,
         error::{

--- a/crates/ruma-common/tests/it/api/ui/request-only.rs
+++ b/crates/ruma-common/tests/it/api/ui/request-only.rs
@@ -5,7 +5,7 @@ use ruma_common::{
     api::{
         IncomingResponse, OutgoingResponse,
         auth_scheme::NoAuthentication,
-        error::{Error, FromHttpResponseError, IntoHttpError},
+        error::{DeserializationError, Error, IntoHttpError},
         request,
     },
     metadata,
@@ -33,9 +33,9 @@ pub struct Response;
 impl IncomingResponse for Response {
     type EndpointError = Error;
 
-    fn try_from_http_response(
+    fn try_from_http_response_inner(
         _: http::Response<&[u8]>,
-    ) -> Result<Self, FromHttpResponseError<Error>> {
+    ) -> Result<Self, DeserializationError> {
         todo!()
     }
 }

--- a/crates/ruma-common/tests/it/api/ui/request-only.rs
+++ b/crates/ruma-common/tests/it/api/ui/request-only.rs
@@ -33,8 +33,8 @@ pub struct Response;
 impl IncomingResponse for Response {
     type EndpointError = Error;
 
-    fn try_from_http_response<T: AsRef<[u8]>>(
-        _: http::Response<T>,
+    fn try_from_http_response(
+        _: http::Response<&[u8]>,
     ) -> Result<Self, FromHttpResponseError<Error>> {
         todo!()
     }

--- a/crates/ruma-federation-api/src/authenticated_media.rs
+++ b/crates/ruma-federation-api/src/authenticated_media.rs
@@ -146,10 +146,7 @@ fn try_into_multipart_mixed_response<T: Default + bytes::BufMut>(
 #[cfg(feature = "client")]
 fn try_from_multipart_mixed_response(
     http_response: http::Response<&[u8]>,
-) -> Result<
-    (ContentMetadata, FileOrLocation),
-    ruma_common::api::error::FromHttpResponseError<ruma_common::api::error::Error>,
-> {
+) -> Result<(ContentMetadata, FileOrLocation), ruma_common::api::error::DeserializationError> {
     use ruma_common::api::error::{HeaderDeserializationError, MultipartMixedDeserializationError};
 
     // First, get the boundary from the content type header.

--- a/crates/ruma-federation-api/src/authenticated_media.rs
+++ b/crates/ruma-federation-api/src/authenticated_media.rs
@@ -144,8 +144,8 @@ fn try_into_multipart_mixed_response<T: Default + bytes::BufMut>(
 /// Deserialize the given metadata and content from a `http::Response` with a `multipart/mixed`
 /// body.
 #[cfg(feature = "client")]
-fn try_from_multipart_mixed_response<T: AsRef<[u8]>>(
-    http_response: http::Response<T>,
+fn try_from_multipart_mixed_response(
+    http_response: http::Response<&[u8]>,
 ) -> Result<
     (ContentMetadata, FileOrLocation),
     ruma_common::api::error::FromHttpResponseError<ruma_common::api::error::Error>,
@@ -177,7 +177,7 @@ fn try_from_multipart_mixed_response<T: AsRef<[u8]>>(
         .as_bytes();
 
     // Split the body with the boundary.
-    let body = http_response.body().as_ref();
+    let body = http_response.body();
 
     let mut full_boundary = Vec::with_capacity(boundary.len() + 4);
     full_boundary.extend_from_slice(b"\r\n--");
@@ -321,9 +321,11 @@ mod tests {
             content_disposition: Some(content_disposition.clone()),
         });
 
-        let response =
+        let (parts, body) =
             try_into_multipart_mixed_response::<Vec<u8>>(&outgoing_metadata, &outgoing_content)
-                .unwrap();
+                .unwrap()
+                .into_parts();
+        let response = http::Response::from_parts(parts, body.as_slice());
 
         let (_incoming_metadata, incoming_content) =
             try_from_multipart_mixed_response(response).unwrap();
@@ -348,9 +350,11 @@ mod tests {
             content_disposition: Some(content_disposition.clone()),
         });
 
-        let response =
+        let (parts, body) =
             try_into_multipart_mixed_response::<Vec<u8>>(&outgoing_metadata, &outgoing_content)
-                .unwrap();
+                .unwrap()
+                .into_parts();
+        let response = http::Response::from_parts(parts, body.as_slice());
 
         let (_incoming_metadata, incoming_content) =
             try_from_multipart_mixed_response(response).unwrap();
@@ -368,9 +372,11 @@ mod tests {
         let outgoing_metadata = ContentMetadata::new();
         let outgoing_content = FileOrLocation::Location(location.to_owned());
 
-        let response =
+        let (parts, body) =
             try_into_multipart_mixed_response::<Vec<u8>>(&outgoing_metadata, &outgoing_content)
-                .unwrap();
+                .unwrap()
+                .into_parts();
+        let response = http::Response::from_parts(parts, body.as_slice());
 
         let (_incoming_metadata, incoming_content) =
             try_from_multipart_mixed_response(response).unwrap();
@@ -382,56 +388,56 @@ mod tests {
     #[test]
     fn multipart_mixed_deserialize_invalid() {
         // Missing boundary in headers.
-        let body = "\r\n--abcdef\r\n\r\n{}\r\n--abcdef\r\nContent-Type: text/plain\r\n\r\nsome plain text\r\n--abcdef--";
+        let body = b"\r\n--abcdef\r\n\r\n{}\r\n--abcdef\r\nContent-Type: text/plain\r\n\r\nsome plain text\r\n--abcdef--";
         let response = http::Response::builder()
             .header(http::header::CONTENT_TYPE, "multipart/mixed")
-            .body(body)
+            .body(body.as_slice())
             .unwrap();
 
         try_from_multipart_mixed_response(response).unwrap_err();
 
         // Wrong boundary.
-        let body = "\r\n--abcdef\r\n\r\n{}\r\n--abcdef\r\nContent-Type: text/plain\r\n\r\nsome plain text\r\n--abcdef--";
+        let body = b"\r\n--abcdef\r\n\r\n{}\r\n--abcdef\r\nContent-Type: text/plain\r\n\r\nsome plain text\r\n--abcdef--";
         let response = http::Response::builder()
             .header(http::header::CONTENT_TYPE, "multipart/mixed; boundary=012345")
-            .body(body)
+            .body(body.as_slice())
             .unwrap();
 
         try_from_multipart_mixed_response(response).unwrap_err();
 
         // Missing boundary in body.
         let body =
-            "\r\n--abcdef\r\n\r\n{}\r\n--abcdef\r\nContent-Type: text/plain\r\n\r\nsome plain text";
+            b"\r\n--abcdef\r\n\r\n{}\r\n--abcdef\r\nContent-Type: text/plain\r\n\r\nsome plain text";
         let response = http::Response::builder()
             .header(http::header::CONTENT_TYPE, "multipart/mixed; boundary=abcdef")
-            .body(body)
+            .body(body.as_slice())
             .unwrap();
 
         try_from_multipart_mixed_response(response).unwrap_err();
 
         // Missing header and content empty line separator in body part.
-        let body = "\r\n--abcdef\r\n{}\r\n--abcdef\r\nContent-Type: text/plain\r\n\r\nsome plain text\r\n--abcdef--";
+        let body = b"\r\n--abcdef\r\n{}\r\n--abcdef\r\nContent-Type: text/plain\r\n\r\nsome plain text\r\n--abcdef--";
         let response = http::Response::builder()
             .header(http::header::CONTENT_TYPE, "multipart/mixed; boundary=abcdef")
-            .body(body)
+            .body(body.as_slice())
             .unwrap();
 
         try_from_multipart_mixed_response(response).unwrap_err();
 
         // Control character in header.
-        let body = "\r\n--abcdef\r\n\r\n{}\r\n--abcdef\r\nContent-Type: text/plain\r\nContent-Disposition: inline; filename=\"my\nfile\"\r\nsome plain text\r\n--abcdef--";
+        let body = b"\r\n--abcdef\r\n\r\n{}\r\n--abcdef\r\nContent-Type: text/plain\r\nContent-Disposition: inline; filename=\"my\nfile\"\r\nsome plain text\r\n--abcdef--";
         let response = http::Response::builder()
             .header(http::header::CONTENT_TYPE, "multipart/mixed; boundary=abcdef")
-            .body(body)
+            .body(body.as_slice())
             .unwrap();
 
         try_from_multipart_mixed_response(response).unwrap_err();
 
         // Boundary without CRLF with preamble.
-        let body = "foo--abcdef\r\n\r\n{}\r\n--abcdef\r\n\r\nsome plain text\r\n--abcdef--";
+        let body = b"foo--abcdef\r\n\r\n{}\r\n--abcdef\r\n\r\nsome plain text\r\n--abcdef--";
         let response = http::Response::builder()
             .header(http::header::CONTENT_TYPE, "multipart/mixed; boundary=abcdef")
-            .body(body)
+            .body(body.as_slice())
             .unwrap();
 
         try_from_multipart_mixed_response(response).unwrap_err();
@@ -440,10 +446,10 @@ mod tests {
     #[test]
     fn multipart_mixed_deserialize_valid() {
         // Simple.
-        let body = "\r\n--abcdef\r\ncontent-type: application/json\r\n\r\n{}\r\n--abcdef\r\ncontent-type: text/plain\r\n\r\nsome plain text\r\n--abcdef--";
+        let body = b"\r\n--abcdef\r\ncontent-type: application/json\r\n\r\n{}\r\n--abcdef\r\ncontent-type: text/plain\r\n\r\nsome plain text\r\n--abcdef--";
         let response = http::Response::builder()
             .header(http::header::CONTENT_TYPE, "multipart/mixed; boundary=abcdef")
-            .body(body)
+            .body(body.as_slice())
             .unwrap();
 
         let (_metadata, content) = try_from_multipart_mixed_response(response).unwrap();
@@ -454,10 +460,10 @@ mod tests {
         assert_eq!(file_content.content_disposition, None);
 
         // Case-insensitive headers.
-        let body = "\r\n--abcdef\r\nCONTENT-type: application/json\r\n\r\n{}\r\n--abcdef\r\nCONTENT-TYPE: text/plain\r\ncoNtenT-disPosItioN: attachment; filename=my_file.txt\r\n\r\nsome plain text\r\n--abcdef--";
+        let body = b"\r\n--abcdef\r\nCONTENT-type: application/json\r\n\r\n{}\r\n--abcdef\r\nCONTENT-TYPE: text/plain\r\ncoNtenT-disPosItioN: attachment; filename=my_file.txt\r\n\r\nsome plain text\r\n--abcdef--";
         let response = http::Response::builder()
             .header(http::header::CONTENT_TYPE, "multipart/mixed; boundary=abcdef")
-            .body(body)
+            .body(body.as_slice())
             .unwrap();
 
         let (_metadata, content) = try_from_multipart_mixed_response(response).unwrap();
@@ -470,10 +476,10 @@ mod tests {
         assert_eq!(content_disposition.filename.unwrap(), "my_file.txt");
 
         // Extra whitespace.
-        let body = "   \r\n--abcdef\r\ncontent-type:   application/json   \r\n\r\n {} \r\n--abcdef\r\ncontent-type: text/plain  \r\n\r\nsome plain text\r\n--abcdef--  ";
+        let body = b"   \r\n--abcdef\r\ncontent-type:   application/json   \r\n\r\n {} \r\n--abcdef\r\ncontent-type: text/plain  \r\n\r\nsome plain text\r\n--abcdef--  ";
         let response = http::Response::builder()
             .header(http::header::CONTENT_TYPE, "multipart/mixed; boundary=abcdef")
-            .body(body)
+            .body(body.as_slice())
             .unwrap();
 
         let (_metadata, content) = try_from_multipart_mixed_response(response).unwrap();
@@ -484,10 +490,10 @@ mod tests {
         assert_eq!(file_content.content_disposition, None);
 
         // Missing CR except in boundaries.
-        let body = "\r\n--abcdef\ncontent-type: application/json\n\n{}\r\n--abcdef\ncontent-type: text/plain  \n\nsome plain text\r\n--abcdef--";
+        let body = b"\r\n--abcdef\ncontent-type: application/json\n\n{}\r\n--abcdef\ncontent-type: text/plain  \n\nsome plain text\r\n--abcdef--";
         let response = http::Response::builder()
             .header(http::header::CONTENT_TYPE, "multipart/mixed; boundary=abcdef")
-            .body(body)
+            .body(body.as_slice())
             .unwrap();
 
         let (_metadata, content) = try_from_multipart_mixed_response(response).unwrap();
@@ -498,10 +504,10 @@ mod tests {
         assert_eq!(file_content.content_disposition, None);
 
         // No leading CRLF (and no preamble)
-        let body = "--abcdef\r\n\r\n{}\r\n--abcdef\r\n\r\nsome plain text\r\n--abcdef--";
+        let body = b"--abcdef\r\n\r\n{}\r\n--abcdef\r\n\r\nsome plain text\r\n--abcdef--";
         let response = http::Response::builder()
             .header(http::header::CONTENT_TYPE, "multipart/mixed; boundary=abcdef")
-            .body(body)
+            .body(body.as_slice())
             .unwrap();
 
         let (_metadata, content) = try_from_multipart_mixed_response(response).unwrap();
@@ -514,10 +520,10 @@ mod tests {
         // Boundary text in preamble, but no leading CRLF, so it should be
         // ignored.
         let body =
-            "foo--abcdef\r\n--abcdef\r\n\r\n{}\r\n--abcdef\r\n\r\nsome plain text\r\n--abcdef--";
+            b"foo--abcdef\r\n--abcdef\r\n\r\n{}\r\n--abcdef\r\n\r\nsome plain text\r\n--abcdef--";
         let response = http::Response::builder()
             .header(http::header::CONTENT_TYPE, "multipart/mixed; boundary=abcdef")
-            .body(body)
+            .body(body.as_slice())
             .unwrap();
 
         let (_metadata, content) = try_from_multipart_mixed_response(response).unwrap();
@@ -528,10 +534,10 @@ mod tests {
         assert_eq!(file_content.content_disposition, None);
 
         // No body part headers.
-        let body = "\r\n--abcdef\r\n\r\n{}\r\n--abcdef\r\n\r\nsome plain text\r\n--abcdef--";
+        let body = b"\r\n--abcdef\r\n\r\n{}\r\n--abcdef\r\n\r\nsome plain text\r\n--abcdef--";
         let response = http::Response::builder()
             .header(http::header::CONTENT_TYPE, "multipart/mixed; boundary=abcdef")
-            .body(body)
+            .body(body.as_slice())
             .unwrap();
 
         let (_metadata, content) = try_from_multipart_mixed_response(response).unwrap();
@@ -545,7 +551,7 @@ mod tests {
         let body = "\r\n--abcdef\r\ncontent-type: application/json\r\n\r\n{}\r\n--abcdef\r\ncontent-type: text/plain\r\ncontent-disposition: inline; filename=\"ȵ⌾Ⱦԩ💈Ňɠ\"\r\n\r\nsome plain text\r\n--abcdef--";
         let response = http::Response::builder()
             .header(http::header::CONTENT_TYPE, "multipart/mixed; boundary=abcdef")
-            .body(body)
+            .body(body.as_bytes())
             .unwrap();
 
         let (_metadata, content) = try_from_multipart_mixed_response(response).unwrap();

--- a/crates/ruma-federation-api/src/authenticated_media/get_content/unstable.rs
+++ b/crates/ruma-federation-api/src/authenticated_media/get_content/unstable.rs
@@ -81,11 +81,11 @@ impl Response {
 impl ruma_common::api::IncomingResponse for Response {
     type EndpointError = <super::v1::Response as ruma_common::api::IncomingResponse>::EndpointError;
 
-    fn try_from_http_response(
+    fn try_from_http_response_inner(
         http_response: http::Response<&[u8]>,
-    ) -> Result<Self, ruma_common::api::error::FromHttpResponseError<Self::EndpointError>> {
+    ) -> Result<Self, ruma_common::api::error::DeserializationError> {
         // Reuse the custom deserialization.
-        Ok(super::v1::Response::try_from_http_response(http_response)?.into())
+        Ok(super::v1::Response::try_from_http_response_inner(http_response)?.into())
     }
 }
 

--- a/crates/ruma-federation-api/src/authenticated_media/get_content/unstable.rs
+++ b/crates/ruma-federation-api/src/authenticated_media/get_content/unstable.rs
@@ -81,8 +81,8 @@ impl Response {
 impl ruma_common::api::IncomingResponse for Response {
     type EndpointError = <super::v1::Response as ruma_common::api::IncomingResponse>::EndpointError;
 
-    fn try_from_http_response<T: AsRef<[u8]>>(
-        http_response: http::Response<T>,
+    fn try_from_http_response(
+        http_response: http::Response<&[u8]>,
     ) -> Result<Self, ruma_common::api::error::FromHttpResponseError<Self::EndpointError>> {
         // Reuse the custom deserialization.
         Ok(super::v1::Response::try_from_http_response(http_response)?.into())

--- a/crates/ruma-federation-api/src/authenticated_media/get_content/v1.rs
+++ b/crates/ruma-federation-api/src/authenticated_media/get_content/v1.rs
@@ -67,8 +67,8 @@ impl Response {
 impl ruma_common::api::IncomingResponse for Response {
     type EndpointError = ruma_common::api::error::Error;
 
-    fn try_from_http_response<T: AsRef<[u8]>>(
-        http_response: http::Response<T>,
+    fn try_from_http_response(
+        http_response: http::Response<&[u8]>,
     ) -> Result<Self, ruma_common::api::error::FromHttpResponseError<Self::EndpointError>> {
         use ruma_common::api::EndpointError;
 

--- a/crates/ruma-federation-api/src/authenticated_media/get_content/v1.rs
+++ b/crates/ruma-federation-api/src/authenticated_media/get_content/v1.rs
@@ -67,20 +67,12 @@ impl Response {
 impl ruma_common::api::IncomingResponse for Response {
     type EndpointError = ruma_common::api::error::Error;
 
-    fn try_from_http_response(
+    fn try_from_http_response_inner(
         http_response: http::Response<&[u8]>,
-    ) -> Result<Self, ruma_common::api::error::FromHttpResponseError<Self::EndpointError>> {
-        use ruma_common::api::EndpointError;
-
-        if http_response.status().as_u16() < 400 {
-            let (metadata, content) =
-                crate::authenticated_media::try_from_multipart_mixed_response(http_response)?;
-            Ok(Self { metadata, content })
-        } else {
-            Err(ruma_common::api::error::FromHttpResponseError::Server(
-                ruma_common::api::error::Error::from_http_response(http_response),
-            ))
-        }
+    ) -> Result<Self, ruma_common::api::error::DeserializationError> {
+        let (metadata, content) =
+            crate::authenticated_media::try_from_multipart_mixed_response(http_response)?;
+        Ok(Self { metadata, content })
     }
 }
 

--- a/crates/ruma-federation-api/src/authenticated_media/get_content_thumbnail/unstable.rs
+++ b/crates/ruma-federation-api/src/authenticated_media/get_content_thumbnail/unstable.rs
@@ -119,11 +119,11 @@ impl Response {
 impl ruma_common::api::IncomingResponse for Response {
     type EndpointError = <super::v1::Response as ruma_common::api::IncomingResponse>::EndpointError;
 
-    fn try_from_http_response(
+    fn try_from_http_response_inner(
         http_response: http::Response<&[u8]>,
-    ) -> Result<Self, ruma_common::api::error::FromHttpResponseError<Self::EndpointError>> {
+    ) -> Result<Self, ruma_common::api::error::DeserializationError> {
         // Reuse the custom deserialization.
-        Ok(super::v1::Response::try_from_http_response(http_response)?.into())
+        Ok(super::v1::Response::try_from_http_response_inner(http_response)?.into())
     }
 }
 

--- a/crates/ruma-federation-api/src/authenticated_media/get_content_thumbnail/unstable.rs
+++ b/crates/ruma-federation-api/src/authenticated_media/get_content_thumbnail/unstable.rs
@@ -119,8 +119,8 @@ impl Response {
 impl ruma_common::api::IncomingResponse for Response {
     type EndpointError = <super::v1::Response as ruma_common::api::IncomingResponse>::EndpointError;
 
-    fn try_from_http_response<T: AsRef<[u8]>>(
-        http_response: http::Response<T>,
+    fn try_from_http_response(
+        http_response: http::Response<&[u8]>,
     ) -> Result<Self, ruma_common::api::error::FromHttpResponseError<Self::EndpointError>> {
         // Reuse the custom deserialization.
         Ok(super::v1::Response::try_from_http_response(http_response)?.into())

--- a/crates/ruma-federation-api/src/authenticated_media/get_content_thumbnail/v1.rs
+++ b/crates/ruma-federation-api/src/authenticated_media/get_content_thumbnail/v1.rs
@@ -102,8 +102,8 @@ impl Response {
 impl ruma_common::api::IncomingResponse for Response {
     type EndpointError = ruma_common::api::error::Error;
 
-    fn try_from_http_response<T: AsRef<[u8]>>(
-        http_response: http::Response<T>,
+    fn try_from_http_response(
+        http_response: http::Response<&[u8]>,
     ) -> Result<Self, ruma_common::api::error::FromHttpResponseError<Self::EndpointError>> {
         use ruma_common::api::EndpointError;
 

--- a/crates/ruma-federation-api/src/authenticated_media/get_content_thumbnail/v1.rs
+++ b/crates/ruma-federation-api/src/authenticated_media/get_content_thumbnail/v1.rs
@@ -102,20 +102,12 @@ impl Response {
 impl ruma_common::api::IncomingResponse for Response {
     type EndpointError = ruma_common::api::error::Error;
 
-    fn try_from_http_response(
+    fn try_from_http_response_inner(
         http_response: http::Response<&[u8]>,
-    ) -> Result<Self, ruma_common::api::error::FromHttpResponseError<Self::EndpointError>> {
-        use ruma_common::api::EndpointError;
-
-        if http_response.status().as_u16() < 400 {
-            let (metadata, content) =
-                crate::authenticated_media::try_from_multipart_mixed_response(http_response)?;
-            Ok(Self { metadata, content })
-        } else {
-            Err(ruma_common::api::error::FromHttpResponseError::Server(
-                ruma_common::api::error::Error::from_http_response(http_response),
-            ))
-        }
+    ) -> Result<Self, ruma_common::api::error::DeserializationError> {
+        let (metadata, content) =
+            crate::authenticated_media::try_from_multipart_mixed_response(http_response)?;
+        Ok(Self { metadata, content })
     }
 }
 

--- a/crates/ruma-federation-api/src/policy/sign_event.rs
+++ b/crates/ruma-federation-api/src/policy/sign_event.rs
@@ -119,13 +119,15 @@ mod tests {
     #[test]
     fn deserialize_response() {
         use ruma_common::{api::IncomingResponse, server_name};
-        use serde_json::{json, to_vec as to_json_vec};
+        use serde_json::json;
 
-        let http_response = http::Response::new(to_json_vec(&json!({
+        let body = json!({
             "policy.example.org": {
                 "ed25519:policy_server": "zLFxllD0pbBuBpfHh8NuHNaICpReF/PAOpUQTsw+bFGKiGfDNAsnhcP7pbrmhhpfbOAxIdLraQLeeiXBryLmBw",
             },
-        })).unwrap());
+        })
+        .to_string();
+        let http_response = http::Response::new(body.as_bytes());
 
         let response = Response::try_from_http_response(http_response).unwrap();
 

--- a/crates/ruma-federation-api/src/policy/sign_event.rs
+++ b/crates/ruma-federation-api/src/policy/sign_event.rs
@@ -118,7 +118,7 @@ mod tests {
     #[cfg(feature = "client")]
     #[test]
     fn deserialize_response() {
-        use ruma_common::{api::IncomingResponse, server_name};
+        use ruma_common::{api::IncomingResponseExt as _, server_name};
         use serde_json::json;
 
         let body = json!({

--- a/crates/ruma-federation-api/src/space/get_hierarchy/v1.rs
+++ b/crates/ruma-federation-api/src/space/get_hierarchy/v1.rs
@@ -67,7 +67,7 @@ impl Response {
 
 #[cfg(all(test, feature = "client"))]
 mod tests {
-    use ruma_common::{OwnedRoomId, api::IncomingResponse};
+    use ruma_common::{OwnedRoomId, api::IncomingResponseExt as _};
     use serde_json::json;
 
     use super::Response;

--- a/crates/ruma-federation-api/src/space/get_hierarchy/v1.rs
+++ b/crates/ruma-federation-api/src/space/get_hierarchy/v1.rs
@@ -68,7 +68,7 @@ impl Response {
 #[cfg(all(test, feature = "client"))]
 mod tests {
     use ruma_common::{OwnedRoomId, api::IncomingResponse};
-    use serde_json::{json, to_vec as to_json_vec};
+    use serde_json::json;
 
     use super::Response;
 
@@ -107,9 +107,10 @@ mod tests {
                     }
                 ],
             },
-        });
-        let response = http::Response::new(to_json_vec(&body).unwrap());
+        })
+        .to_string();
 
+        let response = http::Response::new(body.as_bytes());
         let response = Response::try_from_http_response(response).unwrap();
 
         assert_eq!(response.room.summary.room_id, "!room:localhost");

--- a/crates/ruma-macros/src/api/response/incoming.rs
+++ b/crates/ruma-macros/src/api/response/incoming.rs
@@ -26,8 +26,8 @@ impl Response {
             impl #ruma_common::api::IncomingResponse for #ident {
                 type EndpointError = #error_ty;
 
-                fn try_from_http_response<T: ::std::convert::AsRef<[::std::primitive::u8]>>(
-                    #src: #http::Response<T>,
+                fn try_from_http_response(
+                    #src: #http::Response<&[::std::primitive::u8]>,
                 ) -> ::std::result::Result<
                     Self,
                     #ruma_common::api::error::FromHttpResponseError<#error_ty>,

--- a/crates/ruma-macros/src/api/response/incoming.rs
+++ b/crates/ruma-macros/src/api/response/incoming.rs
@@ -26,22 +26,9 @@ impl Response {
             impl #ruma_common::api::IncomingResponse for #ident {
                 type EndpointError = #error_ty;
 
-                fn try_from_http_response(
+                fn try_from_http_response_inner(
                     #src: #http::Response<&[::std::primitive::u8]>,
-                ) -> ::std::result::Result<
-                    Self,
-                    #ruma_common::api::error::FromHttpResponseError<#error_ty>,
-                > {
-                    if #src.status().as_u16() >= 400 {
-                        return ::std::result::Result::Err(
-                            #ruma_common::api::error::FromHttpResponseError::Server(
-                                <#error_ty as #ruma_common::api::EndpointError>::from_http_response(
-                                    #src,
-                                )
-                            )
-                        );
-                    }
-
+                ) -> ::std::result::Result<Self, #ruma_common::api::error::DeserializationError> {
                     #headers_parse
                     #body_parse
 


### PR DESCRIPTION
I also want to introduce an associated `Body` type here, but this is as far as I got for now.