### PR TITLE
Support for MSC1763

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -36,6 +36,9 @@ Improvements:
   being decoded directly. The profile updates now use a `UserProfileUpdate` enum to signal if the
   profile changed or should be dropped.
 - Stabilize support for [MSC2666](https://github.com/matrix-org/matrix-spec-proposals/pull/2666) (Get rooms in common with another user).
+- Add support for [MSC1763] (Configurable per-room message retention periods).
+
+[MSC1763]: https://github.com/matrix-org/matrix-spec-proposals/pull/1763
 
 ## 0.24.0
 

--- a/crates/ruma-client-api/Cargo.toml
+++ b/crates/ruma-client-api/Cargo.toml
@@ -43,6 +43,7 @@ compat-upload-signatures = []
 # to be ignored if they have an invalid format and their deserialization fails.
 unstable-compat-lax-syncv5-deser = ["unstable-msc4186"]
 
+unstable-msc1763 = ["ruma-events/unstable-msc1763"]
 unstable-msc2448 = []
 unstable-msc2654 = []
 unstable-msc3488 = []

--- a/crates/ruma-client-api/src/lib.rs
+++ b/crates/ruma-client-api/src/lib.rs
@@ -43,6 +43,8 @@ pub mod relations;
 #[cfg(any(feature = "unstable-msc4108", feature = "unstable-msc4388"))]
 pub mod rendezvous;
 pub mod reporting;
+#[cfg(feature = "unstable-msc1763")]
+pub mod retention;
 pub mod room;
 #[cfg(feature = "unstable-msc4143")]
 pub mod rtc;

--- a/crates/ruma-client-api/src/retention.rs
+++ b/crates/ruma-client-api/src/retention.rs
@@ -1,0 +1,77 @@
+//! Endpoints for managing message retention periods
+
+use ruma_common::{
+    OwnedRoomId,
+    serde::{DisplayAsRefStr, SerializeAsRefStr},
+};
+use serde::{
+    Deserialize, Deserializer,
+    de::{self, Unexpected},
+};
+
+pub mod get_retention_configuration;
+
+/// Represents one or all rooms of a homeserver.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, DisplayAsRefStr, SerializeAsRefStr)]
+#[allow(clippy::exhaustive_enums)]
+pub enum RoomIdOrAllRooms {
+    /// Represents a specific room ID.
+    RoomId(OwnedRoomId),
+
+    /// Represents all rooms on a homeserver.
+    AllRooms,
+}
+
+impl RoomIdOrAllRooms {
+    /// Get the string representation of [`RoomIdOrAllRooms`].
+    ///
+    /// Returns the string representation of the room ID for the [`RoomIdOrAllRooms::RoomId`]
+    /// variant, or "*" for the [`RoomIdOrAllRooms::AllRooms`] variant.
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::RoomId(room_id) => room_id.as_str(),
+            Self::AllRooms => "*",
+        }
+    }
+}
+
+impl AsRef<str> for RoomIdOrAllRooms {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl From<OwnedRoomId> for RoomIdOrAllRooms {
+    fn from(r: OwnedRoomId) -> Self {
+        RoomIdOrAllRooms::RoomId(r)
+    }
+}
+
+impl TryFrom<&str> for RoomIdOrAllRooms {
+    type Error = &'static str;
+
+    fn try_from(room_id_or_wildcard: &str) -> Result<Self, Self::Error> {
+        if room_id_or_wildcard.is_empty() {
+            Err("The Room identifier cannot be empty")
+        } else if "*" == room_id_or_wildcard {
+            Ok(RoomIdOrAllRooms::AllRooms)
+        } else {
+            Ok(RoomIdOrAllRooms::RoomId(
+                room_id_or_wildcard
+                    .try_into()
+                    .map_err(|_| "The Room identifier needs to be a valid room id or *")?,
+            ))
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for RoomIdOrAllRooms {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = ruma_common::serde::deserialize_cow_str(deserializer)?;
+        RoomIdOrAllRooms::try_from(s.as_ref())
+            .map_err(|_| de::Error::invalid_value(Unexpected::Str(&s), &"a valid room ID or '*'"))
+    }
+}

--- a/crates/ruma-client-api/src/retention.rs
+++ b/crates/ruma-client-api/src/retention.rs
@@ -1,0 +1,78 @@
+//! Endpoints for managing message retention periods
+
+use std::fmt::{Display, Formatter, Result as FmtResult};
+
+use ruma_common::OwnedRoomId;
+use serde::{
+    Deserialize, Deserializer, Serialize, Serializer,
+    de::{self, Unexpected},
+};
+
+pub mod get_retention_configuration;
+
+/// Represents one or all rooms of a homeserver.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[allow(clippy::exhaustive_enums)]
+pub enum RoomIdOrAllRooms {
+    /// Represents a specific room ID.
+    RoomId(OwnedRoomId),
+
+    /// Represents all rooms on a homeserver.
+    AllRooms,
+}
+
+impl Display for RoomIdOrAllRooms {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            RoomIdOrAllRooms::RoomId(room_id) => write!(f, "{room_id}"),
+            RoomIdOrAllRooms::AllRooms => write!(f, "*"),
+        }
+    }
+}
+
+impl From<OwnedRoomId> for RoomIdOrAllRooms {
+    fn from(r: OwnedRoomId) -> Self {
+        RoomIdOrAllRooms::RoomId(r)
+    }
+}
+
+impl TryFrom<&str> for RoomIdOrAllRooms {
+    type Error = &'static str;
+
+    fn try_from(room_id_or_wildcard: &str) -> Result<Self, Self::Error> {
+        if room_id_or_wildcard.is_empty() {
+            Err("The Room identifier cannot be empty")
+        } else if "*" == room_id_or_wildcard {
+            Ok(RoomIdOrAllRooms::AllRooms)
+        } else {
+            Ok(RoomIdOrAllRooms::RoomId(
+                room_id_or_wildcard
+                    .try_into()
+                    .map_err(|_| "The Room identifier needs to be a valid room id or *")?,
+            ))
+        }
+    }
+}
+
+impl Serialize for RoomIdOrAllRooms {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::RoomId(room_id) => room_id.serialize(serializer),
+            Self::AllRooms => serializer.serialize_str("*"),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for RoomIdOrAllRooms {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = ruma_common::serde::deserialize_cow_str(deserializer)?;
+        RoomIdOrAllRooms::try_from(s.as_ref())
+            .map_err(|_| de::Error::invalid_value(Unexpected::Str(&s), &"a valid room ID or '*'"))
+    }
+}

--- a/crates/ruma-client-api/src/retention/get_retention_configuration.rs
+++ b/crates/ruma-client-api/src/retention/get_retention_configuration.rs
@@ -1,0 +1,196 @@
+//! `GET /_matrix/client/*/retention/configuration`
+//!
+//! Get the configuration for the message retention policy.
+
+pub mod unstable {
+    //! `msc1763` ([MSC])
+    //!
+    //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/1763
+
+    use std::{collections::BTreeMap, ops::RangeBounds, time::Duration};
+
+    use js_int::UInt;
+    use ruma_common::{
+        api::{auth_scheme::AccessToken, request, response},
+        metadata,
+    };
+    use ruma_events::room::retention::{RoomRetentionEventContent, is_valid_lifetime_combination};
+    use serde::{Deserialize, Serialize};
+
+    use crate::retention::RoomIdOrAllRooms;
+
+    metadata! {
+        method: GET,
+        rate_limited: false,
+        authentication: AccessToken,
+        history: {
+            unstable => "/_matrix/client/unstable/org.matrix.msc1763/retention/configuration",
+        }
+    }
+
+    /// Request type for the `GET` `retention/configuration` endpoint.
+    #[request]
+    pub struct Request {}
+
+    /// Response type for the `GET` `retention/configuration` endpoint.
+    #[response]
+    pub struct Response {
+        /// Map between a Room ID and their respective room retention policy.
+        pub policies: BTreeMap<RoomIdOrAllRooms, RoomRetentionEventContent>,
+
+        /// Limits to apply to policies defined by m.room.retention state events.
+        pub limits: RetentionLimits,
+    }
+
+    /// Struct describing limits to apply to policies defined by `m.room.retention` state events.
+    #[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]
+    #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+    pub struct RetentionLimits {
+        /// Limits to apply to the maximum lifetime of `m.room.retention` limits.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub max_lifetime: Option<LifetimeLimits>,
+
+        /// Limits to apply to the minimum lifetime of `m.room.retention` limits.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub min_lifetime: Option<LifetimeLimits>,
+    }
+
+    impl RetentionLimits {
+        /// Create a new [`RetentionLimits`] object with the given maximum and minimum limits.
+        pub fn new(
+            min_lifetime: Option<LifetimeLimits>,
+            max_lifetime: Option<LifetimeLimits>,
+        ) -> Self {
+            Self { min_lifetime, max_lifetime }
+        }
+    }
+
+    /// Global limits for the per-room retention policy lifetimes.
+    #[derive(Clone, Copy, Debug, Default, Serialize)]
+    pub struct LifetimeLimits {
+        /// The minimum accepted value for this limit.
+        min: Option<UInt>,
+
+        /// The maximum accepted value for this limit.
+        max: Option<UInt>,
+    }
+
+    impl LifetimeLimits {
+        /// Create a new [`LifetimeLimits`] object with no limits set.
+        ///
+        /// This method can be combined with the [`LifetimeLimits::at_least`] and
+        /// [`LifetimeLimits::at_most`] methods to configure the individual limits.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// # use std::time::Duration;
+        /// # use ruma_client_api::retention::get_retention_configuration::unstable::LifetimeLimits;
+        /// # fn doctest() -> Option<()> {
+        /// let content = LifetimeLimits::new()
+        ///     .at_least(Duration::from_hours(24))?
+        ///     .at_most(Duration::from_hours(24 * 10))?;
+        /// # None
+        /// # }
+        /// ```
+        pub fn new() -> Self {
+            Self::default()
+        }
+
+        /// Create a new [`LifetimeLimits`] object with the given maximum and minimum limits.
+        ///
+        /// This will return `None` if the duration of one of the limits, expressed as
+        /// milliseconds, doesn't fall into the [0, (2^53)-1] range.
+        fn new_impl(min: Option<Duration>, max: Option<Duration>) -> Option<Self> {
+            let max = max.map(|l| UInt::try_from(l.as_millis())).transpose().ok()?;
+            let min = min.map(|l| UInt::try_from(l.as_millis())).transpose().ok()?;
+
+            if is_valid_lifetime_combination(min, max) { Some(Self { min, max }) } else { None }
+        }
+
+        /// Create a new [`LifetimeLimits`] object from a range.
+        ///
+        /// Returns `None` if the duration of one of the limits, expressed as milliseconds, doesn't
+        /// fall into the [0, (2^53)-1] range, or if the lower bound of the range is bigger than the
+        /// upper bound, i.e. `10..0`.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// # use std::time::Duration;
+        /// # use ruma_client_api::retention::get_retention_configuration::unstable::LifetimeLimits;
+        /// # fn doctest() -> Option<()> {
+        /// let content =
+        ///     LifetimeLimits::from_range(Duration::from_hours(24)..Duration::from_hours(24 * 10))?;
+        /// # None
+        /// # }
+        /// ```
+        pub fn from_range(lifetime_range: impl RangeBounds<Duration>) -> Option<Self> {
+            let min_lifetime = match lifetime_range.start_bound() {
+                std::ops::Bound::Included(v) => Some(*v),
+                std::ops::Bound::Excluded(v) => Some(v.saturating_add(Duration::from_millis(1))),
+                std::ops::Bound::Unbounded => None,
+            };
+
+            let max_lifetime = match lifetime_range.end_bound() {
+                std::ops::Bound::Included(v) => Some(*v),
+                std::ops::Bound::Excluded(v) => Some(v.saturating_sub(Duration::from_millis(1))),
+                std::ops::Bound::Unbounded => None,
+            };
+
+            Self::new_impl(min_lifetime, max_lifetime)
+        }
+
+        /// Sets the maximum value that a retention policy limit is allowed to have.
+        ///
+        /// Returns `None` if the given limit, expressed as milliseconds, doesn't fall into the [0,
+        /// (2^53)-1] range, or if the limits don't adhere to the `max` < `min` constraint.
+        pub fn at_most(self, max: Duration) -> Option<Self> {
+            let min = self.min();
+            Self::new_impl(min, Some(max))
+        }
+
+        /// Sets the minimum value that a retention policy limit is allowed to have.
+        ///
+        /// Returns `None` if the given limit, expressed as milliseconds, doesn't fall into the [0,
+        /// (2^53)-1] range, or if the limits don't adhere to the `max` < `min` constraint.
+        pub fn at_least(self, min: Duration) -> Option<Self> {
+            let max = self.max();
+            Self::new_impl(Some(min), max)
+        }
+
+        /// Get the minimum accepted value of this limit.
+        pub fn min(&self) -> Option<Duration> {
+            self.min.map(|l| Duration::from_millis(l.into()))
+        }
+
+        /// Get the maximum accepted value of this limit.
+        pub fn max(&self) -> Option<Duration> {
+            self.max.map(|l| Duration::from_millis(l.into()))
+        }
+    }
+
+    impl<'de> Deserialize<'de> for LifetimeLimits {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            #[derive(Deserialize)]
+            struct Helper {
+                min: Option<UInt>,
+                max: Option<UInt>,
+            }
+
+            let Helper { min, max } = Helper::deserialize(deserializer)?;
+
+            if is_valid_lifetime_combination(min, max) {
+                Ok(Self { min, max })
+            } else {
+                Err(serde::de::Error::custom(
+                "Invalid lifetime limits, the max limit must always be higher or equal to the min limit."
+                    .to_owned(),
+            ))
+            }
+        }
+    }
+}

--- a/crates/ruma-client-api/src/retention/get_retention_configuration.rs
+++ b/crates/ruma-client-api/src/retention/get_retention_configuration.rs
@@ -1,0 +1,93 @@
+//! `GET /_matrix/client/*/retention/configuration`
+//!
+//! Get the configuration for the message retention policy.
+
+pub mod unstable {
+    //! `msc1763` ([MSC])
+    //!
+    //! [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/1763
+
+    use std::{collections::BTreeMap, time::Duration};
+
+    use js_int::UInt;
+    use ruma_common::{
+        api::{auth_scheme::AccessToken, request, response},
+        metadata,
+    };
+    use ruma_events::room::retention::RoomRetentionEventContent;
+    use serde::Deserialize;
+
+    use crate::retention::RoomIdOrAllRooms;
+
+    metadata! {
+        method: GET,
+        rate_limited: false,
+        authentication: AccessToken,
+        history: {
+            unstable => "/_matrix/client/unstable/org.matrix.msc1763/retention/configuration",
+        }
+    }
+
+    /// Request type for the `GET` `retention/configuration` endpoint.
+    #[request]
+    pub struct Request {}
+
+    /// Response type for the `GET` `retention/configuration` endpoint.
+    #[response]
+    pub struct Response {
+        /// Map between a Room ID and their respective room retention policy.
+        pub policies: BTreeMap<RoomIdOrAllRooms, RoomRetentionEventContent>,
+        /// Map between a Room ID and their respective room retention policy.
+        pub limits: BTreeMap<RoomIdOrAllRooms, RoomRetentionEventContent>,
+    }
+
+    /// Limits to apply to policies defined by `m.room.retention` state events.
+    #[derive(Debug, Deserialize)]
+    #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+    pub struct RetentionLimits {
+        /// Limits to apply to the maximum lifetime of `m.room.retention` limits.
+        pub max_lifetime: Option<LifetimeLimits>,
+        /// Limits to apply to the minimum lifetime of `m.room.retention` limits.
+        pub min_lifetime: Option<LifetimeLimits>,
+    }
+
+    impl RetentionLimits {
+        /// Create a new [`RetentionLimits`] object with the given maximum and minimum limits.
+        pub fn new(
+            min_lifetime: Option<LifetimeLimits>,
+            max_lifetime: Option<LifetimeLimits>,
+        ) -> Self {
+            Self { min_lifetime, max_lifetime }
+        }
+    }
+
+    /// Global limits for the per-room retention policy lifetimes.
+    #[derive(Debug, Deserialize)]
+    pub struct LifetimeLimits {
+        min: Option<UInt>,
+        max: Option<UInt>,
+    }
+
+    impl LifetimeLimits {
+        /// Create a new [`LifetimeLimits`] object with the given maximum and minimum limits.
+        ///
+        /// This will return `None` if the duration of one of the limites, expressed as
+        /// miliseconnds, doesn't fall into the [0, (2^53)-1] range.
+        pub fn new(min: Option<Duration>, max: Option<Duration>) -> Option<Self> {
+            let max = max.map(|l| UInt::try_from(l.as_millis())).transpose().ok()?;
+            let min = min.map(|l| UInt::try_from(l.as_millis())).transpose().ok()?;
+
+            Some(Self { min, max })
+        }
+
+        /// Get the minimum accepted value of this limit.
+        pub fn min(&self) -> Option<Duration> {
+            self.min.map(|l| Duration::from_millis(l.into()))
+        }
+
+        /// Get the maximum accepted value of this limit.
+        pub fn max(&self) -> Option<Duration> {
+            self.max.map(|l| Duration::from_millis(l.into()))
+        }
+    }
+}

--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -23,7 +23,9 @@ Improvements:
 - Add `RoomMessageEventContent::thread` accessor.
 - Add experimental support for [MSC4495] (Selective Presence).
 - Add experimental support for [MSC4494] (Membership-based invite blocking).
+- Add support for [MSC1763] (Configurable per-room message retention periods).
 
+[MSC1763]: https://github.com/matrix-org/matrix-spec-proposals/pull/1763
 [MSC4495]: https://github.com/matrix-org/matrix-spec-proposals/pull/4495
 [MSC4494]: https://github.com/matrix-org/matrix-spec-proposals/pull/4494
 

--- a/crates/ruma-events/Cargo.toml
+++ b/crates/ruma-events/Cargo.toml
@@ -17,6 +17,7 @@ all-features = true
 html = ["dep:ruma-html"]
 markdown = ["dep:pulldown-cmark"]
 
+unstable-msc1763 = []
 unstable-msc1767 = []
 unstable-msc2448 = []
 unstable-msc2747 = []

--- a/crates/ruma-events/src/enums.rs
+++ b/crates/ruma-events/src/enums.rs
@@ -203,6 +203,9 @@ event_enum! {
         "m.room.pinned_events" => super::room::pinned_events,
         "m.room.policy" => super::room::policy,
         "m.room.power_levels" => super::room::power_levels,
+        #[cfg(feature = "unstable-msc1763")]
+        #[ruma_enum(alias = "m.room.retention")]
+        "org.matrix.msc1763.retention" => super::room::retention,
         "m.room.server_acl" => super::room::server_acl,
         "m.room.third_party_invite" => super::room::third_party_invite,
         "m.room.tombstone" => super::room::tombstone,

--- a/crates/ruma-events/src/room.rs
+++ b/crates/ruma-events/src/room.rs
@@ -45,6 +45,8 @@ pub mod power_levels;
 #[cfg(feature = "unstable-msc4495")]
 pub mod presence_sharing;
 pub mod redaction;
+#[cfg(feature = "unstable-msc1763")]
+pub mod retention;
 pub mod server_acl;
 pub mod third_party_invite;
 mod thumbnail_source_serde;

--- a/crates/ruma-events/src/room/retention.rs
+++ b/crates/ruma-events/src/room/retention.rs
@@ -1,0 +1,183 @@
+//! Types for the `m.room.retention` state event.
+//!
+//! This event uses the unstable prefix defined in [MSC1763].
+//!
+//! [MSC1763]: https://github.com/matrix-org/matrix-spec-proposals/pull/1763
+
+use std::time::Duration;
+
+use js_int::UInt;
+use ruma_macros::EventContent;
+use serde::{Deserialize, Serialize};
+
+use crate::EmptyStateKey;
+
+/// The content of an `m.room.retention` state event.
+///
+/// The `m.room.retention` state event lets room admins or moderators set or modify the history
+/// retention behaviour for a given room.
+///
+/// This event uses the unstable prefix defined in [MSC1763].
+///
+/// [MSC1763]: https://github.com/matrix-org/matrix-spec-proposals/pull/1763
+#[derive(Clone, Debug, Serialize, EventContent)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+#[ruma_event(type = "org.matrix.msc1763.retention", kind = State, state_key_type = EmptyStateKey)]
+pub struct RoomRetentionEventContent {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_lifetime: Option<UInt>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    min_lifetime: Option<UInt>,
+}
+
+impl RoomRetentionEventContent {
+    /// Create a new [`RoomRetentionEventContent`] with the given maximum and minimum limits.
+    ///
+    /// This will return `None` if the duration of one of the limites, expressed as miliseconnds,
+    /// doesn't fall into the [0, (2^53)-1] range, or if `max_lifetime` < `min_lifetime`.
+    pub fn new(min_lifetime: Option<Duration>, max_lifetime: Option<Duration>) -> Option<Self> {
+        // The lifetimes are defined as a duration in milliseconds represented as an integer in the
+        // range [0, (2^53)-1], this range is the same as what our UInt type enforces.
+
+        // First convert the duration into milliseconds, then then attempt to convert the number of
+        // milliseconds into an UInt.
+        let max_lifetime = max_lifetime.map(|l| UInt::try_from(l.as_millis())).transpose().ok()?;
+        let min_lifetime = min_lifetime.map(|l| UInt::try_from(l.as_millis())).transpose().ok()?;
+
+        if is_valid_lifetime_combination(max_lifetime, min_lifetime) {
+            Some(Self { max_lifetime, min_lifetime })
+        } else {
+            None
+        }
+    }
+
+    /// Get the maximum event lifetime defined by this state event, if any.
+    pub fn max_lifetime(&self) -> Option<Duration> {
+        self.max_lifetime.map(|l| Duration::from_millis(l.into()))
+    }
+
+    /// Get the minimum event lifetime defined by this state event, if any.
+    pub fn min_lifetime(&self) -> Option<Duration> {
+        self.max_lifetime.map(|l| Duration::from_millis(l.into()))
+    }
+}
+
+/// Validate a lifetime retention lifetime pair.
+///
+/// Returns false if both lifetimes are defined and the max lifetime is smaller than the min
+/// lifetime.
+fn is_valid_lifetime_combination(max_lifetime: Option<UInt>, min_lifetime: Option<UInt>) -> bool {
+    match (max_lifetime, min_lifetime) {
+        (Some(max), Some(min)) if max < min => false,
+        (Some(_), Some(_)) | (None, None) | (None, Some(_)) | (Some(_), None) => true,
+    }
+}
+
+impl<'de> Deserialize<'de> for RoomRetentionEventContent {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Helper {
+            max_lifetime: Option<UInt>,
+            min_lifetime: Option<UInt>,
+        }
+
+        let Helper { max_lifetime, min_lifetime } = Helper::deserialize(deserializer)?;
+
+        if is_valid_lifetime_combination(max_lifetime, min_lifetime) {
+            Ok(Self { max_lifetime, min_lifetime })
+        } else {
+            Err(serde::de::Error::custom(
+                "Invalid lifetimes, max_lifetime must always be higher or equal to min_lifetime."
+                    .to_owned(),
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use js_int::uint;
+    use ruma_common::canonical_json::assert_to_canonical_json_eq;
+    use serde_json::{Value as JsonValue, from_value as from_json_value, json};
+
+    use super::*;
+    use crate::OriginalStateEvent;
+
+    fn raw_json(
+        min_lifetime: impl Into<Option<UInt>>,
+        max_lifetime: impl Into<Option<UInt>>,
+    ) -> JsonValue {
+        json!({
+            "content": {
+                "max_lifetime": max_lifetime.into(),
+                "min_lifetime": min_lifetime.into(),
+            },
+            "event_id": "$h29iv0s8:example.com",
+            "origin_server_ts": 1,
+            "room_id": "!n8f893n9:example.com",
+            "sender": "@carl:example.com",
+            "state_key": "",
+            "type": "org.matrix.msc1763.retention"
+        })
+    }
+
+    #[test]
+    fn deserialization() {
+        let json_data = raw_json(None, None);
+        let RoomRetentionEventContent { max_lifetime, min_lifetime, .. } =
+            from_json_value::<OriginalStateEvent<RoomRetentionEventContent>>(json_data)
+                .expect("No lifetimes should deserliaze")
+                .content;
+
+        assert_eq!(max_lifetime, None);
+        assert_eq!(min_lifetime, None);
+
+        let json_data = raw_json(uint!(10), None);
+        let RoomRetentionEventContent { max_lifetime, min_lifetime, .. } =
+            from_json_value::<OriginalStateEvent<RoomRetentionEventContent>>(json_data)
+                .expect("A max lifetime and no min lifetime should deserialize")
+                .content;
+
+        assert_eq!(min_lifetime, Some(uint!(10)));
+        assert_eq!(max_lifetime, None);
+
+        let json_data = raw_json(uint!(10), uint!(10));
+        let RoomRetentionEventContent { max_lifetime, min_lifetime, .. } =
+            from_json_value::<OriginalStateEvent<RoomRetentionEventContent>>(json_data)
+                .expect("Setting both lifetimes, should still deserialize")
+                .content;
+
+        assert_eq!(min_lifetime, Some(uint!(10)));
+        assert_eq!(max_lifetime, Some(uint!(10)));
+
+        let json_data = raw_json(uint!(20), uint!(10));
+        from_json_value::<OriginalStateEvent<RoomRetentionEventContent>>(json_data).expect_err(
+            "If the max lifetime is smaller than the min lifetime, we should fail to deserialize",
+        );
+    }
+
+    #[test]
+    fn serialization() {
+        assert!(
+            RoomRetentionEventContent::new(
+                Some(Duration::from_millis(10)),
+                Some(Duration::from_millis(0))
+            )
+            .is_none(),
+            "Giving a max lifetime that's smaller than the min lifetime should give you a None"
+        );
+
+        let content =
+            RoomRetentionEventContent::new(Some(Duration::from_millis(10)), None).unwrap();
+
+        assert_to_canonical_json_eq!(
+            content,
+            json!({
+                "min_lifetime": uint!(10),
+            }),
+        );
+    }
+}

--- a/crates/ruma-events/src/room/retention.rs
+++ b/crates/ruma-events/src/room/retention.rs
@@ -1,0 +1,280 @@
+//! Types for the `m.room.retention` state event.
+//!
+//! This event uses the unstable prefix defined in [MSC1763].
+//!
+//! [MSC1763]: https://github.com/matrix-org/matrix-spec-proposals/pull/1763
+
+use std::{ops::RangeBounds, time::Duration};
+
+use js_int::UInt;
+use ruma_macros::EventContent;
+use serde::{Deserialize, Serialize};
+
+use crate::{EmptyStateKey, PossiblyRedactedStateEventContent, StateEventType};
+
+/// The content of an `m.room.retention` state event.
+///
+/// The `m.room.retention` state event lets room admins or moderators set or modify the history
+/// retention behaviour for a given room.
+///
+/// This event uses the unstable prefix defined in [MSC1763].
+///
+/// [MSC1763]: https://github.com/matrix-org/matrix-spec-proposals/pull/1763
+#[derive(Clone, Debug, Default, Serialize, EventContent)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+#[ruma_event(type = "org.matrix.msc1763.retention", kind = State, state_key_type = EmptyStateKey, custom_possibly_redacted)]
+pub struct RoomRetentionEventContent {
+    /// The minimum amount of time messages should be kept on the homeserver.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    min_lifetime: Option<UInt>,
+
+    /// The maximum amount of time messages should be kept on the homeserver.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_lifetime: Option<UInt>,
+}
+
+impl RoomRetentionEventContent {
+    /// Create a new [`RoomRetentionEventContent`] with no retention limits set.
+    ///
+    /// This method can be combined with the [`RoomRetentionEventContent::at_least`] and
+    /// [`RoomRetentionEventContent::at_most`] methods to configure the individual limits.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::time::Duration;
+    /// # use ruma_events::room::retention::RoomRetentionEventContent;
+    /// # fn doctest() -> Option<()> {
+    /// let content = RoomRetentionEventContent::new()
+    ///     .at_least(Duration::from_hours(24))?
+    ///     .at_most(Duration::from_hours(24 * 10))?;
+    /// # None
+    /// # }
+    /// ```
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create a new [`RoomRetentionEventContent`] with the given maximum and minimum limits.
+    ///
+    /// This will return `None` if the duration of one of the limits, expressed as milliseconds,
+    /// doesn't fall into the [0, (2^53)-1] range, or if `max_lifetime` < `min_lifetime`.
+    fn new_impl(min_lifetime: Option<Duration>, max_lifetime: Option<Duration>) -> Option<Self> {
+        // The lifetimes are defined as a duration in milliseconds represented as an integer in the
+        // range [0, (2^53)-1], this range is the same as what our UInt type enforces.
+
+        // First convert the duration into milliseconds, then attempt to convert the number of
+        // milliseconds into an UInt.
+        let max_lifetime = max_lifetime.map(|l| UInt::try_from(l.as_millis())).transpose().ok()?;
+        let min_lifetime = min_lifetime.map(|l| UInt::try_from(l.as_millis())).transpose().ok()?;
+
+        if is_valid_lifetime_combination(min_lifetime, max_lifetime) {
+            Some(Self { max_lifetime, min_lifetime })
+        } else {
+            None
+        }
+    }
+
+    /// Create a new [`RoomRetentionEventContent`] from a range.
+    ///
+    /// Returns `None` if the duration of one of the limits, expressed as milliseconds, doesn't
+    /// fall into the [0, (2^53)-1] range, or if the lower bound of the range is bigger than the
+    /// upper bound, i.e. `10..0`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use std::time::Duration;
+    /// # use ruma_events::room::retention::RoomRetentionEventContent;
+    /// # fn doctest() -> Option<()> {
+    /// let content = RoomRetentionEventContent::from_range(
+    ///     Duration::from_hours(24)..Duration::from_hours(24 * 10),
+    /// )?;
+    /// # None
+    /// # }
+    /// ```
+    pub fn from_range(lifetime_range: impl RangeBounds<Duration>) -> Option<Self> {
+        let min_lifetime = match lifetime_range.start_bound() {
+            std::ops::Bound::Included(v) => Some(*v),
+            std::ops::Bound::Excluded(v) => Some(v.saturating_add(Duration::from_millis(1))),
+            std::ops::Bound::Unbounded => None,
+        };
+
+        let max_lifetime = match lifetime_range.end_bound() {
+            std::ops::Bound::Included(v) => Some(*v),
+            std::ops::Bound::Excluded(v) => Some(v.saturating_sub(Duration::from_millis(1))),
+            std::ops::Bound::Unbounded => None,
+        };
+
+        Self::new_impl(min_lifetime, max_lifetime)
+    }
+
+    /// Set the maximum amount of time a message should be kept on the homeserver.
+    ///
+    /// Returns `None` if the given limit, expressed as milliseconds, doesn't fall into the [0,
+    /// (2^53)-1] range, or if the limits don't adhere to the `max` < `min` constraint.
+    pub fn at_most(self, max: Duration) -> Option<Self> {
+        let min = self.min_lifetime();
+        Self::new_impl(min, Some(max))
+    }
+
+    /// Set the minimum amount of time a message should be kept on the homeserver.
+    ///
+    /// Returns `None` if the given limit, expressed as milliseconds, doesn't fall into the [0,
+    /// (2^53)-1] range, or if the limits don't adhere to the `max` < `min` constraint.
+    pub fn at_least(self, min: Duration) -> Option<Self> {
+        let max = self.max_lifetime();
+        Self::new_impl(Some(min), max)
+    }
+
+    /// Get the maximum event lifetime defined by this state event, if any.
+    pub fn max_lifetime(&self) -> Option<Duration> {
+        self.max_lifetime.map(|l| Duration::from_millis(l.into()))
+    }
+
+    /// Get the minimum event lifetime defined by this state event, if any.
+    pub fn min_lifetime(&self) -> Option<Duration> {
+        self.min_lifetime.map(|l| Duration::from_millis(l.into()))
+    }
+}
+
+/// Validate a retention lifetime pair.
+///
+/// Returns false if both lifetimes are defined and the max lifetime is smaller than the min
+/// lifetime.
+pub fn is_valid_lifetime_combination(
+    min_lifetime: Option<UInt>,
+    max_lifetime: Option<UInt>,
+) -> bool {
+    match (min_lifetime, max_lifetime) {
+        (Some(min), Some(max)) if max < min => false,
+        (Some(_), Some(_)) | (None, None) | (None, Some(_)) | (Some(_), None) => true,
+    }
+}
+
+impl<'de> Deserialize<'de> for RoomRetentionEventContent {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Helper {
+            max_lifetime: Option<UInt>,
+            min_lifetime: Option<UInt>,
+        }
+
+        let Helper { max_lifetime, min_lifetime } = Helper::deserialize(deserializer)?;
+
+        if is_valid_lifetime_combination(min_lifetime, max_lifetime) {
+            Ok(Self { max_lifetime, min_lifetime })
+        } else {
+            Err(serde::de::Error::custom(
+                "Invalid lifetimes, max_lifetime must always be higher or equal to min_lifetime."
+                    .to_owned(),
+            ))
+        }
+    }
+}
+
+/// The PossiblyRedacted version of [`RoomRetentionEventContent`].
+///
+/// Since the event has only optional fields it's already compatible with the redacted version of
+/// the state event content.
+pub type PossiblyRedactedRoomRetentionEventContent = RoomRetentionEventContent;
+
+impl PossiblyRedactedStateEventContent for PossiblyRedactedRoomRetentionEventContent {
+    type StateKey = EmptyStateKey;
+
+    fn event_type(&self) -> StateEventType {
+        StateEventType::RoomRetention
+    }
+}
+
+impl From<RedactedRoomRetentionEventContent> for PossiblyRedactedRoomRetentionEventContent {
+    fn from(_value: RedactedRoomRetentionEventContent) -> Self {
+        Self { min_lifetime: None, max_lifetime: None }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use js_int::uint;
+    use ruma_common::canonical_json::assert_to_canonical_json_eq;
+    use serde_json::{Value as JsonValue, from_value as from_json_value, json};
+
+    use super::*;
+    use crate::OriginalStateEvent;
+
+    fn raw_json(
+        min_lifetime: impl Into<Option<UInt>>,
+        max_lifetime: impl Into<Option<UInt>>,
+    ) -> JsonValue {
+        json!({
+            "content": {
+                "max_lifetime": max_lifetime.into(),
+                "min_lifetime": min_lifetime.into(),
+            },
+            "event_id": "$h29iv0s8:example.com",
+            "origin_server_ts": 1,
+            "room_id": "!n8f893n9:example.com",
+            "sender": "@carl:example.com",
+            "state_key": "",
+            "type": "org.matrix.msc1763.retention"
+        })
+    }
+
+    #[test]
+    fn deserialization() {
+        let json_data = raw_json(None, None);
+        let RoomRetentionEventContent { max_lifetime, min_lifetime, .. } =
+            from_json_value::<OriginalStateEvent<RoomRetentionEventContent>>(json_data)
+                .expect("No lifetimes should deserliaze")
+                .content;
+
+        assert_eq!(max_lifetime, None);
+        assert_eq!(min_lifetime, None);
+
+        let json_data = raw_json(uint!(10), None);
+        let RoomRetentionEventContent { max_lifetime, min_lifetime, .. } =
+            from_json_value::<OriginalStateEvent<RoomRetentionEventContent>>(json_data)
+                .expect("A min lifetime and no max lifetime should deserialize")
+                .content;
+
+        assert_eq!(min_lifetime, Some(uint!(10)));
+        assert_eq!(max_lifetime, None);
+
+        let json_data = raw_json(uint!(10), uint!(10));
+        let RoomRetentionEventContent { max_lifetime, min_lifetime, .. } =
+            from_json_value::<OriginalStateEvent<RoomRetentionEventContent>>(json_data)
+                .expect("Setting both lifetimes, should still deserialize")
+                .content;
+
+        assert_eq!(min_lifetime, Some(uint!(10)));
+        assert_eq!(max_lifetime, Some(uint!(10)));
+
+        let json_data = raw_json(uint!(20), uint!(10));
+        from_json_value::<OriginalStateEvent<RoomRetentionEventContent>>(json_data).expect_err(
+            "If the max lifetime is smaller than the min lifetime, we should fail to deserialize",
+        );
+    }
+
+    #[test]
+    fn serialization() {
+        assert!(
+            RoomRetentionEventContent::from_range(
+                Duration::from_millis(10)..Duration::from_millis(0)
+            )
+            .is_none(),
+            "Giving a max lifetime that's smaller than the min lifetime should give you a None"
+        );
+
+        let content = RoomRetentionEventContent::new().at_least(Duration::from_millis(10)).unwrap();
+
+        assert_to_canonical_json_eq!(
+            content,
+            json!({
+                "min_lifetime": uint!(10),
+            }),
+        );
+    }
+}

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -135,7 +135,7 @@ unstable-extensible-events = [
     "unstable-msc3954",
     "unstable-msc3955",
 ]
-unstable-msc1763 = ["ruma-events?/unstable-msc1763"]
+unstable-msc1763 = ["ruma-client-api/unstable-msc1763", "ruma-events?/unstable-msc1763"]
 unstable-msc1767 = ["ruma-events?/unstable-msc1767"]
 unstable-msc2448 = ["ruma-client-api?/unstable-msc2448", "ruma-events?/unstable-msc2448"]
 unstable-msc2654 = ["ruma-client-api?/unstable-msc2654"]

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -135,7 +135,7 @@ unstable-extensible-events = [
     "unstable-msc3954",
     "unstable-msc3955",
 ]
-unstable-msc1763 = ["ruma-events?/unstable-msc1763"]
+unstable-msc1763 = ["ruma-client-api?/unstable-msc1763", "ruma-events?/unstable-msc1763"]
 unstable-msc1767 = ["ruma-events?/unstable-msc1767"]
 unstable-msc2448 = ["ruma-client-api?/unstable-msc2448", "ruma-events?/unstable-msc2448"]
 unstable-msc2654 = ["ruma-client-api?/unstable-msc2654"]

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -135,6 +135,7 @@ unstable-extensible-events = [
     "unstable-msc3954",
     "unstable-msc3955",
 ]
+unstable-msc1763 = ["ruma-events?/unstable-msc1763"]
 unstable-msc1767 = ["ruma-events?/unstable-msc1767"]
 unstable-msc2448 = ["ruma-client-api?/unstable-msc2448", "ruma-events?/unstable-msc2448"]
 unstable-msc2654 = ["ruma-client-api?/unstable-msc2654"]


### PR DESCRIPTION
This PR adds support for [MSC1763](https://github.com/matrix-org/matrix-spec-proposals/pull/1763).

The `RoomIdOrAllRooms` type is mostly a copy of the `DeviceIdOrAllDevices` type, not sure if we want to make a generic, common, type that's shared between those two.

The limits also mention various relationships the different settings have. I have only modeled the relationship the event content has (max must be bigger than the min limit). The other relationships are server-side configuration and a bit harder to enforce, i.e. we would need to go through the `policies` map and check that the values are withing the ranges defined in the `limits` fields.