### PR TITLE
client-api: do not send a null `m.identity_server` as a response to `login`

### DIFF
--- a/crates/ruma-client-api/CHANGELOG.md
+++ b/crates/ruma-client-api/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+Bug fixes:
+
+- In the `session::login::v3` module, the `identity_server` field is no longer
+  serialized when it is `Option::None`.
+
 ## 0.25.0
 
 Breaking changes:

--- a/crates/ruma-client-api/src/session/login.rs
+++ b/crates/ruma-client-api/src/session/login.rs
@@ -393,7 +393,7 @@ pub mod v3 {
         pub homeserver: HomeserverInfo,
 
         /// Information about the identity server to connect to.
-        #[serde(rename = "m.identity_server")]
+        #[serde(rename = "m.identity_server", skip_serializing_if = "Option::is_none")]
         pub identity_server: Option<IdentityServerInfo>,
     }
 


### PR DESCRIPTION
According to the matrix spec [1], the m.identity_server in the
"Discovery Informaiton" structure in the login response is optional and
must strictly be of type "Identity Server Information", which means that
null is not an acceptable value.

As such, sending a response with a null "m.identity_server" is invalid
according to the spec.

This is actually causing a problem when trying to log in to recent
versions of continuwuity from recent versions of nheko [2].

[1]: https://spec.matrix.org/v1.19/client-server-api/#post_matrixclientv3login_response-200_discovery-information
[2]: https://github.com/Nheko-Reborn/nheko/issues/2067

PR checklist

- [x] Run `cargo xtask ci` locally before posting the PR
  * There were two warnings and a failure but both seem completely unrelated to my PR
- [x] Documented public API changes in CHANGELOG.md files

