### PR TITLE
events: Add MSC4494 invite permission action

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -28,9 +28,12 @@ Improvements:
   dropped.
 - `UserProfile::merge` has been renamed to `UserProfile::apply`.
 - Add experimental support for [MSC4495] (Selective Presence).
+- Add experimental support for [MSC4494] (Membership-based invite blocking).
+
 
 [MSC4438]: https://github.com/matrix-org/matrix-spec-proposals/pull/4438
 [MSC4495]: https://github.com/matrix-org/matrix-spec-proposals/pull/4495
+[MSC4494]: https://github.com/matrix-org/matrix-spec-proposals/pull/4494
 
 ## 0.19.0
 

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -30,7 +30,6 @@ Improvements:
 - Add experimental support for [MSC4495] (Selective Presence).
 - Add experimental support for [MSC4494] (Membership-based invite blocking).
 
-
 [MSC4438]: https://github.com/matrix-org/matrix-spec-proposals/pull/4438
 [MSC4495]: https://github.com/matrix-org/matrix-spec-proposals/pull/4495
 [MSC4494]: https://github.com/matrix-org/matrix-spec-proposals/pull/4494

--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -52,6 +52,7 @@ unstable-msc4406 = []
 unstable-msc4426 = []
 # Selective Presence
 unstable-msc4495 = []
+unstable-msc4494 = []
 
 # Allow IDs to exceed 255 bytes.
 compat-arbitrary-length-ids = ["ruma-identifiers-validation/compat-arbitrary-length-ids"]

--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -50,9 +50,9 @@ unstable-msc4388 = []
 unstable-msc4406 = []
 # User Status Profile Fields.
 unstable-msc4426 = []
+unstable-msc4494 = []
 # Selective Presence
 unstable-msc4495 = []
-unstable-msc4494 = []
 
 # Allow IDs to exceed 255 bytes.
 compat-arbitrary-length-ids = ["ruma-identifiers-validation/compat-arbitrary-length-ids"]

--- a/crates/ruma-common/src/api/metadata.rs
+++ b/crates/ruma-common/src/api/metadata.rs
@@ -812,6 +812,15 @@ pub enum FeatureFlag {
     #[ruma_enum(rename = "org.continuwuity.presence_v2.msc4495")]
     Msc4495,
 
+    /// `uk.timedout.msc4494` ([MSC])
+    ///
+    /// Membership-based invite blocking
+    ///
+    /// [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/4494
+    #[cfg(feature = "unstable-msc4494")]
+    #[ruma_enum(rename = "uk.timedout.msc4494")]
+    Msc4494,
+
     #[doc(hidden)]
     _Custom(PrivOwnedStr),
 }

--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -22,8 +22,10 @@ Improvements:
 - Add the `zeroize(mut self)` method on identifiers, which will call the `zeroize` crate.
 - Add `RoomMessageEventContent::thread` accessor.
 - Add experimental support for [MSC4495] (Selective Presence).
+- Add experimental support for [MSC4494] (Membership-based invite blocking).
 
 [MSC4495]: https://github.com/matrix-org/matrix-spec-proposals/pull/4495
+[MSC4494]: https://github.com/matrix-org/matrix-spec-proposals/pull/4494
 
 Bug fixes:
 

--- a/crates/ruma-events/Cargo.toml
+++ b/crates/ruma-events/Cargo.toml
@@ -59,6 +59,7 @@ unstable-msc4362 = []
 unstable-msc4380 = []
 unstable-msc4385 = []
 unstable-msc4471 = []
+unstable-msc4494 = []
 unstable-msc4495 = []
 unstable-uniffi = ["dep:uniffi"]
 

--- a/crates/ruma-events/src/invite_permission_config.rs
+++ b/crates/ruma-events/src/invite_permission_config.rs
@@ -51,6 +51,10 @@ pub enum InvitePermissionAction {
     /// Reject the invite.
     Block,
 
+    /// Reject the invite if no non-public rooms are shared between the sender and recipient.
+    #[ruma_enum(rename = "uk.timedout.msc4494.deny_public")]
+    DenyPublic,
+
     #[doc(hidden)]
     _Custom(PrivOwnedStr),
 }

--- a/crates/ruma-events/src/invite_permission_config.rs
+++ b/crates/ruma-events/src/invite_permission_config.rs
@@ -52,6 +52,7 @@ pub enum InvitePermissionAction {
     Block,
 
     /// Reject the invite if no non-public rooms are shared between the sender and recipient.
+    #[cfg(feature = "unstable-msc4494")]
     #[ruma_enum(rename = "uk.timedout.msc4494.deny_public")]
     DenyPublic,
 

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -208,7 +208,7 @@ unstable-msc4439 = ["ruma-client-api?/unstable-msc4439"]
 unstable-msc4466 = ["ruma-client-api?/unstable-msc4466"]
 unstable-msc4471 = ["ruma-events?/unstable-msc4471"]
 unstable-msc4480 = ["unstable-msc4354", "ruma-client-api?/unstable-msc4480"]
-unstable-msc4494 = ["ruma-events?/unstable-msc4494"]
+unstable-msc4494 = ["ruma-events?/unstable-msc4494", "ruma-common/unstable-msc4494"]
 unstable-msc4495 = [
     "ruma-common/unstable-msc4495",
     "ruma-federation-api?/unstable-msc4495",

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -208,6 +208,7 @@ unstable-msc4439 = ["ruma-client-api?/unstable-msc4439"]
 unstable-msc4466 = ["ruma-client-api?/unstable-msc4466"]
 unstable-msc4471 = ["ruma-events?/unstable-msc4471"]
 unstable-msc4480 = ["unstable-msc4354", "ruma-client-api?/unstable-msc4480"]
+unstable-msc4494 = ["ruma-events?/unstable-msc4494"]
 unstable-msc4495 = [
     "ruma-common/unstable-msc4495",
     "ruma-federation-api?/unstable-msc4495",


### PR DESCRIPTION
Adds the `deny_public` invite permission action from [MSC4494: Membership-based invite blocking](https://github.com/matrix-org/matrix-spec-proposals/pull/4494) to the InvitePermissionAction enum.
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
