### PR TITLE
identifiers: Add `SmallVec` internal storage representation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,9 @@ jobs:
           - name: Check identifiers with ThinArc storage
             cmd: msrv-identifiers --features triomphe ThinArc
 
+          - name: Check identifiers with SmallVec storage
+            cmd: msrv-identifiers --features smallvec SmallVec
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1929,6 +1929,7 @@ dependencies = [
  "serde",
  "serde_html_form",
  "serde_json",
+ "smallvec",
  "smol-macros",
  "thiserror",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ rust_2018_idioms = { level = "warn", priority = -1 }
 semicolon_in_expressions_from_macros = "warn"
 unexpected_cfgs = { level = "warn", check-cfg = [
     # used by the IdDst macro
-    'cfg(ruma_identifiers_storage, values("Arc", "ThinArc"))',
+    'cfg(ruma_identifiers_storage, values("Arc", "SmallVec", "ThinArc"))',
     # set all types as exhaustive
     'cfg(ruma_unstable_exhaustive_types)',
 ] }

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -53,8 +53,11 @@ Improvements:
 - Add `required_client_scopes` function to `Metadata` and accompanying `required_client_scopes` syntax
   to `metadata!` macro, to allow request structs to define what OAuth 2.0 scopes they require.
 - Add unstable support for [MSC4484] "Server Administration OAuth Scope".
-- `ruma_identifiers_storage` supports a new `ThinArc` value. It uses `triomphe::ThinArc<(), u8>` as
-  internal representation for the owned identifier types, and requires the `triomphe` cargo feature.
+- `ruma_identifiers_storage` supports new values:
+  - `ThinArc` uses `triomphe::ThinArc<(), u8>` as internal representation for the owned identifier
+    types, and requires the `triomphe` cargo feature.
+  - `SmallVec` uses `smallvec::SmallVec<[u8; N]>` as internal representation for the owned identifier
+    types, and requires the `smallvec` cargo feature.
 
 [MSC4438]: https://github.com/matrix-org/matrix-spec-proposals/pull/4438
 [MSC4484]: https://github.com/matrix-org/matrix-spec-proposals/pull/4484

--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -92,6 +92,7 @@ ruma-macros = { workspace = true }
 serde = { workspace = true }
 serde_html_form = { workspace = true }
 serde_json = { workspace = true, features = ["raw_value"] }
+smallvec = { version = "1.15.2", features = ["const_generics", "union"], optional = true }
 thiserror = { workspace = true }
 time = "0.3.47"
 tracing = { workspace = true, features = ["attributes"] }

--- a/crates/ruma-common/src/identifiers/event_id.rs
+++ b/crates/ruma-common/src/identifiers/event_id.rs
@@ -55,7 +55,7 @@ use super::{IdParseError, ServerName};
 /// [room versions]: https://spec.matrix.org/v1.19/rooms/
 #[repr(transparent)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
-#[ruma_id(validate = ruma_identifiers_validation::event_id::validate)]
+#[ruma_id(validate = ruma_identifiers_validation::event_id::validate, smallvec_inline_bytes = 48)]
 pub struct EventId(str);
 
 impl EventId {

--- a/crates/ruma-common/src/identifiers/mxc_uri.rs
+++ b/crates/ruma-common/src/identifiers/mxc_uri.rs
@@ -16,6 +16,7 @@ type Result<T, E = MxcUriError> = std::result::Result<T, E>;
 /// [MXC URI]: https://spec.matrix.org/v1.19/client-server-api/#matrix-content-mxc-uris
 #[repr(transparent)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
+#[ruma_id(smallvec_inline_bytes = 60)]
 pub struct MxcUri(str);
 
 impl MxcUri {

--- a/crates/ruma-common/src/identifiers/room_alias_id.rs
+++ b/crates/ruma-common/src/identifiers/room_alias_id.rs
@@ -17,7 +17,7 @@ use super::{MatrixToUri, MatrixUri, OwnedEventId, matrix_uri::UriAction, server_
 /// [room alias ID]: https://spec.matrix.org/v1.19/appendices/#room-aliases
 #[repr(transparent)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
-#[ruma_id(validate = ruma_identifiers_validation::room_alias_id::validate)]
+#[ruma_id(validate = ruma_identifiers_validation::room_alias_id::validate, smallvec_inline_bytes = 48)]
 pub struct RoomAliasId(str);
 
 impl RoomAliasId {

--- a/crates/ruma-common/src/identifiers/room_id.rs
+++ b/crates/ruma-common/src/identifiers/room_id.rs
@@ -21,7 +21,7 @@ use crate::RoomOrAliasId;
 /// [room ID]: https://spec.matrix.org/v1.19/appendices/#room-ids
 #[repr(transparent)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
-#[ruma_id(validate = ruma_identifiers_validation::room_id::validate)]
+#[ruma_id(validate = ruma_identifiers_validation::room_id::validate, smallvec_inline_bytes = 48)]
 pub struct RoomId(str);
 
 impl RoomId {

--- a/crates/ruma-common/src/identifiers/room_or_alias_id.rs
+++ b/crates/ruma-common/src/identifiers/room_or_alias_id.rs
@@ -31,7 +31,7 @@ use super::{OwnedRoomAliasId, OwnedRoomId, RoomAliasId, RoomId, server_name::Ser
 /// [room alias ID]: https://spec.matrix.org/v1.19/appendices/#room-aliases
 #[repr(transparent)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
-#[ruma_id(validate = ruma_identifiers_validation::room_id_or_alias_id::validate)]
+#[ruma_id(validate = ruma_identifiers_validation::room_id_or_alias_id::validate, smallvec_inline_bytes = 48)]
 pub struct RoomOrAliasId(str);
 
 impl RoomOrAliasId {

--- a/crates/ruma-common/src/identifiers/server_signing_key_version.rs
+++ b/crates/ruma-common/src/identifiers/server_signing_key_version.rs
@@ -15,6 +15,7 @@ use super::{IdParseError, KeyName};
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
 #[ruma_id(
     validate = ruma_identifiers_validation::server_signing_key_version::validate,
+    smallvec_inline_bytes = 16,
 )]
 pub struct ServerSigningKeyVersion(str);
 

--- a/crates/ruma-common/src/identifiers/space_child_order.rs
+++ b/crates/ruma-common/src/identifiers/space_child_order.rs
@@ -11,7 +11,7 @@ use ruma_macros::IdDst;
 /// [`m.space.child`]: https://spec.matrix.org/v1.19/client-server-api/#mspacechild
 #[repr(transparent)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
-#[ruma_id(validate = ruma_identifiers_validation::space_child_order::validate)]
+#[ruma_id(validate = ruma_identifiers_validation::space_child_order::validate, smallvec_inline_bytes = 50)]
 pub struct SpaceChildOrder(str);
 
 #[cfg(test)]

--- a/crates/ruma-common/src/identifiers/user_id.rs
+++ b/crates/ruma-common/src/identifiers/user_id.rs
@@ -19,7 +19,7 @@ use super::{IdParseError, MatrixToUri, MatrixUri, ServerName, matrix_uri::UriAct
 /// [user ID]: https://spec.matrix.org/v1.19/appendices/#user-identifiers
 #[repr(transparent)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
-#[ruma_id(validate = ruma_identifiers_validation::user_id::validate)]
+#[ruma_id(validate = ruma_identifiers_validation::user_id::validate, smallvec_inline_bytes = 40)]
 pub struct UserId(str);
 
 impl UserId {

--- a/crates/ruma-common/src/lib.rs
+++ b/crates/ruma-common/src/lib.rs
@@ -18,6 +18,11 @@ compile_error!(
     "the `ThinArc` value for the `ruma_identifiers_storage` compile-time setting requires ruma-common's `triomphe` cargo feature"
 );
 
+#[cfg(all(ruma_identifiers_storage = "SmallVec", not(feature = "smallvec")))]
+compile_error!(
+    "the `SmallVec` value for the `ruma_identifiers_storage` compile-time setting requires ruma-common's `smallvec` cargo feature"
+);
+
 // Hack to allow both ruma-common itself and external crates (or tests) to use procedural macros
 // that expect `ruma_common` to exist in the prelude.
 extern crate self as ruma_common;
@@ -67,6 +72,8 @@ pub mod exports {
     pub use serde;
     pub use serde_html_form;
     pub use serde_json;
+    #[cfg(feature = "smallvec")]
+    pub use smallvec;
     #[cfg(feature = "triomphe")]
     pub use triomphe;
 }

--- a/crates/ruma-macros/src/identifiers/id_dst.rs
+++ b/crates/ruma-macros/src/identifiers/id_dst.rs
@@ -513,14 +513,21 @@ struct Types {
 
     /// `triomphe::ThinArc<(), u8>`.
     thin_arc_bytes: syn::Type,
+
+    /// `smallvec::SmallVec<[u8; N]`.
+    small_vec_bytes: syn::Type,
 }
 
 impl Types {
-    fn new(ruma_common: &RumaCommon) -> Self {
+    fn new(ruma_common: &RumaCommon, owned_id: &OwnedId) -> Self {
         let str = parse_quote! { ::std::primitive::str };
         let byte = quote! { ::std::primitive::u8 };
         let cow = parse_quote! { ::std::borrow::Cow };
+
         let triomphe = ruma_common.reexported(RumaCommonReexport::Triomphe);
+        let smallvec = ruma_common.reexported(RumaCommonReexport::Smallvec);
+
+        let smallvec_inline_bytes = owned_id.smallvec_inline_bytes;
 
         Self {
             box_str: parse_quote! { ::std::boxed::Box<#str> },
@@ -529,6 +536,7 @@ impl Types {
             cow_str: parse_quote! { #cow<'a, #str> },
             bytes: parse_quote! { [#byte] },
             thin_arc_bytes: parse_quote! { #triomphe::ThinArc<(), #byte> },
+            small_vec_bytes: parse_quote! { #smallvec::SmallVec<[#byte; #smallvec_inline_bytes]> },
             str,
             cow,
         }

--- a/crates/ruma-macros/src/identifiers/id_dst/owned_id.rs
+++ b/crates/ruma-macros/src/identifiers/id_dst/owned_id.rs
@@ -1,5 +1,7 @@
 //! Types and functions to handle the identifiers internal storage representations.
 
+use std::borrow::Cow;
+
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use syn::parse_quote;
@@ -15,14 +17,17 @@ pub(super) struct OwnedId {
     /// The owned type with generics, if any.
     pub(super) id_type: syn::Type,
 
+    /// The size of the inline array for the `SmallVec` inner representation.
+    pub(super) smallvec_inline_bytes: usize,
+
     /// `#[cfg]` attributes for the internal storage representations.
     storage_attrs: StorageCfgAttributes,
 }
 
 impl OwnedId {
     /// Construct a new `OwnedId`.
-    pub(super) fn new(ident: syn::Ident, id_type: syn::Type) -> Self {
-        Self { ident, id_type, storage_attrs: StorageCfgAttributes::new() }
+    pub(super) fn new(ident: syn::Ident, id_type: syn::Type, smallvec_inline_bytes: usize) -> Self {
+        Self { ident, id_type, smallvec_inline_bytes, storage_attrs: StorageCfgAttributes::new() }
     }
 
     /// Expand an implementation for all the internal storage representations by calling the given
@@ -82,8 +87,11 @@ impl OwnedId {
         .unzip();
 
         let doc_header = format!("Owned variant of [`{}`].", id_dst.ident);
-        let doc_values =
-            StorageCfgValue::ALL.iter().map(StorageCfgValue::doc).collect::<Vec<_>>().join("\n* ");
+        let doc_values = StorageCfgValue::ALL
+            .iter()
+            .map(|value| StorageCfgValue::doc(value, self))
+            .collect::<Vec<_>>()
+            .join("\n* ");
 
         let inner_types_decl = self.expand_for_each_storage_value(|value| {
             let inner_type = value.inner_type(types);
@@ -145,7 +153,8 @@ impl OwnedId {
             "Securely zero memory (aka [zeroize](https://en.wikipedia.org/wiki/Zeroisation)) of `{owned_ident}`."
         );
         let zeroize_impls = self.expand_for_each_storage_value(|value| {
-            value.expand_zeroize_impl(&self_inner_field, ruma_common)
+            let expanded = value.expand_zeroize_impl(&self_inner_field, ruma_common);
+            quote! { { #expanded } }
         });
 
         let into_box_str_impls = self.expand_for_each_storage_value(|value| {
@@ -153,7 +162,7 @@ impl OwnedId {
             quote! { { #expanded } }
         });
         let into_string_impls = self.expand_for_each_storage_value(|value| {
-            let expanded = value.expand_into_string_impl(&id_var, &id_inner_field);
+            let expanded = value.expand_into_string_impl(&id_var, &id_inner_field, types);
             quote! { { #expanded } }
         });
 
@@ -347,11 +356,14 @@ enum StorageCfgValue {
 
     /// `ThinArc`, the `triomphe::ThinArc<(), u8>` internal representation.
     ThinArc,
+
+    /// `SmallVec`, the `smallvec::SmallVec<[u8; N]>` internal representation.
+    SmallVec,
 }
 
 impl StorageCfgValue {
     /// All the possible values.
-    const ALL: &'static [Self] = &[Self::Default, Self::Arc, Self::ThinArc];
+    const ALL: &'static [Self] = &[Self::Default, Self::Arc, Self::ThinArc, Self::SmallVec];
 
     /// The string representation for this value.
     ///
@@ -361,6 +373,7 @@ impl StorageCfgValue {
             Self::Default => None?,
             Self::Arc => "Arc",
             Self::ThinArc => "ThinArc",
+            Self::SmallVec => "SmallVec",
         })
     }
 
@@ -370,20 +383,26 @@ impl StorageCfgValue {
             Self::Default => &attrs.default,
             Self::Arc => &attrs.arc,
             Self::ThinArc => &attrs.thin_arc,
+            Self::SmallVec => &attrs.small_vec,
         }
     }
 
     /// The docs for this value.
     ///
     /// This should be a doc string that looks like `` `{value}` -- Use a `{type}`.``.
-    fn doc(&self) -> &'static str {
+    fn doc(&self, owned_id: &OwnedId) -> Cow<'static, str> {
         match self {
-            Self::Default => "",
-            Self::Arc => "`Arc` -- Use an `Arc<str>`.",
-            Self::ThinArc => {
+            Self::Default => Cow::Borrowed(""),
+            Self::Arc => Cow::Borrowed("`Arc` -- Use an `Arc<str>`."),
+            Self::ThinArc => Cow::Borrowed(
                 "`ThinArc` -- Use a `triomphe::ThinArc<(), u8>`. \
-                 Requires the `triomphe` cargo feature."
-            }
+                 Requires the `triomphe` cargo feature.",
+            ),
+            Self::SmallVec => Cow::Owned(format!(
+                "`SmallVec` -- Use a `smallvec::SmallVec<[u8; {}]>`. \
+                 Requires the `smallvec` cargo feature.",
+                owned_id.smallvec_inline_bytes
+            )),
         }
     }
 
@@ -393,6 +412,7 @@ impl StorageCfgValue {
             Self::Default => &types.box_str,
             Self::Arc => &types.arc_str,
             Self::ThinArc => &types.thin_arc_bytes,
+            Self::SmallVec => &types.small_vec_bytes,
         }
     }
 
@@ -406,6 +426,12 @@ impl StorageCfgValue {
                 let thin_arc_bytes = &types.thin_arc_bytes;
                 quote! {
                     <#thin_arc_bytes>::from_header_and_slice((), #string_var.as_bytes())
+                }
+            }
+            Self::SmallVec => {
+                let small_vec_bytes = &types.small_vec_bytes;
+                quote! {
+                    <#small_vec_bytes>::from_slice(#string_var.as_bytes())
                 }
             }
         }
@@ -424,6 +450,13 @@ impl StorageCfgValue {
                     <#thin_arc_bytes>::from_header_and_slice((), #string_var.as_bytes())
                 }
             }
+            Self::SmallVec => {
+                let str = &types.str;
+                let small_vec_bytes = &types.small_vec_bytes;
+                quote! {
+                    <#small_vec_bytes>::from_vec(#str::into_boxed_bytes(#string_var).into())
+                }
+            }
         }
     }
 
@@ -437,6 +470,12 @@ impl StorageCfgValue {
                 let thin_arc_bytes = &types.thin_arc_bytes;
                 quote! {
                     <#thin_arc_bytes>::from_header_and_slice((), #string_var.as_bytes())
+                }
+            }
+            Self::SmallVec => {
+                let small_vec_bytes = &types.small_vec_bytes;
+                quote! {
+                    <#small_vec_bytes>::from_vec(#string_var.into_bytes())
                 }
             }
         }
@@ -454,6 +493,12 @@ impl StorageCfgValue {
                     unsafe { #str::from_utf8_unchecked(&#inner_field.slice) }
                 }
             }
+            Self::SmallVec => {
+                let str = &types.str;
+                quote! {
+                    unsafe { #str::from_utf8_unchecked(&#inner_field) }
+                }
+            }
         }
     }
 
@@ -465,6 +510,9 @@ impl StorageCfgValue {
             },
             Self::ThinArc => quote! {
                 &#inner_field.slice
+            },
+            Self::SmallVec => quote! {
+                &#inner_field
             },
         }
     }
@@ -494,6 +542,9 @@ impl StorageCfgValue {
                     })
                 }
             }
+            Self::SmallVec => quote! {
+                ::zeroize::Zeroize::zeroize(#inner_field.as_mut_slice());
+            },
         }
     }
 
@@ -508,6 +559,11 @@ impl StorageCfgValue {
             Self::Arc | Self::ThinArc => quote! {
                 #id_var.as_inner_str().into()
             },
+            Self::SmallVec => {
+                quote! {
+                    unsafe { ::std::str::from_boxed_utf8_unchecked(#inner_field.into_boxed_slice()) }
+                }
+            }
         }
     }
 
@@ -516,12 +572,19 @@ impl StorageCfgValue {
         &self,
         id_var: &TokenStream,
         inner_field: &TokenStream,
+        types: &Types,
     ) -> TokenStream {
         match self {
             Self::Default => quote! { #inner_field.into() },
             Self::Arc | Self::ThinArc => quote! {
                 #id_var.as_inner_str().into()
             },
+            Self::SmallVec => {
+                let string = &types.string;
+                quote! {
+                    unsafe { #string::from_utf8_unchecked(#inner_field.into_vec()) }
+                }
+            }
         }
     }
 }
@@ -533,6 +596,9 @@ struct StorageCfgAttributes {
 
     /// Attribute for the `Arc` value.
     arc: syn::Attribute,
+
+    /// Attribute for the `SmallVec` value.
+    small_vec: syn::Attribute,
 
     /// Attribute for the `ThinArc` value.
     thin_arc: syn::Attribute,
@@ -552,6 +618,7 @@ impl StorageCfgAttributes {
         Self {
             default: parse_quote! { #[cfg(not(any(#( #key = #all_values ),*)))] },
             arc: value_to_attribute(StorageCfgValue::Arc),
+            small_vec: value_to_attribute(StorageCfgValue::SmallVec),
             thin_arc: value_to_attribute(StorageCfgValue::ThinArc),
         }
     }

--- a/crates/ruma-macros/src/identifiers/id_dst/parse.rs
+++ b/crates/ruma-macros/src/identifiers/id_dst/parse.rs
@@ -8,6 +8,9 @@ use syn::{meta::ParseNestedMeta, parse_quote};
 use super::{IdDst, OwnedId, Types};
 use crate::util::RumaCommon;
 
+/// The default size of the inline array for the `SmallVec` inner representation.
+const SMALLVEC_INLINE_BYTES_DEFAULT: usize = 32;
+
 impl IdDst {
     /// Parse the given `IdDst` macro input.
     pub(super) fn parse(input: syn::ItemStruct) -> syn::Result<Self> {
@@ -21,7 +24,7 @@ impl IdDst {
             attr.parse_nested_meta(|meta| id_dst_attrs.try_merge(meta, attr))?;
         }
 
-        let IdDstAttrs { validate } = id_dst_attrs;
+        let IdDstAttrs { validate, smallvec_inline_bytes } = id_dst_attrs;
 
         if validate.is_none() && !input.generics.params.is_empty() {
             return Err(syn::Error::new(
@@ -52,6 +55,8 @@ impl IdDst {
         })?
         .into();
 
+        let smallvec_inline_bytes = smallvec_inline_bytes.unwrap_or(SMALLVEC_INLINE_BYTES_DEFAULT);
+
         let generics = input.generics;
         let (impl_generics, type_generics, _where_clause) = generics.split_for_impl();
         let impl_generics = quote! { #impl_generics };
@@ -61,9 +66,9 @@ impl IdDst {
         let owned_ident = format_ident!("Owned{ident}");
         let owned_id_type = parse_quote! { #owned_ident #type_generics };
 
-        let owned_id = OwnedId::new(owned_ident, owned_id_type);
-
+        let owned_id = OwnedId::new(owned_ident, owned_id_type, smallvec_inline_bytes);
         let ruma_common = RumaCommon::new();
+        let types = Types::new(&ruma_common, &owned_id);
 
         Ok(Self {
             ident,
@@ -73,7 +78,7 @@ impl IdDst {
             validate,
             str_field_index,
             owned_id,
-            types: Types::new(&ruma_common),
+            types,
             ruma_common,
         })
     }
@@ -84,6 +89,9 @@ impl IdDst {
 struct IdDstAttrs {
     /// The path to the function to use to validate the identifier.
     validate: Option<syn::Path>,
+
+    /// The size of the inline array for the `SmallVec` inner representation.
+    smallvec_inline_bytes: Option<usize>,
 }
 
 impl IdDstAttrs {
@@ -102,6 +110,25 @@ impl IdDstAttrs {
         Ok(())
     }
 
+    /// Set the size of the inline array for the `SmallVec` inner representation.
+    ///
+    /// Returns an error if it is already set or if the value doesn't fit into a `usize`.
+    fn set_smallvec_inline_bytes(
+        &mut self,
+        inline_bytes: syn::LitInt,
+        attr: &syn::Attribute,
+    ) -> syn::Result<()> {
+        if self.smallvec_inline_bytes.is_some() {
+            return Err(syn::Error::new_spanned(
+                attr,
+                "cannot have multiple values for `smallvec_inline_bytes` attribute",
+            ));
+        }
+
+        self.smallvec_inline_bytes = Some(inline_bytes.base10_parse()?);
+        Ok(())
+    }
+
     /// Try to parse the given meta item and merge it into this `IdDstAttrs`.
     ///
     /// Returns an error if an unknown `ruma_id` attribute is encountered, or if an attribute
@@ -109,6 +136,10 @@ impl IdDstAttrs {
     fn try_merge(&mut self, meta: ParseNestedMeta<'_>, attr: &syn::Attribute) -> syn::Result<()> {
         if meta.path.is_ident("validate") {
             return self.set_validate(meta.value()?.parse()?, attr);
+        }
+
+        if meta.path.is_ident("smallvec_inline_bytes") {
+            return self.set_smallvec_inline_bytes(meta.value()?.parse()?, attr);
         }
 
         Err(meta.error("unsupported `ruma_id` attribute"))

--- a/crates/ruma-macros/src/lib.rs
+++ b/crates/ruma-macros/src/lib.rs
@@ -463,9 +463,11 @@ pub fn derive_from_event_to_enum(input: TokenStream) -> TokenStream {
 ///
 /// # Attributes
 ///
-/// * `#[ruma_api(validate = PATH)]`: the path to a function to validate the string during parsing
+/// * `#[ruma_id(validate = PATH)]`: the path to a function to validate the string during parsing
 ///   and deserialization. By default, the types implement `From` string types, when this is set
 ///   they implement `TryFrom`.
+/// * `#[ruma_id(smallvec_inline_bytes = USIZE)]`: the size of the inline array for the `SmallVec`
+///   inner representation. If this is not provided the default inline size is `32`.
 ///
 /// # Examples
 ///
@@ -474,7 +476,7 @@ pub fn derive_from_event_to_enum(input: TokenStream) -> TokenStream {
 /// use ruma_macros::IdDst;
 ///
 /// #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, IdDst)]
-/// #[ruma_id(validate = ruma_identifiers_validation::user_id::validate)]
+/// #[ruma_id(validate = ruma_identifiers_validation::user_id::validate, smallvec_inline_bytes = 40)]
 /// pub struct UserId(str);
 /// ```
 #[proc_macro_derive(IdDst, attributes(ruma_id))]

--- a/crates/ruma-macros/src/util.rs
+++ b/crates/ruma-macros/src/util.rs
@@ -64,6 +64,9 @@ pub(crate) enum RumaCommonReexport {
 
     /// The triomphe crate.
     Triomphe,
+
+    /// The smallvec crate.
+    Smallvec,
 }
 
 impl ToTokens for RumaCommonReexport {
@@ -76,6 +79,7 @@ impl ToTokens for RumaCommonReexport {
             Self::Http => "http",
             Self::Bytes => "bytes",
             Self::Triomphe => "triomphe",
+            Self::Smallvec => "smallvec",
         };
 
         tokens.append(Ident::new(crate_name, Span::call_site()));

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -50,6 +50,7 @@ html = ["dep:ruma-html", "ruma-events?/html"]
 html-matrix = ["html", "ruma-html/matrix"]
 
 # Internal representations for identifiers generated with the IdDst macro.
+smallvec = ["ruma-common/smallvec"]
 triomphe = ["ruma-common/triomphe"]
 
 # Everything except compat, js and unstable features


### PR DESCRIPTION
Uses `smallvec::SmallVec<[u8; N]>` as internal representation, which should allow to improve performance by allocating most identifiers on the stack rather than on the heap.

This is the representation that is currently used downstream by tuwunel, and that was used by conduwuit.

The default size of the inline array on the stack is `32`, but it is adjusted for some identifier types.
