### PR TITLE
Export nothing from API crates if neither the `client` nor the `server` feature is enabled

### DIFF
--- a/crates/ruma-appservice-api/CHANGELOG.md
+++ b/crates/ruma-appservice-api/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+Breaking changes:
+
+- Export nothing from the crate if neither the `client` nor the `server` feature is active, because
+  the crate is not useful without them.
+
 ## 0.16.0
 
 Breaking changes:

--- a/crates/ruma-appservice-api/src/lib.rs
+++ b/crates/ruma-appservice-api/src/lib.rs
@@ -5,6 +5,9 @@
 //!
 //! [appservice-api]: https://spec.matrix.org/v1.19/application-service-api/
 
+// This crate is not useful without either of those features, so export nothing if they are not
+// enabled to avoid errors when running checks wrongly without enabling any of them.
+#![cfg(any(feature = "client", feature = "server"))]
 #![warn(missing_docs)]
 
 use serde::{Deserialize, Serialize};

--- a/crates/ruma-appservice-api/tests/it/main.rs
+++ b/crates/ruma-appservice-api/tests/it/main.rs
@@ -1,1 +1,5 @@
+// This crate is not useful without either of those features, so export nothing if they are not
+// enabled to avoid errors when running checks wrongly without enabling any of them.
+#![cfg(any(feature = "client", feature = "server"))]
+
 mod appservice_registration;

--- a/crates/ruma-client-api/src/directory/get_public_rooms.rs
+++ b/crates/ruma-client-api/src/directory/get_public_rooms.rs
@@ -80,7 +80,7 @@ pub mod v3 {
         }
     }
 
-    #[cfg(all(test, any(feature = "client", feature = "server")))]
+    #[cfg(test)]
     mod tests {
         use js_int::uint;
 

--- a/crates/ruma-client-api/src/filter/create_filter.rs
+++ b/crates/ruma-client-api/src/filter/create_filter.rs
@@ -60,7 +60,7 @@ pub mod v3 {
         }
     }
 
-    #[cfg(all(test, any(feature = "client", feature = "server")))]
+    #[cfg(test)]
     mod tests {
         #[cfg(feature = "server")]
         #[test]

--- a/crates/ruma-client-api/src/filter/get_filter.rs
+++ b/crates/ruma-client-api/src/filter/get_filter.rs
@@ -59,7 +59,7 @@ pub mod v3 {
         }
     }
 
-    #[cfg(all(test, any(feature = "client", feature = "server")))]
+    #[cfg(test)]
     mod tests {
         #[cfg(feature = "client")]
         #[test]

--- a/crates/ruma-client-api/src/lib.rs
+++ b/crates/ruma-client-api/src/lib.rs
@@ -5,6 +5,8 @@
 //!
 //! [client-api]: https://spec.matrix.org/v1.19/client-server-api/
 
+// This crate is not useful without either of those features, so export nothing if they are not
+// enabled to avoid errors when running checks wrongly without enabling any of them.
 #![cfg(any(feature = "client", feature = "server"))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs)]

--- a/crates/ruma-client-api/tests/it/main.rs
+++ b/crates/ruma-client-api/tests/it/main.rs
@@ -1,3 +1,7 @@
+// This crate is not useful without either of those features, so export nothing if they are not
+// enabled to avoid errors when running checks wrongly without enabling any of them.
+#![cfg(any(feature = "client", feature = "server"))]
+
 mod event_content;
 mod headers;
 mod uiaa;

--- a/crates/ruma-client-api/tests/it/uiaa.rs
+++ b/crates/ruma-client-api/tests/it/uiaa.rs
@@ -1,5 +1,3 @@
-#![cfg(any(feature = "client", feature = "server"))]
-
 use assert_matches2::assert_matches;
 use assign::assign;
 use ruma_client_api::uiaa::{

--- a/crates/ruma-federation-api/CHANGELOG.md
+++ b/crates/ruma-federation-api/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+Breaking changes:
+
+- Export nothing from the crate if neither the `client` nor the `server` feature is active, because
+  the crate is not useful without them.
+
 Improvements:
 
 - Remove support for MSC4373, as the MSC is now closed.

--- a/crates/ruma-federation-api/src/lib.rs
+++ b/crates/ruma-federation-api/src/lib.rs
@@ -5,8 +5,11 @@
 //!
 //! [federation-api]: https://spec.matrix.org/v1.19/server-server-api/
 
-#![warn(missing_docs)]
+// This crate is not useful without either of those features, so export nothing if they are not
+// enabled to avoid errors when running checks wrongly without enabling any of them.
+#![cfg(any(feature = "client", feature = "server"))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![warn(missing_docs)]
 
 mod serde;
 

--- a/crates/ruma-federation-api/tests/it/main.rs
+++ b/crates/ruma-federation-api/tests/it/main.rs
@@ -1,1 +1,5 @@
+// This crate is not useful without either of those features, so export nothing if they are not
+// enabled to avoid errors when running checks wrongly without enabling any of them.
+#![cfg(any(feature = "client", feature = "server"))]
+
 mod authentication;

--- a/crates/ruma-identity-service-api/CHANGELOG.md
+++ b/crates/ruma-identity-service-api/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+Breaking changes:
+
+- Export nothing from the crate if neither the `client` nor the `server` feature is active, because
+  the crate is not useful without them.
+
 ## 0.15.0
 
 Breaking changes:

--- a/crates/ruma-identity-service-api/src/lib.rs
+++ b/crates/ruma-identity-service-api/src/lib.rs
@@ -5,6 +5,9 @@
 //!
 //! [identity-api]: https://spec.matrix.org/v1.19/identity-service-api/
 
+// This crate is not useful without either of those features, so export nothing if they are not
+// enabled to avoid errors when running checks wrongly without enabling any of them.
+#![cfg(any(feature = "client", feature = "server"))]
 #![warn(missing_docs)]
 
 pub mod association;

--- a/crates/ruma-macros/src/api/common.rs
+++ b/crates/ruma-macros/src/api/common.rs
@@ -347,7 +347,6 @@ impl Body {
         Some(quote! {
             /// Data in the request body.
             #[doc(hidden)]
-            #[cfg(any(feature = "client", feature = "server"))]
             #[derive(Debug, #ruma_macros::_FakeDeriveRumaApi, #ruma_macros::_FakeDeriveSerde)]
             #[cfg_attr(feature = #outgoing_body_feature, derive(#ruma_macros::OutgoingBodyJson))]
             #extra_attrs

--- a/crates/ruma-macros/src/api/request.rs
+++ b/crates/ruma-macros/src/api/request.rs
@@ -222,7 +222,6 @@ impl RequestQuery {
 
         Some(quote! {
             /// Data in the request's query string.
-            #[cfg(any(feature = "client", feature = "server"))]
             #[derive(Debug, #ruma_macros::_FakeDeriveRumaApi, #ruma_macros::_FakeDeriveSerde)]
             #[cfg_attr(feature = "client", derive(#serde::Serialize))]
             #[cfg_attr(feature = "server", derive(#serde::Deserialize))]


### PR DESCRIPTION
Those crates are not useful if neither of those features is enabled.

This was already the case for ruma-client-api, but the reason why is clarified in the code, and it is propagated to the other API crates.
