### PR TITLE
api: Restructure `OutgoingResponse`

### DIFF
--- a/crates/ruma-client-api/src/delayed_events/get_all_delayed_events.rs
+++ b/crates/ruma-client-api/src/delayed_events/get_all_delayed_events.rs
@@ -63,8 +63,8 @@ pub mod unstable {
 
         use js_int::UInt;
         use ruma_common::{
-            MilliSecondsSinceUnixEpoch, api::OutgoingResponse, owned_event_id, owned_room_id,
-            serde::Raw,
+            MilliSecondsSinceUnixEpoch, api::OutgoingResponseExt as _, owned_event_id,
+            owned_room_id, serde::Raw,
         };
         use ruma_events::TimelineEventType;
         use serde_json::{Value as JsonValue, json};

--- a/crates/ruma-client-api/src/delayed_events/get_delayed_event.rs
+++ b/crates/ruma-client-api/src/delayed_events/get_delayed_event.rs
@@ -67,8 +67,8 @@ pub mod unstable {
 
         use js_int::UInt;
         use ruma_common::{
-            MilliSecondsSinceUnixEpoch, api::OutgoingResponse, owned_event_id, owned_room_id,
-            serde::Raw,
+            MilliSecondsSinceUnixEpoch, api::OutgoingResponseExt as _, owned_event_id,
+            owned_room_id, serde::Raw,
         };
         use ruma_events::TimelineEventType;
         use serde_json::{Value as JsonValue, json};

--- a/crates/ruma-client-api/src/directory/get_public_rooms.rs
+++ b/crates/ruma-client-api/src/directory/get_public_rooms.rs
@@ -126,7 +126,7 @@ pub mod v3 {
         #[cfg(feature = "server")]
         #[test]
         fn construct_response_from_refs() {
-            use ruma_common::api::OutgoingResponse as _;
+            use ruma_common::api::OutgoingResponseExt as _;
 
             let res = super::Response {
                 chunk: vec![],

--- a/crates/ruma-client-api/src/filter/get_filter.rs
+++ b/crates/ruma-client-api/src/filter/get_filter.rs
@@ -76,7 +76,7 @@ pub mod v3 {
         #[cfg(feature = "server")]
         #[test]
         fn serialize_response() {
-            use ruma_common::api::OutgoingResponse;
+            use ruma_common::api::OutgoingResponseExt as _;
 
             use crate::filter::FilterDefinition;
 

--- a/crates/ruma-client-api/src/profile/get_profile.rs
+++ b/crates/ruma-client-api/src/profile/get_profile.rs
@@ -145,7 +145,9 @@ mod tests {
     #[test]
     #[cfg(feature = "server")]
     fn serialize_response() {
-        use ruma_common::{api::OutgoingResponse, owned_mxc_uri, profile::ProfileFieldValue};
+        use ruma_common::{
+            api::OutgoingResponseExt as _, owned_mxc_uri, profile::ProfileFieldValue,
+        };
         use serde_json::{Value as JsonValue, from_slice as from_json_slice};
 
         let response = [

--- a/crates/ruma-client-api/src/profile/get_profile_field.rs
+++ b/crates/ruma-client-api/src/profile/get_profile_field.rs
@@ -182,6 +182,42 @@ pub mod v3 {
         }
     }
 
+    #[doc(hidden)]
+    #[derive(ruma_common::serde::_FakeDeriveSerde)]
+    #[cfg_attr(feature = "server", derive(ruma_common::api::OutgoingBodyJson))]
+    #[serde(transparent)]
+    pub struct ResponseBody(Option<ProfileFieldValue>);
+
+    #[cfg(feature = "server")]
+    impl serde::Serialize for ResponseBody {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            use ruma_common::serde::JsonObject;
+
+            if let Some(value) = &self.0 {
+                value.serialize(serializer)
+            } else {
+                JsonObject::new().serialize(serializer)
+            }
+        }
+    }
+
+    #[cfg(feature = "client")]
+    impl<'de> serde::Deserialize<'de> for ResponseBody {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            use ruma_common::profile::ProfileFieldValueVisitor;
+
+            let value = deserializer.deserialize_map(ProfileFieldValueVisitor::new(None))?;
+
+            Ok(Self(value))
+        }
+    }
+
     #[cfg(feature = "client")]
     impl ruma_common::api::IncomingResponse for Response {
         type EndpointError = Error;
@@ -189,36 +225,22 @@ pub mod v3 {
         fn try_from_http_response_inner(
             response: http::Response<&[u8]>,
         ) -> Result<Self, ruma_common::api::error::DeserializationError> {
-            use ruma_common::profile::ProfileFieldValueVisitor;
-            use serde::Deserializer;
-
-            let mut de = serde_json::Deserializer::from_slice(response.body());
-            let value = de.deserialize_map(ProfileFieldValueVisitor::new(None))?;
-            de.end()?;
-
+            let ResponseBody(value) = serde_json::from_slice(response.body())?;
             Ok(Self { value })
         }
     }
 
     #[cfg(feature = "server")]
     impl ruma_common::api::OutgoingResponse for Response {
-        fn try_into_http_response<T: Default + bytes::BufMut>(
+        type Body = ResponseBody;
+
+        fn try_into_http_response_inner(
             self,
-        ) -> Result<http::Response<T>, ruma_common::api::error::IntoHttpError> {
-            use ruma_common::serde::JsonObject;
-
-            let body = self
-                .value
-                .as_ref()
-                .map(|value| ruma_common::serde::json_to_buf(value))
-                .unwrap_or_else(||
-                   // Send an empty object.
-                    ruma_common::serde::json_to_buf(&JsonObject::new()))?;
-
+        ) -> Result<http::Response<Self::Body>, ruma_common::api::error::IntoHttpError> {
             Ok(http::Response::builder()
                 .status(http::StatusCode::OK)
                 .header(http::header::CONTENT_TYPE, ruma_common::http_headers::APPLICATION_JSON)
-                .body(body)?)
+                .body(ResponseBody(self.value))?)
         }
     }
 
@@ -439,7 +461,7 @@ mod tests_server {
 
     #[test]
     fn serialize_response() {
-        use ruma_common::api::OutgoingResponse;
+        use ruma_common::api::OutgoingResponseExt;
 
         let response =
             Response::new(ProfileFieldValue::AvatarUrl(owned_mxc_uri!("mxc://localhost/abcdef")));

--- a/crates/ruma-client-api/src/rendezvous/create_rendezvous_session.rs
+++ b/crates/ruma-client-api/src/rendezvous/create_rendezvous_session.rs
@@ -18,7 +18,6 @@ pub mod unstable_msc4108 {
         },
         metadata,
     };
-    use serde::{Deserialize, Serialize};
     use url::Url;
     use web_time::SystemTime;
 
@@ -135,8 +134,11 @@ pub mod unstable_msc4108 {
         pub last_modified: SystemTime,
     }
 
-    #[derive(Serialize, Deserialize)]
-    struct ResponseBody {
+    #[doc(hidden)]
+    #[derive(ruma_common::serde::_FakeDeriveSerde)]
+    #[cfg_attr(feature = "server", derive(serde::Serialize, ruma_common::api::OutgoingBodyJson))]
+    #[cfg_attr(feature = "client", derive(serde::Deserialize))]
+    pub struct ResponseBody {
         url: Url,
     }
 
@@ -175,14 +177,15 @@ pub mod unstable_msc4108 {
 
     #[cfg(feature = "server")]
     impl ruma_common::api::OutgoingResponse for Response {
-        fn try_into_http_response<T: Default + bytes::BufMut>(
+        type Body = ResponseBody;
+
+        fn try_into_http_response_inner(
             self,
-        ) -> Result<http::Response<T>, ruma_common::api::error::IntoHttpError> {
+        ) -> Result<http::Response<Self::Body>, ruma_common::api::error::IntoHttpError> {
             use http::header::{CACHE_CONTROL, PRAGMA};
             use ruma_common::http_headers::system_time_to_http_date;
 
             let body = ResponseBody { url: self.url };
-            let body = ruma_common::serde::json_to_buf(&body)?;
 
             let expires = system_time_to_http_date(&self.expires)?;
             let last_modified = system_time_to_http_date(&self.last_modified)?;

--- a/crates/ruma-client-api/src/room/get_summary.rs
+++ b/crates/ruma-client-api/src/room/get_summary.rs
@@ -75,24 +75,50 @@ pub mod v1 {
         }
     }
 
-    #[cfg(feature = "server")]
-    impl ruma_common::api::OutgoingResponse for Response {
-        fn try_into_http_response<T: Default + bytes::BufMut>(
-            self,
-        ) -> Result<http::Response<T>, ruma_common::api::error::IntoHttpError> {
-            #[derive(serde::Serialize)]
-            struct ResponseSerHelper {
-                #[serde(flatten)]
-                summary: RoomSummary,
-                #[serde(skip_serializing_if = "Option::is_none")]
+    #[doc(hidden)]
+    #[derive(ruma_common::serde::_FakeDeriveSerde)]
+    #[cfg_attr(feature = "server", derive(serde::Serialize, ruma_common::api::OutgoingBodyJson))]
+    pub struct ResponseBody {
+        #[serde(flatten)]
+        summary: RoomSummary,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        membership: Option<MembershipState>,
+    }
+
+    #[cfg(feature = "client")]
+    impl<'de> serde::Deserialize<'de> for ResponseBody {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            use ruma_common::serde::from_raw_json_value;
+            use serde_json::value::RawValue as RawJsonValue;
+
+            #[derive(serde::Deserialize)]
+            struct ResponseBodyDeHelper {
                 membership: Option<MembershipState>,
             }
 
-            let body = ResponseSerHelper { summary: self.summary, membership: self.membership };
+            let json = Box::<RawJsonValue>::deserialize(deserializer)?;
+            let summary = from_raw_json_value(&json)?;
+            let membership = from_raw_json_value::<ResponseBodyDeHelper, _>(&json)?.membership;
+
+            Ok(Self { membership, summary })
+        }
+    }
+
+    #[cfg(feature = "server")]
+    impl ruma_common::api::OutgoingResponse for Response {
+        type Body = ResponseBody;
+
+        fn try_into_http_response_inner(
+            self,
+        ) -> Result<http::Response<Self::Body>, ruma_common::api::error::IntoHttpError> {
+            let Self { summary, membership } = self;
 
             http::Response::builder()
                 .header(http::header::CONTENT_TYPE, ruma_common::http_headers::APPLICATION_JSON)
-                .body(ruma_common::serde::json_to_buf(&body)?)
+                .body(ResponseBody { summary, membership })
                 .map_err(Into::into)
         }
     }
@@ -104,19 +130,7 @@ pub mod v1 {
         fn try_from_http_response_inner(
             response: http::Response<&[u8]>,
         ) -> Result<Self, ruma_common::api::error::DeserializationError> {
-            use ruma_common::serde::from_raw_json_value;
-
-            #[derive(serde::Deserialize)]
-            struct ResponseDeHelper {
-                membership: Option<MembershipState>,
-            }
-
-            let raw_json =
-                serde_json::from_slice::<Box<serde_json::value::RawValue>>(response.body())?;
-            let summary = from_raw_json_value::<RoomSummary, serde_json::Error>(&raw_json)?;
-            let membership =
-                from_raw_json_value::<ResponseDeHelper, serde_json::Error>(&raw_json)?.membership;
-
+            let ResponseBody { summary, membership } = serde_json::from_slice(response.body())?;
             Ok(Self { summary, membership })
         }
     }

--- a/crates/ruma-client-api/src/search/search_events.rs
+++ b/crates/ruma-client-api/src/search/search_events.rs
@@ -605,8 +605,8 @@ mod tests {
     use js_int::uint;
     use ruma_common::{
         api::{
-            IncomingRequest, IncomingResponseExt as _, OutgoingRequestExt as _, OutgoingResponse,
-            SupportedVersions, auth_scheme::SendAccessToken,
+            IncomingRequest, IncomingResponseExt as _, OutgoingRequestExt as _,
+            OutgoingResponseExt as _, SupportedVersions, auth_scheme::SendAccessToken,
         },
         event_id, room_id,
     };

--- a/crates/ruma-client-api/src/session/login_fallback.rs
+++ b/crates/ruma-client-api/src/session/login_fallback.rs
@@ -61,13 +61,15 @@ impl Response {
 
 #[cfg(feature = "server")]
 impl ruma_common::api::OutgoingResponse for Response {
-    fn try_into_http_response<T: Default + bytes::BufMut>(
+    type Body = ruma_common::api::BytesBody;
+
+    fn try_into_http_response_inner(
         self,
-    ) -> Result<http::Response<T>, ruma_common::api::error::IntoHttpError> {
+    ) -> Result<http::Response<Self::Body>, ruma_common::api::error::IntoHttpError> {
         Ok(http::Response::builder()
             .status(http::StatusCode::OK)
             .header(http::header::CONTENT_TYPE, "text/html")
-            .body(ruma_common::serde::slice_to_buf(&self.body))?)
+            .body(ruma_common::api::BytesBody(self.body))?)
     }
 }
 

--- a/crates/ruma-client-api/src/sync/sync_events/v3.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v3.rs
@@ -1130,7 +1130,7 @@ mod server_tests {
 
     use assert_matches2::assert_matches;
     use ruma_common::{
-        api::{IncomingRequest as _, OutgoingResponse as _},
+        api::{IncomingRequest as _, OutgoingResponseExt as _},
         owned_room_id,
         presence::PresenceState,
         serde::Raw,

--- a/crates/ruma-client-api/src/tag/get_tags.rs
+++ b/crates/ruma-client-api/src/tag/get_tags.rs
@@ -60,7 +60,7 @@ pub mod v3 {
     #[cfg(all(test, feature = "server"))]
     mod server_tests {
         use assign::assign;
-        use ruma_common::api::OutgoingResponse;
+        use ruma_common::api::OutgoingResponseExt as _;
         use ruma_events::tag::{TagInfo, Tags};
         use serde_json::json;
 

--- a/crates/ruma-client-api/src/uiaa.rs
+++ b/crates/ruma-client-api/src/uiaa.rs
@@ -7,8 +7,8 @@ use std::{borrow::Cow, fmt, marker::PhantomData};
 use bytes::BufMut;
 use ruma_common::{
     api::{
-        EndpointError, OutgoingResponse,
-        error::{Error as MatrixError, IntoHttpError, StandardErrorBody},
+        EndpointError, OutgoingBody, OutgoingBodyJson, OutgoingResponse,
+        error::{Error as MatrixError, ErrorResponseBody, IntoHttpError, StandardErrorBody},
     },
     serde::StringEnum,
 };
@@ -75,7 +75,7 @@ pub enum AuthType {
 
 /// Information about available authentication flows and status for User-Interactive Authenticiation
 /// API.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, OutgoingBodyJson)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
 pub struct UiaaInfo {
     /// List of authentication flows available for this endpoint.
@@ -228,17 +228,37 @@ impl EndpointError for UiaaResponse {
 impl std::error::Error for UiaaResponse {}
 
 impl OutgoingResponse for UiaaResponse {
-    fn try_into_http_response<T: Default + BufMut>(
-        self,
-    ) -> Result<http::Response<T>, IntoHttpError> {
-        match self {
+    type Body = ResponseBody;
+
+    fn try_into_http_response_inner(self) -> Result<http::Response<Self::Body>, IntoHttpError> {
+        Ok(match self {
             UiaaResponse::AuthResponse(authentication_info) => http::Response::builder()
                 .header(http::header::CONTENT_TYPE, ruma_common::http_headers::APPLICATION_JSON)
                 .status(http::StatusCode::UNAUTHORIZED)
-                .body(ruma_common::serde::json_to_buf(&authentication_info)?)
-                .map_err(Into::into),
-            UiaaResponse::MatrixError(error) => error.try_into_http_response(),
-        }
+                .body(ResponseBody::AuthResponse(authentication_info))?,
+            UiaaResponse::MatrixError(error) => {
+                let (parts, body) = error.try_into_http_response_inner()?.into_parts();
+                http::Response::from_parts(parts, ResponseBody::MatrixError(body))
+            }
+        })
+    }
+}
+
+#[doc(hidden)]
+#[allow(clippy::exhaustive_enums)]
+pub enum ResponseBody {
+    AuthResponse(UiaaInfo),
+    MatrixError(ErrorResponseBody),
+}
+
+impl OutgoingBody for ResponseBody {
+    type Error = IntoHttpError;
+
+    fn try_into_buf<T: Default + BufMut + AsRef<[u8]>>(self) -> Result<T, Self::Error> {
+        Ok(match self {
+            Self::AuthResponse(uiaa_info) => uiaa_info.try_into_buf()?,
+            Self::MatrixError(error_response_body) => error_response_body.try_into_buf()?,
+        })
     }
 }
 

--- a/crates/ruma-client-api/src/uiaa/get_uiaa_fallback_page.rs
+++ b/crates/ruma-client-api/src/uiaa/get_uiaa_fallback_page.rs
@@ -82,20 +82,43 @@ pub mod v3 {
         }
     }
 
+    #[doc(hidden)]
+    #[allow(clippy::exhaustive_enums)]
+    pub enum ResponseBody {
+        Redirect,
+        Html(HtmlPage),
+    }
+
+    #[cfg(feature = "server")]
+    impl ruma_common::api::OutgoingBody for ResponseBody {
+        type Error = ruma_common::api::error::IntoHttpError;
+
+        fn try_into_buf<T: Default + bytes::BufMut + AsRef<[u8]>>(self) -> Result<T, Self::Error> {
+            let body = match self {
+                Self::Redirect => Vec::new(),
+                Self::Html(HtmlPage { body }) => body,
+            };
+
+            Ok(ruma_common::api::BytesBody(body).try_into_buf()?)
+        }
+    }
+
     #[cfg(feature = "server")]
     impl ruma_common::api::OutgoingResponse for Response {
-        fn try_into_http_response<T: Default + bytes::BufMut>(
+        type Body = ResponseBody;
+
+        fn try_into_http_response_inner(
             self,
-        ) -> Result<http::Response<T>, ruma_common::api::error::IntoHttpError> {
+        ) -> Result<http::Response<Self::Body>, ruma_common::api::error::IntoHttpError> {
             match self {
                 Response::Redirect(Redirect { url }) => Ok(http::Response::builder()
                     .status(http::StatusCode::FOUND)
                     .header(http::header::LOCATION, url)
-                    .body(T::default())?),
-                Response::Html(HtmlPage { body }) => Ok(http::Response::builder()
+                    .body(ResponseBody::Redirect)?),
+                Response::Html(html) => Ok(http::Response::builder()
                     .status(http::StatusCode::OK)
                     .header(http::header::CONTENT_TYPE, "text/html; charset=utf-8")
-                    .body(ruma_common::serde::slice_to_buf(&body))?),
+                    .body(ResponseBody::Html(html))?),
             }
         }
     }
@@ -168,7 +191,7 @@ pub mod v3 {
     #[cfg(all(test, feature = "server"))]
     mod tests_server {
         use http::header::{CONTENT_TYPE, LOCATION};
-        use ruma_common::api::OutgoingResponse;
+        use ruma_common::api::OutgoingResponseExt as _;
 
         use super::Response;
 

--- a/crates/ruma-client-api/tests/it/uiaa.rs
+++ b/crates/ruma-client-api/tests/it/uiaa.rs
@@ -4,7 +4,7 @@ use ruma_client_api::uiaa::{
     self, AuthData, AuthFlow, AuthType, UiaaInfo, UiaaResponse, UserIdentifier,
 };
 use ruma_common::{
-    api::{EndpointError, OutgoingResponse, error::ErrorKind},
+    api::{EndpointError, OutgoingResponseExt as _, error::ErrorKind},
     canonical_json::assert_to_canonical_json_eq,
 };
 use serde_json::{

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -8,6 +8,10 @@ Breaking changes:
   that is automatically implemented for any `T: OutgoingRequest`
   - Implementors of `OutgoingRequest` now instead have to provide the new `type Body`
     and `fn try_into_http_request_inner`
+- `OutgoingResponse::try_into_http_response` has been moved to a new `OutgoingResponseExt` trait
+  that is automatically implemented for any `T: OutgoingResponse`
+  - Implementors of `OutgoingResponse` now instead have to provide the new `type Body`
+    and `fn try_into_http_response_inner`
 
 Bug fixes:
 

--- a/crates/ruma-common/src/api.rs
+++ b/crates/ruma-common/src/api.rs
@@ -444,15 +444,32 @@ pub trait IncomingRequest: Metadata {
 }
 
 /// A request type for a Matrix API endpoint, used for sending responses.
-pub trait OutgoingResponse {
+pub trait OutgoingResponse: Sized {
+    /// HTTP body type pre-serialization.
+    type Body: OutgoingBody;
+
     /// Tries to convert this response into an `http::Response`.
     ///
-    /// This method should only fail when when invalid header values are specified. It may also
-    /// fail with a serialization error in case of bugs in Ruma though.
-    fn try_into_http_response<T: Default + BufMut>(
-        self,
-    ) -> Result<http::Response<T>, IntoHttpError>;
+    /// This method should only fail when invalid header values are specified. It may also fail with
+    /// a serialization error in case of bugs in Ruma though.
+    fn try_into_http_response_inner(self) -> Result<http::Response<Self::Body>, IntoHttpError>;
 }
+
+/// A request type for a Matrix API endpoint, used for sending responses.
+pub trait OutgoingResponseExt: OutgoingResponse {
+    /// Tries to convert this response into an `http::Response`.
+    ///
+    /// This method should only fail when invalid header values are specified. It may also fail with
+    /// a serialization error in case of bugs in Ruma though.
+    fn try_into_http_response<T: Default + BufMut + AsRef<[u8]>>(
+        self,
+    ) -> Result<http::Response<T>, IntoHttpError> {
+        let (parts, body) = self.try_into_http_response_inner()?.into_parts();
+        Ok(http::Response::from_parts(parts, body.try_into_buf().map_err(Into::into)?))
+    }
+}
+
+impl<T: OutgoingResponse> OutgoingResponseExt for T {}
 
 /// Gives users the ability to define their own serializable / deserializable errors.
 pub trait EndpointError: OutgoingResponse + StdError + Sized + Send + 'static {

--- a/crates/ruma-common/src/api/error.rs
+++ b/crates/ruma-common/src/api/error.rs
@@ -5,7 +5,8 @@
 use std::{error::Error as StdError, fmt, num::ParseIntError, sync::Arc};
 
 use as_variant::as_variant;
-use bytes::{BufMut, Bytes};
+use bytes::Bytes;
+use ruma_macros::OutgoingBodyJson;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value as JsonValue, from_slice as from_json_slice};
 use thiserror::Error;
@@ -74,9 +75,9 @@ impl fmt::Display for Error {
 impl StdError for Error {}
 
 impl OutgoingResponse for Error {
-    fn try_into_http_response<T: Default + BufMut>(
-        self,
-    ) -> Result<http::Response<T>, IntoHttpError> {
+    type Body = ErrorResponseBody;
+
+    fn try_into_http_response_inner(self) -> Result<http::Response<Self::Body>, IntoHttpError> {
         let mut builder = http::Response::builder()
             .header(http::header::CONTENT_TYPE, ruma_common::http_headers::APPLICATION_JSON)
             .status(self.status_code);
@@ -90,19 +91,7 @@ impl OutgoingResponse for Error {
             builder = builder.header(http::header::RETRY_AFTER, header_value);
         }
 
-        builder
-            .body(match self.body {
-                ErrorBody::Standard(standard_body) => {
-                    ruma_common::serde::json_to_buf(&standard_body)?
-                }
-                ErrorBody::Json(json) => ruma_common::serde::json_to_buf(&json)?,
-                ErrorBody::NotJson { .. } => {
-                    return Err(IntoHttpError::Json(serde::ser::Error::custom(
-                        "attempted to serialize ErrorBody::NotJson",
-                    )));
-                }
-            })
-            .map_err(Into::into)
+        builder.body(ErrorResponseBody(self.body)).map_err(Into::into)
     }
 }
 
@@ -188,6 +177,29 @@ impl StandardErrorBody {
     /// Construct a new `StandardErrorBody` with the given kind and message.
     pub fn new(kind: ErrorKind, message: String) -> Self {
         Self { kind, message }
+    }
+}
+
+/// Helper type for the serialization of an [`ErrorBody`] as an HTTP response body.
+///
+/// This is a wrapper around `ErrorBody` that cannot implement `Serialize` and `Deserialize` because
+/// part of its serialization might occur in the HTTP headers.
+#[doc(hidden)]
+#[derive(OutgoingBodyJson)]
+pub struct ErrorResponseBody(ErrorBody);
+
+impl Serialize for ErrorResponseBody {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match &self.0 {
+            ErrorBody::Standard(standard_body) => standard_body.serialize(serializer),
+            ErrorBody::Json(json) => json.serialize(serializer),
+            ErrorBody::NotJson { .. } => {
+                Err(serde::ser::Error::custom("attempted to serialize ErrorBody::NotJson"))
+            }
+        }
     }
 }
 

--- a/crates/ruma-common/src/api/error/tests.rs
+++ b/crates/ruma-common/src/api/error/tests.rs
@@ -1,5 +1,5 @@
 use assert_matches2::assert_let;
-use ruma_common::api::{EndpointError, OutgoingResponse};
+use ruma_common::api::{EndpointError, OutgoingResponseExt as _};
 use serde_json::{
     Value as JsonValue, from_slice as from_json_slice, from_value as from_json_value, json,
 };

--- a/crates/ruma-common/tests/it/api/default_status.rs
+++ b/crates/ruma-common/tests/it/api/default_status.rs
@@ -3,7 +3,7 @@
 
 use http::StatusCode;
 use ruma_common::{
-    api::{OutgoingResponse as _, auth_scheme::NoAuthentication, request, response},
+    api::{OutgoingResponseExt as _, auth_scheme::NoAuthentication, request, response},
     metadata,
 };
 

--- a/crates/ruma-common/tests/it/api/header_override.rs
+++ b/crates/ruma-common/tests/it/api/header_override.rs
@@ -5,7 +5,7 @@ use std::borrow::Cow;
 use http::header::{CONTENT_TYPE, Entry, LOCATION};
 use ruma_common::{
     api::{
-        MatrixVersion, OutgoingRequestExt as _, OutgoingResponse as _, SupportedVersions,
+        MatrixVersion, OutgoingRequestExt as _, OutgoingResponseExt as _, SupportedVersions,
         auth_scheme::NoAuthentication, request, response,
     },
     metadata,

--- a/crates/ruma-common/tests/it/api/manual_endpoint_impl.rs
+++ b/crates/ruma-common/tests/it/api/manual_endpoint_impl.rs
@@ -10,8 +10,8 @@ use http::{header::CONTENT_TYPE, method::Method};
 use ruma_common::{
     OwnedRoomAliasId, OwnedRoomId,
     api::{
-        IncomingRequest, IncomingResponse, MatrixVersion, Metadata, OutgoingBody, OutgoingRequest,
-        OutgoingResponse, SupportedVersions,
+        EmptyBody, IncomingRequest, IncomingResponse, MatrixVersion, Metadata, OutgoingBody,
+        OutgoingRequest, OutgoingResponse, SupportedVersions,
         auth_scheme::NoAuthentication,
         error::{DeserializationError, Error, FromHttpRequestError, IntoHttpError},
         path_builder::{StablePathSelector, VersionHistory},
@@ -139,12 +139,12 @@ impl IncomingResponse for Response {
 }
 
 impl OutgoingResponse for Response {
-    fn try_into_http_response<T: Default + BufMut>(
-        self,
-    ) -> Result<http::Response<T>, IntoHttpError> {
+    type Body = EmptyBody<false>;
+
+    fn try_into_http_response_inner(self) -> Result<http::Response<Self::Body>, IntoHttpError> {
         let response = http::Response::builder()
             .header(CONTENT_TYPE, ruma_common::http_headers::APPLICATION_JSON)
-            .body(ruma_common::serde::slice_to_buf(b"{}"))
+            .body(EmptyBody)
             .unwrap();
 
         Ok(response)

--- a/crates/ruma-common/tests/it/api/no_fields.rs
+++ b/crates/ruma-common/tests/it/api/no_fields.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use ruma_common::api::{
-    MatrixVersion, OutgoingRequestExt as _, OutgoingResponse as _, SupportedVersions,
+    MatrixVersion, OutgoingRequestExt as _, OutgoingResponseExt as _, SupportedVersions,
 };
 
 mod get {

--- a/crates/ruma-common/tests/it/api/optional_headers.rs
+++ b/crates/ruma-common/tests/it/api/optional_headers.rs
@@ -5,7 +5,8 @@ use http::header::{CONTENT_DISPOSITION, LOCATION};
 use ruma_common::{
     api::{
         IncomingRequest, IncomingResponseExt as _, MatrixVersion, OutgoingRequestExt as _,
-        OutgoingResponse, SupportedVersions, auth_scheme::NoAuthentication, request, response,
+        OutgoingResponseExt as _, SupportedVersions, auth_scheme::NoAuthentication, request,
+        response,
     },
     http_headers::{ContentDisposition, ContentDispositionType},
     metadata,

--- a/crates/ruma-common/tests/it/api/required_headers.rs
+++ b/crates/ruma-common/tests/it/api/required_headers.rs
@@ -5,7 +5,7 @@ use http::header::{CONTENT_DISPOSITION, LOCATION};
 use ruma_common::{
     api::{
         IncomingRequest, IncomingResponseExt as _, MatrixVersion, OutgoingRequestExt as _,
-        OutgoingResponse, SupportedVersions,
+        OutgoingResponseExt as _, SupportedVersions,
         auth_scheme::NoAuthentication,
         error::{
             DeserializationError, FromHttpRequestError, FromHttpResponseError,

--- a/crates/ruma-common/tests/it/api/status_override.rs
+++ b/crates/ruma-common/tests/it/api/status_override.rs
@@ -6,7 +6,7 @@ use http::{
     header::{Entry, LOCATION},
 };
 use ruma_common::{
-    api::{OutgoingResponse as _, auth_scheme::NoAuthentication, request, response},
+    api::{OutgoingResponseExt as _, auth_scheme::NoAuthentication, request, response},
     metadata,
 };
 

--- a/crates/ruma-common/tests/it/api/ui/request-only.rs
+++ b/crates/ruma-common/tests/it/api/ui/request-only.rs
@@ -1,9 +1,8 @@
 #![allow(unexpected_cfgs)]
 
-use bytes::BufMut;
 use ruma_common::{
     api::{
-        IncomingResponse, OutgoingResponse,
+        EmptyBody, IncomingResponse, OutgoingResponse,
         auth_scheme::NoAuthentication,
         error::{DeserializationError, Error, IntoHttpError},
         request,
@@ -41,9 +40,9 @@ impl IncomingResponse for Response {
 }
 
 impl OutgoingResponse for Response {
-    fn try_into_http_response<T: Default + BufMut>(
-        self,
-    ) -> Result<http::Response<T>, IntoHttpError> {
+    type Body = EmptyBody<false>;
+
+    fn try_into_http_response_inner(self) -> Result<http::Response<Self::Body>, IntoHttpError> {
         todo!()
     }
 }

--- a/crates/ruma-federation-api/src/authenticated_media.rs
+++ b/crates/ruma-federation-api/src/authenticated_media.rs
@@ -4,6 +4,8 @@
 
 use std::ops::Deref;
 
+#[cfg(feature = "server")]
+use ruma_common::api::OutgoingBody;
 #[cfg(feature = "client")]
 use ruma_common::api::error::HeaderDeserializationError;
 use ruma_common::http_headers::ContentDisposition;
@@ -150,8 +152,9 @@ impl Deref for MultipartMixedBoundary {
 }
 
 /// A `multipart/mixed` response body.
+#[doc(hidden)]
 #[derive(Debug, Clone)]
-struct ResponseBody {
+pub struct ResponseBody {
     metadata: ContentMetadata,
     content: FileOrLocation,
     // This field is never read when deserializing.
@@ -168,10 +171,21 @@ impl ResponseBody {
         Self { metadata, content, boundary: MultipartMixedBoundary::new() }
     }
 
-    /// Serialize this `ResponseBody` into a buffer.
-    fn try_into_buf<T: Default + bytes::BufMut>(
+    /// Convert this `ResponseBody` into an `http::Response<ResponseBody>`.
+    fn try_into_http_response(
         self,
-    ) -> Result<T, ruma_common::api::error::IntoHttpError> {
+    ) -> Result<http::Response<Self>, ruma_common::api::error::IntoHttpError> {
+        let content_type = self.boundary.content_type();
+
+        Ok(http::Response::builder().header(http::header::CONTENT_TYPE, content_type).body(self)?)
+    }
+}
+
+#[cfg(feature = "server")]
+impl OutgoingBody for ResponseBody {
+    type Error = ruma_common::api::error::IntoHttpError;
+
+    fn try_into_buf<T: Default + bytes::BufMut>(self) -> Result<T, Self::Error> {
         use std::io::Write as _;
 
         let mut body_writer = T::default().writer();
@@ -228,17 +242,6 @@ impl ResponseBody {
         boundary.write_end(&mut body_writer);
 
         Ok(body_writer.into_inner())
-    }
-
-    /// Serialize this `ResponseBody` into an `http::Response`.
-    fn try_into_http_response<T: Default + bytes::BufMut>(
-        self,
-    ) -> Result<http::Response<T>, ruma_common::api::error::IntoHttpError> {
-        let content_type = self.boundary.content_type();
-
-        Ok(http::Response::builder()
-            .header(http::header::CONTENT_TYPE, content_type)
-            .body(self.try_into_buf()?)?)
     }
 }
 
@@ -383,7 +386,10 @@ fn parse_multipart_body_part(
 #[cfg(all(test, feature = "client", feature = "server"))]
 mod tests {
     use assert_matches2::assert_matches;
-    use ruma_common::http_headers::{ContentDisposition, ContentDispositionType};
+    use ruma_common::{
+        api::OutgoingBody,
+        http_headers::{ContentDisposition, ContentDispositionType},
+    };
 
     use super::{Content, ContentMetadata, FileOrLocation, ResponseBody};
 
@@ -402,9 +408,10 @@ mod tests {
         });
 
         let (parts, body) = ResponseBody::new(outgoing_metadata, outgoing_content)
-            .try_into_http_response::<Vec<u8>>()
+            .try_into_http_response()
             .unwrap()
             .into_parts();
+        let body = body.try_into_buf::<Vec<u8>>().unwrap();
         let response = http::Response::from_parts(parts, body.as_slice());
 
         let ResponseBody { content: incoming_content, .. } =
@@ -431,9 +438,10 @@ mod tests {
         });
 
         let (parts, body) = ResponseBody::new(outgoing_metadata, outgoing_content)
-            .try_into_http_response::<Vec<u8>>()
+            .try_into_http_response()
             .unwrap()
             .into_parts();
+        let body = body.try_into_buf::<Vec<u8>>().unwrap();
         let response = http::Response::from_parts(parts, body.as_slice());
 
         let ResponseBody { content: incoming_content, .. } =
@@ -453,9 +461,10 @@ mod tests {
         let outgoing_content = FileOrLocation::Location(location.to_owned());
 
         let (parts, body) = ResponseBody::new(outgoing_metadata, outgoing_content)
-            .try_into_http_response::<Vec<u8>>()
+            .try_into_http_response()
             .unwrap()
             .into_parts();
+        let body = body.try_into_buf::<Vec<u8>>().unwrap();
         let response = http::Response::from_parts(parts, body.as_slice());
 
         let ResponseBody { content: incoming_content, .. } =

--- a/crates/ruma-federation-api/src/authenticated_media.rs
+++ b/crates/ruma-federation-api/src/authenticated_media.rs
@@ -2,6 +2,10 @@
 //!
 //! [MSC3916]: https://github.com/matrix-org/matrix-spec-proposals/pull/3916
 
+use std::ops::Deref;
+
+#[cfg(feature = "client")]
+use ruma_common::api::error::HeaderDeserializationError;
 use ruma_common::http_headers::ContentDisposition;
 use serde::{Deserialize, Serialize};
 
@@ -70,189 +74,271 @@ impl Content {
     }
 }
 
-/// Serialize the given metadata and content into a `http::Response` `multipart/mixed` body.
-///
-/// Returns a tuple containing the boundary used
+/// A boundary in a `multipart/mixed` body.
+#[derive(Debug, Clone)]
+struct MultipartMixedBoundary(String);
+
 #[cfg(feature = "server")]
-fn try_into_multipart_mixed_response<T: Default + bytes::BufMut>(
-    metadata: &ContentMetadata,
-    content: &FileOrLocation,
-) -> Result<http::Response<T>, ruma_common::api::error::IntoHttpError> {
-    use std::io::Write as _;
+impl MultipartMixedBoundary {
+    /// Generate a new random boundary.
+    fn new() -> Self {
+        use rand::RngExt as _;
 
-    use rand::RngExt as _;
-
-    let boundary = rand::rng()
-        .sample_iter(&rand::distr::Alphanumeric)
-        .map(char::from)
-        .take(GENERATED_BOUNDARY_LENGTH)
-        .collect::<String>();
-
-    let mut body_writer = T::default().writer();
-
-    // Add first boundary separator and header for the metadata.
-    let _ = write!(
-        body_writer,
-        "\r\n--{boundary}\r\n{}: {}\r\n\r\n",
-        http::header::CONTENT_TYPE,
-        mime::APPLICATION_JSON
-    );
-
-    // Add serialized metadata.
-    serde_json::to_writer(&mut body_writer, metadata)?;
-
-    // Add second boundary separator.
-    let _ = write!(body_writer, "\r\n--{boundary}\r\n");
-
-    // Add content.
-    match content {
-        FileOrLocation::File(content) => {
-            // Add headers.
-            let content_type =
-                content.content_type.as_deref().unwrap_or(mime::APPLICATION_OCTET_STREAM.as_ref());
-            let _ = write!(body_writer, "{}: {content_type}\r\n", http::header::CONTENT_TYPE);
-
-            if let Some(content_disposition) = &content.content_disposition {
-                let _ = write!(
-                    body_writer,
-                    "{}: {content_disposition}\r\n",
-                    http::header::CONTENT_DISPOSITION
-                );
-            }
-
-            // Add empty line separator after headers.
-            let _ = body_writer.write_all(b"\r\n");
-
-            // Add bytes.
-            let _ = body_writer.write_all(&content.file);
-        }
-        FileOrLocation::Location(location) => {
-            // Only add location header and empty line separator.
-            let _ = write!(body_writer, "{}: {location}\r\n\r\n", http::header::LOCATION);
-        }
+        Self(
+            rand::rng()
+                .sample_iter(&rand::distr::Alphanumeric)
+                .map(char::from)
+                .take(GENERATED_BOUNDARY_LENGTH)
+                .collect(),
+        )
     }
 
-    // Add final boundary.
-    let _ = write!(body_writer, "\r\n--{boundary}--");
+    /// Get the value of the `Content-Type` HTTP header for this boundary.
+    fn content_type(&self) -> String {
+        format!("{MULTIPART_MIXED}; boundary={}", self.0)
+    }
 
-    let content_type = format!("{MULTIPART_MIXED}; boundary={boundary}");
-    let body = body_writer.into_inner();
+    /// Write this boundary as a separator between parts of the body.
+    fn write_separator(&self, buf: &mut impl std::io::Write) {
+        let _ = write!(buf, "\r\n--{}\r\n", self.0);
+    }
 
-    Ok(http::Response::builder().header(http::header::CONTENT_TYPE, content_type).body(body)?)
+    /// Write this boundary at the end of the body.
+    fn write_end(&self, buf: &mut impl std::io::Write) {
+        let _ = write!(buf, "\r\n--{}", self.0);
+    }
 }
 
-/// Deserialize the given metadata and content from a `http::Response` with a `multipart/mixed`
-/// body.
 #[cfg(feature = "client")]
-fn try_from_multipart_mixed_response(
-    http_response: http::Response<&[u8]>,
-) -> Result<(ContentMetadata, FileOrLocation), ruma_common::api::error::DeserializationError> {
-    use ruma_common::api::error::{HeaderDeserializationError, MultipartMixedDeserializationError};
+impl MultipartMixedBoundary {
+    /// Parse the boundary in the headers of the given `http::Response`.
+    fn parse_http_response_headers(
+        http_response: &http::Response<&[u8]>,
+    ) -> Result<Self, HeaderDeserializationError> {
+        let body_content_type = http_response
+            .headers()
+            .get(http::header::CONTENT_TYPE)
+            .ok_or_else(|| HeaderDeserializationError::MissingHeader("Content-Type".to_owned()))?
+            .to_str()?
+            .parse::<mime::Mime>()
+            .map_err(|e| HeaderDeserializationError::InvalidHeader(e.into()))?;
 
-    // First, get the boundary from the content type header.
-    let body_content_type = http_response
-        .headers()
-        .get(http::header::CONTENT_TYPE)
-        .ok_or_else(|| HeaderDeserializationError::MissingHeader("Content-Type".to_owned()))?
-        .to_str()?
-        .parse::<mime::Mime>()
-        .map_err(|e| HeaderDeserializationError::InvalidHeader(e.into()))?;
-
-    if !body_content_type.essence_str().eq_ignore_ascii_case(MULTIPART_MIXED) {
-        return Err(HeaderDeserializationError::InvalidHeaderValue {
-            header: "Content-Type".to_owned(),
-            expected: MULTIPART_MIXED.to_owned(),
-            unexpected: body_content_type.essence_str().to_owned(),
+        if !body_content_type.essence_str().eq_ignore_ascii_case(MULTIPART_MIXED) {
+            return Err(HeaderDeserializationError::InvalidHeaderValue {
+                header: "Content-Type".to_owned(),
+                expected: MULTIPART_MIXED.to_owned(),
+                unexpected: body_content_type.essence_str().to_owned(),
+            });
         }
-        .into());
+
+        Ok(Self(
+            body_content_type
+                .get_param("boundary")
+                .ok_or(HeaderDeserializationError::MissingMultipartBoundary)?
+                .as_str()
+                .to_owned(),
+        ))
+    }
+}
+
+impl Deref for MultipartMixedBoundary {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// A `multipart/mixed` response body.
+#[derive(Debug, Clone)]
+struct ResponseBody {
+    metadata: ContentMetadata,
+    content: FileOrLocation,
+    // This field is never read when deserializing.
+    #[cfg_attr(not(feature = "server"), expect(dead_code))]
+    boundary: MultipartMixedBoundary,
+}
+
+#[cfg(feature = "server")]
+impl ResponseBody {
+    /// Construct a `ResponseBody` with the given metadata and content.
+    ///
+    /// The boundary is generated randomly.
+    fn new(metadata: ContentMetadata, content: FileOrLocation) -> Self {
+        Self { metadata, content, boundary: MultipartMixedBoundary::new() }
     }
 
-    let boundary = body_content_type
-        .get_param("boundary")
-        .ok_or(HeaderDeserializationError::MissingMultipartBoundary)?
-        .as_str()
-        .as_bytes();
+    /// Serialize this `ResponseBody` into a buffer.
+    fn try_into_buf<T: Default + bytes::BufMut>(
+        self,
+    ) -> Result<T, ruma_common::api::error::IntoHttpError> {
+        use std::io::Write as _;
 
-    // Split the body with the boundary.
-    let body = http_response.body();
+        let mut body_writer = T::default().writer();
+        let Self { metadata, content, boundary } = &self;
 
-    let mut full_boundary = Vec::with_capacity(boundary.len() + 4);
-    full_boundary.extend_from_slice(b"\r\n--");
-    full_boundary.extend_from_slice(boundary);
-    let full_boundary_no_crlf = full_boundary.strip_prefix(b"\r\n").unwrap();
+        // Add first boundary separator.
+        boundary.write_separator(&mut body_writer);
 
-    let mut boundaries = memchr::memmem::find_iter(body, &full_boundary);
+        // Add headers for the metadata.
+        let _ = write!(
+            body_writer,
+            "{}: {}\r\n\r\n",
+            http::header::CONTENT_TYPE,
+            mime::APPLICATION_JSON
+        );
 
-    let metadata_start = if body.starts_with(full_boundary_no_crlf) {
-        // If there is no preamble before the first boundary, it may omit the
-        // preceding CRLF.
-        full_boundary_no_crlf.len()
-    } else {
-        boundaries.next().ok_or_else(|| MultipartMixedDeserializationError::MissingBodyParts {
-            expected: 2,
-            found: 0,
-        })? + full_boundary.len()
-    };
-    let metadata_end = boundaries.next().ok_or_else(|| {
-        MultipartMixedDeserializationError::MissingBodyParts { expected: 2, found: 0 }
-    })?;
+        // Add serialized metadata.
+        serde_json::to_writer(&mut body_writer, metadata)?;
 
-    let (_raw_metadata_headers, serialized_metadata) =
-        parse_multipart_body_part(body, metadata_start, metadata_end)?;
+        // Add second boundary separator.
+        boundary.write_separator(&mut body_writer);
 
-    // Don't search for anything in the headers, just deserialize the content that should be JSON.
-    let metadata = serde_json::from_slice(serialized_metadata)?;
+        // Add content.
+        match content {
+            FileOrLocation::File(content) => {
+                // Add headers.
+                let content_type = content
+                    .content_type
+                    .as_deref()
+                    .unwrap_or(mime::APPLICATION_OCTET_STREAM.as_ref());
+                let _ = write!(body_writer, "{}: {content_type}\r\n", http::header::CONTENT_TYPE);
 
-    // Look at the part containing the media content now.
-    let content_start = metadata_end + full_boundary.len();
-    let content_end = boundaries.next().ok_or_else(|| {
-        MultipartMixedDeserializationError::MissingBodyParts { expected: 2, found: 1 }
-    })?;
+                if let Some(content_disposition) = &content.content_disposition {
+                    let _ = write!(
+                        body_writer,
+                        "{}: {content_disposition}\r\n",
+                        http::header::CONTENT_DISPOSITION
+                    );
+                }
 
-    let (raw_content_headers, file) = parse_multipart_body_part(body, content_start, content_end)?;
+                // Add empty line separator after headers.
+                let _ = body_writer.write_all(b"\r\n");
 
-    // Parse the headers to retrieve the content type and content disposition.
-    let mut content_headers = [httparse::EMPTY_HEADER; MAX_HEADERS_COUNT];
-    httparse::parse_headers(raw_content_headers, &mut content_headers)
-        .map_err(|e| MultipartMixedDeserializationError::InvalidHeader(e.into()))?;
-
-    let mut location = None;
-    let mut content_type = None;
-    let mut content_disposition = None;
-    for header in content_headers {
-        if header.name.is_empty() {
-            // This is a empty header, we have reached the end of the parsed headers.
-            break;
+                // Add bytes.
+                let _ = body_writer.write_all(&content.file);
+            }
+            FileOrLocation::Location(location) => {
+                // Only add location header and empty line separator.
+                let _ = write!(body_writer, "{}: {location}\r\n\r\n", http::header::LOCATION);
+            }
         }
 
-        if header.name == http::header::LOCATION {
-            location = Some(
-                String::from_utf8(header.value.to_vec())
-                    .map_err(|e| MultipartMixedDeserializationError::InvalidHeader(e.into()))?,
-            );
+        // Add final boundary.
+        boundary.write_end(&mut body_writer);
 
-            // This is the only header we need, stop parsing.
-            break;
-        } else if header.name == http::header::CONTENT_TYPE {
-            content_type = Some(
-                String::from_utf8(header.value.to_vec())
-                    .map_err(|e| MultipartMixedDeserializationError::InvalidHeader(e.into()))?,
-            );
-        } else if header.name == http::header::CONTENT_DISPOSITION {
-            content_disposition = Some(
-                ContentDisposition::try_from(header.value)
-                    .map_err(|e| MultipartMixedDeserializationError::InvalidHeader(e.into()))?,
-            );
-        }
+        Ok(body_writer.into_inner())
     }
 
-    let content = if let Some(location) = location {
-        FileOrLocation::Location(location)
-    } else {
-        FileOrLocation::File(Content { file: file.to_owned(), content_type, content_disposition })
-    };
+    /// Serialize this `ResponseBody` into an `http::Response`.
+    fn try_into_http_response<T: Default + bytes::BufMut>(
+        self,
+    ) -> Result<http::Response<T>, ruma_common::api::error::IntoHttpError> {
+        let content_type = self.boundary.content_type();
 
-    Ok((metadata, content))
+        Ok(http::Response::builder()
+            .header(http::header::CONTENT_TYPE, content_type)
+            .body(self.try_into_buf()?)?)
+    }
+}
+
+#[cfg(feature = "client")]
+impl ResponseBody {
+    /// Deserialize a `ResponseBody` from the given `http::Response`.
+    fn try_from_http_response(
+        http_response: http::Response<&[u8]>,
+    ) -> Result<Self, ruma_common::api::error::DeserializationError> {
+        use ruma_common::api::error::MultipartMixedDeserializationError;
+
+        // First, get the boundary.
+        let boundary = MultipartMixedBoundary::parse_http_response_headers(&http_response)?;
+
+        // Split the body with the boundary.
+        let body = http_response.body();
+
+        let mut full_boundary = Vec::with_capacity(boundary.len() + 4);
+        full_boundary.extend_from_slice(b"\r\n--");
+        full_boundary.extend_from_slice(boundary.as_bytes());
+        let full_boundary_no_crlf = full_boundary.strip_prefix(b"\r\n").unwrap();
+
+        let mut boundaries = memchr::memmem::find_iter(body, &full_boundary);
+
+        let metadata_start = if body.starts_with(full_boundary_no_crlf) {
+            // If there is no preamble before the first boundary, it may omit the
+            // preceding CRLF.
+            full_boundary_no_crlf.len()
+        } else {
+            boundaries.next().ok_or_else(|| {
+                MultipartMixedDeserializationError::MissingBodyParts { expected: 2, found: 0 }
+            })? + full_boundary.len()
+        };
+        let metadata_end = boundaries.next().ok_or_else(|| {
+            MultipartMixedDeserializationError::MissingBodyParts { expected: 2, found: 0 }
+        })?;
+
+        let (_raw_metadata_headers, serialized_metadata) =
+            parse_multipart_body_part(body, metadata_start, metadata_end)?;
+
+        // Don't search for anything in the headers, just deserialize the content that should be
+        // JSON.
+        let metadata = serde_json::from_slice(serialized_metadata)?;
+
+        // Look at the part containing the media content now.
+        let content_start = metadata_end + full_boundary.len();
+        let content_end = boundaries.next().ok_or_else(|| {
+            MultipartMixedDeserializationError::MissingBodyParts { expected: 2, found: 1 }
+        })?;
+
+        let (raw_content_headers, file) =
+            parse_multipart_body_part(body, content_start, content_end)?;
+
+        // Parse the headers to retrieve the content type and content disposition.
+        let mut content_headers = [httparse::EMPTY_HEADER; MAX_HEADERS_COUNT];
+        httparse::parse_headers(raw_content_headers, &mut content_headers)
+            .map_err(|e| MultipartMixedDeserializationError::InvalidHeader(e.into()))?;
+
+        let mut location = None;
+        let mut content_type = None;
+        let mut content_disposition = None;
+        for header in content_headers {
+            if header.name.is_empty() {
+                // This is a empty header, we have reached the end of the parsed headers.
+                break;
+            }
+
+            if header.name == http::header::LOCATION {
+                location =
+                    Some(String::from_utf8(header.value.to_vec()).map_err(|e| {
+                        MultipartMixedDeserializationError::InvalidHeader(e.into())
+                    })?);
+
+                // This is the only header we need, stop parsing.
+                break;
+            } else if header.name == http::header::CONTENT_TYPE {
+                content_type =
+                    Some(String::from_utf8(header.value.to_vec()).map_err(|e| {
+                        MultipartMixedDeserializationError::InvalidHeader(e.into())
+                    })?);
+            } else if header.name == http::header::CONTENT_DISPOSITION {
+                content_disposition =
+                    Some(ContentDisposition::try_from(header.value).map_err(|e| {
+                        MultipartMixedDeserializationError::InvalidHeader(e.into())
+                    })?);
+            }
+        }
+
+        let content = if let Some(location) = location {
+            FileOrLocation::Location(location)
+        } else {
+            FileOrLocation::File(Content {
+                file: file.to_owned(),
+                content_type,
+                content_disposition,
+            })
+        };
+
+        Ok(Self { metadata, content, boundary })
+    }
 }
 
 /// Parse the multipart body part in the given bytes, starting and ending at the given positions.
@@ -299,10 +385,7 @@ mod tests {
     use assert_matches2::assert_matches;
     use ruma_common::http_headers::{ContentDisposition, ContentDispositionType};
 
-    use super::{
-        Content, ContentMetadata, FileOrLocation, try_from_multipart_mixed_response,
-        try_into_multipart_mixed_response,
-    };
+    use super::{Content, ContentMetadata, FileOrLocation, ResponseBody};
 
     #[test]
     fn multipart_mixed_content_ascii_filename_conversions() {
@@ -318,14 +401,14 @@ mod tests {
             content_disposition: Some(content_disposition.clone()),
         });
 
-        let (parts, body) =
-            try_into_multipart_mixed_response::<Vec<u8>>(&outgoing_metadata, &outgoing_content)
-                .unwrap()
-                .into_parts();
+        let (parts, body) = ResponseBody::new(outgoing_metadata, outgoing_content)
+            .try_into_http_response::<Vec<u8>>()
+            .unwrap()
+            .into_parts();
         let response = http::Response::from_parts(parts, body.as_slice());
 
-        let (_incoming_metadata, incoming_content) =
-            try_from_multipart_mixed_response(response).unwrap();
+        let ResponseBody { content: incoming_content, .. } =
+            ResponseBody::try_from_http_response(response).unwrap();
 
         assert_matches!(incoming_content, FileOrLocation::File(incoming_content));
         assert_eq!(incoming_content.file, file);
@@ -347,14 +430,14 @@ mod tests {
             content_disposition: Some(content_disposition.clone()),
         });
 
-        let (parts, body) =
-            try_into_multipart_mixed_response::<Vec<u8>>(&outgoing_metadata, &outgoing_content)
-                .unwrap()
-                .into_parts();
+        let (parts, body) = ResponseBody::new(outgoing_metadata, outgoing_content)
+            .try_into_http_response::<Vec<u8>>()
+            .unwrap()
+            .into_parts();
         let response = http::Response::from_parts(parts, body.as_slice());
 
-        let (_incoming_metadata, incoming_content) =
-            try_from_multipart_mixed_response(response).unwrap();
+        let ResponseBody { content: incoming_content, .. } =
+            ResponseBody::try_from_http_response(response).unwrap();
 
         assert_matches!(incoming_content, FileOrLocation::File(incoming_content));
         assert_eq!(incoming_content.file, file);
@@ -369,14 +452,14 @@ mod tests {
         let outgoing_metadata = ContentMetadata::new();
         let outgoing_content = FileOrLocation::Location(location.to_owned());
 
-        let (parts, body) =
-            try_into_multipart_mixed_response::<Vec<u8>>(&outgoing_metadata, &outgoing_content)
-                .unwrap()
-                .into_parts();
+        let (parts, body) = ResponseBody::new(outgoing_metadata, outgoing_content)
+            .try_into_http_response::<Vec<u8>>()
+            .unwrap()
+            .into_parts();
         let response = http::Response::from_parts(parts, body.as_slice());
 
-        let (_incoming_metadata, incoming_content) =
-            try_from_multipart_mixed_response(response).unwrap();
+        let ResponseBody { content: incoming_content, .. } =
+            ResponseBody::try_from_http_response(response).unwrap();
 
         assert_matches!(incoming_content, FileOrLocation::Location(incoming_location));
         assert_eq!(incoming_location, location);
@@ -391,7 +474,7 @@ mod tests {
             .body(body.as_slice())
             .unwrap();
 
-        try_from_multipart_mixed_response(response).unwrap_err();
+        ResponseBody::try_from_http_response(response).unwrap_err();
 
         // Wrong boundary.
         let body = b"\r\n--abcdef\r\n\r\n{}\r\n--abcdef\r\nContent-Type: text/plain\r\n\r\nsome plain text\r\n--abcdef--";
@@ -400,7 +483,7 @@ mod tests {
             .body(body.as_slice())
             .unwrap();
 
-        try_from_multipart_mixed_response(response).unwrap_err();
+        ResponseBody::try_from_http_response(response).unwrap_err();
 
         // Missing boundary in body.
         let body =
@@ -410,7 +493,7 @@ mod tests {
             .body(body.as_slice())
             .unwrap();
 
-        try_from_multipart_mixed_response(response).unwrap_err();
+        ResponseBody::try_from_http_response(response).unwrap_err();
 
         // Missing header and content empty line separator in body part.
         let body = b"\r\n--abcdef\r\n{}\r\n--abcdef\r\nContent-Type: text/plain\r\n\r\nsome plain text\r\n--abcdef--";
@@ -419,7 +502,7 @@ mod tests {
             .body(body.as_slice())
             .unwrap();
 
-        try_from_multipart_mixed_response(response).unwrap_err();
+        ResponseBody::try_from_http_response(response).unwrap_err();
 
         // Control character in header.
         let body = b"\r\n--abcdef\r\n\r\n{}\r\n--abcdef\r\nContent-Type: text/plain\r\nContent-Disposition: inline; filename=\"my\nfile\"\r\nsome plain text\r\n--abcdef--";
@@ -428,7 +511,7 @@ mod tests {
             .body(body.as_slice())
             .unwrap();
 
-        try_from_multipart_mixed_response(response).unwrap_err();
+        ResponseBody::try_from_http_response(response).unwrap_err();
 
         // Boundary without CRLF with preamble.
         let body = b"foo--abcdef\r\n\r\n{}\r\n--abcdef\r\n\r\nsome plain text\r\n--abcdef--";
@@ -437,7 +520,7 @@ mod tests {
             .body(body.as_slice())
             .unwrap();
 
-        try_from_multipart_mixed_response(response).unwrap_err();
+        ResponseBody::try_from_http_response(response).unwrap_err();
     }
 
     #[test]
@@ -449,7 +532,7 @@ mod tests {
             .body(body.as_slice())
             .unwrap();
 
-        let (_metadata, content) = try_from_multipart_mixed_response(response).unwrap();
+        let ResponseBody { content, .. } = ResponseBody::try_from_http_response(response).unwrap();
 
         assert_matches!(content, FileOrLocation::File(file_content));
         assert_eq!(file_content.file, b"some plain text");
@@ -463,7 +546,7 @@ mod tests {
             .body(body.as_slice())
             .unwrap();
 
-        let (_metadata, content) = try_from_multipart_mixed_response(response).unwrap();
+        let ResponseBody { content, .. } = ResponseBody::try_from_http_response(response).unwrap();
 
         assert_matches!(content, FileOrLocation::File(file_content));
         assert_eq!(file_content.file, b"some plain text");
@@ -479,7 +562,7 @@ mod tests {
             .body(body.as_slice())
             .unwrap();
 
-        let (_metadata, content) = try_from_multipart_mixed_response(response).unwrap();
+        let ResponseBody { content, .. } = ResponseBody::try_from_http_response(response).unwrap();
 
         assert_matches!(content, FileOrLocation::File(file_content));
         assert_eq!(file_content.file, b"some plain text");
@@ -493,7 +576,7 @@ mod tests {
             .body(body.as_slice())
             .unwrap();
 
-        let (_metadata, content) = try_from_multipart_mixed_response(response).unwrap();
+        let ResponseBody { content, .. } = ResponseBody::try_from_http_response(response).unwrap();
 
         assert_matches!(content, FileOrLocation::File(file_content));
         assert_eq!(file_content.file, b"some plain text");
@@ -507,7 +590,7 @@ mod tests {
             .body(body.as_slice())
             .unwrap();
 
-        let (_metadata, content) = try_from_multipart_mixed_response(response).unwrap();
+        let ResponseBody { content, .. } = ResponseBody::try_from_http_response(response).unwrap();
 
         assert_matches!(content, FileOrLocation::File(file_content));
         assert_eq!(file_content.file, b"some plain text");
@@ -523,7 +606,7 @@ mod tests {
             .body(body.as_slice())
             .unwrap();
 
-        let (_metadata, content) = try_from_multipart_mixed_response(response).unwrap();
+        let ResponseBody { content, .. } = ResponseBody::try_from_http_response(response).unwrap();
 
         assert_matches!(content, FileOrLocation::File(file_content));
         assert_eq!(file_content.file, b"some plain text");
@@ -537,7 +620,7 @@ mod tests {
             .body(body.as_slice())
             .unwrap();
 
-        let (_metadata, content) = try_from_multipart_mixed_response(response).unwrap();
+        let ResponseBody { content, .. } = ResponseBody::try_from_http_response(response).unwrap();
 
         assert_matches!(content, FileOrLocation::File(file_content));
         assert_eq!(file_content.file, b"some plain text");
@@ -551,7 +634,7 @@ mod tests {
             .body(body.as_bytes())
             .unwrap();
 
-        let (_metadata, content) = try_from_multipart_mixed_response(response).unwrap();
+        let ResponseBody { content, .. } = ResponseBody::try_from_http_response(response).unwrap();
 
         assert_matches!(content, FileOrLocation::File(file_content));
         assert_eq!(file_content.file, b"some plain text");

--- a/crates/ruma-federation-api/src/authenticated_media/get_content/unstable.rs
+++ b/crates/ruma-federation-api/src/authenticated_media/get_content/unstable.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use ruma_common::api::{Metadata, path_builder::SinglePath, request};
 
-use crate::authenticated_media::{ContentMetadata, FileOrLocation};
+use crate::authenticated_media::{ContentMetadata, FileOrLocation, ResponseBody};
 
 /// Request type for the `get_content` endpoint.
 #[request]
@@ -84,8 +84,9 @@ impl ruma_common::api::IncomingResponse for Response {
     fn try_from_http_response_inner(
         http_response: http::Response<&[u8]>,
     ) -> Result<Self, ruma_common::api::error::DeserializationError> {
-        // Reuse the custom deserialization.
-        Ok(super::v1::Response::try_from_http_response_inner(http_response)?.into())
+        let ResponseBody { metadata, content, .. } =
+            ResponseBody::try_from_http_response(http_response)?;
+        Ok(Self { metadata, content })
     }
 }
 
@@ -94,8 +95,7 @@ impl ruma_common::api::OutgoingResponse for Response {
     fn try_into_http_response<T: Default + bytes::BufMut>(
         self,
     ) -> Result<http::Response<T>, ruma_common::api::error::IntoHttpError> {
-        // Reuse the custom serialization.
-        super::v1::Response::from(self).try_into_http_response()
+        ResponseBody::new(self.metadata, self.content).try_into_http_response()
     }
 }
 

--- a/crates/ruma-federation-api/src/authenticated_media/get_content/unstable.rs
+++ b/crates/ruma-federation-api/src/authenticated_media/get_content/unstable.rs
@@ -92,9 +92,11 @@ impl ruma_common::api::IncomingResponse for Response {
 
 #[cfg(feature = "server")]
 impl ruma_common::api::OutgoingResponse for Response {
-    fn try_into_http_response<T: Default + bytes::BufMut>(
+    type Body = ResponseBody;
+
+    fn try_into_http_response_inner(
         self,
-    ) -> Result<http::Response<T>, ruma_common::api::error::IntoHttpError> {
+    ) -> Result<http::Response<Self::Body>, ruma_common::api::error::IntoHttpError> {
         ResponseBody::new(self.metadata, self.content).try_into_http_response()
     }
 }

--- a/crates/ruma-federation-api/src/authenticated_media/get_content/v1.rs
+++ b/crates/ruma-federation-api/src/authenticated_media/get_content/v1.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use ruma_common::{api::request, metadata};
 
 use crate::{
-    authenticated_media::{ContentMetadata, FileOrLocation},
+    authenticated_media::{ContentMetadata, FileOrLocation, ResponseBody},
     authentication::ServerSignatures,
 };
 
@@ -70,8 +70,8 @@ impl ruma_common::api::IncomingResponse for Response {
     fn try_from_http_response_inner(
         http_response: http::Response<&[u8]>,
     ) -> Result<Self, ruma_common::api::error::DeserializationError> {
-        let (metadata, content) =
-            crate::authenticated_media::try_from_multipart_mixed_response(http_response)?;
+        let ResponseBody { metadata, content, .. } =
+            ResponseBody::try_from_http_response(http_response)?;
         Ok(Self { metadata, content })
     }
 }
@@ -81,6 +81,6 @@ impl ruma_common::api::OutgoingResponse for Response {
     fn try_into_http_response<T: Default + bytes::BufMut>(
         self,
     ) -> Result<http::Response<T>, ruma_common::api::error::IntoHttpError> {
-        crate::authenticated_media::try_into_multipart_mixed_response(&self.metadata, &self.content)
+        ResponseBody::new(self.metadata, self.content).try_into_http_response()
     }
 }

--- a/crates/ruma-federation-api/src/authenticated_media/get_content/v1.rs
+++ b/crates/ruma-federation-api/src/authenticated_media/get_content/v1.rs
@@ -78,9 +78,11 @@ impl ruma_common::api::IncomingResponse for Response {
 
 #[cfg(feature = "server")]
 impl ruma_common::api::OutgoingResponse for Response {
-    fn try_into_http_response<T: Default + bytes::BufMut>(
+    type Body = ResponseBody;
+
+    fn try_into_http_response_inner(
         self,
-    ) -> Result<http::Response<T>, ruma_common::api::error::IntoHttpError> {
+    ) -> Result<http::Response<Self::Body>, ruma_common::api::error::IntoHttpError> {
         ResponseBody::new(self.metadata, self.content).try_into_http_response()
     }
 }

--- a/crates/ruma-federation-api/src/authenticated_media/get_content_thumbnail/unstable.rs
+++ b/crates/ruma-federation-api/src/authenticated_media/get_content_thumbnail/unstable.rs
@@ -130,9 +130,11 @@ impl ruma_common::api::IncomingResponse for Response {
 
 #[cfg(feature = "server")]
 impl ruma_common::api::OutgoingResponse for Response {
-    fn try_into_http_response<T: Default + bytes::BufMut>(
+    type Body = ResponseBody;
+
+    fn try_into_http_response_inner(
         self,
-    ) -> Result<http::Response<T>, ruma_common::api::error::IntoHttpError> {
+    ) -> Result<http::Response<Self::Body>, ruma_common::api::error::IntoHttpError> {
         ResponseBody::new(self.metadata, self.content).try_into_http_response()
     }
 }

--- a/crates/ruma-federation-api/src/authenticated_media/get_content_thumbnail/unstable.rs
+++ b/crates/ruma-federation-api/src/authenticated_media/get_content_thumbnail/unstable.rs
@@ -10,7 +10,7 @@ use ruma_common::{
     media::Method,
 };
 
-use crate::authenticated_media::{ContentMetadata, FileOrLocation};
+use crate::authenticated_media::{ContentMetadata, FileOrLocation, ResponseBody};
 
 /// Request type for the `get_content_thumbnail` endpoint.
 #[request]
@@ -122,8 +122,9 @@ impl ruma_common::api::IncomingResponse for Response {
     fn try_from_http_response_inner(
         http_response: http::Response<&[u8]>,
     ) -> Result<Self, ruma_common::api::error::DeserializationError> {
-        // Reuse the custom deserialization.
-        Ok(super::v1::Response::try_from_http_response_inner(http_response)?.into())
+        let ResponseBody { metadata, content, .. } =
+            ResponseBody::try_from_http_response(http_response)?;
+        Ok(Self { metadata, content })
     }
 }
 
@@ -132,8 +133,7 @@ impl ruma_common::api::OutgoingResponse for Response {
     fn try_into_http_response<T: Default + bytes::BufMut>(
         self,
     ) -> Result<http::Response<T>, ruma_common::api::error::IntoHttpError> {
-        // Reuse the custom serialization.
-        super::v1::Response::from(self).try_into_http_response()
+        ResponseBody::new(self.metadata, self.content).try_into_http_response()
     }
 }
 

--- a/crates/ruma-federation-api/src/authenticated_media/get_content_thumbnail/v1.rs
+++ b/crates/ruma-federation-api/src/authenticated_media/get_content_thumbnail/v1.rs
@@ -113,9 +113,11 @@ impl ruma_common::api::IncomingResponse for Response {
 
 #[cfg(feature = "server")]
 impl ruma_common::api::OutgoingResponse for Response {
-    fn try_into_http_response<T: Default + bytes::BufMut>(
+    type Body = ResponseBody;
+
+    fn try_into_http_response_inner(
         self,
-    ) -> Result<http::Response<T>, ruma_common::api::error::IntoHttpError> {
+    ) -> Result<http::Response<Self::Body>, ruma_common::api::error::IntoHttpError> {
         ResponseBody::new(self.metadata, self.content).try_into_http_response()
     }
 }

--- a/crates/ruma-federation-api/src/authenticated_media/get_content_thumbnail/v1.rs
+++ b/crates/ruma-federation-api/src/authenticated_media/get_content_thumbnail/v1.rs
@@ -8,7 +8,7 @@ use js_int::UInt;
 use ruma_common::{api::request, media::Method, metadata};
 
 use crate::{
-    authenticated_media::{ContentMetadata, FileOrLocation},
+    authenticated_media::{ContentMetadata, FileOrLocation, ResponseBody},
     authentication::ServerSignatures,
 };
 
@@ -105,8 +105,8 @@ impl ruma_common::api::IncomingResponse for Response {
     fn try_from_http_response_inner(
         http_response: http::Response<&[u8]>,
     ) -> Result<Self, ruma_common::api::error::DeserializationError> {
-        let (metadata, content) =
-            crate::authenticated_media::try_from_multipart_mixed_response(http_response)?;
+        let ResponseBody { metadata, content, .. } =
+            ResponseBody::try_from_http_response(http_response)?;
         Ok(Self { metadata, content })
     }
 }
@@ -116,6 +116,6 @@ impl ruma_common::api::OutgoingResponse for Response {
     fn try_into_http_response<T: Default + bytes::BufMut>(
         self,
     ) -> Result<http::Response<T>, ruma_common::api::error::IntoHttpError> {
-        crate::authenticated_media::try_into_multipart_mixed_response(&self.metadata, &self.content)
+        ResponseBody::new(self.metadata, self.content).try_into_http_response()
     }
 }

--- a/crates/ruma-federation-api/src/membership/create_leave_event/v2.rs
+++ b/crates/ruma-federation-api/src/membership/create_leave_event/v2.rs
@@ -57,7 +57,7 @@ impl Response {
 
 #[cfg(all(test, feature = "server"))]
 mod tests {
-    use ruma_common::api::OutgoingResponse;
+    use ruma_common::api::OutgoingResponseExt as _;
 
     use super::Response;
 

--- a/crates/ruma-federation-api/src/policy/sign_event.rs
+++ b/crates/ruma-federation-api/src/policy/sign_event.rs
@@ -98,7 +98,7 @@ mod tests {
     #[cfg(feature = "server")]
     #[test]
     fn construct_and_serialize_response() {
-        use ruma_common::{api::OutgoingResponse, owned_server_name};
+        use ruma_common::{api::OutgoingResponseExt as _, owned_server_name};
         use serde_json::{Value as JsonValue, from_slice as from_json_slice, json};
 
         let response = Response::new(owned_server_name!("policy.example.org"), "zLFxllD0pbBuBpfHh8NuHNaICpReF/PAOpUQTsw+bFGKiGfDNAsnhcP7pbrmhhpfbOAxIdLraQLeeiXBryLmBw".to_owned());

--- a/crates/ruma-macros/src/api/common.rs
+++ b/crates/ruma-macros/src/api/common.rs
@@ -253,19 +253,27 @@ impl Body {
     ) -> TokenStream {
         match &self.fields {
             BodyFields::Empty => {
-                let http = ruma_common.reexported(RumaCommonReexport::Http);
-                quote! {
-                    #ruma_common::api::EmptyBody<{
-                        // Need this static to work around
-                        // 'destructor of http::Method cannot be evaluated at compile-time'.
-                        static M: #http::Method = <#meta_ident as #ruma_common::api::Metadata>::METHOD;
-                        // Need to use match instead of == since the latter goes through the
-                        // PartialEq trait and that can't be used in const contexts yet.
-                        match M {
-                            #http::Method::GET => true,
-                            _ => false
+                match kind {
+                    MacroKind::Request => {
+                        let http = ruma_common.reexported(RumaCommonReexport::Http);
+                        quote! {
+                            #ruma_common::api::EmptyBody<{
+                                // Need this static to work around
+                                // 'destructor of http::Method cannot be evaluated at compile-time'.
+                                static M: #http::Method = <#meta_ident as #ruma_common::api::Metadata>::METHOD;
+                                // Need to use match instead of == since the latter goes through the
+                                // PartialEq trait and that can't be used in const contexts yet.
+                                match M {
+                                    #http::Method::GET => true,
+                                    _ => false
+                                }
+                            }>
                         }
-                    }>
+                    }
+                    MacroKind::Response => {
+                        // A response always returns a JSON body.
+                        quote! { #ruma_common::api::EmptyBody<false> }
+                    }
                 }
             }
             BodyFields::JsonFields(_) | BodyFields::JsonAll(_) => {
@@ -432,40 +440,6 @@ impl Body {
                     #ruma_common::api::BytesBody(#field_ident)
                 }
             }
-        }
-    }
-
-    /// Generate code to serialize the body.
-    pub(super) fn expand_serialize(
-        &self,
-        kind: MacroKind,
-        ruma_common: &RumaCommon,
-    ) -> TokenStream {
-        match &self.fields {
-            BodyFields::Empty => match kind {
-                MacroKind::Request => {
-                    quote! { <Self as #ruma_common::api::Metadata>::empty_request_body::<T>() }
-                }
-                // A response always returns a JSON body.
-                MacroKind::Response => quote! { #ruma_common::serde::slice_to_buf(b"{}") },
-            },
-            BodyFields::JsonFields(_) | BodyFields::JsonAll(_) => {
-                self.expand_serialize_json(kind, ruma_common)
-            }
-            BodyFields::Raw(field) => {
-                let ident = field.ident();
-                quote! { #ruma_common::serde::slice_to_buf(&#ident) }
-            }
-        }
-    }
-
-    /// Generate code to serialize the JSON body with the given fields.
-    fn expand_serialize_json(&self, kind: MacroKind, ruma_common: &RumaCommon) -> TokenStream {
-        let fields = self.expand_fields();
-        let serde_struct = kind.as_struct_ident(StructSuffix::Body);
-
-        quote! {
-            #ruma_common::serde::json_to_buf(&#serde_struct { #fields })?
         }
     }
 }

--- a/crates/ruma-macros/src/api/response/outgoing.rs
+++ b/crates/ruma-macros/src/api/response/outgoing.rs
@@ -7,13 +7,13 @@ use crate::util::{RumaCommon, RumaCommonReexport};
 impl Response {
     /// Generate the `ruma_common::api::OutgoingResponse` implementation for this response struct.
     pub fn expand_outgoing(&self, ruma_common: &RumaCommon) -> TokenStream {
-        let bytes = ruma_common.reexported(RumaCommonReexport::Bytes);
         let http = ruma_common.reexported(RumaCommonReexport::Http);
 
         let headers_serialize = self.headers.expand_serialize(KIND, &self.body, ruma_common, &http);
         let headers_fields = self.headers.expand_fields();
 
-        let body_serialize = self.body.expand_serialize(KIND, ruma_common);
+        let body_type = self.body.type_name(KIND, ruma_common, &self.ident);
+        let body_expr = self.body.body_expr(KIND, ruma_common);
         let body_fields = self.body.expand_fields();
 
         let ident = &self.ident;
@@ -25,9 +25,11 @@ impl Response {
             #[cfg(feature = "server")]
             #[allow(deprecated)]
             impl #ruma_common::api::OutgoingResponse for #ident {
-                fn try_into_http_response<T: ::std::default::Default + #bytes::BufMut>(
+                type Body = #body_type;
+
+                fn try_into_http_response_inner(
                     self,
-                ) -> ::std::result::Result<#http::Response<T>, #ruma_common::api::error::IntoHttpError> {
+                ) -> ::std::result::Result<#http::Response<Self::Body>, #ruma_common::api::error::IntoHttpError> {
                     let Self {
                         #headers_fields
                         #body_fields
@@ -35,7 +37,7 @@ impl Response {
 
                     let mut #src = #http::Response::builder()
                         .status(#http::StatusCode::#status)
-                        .body(#body_serialize)?;
+                        .body(#body_expr)?;
 
                     #headers_serialize
 


### PR DESCRIPTION
The main commit is the second one. The first commit allows to simplify the second one.

- Rename the main trait method from `try_into_http_response` to
  `try_into_http_response_inner`
- Make the main trait method non-generic, by introducing a new
  associated type `Body`, and changing the `Ok` return value from
  `http::Response<T: Default + BufMut>` to
  `http::Response<Self::Body>`, where `Body` implements the `OutgoingBody`
  trait.
- Add trait `OutgoingResponseExt` that provides `try_into_http_response`
  with the same functionality / semantics as the previous
  `OutgoingResponse::try_into_http_response`.

Part of #2558.