### PR TITLE
Update cargo-deny config

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -9,6 +9,7 @@ exclude = [
 
 [advisories]
 version = 2
+yanked = "deny"
 
 [licenses]
 version = 2

--- a/.deny.toml
+++ b/.deny.toml
@@ -9,9 +9,6 @@ exclude = [
 
 [advisories]
 version = 2
-ignore = [
-    "RUSTSEC-2024-0436" # in paste, used transitively by `smol_macros`, which is test-only.
-]
 
 [licenses]
 version = 2
@@ -22,9 +19,7 @@ allow = [
     "ISC",
     "MIT",
     "MPL-2.0",
-    "OpenSSL",
     "Unicode-3.0",
-    "Unicode-DFS-2016",
     "Zlib",
 ]
 private = { ignore = true }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,9 +261,9 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures",


### PR DESCRIPTION
The intent of this is to remove some warnings when running `cargo deny check`.

The first commit removes licenses and advisories that were not encountered, and the second commit disallows yanked crates, which results in the third commit because the version of the `chacha20` crate just got yanked.

The only warnings left are about duplicate dependencies, which can't be fixed at the moment.