### PR TITLE
events: Hide EventContentFromType from public API and restrict event_enum! visibility

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -40,7 +40,8 @@ Improvements:
 Bug fixes:
 
 - Avoid creating empty formatted body fields when editing plain text message events.
-- Hide `EventContentFromType` from public API and restrict `event_enum!` macro visibility
+- Prevent custom event content types used by `_Custom` event variants from implementing
+  `EventContentFromType`.
 
 ## 0.34.0
 

--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -40,6 +40,7 @@ Improvements:
 Bug fixes:
 
 - Avoid creating empty formatted body fields when editing plain text message events.
+- Hide `EventContentFromType` from public API and restrict `event_enum!` macro visibility
 
 ## 0.34.0
 

--- a/crates/ruma-events/src/_custom.rs
+++ b/crates/ruma-events/src/_custom.rs
@@ -22,7 +22,6 @@ macro_rules! custom_event_content {
             #[serde(skip)]
             pub(crate) event_type: Box<str>,
         }
-
     };
 }
 

--- a/crates/ruma-events/src/_custom.rs
+++ b/crates/ruma-events/src/_custom.rs
@@ -20,7 +20,7 @@ macro_rules! custom_event_content {
         #[allow(clippy::exhaustive_structs)]
         pub struct $i {
             #[serde(skip)]
-            event_type: Box<str>,
+            pub(crate) event_type: Box<str>,
         }
 
         impl EventContentFromType for $i {

--- a/crates/ruma-events/src/_custom.rs
+++ b/crates/ruma-events/src/_custom.rs
@@ -23,11 +23,6 @@ macro_rules! custom_event_content {
             pub(crate) event_type: Box<str>,
         }
 
-        impl EventContentFromType for $i {
-            fn from_parts(event_type: &str, _content: &RawJsonValue) -> serde_json::Result<Self> {
-                Ok(Self { event_type: event_type.into() })
-            }
-        }
     };
 }
 
@@ -78,6 +73,64 @@ impl RedactedMessageLikeEventContent for CustomMessageLikeEventContent {
     }
 }
 
+#[doc(hidden)]
+#[derive(Clone, Debug, Serialize)]
+#[allow(clippy::exhaustive_structs)]
+pub struct CustomMessageLikeEventContentDeHelper {
+    #[serde(skip)]
+    pub(crate) event_type: Box<str>,
+}
+
+// This helper keeps the state unsigned data deserializable without exposing the construction
+// on the custom event content types.
+impl EventContentFromType for CustomMessageLikeEventContentDeHelper {
+    fn from_parts(event_type: &str, _: &RawJsonValue) -> serde_json::Result<Self> {
+        Ok(Self { event_type: event_type.into() })
+    }
+}
+impl MessageLikeEventContent for CustomMessageLikeEventContentDeHelper {
+    fn event_type(&self) -> MessageLikeEventType {
+        self.event_type[..].into()
+    }
+}
+impl RedactedMessageLikeEventContent for CustomMessageLikeEventContentDeHelper {
+    fn event_type(&self) -> MessageLikeEventType {
+        self.event_type[..].into()
+    }
+}
+impl RedactContent for CustomMessageLikeEventContentDeHelper {
+    type Redacted = Self;
+
+    fn redact(self, _: &RedactionRules) -> Self {
+        self
+    }
+}
+impl StateEventContent for CustomMessageLikeEventContentDeHelper {
+    type StateKey = String;
+
+    fn event_type(&self) -> StateEventType {
+        self.event_type[..].into()
+    }
+}
+impl StaticStateEventContent for CustomMessageLikeEventContentDeHelper {
+    type Unsigned = MessageLikeUnsigned<Self>;
+    type PossiblyRedacted = Self;
+}
+impl PossiblyRedactedStateEventContent for CustomMessageLikeEventContentDeHelper {
+    type StateKey = String;
+
+    fn event_type(&self) -> StateEventType {
+        self.event_type[..].into()
+    }
+}
+impl RedactedStateEventContent for CustomMessageLikeEventContentDeHelper {
+    type StateKey = String;
+
+    fn event_type(&self) -> StateEventType {
+        self.event_type[..].into()
+    }
+}
+
 custom_room_event_content!(CustomStateEventContent, StateEventType);
 impl StateEventContent for CustomStateEventContent {
     type StateKey = String;
@@ -90,7 +143,7 @@ impl StaticStateEventContent for CustomStateEventContent {
     // Like `StateUnsigned`, but without `prev_content`.
     // We don't care about `prev_content` since we'd only store the event type that is the same
     // as in the content.
-    type Unsigned = MessageLikeUnsigned<CustomMessageLikeEventContent>;
+    type Unsigned = MessageLikeUnsigned<CustomMessageLikeEventContentDeHelper>;
     type PossiblyRedacted = Self;
 }
 impl PossiblyRedactedStateEventContent for CustomStateEventContent {

--- a/crates/ruma-events/src/content.rs
+++ b/crates/ruma-events/src/content.rs
@@ -149,6 +149,7 @@ pub trait ToDeviceEventContent: Sized + Serialize {
 }
 
 /// Event content that can be deserialized with its event type.
+#[doc(hidden)]
 pub trait EventContentFromType: Sized {
     /// Constructs this event content from the given event type and JSON.
     fn from_parts(event_type: &str, content: &RawJsonValue) -> serde_json::Result<Self>;

--- a/crates/ruma-macros/src/events/event_enum.rs
+++ b/crates/ruma-macros/src/events/event_enum.rs
@@ -16,7 +16,7 @@ use self::{
 use super::common::{
     CommonEventField, CommonEventKind, EventContentTraitVariation, EventTypes, EventVariation,
 };
-use crate::util::RumaEvents;
+use crate::util::{RumaEvents, RumaEventsReexport};
 
 /// Generates enums to represent the various Matrix event types.
 pub(crate) fn expand_event_enum(input: EventEnumInput) -> TokenStream {
@@ -26,6 +26,7 @@ pub(crate) fn expand_event_enum(input: EventEnumInput) -> TokenStream {
     let mut timeline_data = None;
 
     for data in &event_enums_data {
+        tokens.extend(expand_custom_content(data.kind, &ruma_events));
         tokens.extend(
             EventEnum::new(data, &ruma_events)
                 .expand()
@@ -80,6 +81,83 @@ pub(crate) fn expand_event_enum(input: EventEnumInput) -> TokenStream {
     );
 
     tokens
+}
+
+/// Generate a private content type so custom events can be deserialized without making the
+/// public `Custom*EventContent` types implement `EventContentFromType`.
+fn expand_custom_content(kind: EventEnumKind, ruma_events: &RumaEvents) -> TokenStream {
+    let serde = ruma_events.reexported(RumaEventsReexport::Serde);
+    let serde_json = ruma_events.reexported(RumaEventsReexport::SerdeJson);
+    let ident = kind.to_custom_content_ident();
+    let event_type = kind.to_event_type_enum();
+    let trait_ident = kind.to_content_kind_trait(EventContentTraitVariation::Original);
+    let event_type_impl = quote! {
+        fn event_type(&self) -> #ruma_events::#event_type {
+            self.event_type[..].into()
+        }
+    };
+
+    let extra = match kind {
+        EventEnumKind::MessageLike => quote! {
+            impl #ruma_events::RedactedMessageLikeEventContent for #ident {
+                #event_type_impl
+            }
+            impl #ruma_events::RedactContent for #ident {
+                type Redacted = Self;
+                fn redact(self, _: &#ruma_events::RedactionRules) -> Self { self }
+            }
+        },
+        EventEnumKind::State => quote! {
+            impl #ruma_events::MessageLikeEventContent for #ident {
+                fn event_type(&self) -> #ruma_events::MessageLikeEventType {
+                    self.event_type[..].into()
+                }
+            }
+            impl #ruma_events::RedactContent for #ident {
+                type Redacted = Self;
+                fn redact(self, _: &#ruma_events::RedactionRules) -> Self { self }
+            }
+            impl #ruma_events::RedactedStateEventContent for #ident {
+                type StateKey = String;
+                #event_type_impl
+            }
+            impl #ruma_events::PossiblyRedactedStateEventContent for #ident {
+                type StateKey = String;
+                #event_type_impl
+            }
+            impl #ruma_events::StaticStateEventContent for #ident {
+                type Unsigned = #ruma_events::MessageLikeUnsigned<Self>;
+                type PossiblyRedacted = Self;
+            }
+        },
+        _ => quote! {},
+    };
+
+    let state_key = (kind == EventEnumKind::State).then(|| quote! { type StateKey = String; });
+
+    quote! {
+        // This helper is local to the generated event enum and is not part of its public API.
+        #[derive(Clone, Debug, #serde::Serialize)]
+        struct #ident {
+            #[serde(skip)]
+            event_type: Box<str>,
+        }
+
+        impl #ruma_events::EventContentFromType for #ident {
+            fn from_parts(event_type: &str, _: &#serde_json::value::RawValue)
+                -> #serde_json::Result<Self>
+            {
+                Ok(Self { event_type: event_type.into() })
+            }
+        }
+
+        impl #ruma_events::#trait_ident for #ident {
+            #state_key
+            #event_type_impl
+        }
+
+        #extra
+    }
 }
 
 /// The parsed `event_enum!` macro.

--- a/crates/ruma-macros/src/events/event_enum/event_kind_enum.rs
+++ b/crates/ruma-macros/src/events/event_enum/event_kind_enum.rs
@@ -196,11 +196,7 @@ impl<'a> EventEnumVariation<'a> {
                 )*
                 /// An event not defined by the Matrix specification
                 #[doc(hidden)]
-                _Custom(
-                    #ruma_events::#event_struct<
-                        #ruma_events::_custom::#custom_content_struct
-                    >,
-                ),
+                _Custom(#ruma_events::#event_struct<#custom_content_struct>),
             }
 
             #deserialize_impl

--- a/crates/ruma-macros/src/events/event_enum/event_kind_enum/content.rs
+++ b/crates/ruma-macros/src/events/event_enum/event_kind_enum/content.rs
@@ -132,7 +132,7 @@ impl EventContentEnumVariation<'_> {
                 )*
                 #[doc(hidden)]
                 #[serde(serialize_with = #serialize_custom_event_error_path)]
-                _Custom(#ruma_events::_custom::#custom_content_struct),
+                _Custom(#custom_content_struct),
             }
 
             #event_content_from_type_impl
@@ -187,9 +187,9 @@ impl EventContentEnumVariation<'_> {
                             },
                         )*
                         _ => {
-                            Ok(Self::_Custom(
-                                #ruma_events::_custom::#custom_content_struct::from_parts(event_type, json)?
-                            ))
+                            Ok(Self::_Custom(#custom_content_struct {
+                                event_type: event_type.into(),
+                            }))
                         }
                     }
                 }
@@ -423,7 +423,7 @@ impl EventContentChangeEnum<'_> {
                     #variants(#ruma_events::StateEventContentChange<#event_content_types>),
                 )*
                 #[doc(hidden)]
-                _Custom(#ruma_events::_custom::#custom_content_struct),
+                _Custom(#custom_content_struct),
             }
 
             impl #ident {

--- a/crates/ruma-macros/src/lib.rs
+++ b/crates/ruma-macros/src/lib.rs
@@ -183,7 +183,6 @@ use self::{
 ///     }
 /// }
 /// ```
-#[doc(hidden)]
 #[proc_macro]
 pub fn event_enum(input: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(input as EventEnumInput);

--- a/crates/ruma-macros/src/lib.rs
+++ b/crates/ruma-macros/src/lib.rs
@@ -183,6 +183,7 @@ use self::{
 ///     }
 /// }
 /// ```
+#[doc(hidden)]
 #[proc_macro]
 pub fn event_enum(input: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(input as EventEnumInput);


### PR DESCRIPTION
If merged, will add .map() methods to event types, MessageLikeUnsigned, and BundledMessageLikeRelations and will add a EventContentFromType for custom_event_content! macro. 

- Fixes #2475 and allows custom events to be deserialized dynamically from event types.