### PR TITLE
Add appservice and identity service API auth types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1944,6 +1944,7 @@ name = "ruma-appservice-api"
 version = "0.16.0"
 dependencies = [
  "assert_matches2",
+ "http",
  "js_int",
  "ruma-common",
  "ruma-events",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2088,6 +2088,7 @@ dependencies = [
 name = "ruma-identity-service-api"
 version = "0.15.0"
 dependencies = [
+ "http",
  "js_int",
  "ruma-common",
  "ruma-events",

--- a/crates/ruma-appservice-api/CHANGELOG.md
+++ b/crates/ruma-appservice-api/CHANGELOG.md
@@ -6,6 +6,7 @@ Breaking changes:
 
 - Export nothing from the crate if neither the `client` nor the `server` feature is active, because
   the crate is not useful without them.
+- All appservice API routes now use the new `HomeserverToken` auth scheme struct.
 
 ## 0.16.0
 

--- a/crates/ruma-appservice-api/Cargo.toml
+++ b/crates/ruma-appservice-api/Cargo.toml
@@ -22,6 +22,7 @@ unstable-msc3202 = []
 unstable-msc4203 = []
 
 [dependencies]
+http = { workspace = true }
 js_int = { workspace = true, features = ["serde"] }
 ruma-common = { workspace = true, features = ["api"] }
 ruma-events = { workspace = true }

--- a/crates/ruma-appservice-api/src/event/push_events.rs
+++ b/crates/ruma-appservice-api/src/event/push_events.rs
@@ -19,7 +19,7 @@ pub mod v1 {
     use ruma_common::{OwnedDeviceId, OwnedUserId};
     use ruma_common::{
         OwnedTransactionId,
-        api::{auth_scheme::AccessToken, request, response},
+        api::{request, response},
         metadata,
         serde::{JsonObject, Raw, from_raw_json_value},
     };
@@ -33,10 +33,12 @@ pub mod v1 {
     use serde::{Deserialize, Deserializer, Serialize};
     use serde_json::value::{RawValue as RawJsonValue, Value as JsonValue};
 
+    use crate::HomeserverToken;
+
     metadata! {
         method: PUT,
         rate_limited: false,
-        authentication: AccessToken,
+        authentication: HomeserverToken,
         path: "/_matrix/app/v1/transactions/{txn_id}",
     }
 
@@ -341,7 +343,7 @@ pub mod v1 {
         #[cfg(feature = "client")]
         #[test]
         fn request_contains_events_field() {
-            use ruma_common::api::{OutgoingRequestExt as _, auth_scheme::SendAccessToken};
+            use ruma_common::api::OutgoingRequestExt as _;
 
             let dummy_event_json = json!({
                 "type": "m.room.message",
@@ -358,11 +360,7 @@ pub mod v1 {
             let events = vec![dummy_event];
 
             let req = super::Request::new("any_txn_id".into(), events)
-                .try_into_http_request::<Vec<u8>>(
-                    "https://homeserver.tld",
-                    SendAccessToken::IfRequired("auth_tok"),
-                    (),
-                )
+                .try_into_http_request::<Vec<u8>>("https://homeserver.tld", "auth_tok", ())
                 .unwrap();
             let json_body: serde_json::Value = serde_json::from_slice(req.body()).unwrap();
 

--- a/crates/ruma-appservice-api/src/lib.rs
+++ b/crates/ruma-appservice-api/src/lib.rs
@@ -10,6 +10,10 @@
 #![cfg(any(feature = "client", feature = "server"))]
 #![warn(missing_docs)]
 
+use ruma_common::api::auth_scheme::{
+    AuthScheme, ExtractTokenError, add_access_token_as_authorization_header,
+    extract_bearer_or_query_token,
+};
 use serde::{Deserialize, Serialize};
 
 pub mod event;
@@ -172,5 +176,35 @@ impl From<RegistrationInit> for Registration {
             protocols,
             receive_ephemeral: false,
         }
+    }
+}
+
+/// Authentication is required, and can only be performed by a homeserver sending a request to an
+/// appservice, by including a homeserver access token in the `Authentication` http header, or an
+/// `access_token` query parameter.
+///
+/// Using the query parameter is deprecated since Matrix 1.11.
+#[derive(Debug, Clone, Copy, Default)]
+#[allow(clippy::exhaustive_structs)]
+pub struct HomeserverToken;
+
+impl AuthScheme for HomeserverToken {
+    type Input<'a> = &'a str;
+    type AddAuthenticationError = http::header::InvalidHeaderValue;
+    /// The homeserver token.
+    type Output = String;
+    type ExtractAuthenticationError = ExtractTokenError;
+
+    fn add_authentication<T: AsRef<[u8]>>(
+        request: &mut http::Request<T>,
+        access_token: Self::Input<'_>,
+    ) -> Result<(), Self::AddAuthenticationError> {
+        add_access_token_as_authorization_header(request.headers_mut(), access_token)
+    }
+
+    fn extract_authentication<T>(
+        request: &http::Request<T>,
+    ) -> Result<Self::Output, Self::ExtractAuthenticationError> {
+        extract_bearer_or_query_token(request)?.ok_or(ExtractTokenError::MissingAccessToken)
     }
 }

--- a/crates/ruma-appservice-api/src/ping/send_ping.rs
+++ b/crates/ruma-appservice-api/src/ping/send_ping.rs
@@ -9,14 +9,16 @@ pub mod unstable {
 
     use ruma_common::{
         OwnedTransactionId,
-        api::{auth_scheme::AccessToken, request, response},
+        api::{request, response},
         metadata,
     };
+
+    use crate::HomeserverToken;
 
     metadata! {
         method: POST,
         rate_limited: false,
-        authentication: AccessToken,
+        authentication: HomeserverToken,
         path: "/_matrix/app/unstable/fi.mau.msc2659/ping",
     }
 
@@ -57,14 +59,16 @@ pub mod v1 {
 
     use ruma_common::{
         OwnedTransactionId,
-        api::{auth_scheme::AccessToken, request, response},
+        api::{request, response},
         metadata,
     };
+
+    use crate::HomeserverToken;
 
     metadata! {
         method: POST,
         rate_limited: false,
-        authentication: AccessToken,
+        authentication: HomeserverToken,
         path: "/_matrix/app/v1/ping",
     }
 

--- a/crates/ruma-appservice-api/src/query/query_room_alias.rs
+++ b/crates/ruma-appservice-api/src/query/query_room_alias.rs
@@ -9,14 +9,16 @@ pub mod v1 {
 
     use ruma_common::{
         OwnedRoomAliasId,
-        api::{auth_scheme::AccessToken, request, response},
+        api::{request, response},
         metadata,
     };
+
+    use crate::HomeserverToken;
 
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: AccessToken,
+        authentication: HomeserverToken,
         path: "/_matrix/app/v1/rooms/{room_alias}",
     }
 

--- a/crates/ruma-appservice-api/src/query/query_user_id.rs
+++ b/crates/ruma-appservice-api/src/query/query_user_id.rs
@@ -9,14 +9,16 @@ pub mod v1 {
 
     use ruma_common::{
         OwnedUserId,
-        api::{auth_scheme::AccessToken, request, response},
+        api::{request, response},
         metadata,
     };
+
+    use crate::HomeserverToken;
 
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: AccessToken,
+        authentication: HomeserverToken,
         path: "/_matrix/app/v1/users/{user_id}",
     }
 

--- a/crates/ruma-appservice-api/src/thirdparty/get_location_for_protocol.rs
+++ b/crates/ruma-appservice-api/src/thirdparty/get_location_for_protocol.rs
@@ -10,15 +10,17 @@ pub mod v1 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{auth_scheme::AccessToken, request, response},
+        api::{request, response},
         metadata,
         thirdparty::Location,
     };
 
+    use crate::HomeserverToken;
+
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: AccessToken,
+        authentication: HomeserverToken,
         path: "/_matrix/app/v1/thirdparty/location/{protocol}",
     }
 

--- a/crates/ruma-appservice-api/src/thirdparty/get_location_for_room_alias.rs
+++ b/crates/ruma-appservice-api/src/thirdparty/get_location_for_room_alias.rs
@@ -9,15 +9,17 @@ pub mod v1 {
 
     use ruma_common::{
         OwnedRoomAliasId,
-        api::{auth_scheme::AccessToken, request, response},
+        api::{request, response},
         metadata,
         thirdparty::Location,
     };
 
+    use crate::HomeserverToken;
+
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: AccessToken,
+        authentication: HomeserverToken,
         path: "/_matrix/app/v1/thirdparty/location",
     }
 

--- a/crates/ruma-appservice-api/src/thirdparty/get_protocol.rs
+++ b/crates/ruma-appservice-api/src/thirdparty/get_protocol.rs
@@ -10,16 +10,18 @@ pub mod v1 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{auth_scheme::AccessToken, request, response},
+        api::{request, response},
         metadata,
         thirdparty::{Protocol, ProtocolInstance, ProtocolInstanceInit},
     };
     use serde::{Deserialize, Serialize};
 
+    use crate::HomeserverToken;
+
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: AccessToken,
+        authentication: HomeserverToken,
         path: "/_matrix/app/v1/thirdparty/protocol/{protocol}",
     }
 

--- a/crates/ruma-appservice-api/src/thirdparty/get_user_for_protocol.rs
+++ b/crates/ruma-appservice-api/src/thirdparty/get_user_for_protocol.rs
@@ -11,15 +11,17 @@ pub mod v1 {
     use std::collections::BTreeMap;
 
     use ruma_common::{
-        api::{auth_scheme::AccessToken, request, response},
+        api::{request, response},
         metadata,
         thirdparty::User,
     };
 
+    use crate::HomeserverToken;
+
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: AccessToken,
+        authentication: HomeserverToken,
         path: "/_matrix/app/v1/thirdparty/user/{protocol}",
     }
 

--- a/crates/ruma-appservice-api/src/thirdparty/get_user_for_user_id.rs
+++ b/crates/ruma-appservice-api/src/thirdparty/get_user_for_user_id.rs
@@ -9,15 +9,17 @@ pub mod v1 {
 
     use ruma_common::{
         OwnedUserId,
-        api::{auth_scheme::AccessToken, request, response},
+        api::{request, response},
         metadata,
         thirdparty::User,
     };
 
+    use crate::HomeserverToken;
+
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: AccessToken,
+        authentication: HomeserverToken,
         path: "/_matrix/app/v1/thirdparty/user",
     }
 

--- a/crates/ruma-common/src/api/auth_scheme.rs
+++ b/crates/ruma-common/src/api/auth_scheme.rs
@@ -225,7 +225,7 @@ impl AuthScheme for AppserviceTokenOptional {
 }
 
 /// Add the given access token as an `Authorization` HTTP header to the given map.
-fn add_access_token_as_authorization_header(
+pub fn add_access_token_as_authorization_header(
     headers: &mut HeaderMap,
     token: &str,
 ) -> Result<(), header::InvalidHeaderValue> {
@@ -235,7 +235,7 @@ fn add_access_token_as_authorization_header(
 
 /// Extract the access token from the `Authorization` HTTP header or the query string of the given
 /// request.
-fn extract_bearer_or_query_token<T>(
+pub fn extract_bearer_or_query_token<T>(
     request: &http::Request<T>,
 ) -> Result<Option<String>, ExtractTokenError> {
     if let Some(token) = extract_bearer_token_from_authorization_header(request.headers())? {

--- a/crates/ruma-identity-service-api/CHANGELOG.md
+++ b/crates/ruma-identity-service-api/CHANGELOG.md
@@ -6,6 +6,7 @@ Breaking changes:
 
 - Export nothing from the crate if neither the `client` nor the `server` feature is active, because
   the crate is not useful without them.
+- All identity service API routes now use the new `IdentityServiceToken` auth scheme struct.
 
 ## 0.15.0
 

--- a/crates/ruma-identity-service-api/Cargo.toml
+++ b/crates/ruma-identity-service-api/Cargo.toml
@@ -18,6 +18,7 @@ client = []
 server = []
 
 [dependencies]
+http = { workspace = true }
 js_int = { workspace = true, features = ["serde"] }
 ruma-common = { workspace = true, features = ["api"] }
 ruma-events = { workspace = true }

--- a/crates/ruma-identity-service-api/src/association/bind_3pid.rs
+++ b/crates/ruma-identity-service-api/src/association/bind_3pid.rs
@@ -10,15 +10,17 @@ pub mod v2 {
     use ruma_common::{
         MilliSecondsSinceUnixEpoch, OwnedClientSecret, OwnedSessionId, OwnedUserId,
         ServerSignatures,
-        api::{auth_scheme::AccessToken, request, response},
+        api::{request, response},
         metadata,
         thirdparty::Medium,
     };
 
+    use crate::IdentityServiceToken;
+
     metadata! {
         method: POST,
         rate_limited: false,
-        authentication: AccessToken,
+        authentication: IdentityServiceToken,
         history: {
             1.0 => "/_matrix/identity/v2/3pid/bind",
         }

--- a/crates/ruma-identity-service-api/src/association/check_3pid_validity.rs
+++ b/crates/ruma-identity-service-api/src/association/check_3pid_validity.rs
@@ -10,15 +10,17 @@ pub mod v2 {
     use js_int::UInt;
     use ruma_common::{
         OwnedClientSecret, OwnedSessionId,
-        api::{auth_scheme::AccessToken, request, response},
+        api::{request, response},
         metadata,
         thirdparty::Medium,
     };
 
+    use crate::IdentityServiceToken;
+
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: AccessToken,
+        authentication: IdentityServiceToken,
         history: {
             1.0 => "/_matrix/identity/v2/3pid/getValidated3pid/",
         }

--- a/crates/ruma-identity-service-api/src/association/email/create_email_validation_session.rs
+++ b/crates/ruma-identity-service-api/src/association/email/create_email_validation_session.rs
@@ -10,14 +10,16 @@ pub mod v2 {
     use js_int::UInt;
     use ruma_common::{
         OwnedClientSecret, OwnedSessionId,
-        api::{auth_scheme::AccessToken, request, response},
+        api::{request, response},
         metadata,
     };
+
+    use crate::IdentityServiceToken;
 
     metadata! {
         method: POST,
         rate_limited: false,
-        authentication: AccessToken,
+        authentication: IdentityServiceToken,
         history: {
             1.0 => "/_matrix/identity/v2/validate/email/requestToken",
         }

--- a/crates/ruma-identity-service-api/src/association/email/validate_email.rs
+++ b/crates/ruma-identity-service-api/src/association/email/validate_email.rs
@@ -9,14 +9,16 @@ pub mod v2 {
 
     use ruma_common::{
         OwnedClientSecret, OwnedSessionId,
-        api::{auth_scheme::AccessToken, request, response},
+        api::{request, response},
         metadata,
     };
+
+    use crate::IdentityServiceToken;
 
     metadata! {
         method: POST,
         rate_limited: false,
-        authentication: AccessToken,
+        authentication: IdentityServiceToken,
         history: {
             1.0 => "/_matrix/identity/v2/validate/email/submitToken",
         }

--- a/crates/ruma-identity-service-api/src/association/email/validate_email_by_end_user.rs
+++ b/crates/ruma-identity-service-api/src/association/email/validate_email_by_end_user.rs
@@ -9,14 +9,16 @@ pub mod v2 {
 
     use ruma_common::{
         OwnedClientSecret, OwnedSessionId,
-        api::{auth_scheme::AccessToken, request, response},
+        api::{request, response},
         metadata,
     };
+
+    use crate::IdentityServiceToken;
 
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: AccessToken,
+        authentication: IdentityServiceToken,
         history: {
             1.0 => "/_matrix/identity/v2/validate/email/submitToken",
         }

--- a/crates/ruma-identity-service-api/src/association/msisdn/create_msisdn_validation_session.rs
+++ b/crates/ruma-identity-service-api/src/association/msisdn/create_msisdn_validation_session.rs
@@ -10,14 +10,16 @@ pub mod v2 {
     use js_int::UInt;
     use ruma_common::{
         OwnedClientSecret, OwnedSessionId,
-        api::{auth_scheme::AccessToken, request, response},
+        api::{request, response},
         metadata,
     };
+
+    use crate::IdentityServiceToken;
 
     metadata! {
         method: POST,
         rate_limited: false,
-        authentication: AccessToken,
+        authentication: IdentityServiceToken,
         history: {
             1.0 => "/_matrix/identity/v2/validate/msisdn/requestToken",
         }

--- a/crates/ruma-identity-service-api/src/association/msisdn/validate_msisdn.rs
+++ b/crates/ruma-identity-service-api/src/association/msisdn/validate_msisdn.rs
@@ -9,14 +9,16 @@ pub mod v2 {
 
     use ruma_common::{
         OwnedClientSecret, OwnedSessionId,
-        api::{auth_scheme::AccessToken, request, response},
+        api::{request, response},
         metadata,
     };
+
+    use crate::IdentityServiceToken;
 
     metadata! {
         method: POST,
         rate_limited: false,
-        authentication: AccessToken,
+        authentication: IdentityServiceToken,
         history: {
             1.0 => "/_matrix/identity/v2/validate/msisdn/submitToken",
         }

--- a/crates/ruma-identity-service-api/src/association/msisdn/validate_msisdn_by_phone_number.rs
+++ b/crates/ruma-identity-service-api/src/association/msisdn/validate_msisdn_by_phone_number.rs
@@ -9,14 +9,16 @@ pub mod v2 {
 
     use ruma_common::{
         OwnedClientSecret, OwnedSessionId,
-        api::{auth_scheme::AccessToken, request, response},
+        api::{request, response},
         metadata,
     };
+
+    use crate::IdentityServiceToken;
 
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: AccessToken,
+        authentication: IdentityServiceToken,
         history: {
             1.0 => "/_matrix/identity/v2/validate/msisdn/submitToken",
         }

--- a/crates/ruma-identity-service-api/src/association/unbind_3pid.rs
+++ b/crates/ruma-identity-service-api/src/association/unbind_3pid.rs
@@ -9,16 +9,18 @@ pub mod v2 {
 
     use ruma_common::{
         OwnedClientSecret, OwnedSessionId, OwnedUserId,
-        api::{auth_scheme::AccessToken, request, response},
+        api::{request, response},
         metadata,
         thirdparty::Medium,
     };
     use serde::{Deserialize, Serialize};
 
+    use crate::IdentityServiceToken;
+
     metadata! {
         method: POST,
         rate_limited: false,
-        authentication: AccessToken,
+        authentication: IdentityServiceToken,
         history: {
             1.0 => "/_matrix/identity/v2/3pid/unbind",
         }

--- a/crates/ruma-identity-service-api/src/authentication/get_account_information.rs
+++ b/crates/ruma-identity-service-api/src/authentication/get_account_information.rs
@@ -9,14 +9,16 @@ pub mod v2 {
 
     use ruma_common::{
         OwnedUserId,
-        api::{auth_scheme::AccessToken, request, response},
+        api::{request, response},
         metadata,
     };
+
+    use crate::IdentityServiceToken;
 
     metadata! {
         method: POST,
         rate_limited: false,
-        authentication: AccessToken,
+        authentication: IdentityServiceToken,
         history: {
             1.0 => "/_matrix/identity/v2/account",
         }

--- a/crates/ruma-identity-service-api/src/authentication/logout.rs
+++ b/crates/ruma-identity-service-api/src/authentication/logout.rs
@@ -9,14 +9,16 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/v1.19/identity-service-api/#post_matrixidentityv2accountlogout
 
     use ruma_common::{
-        api::{auth_scheme::AccessToken, request, response},
+        api::{request, response},
         metadata,
     };
+
+    use crate::IdentityServiceToken;
 
     metadata! {
         method: POST,
         rate_limited: false,
-        authentication: AccessToken,
+        authentication: IdentityServiceToken,
         history: {
             1.0 => "/_matrix/identity/v2/account/logout",
         }

--- a/crates/ruma-identity-service-api/src/invitation/sign_invitation_ed25519.rs
+++ b/crates/ruma-identity-service-api/src/invitation/sign_invitation_ed25519.rs
@@ -9,15 +9,17 @@ pub mod v2 {
 
     use ruma_common::{
         OwnedUserId, ServerSignatures,
-        api::{auth_scheme::AccessToken, request, response},
+        api::{request, response},
         metadata,
         serde::Base64,
     };
 
+    use crate::IdentityServiceToken;
+
     metadata! {
         method: POST,
         rate_limited: false,
-        authentication: AccessToken,
+        authentication: IdentityServiceToken,
         history: {
             1.0 => "/_matrix/identity/v2/sign-ed25519",
         }

--- a/crates/ruma-identity-service-api/src/invitation/store_invitation.rs
+++ b/crates/ruma-identity-service-api/src/invitation/store_invitation.rs
@@ -9,7 +9,7 @@ pub mod v2 {
 
     use ruma_common::{
         OwnedMxcUri, OwnedRoomAliasId, OwnedRoomId, OwnedUserId,
-        api::{auth_scheme::AccessToken, request, response},
+        api::{request, response},
         metadata,
         room::RoomType,
         third_party_invite::IdentityServerBase64PublicKey,
@@ -18,10 +18,12 @@ pub mod v2 {
     use ruma_events::room::third_party_invite::RoomThirdPartyInviteEventContent;
     use serde::{Deserialize, Serialize, ser::SerializeSeq};
 
+    use crate::IdentityServiceToken;
+
     metadata! {
         method: POST,
         rate_limited: false,
-        authentication: AccessToken,
+        authentication: IdentityServiceToken,
         history: {
             1.0 => "/_matrix/identity/v2/store-invite",
         }

--- a/crates/ruma-identity-service-api/src/lib.rs
+++ b/crates/ruma-identity-service-api/src/lib.rs
@@ -10,6 +10,11 @@
 #![cfg(any(feature = "client", feature = "server"))]
 #![warn(missing_docs)]
 
+use ruma_common::api::auth_scheme::{
+    AuthScheme, ExtractTokenError, add_access_token_as_authorization_header,
+    extract_bearer_or_query_token,
+};
+
 pub mod association;
 pub mod authentication;
 pub mod discovery;
@@ -19,3 +24,32 @@ pub mod lookup;
 pub mod tos;
 
 ruma_common::priv_owned_str!();
+
+/// Authentication is required by including an identity server access token in the
+/// `Authentication` http header, or an `access_token` query parameter.
+///
+/// Using the query parameter is deprecated since Matrix 1.11.
+#[derive(Debug, Clone, Copy, Default)]
+#[allow(clippy::exhaustive_structs)]
+pub struct IdentityServiceToken;
+
+impl AuthScheme for IdentityServiceToken {
+    type Input<'a> = &'a str;
+    type AddAuthenticationError = http::header::InvalidHeaderValue;
+    /// The identity service token.
+    type Output = String;
+    type ExtractAuthenticationError = ExtractTokenError;
+
+    fn add_authentication<T: AsRef<[u8]>>(
+        request: &mut http::Request<T>,
+        access_token: Self::Input<'_>,
+    ) -> Result<(), Self::AddAuthenticationError> {
+        add_access_token_as_authorization_header(request.headers_mut(), access_token)
+    }
+
+    fn extract_authentication<T>(
+        request: &http::Request<T>,
+    ) -> Result<Self::Output, Self::ExtractAuthenticationError> {
+        extract_bearer_or_query_token(request)?.ok_or(ExtractTokenError::MissingAccessToken)
+    }
+}

--- a/crates/ruma-identity-service-api/src/lookup/get_hash_parameters.rs
+++ b/crates/ruma-identity-service-api/src/lookup/get_hash_parameters.rs
@@ -9,16 +9,16 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/v1.19/identity-service-api/#get_matrixidentityv2hash_details
 
     use ruma_common::{
-        api::{auth_scheme::AccessToken, request, response},
+        api::{request, response},
         metadata,
     };
 
-    use crate::lookup::IdentifierHashingAlgorithm;
+    use crate::{IdentityServiceToken, lookup::IdentifierHashingAlgorithm};
 
     metadata! {
         method: GET,
         rate_limited: false,
-        authentication: AccessToken,
+        authentication: IdentityServiceToken,
         history: {
             1.0 => "/_matrix/identity/v2/hash_details",
         }

--- a/crates/ruma-identity-service-api/src/lookup/lookup_3pid.rs
+++ b/crates/ruma-identity-service-api/src/lookup/lookup_3pid.rs
@@ -11,16 +11,16 @@ pub mod v2 {
 
     use ruma_common::{
         OwnedUserId,
-        api::{auth_scheme::AccessToken, request, response},
+        api::{request, response},
         metadata,
     };
 
-    use crate::lookup::IdentifierHashingAlgorithm;
+    use crate::{IdentityServiceToken, lookup::IdentifierHashingAlgorithm};
 
     metadata! {
         method: POST,
         rate_limited: false,
-        authentication: AccessToken,
+        authentication: IdentityServiceToken,
         history: {
             1.0 => "/_matrix/identity/v2/lookup",
         }

--- a/crates/ruma-identity-service-api/src/tos/accept_terms_of_service.rs
+++ b/crates/ruma-identity-service-api/src/tos/accept_terms_of_service.rs
@@ -8,14 +8,16 @@ pub mod v2 {
     //! [spec]: https://spec.matrix.org/v1.19/identity-service-api/#post_matrixidentityv2terms
 
     use ruma_common::{
-        api::{auth_scheme::AccessToken, request, response},
+        api::{request, response},
         metadata,
     };
+
+    use crate::IdentityServiceToken;
 
     metadata! {
         method: POST,
         rate_limited: false,
-        authentication: AccessToken,
+        authentication: IdentityServiceToken,
         history: {
             1.0 => "/_matrix/identity/v2/terms",
         }


### PR DESCRIPTION
This pull request adds new `HomeserverToken` and `IdentityServiceToken` auth schemes for access tokens in the appservice and identity service API crates.