### PR TITLE
events: Deserialize removed space relationships

### DIFF
--- a/crates/ruma-events/CHANGELOG.md
+++ b/crates/ruma-events/CHANGELOG.md
@@ -40,6 +40,8 @@ Improvements:
 Bug fixes:
 
 - Avoid creating empty formatted body fields when editing plain text message events.
+- Deserialize the empty `m.space.child` and `m.space.parent` event contents used to remove space
+  relationships.
 
 ## 0.34.0
 

--- a/crates/ruma-events/src/space/child.rs
+++ b/crates/ruma-events/src/space/child.rs
@@ -26,6 +26,9 @@ use crate::{StateEvent, SyncStateEvent};
 #[ruma_event(type = "m.space.child", kind = State, state_key_type = OwnedRoomId)]
 pub struct SpaceChildEventContent {
     /// List of candidate servers that can be used to join the room.
+    ///
+    /// When absent, the child relationship is removed.
+    #[serde(default)]
     pub via: Vec<OwnedServerName>,
 
     /// Provide a default ordering of siblings in the room list.
@@ -72,9 +75,9 @@ impl PossiblyRedactedSpaceChildEventContent {
     /// The room in the state key of the event should only be considered a child of this space
     /// if this returns `true`.
     ///
-    /// Returns `false` if the `via` field is `None`.
+    /// Returns `false` if there are no candidate servers.
     pub fn is_valid(&self) -> bool {
-        self.via.is_some()
+        !self.via.is_empty()
     }
 }
 
@@ -336,6 +339,15 @@ mod tests {
         let content = SpaceChildEventContent { via: vec![], order: None, suggested: false };
 
         assert_to_canonical_json_eq!(content, json!({ "via": [] }));
+    }
+
+    #[test]
+    fn space_child_removal_deserialization() {
+        let content = from_json_value::<SpaceChildEventContent>(json!({})).unwrap();
+
+        assert!(content.via.is_empty());
+        assert_eq!(content.order, None);
+        assert!(!content.suggested);
     }
 
     #[test]

--- a/crates/ruma-events/src/space/parent.rs
+++ b/crates/ruma-events/src/space/parent.rs
@@ -18,6 +18,9 @@ use serde::{Deserialize, Serialize};
 #[ruma_event(type = "m.space.parent", kind = State, state_key_type = OwnedRoomId)]
 pub struct SpaceParentEventContent {
     /// List of candidate servers that can be used to join the room.
+    ///
+    /// When absent, the parent relationship is removed.
+    #[serde(default)]
     pub via: Vec<OwnedServerName>,
 
     /// Determines whether this is the main parent for the space.
@@ -47,16 +50,16 @@ impl PossiblyRedactedSpaceParentEventContent {
     /// The room in the state key of the event should only be considered a parent space of this room
     /// if this returns `true`.
     ///
-    /// Returns `false` if the `via` field is `None`.
+    /// Returns `false` if there are no candidate servers.
     pub fn is_valid(&self) -> bool {
-        self.via.is_some()
+        !self.via.is_empty()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use ruma_common::{canonical_json::assert_to_canonical_json_eq, owned_server_name};
-    use serde_json::json;
+    use serde_json::{from_value as from_json_value, json};
 
     use super::SpaceParentEventContent;
 
@@ -81,5 +84,13 @@ mod tests {
         let content = SpaceParentEventContent { via: vec![], canonical: false };
 
         assert_to_canonical_json_eq!(content, json!({ "via": [] }));
+    }
+
+    #[test]
+    fn space_parent_removal_deserialization() {
+        let content = from_json_value::<SpaceParentEventContent>(json!({})).unwrap();
+
+        assert!(content.via.is_empty());
+        assert!(!content.canonical);
     }
 }


### PR DESCRIPTION
- Accept empty m.space.child and m.space.parent content during deserialization.
- Treat missing routing data as an invalid space relationship.
- Add regression tests for the Matrix-spec-defined removal payloads.
The Matrix specification and MSC1772 remove space relationships by omitting via, yielding content: {}. Previously, Ruma required via and rejected these valid state events during deserialization.