### PR TITLE
api: Remove `Metadata:empty_request_body()`

### DIFF
--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -27,6 +27,8 @@ Breaking changes:
     response type.
   - The generic parameter was removed from `try_from_http_response`, the body of the response is a
     `&[u8]`.
+- Remove `Metadata::empty_request_body()`. It is now unused and the types implementing
+  `OutgoingBody` should be used instead.
 
 Bug fixes:
 

--- a/crates/ruma-common/src/api/metadata.rs
+++ b/crates/ruma-common/src/api/metadata.rs
@@ -5,7 +5,6 @@ use std::{
     str::FromStr,
 };
 
-use bytes::BufMut;
 use http::Method;
 use ruma_macros::StringEnum;
 
@@ -13,7 +12,6 @@ use super::{auth_scheme::AuthScheme, error::UnknownVersionError, path_builder::P
 use crate::{
     PrivOwnedStr, RoomVersionId,
     api::{auth_scheme::ClientScopedAuthScheme, error::IntoHttpError},
-    serde::slice_to_buf,
 };
 
 /// Convenient constructor for [`Metadata`] implementation.
@@ -253,17 +251,6 @@ pub trait Metadata: Sized {
 
     /// All info pertaining to an endpoint's path.
     const PATH_BUILDER: Self::PathBuilder;
-
-    /// Returns an empty request body for this Matrix request.
-    ///
-    /// For `GET` requests, it returns an entirely empty buffer, for others it returns an empty JSON
-    /// object (`{}`).
-    fn empty_request_body<B>() -> B
-    where
-        B: Default + BufMut,
-    {
-        if Self::METHOD == Method::GET { Default::default() } else { slice_to_buf(b"{}") }
-    }
 
     /// Generate the endpoint URL for this endpoint.
     fn make_endpoint_url(


### PR DESCRIPTION
It is now unused because we use the types implementing `OutgoingBody`.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
