### PR TITLE
signatures: Upgrade Rust Crypto crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,6 +212,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,7 +276,7 @@ checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core 0.10.1",
+ "rand_core",
 ]
 
 [[package]]
@@ -384,9 +393,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.6"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const_panic"
@@ -518,15 +527,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "curve25519-dalek"
-version = "4.1.3"
+name = "crypto-common"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.11.3",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -552,9 +570,9 @@ checksum = "0c03c416ed1a30fbb027ef484ba6ab6f80e1eada675e1a2b92fd673c045a1f1d"
 
 [[package]]
 name = "der"
-version = "0.7.10"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -572,8 +590,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -595,9 +624,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "ed25519"
-version = "2.2.3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
 dependencies = [
  "pkcs8",
  "signature",
@@ -605,14 +634,15 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
  "sha2",
+ "signature",
  "subtle",
  "zeroize",
 ]
@@ -682,9 +712,9 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.9"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "find-msvc-tools"
@@ -817,7 +847,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi",
- "rand_core 0.10.1",
+ "rand_core",
  "wasm-bindgen",
 ]
 
@@ -971,6 +1001,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1554,9 +1593,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkcs8"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
 dependencies = [
  "der",
  "spki",
@@ -1747,16 +1786,7 @@ checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.3",
- "rand_core 0.10.1",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
+ "rand_core",
 ]
 
 [[package]]
@@ -1771,7 +1801,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
- "rand_core 0.10.1",
+ "rand_core",
 ]
 
 [[package]]
@@ -2384,18 +2414,18 @@ checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
- "digest",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2415,12 +2445,9 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signature"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "rand_core 0.6.4",
-]
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 
 [[package]]
 name = "simd_cesu8"
@@ -2487,9 +2514,9 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
 dependencies = [
  "base64ct",
  "der",

--- a/crates/ruma-signatures/CHANGELOG.md
+++ b/crates/ruma-signatures/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+Breaking changes:
+
+- Upgrade `ed25519-dalek` and `pkcs8` crates
+  - `Ed25519KeyPair::from_pkcs8_(oak/pki)()` take a `PrivateKeyInfoRef`.
+
 Improvements:
 
 - Add `verify_policy_server_signature()` as a helper method to check the signature of the policy

--- a/crates/ruma-signatures/Cargo.toml
+++ b/crates/ruma-signatures/Cargo.toml
@@ -19,14 +19,14 @@ ring-compat = ["dep:memchr"]
 
 [dependencies]
 base64 = { workspace = true }
-ed25519-dalek = { version = "2.0.0", features = ["pkcs8"] }
+ed25519-dalek = { version = "3.0.0", features = ["alloc", "pkcs8"] }
 memchr = { version = "2.4", optional = true }
-pkcs8 = { version = "0.10.0", features = ["alloc"] }
+pkcs8 = { version = "0.11.0", features = ["alloc"] }
 rand = { workspace = true, features = ["sys_rng"] }
 ruma-common = { workspace = true }
 ruma-events = { workspace = true }
 serde_json = { workspace = true }
-sha2 = "0.10.6"
+sha2 = "0.11.0"
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/crates/ruma-signatures/src/ed25519.rs
+++ b/crates/ruma-signatures/src/ed25519.rs
@@ -8,7 +8,8 @@ use ed25519_dalek::{
     pkcs8::ALGORITHM_OID,
 };
 use pkcs8::{
-    DecodePrivateKey, EncodePrivateKey, ObjectIdentifier, PrivateKeyInfo, der::zeroize::Zeroizing,
+    DecodePrivateKey, EncodePrivateKey, ObjectIdentifier, PrivateKeyInfoRef,
+    der::zeroize::Zeroizing,
 };
 use rand::TryCryptoRng;
 use ruma_common::{SigningKeyAlgorithm, SigningKeyId};
@@ -98,20 +99,25 @@ impl Ed25519KeyPair {
         Ok(Self { signing_key, version })
     }
 
-    /// Constructs a key pair from [`pkcs8::PrivateKeyInfo`].
+    /// Constructs a key pair from [`pkcs8::PrivateKeyInfoRef`].
     pub fn from_pkcs8_oak(
-        oak: PrivateKeyInfo<'_>,
+        oak: PrivateKeyInfoRef<'_>,
         version: String,
     ) -> Result<Self, Ed25519KeyPairParseError> {
-        Self::new(oak.algorithm.oid, oak.private_key, oak.public_key, version)
+        Self::new(
+            oak.algorithm.oid,
+            oak.private_key.as_ref(),
+            oak.public_key.and_then(|key| key.as_bytes()),
+            version,
+        )
     }
 
-    /// Constructs a key pair from [`pkcs8::PrivateKeyInfo`].
+    /// Constructs a key pair from [`pkcs8::PrivateKeyInfoRef`].
     pub fn from_pkcs8_pki(
-        oak: PrivateKeyInfo<'_>,
+        oak: PrivateKeyInfoRef<'_>,
         version: String,
     ) -> Result<Self, Ed25519KeyPairParseError> {
-        Self::new(oak.algorithm.oid, oak.private_key, None, version)
+        Self::new(oak.algorithm.oid, oak.private_key.as_ref(), None, version)
     }
 
     /// PKCS#8's "private key" is not yet actually the entire key,

--- a/crates/ruma-signatures/src/lib.rs
+++ b/crates/ruma-signatures/src/lib.rs
@@ -85,7 +85,7 @@ mod verify;
 mod tests {
     use std::collections::BTreeMap;
 
-    use pkcs8::{PrivateKeyInfo, der::Decode};
+    use pkcs8::{PrivateKeyInfoRef, der::Decode};
     use ruma_common::{
         room_version_rules::{RedactionRules, RoomVersionRules},
         serde::{Base64, base64::Standard},
@@ -108,7 +108,14 @@ mod tests {
 
     /// Convenience method for getting the public key as a string
     fn public_key_string() -> Base64 {
-        Base64::new(PrivateKeyInfo::from_der(&pkcs8()).unwrap().public_key.unwrap().to_owned())
+        Base64::new(
+            PrivateKeyInfoRef::from_der(&pkcs8())
+                .unwrap()
+                .public_key
+                .unwrap()
+                .raw_bytes()
+                .to_owned(),
+        )
     }
 
     /// Convenience for converting a string of JSON into its canonical form.


### PR DESCRIPTION
We can finally get rid of the old `rand_core` dependency. Sadly we have duplicate dependencies in `Cargo.lock` because of the outdated `sha1` crate used by the `headers` crate, a dependency of ruma-federation-api.