### PR TITLE
fix(events): deserialize sticky duration query parameters

### DIFF
--- a/crates/ruma-client-api/src/message/send_message_event.rs
+++ b/crates/ruma-client-api/src/message/send_message_event.rs
@@ -189,3 +189,30 @@ mod tests {
         );
     }
 }
+
+#[cfg(all(test, feature = "server", feature = "unstable-msc4354"))]
+mod server_tests {
+    use ruma_common::{api::IncomingRequest, owned_room_id};
+
+    use super::v3::Request;
+
+    #[test]
+    fn deserialize_sticky_duration() {
+        let request = http::Request::builder()
+            .method("PUT")
+            .uri(
+                "/_matrix/client/v3/rooms/!roomid:example.org/send/m.room.message/0000?org.matrix.msc4354.sticky_duration_ms=123456",
+            )
+            .body(r#"{"body":"Hello"}"#)
+            .unwrap();
+
+        let request = Request::try_from_http_request(
+            request,
+            &["!roomid:example.org", "m.room.message", "0000"],
+        )
+        .unwrap();
+
+        assert_eq!(request.room_id, owned_room_id!("!roomid:example.org"));
+        assert_eq!(request.sticky_duration_ms.map(|duration| duration.get()), Some(123_456));
+    }
+}

--- a/crates/ruma-client-api/src/state/send_state_event.rs
+++ b/crates/ruma-client-api/src/state/send_state_event.rs
@@ -317,3 +317,28 @@ mod tests {
         assert_eq!(http_req.uri().query().unwrap(), "org.matrix.msc4354.sticky_duration_ms=1000");
     }
 }
+
+#[cfg(all(test, feature = "server", feature = "unstable-msc4354"))]
+mod server_tests {
+    use ruma_common::{api::IncomingRequest, owned_room_id};
+
+    use super::v3::Request;
+
+    #[test]
+    fn deserialize_sticky_duration() {
+        let request = http::Request::builder()
+            .method("PUT")
+            .uri(
+                "/_matrix/client/v3/rooms/!roomid:example.org/state/m.room.name/?org.matrix.msc4354.sticky_duration_ms=123456",
+            )
+            .body(r#"{"name":"A room"}"#)
+            .unwrap();
+
+        let request =
+            Request::try_from_http_request(request, &["!roomid:example.org", "m.room.name", ""])
+                .unwrap();
+
+        assert_eq!(request.room_id, owned_room_id!("!roomid:example.org"));
+        assert_eq!(request.sticky_duration_ms.map(|duration| duration.get()), Some(123_456));
+    }
+}

--- a/crates/ruma-events/src/sticky.rs
+++ b/crates/ruma-events/src/sticky.rs
@@ -81,7 +81,7 @@ impl<'de> Deserialize<'de> for StickyDurationMs {
             }
         }
 
-        deserializer.deserialize_any(StickyDurationMsVisitor)
+        deserializer.deserialize_u32(StickyDurationMsVisitor)
     }
 }
 
@@ -130,6 +130,20 @@ mod tests {
     }
 
     #[test]
+    fn deserialize_sticky_string_err() {
+        let raw = r#""3000""#;
+        let res: Result<StickyDurationMs, _> = serde_json::from_str(raw);
+        assert!(res.is_err());
+
+        let err = res.unwrap_err();
+        assert!(
+            err.to_string().contains(
+                "invalid type: string \"3000\", expected an integer in the range 0-3600000"
+            )
+        );
+    }
+
+    #[test]
     fn deserialize_sticky_neg_err() {
         let raw = "-1";
         let res: Result<StickyDurationMs, _> = serde_json::from_str(raw);
@@ -150,6 +164,13 @@ mod tests {
         let ser = r#"{"duration_ms":78000}"#;
         let sticky_object: StickyObject = serde_json::from_str(ser).unwrap();
         assert_eq!(sticky_object.duration_ms.get(), 78_000_u32);
+    }
+
+    #[test]
+    fn serialize_sticky_object() {
+        let sticky_object = StickyObject { duration_ms: StickyDurationMs::new_clamped(78_000_u32) };
+        let ser = serde_json::to_string(&sticky_object).unwrap();
+        assert_eq!(ser, r#"{"duration_ms":78000}"#);
     }
 
     #[test]

--- a/crates/ruma-events/tests/it/sticky.rs
+++ b/crates/ruma-events/tests/it/sticky.rs
@@ -60,6 +60,31 @@ fn deserialize_sticky_event() {
 }
 
 #[test]
+fn deserialize_sticky_event_with_string_duration_is_ignored() {
+    let json_data = json!({
+        "content": {
+            "body": "Hello, but sticky",
+            "msgtype": "m.text",
+        },
+        "event_id": "$h29iv0s8:example.com",
+        "origin_server_ts": 1,
+        "room_id": "!roomid:room.com",
+        "sender": "@alice:example.com",
+        "type": "m.room.message",
+        "msc4354_sticky": {
+            "duration_ms": "3600000"
+        }
+    });
+
+    assert_matches!(
+        from_json_value::<AnyMessageLikeEvent>(json_data).unwrap(),
+        AnyMessageLikeEvent::RoomMessage(MessageLikeEvent::Original(message_event))
+    );
+
+    assert!(message_event.sticky.is_none());
+}
+
+#[test]
 fn deserialize_sticky_top_level_support_server_sends_both_stable_unstable() {
     let json_data = json!({
         "content": {


### PR DESCRIPTION
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->

Fixes MSC4354 sticky duration query parsing.
StickyDurationMs now deserializes URL query parameters as integers, allowing clients to send org.matrix.msc4354.sticky_duration_ms on message and state event requests. JSON event duration_ms values remain numeric-only.
Adds request deserialization and event serialization/rejection regression tests.