### PR TITLE
api: Restructure `IncomingRequest`

### DIFF
--- a/crates/ruma-client-api/src/delayed_events/send_delayed_event.rs
+++ b/crates/ruma-client-api/src/delayed_events/send_delayed_event.rs
@@ -241,7 +241,7 @@ pub mod unstable {
 
         use std::time::Duration;
 
-        use ruma_common::{OwnedTransactionId, api::IncomingRequest, owned_room_id};
+        use ruma_common::{OwnedTransactionId, api::IncomingRequestExt as _, owned_room_id};
         use serde_json::json;
 
         use super::Request;
@@ -260,7 +260,11 @@ pub mod unstable {
             let body = json!({"content":{"msgtype":"m.text","body":"test"}, "delay": 103});
 
             let req = Request::try_from_http_request(
-                http::Request::builder().method("PUT").uri(uri).body(body.to_string()).unwrap(),
+                http::Request::builder()
+                    .method("PUT")
+                    .uri(uri)
+                    .body(body.to_string().as_bytes())
+                    .unwrap(),
                 &["!roomid:example.org", "m.room.message", "5678"],
             )
             .unwrap();
@@ -293,7 +297,11 @@ pub mod unstable {
             let body = json!({"content":{"msgtype":"m.text","body":"test"}, "delay": 103});
 
             let req = Request::try_from_http_request(
-                http::Request::builder().method("PUT").uri(uri).body(body.to_string()).unwrap(),
+                http::Request::builder()
+                    .method("PUT")
+                    .uri(uri)
+                    .body(body.to_string().as_bytes())
+                    .unwrap(),
                 &["!roomid:example.org", "m.room.message", "5678"],
             )
             .unwrap();

--- a/crates/ruma-client-api/src/delayed_events/update_delayed_event.rs
+++ b/crates/ruma-client-api/src/delayed_events/update_delayed_event.rs
@@ -121,7 +121,7 @@ pub mod unstable_v2 {
     #[cfg(all(test, feature = "server"))]
     mod server_tests {
 
-        use ruma_common::api::IncomingRequest;
+        use ruma_common::api::IncomingRequestExt as _;
 
         use super::{Request, UpdateAction};
 
@@ -137,7 +137,7 @@ pub mod unstable_v2 {
                 .unwrap();
 
             let req = Request::try_from_http_request(
-                http::Request::builder().method("POST").uri(uri).body("").unwrap(),
+                http::Request::builder().method("POST").uri(uri).body(&[] as &[u8]).unwrap(),
                 &["a_delay_id", "send"],
             )
             .unwrap();

--- a/crates/ruma-client-api/src/filter/create_filter.rs
+++ b/crates/ruma-client-api/src/filter/create_filter.rs
@@ -65,7 +65,7 @@ pub mod v3 {
         #[cfg(feature = "server")]
         #[test]
         fn deserialize_request() {
-            use ruma_common::api::IncomingRequest as _;
+            use ruma_common::api::IncomingRequestExt as _;
 
             use super::Request;
 

--- a/crates/ruma-client-api/src/knock/knock_room.rs
+++ b/crates/ruma-client-api/src/knock/knock_room.rs
@@ -119,23 +119,15 @@ pub mod v3 {
         type EndpointError = Error;
         type OutgoingResponse = Response;
 
-        fn try_from_http_request<B, S>(
-            request: http::Request<B>,
-            path_args: &[S],
-        ) -> Result<Self, ruma_common::api::error::FromHttpRequestError>
-        where
-            B: AsRef<[u8]>,
-            S: AsRef<str>,
-        {
-            Self::check_request_method(request.method())?;
-
+        fn try_from_http_request_inner(
+            request: http::Request<&[u8]>,
+            path_args: &[&str],
+        ) -> Result<Self, ruma_common::api::error::DeserializationError> {
             let (room_id_or_alias,) =
                 serde::Deserialize::deserialize(serde::de::value::SeqDeserializer::<
                     _,
                     serde::de::value::Error,
-                >::new(
-                    path_args.iter().map(::std::convert::AsRef::as_ref),
-                ))?;
+                >::new(path_args.iter().copied()))?;
 
             let request_query: RequestQuery =
                 serde_html_form::from_str(request.uri().query().unwrap_or(""))?;
@@ -145,7 +137,7 @@ pub mod v3 {
                 request_query.via
             };
 
-            let body: RequestBody = serde_json::from_slice(request.body().as_ref())?;
+            let body: RequestBody = serde_json::from_slice(request.body())?;
 
             Ok(Self { room_id_or_alias, reason: body.reason, via })
         }
@@ -227,7 +219,7 @@ pub mod v3 {
 
     #[cfg(all(test, feature = "server"))]
     mod tests_server {
-        use ruma_common::{api::IncomingRequest as _, owned_server_name};
+        use ruma_common::{api::IncomingRequestExt as _, owned_server_name};
 
         use super::Request;
 

--- a/crates/ruma-client-api/src/membership/get_member_events.rs
+++ b/crates/ruma-client-api/src/membership/get_member_events.rs
@@ -80,7 +80,7 @@ pub mod v3 {
 
     #[cfg(all(test, feature = "server"))]
     mod tests {
-        use ruma_common::api::IncomingRequest as _;
+        use ruma_common::api::IncomingRequestExt as _;
 
         use super::{MembershipState, Request};
 

--- a/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
+++ b/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
@@ -133,23 +133,15 @@ pub mod v3 {
         type EndpointError = Error;
         type OutgoingResponse = Response;
 
-        fn try_from_http_request<B, S>(
-            request: http::Request<B>,
-            path_args: &[S],
-        ) -> Result<Self, ruma_common::api::error::FromHttpRequestError>
-        where
-            B: AsRef<[u8]>,
-            S: AsRef<str>,
-        {
-            Self::check_request_method(request.method())?;
-
+        fn try_from_http_request_inner(
+            request: http::Request<&[u8]>,
+            path_args: &[&str],
+        ) -> Result<Self, ruma_common::api::error::DeserializationError> {
             let (room_id_or_alias,) =
                 serde::Deserialize::deserialize(serde::de::value::SeqDeserializer::<
                     _,
                     serde::de::value::Error,
-                >::new(
-                    path_args.iter().map(::std::convert::AsRef::as_ref),
-                ))?;
+                >::new(path_args.iter().copied()))?;
 
             let request_query: RequestQuery =
                 serde_html_form::from_str(request.uri().query().unwrap_or(""))?;
@@ -159,7 +151,7 @@ pub mod v3 {
                 request_query.via
             };
 
-            let body: RequestBody = serde_json::from_slice(request.body().as_ref())?;
+            let body: RequestBody = serde_json::from_slice(request.body())?;
 
             Ok(Self {
                 room_id_or_alias,
@@ -246,7 +238,7 @@ pub mod v3 {
 
     #[cfg(all(test, feature = "server"))]
     mod tests_server {
-        use ruma_common::{api::IncomingRequest as _, owned_server_name};
+        use ruma_common::{api::IncomingRequestExt as _, owned_server_name};
 
         use super::Request;
 

--- a/crates/ruma-client-api/src/profile/get_profile_field.rs
+++ b/crates/ruma-client-api/src/profile/get_profile_field.rs
@@ -97,23 +97,15 @@ pub mod v3 {
         type EndpointError = Error;
         type OutgoingResponse = Response;
 
-        fn try_from_http_request<B, S>(
-            request: http::Request<B>,
-            path_args: &[S],
-        ) -> Result<Self, ruma_common::api::error::FromHttpRequestError>
-        where
-            B: AsRef<[u8]>,
-            S: AsRef<str>,
-        {
-            Self::check_request_method(request.method())?;
-
+        fn try_from_http_request_inner(
+            _request: http::Request<&[u8]>,
+            path_args: &[&str],
+        ) -> Result<Self, ruma_common::api::error::DeserializationError> {
             let (user_id, field) =
                 serde::Deserialize::deserialize(serde::de::value::SeqDeserializer::<
                     _,
                     serde::de::value::Error,
-                >::new(
-                    path_args.iter().map(::std::convert::AsRef::as_ref),
-                ))?;
+                >::new(path_args.iter().copied()))?;
 
             Ok(Self { user_id, field })
         }
@@ -443,13 +435,13 @@ mod tests_server {
 
     #[test]
     fn deserialize_request() {
-        use ruma_common::api::IncomingRequest;
+        use ruma_common::api::IncomingRequestExt as _;
 
         let request = Request::try_from_http_request(
             http::Request::get(
                 "http://localhost/_matrix/client/v3/profile/@alice:localhost/displayname",
             )
-            .body(Vec::<u8>::new())
+            .body(&[] as &[u8])
             .unwrap(),
             &["@alice:localhost", "displayname"],
         )

--- a/crates/ruma-client-api/src/profile/set_avatar_url.rs
+++ b/crates/ruma-client-api/src/profile/set_avatar_url.rs
@@ -102,7 +102,7 @@ pub mod v3 {
 
     #[cfg(all(test, feature = "server"))]
     mod tests {
-        use ruma_common::api::IncomingRequest as _;
+        use ruma_common::api::IncomingRequestExt as _;
 
         use super::Request;
 
@@ -126,7 +126,11 @@ pub mod v3 {
                     http::Request::builder()
                         .method("PUT")
                         .uri("https://bar.org/_matrix/client/r0/profile/@foo:bar.org/avatar_url")
-                        .body(serde_json::to_vec(&serde_json::json!({ "avatar_url": "" })).unwrap())
+                        .body(
+                            serde_json::to_vec(&serde_json::json!({ "avatar_url": "" }))
+                                .unwrap()
+                                .as_slice(),
+                        )
                         .unwrap(),
                     &["@foo:bar.org"],
                 )

--- a/crates/ruma-client-api/src/profile/set_profile_field.rs
+++ b/crates/ruma-client-api/src/profile/set_profile_field.rs
@@ -125,28 +125,20 @@ pub mod v3 {
         type EndpointError = Error;
         type OutgoingResponse = Response;
 
-        fn try_from_http_request<B, S>(
-            request: http::Request<B>,
-            path_args: &[S],
-        ) -> Result<Self, ruma_common::api::error::FromHttpRequestError>
-        where
-            B: AsRef<[u8]>,
-            S: AsRef<str>,
-        {
+        fn try_from_http_request_inner(
+            request: http::Request<&[u8]>,
+            path_args: &[&str],
+        ) -> Result<Self, ruma_common::api::error::DeserializationError> {
             use ruma_common::profile::{ProfileFieldName, ProfileFieldValueVisitor};
             use serde::de::{Deserializer, Error as _};
-
-            Self::check_request_method(request.method())?;
 
             let (user_id, field): (OwnedUserId, ProfileFieldName) =
                 serde::Deserialize::deserialize(serde::de::value::SeqDeserializer::<
                     _,
                     serde::de::value::Error,
-                >::new(
-                    path_args.iter().map(::std::convert::AsRef::as_ref),
-                ))?;
+                >::new(path_args.iter().copied()))?;
 
-            let value = serde_json::Deserializer::from_slice(request.body().as_ref())
+            let value = serde_json::Deserializer::from_slice(request.body())
                 .deserialize_map(ProfileFieldValueVisitor::new(Some(field.clone())))?
                 .ok_or_else(|| serde_json::Error::custom(format!("missing field `{field}`")))?;
 
@@ -326,7 +318,7 @@ mod tests_client {
 #[cfg(all(test, feature = "server"))]
 mod tests_server {
     use assert_matches2::assert_let;
-    use ruma_common::{api::IncomingRequest, profile::ProfileFieldValue};
+    use ruma_common::{api::IncomingRequestExt as _, profile::ProfileFieldValue};
     use serde_json::{json, to_vec as to_json_vec};
 
     use super::v3::Request;
@@ -342,7 +334,7 @@ mod tests_server {
             http::Request::put(
                 "http://localhost/_matrix/client/v3/profile/@alice:localhost/displayname",
             )
-            .body(body)
+            .body(body.as_slice())
             .unwrap(),
             &["@alice:localhost", "displayname"],
         )
@@ -364,7 +356,7 @@ mod tests_server {
             http::Request::put(
                 "http://localhost/_matrix/client/v3/profile/@alice:localhost/displayname",
             )
-            .body(body)
+            .body(body.as_slice())
             .unwrap(),
             &["@alice:localhost", "displayname"],
         )

--- a/crates/ruma-client-api/src/push/set_pushrule.rs
+++ b/crates/ruma-client-api/src/push/set_pushrule.rs
@@ -132,14 +132,10 @@ pub mod v3 {
         type EndpointError = Error;
         type OutgoingResponse = Response;
 
-        fn try_from_http_request<B, S>(
-            request: http::Request<B>,
-            path_args: &[S],
-        ) -> Result<Self, ruma_common::api::error::FromHttpRequestError>
-        where
-            B: AsRef<[u8]>,
-            S: AsRef<str>,
-        {
+        fn try_from_http_request_inner(
+            request: http::Request<&[u8]>,
+            path_args: &[&str],
+        ) -> Result<Self, ruma_common::api::error::DeserializationError> {
             use ruma_common::push::{
                 NewConditionalPushRule, NewPatternedPushRule, NewSimplePushRule,
             };
@@ -155,15 +151,11 @@ pub mod v3 {
                 Content,
             }
 
-            Self::check_request_method(request.method())?;
-
             let (kind, rule_id): (RuleKind, String) =
                 serde::Deserialize::deserialize(serde::de::value::SeqDeserializer::<
                     _,
                     serde::de::value::Error,
-                >::new(
-                    path_args.iter().map(::std::convert::AsRef::as_ref),
-                ))?;
+                >::new(path_args.iter().copied()))?;
 
             let RequestQuery { before, after } =
                 serde_html_form::from_str(request.uri().query().unwrap_or(""))?;
@@ -171,31 +163,29 @@ pub mod v3 {
             let rule = match kind {
                 RuleKind::Override => {
                     let ConditionalRequestBody { actions, conditions } =
-                        serde_json::from_slice(request.body().as_ref())?;
+                        serde_json::from_slice(request.body())?;
                     NewPushRule::Override(NewConditionalPushRule::new(rule_id, conditions, actions))
                 }
                 RuleKind::Underride => {
                     let ConditionalRequestBody { actions, conditions } =
-                        serde_json::from_slice(request.body().as_ref())?;
+                        serde_json::from_slice(request.body())?;
                     NewPushRule::Underride(NewConditionalPushRule::new(
                         rule_id, conditions, actions,
                     ))
                 }
                 RuleKind::Sender => {
-                    let SimpleRequestBody { actions } =
-                        serde_json::from_slice(request.body().as_ref())?;
+                    let SimpleRequestBody { actions } = serde_json::from_slice(request.body())?;
                     let rule_id = rule_id.try_into()?;
                     NewPushRule::Sender(NewSimplePushRule::new(rule_id, actions))
                 }
                 RuleKind::Room => {
-                    let SimpleRequestBody { actions } =
-                        serde_json::from_slice(request.body().as_ref())?;
+                    let SimpleRequestBody { actions } = serde_json::from_slice(request.body())?;
                     let rule_id = rule_id.try_into()?;
                     NewPushRule::Room(NewSimplePushRule::new(rule_id, actions))
                 }
                 RuleKind::Content => {
                     let PatternedRequestBody { actions, pattern } =
-                        serde_json::from_slice(request.body().as_ref())?;
+                        serde_json::from_slice(request.body())?;
                     NewPushRule::Content(NewPatternedPushRule::new(rule_id, pattern, actions))
                 }
             };

--- a/crates/ruma-client-api/src/rendezvous/create_rendezvous_session.rs
+++ b/crates/ruma-client-api/src/rendezvous/create_rendezvous_session.rs
@@ -10,11 +10,11 @@ pub mod unstable_msc4108 {
 
     use http::header::{CONTENT_TYPE, ETAG, EXPIRES, LAST_MODIFIED};
     #[cfg(feature = "client")]
-    use ruma_common::api::{BytesBody, error::DeserializationError};
+    use ruma_common::api::BytesBody;
     use ruma_common::{
         api::{
             auth_scheme::NoAccessToken,
-            error::{Error, HeaderDeserializationError},
+            error::{DeserializationError, Error, HeaderDeserializationError},
         },
         metadata,
     };
@@ -69,19 +69,11 @@ pub mod unstable_msc4108 {
         type EndpointError = Error;
         type OutgoingResponse = Response;
 
-        fn try_from_http_request<B, S>(
-            request: http::Request<B>,
-            _path_args: &[S],
-        ) -> Result<Self, ruma_common::api::error::FromHttpRequestError>
-        where
-            B: AsRef<[u8]>,
-            S: AsRef<str>,
-        {
+        fn try_from_http_request_inner(
+            request: http::Request<&[u8]>,
+            _path_args: &[&str],
+        ) -> Result<Self, DeserializationError> {
             const EXPECTED_CONTENT_TYPE: &str = "text/plain";
-
-            use ruma_common::api::error::DeserializationError;
-
-            Self::check_request_method(request.method())?;
 
             let content_type = request
                 .headers()
@@ -98,7 +90,7 @@ pub mod unstable_msc4108 {
                 }
                 .into())
             } else {
-                let body = request.into_body().as_ref().to_vec();
+                let body = request.into_body().to_vec();
                 let content = String::from_utf8(body)
                     .map_err(|e| DeserializationError::Utf8(e.utf8_error()))?;
 

--- a/crates/ruma-client-api/src/search/search_events.rs
+++ b/crates/ruma-client-api/src/search/search_events.rs
@@ -605,7 +605,7 @@ mod tests {
     use js_int::uint;
     use ruma_common::{
         api::{
-            IncomingRequest, IncomingResponseExt as _, OutgoingRequestExt as _,
+            IncomingRequestExt as _, IncomingResponseExt as _, OutgoingRequestExt as _,
             OutgoingResponseExt as _, SupportedVersions, auth_scheme::SendAccessToken,
         },
         event_id, room_id,
@@ -633,10 +633,13 @@ mod tests {
             }
         });
 
-        let http_request = http::Request::post("http://localhost/_matrix/client/v3/search")
-            .body(to_json_vec(&body).unwrap())
-            .unwrap();
-        let request = Request::try_from_http_request(http_request, &[] as &[&str]).unwrap();
+        let request = Request::try_from_http_request(
+            http::Request::post("http://localhost/_matrix/client/v3/search")
+                .body(to_json_vec(&body).unwrap().as_slice())
+                .unwrap(),
+            &[],
+        )
+        .unwrap();
 
         let criteria = request.search_categories.room_events.as_ref().unwrap();
         assert_eq!(criteria.groupings.group_by.len(), 1);

--- a/crates/ruma-client-api/src/session/logout.rs
+++ b/crates/ruma-client-api/src/session/logout.rs
@@ -63,16 +63,10 @@ pub mod v3 {
         type EndpointError = Error;
         type OutgoingResponse = Response;
 
-        fn try_from_http_request<B, S>(
-            request: http::Request<B>,
-            _path_args: &[S],
-        ) -> Result<Self, ruma_common::api::error::FromHttpRequestError>
-        where
-            B: AsRef<[u8]>,
-            S: AsRef<str>,
-        {
-            Self::check_request_method(request.method())?;
-
+        fn try_from_http_request_inner(
+            _request: http::Request<&[u8]>,
+            _path_args: &[&str],
+        ) -> Result<Self, ruma_common::api::error::DeserializationError> {
             Ok(Self {})
         }
     }

--- a/crates/ruma-client-api/src/session/logout_all.rs
+++ b/crates/ruma-client-api/src/session/logout_all.rs
@@ -63,16 +63,10 @@ pub mod v3 {
         type EndpointError = Error;
         type OutgoingResponse = Response;
 
-        fn try_from_http_request<B, S>(
-            request: http::Request<B>,
-            _path_args: &[S],
-        ) -> Result<Self, ruma_common::api::error::FromHttpRequestError>
-        where
-            B: AsRef<[u8]>,
-            S: AsRef<str>,
-        {
-            Self::check_request_method(request.method())?;
-
+        fn try_from_http_request_inner(
+            _request: http::Request<&[u8]>,
+            _path_args: &[&str],
+        ) -> Result<Self, ruma_common::api::error::DeserializationError> {
             Ok(Self {})
         }
     }

--- a/crates/ruma-client-api/src/state/get_state_event_for_key.rs
+++ b/crates/ruma-client-api/src/state/get_state_event_for_key.rs
@@ -159,16 +159,10 @@ pub mod v3 {
         type EndpointError = Error;
         type OutgoingResponse = Response;
 
-        fn try_from_http_request<B, S>(
-            request: http::Request<B>,
-            path_args: &[S],
-        ) -> Result<Self, ruma_common::api::error::FromHttpRequestError>
-        where
-            B: AsRef<[u8]>,
-            S: AsRef<str>,
-        {
-            Self::check_request_method(request.method())?;
-
+        fn try_from_http_request_inner(
+            request: http::Request<&[u8]>,
+            path_args: &[&str],
+        ) -> Result<Self, ruma_common::api::error::DeserializationError> {
             // FIXME: find a way to make this if-else collapse with serde recognizing trailing
             // Option
             let (room_id, event_type, state_key): (OwnedRoomId, StateEventType, String) =
@@ -177,7 +171,7 @@ pub mod v3 {
                         _,
                         serde::de::value::Error,
                     >::new(
-                        path_args.iter().map(::std::convert::AsRef::as_ref),
+                        path_args.iter().copied()
                     ))?
                 } else {
                     let (a, b) =
@@ -185,7 +179,7 @@ pub mod v3 {
                             _,
                             serde::de::value::Error,
                         >::new(
-                            path_args.iter().map(::std::convert::AsRef::as_ref),
+                            path_args.iter().copied()
                         ))?;
 
                     (a, b, "".into())

--- a/crates/ruma-client-api/src/state/send_state_event.rs
+++ b/crates/ruma-client-api/src/state/send_state_event.rs
@@ -176,16 +176,10 @@ pub mod v3 {
         type EndpointError = Error;
         type OutgoingResponse = Response;
 
-        fn try_from_http_request<B, S>(
-            request: http::Request<B>,
-            path_args: &[S],
-        ) -> Result<Self, ruma_common::api::error::FromHttpRequestError>
-        where
-            B: AsRef<[u8]>,
-            S: AsRef<str>,
-        {
-            Self::check_request_method(request.method())?;
-
+        fn try_from_http_request_inner(
+            request: http::Request<&[u8]>,
+            path_args: &[&str],
+        ) -> Result<Self, ruma_common::api::error::DeserializationError> {
             // FIXME: find a way to make this if-else collapse with serde recognizing trailing
             // Option
             let (room_id, event_type, state_key): (OwnedRoomId, StateEventType, String) =
@@ -194,7 +188,7 @@ pub mod v3 {
                         _,
                         serde::de::value::Error,
                     >::new(
-                        path_args.iter().map(::std::convert::AsRef::as_ref),
+                        path_args.iter().copied()
                     ))?
                 } else {
                     let (a, b) =
@@ -202,7 +196,7 @@ pub mod v3 {
                             _,
                             serde::de::value::Error,
                         >::new(
-                            path_args.iter().map(::std::convert::AsRef::as_ref),
+                            path_args.iter().copied()
                         ))?;
 
                     (a, b, "".into())
@@ -212,7 +206,7 @@ pub mod v3 {
                 serde_html_form::from_str(request.uri().query().unwrap_or(""))?;
 
             let body: Raw<AnyStateEventContent> = ruma_common::serde::deserialize_raw_object(
-                &mut serde_json::Deserializer::from_slice(request.body().as_ref()),
+                &mut serde_json::Deserializer::from_slice(request.into_body()),
             )?;
 
             Ok(Self {

--- a/crates/ruma-client-api/src/sync/sync_events/v3.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v3.rs
@@ -1130,7 +1130,7 @@ mod server_tests {
 
     use assert_matches2::assert_matches;
     use ruma_common::{
-        api::{IncomingRequest as _, OutgoingResponseExt as _},
+        api::{IncomingRequestExt as _, OutgoingResponseExt as _},
         owned_room_id,
         presence::PresenceState,
         serde::Raw,
@@ -1179,7 +1179,7 @@ mod server_tests {
 
         let req = Request::try_from_http_request(
             http::Request::builder().uri(uri).body(&[] as &[u8]).unwrap(),
-            &[] as &[String],
+            &[],
         )
         .unwrap();
 
@@ -1202,7 +1202,7 @@ mod server_tests {
 
         let req = Request::try_from_http_request(
             http::Request::builder().uri(uri).body(&[] as &[u8]).unwrap(),
-            &[] as &[String],
+            &[],
         )
         .unwrap();
 
@@ -1228,7 +1228,7 @@ mod server_tests {
 
         let req = Request::try_from_http_request(
             http::Request::builder().uri(uri).body(&[] as &[u8]).unwrap(),
-            &[] as &[String],
+            &[],
         )
         .unwrap();
 

--- a/crates/ruma-client-api/src/threads/get_threads.rs
+++ b/crates/ruma-client-api/src/threads/get_threads.rs
@@ -114,7 +114,7 @@ pub mod v1 {
 
 #[cfg(all(test, feature = "server"))]
 mod tests {
-    use ruma_common::{api::IncomingRequest, room_id};
+    use ruma_common::{api::IncomingRequestExt as _, room_id};
 
     use super::v1::{IncludeThreads, Request};
 
@@ -125,7 +125,7 @@ mod tests {
         let http_req = http::Request::builder()
             .method(http::Method::GET)
             .uri("/_matrix/client/v1/rooms/!room:example.com/threads")
-            .body(Vec::<u8>::new())
+            .body(&[] as &[u8])
             .unwrap();
 
         let req = Request::try_from_http_request(http_req, &["!room:example.com"]).unwrap();
@@ -142,7 +142,7 @@ mod tests {
         let http_req = http::Request::builder()
             .method(http::Method::GET)
             .uri("/_matrix/client/v1/rooms/!room:example.com/threads?include=participated")
-            .body(Vec::<u8>::new())
+            .body(&[] as &[u8])
             .unwrap();
 
         let req = Request::try_from_http_request(http_req, &["!room:example.com"]).unwrap();

--- a/crates/ruma-client-api/tests/it/event_content.rs
+++ b/crates/ruma-client-api/tests/it/event_content.rs
@@ -3,14 +3,14 @@
 use assert_matches2::assert_matches;
 use ruma_client_api::{message::send_message_event, state::send_state_event};
 use ruma_common::api::{
-    IncomingRequest as _,
+    IncomingRequestExt as _,
     error::{DeserializationError, FromHttpRequestError},
 };
 
 const ROOM_ID: &str = "!room:server.tld";
 
-fn http_put(uri: &str, body: &[u8]) -> http::Request<Vec<u8>> {
-    http::Request::builder().method(http::Method::PUT).uri(uri).body(body.to_vec()).unwrap()
+fn http_put<'a>(uri: &str, body: &'a [u8]) -> http::Request<&'a [u8]> {
+    http::Request::builder().method(http::Method::PUT).uri(uri).body(body).unwrap()
 }
 
 fn assert_non_object_rejected(err: FromHttpRequestError) {

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -12,6 +12,14 @@ Breaking changes:
   that is automatically implemented for any `T: OutgoingResponse`
   - Implementors of `OutgoingResponse` now instead have to provide the new `type Body`
     and `fn try_into_http_response_inner`
+- `IncomingRequest::try_from_http_request` has been moved to a new `IncomingRequestExt` trait
+  that is automatically implemented for any `T: IncomingRequest`
+  - Implementors of `IncomingRequest` now instead have to provide the
+    `fn try_from_http_request_inner`
+  - The generics were removed from `try_from_http_request`, the body of the request is a `&[u8]` and
+    the path args is a `&[&str]`.
+  - `IncomingRequest::check_request_method` was removed, this check is part of
+    `IncomingRequestExt::try_from_http_request`.
 
 Bug fixes:
 

--- a/crates/ruma-common/src/api.rs
+++ b/crates/ruma-common/src/api.rs
@@ -415,9 +415,28 @@ pub trait IncomingRequest: Metadata {
     /// Response type to return when the request is successful.
     type OutgoingResponse: OutgoingResponse;
 
-    /// Check whether the given HTTP method from an incoming request is compatible with the expected
-    /// [`METHOD`](Metadata::METHOD) of this endpoint.
-    fn check_request_method(method: &http::Method) -> Result<(), FromHttpRequestError> {
+    /// Tries to turn the given `http::Request` into this request type,
+    /// together with the corresponding path arguments.
+    ///
+    /// Note: The strings in `path_args` need to be percent-decoded.
+    ///
+    /// This function should not check the method of the HTTP request, this check is performed
+    /// in [`IncomingRequestExt::try_from_http_request()`].
+    fn try_from_http_request_inner(
+        request: http::Request<&[u8]>,
+        path_args: &[&str],
+    ) -> Result<Self, DeserializationError>;
+}
+
+/// Convenience functionality on top of [`IncomingRequest`].
+pub trait IncomingRequestExt: IncomingRequest {
+    /// Tries to convert the given `http::Request` into this request type.
+    fn try_from_http_request(
+        request: http::Request<&[u8]>,
+        path_args: &[&str],
+    ) -> Result<Self, FromHttpRequestError> {
+        let method = request.method();
+
         if !(method == Self::METHOD
             || (Self::METHOD == http::Method::GET && method == http::Method::HEAD))
         {
@@ -427,21 +446,11 @@ pub trait IncomingRequest: Metadata {
             });
         }
 
-        Ok(())
+        Ok(Self::try_from_http_request_inner(request, path_args)?)
     }
-
-    /// Tries to turn the given `http::Request` into this request type,
-    /// together with the corresponding path arguments.
-    ///
-    /// Note: The strings in path_args need to be percent-decoded.
-    fn try_from_http_request<B, S>(
-        req: http::Request<B>,
-        path_args: &[S],
-    ) -> Result<Self, FromHttpRequestError>
-    where
-        B: AsRef<[u8]>,
-        S: AsRef<str>;
 }
+
+impl<T: IncomingRequest> IncomingRequestExt for T {}
 
 /// A request type for a Matrix API endpoint, used for sending responses.
 pub trait OutgoingResponse: Sized {

--- a/crates/ruma-common/tests/it/api/conversions.rs
+++ b/crates/ruma-common/tests/it/api/conversions.rs
@@ -6,8 +6,8 @@ use http::header::CONTENT_TYPE;
 use ruma_common::{
     OwnedUserId,
     api::{
-        AppserviceUserIdentity, IncomingRequest as _, MatrixVersion, OutgoingRequestAppserviceExt,
-        OutgoingRequestExt as _, SupportedVersions,
+        AppserviceUserIdentity, IncomingRequestExt as _, MatrixVersion,
+        OutgoingRequestAppserviceExt, OutgoingRequestExt as _, SupportedVersions,
         auth_scheme::{NoAccessToken, SendAccessToken},
         request, response,
     },
@@ -69,14 +69,16 @@ fn request_serde() {
     let supported =
         SupportedVersions { versions: [MatrixVersion::V1_1].into(), features: Default::default() };
 
-    let http_req = req
+    let (parts, body) = req
         .clone()
         .try_into_http_request::<Vec<u8>>(
             "https://homeserver.tld",
             SendAccessToken::None,
             Cow::Owned(supported),
         )
-        .unwrap();
+        .unwrap()
+        .into_parts();
+    let http_req = http::Request::from_parts(parts, body.as_slice());
     let req2 = Request::try_from_http_request(http_req, &["barVal", "@bazme:ruma.io"]).unwrap();
 
     assert_eq!(req.hello, req2.hello);

--- a/crates/ruma-common/tests/it/api/manual_endpoint_impl.rs
+++ b/crates/ruma-common/tests/it/api/manual_endpoint_impl.rs
@@ -13,7 +13,7 @@ use ruma_common::{
         EmptyBody, IncomingRequest, IncomingResponse, MatrixVersion, Metadata, OutgoingBody,
         OutgoingRequest, OutgoingResponse, SupportedVersions,
         auth_scheme::NoAuthentication,
-        error::{DeserializationError, Error, FromHttpRequestError, IntoHttpError},
+        error::{DeserializationError, Error, IntoHttpError},
         path_builder::{StablePathSelector, VersionHistory},
     },
     serde::json_to_buf,
@@ -88,24 +88,16 @@ impl IncomingRequest for Request {
     type EndpointError = Error;
     type OutgoingResponse = Response;
 
-    fn try_from_http_request<B, S>(
-        request: http::Request<B>,
-        path_args: &[S],
-    ) -> Result<Self, FromHttpRequestError>
-    where
-        B: AsRef<[u8]>,
-        S: AsRef<str>,
-    {
-        Self::check_request_method(request.method())?;
-
+    fn try_from_http_request_inner(
+        request: http::Request<&[u8]>,
+        path_args: &[&str],
+    ) -> Result<Self, DeserializationError> {
         let (room_alias,) = Deserialize::deserialize(serde::de::value::SeqDeserializer::<
             _,
             serde::de::value::Error,
-        >::new(
-            path_args.iter().map(::std::convert::AsRef::as_ref),
-        ))?;
+        >::new(path_args.iter().copied()))?;
 
-        let request_body: RequestBody = serde_json::from_slice(request.body().as_ref())?;
+        let request_body: RequestBody = serde_json::from_slice(request.into_body())?;
 
         Ok(Request { room_id: request_body.room_id, room_alias })
     }

--- a/crates/ruma-common/tests/it/api/optional_headers.rs
+++ b/crates/ruma-common/tests/it/api/optional_headers.rs
@@ -4,7 +4,7 @@ use assert_matches2::assert_matches;
 use http::header::{CONTENT_DISPOSITION, LOCATION};
 use ruma_common::{
     api::{
-        IncomingRequest, IncomingResponseExt as _, MatrixVersion, OutgoingRequestExt as _,
+        IncomingRequestExt as _, IncomingResponseExt as _, MatrixVersion, OutgoingRequestExt as _,
         OutgoingResponseExt as _, SupportedVersions, auth_scheme::NoAuthentication, request,
         response,
     },
@@ -52,7 +52,9 @@ fn request_serde_no_header() {
     assert_matches!(http_req.headers().get(LOCATION), None);
     assert_matches!(http_req.headers().get(CONTENT_DISPOSITION), None);
 
-    let req2 = Request::try_from_http_request::<_, &str>(http_req, &[]).unwrap();
+    let (parts, body) = http_req.into_parts();
+    let http_req = http::Request::from_parts(parts, body.as_slice());
+    let req2 = Request::try_from_http_request(http_req, &[]).unwrap();
     assert_eq!(req2.location, None);
     assert_eq!(req2.content_disposition, None);
 }
@@ -76,7 +78,9 @@ fn request_serde_with_header() {
     assert_matches!(http_req.headers().get(LOCATION), Some(_));
     assert_matches!(http_req.headers().get(CONTENT_DISPOSITION), Some(_));
 
-    let req2 = Request::try_from_http_request::<_, &str>(http_req.clone(), &[]).unwrap();
+    let (parts, body) = http_req.clone().into_parts();
+    let http_req2 = http::Request::from_parts(parts, body.as_slice());
+    let req2 = Request::try_from_http_request(http_req2, &[]).unwrap();
     assert_eq!(req2.location.unwrap(), location);
     assert_eq!(req2.content_disposition.unwrap(), content_disposition);
 
@@ -84,14 +88,18 @@ fn request_serde_with_header() {
     http_req.headers_mut().remove(LOCATION).unwrap();
     http_req.headers_mut().remove(CONTENT_DISPOSITION).unwrap();
 
-    let req3 = Request::try_from_http_request::<_, &str>(http_req.clone(), &[]).unwrap();
+    let (parts, body) = http_req.clone().into_parts();
+    let http_req3 = http::Request::from_parts(parts, body.as_slice());
+    let req3 = Request::try_from_http_request(http_req3, &[]).unwrap();
     assert_eq!(req3.location, None);
     assert_eq!(req3.content_disposition, None);
 
     // Try setting invalid header.
     http_req.headers_mut().insert(CONTENT_DISPOSITION, ";".try_into().unwrap());
 
-    let req4 = Request::try_from_http_request::<_, &str>(http_req, &[]).unwrap();
+    let (parts, body) = http_req.into_parts();
+    let http_req4 = http::Request::from_parts(parts, body.as_slice());
+    let req4 = Request::try_from_http_request(http_req4, &[]).unwrap();
     assert_eq!(req4.location, None);
     assert_eq!(req4.content_disposition, None);
 }

--- a/crates/ruma-common/tests/it/api/required_headers.rs
+++ b/crates/ruma-common/tests/it/api/required_headers.rs
@@ -4,7 +4,7 @@ use assert_matches2::assert_matches;
 use http::header::{CONTENT_DISPOSITION, LOCATION};
 use ruma_common::{
     api::{
-        IncomingRequest, IncomingResponseExt as _, MatrixVersion, OutgoingRequestExt as _,
+        IncomingRequestExt as _, IncomingResponseExt as _, MatrixVersion, OutgoingRequestExt as _,
         OutgoingResponseExt as _, SupportedVersions,
         auth_scheme::NoAuthentication,
         error::{
@@ -61,7 +61,9 @@ fn request_serde() {
     assert_matches!(http_req.headers().get(LOCATION), Some(_));
     assert_matches!(http_req.headers().get(CONTENT_DISPOSITION), Some(_));
 
-    let req2 = Request::try_from_http_request::<_, &str>(http_req.clone(), &[]).unwrap();
+    let (parts, body) = http_req.clone().into_parts();
+    let http_req2 = http::Request::from_parts(parts, body.as_slice());
+    let req2 = Request::try_from_http_request(http_req2, &[]).unwrap();
     assert_eq!(req2.location, location);
     assert_eq!(req2.content_disposition, content_disposition);
 
@@ -69,7 +71,9 @@ fn request_serde() {
     http_req.headers_mut().remove(LOCATION).unwrap();
     http_req.headers_mut().remove(CONTENT_DISPOSITION).unwrap();
 
-    let err = Request::try_from_http_request::<_, &str>(http_req.clone(), &[]).unwrap_err();
+    let (parts, body) = http_req.clone().into_parts();
+    let http_req3 = http::Request::from_parts(parts, body.as_slice());
+    let err = Request::try_from_http_request(http_req3, &[]).unwrap_err();
     assert_matches!(
         err,
         FromHttpRequestError::Deserialization(DeserializationError::Header(
@@ -81,7 +85,9 @@ fn request_serde() {
     http_req.headers_mut().insert(LOCATION, location.try_into().unwrap());
     http_req.headers_mut().insert(CONTENT_DISPOSITION, ";".try_into().unwrap());
 
-    let err = Request::try_from_http_request::<_, &str>(http_req, &[]).unwrap_err();
+    let (parts, body) = http_req.into_parts();
+    let http_req4 = http::Request::from_parts(parts, body.as_slice());
+    let err = Request::try_from_http_request(http_req4, &[]).unwrap_err();
     assert_matches!(
         err,
         FromHttpRequestError::Deserialization(DeserializationError::Header(

--- a/crates/ruma-macros/src/api/common.rs
+++ b/crates/ruma-macros/src/api/common.rs
@@ -405,18 +405,12 @@ impl Body {
         let body_fields = expand_fields_as_list(fields);
 
         quote! {
-            let body: #body_ident = {
-                let body = ::std::convert::AsRef::<[::std::primitive::u8]>::as_ref(
-                    #src.body(),
-                );
-
-                #serde_json::from_slice(match body {
-                    // If the body is completely empty, pretend it is an empty JSON object instead.
-                    // This allows bodies with only optional fields to be deserialized in that case.
-                    [] => b"{}",
-                    b => b,
-                })?
-            };
+            let body: #body_ident = #serde_json::from_slice(match *#src.body() {
+                // If the body is completely empty, pretend it is an empty JSON object instead.
+                // This allows bodies with only optional fields to be deserialized in that case.
+                [] => b"{}",
+                b => b,
+            })?;
 
             let #body_ident {
                 #body_fields

--- a/crates/ruma-macros/src/api/request/incoming.rs
+++ b/crates/ruma-macros/src/api/request/incoming.rs
@@ -35,16 +35,11 @@ impl Request {
                 type EndpointError = #error_ty;
                 type OutgoingResponse = Response;
 
-                fn try_from_http_request<B, S>(
-                    #request: #http::Request<B>,
-                    path_args: &[S],
-                ) -> ::std::result::Result<Self, #ruma_common::api::error::FromHttpRequestError>
-                where
-                    B: ::std::convert::AsRef<[::std::primitive::u8]>,
-                    S: ::std::convert::AsRef<::std::primitive::str>,
+                fn try_from_http_request_inner(
+                    #request: #http::Request<&[::std::primitive::u8]>,
+                    path_args: &[&::std::primitive::str],
+                ) -> ::std::result::Result<Self, #ruma_common::api::error::DeserializationError>
                 {
-                    <Self as #ruma_common::api::IncomingRequest>::check_request_method(#request.method())?;
-
                     #path_parse
                     #query_parse
                     #headers_parse
@@ -75,7 +70,7 @@ impl RequestPath {
         Some(quote! {
             let (#fields) = #serde::Deserialize::deserialize(
                 #serde::de::value::SeqDeserializer::<_, #serde::de::value::Error>::new(
-                    path_args.iter().map(::std::convert::AsRef::as_ref)
+                    path_args.iter().copied()
                 )
             )?;
         })


### PR DESCRIPTION
- Rename the main trait method from `try_from_http_request` to `try_from_http_request_inner`
- Make the main trait method non-generic, by using `&[u8]` for the request body and `&[&str]` for the path args.
- Add trait `IncomingRequestExt` that provides `try_from_http_request` with the same functionality as the previous `IncomingResponse::try_from_http_request`.

Part of #2558.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
