### PR TITLE
feat: Allow sending delayed sticky events (combining MSC4354 with MSC4140)

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -30,6 +30,10 @@ Improvements:
   the `unstable-msc4354` feature flag. Adds a `sticky_duration_ms` query parameter to `send_message_event`
   and `send_state_event` as well as sync v3 support. Add sync extension v5 behind the `unstable-msc4480`
   feature flag as per [MSC4480](https://github.com/matrix-org/matrix-spec-proposals/pull/4480).
+- Allow combining MSC4354 sticky events with
+  [MSC4140](https://github.com/matrix-org/matrix-spec-proposals/pull/4140) delayed events.
+  `send_delayed_event::unstable::Request` gains a `sticky_duration_ms` field.
+  Requires both `unstable-msc4140` and `unstable-msc4354`.
 - The `Profiles` sliding sync extension request no longer contains an `include_history` field as
   this was removed from the MSC.
 - The `Profiles` sliding sync extension response data is wrapped in a `users` field instead of

--- a/crates/ruma-client-api/src/delayed_events/send_delayed_event.rs
+++ b/crates/ruma-client-api/src/delayed_events/send_delayed_event.rs
@@ -15,6 +15,8 @@ pub mod unstable {
         metadata,
         serde::Raw,
     };
+    #[cfg(feature = "unstable-msc4354")]
+    use ruma_events::sticky::StickyDurationMs;
     use ruma_events::{AnyTimelineEventContent, TimelineEventType};
 
     metadata! {
@@ -53,6 +55,20 @@ pub mod unstable {
         #[serde(with = "ruma_common::serde::duration::ms")]
         pub delay: Duration,
 
+        /// The duration to stick the delayed event.
+        ///
+        /// Caller must first check that the server supports sticky events (via `/versions`),
+        /// or it will be no-op.
+        ///
+        /// See [MSC4354 sticky events](https://github.com/matrix-org/matrix-spec-proposals/pull/4354).
+        #[cfg(feature = "unstable-msc4354")]
+        #[ruma_api(query)]
+        #[serde(
+            skip_serializing_if = "Option::is_none",
+            rename = "org.matrix.msc4354.sticky_duration_ms"
+        )]
+        pub sticky_duration_ms: Option<StickyDurationMs>,
+
         /// The State Key if the event is a state event, nothing otherwise
         #[serde(skip_serializing_if = "Option::is_none")]
         pub state_key: Option<String>,
@@ -90,6 +106,8 @@ pub mod unstable {
                 event_type: content.event_type(),
                 state_key,
                 delay,
+                #[cfg(feature = "unstable-msc4354")]
+                sticky_duration_ms: None,
                 content: Raw::new(content)?,
             })
         }
@@ -104,7 +122,16 @@ pub mod unstable {
             state_key: Option<String>,
             content: Raw<AnyTimelineEventContent>,
         ) -> serde_json::Result<Self> {
-            Ok(Self { room_id, txn_id, event_type, state_key, delay, content })
+            Ok(Self {
+                room_id,
+                txn_id,
+                event_type,
+                state_key,
+                delay,
+                #[cfg(feature = "unstable-msc4354")]
+                sticky_duration_ms: None,
+                content,
+            })
         }
     }
 
@@ -168,6 +195,45 @@ pub mod unstable {
                 serde_json::from_str::<JsonValue>(std::str::from_utf8(&body).unwrap()).unwrap()
             );
         }
+
+        #[cfg(feature = "unstable-msc4354")]
+        #[test]
+        fn serialize_send_delayed_sticky_event_request() {
+            use ruma_events::sticky::StickyDurationMs;
+
+            let supported = SupportedVersions {
+                versions: [MatrixVersion::V1_1].into(),
+                features: Default::default(),
+            };
+
+            let mut req = Request::new(
+                owned_room_id!("!roomid:example.org"),
+                "1234".into(),
+                Duration::from_millis(30_000),
+                None,
+                &AnyMessageLikeEventContent::from(RoomMessageEventContent::text_plain("test"))
+                    .into(),
+            )
+            .unwrap();
+            req.sticky_duration_ms = Some(StickyDurationMs::new_clamped(300_000_u32));
+
+            let request: http::Request<Vec<u8>> = req
+                .try_into_http_request(
+                    "https://homeserver.tld",
+                    SendAccessToken::IfRequired("auth_tok"),
+                    Cow::Owned(supported),
+                )
+                .unwrap();
+            let (parts, body) = request.into_parts();
+            assert_eq!(
+                "https://homeserver.tld/_matrix/client/unstable/org.matrix.msc4140/rooms/!roomid:example.org/delayed_event/m.room.message/1234?org.matrix.msc4354.sticky_duration_ms=300000",
+                parts.uri.to_string()
+            );
+            assert_eq!(
+                json!({"content":{"msgtype":"m.text","body":"test"}, "delay": 30000}),
+                serde_json::from_str::<JsonValue>(std::str::from_utf8(&body).unwrap()).unwrap()
+            );
+        }
     }
 
     #[cfg(all(test, feature = "server"))]
@@ -208,6 +274,31 @@ pub mod unstable {
                 serde_json::from_str::<serde_json::Value>(req.content.json().get()).unwrap(),
                 json!({"msgtype":"m.text","body":"test"}),
             );
+        }
+
+        /// Without the query parameter the delayed event is scheduled as a regular, non-sticky
+        /// event.
+        #[cfg(feature = "unstable-msc4354")]
+        #[test]
+        fn deserialize_send_delayed_event_request_without_sticky() {
+            let uri = http::Uri::builder()
+                .scheme("https")
+                .authority("matrix.org")
+                .path_and_query(
+                    "/_matrix/client/unstable/org.matrix.msc4140/rooms/!roomid:example.org/delayed_event/m.room.message/5678",
+                )
+                .build()
+                .unwrap();
+
+            let body = json!({"content":{"msgtype":"m.text","body":"test"}, "delay": 103});
+
+            let req = Request::try_from_http_request(
+                http::Request::builder().method("PUT").uri(uri).body(body.to_string()).unwrap(),
+                &["!roomid:example.org", "m.room.message", "5678"],
+            )
+            .unwrap();
+
+            assert_eq!(req.sticky_duration_ms, None);
         }
     }
 }


### PR DESCRIPTION
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->

As per the sticky event MSC it should be possible to combine delay and sticky events.
