### PR TITLE
client-api: Fix tests

### DIFF
--- a/crates/ruma-client-api/src/message/send_message_event.rs
+++ b/crates/ruma-client-api/src/message/send_message_event.rs
@@ -192,7 +192,7 @@ mod tests {
 
 #[cfg(all(test, feature = "server", feature = "unstable-msc4354"))]
 mod server_tests {
-    use ruma_common::{api::IncomingRequest, owned_room_id};
+    use ruma_common::{api::IncomingRequestExt as _, owned_room_id};
 
     use super::v3::Request;
 
@@ -203,7 +203,7 @@ mod server_tests {
             .uri(
                 "/_matrix/client/v3/rooms/!roomid:example.org/send/m.room.message/0000?org.matrix.msc4354.sticky_duration_ms=123456",
             )
-            .body(r#"{"body":"Hello"}"#)
+            .body(br#"{"body":"Hello"}"# as &[u8])
             .unwrap();
 
         let request = Request::try_from_http_request(

--- a/crates/ruma-client-api/src/state/send_state_event.rs
+++ b/crates/ruma-client-api/src/state/send_state_event.rs
@@ -314,7 +314,7 @@ mod tests {
 
 #[cfg(all(test, feature = "server", feature = "unstable-msc4354"))]
 mod server_tests {
-    use ruma_common::{api::IncomingRequest, owned_room_id};
+    use ruma_common::{api::IncomingRequestExt as _, owned_room_id};
 
     use super::v3::Request;
 
@@ -325,7 +325,7 @@ mod server_tests {
             .uri(
                 "/_matrix/client/v3/rooms/!roomid:example.org/state/m.room.name/?org.matrix.msc4354.sticky_duration_ms=123456",
             )
-            .body(r#"{"name":"A room"}"#)
+            .body(br#"{"name":"A room"}"# as &[u8])
             .unwrap();
 
         let request =


### PR DESCRIPTION
Regression due to merging two conflicting PRs without rebasing:

- New tests that rely on `IncomingRequest` (#2566).
- Breaking changes to the `IncomingRequest` trait (#2565).

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
