### PR TITLE
signatures: Merge `Ed25519KeyPair::from_pkcs8_(oak/pki)()`

### DIFF
--- a/crates/ruma-signatures/CHANGELOG.md
+++ b/crates/ruma-signatures/CHANGELOG.md
@@ -5,7 +5,10 @@
 Breaking changes:
 
 - Upgrade `ed25519-dalek` and `pkcs8` crates
-  - `Ed25519KeyPair::from_pkcs8_(oak/pki)()` take a `PrivateKeyInfoRef`.
+  - `Ed25519KeyPair::from_pkcs8()` takes a `PrivateKeyInfoRef`.
+- `Ed25519KeyPair::from_pkcs8_oak()` was renamed to `Ed25519KeyPair::from_pkcs8()`.
+- `Ed25519KeyPair::from_pkcs8_pki()` was removed. `Ed25519KeyPair::from_pkcs8()` can be used
+  instead.
 
 Improvements:
 

--- a/crates/ruma-signatures/src/ed25519.rs
+++ b/crates/ruma-signatures/src/ed25519.rs
@@ -100,7 +100,7 @@ impl Ed25519KeyPair {
     }
 
     /// Constructs a key pair from [`pkcs8::PrivateKeyInfoRef`].
-    pub fn from_pkcs8_oak(
+    pub fn from_pkcs8(
         oak: PrivateKeyInfoRef<'_>,
         version: String,
     ) -> Result<Self, Ed25519KeyPairParseError> {
@@ -110,14 +110,6 @@ impl Ed25519KeyPair {
             oak.public_key.and_then(|key| key.as_bytes()),
             version,
         )
-    }
-
-    /// Constructs a key pair from [`pkcs8::PrivateKeyInfoRef`].
-    pub fn from_pkcs8_pki(
-        oak: PrivateKeyInfoRef<'_>,
-        version: String,
-    ) -> Result<Self, Ed25519KeyPairParseError> {
-        Self::new(oak.algorithm.oid, oak.private_key.as_ref(), None, version)
     }
 
     /// PKCS#8's "private key" is not yet actually the entire key,


### PR DESCRIPTION
They are remnants from a time when `pkcs8` had different types for the different versions of PKCS#8. Both versions have been using the same type for a while so it's confusing to have 2 methods with the same signature and docs, but with a slightly different behavior.

Whether the `PrivateKeyInfoRef` contains a public key or not is for its parsing code to handle.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
