### PR TITLE
ci: Upgrade Rust nightly toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
   # Keep in sync with version in `rust-toolchain.toml` and `xtask/src/main.rs`
-  NIGHTLY: nightly-2026-07-18
+  NIGHTLY: nightly-2026-08-24
 
 on:
   push:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 # Keep in sync with version in `xtask/src/main.rs` and `.github/workflows/ci.yml`
-channel = "nightly-2026-07-18"
+channel = "nightly-2026-08-24"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -16,7 +16,7 @@ use serde_json::from_str as from_json_str;
 use xshell::Shell;
 
 // Keep in sync with version in `rust-toolchain.toml` and `.github/workflows/ci.yml`
-const NIGHTLY: &str = "nightly-2026-07-18";
+const NIGHTLY: &str = "nightly-2026-08-24";
 
 mod bench;
 mod cargo;


### PR DESCRIPTION
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
