### PR TITLE
Clean up post-api traits refactor

### DIFF
--- a/crates/ruma-client-api/src/profile/set_profile_field.rs
+++ b/crates/ruma-client-api/src/profile/set_profile_field.rs
@@ -64,12 +64,9 @@ pub mod v3 {
     }
 
     #[doc(hidden)]
-    #[derive(ruma_common::serde::_FakeDeriveSerde)]
-    #[cfg_attr(feature = "client", derive(serde::Serialize, ruma_common::api::OutgoingBodyJson))]
-    #[cfg_attr(feature = "server", derive(serde::Deserialize))]
+    #[cfg(feature = "client")]
+    #[derive(serde::Serialize, ruma_common::api::OutgoingBodyJson)]
     #[serde(transparent)]
-    // attribute will go away when we update IncomingRequest to also use RequestBody
-    #[cfg_attr(not(feature = "client"), expect(dead_code))]
     pub struct RequestBody(ProfileFieldValue);
 
     #[cfg(feature = "client")]

--- a/crates/ruma-client-api/src/push/set_pushrule.rs
+++ b/crates/ruma-client-api/src/push/set_pushrule.rs
@@ -59,8 +59,7 @@ pub mod v3 {
     }
 
     #[doc(hidden)]
-    // attribute will go away when we update IncomingRequest to also use RequestBody
-    #[cfg_attr(not(feature = "client"), expect(dead_code))]
+    #[cfg(feature = "client")]
     pub struct RequestBody(NewPushRule);
 
     #[cfg(feature = "client")]

--- a/crates/ruma-client-api/src/state/send_state_event.rs
+++ b/crates/ruma-client-api/src/state/send_state_event.rs
@@ -129,12 +129,9 @@ pub mod v3 {
     }
 
     #[doc(hidden)]
-    #[derive(ruma_common::serde::_FakeDeriveSerde)]
-    #[cfg_attr(feature = "client", derive(serde::Serialize, ruma_common::api::OutgoingBodyJson))]
-    #[cfg_attr(feature = "server", derive(serde::Deserialize))]
+    #[cfg(feature = "client")]
+    #[derive(serde::Serialize, ruma_common::api::OutgoingBodyJson)]
     #[serde(transparent)]
-    // attribute will go away when we update IncomingRequest to also use RequestBody
-    #[cfg_attr(not(feature = "client"), expect(dead_code))]
     pub struct RequestBody(Raw<AnyStateEventContent>);
 
     #[cfg(feature = "client")]

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -20,6 +20,13 @@ Breaking changes:
     the path args is a `&[&str]`.
   - `IncomingRequest::check_request_method` was removed, this check is part of
     `IncomingRequestExt::try_from_http_request`.
+- `IncomingResponse::try_from_http_response` has been moved to a new `IncomingResponseExt` trait
+  that is automatically implemented for any `T: IncomingResponse`.
+  - Implementors of `IncomingResponse` now instead have to provide the
+    `fn try_from_http_response_inner` which should only perform the deserialization of the
+    response type.
+  - The generic parameter was removed from `try_from_http_response`, the body of the response is a
+    `&[u8]`.
 
 Bug fixes:
 


### PR DESCRIPTION
<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
