### PR TITLE
api: Add `content_type` method to `OutgoingBody` trait

### DIFF
--- a/crates/ruma-client-api/src/knock/knock_room.rs
+++ b/crates/ruma-client-api/src/knock/knock_room.rs
@@ -107,7 +107,6 @@ pub mod v3 {
                     &[&self.room_id_or_alias],
                     &query_string,
                 )?)
-                .header(http::header::CONTENT_TYPE, ruma_common::http_headers::APPLICATION_JSON)
                 .body(RequestBody { reason: self.reason })?;
 
             Ok(http_request)

--- a/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
+++ b/crates/ruma-client-api/src/membership/join_room_by_id_or_alias.rs
@@ -118,7 +118,6 @@ pub mod v3 {
                     &[&self.room_id_or_alias],
                     &query_string,
                 )?)
-                .header(http::header::CONTENT_TYPE, ruma_common::http_headers::APPLICATION_JSON)
                 .body(RequestBody {
                     third_party_signed: self.third_party_signed,
                     reason: self.reason,

--- a/crates/ruma-client-api/src/profile/get_profile_field.rs
+++ b/crates/ruma-client-api/src/profile/get_profile_field.rs
@@ -231,7 +231,6 @@ pub mod v3 {
         ) -> Result<http::Response<Self::Body>, ruma_common::api::error::IntoHttpError> {
             Ok(http::Response::builder()
                 .status(http::StatusCode::OK)
-                .header(http::header::CONTENT_TYPE, ruma_common::http_headers::APPLICATION_JSON)
                 .body(ResponseBody(self.value))?)
         }
     }

--- a/crates/ruma-client-api/src/profile/set_profile_field.rs
+++ b/crates/ruma-client-api/src/profile/set_profile_field.rs
@@ -110,7 +110,6 @@ pub mod v3 {
             let http_request = http::Request::builder()
                 .method(Self::METHOD)
                 .uri(url)
-                .header(http::header::CONTENT_TYPE, ruma_common::http_headers::APPLICATION_JSON)
                 .body(RequestBody(self.value))?;
 
             Ok(http_request)

--- a/crates/ruma-client-api/src/push/set_pushrule.rs
+++ b/crates/ruma-client-api/src/push/set_pushrule.rs
@@ -66,6 +66,10 @@ pub mod v3 {
     impl ruma_common::api::OutgoingBody for RequestBody {
         type Error = serde_json::Error;
 
+        fn content_type(&self) -> Option<http::HeaderValue> {
+            Some(ruma_common::http_headers::APPLICATION_JSON)
+        }
+
         fn try_into_buf<T: Default + bytes::BufMut + AsRef<[u8]>>(self) -> serde_json::Result<T> {
             match self.0 {
                 NewPushRule::Override(r) | NewPushRule::Underride(r) => {
@@ -119,7 +123,6 @@ pub mod v3 {
             let http_request = http::Request::builder()
                 .method(Self::METHOD)
                 .uri(url)
-                .header(http::header::CONTENT_TYPE, ruma_common::http_headers::APPLICATION_JSON)
                 .body(RequestBody(self.rule))?;
 
             Ok(http_request)

--- a/crates/ruma-client-api/src/rendezvous/create_rendezvous_session.rs
+++ b/crates/ruma-client-api/src/rendezvous/create_rendezvous_session.rs
@@ -16,6 +16,7 @@ pub mod unstable_msc4108 {
             auth_scheme::NoAccessToken,
             error::{DeserializationError, Error, HeaderDeserializationError},
         },
+        http_headers::TEXT_PLAIN,
         metadata,
     };
     use url::Url;
@@ -58,7 +59,7 @@ pub mod unstable_msc4108 {
             Ok(http::Request::builder()
                 .method(Self::METHOD)
                 .uri(url)
-                .header(CONTENT_TYPE, "text/plain")
+                .header(CONTENT_TYPE, TEXT_PLAIN)
                 .header(CONTENT_LENGTH, content_length)
                 .body(BytesBody(self.content.into()))?)
         }
@@ -73,20 +74,19 @@ pub mod unstable_msc4108 {
             request: http::Request<&[u8]>,
             _path_args: &[&str],
         ) -> Result<Self, DeserializationError> {
-            const EXPECTED_CONTENT_TYPE: &str = "text/plain";
-
             let content_type = request
                 .headers()
                 .get(CONTENT_TYPE)
                 .ok_or(HeaderDeserializationError::MissingHeader(CONTENT_TYPE.to_string()))?;
 
-            let content_type = content_type.to_str()?;
-
-            if content_type != EXPECTED_CONTENT_TYPE {
+            if content_type != TEXT_PLAIN {
                 Err(HeaderDeserializationError::InvalidHeaderValue {
                     header: CONTENT_TYPE.to_string(),
-                    expected: EXPECTED_CONTENT_TYPE.to_owned(),
-                    unexpected: content_type.to_owned(),
+                    expected: TEXT_PLAIN
+                        .to_str()
+                        .expect("expected content type should be a valid static string")
+                        .to_owned(),
+                    unexpected: content_type.to_str()?.to_owned(),
                 }
                 .into())
             } else {

--- a/crates/ruma-client-api/src/rendezvous/create_rendezvous_session.rs
+++ b/crates/ruma-client-api/src/rendezvous/create_rendezvous_session.rs
@@ -184,7 +184,6 @@ pub mod unstable_msc4108 {
 
             Ok(http::Response::builder()
                 .status(http::StatusCode::OK)
-                .header(CONTENT_TYPE, ruma_common::http_headers::APPLICATION_JSON)
                 .header(PRAGMA, "no-cache")
                 .header(CACHE_CONTROL, "no-store")
                 .header(ETAG, self.etag)

--- a/crates/ruma-client-api/src/room/get_summary.rs
+++ b/crates/ruma-client-api/src/room/get_summary.rs
@@ -116,10 +116,7 @@ pub mod v1 {
         ) -> Result<http::Response<Self::Body>, ruma_common::api::error::IntoHttpError> {
             let Self { summary, membership } = self;
 
-            http::Response::builder()
-                .header(http::header::CONTENT_TYPE, ruma_common::http_headers::APPLICATION_JSON)
-                .body(ResponseBody { summary, membership })
-                .map_err(Into::into)
+            http::Response::builder().body(ResponseBody { summary, membership }).map_err(Into::into)
         }
     }
 

--- a/crates/ruma-client-api/src/session/login_fallback.rs
+++ b/crates/ruma-client-api/src/session/login_fallback.rs
@@ -68,7 +68,7 @@ impl ruma_common::api::OutgoingResponse for Response {
     ) -> Result<http::Response<Self::Body>, ruma_common::api::error::IntoHttpError> {
         Ok(http::Response::builder()
             .status(http::StatusCode::OK)
-            .header(http::header::CONTENT_TYPE, "text/html")
+            .header(http::header::CONTENT_TYPE, ruma_common::http_headers::TEXT_HTML_UTF8)
             .body(ruma_common::api::BytesBody(self.body))?)
     }
 }

--- a/crates/ruma-client-api/src/state/send_state_event.rs
+++ b/crates/ruma-client-api/src/state/send_state_event.rs
@@ -161,7 +161,6 @@ pub mod v3 {
                     &[&self.room_id, &self.event_type, &self.state_key],
                     &query_string,
                 )?)
-                .header(http::header::CONTENT_TYPE, ruma_common::http_headers::APPLICATION_JSON)
                 .body(RequestBody(self.body))?;
 
             Ok(http_request)

--- a/crates/ruma-client-api/src/uiaa.rs
+++ b/crates/ruma-client-api/src/uiaa.rs
@@ -233,7 +233,6 @@ impl OutgoingResponse for UiaaResponse {
     fn try_into_http_response_inner(self) -> Result<http::Response<Self::Body>, IntoHttpError> {
         Ok(match self {
             UiaaResponse::AuthResponse(authentication_info) => http::Response::builder()
-                .header(http::header::CONTENT_TYPE, ruma_common::http_headers::APPLICATION_JSON)
                 .status(http::StatusCode::UNAUTHORIZED)
                 .body(ResponseBody::AuthResponse(authentication_info))?,
             UiaaResponse::MatrixError(error) => {
@@ -253,6 +252,10 @@ pub enum ResponseBody {
 
 impl OutgoingBody for ResponseBody {
     type Error = IntoHttpError;
+
+    fn content_type(&self) -> Option<http::HeaderValue> {
+        Some(ruma_common::http_headers::APPLICATION_JSON)
+    }
 
     fn try_into_buf<T: Default + BufMut + AsRef<[u8]>>(self) -> Result<T, Self::Error> {
         Ok(match self {

--- a/crates/ruma-client-api/src/uiaa/get_uiaa_fallback_page.rs
+++ b/crates/ruma-client-api/src/uiaa/get_uiaa_fallback_page.rs
@@ -93,6 +93,13 @@ pub mod v3 {
     impl ruma_common::api::OutgoingBody for ResponseBody {
         type Error = ruma_common::api::error::IntoHttpError;
 
+        fn content_type(&self) -> Option<http::HeaderValue> {
+            match self {
+                Self::Redirect => None,
+                Self::Html(_) => Some(ruma_common::http_headers::TEXT_HTML_UTF8),
+            }
+        }
+
         fn try_into_buf<T: Default + bytes::BufMut + AsRef<[u8]>>(self) -> Result<T, Self::Error> {
             let body = match self {
                 Self::Redirect => Vec::new(),
@@ -117,7 +124,6 @@ pub mod v3 {
                     .body(ResponseBody::Redirect)?),
                 Response::Html(html) => Ok(http::Response::builder()
                     .status(http::StatusCode::OK)
-                    .header(http::header::CONTENT_TYPE, ruma_common::http_headers::TEXT_HTML_UTF8)
                     .body(ResponseBody::Html(html))?),
             }
         }

--- a/crates/ruma-client-api/src/uiaa/get_uiaa_fallback_page.rs
+++ b/crates/ruma-client-api/src/uiaa/get_uiaa_fallback_page.rs
@@ -117,7 +117,7 @@ pub mod v3 {
                     .body(ResponseBody::Redirect)?),
                 Response::Html(html) => Ok(http::Response::builder()
                     .status(http::StatusCode::OK)
-                    .header(http::header::CONTENT_TYPE, "text/html; charset=utf-8")
+                    .header(http::header::CONTENT_TYPE, ruma_common::http_headers::TEXT_HTML_UTF8)
                     .body(ResponseBody::Html(html))?),
             }
         }
@@ -178,7 +178,7 @@ pub mod v3 {
 
             let http_response = http::Response::builder()
                 .status(http::StatusCode::OK)
-                .header(CONTENT_TYPE, "text/html; charset=utf-8")
+                .header(CONTENT_TYPE, ruma_common::http_headers::TEXT_HTML_UTF8)
                 .body(b"<h1>My Page</h1>".as_slice())
                 .unwrap();
 
@@ -217,8 +217,8 @@ pub mod v3 {
 
             assert_eq!(http_response.status(), http::StatusCode::OK);
             assert_eq!(
-                http_response.headers().get(CONTENT_TYPE).unwrap().to_str().unwrap(),
-                "text/html; charset=utf-8"
+                http_response.headers().get(CONTENT_TYPE).unwrap(),
+                ruma_common::http_headers::TEXT_HTML_UTF8
             );
             assert_eq!(http_response.into_body(), b"<h1>My Page</h1>");
         }

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -58,6 +58,7 @@ Improvements:
     types, and requires the `triomphe` cargo feature.
   - `SmallVec` uses `smallvec::SmallVec<[u8; N]>` as internal representation for the owned identifier
     types, and requires the `smallvec` cargo feature.
+- Add `http_headers::TEXT_PLAIN` for the `text/plain` media type.
 
 [MSC4438]: https://github.com/matrix-org/matrix-spec-proposals/pull/4438
 [MSC4484]: https://github.com/matrix-org/matrix-spec-proposals/pull/4484

--- a/crates/ruma-common/CHANGELOG.md
+++ b/crates/ruma-common/CHANGELOG.md
@@ -58,7 +58,9 @@ Improvements:
     types, and requires the `triomphe` cargo feature.
   - `SmallVec` uses `smallvec::SmallVec<[u8; N]>` as internal representation for the owned identifier
     types, and requires the `smallvec` cargo feature.
-- Add `http_headers::TEXT_PLAIN` for the `text/plain` media type.
+- In the `http_headers` module, add:
+  - `TEXT_PLAIN` for the `text/plain` media type.
+  - `TEXT_HTML_UTF8` for the `text/html; charset=utf-8` media type.
 
 [MSC4438]: https://github.com/matrix-org/matrix-spec-proposals/pull/4438
 [MSC4484]: https://github.com/matrix-org/matrix-spec-proposals/pull/4484

--- a/crates/ruma-common/src/api.rs
+++ b/crates/ruma-common/src/api.rs
@@ -325,8 +325,15 @@ pub trait OutgoingRequestExt: OutgoingRequest {
         authentication_input: <Self::Authentication as auth_scheme::AuthScheme>::Input<'_>,
         path_builder_input: <Self::PathBuilder as path_builder::PathBuilder>::Input<'_>,
     ) -> Result<http::Request<T>, IntoHttpError> {
-        let (parts, body) =
+        let (mut parts, body) =
             self.try_into_http_request_inner(base_url, path_builder_input)?.into_parts();
+
+        if let Some(content_type) = body.content_type()
+            && !parts.headers.contains_key(&http::header::CONTENT_TYPE)
+        {
+            parts.headers.insert(http::header::CONTENT_TYPE, content_type);
+        }
+
         let mut request =
             http::Request::from_parts(parts, body.try_into_buf().map_err(Into::into)?);
 
@@ -473,7 +480,14 @@ pub trait OutgoingResponseExt: OutgoingResponse {
     fn try_into_http_response<T: Default + BufMut + AsRef<[u8]>>(
         self,
     ) -> Result<http::Response<T>, IntoHttpError> {
-        let (parts, body) = self.try_into_http_response_inner()?.into_parts();
+        let (mut parts, body) = self.try_into_http_response_inner()?.into_parts();
+
+        if let Some(content_type) = body.content_type()
+            && !parts.headers.contains_key(&http::header::CONTENT_TYPE)
+        {
+            parts.headers.insert(http::header::CONTENT_TYPE, content_type);
+        }
+
         Ok(http::Response::from_parts(parts, body.try_into_buf().map_err(Into::into)?))
     }
 }

--- a/crates/ruma-common/src/api/body.rs
+++ b/crates/ruma-common/src/api/body.rs
@@ -9,6 +9,14 @@ pub trait OutgoingBody {
     /// The type of error that can happen in `try_info_buf`.
     type Error: Into<IntoHttpError>;
 
+    /// The value for the `Content-Type` HTTP header for this body, if there is one.
+    ///
+    /// This is the value set if the request or response type does not set one dynamically, for
+    /// example with the `#[ruma_api(header = CONTENT_TYPE)]` attribute.
+    ///
+    /// If this is `None`, no `Content-Type` HTTP header is added.
+    fn content_type(&self) -> Option<http::HeaderValue>;
+
     /// Turn `self` into a byte buffer (copying a raw body or serializing a JSON one).
     fn try_into_buf<T: Default + BufMut + AsRef<[u8]>>(self) -> Result<T, Self::Error>;
 }
@@ -24,6 +32,10 @@ pub struct EmptyBody<const TRULY_EMPTY: bool = true>;
 impl<const TRULY_EMPTY: bool> OutgoingBody for EmptyBody<TRULY_EMPTY> {
     type Error = Infallible;
 
+    fn content_type(&self) -> Option<http::HeaderValue> {
+        if TRULY_EMPTY { None } else { Some(crate::http_headers::APPLICATION_JSON) }
+    }
+
     fn try_into_buf<T: Default + BufMut + AsRef<[u8]>>(self) -> Result<T, Infallible> {
         if TRULY_EMPTY { Ok(Default::default()) } else { Ok(slice_to_buf(b"{}")) }
     }
@@ -35,6 +47,10 @@ pub struct BytesBody(pub Vec<u8>);
 
 impl OutgoingBody for BytesBody {
     type Error = Infallible;
+
+    fn content_type(&self) -> Option<http::HeaderValue> {
+        Some(crate::http_headers::APPLICATION_OCTET_STREAM)
+    }
 
     fn try_into_buf<T: Default + BufMut + AsRef<[u8]>>(self) -> Result<T, Infallible> {
         Ok(slice_to_buf(&self.0))

--- a/crates/ruma-common/src/api/error.rs
+++ b/crates/ruma-common/src/api/error.rs
@@ -78,9 +78,7 @@ impl OutgoingResponse for Error {
     type Body = ErrorResponseBody;
 
     fn try_into_http_response_inner(self) -> Result<http::Response<Self::Body>, IntoHttpError> {
-        let mut builder = http::Response::builder()
-            .header(http::header::CONTENT_TYPE, ruma_common::http_headers::APPLICATION_JSON)
-            .status(self.status_code);
+        let mut builder = http::Response::builder().status(self.status_code);
 
         // Add data in headers.
         if let Some(ErrorKind::LimitExceeded(LimitExceededErrorData {

--- a/crates/ruma-common/src/http_headers.rs
+++ b/crates/ruma-common/src/http_headers.rs
@@ -21,6 +21,9 @@ pub const APPLICATION_JSON: HeaderValue = HeaderValue::from_static("application/
 pub const APPLICATION_OCTET_STREAM: HeaderValue =
     HeaderValue::from_static("application/octet-stream");
 
+/// The `text/plain` media type as a [`HeaderValue`].
+pub const TEXT_PLAIN: HeaderValue = HeaderValue::from_static("text/plain");
+
 /// The [`Cross-Origin-Resource-Policy`] HTTP response header.
 ///
 /// [`Cross-Origin-Resource-Policy`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Resource-Policy

--- a/crates/ruma-common/src/http_headers.rs
+++ b/crates/ruma-common/src/http_headers.rs
@@ -24,6 +24,9 @@ pub const APPLICATION_OCTET_STREAM: HeaderValue =
 /// The `text/plain` media type as a [`HeaderValue`].
 pub const TEXT_PLAIN: HeaderValue = HeaderValue::from_static("text/plain");
 
+/// The `text/html; charset=utf-8` media type as a [`HeaderValue`].
+pub const TEXT_HTML_UTF8: HeaderValue = HeaderValue::from_static("text/html; charset=utf-8");
+
 /// The [`Cross-Origin-Resource-Policy`] HTTP response header.
 ///
 /// [`Cross-Origin-Resource-Policy`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Resource-Policy

--- a/crates/ruma-common/tests/it/api/manual_endpoint_impl.rs
+++ b/crates/ruma-common/tests/it/api/manual_endpoint_impl.rs
@@ -6,7 +6,7 @@
 use std::borrow::Cow;
 
 use bytes::BufMut;
-use http::{header::CONTENT_TYPE, method::Method};
+use http::method::Method;
 use ruma_common::{
     OwnedRoomAliasId, OwnedRoomId,
     api::{
@@ -111,6 +111,10 @@ pub struct RequestBody {
 impl OutgoingBody for RequestBody {
     type Error = serde_json::Error;
 
+    fn content_type(&self) -> Option<http::HeaderValue> {
+        Some(ruma_common::http_headers::APPLICATION_JSON)
+    }
+
     fn try_into_buf<T: Default + BufMut + AsRef<[u8]>>(self) -> serde_json::Result<T> {
         json_to_buf(&self)
     }
@@ -134,11 +138,6 @@ impl OutgoingResponse for Response {
     type Body = EmptyBody<false>;
 
     fn try_into_http_response_inner(self) -> Result<http::Response<Self::Body>, IntoHttpError> {
-        let response = http::Response::builder()
-            .header(CONTENT_TYPE, ruma_common::http_headers::APPLICATION_JSON)
-            .body(EmptyBody)
-            .unwrap();
-
-        Ok(response)
+        Ok(http::Response::new(EmptyBody))
     }
 }

--- a/crates/ruma-federation-api/src/authenticated_media.rs
+++ b/crates/ruma-federation-api/src/authenticated_media.rs
@@ -96,8 +96,10 @@ impl MultipartMixedBoundary {
     }
 
     /// Get the value of the `Content-Type` HTTP header for this boundary.
-    fn content_type(&self) -> String {
+    fn content_type(&self) -> http::HeaderValue {
         format!("{MULTIPART_MIXED}; boundary={}", self.0)
+            .try_into()
+            .expect("content type should only contain visible ASCII characters")
     }
 
     /// Write this boundary as a separator between parts of the body.
@@ -170,20 +172,15 @@ impl ResponseBody {
     fn new(metadata: ContentMetadata, content: FileOrLocation) -> Self {
         Self { metadata, content, boundary: MultipartMixedBoundary::new() }
     }
-
-    /// Convert this `ResponseBody` into an `http::Response<ResponseBody>`.
-    fn try_into_http_response(
-        self,
-    ) -> Result<http::Response<Self>, ruma_common::api::error::IntoHttpError> {
-        let content_type = self.boundary.content_type();
-
-        Ok(http::Response::builder().header(http::header::CONTENT_TYPE, content_type).body(self)?)
-    }
 }
 
 #[cfg(feature = "server")]
 impl OutgoingBody for ResponseBody {
     type Error = ruma_common::api::error::IntoHttpError;
+
+    fn content_type(&self) -> Option<http::HeaderValue> {
+        Some(self.boundary.content_type())
+    }
 
     fn try_into_buf<T: Default + bytes::BufMut>(self) -> Result<T, Self::Error> {
         use std::io::Write as _;
@@ -407,12 +404,14 @@ mod tests {
             content_disposition: Some(content_disposition.clone()),
         });
 
-        let (parts, body) = ResponseBody::new(outgoing_metadata, outgoing_content)
-            .try_into_http_response()
-            .unwrap()
-            .into_parts();
+        let body = ResponseBody::new(outgoing_metadata, outgoing_content);
+        let multipart_content_type = body.content_type().unwrap();
         let body = body.try_into_buf::<Vec<u8>>().unwrap();
-        let response = http::Response::from_parts(parts, body.as_slice());
+
+        let response = http::Response::builder()
+            .header(http::header::CONTENT_TYPE, multipart_content_type)
+            .body(body.as_slice())
+            .unwrap();
 
         let ResponseBody { content: incoming_content, .. } =
             ResponseBody::try_from_http_response(response).unwrap();
@@ -437,12 +436,14 @@ mod tests {
             content_disposition: Some(content_disposition.clone()),
         });
 
-        let (parts, body) = ResponseBody::new(outgoing_metadata, outgoing_content)
-            .try_into_http_response()
-            .unwrap()
-            .into_parts();
+        let body = ResponseBody::new(outgoing_metadata, outgoing_content);
+        let multipart_content_type = body.content_type().unwrap();
         let body = body.try_into_buf::<Vec<u8>>().unwrap();
-        let response = http::Response::from_parts(parts, body.as_slice());
+
+        let response = http::Response::builder()
+            .header(http::header::CONTENT_TYPE, multipart_content_type)
+            .body(body.as_slice())
+            .unwrap();
 
         let ResponseBody { content: incoming_content, .. } =
             ResponseBody::try_from_http_response(response).unwrap();
@@ -460,12 +461,14 @@ mod tests {
         let outgoing_metadata = ContentMetadata::new();
         let outgoing_content = FileOrLocation::Location(location.to_owned());
 
-        let (parts, body) = ResponseBody::new(outgoing_metadata, outgoing_content)
-            .try_into_http_response()
-            .unwrap()
-            .into_parts();
+        let body = ResponseBody::new(outgoing_metadata, outgoing_content);
+        let multipart_content_type = body.content_type().unwrap();
         let body = body.try_into_buf::<Vec<u8>>().unwrap();
-        let response = http::Response::from_parts(parts, body.as_slice());
+
+        let response = http::Response::builder()
+            .header(http::header::CONTENT_TYPE, multipart_content_type)
+            .body(body.as_slice())
+            .unwrap();
 
         let ResponseBody { content: incoming_content, .. } =
             ResponseBody::try_from_http_response(response).unwrap();

--- a/crates/ruma-federation-api/src/authenticated_media/get_content/unstable.rs
+++ b/crates/ruma-federation-api/src/authenticated_media/get_content/unstable.rs
@@ -97,7 +97,7 @@ impl ruma_common::api::OutgoingResponse for Response {
     fn try_into_http_response_inner(
         self,
     ) -> Result<http::Response<Self::Body>, ruma_common::api::error::IntoHttpError> {
-        ResponseBody::new(self.metadata, self.content).try_into_http_response()
+        Ok(http::Response::new(ResponseBody::new(self.metadata, self.content)))
     }
 }
 

--- a/crates/ruma-federation-api/src/authenticated_media/get_content/v1.rs
+++ b/crates/ruma-federation-api/src/authenticated_media/get_content/v1.rs
@@ -83,6 +83,6 @@ impl ruma_common::api::OutgoingResponse for Response {
     fn try_into_http_response_inner(
         self,
     ) -> Result<http::Response<Self::Body>, ruma_common::api::error::IntoHttpError> {
-        ResponseBody::new(self.metadata, self.content).try_into_http_response()
+        Ok(http::Response::new(ResponseBody::new(self.metadata, self.content)))
     }
 }

--- a/crates/ruma-federation-api/src/authenticated_media/get_content_thumbnail/unstable.rs
+++ b/crates/ruma-federation-api/src/authenticated_media/get_content_thumbnail/unstable.rs
@@ -135,7 +135,7 @@ impl ruma_common::api::OutgoingResponse for Response {
     fn try_into_http_response_inner(
         self,
     ) -> Result<http::Response<Self::Body>, ruma_common::api::error::IntoHttpError> {
-        ResponseBody::new(self.metadata, self.content).try_into_http_response()
+        Ok(http::Response::new(ResponseBody::new(self.metadata, self.content)))
     }
 }
 

--- a/crates/ruma-federation-api/src/authenticated_media/get_content_thumbnail/v1.rs
+++ b/crates/ruma-federation-api/src/authenticated_media/get_content_thumbnail/v1.rs
@@ -118,6 +118,6 @@ impl ruma_common::api::OutgoingResponse for Response {
     fn try_into_http_response_inner(
         self,
     ) -> Result<http::Response<Self::Body>, ruma_common::api::error::IntoHttpError> {
-        ResponseBody::new(self.metadata, self.content).try_into_http_response()
+        Ok(http::Response::new(ResponseBody::new(self.metadata, self.content)))
     }
 }

--- a/crates/ruma-macros/src/api/body.rs
+++ b/crates/ruma-macros/src/api/body.rs
@@ -8,12 +8,17 @@ pub(crate) fn expand_derive_outgoing_body_json(input: DeriveInput) -> TokenStrea
     let ruma_common = RumaCommon::new();
     let bytes = ruma_common.reexported(RumaCommonReexport::Bytes);
     let serde_json = ruma_common.reexported(RumaCommonReexport::SerdeJson);
+    let http = ruma_common.reexported(RumaCommonReexport::Http);
     let ident = input.ident;
 
     quote! {
         #[automatically_derived]
         impl #ruma_common::api::OutgoingBody for #ident {
             type Error = #serde_json::Error;
+
+            fn content_type(&self) -> ::std::option::Option<#http::HeaderValue> {
+                ::std::option::Option::Some(#ruma_common::http_headers::APPLICATION_JSON)
+            }
 
             fn try_into_buf<T>(self) -> #serde_json::Result<T>
             where

--- a/crates/ruma-macros/src/api/common.rs
+++ b/crates/ruma-macros/src/api/common.rs
@@ -119,28 +119,13 @@ impl Headers {
     pub(super) fn expand_serialize(
         &self,
         kind: MacroKind,
-        body: &Body,
-        ruma_common: &RumaCommon,
         http: &TokenStream,
     ) -> Option<TokenStream> {
-        let mut serialize = TokenStream::new();
-
-        // If there is no `CONTENT_TYPE` header, add one if necessary.
-        let content_type: syn::Ident = parse_quote!(CONTENT_TYPE);
-        if !self.0.contains_key(&content_type)
-            && let Some(content_type) = body.content_type(kind)
-        {
-            serialize.extend(quote! {
-                headers.insert(
-                    #http::header::CONTENT_TYPE,
-                    #ruma_common::http_headers::#content_type,
-                );
-            });
-        }
-
-        if serialize.is_empty() && self.0.is_empty() {
+        if self.0.is_empty() {
             return None;
         }
+
+        let mut serialize = TokenStream::new();
 
         for (header_name, field) in &self.0 {
             let ident = field.ident();
@@ -280,28 +265,6 @@ impl Body {
                 kind.as_struct_ident(StructSuffix::Body).into_token_stream()
             }
             BodyFields::Raw(_) => quote! { #ruma_common::api::BytesBody },
-        }
-    }
-
-    /// The content type of the body, if it can be determined.
-    ///
-    /// Returns a `const` from `ruma_common::http_headers`.
-    fn content_type(&self, kind: MacroKind) -> Option<syn::Ident> {
-        match &self.fields {
-            BodyFields::Empty if matches!(kind, MacroKind::Request) => {
-                // If there are no body fields, the request body might be empty (not `{}`), so the
-                // `application/json` content-type would be wrong. It may also cause problems with
-                // CORS policies that don't allow the `Content-Type` header (for things such as
-                // `.well-known` that are commonly handled by something else than a
-                // homeserver). However, a server should always return a JSON body.
-                None
-            }
-            BodyFields::Empty | BodyFields::JsonFields(_) | BodyFields::JsonAll(_) => {
-                Some(parse_quote! { APPLICATION_JSON })
-            }
-            // This might not be the actual content type, but this is a better default than
-            // `application/json` when sending raw data.
-            BodyFields::Raw(_) => Some(parse_quote! { APPLICATION_OCTET_STREAM }),
         }
     }
 

--- a/crates/ruma-macros/src/api/request/outgoing.rs
+++ b/crates/ruma-macros/src/api/request/outgoing.rs
@@ -23,7 +23,7 @@ impl Request {
         let query_serialize = self.query.expand_serialize(ruma_common);
         let query_fields = self.query.expand_fields();
 
-        let headers_serialize = self.headers.expand_serialize(KIND, &self.body, ruma_common, &http);
+        let headers_serialize = self.headers.expand_serialize(KIND, &http);
         let headers_fields = self.headers.expand_fields();
 
         let body_type = self.body.type_name(KIND, ruma_common, ident);

--- a/crates/ruma-macros/src/api/response/outgoing.rs
+++ b/crates/ruma-macros/src/api/response/outgoing.rs
@@ -9,7 +9,7 @@ impl Response {
     pub fn expand_outgoing(&self, ruma_common: &RumaCommon) -> TokenStream {
         let http = ruma_common.reexported(RumaCommonReexport::Http);
 
-        let headers_serialize = self.headers.expand_serialize(KIND, &self.body, ruma_common, &http);
+        let headers_serialize = self.headers.expand_serialize(KIND, &http);
         let headers_fields = self.headers.expand_fields();
 
         let body_type = self.body.type_name(KIND, ruma_common, &self.ident);


### PR DESCRIPTION
It makes sense because the body should know its content type in most cases, except in the few endpoints where the user can set it manually.

This allows to add the `Content-Type` HTTP header automatically in `OutgoingRequestExt::try_into_http_request()` and
`OutgoingResponseExt::try_into_http_response()` rather than always have to do it manually in `try_into_http_*_inner()`. If the request or response type already sets the HTTP header in `try_into_http_*_inner()` it is not overwritten.

The 2 first commits are a little bit of clean up before adding this.