### PR TITLE
identifiers: Add `ThinArc` internal storage representation 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,9 @@ jobs:
           - name: Check identifiers with Arc storage
             cmd: msrv-identifiers Arc
 
+          - name: Check identifiers with ThinArc storage
+            cmd: msrv-identifiers --features triomphe ThinArc
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1933,6 +1933,7 @@ dependencies = [
  "thiserror",
  "time",
  "tracing",
+ "triomphe",
  "trybuild",
  "url",
  "uuid",
@@ -2905,6 +2906,16 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
+]
+
+[[package]]
+name = "triomphe"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b40688ea6389c8171614b25491f71d4a27946e0c7ce2da1c6de27e25abf1a0ae"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ rust_2018_idioms = { level = "warn", priority = -1 }
 semicolon_in_expressions_from_macros = "warn"
 unexpected_cfgs = { level = "warn", check-cfg = [
     # used by the IdDst macro
-    'cfg(ruma_identifiers_storage, values("Arc"))',
+    'cfg(ruma_identifiers_storage, values("Arc", "ThinArc"))',
     # set all types as exhaustive
     'cfg(ruma_unstable_exhaustive_types)',
 ] }

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -53,6 +53,8 @@ Improvements:
 - Add `required_client_scopes` function to `Metadata` and accompanying `required_client_scopes` syntax
   to `metadata!` macro, to allow request structs to define what OAuth 2.0 scopes they require.
 - Add unstable support for [MSC4484] "Server Administration OAuth Scope".
+- `ruma_identifiers_storage` supports a new `ThinArc` value. It uses `triomphe::ThinArc<(), u8>` as
+  internal representation for the owned identifier types, and requires the `triomphe` cargo feature.
 
 [MSC4438]: https://github.com/matrix-org/matrix-spec-proposals/pull/4438
 [MSC4484]: https://github.com/matrix-org/matrix-spec-proposals/pull/4484

--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -95,6 +95,7 @@ serde_json = { workspace = true, features = ["raw_value"] }
 thiserror = { workspace = true }
 time = "0.3.47"
 tracing = { workspace = true, features = ["attributes"] }
+triomphe = { version = "0.1.16", optional = true }
 url = { workspace = true }
 uuid = { version = "1.0.0", optional = true, features = ["v4"] }
 web-time = { workspace = true }

--- a/crates/ruma-common/src/lib.rs
+++ b/crates/ruma-common/src/lib.rs
@@ -13,6 +13,11 @@ compile_error!(
     "ruma_common's `client` and `server` Cargo features only exist as a workaround are not meant to be disabled"
 );
 
+#[cfg(all(ruma_identifiers_storage = "ThinArc", not(feature = "triomphe")))]
+compile_error!(
+    "the `ThinArc` value for the `ruma_identifiers_storage` compile-time setting requires ruma-common's `triomphe` cargo feature"
+);
+
 // Hack to allow both ruma-common itself and external crates (or tests) to use procedural macros
 // that expect `ruma_common` to exist in the prelude.
 extern crate self as ruma_common;
@@ -62,4 +67,6 @@ pub mod exports {
     pub use serde;
     pub use serde_html_form;
     pub use serde_json;
+    #[cfg(feature = "triomphe")]
+    pub use triomphe;
 }

--- a/crates/ruma-macros/src/identifiers/id_dst.rs
+++ b/crates/ruma-macros/src/identifiers/id_dst.rs
@@ -510,19 +510,25 @@ struct Types {
 
     /// `[u8]`.
     bytes: syn::Type,
+
+    /// `triomphe::ThinArc<(), u8>`.
+    thin_arc_bytes: syn::Type,
 }
 
 impl Types {
-    fn new() -> Self {
+    fn new(ruma_common: &RumaCommon) -> Self {
         let str = parse_quote! { ::std::primitive::str };
+        let byte = quote! { ::std::primitive::u8 };
         let cow = parse_quote! { ::std::borrow::Cow };
+        let triomphe = ruma_common.reexported(RumaCommonReexport::Triomphe);
 
         Self {
             box_str: parse_quote! { ::std::boxed::Box<#str> },
             arc_str: parse_quote! { ::std::sync::Arc<#str> },
             string: parse_quote! { ::std::string::String },
             cow_str: parse_quote! { #cow<'a, #str> },
-            bytes: parse_quote! { [::std::primitive::u8] },
+            bytes: parse_quote! { [#byte] },
+            thin_arc_bytes: parse_quote! { #triomphe::ThinArc<(), #byte> },
             str,
             cow,
         }

--- a/crates/ruma-macros/src/identifiers/id_dst/owned_id.rs
+++ b/crates/ruma-macros/src/identifiers/id_dst/owned_id.rs
@@ -5,6 +5,7 @@ use quote::quote;
 use syn::parse_quote;
 
 use super::{IdDst, Types};
+use crate::util::{RumaCommon, RumaCommonReexport};
 
 /// Data for the owned variant of an identifier.
 pub(super) struct OwnedId {
@@ -53,6 +54,7 @@ impl OwnedId {
         let generics = &id_dst.generics;
         let impl_generics = &id_dst.impl_generics;
         let types = &id_dst.types;
+        let ruma_common = &id_dst.ruma_common;
 
         let str = &types.str;
         let box_str = &types.box_str;
@@ -61,7 +63,8 @@ impl OwnedId {
 
         // Expanded code to access the inner field.
         let self_inner_field = quote! { self.inner };
-        let id_inner_field = quote! { id.inner };
+        let id_var = quote! { id };
+        let id_inner_field = quote! { #id_var.inner };
         // The name of the string variable when constructing an identifier from a string.
         let string_var = syn::Ident::new("s", Span::call_site());
 
@@ -88,19 +91,19 @@ impl OwnedId {
         });
 
         let from_str_impls = self.expand_for_each_storage_value(|value| {
-            let expanded = value.expand_from_str_impl(&string_var);
+            let expanded = value.expand_from_str_impl(&string_var, types);
             quote! { inner: #expanded, }
         });
         let from_box_str_impls = self.expand_for_each_storage_value(|value| {
-            let expanded = value.expand_from_box_str_impl(&string_var);
+            let expanded = value.expand_from_box_str_impl(&string_var, types);
             quote! { inner: #expanded, }
         });
         let from_string_impls = self.expand_for_each_storage_value(|value| {
-            let expanded = value.expand_from_string_impl(&string_var);
+            let expanded = value.expand_from_string_impl(&string_var, types);
             quote! { inner: #expanded, }
         });
         let as_str_impls = self.expand_for_each_storage_value(|value| {
-            let expanded = value.expand_as_str_impl(&self_inner_field);
+            let expanded = value.expand_as_str_impl(&self_inner_field, types);
             quote! { { #expanded } }
         });
         let as_bytes_impls = self.expand_for_each_storage_value(|value| {
@@ -141,15 +144,16 @@ impl OwnedId {
         let zeroize_doc_header = format!(
             "Securely zero memory (aka [zeroize](https://en.wikipedia.org/wiki/Zeroisation)) of `{owned_ident}`."
         );
-        let zeroize_impls = self
-            .expand_for_each_storage_value(|value| value.expand_zeroize_impl(&self_inner_field));
+        let zeroize_impls = self.expand_for_each_storage_value(|value| {
+            value.expand_zeroize_impl(&self_inner_field, ruma_common)
+        });
 
         let into_box_str_impls = self.expand_for_each_storage_value(|value| {
-            let expanded = value.expand_into_box_str_impl(&id_inner_field);
+            let expanded = value.expand_into_box_str_impl(&id_var, &id_inner_field);
             quote! { { #expanded } }
         });
         let into_string_impls = self.expand_for_each_storage_value(|value| {
-            let expanded = value.expand_into_string_impl(&id_inner_field);
+            let expanded = value.expand_into_string_impl(&id_var, &id_inner_field);
             quote! { { #expanded } }
         });
 
@@ -244,13 +248,11 @@ impl OwnedId {
                 ///
                 /// # Implementation details
                 ///
-                /// If the `ruma_identifiers_storage` configuration is
-                /// set to `Arc`, this type will be zeroized if and only if
-                /// [`Arc::get_mut`] returns `Some` reference, i.e. if there is no
-                /// other `Arc` or `Weak` pointers to this same location.
+                /// If the `ruma_identifiers_storage` configuration is set to
+                /// `Arc` or `ThinArc`, this type will be zeroized if and only if
+                /// there is no other strong or weak reference to this same location.
                 ///
                 /// [`zeroize`]: https://docs.rs/zeroize/
-                /// [`Arc::get_mut`]: https://doc.rust-lang.org/std/sync/struct.Arc.html#method.get_mut
                 pub fn zeroize(mut self) {
                     #zeroize_impls
                 }
@@ -342,17 +344,32 @@ enum StorageCfgValue {
 
     /// `Arc`, the `Arc<str>` internal representation.
     Arc,
+
+    /// `ThinArc`, the `triomphe::ThinArc<(), u8>` internal representation.
+    ThinArc,
 }
 
 impl StorageCfgValue {
     /// All the possible values.
-    const ALL: &'static [StorageCfgValue] = &[StorageCfgValue::Default, StorageCfgValue::Arc];
+    const ALL: &'static [Self] = &[Self::Default, Self::Arc, Self::ThinArc];
+
+    /// The string representation for this value.
+    ///
+    /// Returns `None` for the `Default` variant.
+    fn as_str(&self) -> Option<&'static str> {
+        Some(match self {
+            Self::Default => None?,
+            Self::Arc => "Arc",
+            Self::ThinArc => "ThinArc",
+        })
+    }
 
     /// The `#[cfg]` attribute for this value.
     fn cfg_attr<'a>(&self, attrs: &'a StorageCfgAttributes) -> &'a syn::Attribute {
         match self {
             Self::Default => &attrs.default,
             Self::Arc => &attrs.arc,
+            Self::ThinArc => &attrs.thin_arc,
         }
     }
 
@@ -363,6 +380,10 @@ impl StorageCfgValue {
         match self {
             Self::Default => "",
             Self::Arc => "`Arc` -- Use an `Arc<str>`.",
+            Self::ThinArc => {
+                "`ThinArc` -- Use a `triomphe::ThinArc<(), u8>`. \
+                 Requires the `triomphe` cargo feature."
+            }
         }
     }
 
@@ -371,43 +392,68 @@ impl StorageCfgValue {
         match self {
             Self::Default => &types.box_str,
             Self::Arc => &types.arc_str,
+            Self::ThinArc => &types.thin_arc_bytes,
         }
     }
 
     /// Expand the implementation to convert a `&str` to the inner type.
-    fn expand_from_str_impl(&self, string_var: &syn::Ident) -> TokenStream {
+    fn expand_from_str_impl(&self, string_var: &syn::Ident, types: &Types) -> TokenStream {
         match self {
             Self::Default | Self::Arc => quote! {
                 #string_var.into()
             },
+            Self::ThinArc => {
+                let thin_arc_bytes = &types.thin_arc_bytes;
+                quote! {
+                    <#thin_arc_bytes>::from_header_and_slice((), #string_var.as_bytes())
+                }
+            }
         }
     }
 
     /// Expand the implementation to convert a `Box<str>` to the inner type.
-    fn expand_from_box_str_impl(&self, string_var: &syn::Ident) -> TokenStream {
+    fn expand_from_box_str_impl(&self, string_var: &syn::Ident, types: &Types) -> TokenStream {
         match self {
             Self::Default => quote! { #string_var },
             Self::Arc => quote! {
                 #string_var.into()
             },
+            Self::ThinArc => {
+                let thin_arc_bytes = &types.thin_arc_bytes;
+                quote! {
+                    <#thin_arc_bytes>::from_header_and_slice((), #string_var.as_bytes())
+                }
+            }
         }
     }
 
     /// Expand the implementation to convert a `String` to the inner type.
-    fn expand_from_string_impl(&self, string_var: &syn::Ident) -> TokenStream {
+    fn expand_from_string_impl(&self, string_var: &syn::Ident, types: &Types) -> TokenStream {
         match self {
             Self::Default | Self::Arc => quote! {
                 #string_var.into()
             },
+            Self::ThinArc => {
+                let thin_arc_bytes = &types.thin_arc_bytes;
+                quote! {
+                    <#thin_arc_bytes>::from_header_and_slice((), #string_var.as_bytes())
+                }
+            }
         }
     }
 
     /// Expand the implementation to access the inner type as a `&str`.
-    fn expand_as_str_impl(&self, inner_field: &TokenStream) -> TokenStream {
+    fn expand_as_str_impl(&self, inner_field: &TokenStream, types: &Types) -> TokenStream {
         match self {
             Self::Default | Self::Arc => quote! {
                 &#inner_field
             },
+            Self::ThinArc => {
+                let str = &types.str;
+                quote! {
+                    unsafe { #str::from_utf8_unchecked(&#inner_field.slice) }
+                }
+            }
         }
     }
 
@@ -417,11 +463,18 @@ impl StorageCfgValue {
             Self::Default | Self::Arc => quote! {
                 #inner_field.as_bytes()
             },
+            Self::ThinArc => quote! {
+                &#inner_field.slice
+            },
         }
     }
 
     /// Expand the implementation to zeroize the inner type.
-    fn expand_zeroize_impl(&self, inner_field: &TokenStream) -> TokenStream {
+    fn expand_zeroize_impl(
+        &self,
+        inner_field: &TokenStream,
+        ruma_common: &RumaCommon,
+    ) -> TokenStream {
         match self {
             Self::Default => quote! {
                 ::zeroize::Zeroize::zeroize(&mut #inner_field);
@@ -431,25 +484,43 @@ impl StorageCfgValue {
                     ::zeroize::Zeroize::zeroize(value);
                 }
             },
+            Self::ThinArc => {
+                let triomphe = ruma_common.reexported(RumaCommonReexport::Triomphe);
+                quote! {
+                    #inner_field.with_arc_mut(|this| {
+                        if let Some(value) = #triomphe::Arc::get_mut(this) {
+                            ::zeroize::Zeroize::zeroize(value.slice_mut());
+                        }
+                    })
+                }
+            }
         }
     }
 
     /// Expand the implementation to convert the inner type to a `Box<str>`.
-    fn expand_into_box_str_impl(&self, inner_field: &TokenStream) -> TokenStream {
+    fn expand_into_box_str_impl(
+        &self,
+        id_var: &TokenStream,
+        inner_field: &TokenStream,
+    ) -> TokenStream {
         match self {
             Self::Default => quote! { #inner_field },
-            Self::Arc => quote! {
-                #inner_field.as_ref().into()
+            Self::Arc | Self::ThinArc => quote! {
+                #id_var.as_inner_str().into()
             },
         }
     }
 
     /// Expand the implementation to convert the inner type to a `String`.
-    fn expand_into_string_impl(&self, inner_field: &TokenStream) -> TokenStream {
+    fn expand_into_string_impl(
+        &self,
+        id_var: &TokenStream,
+        inner_field: &TokenStream,
+    ) -> TokenStream {
         match self {
             Self::Default => quote! { #inner_field.into() },
-            Self::Arc => quote! {
-                #inner_field.as_ref().into()
+            Self::Arc | Self::ThinArc => quote! {
+                #id_var.as_inner_str().into()
             },
         }
     }
@@ -462,15 +533,26 @@ struct StorageCfgAttributes {
 
     /// Attribute for the `Arc` value.
     arc: syn::Attribute,
+
+    /// Attribute for the `ThinArc` value.
+    thin_arc: syn::Attribute,
 }
 
 impl StorageCfgAttributes {
     fn new() -> Self {
         let key = quote! { ruma_identifiers_storage };
 
+        let all_values = StorageCfgValue::ALL.iter().filter_map(StorageCfgValue::as_str);
+
+        let value_to_attribute = |value: StorageCfgValue| {
+            let value_str = value.as_str().expect("should not be StorageCfgValue::Default");
+            parse_quote! { #[cfg(#key = #value_str)] }
+        };
+
         Self {
-            default: parse_quote! { #[cfg(not(#key = "Arc"))] },
-            arc: parse_quote! { #[cfg(#key = "Arc")] },
+            default: parse_quote! { #[cfg(not(any(#( #key = #all_values ),*)))] },
+            arc: value_to_attribute(StorageCfgValue::Arc),
+            thin_arc: value_to_attribute(StorageCfgValue::ThinArc),
         }
     }
 }

--- a/crates/ruma-macros/src/identifiers/id_dst/parse.rs
+++ b/crates/ruma-macros/src/identifiers/id_dst/parse.rs
@@ -63,6 +63,8 @@ impl IdDst {
 
         let owned_id = OwnedId::new(owned_ident, owned_id_type);
 
+        let ruma_common = RumaCommon::new();
+
         Ok(Self {
             ident,
             id_type,
@@ -71,8 +73,8 @@ impl IdDst {
             validate,
             str_field_index,
             owned_id,
-            types: Types::new(),
-            ruma_common: RumaCommon::new(),
+            types: Types::new(&ruma_common),
+            ruma_common,
         })
     }
 }

--- a/crates/ruma-macros/src/lib.rs
+++ b/crates/ruma-macros/src/lib.rs
@@ -445,11 +445,11 @@ pub fn derive_from_event_to_enum(input: TokenStream) -> TokenStream {
 
 /// Generate methods and trait impl's for DST identifier type.
 ///
-/// This macro generates an `Owned*` wrapper type for the identifier type. This wrapper type is
-/// variable, by default it'll use [`Box`], but it can be changed at compile time
-/// by setting `--cfg=ruma_identifiers_storage=...` using `RUSTFLAGS` or `.cargo/config.toml` (under
-/// `[build]` -> `rustflags = ["..."]`). Currently the only supported value is `Arc`, that uses
-/// [`Arc`](std::sync::Arc) as a wrapper type.
+/// This macro generates an `Owned*` type for the identifier type. The internal representation of
+/// the owned type is variable, by default it'll use a `Box<str>`, but it can be changed at compile
+/// time by setting `--cfg=ruma_identifiers_storage=...` using `RUSTFLAGS` or `.cargo/config.toml`
+/// (under `[build]` -> `rustflags = ["..."]`). The supported values for this setting are listed in
+/// the docs of the owned type.
 ///
 /// This macro implements:
 ///

--- a/crates/ruma-macros/src/util.rs
+++ b/crates/ruma-macros/src/util.rs
@@ -61,6 +61,9 @@ pub(crate) enum RumaCommonReexport {
 
     /// The bytes crate.
     Bytes,
+
+    /// The triomphe crate.
+    Triomphe,
 }
 
 impl ToTokens for RumaCommonReexport {
@@ -72,6 +75,7 @@ impl ToTokens for RumaCommonReexport {
             Self::SerdeJson => "serde_json",
             Self::Http => "http",
             Self::Bytes => "bytes",
+            Self::Triomphe => "triomphe",
         };
 
         tokens.append(Ident::new(crate_name, Span::call_site()));

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -49,6 +49,9 @@ markdown = ["ruma-events?/markdown"]
 html = ["dep:ruma-html", "ruma-events?/html"]
 html-matrix = ["html", "ruma-html/matrix"]
 
+# Internal representations for identifiers generated with the IdDst macro.
+triomphe = ["ruma-common/triomphe"]
+
 # Everything except compat, js and unstable features
 full = [
     "api",

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -38,6 +38,11 @@ pub enum CiCmd {
         ///
         /// If this is not set, the default internal representation will be checked.
         ruma_identifiers_storage: Option<String>,
+
+        /// Comma-separated list of features of ruma-common to enable on top of the default
+        /// features.
+        #[arg(long, short = 'F')]
+        features: Option<String>,
     },
     /// Run all the tasks that use the stable version
     Stable,
@@ -126,8 +131,8 @@ impl CiTask {
             Some(CiCmd::Msrv) => self.msrv()?,
             Some(CiCmd::MsrvAll) => self.msrv_all()?,
             Some(CiCmd::MsrvRuma) => self.msrv_ruma()?,
-            Some(CiCmd::MsrvIdentifiers { ruma_identifiers_storage }) => {
-                self.msrv_identifiers(ruma_identifiers_storage.as_deref())?;
+            Some(CiCmd::MsrvIdentifiers { ruma_identifiers_storage, features }) => {
+                self.msrv_identifiers(ruma_identifiers_storage.as_deref(), features.as_deref())?;
             }
             Some(CiCmd::Stable) => self.stable()?,
             Some(CiCmd::StableAll) => self.stable_all()?,
@@ -316,12 +321,20 @@ impl CiTask {
 
     /// Check ruma-common with default features and the given `ruma_identifiers_storage` cfg
     /// attribute.
-    fn msrv_identifiers(&self, ruma_identifiers_storage: Option<&str>) -> Result<()> {
+    fn msrv_identifiers(
+        &self,
+        ruma_identifiers_storage: Option<&str>,
+        features: Option<&str>,
+    ) -> Result<()> {
         let mut cmd = cmd!(&self.sh, "rustup run {MSRV} cargo check -p ruma-common");
 
         if let Some(value) = ruma_identifiers_storage {
             let rustflags = format!("--cfg=ruma_identifiers_storage=\"{value}\"");
             cmd = cmd.env("RUSTFLAGS", rustflags);
+        }
+
+        if let Some(features) = features {
+            cmd = cmd.args(["--features", features]);
         }
 
         cmd.run().map_err(Into::into)


### PR DESCRIPTION
Uses `triomphe::ThinArc<(), u8>` as internal representation, which should be equivalent to using `arcstr::ArcStr` except that it can be mutated to implement the `zeroize()` method.

This is ready to review, but I'd like to check that this is actually improving things with the matrix-rust-sdk's benchmarks before merging this.