### PR TITLE
Implement MSC4532 (Revised Social Presence)

### DIFF
--- a/crates/ruma-appservice-api/Cargo.toml
+++ b/crates/ruma-appservice-api/Cargo.toml
@@ -20,6 +20,7 @@ server = []
 
 unstable-msc3202 = []
 unstable-msc4203 = []
+unstable-msc4532 = ["ruma-common/unstable-msc4532", "ruma-events/unstable-msc4532"]
 
 [dependencies]
 http = { workspace = true }

--- a/crates/ruma-appservice-api/src/event/push_events.rs
+++ b/crates/ruma-appservice-api/src/event/push_events.rs
@@ -422,24 +422,51 @@ pub mod v1 {
             assert_to_canonical_json_eq!(data, receipt_json);
 
             // Test m.presence serde.
-            let presence_json = json!({
-                "type": "m.presence",
-                "sender": user_id,
-                "content": {
-                    "avatar_url": "mxc://localhost/wefuiwegh8742w",
-                    "currently_active": false,
-                    "last_active_ago": 785,
-                    "presence": "online",
-                    "status_msg": "Making cupcakes",
-                },
-            });
+            #[cfg(not(feature = "unstable-msc4532"))]
+            {
+                let presence_json = json!({
+                    "type": "m.presence",
+                    "sender": user_id,
+                    "content": {
+                        "avatar_url": "mxc://localhost/wefuiwegh8742w",
+                        "currently_active": false,
+                        "last_active_ago": 785,
+                        "presence": "online",
+                        "status_msg": "Making cupcakes",
+                    },
+                });
 
-            let data = from_json_value::<EphemeralData>(presence_json.clone()).unwrap();
-            assert_let!(EphemeralData::Presence(presence) = &data);
-            assert_eq!(presence.sender, user_id);
-            assert_eq!(presence.content.currently_active, Some(false));
+                let data = from_json_value::<EphemeralData>(presence_json.clone()).unwrap();
+                assert_let!(EphemeralData::Presence(presence) = &data);
+                assert_eq!(presence.sender, user_id);
+                assert_eq!(presence.content.currently_active, Some(false));
 
-            assert_to_canonical_json_eq!(data, presence_json);
+                assert_to_canonical_json_eq!(data, presence_json);
+            }
+            #[cfg(feature = "unstable-msc4532")]
+            {
+                let presence_json = json!({
+                    "type": "m.presence",
+                    "sender": user_id,
+                    "content": {
+                        "avatar_url": "mxc://localhost/wefuiwegh8742w",
+                        "currently_active": false,
+                        "last_active_ago": 785,
+                        "presence": "online",
+                        "status_msg": "Making cupcakes",
+                        "org.continuwuity.presence_v2.msc4532.status": {
+                            "msg": "Making cupcakes"
+                        },
+                    },
+                });
+
+                let data = from_json_value::<EphemeralData>(presence_json.clone()).unwrap();
+                assert_let!(EphemeralData::Presence(presence) = &data);
+                assert_eq!(presence.sender, user_id);
+                assert_eq!(presence.content.currently_active, Some(false));
+
+                assert_to_canonical_json_eq!(data, presence_json);
+            }
 
             // Test custom serde.
             let custom_json = json!({

--- a/crates/ruma-client-api/Cargo.toml
+++ b/crates/ruma-client-api/Cargo.toml
@@ -68,6 +68,7 @@ unstable-msc4439 = []
 unstable-msc4466 = []
 unstable-msc4480 = ["unstable-msc4354"]
 unstable-msc4484 = ["ruma-common/unstable-msc4484"]
+unstable-msc4532 = ["ruma-common/unstable-msc4532", "ruma-events/unstable-msc4532"]
 
 [dependencies]
 as_variant = { workspace = true }

--- a/crates/ruma-client-api/src/presence/get_presence.rs
+++ b/crates/ruma-client-api/src/presence/get_presence.rs
@@ -9,12 +9,15 @@ pub mod v3 {
 
     use std::time::Duration;
 
+    #[cfg(feature = "unstable-msc4532")]
+    use ruma_common::presence::PresenceStatus;
     use ruma_common::{
         OwnedUserId,
         api::{auth_scheme::AccessToken, request, response},
         metadata,
         presence::PresenceState,
     };
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
     metadata! {
         method: GET,
@@ -32,14 +35,94 @@ pub mod v3 {
         /// The user whose presence state will be retrieved.
         #[ruma_api(path)]
         pub user_id: OwnedUserId,
+
+        /// Whether to use [MSC4532]'s revised presence states (if the server supports them).
+        ///
+        /// Defaults to `false`.
+        ///
+        /// This uses the unstable prefix defined in [MSC4532].
+        ///
+        /// [MSC4532]: https://github.com/matrix-org/matrix-spec-proposals/pull/4532
+        #[cfg(feature = "unstable-msc4532")]
+        #[serde(
+            default,
+            skip_serializing_if = "ruma_common::serde::is_default",
+            rename = "org.continuwuity.presence_v2.msc4532.revised_presence"
+        )]
+        #[ruma_api(query)]
+        pub revised_presence: bool,
     }
 
     /// Response type for the `get_presence` endpoint.
     #[response]
+    #[ruma_api(manual_body_serde)]
     pub struct Response {
+        /// The state message for this user if one was set.
+        #[cfg(not(feature = "unstable-msc4532"))]
+        pub status_msg: Option<String>,
+
+        /// The status information for this user's presence.
+        ///
+        /// This field uses the unstable prefix defined in [MSC4532].
+        ///
+        /// [MSC4532]: https://github.com/matrix-org/matrix-spec-proposals/pull/4532
+        #[cfg(feature = "unstable-msc4532")]
+        pub status: PresenceStatus,
+
+        /// Whether or not the user is currently active.
+        pub currently_active: Option<bool>,
+
+        /// The length of time in milliseconds since an action was performed by the user.
+        pub last_active_ago: Option<Duration>,
+
+        /// The user's presence state.
+        pub presence: PresenceState,
+    }
+
+    impl Request {
+        /// Creates a new `Request` with the given user ID.
+        pub fn new(user_id: OwnedUserId) -> Self {
+            Self {
+                user_id,
+                #[cfg(feature = "unstable-msc4532")]
+                revised_presence: true,
+            }
+        }
+    }
+
+    impl Response {
+        /// Creates a new `Response` with the given presence state.
+        pub fn new(presence: PresenceState) -> Self {
+            Self {
+                presence,
+                #[cfg(not(feature = "unstable-msc4532"))]
+                status_msg: None,
+                #[cfg(feature = "unstable-msc4532")]
+                status: PresenceStatus::default(),
+                currently_active: None,
+                last_active_ago: None,
+            }
+        }
+    }
+
+    #[derive(Serialize, Deserialize)]
+    struct ResponseBodyRepr {
         /// The state message for this user if one was set.
         #[serde(skip_serializing_if = "Option::is_none")]
         pub status_msg: Option<String>,
+
+        /// The status information for this user's presence.
+        ///
+        /// This field uses the unstable prefix defined in [MSC4532].
+        ///
+        /// [MSC4532]: https://github.com/matrix-org/matrix-spec-proposals/pull/4532
+        #[serde(
+            skip_serializing_if = "ruma_common::serde::is_default",
+            rename = "org.continuwuity.presence_v2.msc4532.status",
+            default
+        )]
+        #[cfg(feature = "unstable-msc4532")]
+        pub status: PresenceStatus,
 
         /// Whether or not the user is currently active.
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -57,17 +140,56 @@ pub mod v3 {
         pub presence: PresenceState,
     }
 
-    impl Request {
-        /// Creates a new `Request` with the given user ID.
-        pub fn new(user_id: OwnedUserId) -> Self {
-            Self { user_id }
+    impl<'de> Deserialize<'de> for ResponseBody {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            let ResponseBodyRepr {
+                status_msg,
+                #[cfg(feature = "unstable-msc4532")]
+                status,
+                currently_active,
+                last_active_ago,
+                presence,
+            } = ResponseBodyRepr::deserialize(deserializer)?;
+
+            Ok(Self {
+                #[cfg(not(feature = "unstable-msc4532"))]
+                status_msg,
+                // If MSC4532 is enabled, utilize the legacy field if that's all we have
+                #[cfg(feature = "unstable-msc4532")]
+                status: if status == PresenceStatus::default() {
+                    PresenceStatus::new(status_msg)
+                } else {
+                    status
+                },
+                currently_active,
+                last_active_ago,
+                presence,
+            })
         }
     }
 
-    impl Response {
-        /// Creates a new `Response` with the given presence state.
-        pub fn new(presence: PresenceState) -> Self {
-            Self { presence, status_msg: None, currently_active: None, last_active_ago: None }
+    impl Serialize for ResponseBody {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            ResponseBodyRepr {
+                // If MSC4532 is enabled, set the legacy field for backwards compatibility
+                #[cfg(not(feature = "unstable-msc4532"))]
+                status_msg: self.status_msg.clone(),
+                #[cfg(feature = "unstable-msc4532")]
+                status_msg: self.status.msg.clone(),
+
+                #[cfg(feature = "unstable-msc4532")]
+                status: self.status.clone(),
+                currently_active: self.currently_active,
+                last_active_ago: self.last_active_ago,
+                presence: self.presence.clone(),
+            }
+            .serialize(serializer)
         }
     }
 }

--- a/crates/ruma-client-api/src/presence/set_presence.rs
+++ b/crates/ruma-client-api/src/presence/set_presence.rs
@@ -7,12 +7,15 @@ pub mod v3 {
     //!
     //! [spec]: https://spec.matrix.org/v1.19/client-server-api/#put_matrixclientv3presenceuseridstatus
 
+    #[cfg(feature = "unstable-msc4532")]
+    use ruma_common::presence::PresenceStatus;
     use ruma_common::{
         OwnedUserId,
         api::{auth_scheme::AccessToken, request, response},
         metadata,
         presence::PresenceState,
     };
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
     metadata! {
         method: PUT,
@@ -26,6 +29,7 @@ pub mod v3 {
 
     /// Request type for the `set_presence` endpoint.
     #[request]
+    #[ruma_api(manual_body_serde)]
     pub struct Request {
         /// The user whose presence state will be updated.
         #[ruma_api(path)]
@@ -35,8 +39,16 @@ pub mod v3 {
         pub presence: PresenceState,
 
         /// The status message to attach to this state.
-        #[serde(skip_serializing_if = "Option::is_none")]
+        #[cfg(not(feature = "unstable-msc4532"))]
         pub status_msg: Option<String>,
+
+        /// The status information to attach to this state.
+        ///
+        /// This field uses the unstable prefix defined in [MSC4532].
+        ///
+        /// [MSC4532]: https://github.com/matrix-org/matrix-spec-proposals/pull/4532
+        #[cfg(feature = "unstable-msc4532")]
+        pub status: PresenceStatus,
     }
 
     /// Response type for the `set_presence` endpoint.
@@ -47,7 +59,14 @@ pub mod v3 {
     impl Request {
         /// Creates a new `Request` with the given user ID and presence state.
         pub fn new(user_id: OwnedUserId, presence: PresenceState) -> Self {
-            Self { user_id, presence, status_msg: None }
+            Self {
+                user_id,
+                presence,
+                #[cfg(not(feature = "unstable-msc4532"))]
+                status_msg: None,
+                #[cfg(feature = "unstable-msc4532")]
+                status: PresenceStatus::default(),
+            }
         }
     }
 
@@ -55,6 +74,77 @@ pub mod v3 {
         /// Creates an empty `Response`.
         pub fn new() -> Self {
             Self {}
+        }
+    }
+
+    #[derive(Serialize, Deserialize)]
+    struct RequestBodyRepr {
+        /// The new presence state.
+        pub presence: PresenceState,
+
+        /// The status message to attach to this state.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub status_msg: Option<String>,
+
+        /// The status information to attach to this state.
+        ///
+        /// This field uses the unstable prefix defined in [MSC4532].
+        ///
+        /// [MSC4532]: https://github.com/matrix-org/matrix-spec-proposals/pull/4532
+        #[serde(
+            skip_serializing_if = "ruma_common::serde::is_default",
+            rename = "org.continuwuity.presence_v2.msc4532.status",
+            default
+        )]
+        #[cfg(feature = "unstable-msc4532")]
+        pub status: PresenceStatus,
+    }
+
+    impl<'de> Deserialize<'de> for RequestBody {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            let RequestBodyRepr {
+                presence,
+                status_msg,
+                #[cfg(feature = "unstable-msc4532")]
+                status,
+            } = RequestBodyRepr::deserialize(deserializer)?;
+
+            Ok(Self {
+                presence,
+                #[cfg(not(feature = "unstable-msc4532"))]
+                status_msg: status_msg.clone(),
+                // If MSC4532 is enabled, utilize the legacy field if that's all we have
+                #[cfg(feature = "unstable-msc4532")]
+                status: if status == PresenceStatus::default() {
+                    PresenceStatus::new(status_msg)
+                } else {
+                    status
+                },
+            })
+        }
+    }
+
+    impl Serialize for RequestBody {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            RequestBodyRepr {
+                presence: self.presence.clone(),
+
+                // If MSC4532 is enabled, set the legacy field for backwards compatibility
+                #[cfg(not(feature = "unstable-msc4532"))]
+                status_msg: self.status_msg.clone(),
+                #[cfg(feature = "unstable-msc4532")]
+                status_msg: self.status.msg.clone(),
+
+                #[cfg(feature = "unstable-msc4532")]
+                status: self.status.clone(),
+            }
+            .serialize(serializer)
         }
     }
 }

--- a/crates/ruma-client-api/src/sync/sync_events/v3.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v3.rs
@@ -64,6 +64,22 @@ pub struct Request {
     #[ruma_api(query)]
     pub set_presence: PresenceState,
 
+    /// Whether to use [MSC4532]'s revised presence states (if the server supports them).
+    ///
+    /// Defaults to `false`.
+    ///
+    /// This uses the unstable prefix defined in [MSC4532].
+    ///
+    /// [MSC4532]: https://github.com/matrix-org/matrix-spec-proposals/pull/4532
+    #[cfg(feature = "unstable-msc4532")]
+    #[serde(
+        default,
+        skip_serializing_if = "ruma_common::serde::is_default",
+        rename = "org.continuwuity.presence_v2.msc4532.revised_presence"
+    )]
+    #[ruma_api(query)]
+    pub revised_presence: bool,
+
     /// The maximum time to poll in milliseconds before returning this request.
     #[serde(
         with = "ruma_common::serde::duration::opt_ms",
@@ -875,6 +891,8 @@ mod client_tests {
             set_presence: PresenceState::Offline,
             timeout: Some(Duration::from_millis(30000)),
             use_state_after: true,
+            #[cfg(feature = "unstable-msc4532")]
+            revised_presence: true,
         }
         .try_into_http_request(
             "https://homeserver.tld",
@@ -893,6 +911,8 @@ mod client_tests {
         assert!(query.contains("set_presence=offline"));
         assert!(query.contains("timeout=30000"));
         assert!(query.contains("use_state_after=true"));
+        #[cfg(feature = "unstable-msc4532")]
+        assert!(query.contains("revised_presence=true"));
     }
 
     #[test]

--- a/crates/ruma-client-api/src/sync/sync_events/v5.rs
+++ b/crates/ruma-client-api/src/sync/sync_events/v5.rs
@@ -78,6 +78,22 @@ pub struct Request {
     #[ruma_api(query)]
     pub set_presence: PresenceState,
 
+    /// Whether to use [MSC4532]'s revised presence states (if the server supports them).
+    ///
+    /// Defaults to `false`.
+    ///
+    /// This uses the unstable prefix defined in [MSC4532].
+    ///
+    /// [MSC4532]: https://github.com/matrix-org/matrix-spec-proposals/pull/4532
+    #[cfg(feature = "unstable-msc4532")]
+    #[serde(
+        default,
+        skip_serializing_if = "ruma_common::serde::is_default",
+        rename = "org.continuwuity.presence_v2.msc4532.revised_presence"
+    )]
+    #[ruma_api(query)]
+    pub revised_presence: bool,
+
     /// Lists of rooms we are interested by, represented by ranges.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub lists: BTreeMap<String, request::List>,

--- a/crates/ruma-common/Cargo.toml
+++ b/crates/ruma-common/Cargo.toml
@@ -54,6 +54,8 @@ unstable-msc4484 = []
 unstable-msc4494 = []
 # Selective Presence
 unstable-msc4495 = []
+# Revised Social Presence
+unstable-msc4532 = []
 
 # Allow IDs to exceed 255 bytes.
 compat-arbitrary-length-ids = ["ruma-identifiers-validation/compat-arbitrary-length-ids"]

--- a/crates/ruma-common/src/api/metadata.rs
+++ b/crates/ruma-common/src/api/metadata.rs
@@ -856,6 +856,15 @@ pub enum FeatureFlag {
     #[ruma_enum(rename = "uk.timedout.msc4494")]
     Msc4494,
 
+    /// `org.continuwuity.presence_v2.msc4532` ([MSC])
+    ///
+    /// Revised Social Presence.
+    ///
+    /// [MSC]: https://github.com/matrix-org/matrix-spec-proposals/pull/4532
+    #[cfg(feature = "unstable-msc4532")]
+    #[ruma_enum(rename = "org.continuwuity.presence_v2.msc4532")]
+    Msc4532,
+
     #[doc(hidden)]
     _Custom(PrivOwnedStr),
 }

--- a/crates/ruma-common/src/presence.rs
+++ b/crates/ruma-common/src/presence.rs
@@ -2,6 +2,11 @@
 //!
 //! [presence]: https://spec.matrix.org/v1.19/client-server-api/#presence
 
+#[cfg(feature = "unstable-msc4532")]
+use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "unstable-msc4532")]
+use crate::serde::JsonObject;
 use crate::{PrivOwnedStr, serde::StringEnum};
 
 /// A description of a user's connectivity and availability for chat.
@@ -20,12 +25,109 @@ pub enum PresenceState {
     /// Connected to the service but not available for chat.
     Unavailable,
 
+    /// The user is available to reply.
+    ///
+    /// This uses the unstable prefix defined in [MSC4532].
+    ///
+    /// [MSC4532]: https://github.com/matrix-org/matrix-spec-proposals/pull/4532
+    #[cfg(feature = "unstable-msc4532")]
+    Active,
+
+    /// The user has a connected client and may reply (potentially unreachable).
+    ///
+    /// This uses the unstable prefix defined in [MSC4532].
+    ///
+    /// [MSC4532]: https://github.com/matrix-org/matrix-spec-proposals/pull/4532
+    #[cfg(feature = "unstable-msc4532")]
+    Idle,
+
+    /// The user is unavailable to reply (fully unreachable).
+    ///
+    /// This uses the unstable prefix defined in [MSC4532].
+    ///
+    /// [MSC4532]: https://github.com/matrix-org/matrix-spec-proposals/pull/4532
+    #[cfg(feature = "unstable-msc4532")]
+    Busy,
+
     #[doc(hidden)]
     _Custom(PrivOwnedStr),
 }
 
+impl PresenceState {
+    /// If this [`PresenceState`] is a legacy (non-[MSC4532]) state, return the equivalent MSC4532
+    /// state.
+    ///
+    /// This uses the behavior map as defined in the proposal.
+    ///
+    /// [MSC4532]: https://github.com/matrix-org/matrix-spec-proposals/pull/4532
+    #[cfg(feature = "unstable-msc4532")]
+    pub fn as_msc4532_state(&self, currently_active: bool) -> Self {
+        match (self, currently_active) {
+            (Self::Online, true) => Self::Active,
+            (Self::Online, false) => Self::Idle,
+            (Self::Unavailable, _) => Self::Idle,
+            (state, _) => state.clone(),
+        }
+    }
+
+    /// If this [`PresenceState`] is an MSC4532 state, return the equivalent legacy (non-MSC4532)
+    /// state.
+    ///
+    /// This uses the behavior map as defined in the proposal.
+    ///
+    /// [MSC4532]: https://github.com/matrix-org/matrix-spec-proposals/pull/4532
+    #[cfg(feature = "unstable-msc4532")]
+    pub fn as_legacy_state(&self) -> Self {
+        match self {
+            Self::Active => Self::Online,
+            Self::Idle => Self::Unavailable,
+            Self::Busy => Self::Unavailable,
+            state => state.clone(),
+        }
+    }
+
+    /// Return a reasonable `currently_active` value for this [`PresenceState`].
+    #[cfg(feature = "unstable-msc4532")]
+    pub fn currently_active(&self) -> bool {
+        matches!(self, Self::Active | Self::Online)
+    }
+}
+
 impl Default for &'_ PresenceState {
     fn default() -> Self {
-        &PresenceState::Online
+        #[cfg(feature = "unstable-msc4532")]
+        {
+            &PresenceState::Active
+        }
+        #[cfg(not(feature = "unstable-msc4532"))]
+        {
+            &PresenceState::Online
+        }
+    }
+}
+
+/// A user's extensible status.
+///
+/// This uses the unstable prefix defined in [MSC4532].
+///
+/// [MSC4532]: https://github.com/matrix-org/matrix-spec-proposals/pull/4532
+#[cfg(feature = "unstable-msc4532")]
+#[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+pub struct PresenceStatus {
+    /// An optional description to accompany the presence.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub msg: Option<String>,
+
+    /// Remaining content.
+    #[serde(flatten)]
+    pub data: JsonObject,
+}
+
+#[cfg(feature = "unstable-msc4532")]
+impl PresenceStatus {
+    /// Creates a new `PresenceStatus` with the given message.
+    pub fn new(msg: Option<String>) -> Self {
+        Self { msg, data: JsonObject::new() }
     }
 }

--- a/crates/ruma-events/Cargo.toml
+++ b/crates/ruma-events/Cargo.toml
@@ -60,6 +60,7 @@ unstable-msc4385 = []
 unstable-msc4471 = []
 unstable-msc4494 = []
 unstable-msc4495 = []
+unstable-msc4532 = ["ruma-common/unstable-msc4532"]
 unstable-uniffi = ["dep:uniffi"]
 
 # Allow some mandatory fields to be missing, defaulting them to an empty string

--- a/crates/ruma-events/src/enums.rs
+++ b/crates/ruma-events/src/enums.rs
@@ -75,6 +75,9 @@ event_enum! {
         #[cfg(feature = "unstable-msc4495")]
         #[ruma_enum(ident = PresencePrompted)]
         "org.continuwuity.presence_v2.msc4495.presence.prompted" => super::presence::prompted,
+        #[cfg(feature = "unstable-msc4532")]
+        #[ruma_enum(ident = PresencePersistent)]
+        "org.continuwuity.presence_v2.msc4532.presence.persistent" => super::presence::persistent,
     }
 
     /// Any room account data event.

--- a/crates/ruma-events/src/presence.rs
+++ b/crates/ruma-events/src/presence.rs
@@ -2,12 +2,16 @@
 //!
 //! The only content valid for this event is `PresenceEventContent`.
 
+#[cfg(feature = "unstable-msc4532")]
+pub mod persistent;
 #[cfg(feature = "unstable-msc4495")]
 pub mod prompted;
 #[cfg(feature = "unstable-msc4495")]
 pub mod sharing;
 
 use js_int::UInt;
+#[cfg(feature = "unstable-msc4532")]
+use ruma_common::presence::PresenceStatus;
 use ruma_common::{OwnedMxcUri, OwnedUserId, presence::PresenceState};
 use serde::{Deserialize, Serialize};
 

--- a/crates/ruma-events/src/presence.rs
+++ b/crates/ruma-events/src/presence.rs
@@ -27,12 +27,14 @@ pub struct PresenceEvent {
     pub sender: OwnedUserId,
 }
 
-/// Informs the room of members presence.
+/// The over-the-wire format for [`PresenceEventContent`]. This exists to enable a custom
+/// (de)serialization implementation providing backwards-compatibility for the `status_msg`
+/// field when [MSC4532] is enabled.
 ///
-/// This is the only type a `PresenceEvent` can contain as its `content` field.
+/// [MSC4532]: https://github.com/matrix-org/matrix-spec-proposals/pull/4532
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
-pub struct PresenceEventContent {
+struct PresenceEventRepr {
     /// The current avatar URL for this user.
     ///
     /// If you activate the `compat-empty-string-null` feature, this field being an empty string in
@@ -62,6 +64,101 @@ pub struct PresenceEventContent {
     /// An optional description to accompany the presence.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status_msg: Option<String>,
+
+    /// Optional information to accompany the presence.
+    ///
+    /// This field uses the unstable prefix defined in [MSC4532].
+    ///
+    /// [MSC4532]: https://github.com/matrix-org/matrix-spec-proposals/pull/4532
+    #[cfg(feature = "unstable-msc4532")]
+    #[serde(
+        skip_serializing_if = "ruma_common::serde::is_default",
+        rename = "org.continuwuity.presence_v2.msc4532.status",
+        default
+    )]
+    pub status: PresenceStatus,
+}
+
+/// Informs the room of members presence.
+///
+/// This is the only type a `PresenceEvent` can contain as its `content` field.
+#[derive(Clone, Debug)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+pub struct PresenceEventContent {
+    /// The current avatar URL for this user.
+    ///
+    /// If you activate the `compat-empty-string-null` feature, this field being an empty string in
+    /// JSON will result in `None` here during deserialization.
+    pub avatar_url: Option<OwnedMxcUri>,
+
+    /// Whether or not the user is currently active.
+    pub currently_active: Option<bool>,
+
+    /// The current display name for this user.
+    pub displayname: Option<String>,
+
+    /// The last time since this user performed some action, in milliseconds.
+    pub last_active_ago: Option<UInt>,
+
+    /// The presence state for this user.
+    pub presence: PresenceState,
+
+    /// An optional description to accompany the presence.
+    #[cfg(not(feature = "unstable-msc4532"))]
+    pub status_msg: Option<String>,
+
+    /// Optional information to accompany the presence.
+    ///
+    /// This field uses the unstable prefix defined in [MSC4532].
+    ///
+    /// [MSC4532]: https://github.com/matrix-org/matrix-spec-proposals/pull/4532
+    #[cfg(feature = "unstable-msc4532")]
+    pub status: PresenceStatus,
+}
+
+impl<'de> Deserialize<'de> for PresenceEventContent {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let repr = PresenceEventRepr::deserialize(deserializer)?;
+        Ok(Self {
+            avatar_url: repr.avatar_url,
+            currently_active: repr.currently_active,
+            displayname: repr.displayname,
+            last_active_ago: repr.last_active_ago,
+            presence: repr.presence,
+            #[cfg(not(feature = "unstable-msc4532"))]
+            status_msg: repr.status_msg,
+            #[cfg(feature = "unstable-msc4532")]
+            status: if repr.status == PresenceStatus::default() {
+                PresenceStatus::new(repr.status_msg)
+            } else {
+                repr.status
+            },
+        })
+    }
+}
+impl Serialize for PresenceEventContent {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        PresenceEventRepr {
+            avatar_url: self.avatar_url.clone(),
+            currently_active: self.currently_active,
+            displayname: self.displayname.clone(),
+            last_active_ago: self.last_active_ago,
+            presence: self.presence.clone(),
+            #[cfg(not(feature = "unstable-msc4532"))]
+            status_msg: self.status_msg.clone(),
+            #[cfg(feature = "unstable-msc4532")]
+            status_msg: self.status.msg.clone(),
+            #[cfg(feature = "unstable-msc4532")]
+            status: self.status.clone(),
+        }
+        .serialize(serializer)
+    }
 }
 
 impl PresenceEventContent {
@@ -73,7 +170,10 @@ impl PresenceEventContent {
             displayname: None,
             last_active_ago: None,
             presence,
+            #[cfg(not(feature = "unstable-msc4532"))]
             status_msg: None,
+            #[cfg(feature = "unstable-msc4532")]
+            status: PresenceStatus::default(),
         }
     }
 }
@@ -81,6 +181,8 @@ impl PresenceEventContent {
 #[cfg(test)]
 mod tests {
     use js_int::uint;
+    #[cfg(feature = "unstable-msc4532")]
+    use ruma_common::presence::PresenceStatus;
     use ruma_common::{
         canonical_json::assert_to_canonical_json_eq, mxc_uri, owned_mxc_uri,
         presence::PresenceState,
@@ -97,9 +199,27 @@ mod tests {
             displayname: None,
             last_active_ago: Some(uint!(2_478_593)),
             presence: PresenceState::Online,
+            #[cfg(not(feature = "unstable-msc4532"))]
             status_msg: Some("Making cupcakes".into()),
+            #[cfg(feature = "unstable-msc4532")]
+            status: PresenceStatus::new(Some("Making cupcakes".into())),
         };
 
+        #[cfg(feature = "unstable-msc4532")]
+        assert_to_canonical_json_eq!(
+            content,
+            json!({
+                "avatar_url": "mxc://localhost/wefuiwegh8742w",
+                "currently_active": false,
+                "last_active_ago": 2_478_593,
+                "presence": "online",
+                "org.continuwuity.presence_v2.msc4532.status": {
+                    "msg": "Making cupcakes"
+                },
+                "status_msg": "Making cupcakes"
+            }),
+        );
+        #[cfg(not(feature = "unstable-msc4532"))]
         assert_to_canonical_json_eq!(
             content,
             json!({
@@ -135,7 +255,10 @@ mod tests {
         assert_eq!(ev.content.displayname, None);
         assert_eq!(ev.content.last_active_ago, Some(uint!(2_478_593)));
         assert_eq!(ev.content.presence, PresenceState::Online);
+        #[cfg(not(feature = "unstable-msc4532"))]
         assert_eq!(ev.content.status_msg.as_deref(), Some("Making cupcakes"));
+        #[cfg(feature = "unstable-msc4532")]
+        assert_eq!(ev.content.status.msg.as_deref(), Some("Making cupcakes"));
         assert_eq!(ev.sender, "@example:localhost");
 
         #[cfg(feature = "compat-empty-string-null")]
@@ -158,7 +281,10 @@ mod tests {
             assert_eq!(ev.content.displayname, None);
             assert_eq!(ev.content.last_active_ago, Some(uint!(2_478_593)));
             assert_eq!(ev.content.presence, PresenceState::Online);
+            #[cfg(not(feature = "unstable-msc4532"))]
             assert_eq!(ev.content.status_msg.as_deref(), Some("Making cupcakes"));
+            #[cfg(feature = "unstable-msc4532")]
+            assert_eq!(ev.content.status.msg.as_deref(), Some("Making cupcakes"));
             assert_eq!(ev.sender, "@example:localhost");
         }
     }

--- a/crates/ruma-events/src/presence/persistent.rs
+++ b/crates/ruma-events/src/presence/persistent.rs
@@ -1,0 +1,27 @@
+//! Types for the `m.presence.persistent` account data key.
+//!
+//! This uses the unstable prefix defined in [MSC4532].
+//!
+//! [MSC4532]: https://github.com/matrix-org/matrix-spec-proposals/pull/4532
+
+use ruma_common::presence::{PresenceState, PresenceStatus};
+use ruma_macros::EventContent;
+use serde::{Deserialize, Serialize};
+
+/// The content of the `m.presence.persistent` account data key.
+///
+/// This uses the unstable prefix defined in [MSC4532].
+///
+/// [MSC4532]: https://github.com/matrix-org/matrix-spec-proposals/pull/4532
+#[derive(Clone, Default, Debug, Deserialize, Serialize, EventContent)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+#[ruma_event(type = "org.continuwuity.presence_v2.msc4532.presence.persistent", kind = GlobalAccountData)]
+pub struct PresencePersistentEventContent {
+    /// A persistent global override for the user's presence state.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state_override: Option<PresenceState>,
+
+    /// The user's extensible status.
+    #[serde(skip_serializing_if = "ruma_common::serde::is_default")]
+    pub status: PresenceStatus,
+}

--- a/crates/ruma-federation-api/Cargo.toml
+++ b/crates/ruma-federation-api/Cargo.toml
@@ -26,6 +26,7 @@ unstable-msc3723 = []
 unstable-msc3843 = ["ruma-common/unstable-msc3843"]
 unstable-msc4125 = []
 unstable-msc4495 = ["ruma-events/unstable-msc4495"]
+unstable-msc4532 = ["ruma-common/unstable-msc4532", "ruma-events/unstable-msc4532"]
 
 [dependencies]
 bytes = { workspace = true, optional = true }

--- a/crates/ruma-federation-api/src/transactions/edu.rs
+++ b/crates/ruma-federation-api/src/transactions/edu.rs
@@ -5,6 +5,8 @@ use std::collections::BTreeMap;
 #[cfg(feature = "unstable-msc4495")]
 use js_int::Int;
 use js_int::UInt;
+#[cfg(feature = "unstable-msc4532")]
+use ruma_common::presence::PresenceStatus;
 use ruma_common::{
     OwnedDeviceId, OwnedEventId, OwnedRoomId, OwnedTransactionId, OwnedUserId,
     encryption::{CrossSigningKey, DeviceKeys},
@@ -121,10 +123,14 @@ impl PresenceRecipientListUpdates {
     }
 }
 
-/// An update to the presence of a user.
+/// The over-the-wire format for [`PresenceUpdate`]. This exists to enable a custom
+/// (de)serialization implementation providing backwards-compatibility for the `status_msg`
+/// field when [MSC4532] is enabled.
+///
+/// [MSC4532]: https://github.com/matrix-org/matrix-spec-proposals/pull/4532
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
-pub struct PresenceUpdate {
+pub struct PresenceUpdateRepr {
     /// The user ID this presence EDU is for.
     pub user_id: OwnedUserId,
 
@@ -134,6 +140,19 @@ pub struct PresenceUpdate {
     /// An optional description to accompany the presence.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status_msg: Option<String>,
+
+    /// Optional status information to accompany the presence.
+    ///
+    /// This field uses the unstable prefix defined in [MSC4532].
+    ///
+    /// [MSC4532]: https://github.com/matrix-org/matrix-spec-proposals/pull/4532
+    #[cfg(feature = "unstable-msc4532")]
+    #[serde(
+        skip_serializing_if = "ruma_common::serde::is_default",
+        rename = "org.continuwuity.presence_v2.msc4532.status",
+        default
+    )]
+    pub status: PresenceStatus,
 
     /// The number of milliseconds that have elapsed since the user last did something.
     pub last_active_ago: UInt,
@@ -177,6 +196,121 @@ pub struct PresenceUpdate {
     pub prev_id: Option<Int>,
 }
 
+/// An update to the presence of a user.
+#[derive(Clone, Debug)]
+#[cfg_attr(not(ruma_unstable_exhaustive_types), non_exhaustive)]
+pub struct PresenceUpdate {
+    /// The user ID this presence EDU is for.
+    pub user_id: OwnedUserId,
+
+    /// The presence of the user.
+    pub presence: PresenceState,
+
+    /// An optional description to accompany the presence.
+    #[cfg(not(feature = "unstable-msc4532"))]
+    pub status_msg: Option<String>,
+
+    /// Optional status information to accompany the presence.
+    ///
+    /// This field uses the unstable prefix defined in [MSC4532].
+    ///
+    /// [MSC4532]: https://github.com/matrix-org/matrix-spec-proposals/pull/4532
+    #[cfg(feature = "unstable-msc4532")]
+    pub status: PresenceStatus,
+
+    /// The number of milliseconds that have elapsed since the user last did something.
+    pub last_active_ago: UInt,
+
+    /// Whether or not the user is currently active.
+    ///
+    /// Defaults to false.
+    pub currently_active: bool,
+
+    /// Changes to the user's presence recipient list since the last EDU was sent, if any.
+    ///
+    /// This field will only be present if `prev_id` is also present.
+    ///
+    /// This field uses the unstable prefix defined in [MSC4495].
+    ///
+    /// [MSC4495]: https://github.com/matrix-org/matrix-spec-proposals/pull/4495
+    #[cfg(feature = "unstable-msc4495")]
+    pub recipients: PresenceRecipientListUpdates,
+
+    /// The stream ID of the user's current presence recipient list.
+    ///
+    /// This field uses the unstable prefix defined in [MSC4495].
+    ///
+    /// [MSC4495]: https://github.com/matrix-org/matrix-spec-proposals/pull/4495
+    #[cfg(feature = "unstable-msc4495")]
+    pub stream_id: Option<Int>,
+
+    /// The prior stream ID in the user's presence delta stream, if any.
+    ///
+    /// If this field does not match the most recently seen `stream_id`, the presence list should
+    /// be re-fetched.
+    ///
+    /// This field uses the unstable prefix defined in [MSC4495].
+    ///
+    /// [MSC4495]: https://github.com/matrix-org/matrix-spec-proposals/pull/4495
+    #[cfg(feature = "unstable-msc4495")]
+    pub prev_id: Option<Int>,
+}
+
+impl<'de> Deserialize<'de> for PresenceUpdate {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        let repr = PresenceUpdateRepr::deserialize(deserializer)?;
+        Ok(Self {
+            user_id: repr.user_id,
+            presence: repr.presence,
+            last_active_ago: repr.last_active_ago,
+            #[cfg(not(feature = "unstable-msc4532"))]
+            status_msg: repr.status_msg,
+            #[cfg(feature = "unstable-msc4532")]
+            status: if repr.status == PresenceStatus::default() {
+                PresenceStatus::new(repr.status_msg)
+            } else {
+                repr.status
+            },
+            currently_active: repr.currently_active,
+            #[cfg(feature = "unstable-msc4495")]
+            recipients: repr.recipients,
+            #[cfg(feature = "unstable-msc4495")]
+            stream_id: repr.stream_id,
+            #[cfg(feature = "unstable-msc4495")]
+            prev_id: repr.prev_id,
+        })
+    }
+}
+impl Serialize for PresenceUpdate {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        PresenceUpdateRepr {
+            user_id: self.user_id.clone(),
+            presence: self.presence.clone(),
+            last_active_ago: self.last_active_ago,
+            #[cfg(not(feature = "unstable-msc4532"))]
+            status_msg: self.status_msg.clone(),
+            #[cfg(feature = "unstable-msc4532")]
+            status_msg: self.status.msg.clone(),
+            #[cfg(feature = "unstable-msc4532")]
+            status: self.status.clone(),
+            currently_active: self.currently_active,
+            #[cfg(feature = "unstable-msc4495")]
+            recipients: self.recipients.clone(),
+            #[cfg(feature = "unstable-msc4495")]
+            stream_id: self.stream_id,
+            #[cfg(feature = "unstable-msc4495")]
+            prev_id: self.prev_id,
+        }
+        .serialize(serializer)
+    }
+}
+
 impl PresenceUpdate {
     /// Creates a new `PresenceUpdate` with the given `user_id`, `presence` and `last_activity`.
     pub fn new(user_id: OwnedUserId, presence: PresenceState, last_activity: UInt) -> Self {
@@ -184,7 +318,10 @@ impl PresenceUpdate {
             user_id,
             presence,
             last_active_ago: last_activity,
+            #[cfg(not(feature = "unstable-msc4532"))]
             status_msg: None,
+            #[cfg(feature = "unstable-msc4532")]
+            status: PresenceStatus::default(),
             currently_active: false,
             #[cfg(feature = "unstable-msc4495")]
             recipients: PresenceRecipientListUpdates::default(),
@@ -643,7 +780,10 @@ mod tests {
         assert_eq!(presence_update.presence, PresenceState::Online);
         assert!(presence_update.currently_active);
         assert_eq!(presence_update.last_active_ago, uint!(1000));
+        #[cfg(not(feature = "unstable-msc4532"))]
         assert_eq!(presence_update.status_msg.as_deref(), Some("Making cupcakes"));
+        #[cfg(feature = "unstable-msc4532")]
+        assert_eq!(presence_update.status.msg.as_deref(), Some("Making cupcakes"));
         #[cfg(feature = "unstable-msc4495")]
         {
             assert!(presence_update.recipients.is_empty());
@@ -690,7 +830,10 @@ mod tests {
         assert_eq!(presence_update.presence, PresenceState::Online);
         assert!(presence_update.currently_active);
         assert_eq!(presence_update.last_active_ago, uint!(1000));
+        #[cfg(not(feature = "unstable-msc4532"))]
         assert_eq!(presence_update.status_msg.as_deref(), Some("Making cupcakes"));
+        #[cfg(feature = "unstable-msc4532")]
+        assert_eq!(presence_update.status.msg.as_deref(), Some("Making cupcakes"));
         assert_eq!(presence_update.stream_id, Some(int!(321)));
         assert_eq!(presence_update.prev_id, Some(int!(123)));
         assert_matches!(&presence_update.recipients, PresenceRecipientListUpdates { add, delete });

--- a/crates/ruma-macros/src/api/request/parse.rs
+++ b/crates/ruma-macros/src/api/request/parse.rs
@@ -46,6 +46,8 @@ impl TryFrom<syn::ItemStruct> for Request {
                 .ok_or_else(|| syn::Error::new(Span::call_site(), "missing `error` attribute"))?,
         };
 
+        request.body.set_manual_serde(request_attrs.manual_body_serde);
+
         // Parse struct fields.
         for field in input.fields {
             let RequestField { inner: field, kind } = field.try_into()?;
@@ -137,6 +139,9 @@ pub(crate) struct RequestAttrs {
     /// The type used for the `EndpointError` associated type on `OutgoingRequest` and
     /// `IncomingRequest` implementations.
     error_ty: Option<syn::Type>,
+
+    /// Whether the request implements `Serialize` and `Deserialize` manually.
+    pub(super) manual_body_serde: bool,
 }
 
 impl RequestAttrs {
@@ -155,12 +160,31 @@ impl RequestAttrs {
         Ok(())
     }
 
+    /// Set that the request implements `Serialize` and `Deserialize` manually.
+    ///
+    /// Returns an error if it is already set.
+    fn set_manual_body_serde(&mut self) -> syn::Result<()> {
+        if self.manual_body_serde {
+            return Err(syn::Error::new(
+                Span::call_site(),
+                "cannot have multiple `manual_body_serde` request attributes",
+            ));
+        }
+
+        self.manual_body_serde = true;
+        Ok(())
+    }
+
     /// Try to parse the given meta item and merge it into this `RequestAttrs`.
     ///
     /// Returns an error if parsing the meta item fails, or if it sets a field that was already set.
     pub(crate) fn try_merge(&mut self, meta: ParseNestedMeta<'_>) -> syn::Result<()> {
         if meta.path.is_ident("error") {
             return self.set_error_ty(meta.value()?.parse()?);
+        }
+
+        if meta.path.is_ident("manual_body_serde") {
+            return self.set_manual_body_serde();
         }
 
         Err(meta.error("unsupported `request` attribute"))

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -218,6 +218,9 @@ unstable-msc4495 = [
     "ruma-federation-api?/unstable-msc4495",
     "ruma-events?/unstable-msc4495"
 ]
+unstable-msc4532 = [
+    "ruma-common/unstable-msc4532"
+]
 unstable-uniffi = ["ruma-events?/unstable-uniffi"]
 
 [dependencies]

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -220,6 +220,7 @@ unstable-msc4495 = [
 ]
 unstable-msc4532 = [
     "ruma-common/unstable-msc4532",
+    "ruma-federation-api?/unstable-msc4532",
     "ruma-appservice-api?/unstable-msc4532",
     "ruma-events?/unstable-msc4532"
 ]

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -220,6 +220,7 @@ unstable-msc4495 = [
 ]
 unstable-msc4532 = [
     "ruma-common/unstable-msc4532",
+    "ruma-appservice-api?/unstable-msc4532",
     "ruma-events?/unstable-msc4532"
 ]
 unstable-uniffi = ["ruma-events?/unstable-uniffi"]

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -220,6 +220,7 @@ unstable-msc4495 = [
 ]
 unstable-msc4532 = [
     "ruma-common/unstable-msc4532",
+    "ruma-client-api?/unstable-msc4532",
     "ruma-federation-api?/unstable-msc4532",
     "ruma-appservice-api?/unstable-msc4532",
     "ruma-events?/unstable-msc4532"

--- a/crates/ruma/Cargo.toml
+++ b/crates/ruma/Cargo.toml
@@ -219,7 +219,8 @@ unstable-msc4495 = [
     "ruma-events?/unstable-msc4495"
 ]
 unstable-msc4532 = [
-    "ruma-common/unstable-msc4532"
+    "ruma-common/unstable-msc4532",
+    "ruma-events?/unstable-msc4532"
 ]
 unstable-uniffi = ["ruma-events?/unstable-uniffi"]
 


### PR DESCRIPTION
This PR adds support for [MSC4532: Revised Social Presence](https://github.com/matrix-org/matrix-spec-proposals/pull/4532) ([rendered](https://github.com/thetayloredman/matrix-spec-proposals/blob/presence-v2/social/proposals/4532-revised-social-presence.md)).

Specifically, making the following changes (all gated behind the `unstable-msc4532` feature):
- `PresenceState` is updated to contain the proposal's new states (active, idle, busy) and functions for converting between the old and new states
- A new struct `PresenceStatus` is introduced, which contains the proposal's new extensible status mechanism
- A new `m.presence.persistent` account data event for storing persistent presence information
- Updates PresenceEvent and the presence update EDU to use the new `status` field instead of `status_msg`
  - Backwards compatibility with `status_msg` is kept using custom serde implementations, which reads `status_msg` if `status` is missing, and writes `status_msg` when serializing
- Updates v3 and v5 sync, and get_presence/set_presence as the proposal does

This PR is reviewable on a commit-by-commit basis (and I recommend doing so).

I am keeping this as a draft so it can be reviewed, but I anticipate things might still change while I work on the implementation in Continuwuity.